### PR TITLE
[ISSUE #9831]🚀Introduce registry-backed Pull deferred infrastructure

### DIFF
--- a/rocketmq-broker/src/long_polling.rs
+++ b/rocketmq-broker/src/long_polling.rs
@@ -19,4 +19,5 @@ pub(crate) mod polling_header;
 pub(crate) mod polling_result;
 pub(crate) mod pop_deferred;
 pub(crate) mod pop_request;
+pub(crate) mod pull_deferred;
 pub(crate) mod pull_request;

--- a/rocketmq-broker/src/long_polling/pull_deferred.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod data;
+mod deadline;
+mod index;
+mod service;
+
+pub(crate) use data::PullHookMetadata;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 freezes the broker-private Pull criteria seam before MIG-04 production wiring"
+)]
+pub(crate) use data::PullMatchCriteria;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 freezes the broker-private retained request seam before MIG-04 production wiring"
+)]
+pub(crate) use data::PullRequestData;
+pub(crate) use data::PullSessionClientLookup;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 freezes the broker-private Pull deadline seam before MIG-04 production wiring"
+)]
+pub(crate) use deadline::PullWaitDeadline;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use index::PullArrivalView;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use index::PullCriteriaLimits;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use service::PreparedPullRegistration;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use service::PullDeferredPrepareError;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use service::PullDeferredRegisterError;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use service::PullDeferredService;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use service::PullProducerStats;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use service::PullRetainedEstimate;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use service::PullSuspendTiming;
+#[allow(
+    unused_imports,
+    reason = "BRK-04 infrastructure is wired to production listeners and composition in BRK-06"
+)]
+pub(crate) use service::ResumePull;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+mod acceptance_tests;

--- a/rocketmq-broker/src/long_polling/pull_deferred/acceptance_tests.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/acceptance_tests.rs
@@ -1,0 +1,745 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use futures::SinkExt;
+use parking_lot::Mutex;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ShutdownReport;
+use rocketmq_store::CqExtUnit;
+use rocketmq_store::MessageFilter;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::ServerConfig;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredId;
+use rocketmq_transport::api::v2::DeferredWaitLimits;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrdering;
+use rocketmq_transport::api::v2::RequestOrderingKey;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::TransportServerV2;
+use rocketmq_transport::api::v2::WriteProgress;
+use rocketmq_transport::test_support::Connection;
+use rocketmq_transport::test_support::RemotingCommandCodec;
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpSocket;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::Notify;
+use tokio_util::codec::Framed;
+
+use super::index::PullArrivalView;
+use super::index::PullCriteriaIndex;
+use super::index::PullCriteriaLimits;
+use super::index::PullIndexSnapshot;
+use super::index::PullScanCursor;
+use super::service::PreparedPullRegistration;
+use super::service::PullDeferredPrepareError;
+use super::service::PullDeferredPrepareErrorKind;
+use super::service::PullDeferredRegisterErrorKind;
+use super::service::PullDeferredService;
+use super::service::PullRetainedEstimate;
+use super::service::PullSuspendTiming;
+use super::PullMatchCriteria;
+
+const TEST_TIMEOUT_MILLIS: u64 = 60_000;
+const SENTINEL_CODE: i32 = 98_311;
+const ORDERING_KEY: u64 = 98_312;
+
+mod lifecycle_tests;
+mod p1_tests;
+#[cfg(windows)]
+mod session_close_tests;
+
+struct CountingBodyOwner {
+    body: Vec<u8>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl CountingBodyOwner {
+    fn new(body: Vec<u8>, drops: Arc<AtomicUsize>) -> Self {
+        Self { body, drops }
+    }
+}
+
+impl AsRef<[u8]> for CountingBodyOwner {
+    fn as_ref(&self) -> &[u8] {
+        &self.body
+    }
+}
+
+impl Drop for CountingBodyOwner {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[cfg(not(windows))]
+fn disable_loopback_fast_path(_socket: &TcpSocket) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn disable_loopback_fast_path(socket: &TcpSocket) -> std::io::Result<()> {
+    use std::ffi::c_void;
+    use std::os::windows::io::AsRawSocket;
+
+    const SIO_LOOPBACK_FAST_PATH: u32 = 0x9800_0010;
+
+    #[link(name = "Ws2_32")]
+    unsafe extern "system" {
+        #[link_name = "WSAIoctl"]
+        fn wsa_ioctl(
+            socket: usize,
+            control_code: u32,
+            input: *const c_void,
+            input_len: u32,
+            output: *mut c_void,
+            output_len: u32,
+            bytes_returned: *mut u32,
+            overlapped: *mut c_void,
+            completion: *mut c_void,
+        ) -> i32;
+    }
+
+    let disabled = 0_i32;
+    let mut bytes_returned = 0_u32;
+    // SAFETY: the socket handle is valid, the input points to a Win32 BOOL for the complete call,
+    // and every optional output/overlapped pointer is null as required for this synchronous IOCTL.
+    let result = unsafe {
+        wsa_ioctl(
+            socket.as_raw_socket() as usize,
+            SIO_LOOPBACK_FAST_PATH,
+            std::ptr::from_ref(&disabled).cast(),
+            std::mem::size_of_val(&disabled) as u32,
+            std::ptr::null_mut(),
+            0,
+            &mut bytes_returned,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn configure_abortive_close(socket: &TcpStream) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let linger = libc::linger {
+        l_onoff: 1,
+        l_linger: 0,
+    };
+    // SAFETY: `linger` has the platform ABI required by `SO_LINGER`, and the socket descriptor
+    // remains valid for the complete call.
+    let linger_result = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_LINGER,
+            std::ptr::from_ref(&linger).cast(),
+            std::mem::size_of_val(&linger) as libc::socklen_t,
+        )
+    };
+    if linger_result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+fn configure_abortive_close(socket: &TcpStream) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+
+    const SOL_SOCKET: i32 = 0xffff;
+    const SO_LINGER: i32 = 0x0080;
+
+    #[repr(C)]
+    struct SocketLinger {
+        onoff: u16,
+        linger: u16,
+    }
+
+    #[link(name = "Ws2_32")]
+    unsafe extern "system" {
+        fn setsockopt(socket: usize, level: i32, name: i32, value: *const i8, value_len: i32) -> i32;
+    }
+
+    let raw_socket = socket.as_raw_socket() as usize;
+    let linger = SocketLinger { onoff: 1, linger: 0 };
+    // SAFETY: `linger` uses the WinSock `linger` layout and the socket handle remains valid for
+    // the complete call.
+    let linger_result = unsafe {
+        setsockopt(
+            raw_socket,
+            SOL_SOCKET,
+            SO_LINGER,
+            std::ptr::from_ref(&linger).cast(),
+            std::mem::size_of_val(&linger) as i32,
+        )
+    };
+    if linger_result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value is non-zero")
+}
+
+struct MatchAll;
+
+impl MessageFilter for MatchAll {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        true
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&std::collections::HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        true
+    }
+}
+
+fn service_with_limits(
+    controller: &AdmissionController,
+    waiters: usize,
+    retained_bytes: usize,
+    index_entries: usize,
+    per_key: usize,
+) -> Arc<PullDeferredService> {
+    let admission = DeferredAdmission::try_configure(controller, DeferredWaitLimits::new(waiters, retained_bytes))
+        .expect("Pull deferred admission");
+    Arc::new(PullDeferredService::new(
+        admission,
+        PullCriteriaLimits::new(nonzero(index_entries), nonzero(per_key)),
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        nonzero(1),
+        nonzero(1),
+    ))
+}
+
+fn service(controller: &AdmissionController) -> Arc<PullDeferredService> {
+    service_with_limits(controller, 4, 16 * 1024 * 1024, 4, 4)
+}
+
+fn request_header() -> PullMessageRequestHeader {
+    PullMessageRequestHeader {
+        consumer_group: CheetahString::from_static_str("GroupA"),
+        topic: CheetahString::from_static_str("TopicA"),
+        queue_id: 0,
+        queue_offset: 7,
+        max_msg_nums: 8,
+        sys_flag: 0,
+        commit_offset: 0,
+        suspend_timeout_millis: TEST_TIMEOUT_MILLIS,
+        sub_version: 0,
+        subscription: Some(CheetahString::from_static_str("*")),
+        expression_type: Some(CheetahString::from_static_str("TAG")),
+        ..Default::default()
+    }
+}
+
+fn request_command(opaque: i32) -> RemotingCommand {
+    let mut command =
+        RemotingCommand::create_request_command(RequestCode::PullMessage, request_header()).set_opaque(opaque);
+    command.make_custom_header_to_net();
+    command
+}
+
+#[derive(Clone, Copy)]
+struct RegistrationObservation {
+    id: DeferredId,
+    peer: SocketAddr,
+}
+
+#[derive(Default)]
+struct ProcessorBarrier {
+    before_outcome: Notify,
+    release_outcome: Notify,
+    commit_observed: Notify,
+}
+
+#[derive(Clone)]
+struct PullDeferredTestProcessor {
+    service: Arc<PullDeferredService>,
+    registrations: mpsc::UnboundedSender<RegistrationObservation>,
+    barrier: Arc<ProcessorBarrier>,
+    hold_before_outcome: bool,
+    rollback_registration: bool,
+}
+
+impl RequestProcessorV2 for PullDeferredTestProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        if request.command().code() == SENTINEL_CODE {
+            self.barrier.commit_observed.notify_one();
+            return success_reply();
+        }
+        let header = request
+            .command()
+            .decode_command_custom_header::<PullMessageRequestHeader>()?;
+        let peer = match request.origin() {
+            rocketmq_transport::api::v2::RequestOrigin::Network { peer } => peer.address(),
+            _ => {
+                return Err(RocketMQError::illegal_argument(
+                    "Pull deferred test requires TCP ingress",
+                ))
+            }
+        };
+        let criteria = PullMatchCriteria::new(
+            header.topic.clone(),
+            header.queue_id,
+            header.queue_offset,
+            SubscriptionData::default(),
+            Arc::new(MatchAll),
+        );
+        let fallback = ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+            ResponseCode::PullNotFound,
+        ))
+        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let prepared = self
+            .service
+            .prepare(
+                request,
+                criteria,
+                fallback,
+                PullSuspendTiming::from_policy(
+                    current_millis(),
+                    tokio::time::Instant::now(),
+                    true,
+                    header.suspend_timeout_millis,
+                    1_000,
+                ),
+                PullRetainedEstimate::default(),
+            )
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let registration = self
+            .service
+            .register(prepared, request)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.registrations
+            .send(RegistrationObservation {
+                id: registration.deferred_id(),
+                peer,
+            })
+            .map_err(|_| RocketMQError::illegal_argument("Pull registration observer closed"))?;
+        if self.rollback_registration {
+            drop(registration);
+            return Err(RocketMQError::illegal_argument(
+                "intentional Pull registration rollback",
+            ));
+        }
+        if self.hold_before_outcome {
+            self.barrier.before_outcome.notify_one();
+            self.barrier.release_outcome.notified().await;
+        }
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+
+    fn request_ordering(&self, _ingress: rocketmq_transport::api::v2::IngressRequestView<'_>) -> RequestOrdering {
+        RequestOrdering::Ordered(RequestOrderingKey::new(ORDERING_KEY))
+    }
+}
+
+fn success_reply() -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+    ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+        ResponseCode::Success,
+    ))
+    .map(HandlerOutcome::Reply)
+    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+}
+
+struct RunningServer {
+    owner: RuntimeOwner,
+    actions: ChildServiceContext,
+    shutdown: Option<oneshot::Sender<()>>,
+    result: oneshot::Receiver<ShutdownReport>,
+}
+
+impl RunningServer {
+    async fn finish(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        let report = self.result.await.expect("owned Pull V2 server report");
+        assert_clean_shutdown("Pull V2 server", &report);
+        let tasks = self.owner.shutdown_tasks().await;
+        assert_clean_shutdown("Pull V2 runtime", &tasks);
+        let background = self.owner.shutdown_background();
+        assert_clean_shutdown("Pull V2 finalization", &background);
+    }
+}
+
+fn assert_clean_shutdown(owner: &str, report: &ShutdownReport) {
+    assert!(report.is_healthy(), "{owner}: {}", report.to_json());
+    assert_eq!(report.aborted, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.panicked, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.timed_out, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.leaked, 0, "{owner}: {}", report.to_json());
+    assert!(report.remaining_tasks.is_empty(), "{owner}: {}", report.to_json());
+    for child in &report.children {
+        assert_clean_shutdown(owner, child);
+    }
+}
+
+async fn start_running_server<P>(processor: P, controller: Arc<AdmissionController>) -> (SocketAddr, RunningServer)
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("broker-pull-deferred-acceptance"))
+        .expect("Pull V2 test runtime owner");
+    let server_context = owner.root_context().component("pull-deferred.server");
+    let runner_context = owner.root_context().component("pull-deferred.runner");
+    let actions = owner.root_context().component("pull-deferred.actions");
+    let server = TransportServerV2::new(
+        Arc::new(ServerConfig {
+            bind_address: "127.0.0.1".to_owned(),
+            listen_port: 0,
+            ..ServerConfig::default()
+        }),
+        server_context,
+        processor,
+    )
+    .with_admission_controller(controller);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    runner_context
+        .spawn_service("pull-deferred-v2-server", async move {
+            let report = server
+                .try_run_with_shutdown_report_and_startup(
+                    async move {
+                        let _ = shutdown_rx.await;
+                    },
+                    startup_tx,
+                )
+                .await
+                .expect("owned Pull V2 server shutdown report");
+            let _ = result_tx.send(report);
+        })
+        .expect("spawn owned Pull V2 server");
+    let address = startup_rx
+        .await
+        .expect("Pull V2 startup channel")
+        .expect("Pull V2 server startup");
+    (
+        address,
+        RunningServer {
+            owner,
+            actions,
+            shutdown: Some(shutdown_tx),
+            result: result_rx,
+        },
+    )
+}
+
+async fn start_server<P>(processor: P, controller: Arc<AdmissionController>) -> (Connection, SocketAddr, RunningServer)
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    let (address, running) = start_running_server(processor, controller).await;
+    let client = Connection::new(TcpStream::connect(address).await.expect("connect Pull V2 client"));
+    (client, address, running)
+}
+
+async fn commit_barrier(client: &mut Connection, barrier: &ProcessorBarrier, opaque: i32) {
+    client
+        .send_command(
+            RemotingCommand::create_remoting_command(SENTINEL_CODE)
+                .set_opaque(opaque)
+                .mark_oneway_rpc(),
+        )
+        .await
+        .expect("send ordered Pull commit sentinel");
+    barrier.commit_observed.notified().await;
+}
+
+fn assert_released(service: &PullDeferredService) {
+    assert_eq!(service.index_snapshot(), PullIndexSnapshot::default());
+    let admission = service.admission_snapshot();
+    assert_eq!(admission.waiting_count(), 0);
+    assert_eq!(admission.retained_bytes(), 0);
+}
+
+#[tokio::test]
+async fn tcp_pending_wake_replays_then_writes_exactly_one_bound_frame() {
+    const ORIGINAL_OPAQUE: i32 = 9_831;
+    const RESPONSE_BODY: &[u8] = b"owner-backed-pull-response";
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = PullDeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: true,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(request_command(ORIGINAL_OPAQUE))
+        .await
+        .expect("send deferred Pull request");
+    let registered = registrations.recv().await.expect("observe Pull registration");
+    barrier.before_outcome.notified().await;
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let mut cursor = PullScanCursor::new();
+    let mut candidates = service.reserve_arrival_batch(&PullArrivalView::new(&topic, 0, 8), &mut cursor);
+    assert_eq!(candidates.len(), 1);
+    let candidate = candidates.pop().expect("one Pull candidate");
+    let mut pending_claim = Box::pin(service.claim_candidate(candidate, DeferredWakeReason::MessageArrived));
+    tokio::select! {
+        biased;
+        result = &mut pending_claim => panic!("prepared Pull claim completed before dispatcher commit: {result:?}"),
+        _ = tokio::task::yield_now() => {}
+    }
+
+    barrier.release_outcome.notify_one();
+    let claim = pending_claim.await.expect("pending Pull wake replays after commit");
+    assert_eq!(claim.reason(), DeferredWakeReason::MessageArrived);
+    assert_eq!(service.index_snapshot(), PullIndexSnapshot::default());
+    assert_eq!(service.admission_snapshot().waiting_count(), 1);
+
+    let rereads = Arc::new(AtomicUsize::new(0));
+    let reread_count = Arc::clone(&rereads);
+    let peer = registered.peer;
+    let service_for_resume = Arc::clone(&service);
+    let owner_drops = Arc::new(AtomicUsize::new(0));
+    let response_owner_drops = Arc::clone(&owner_drops);
+    let (plan_ready_tx, plan_ready_rx) = oneshot::channel();
+    let (release_plan_tx, release_plan_rx) = oneshot::channel();
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .actions
+        .spawn_service("pull-deferred-resume", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    rocketmq_transport::api::v2::DeferredResumeRetainedSize::default(),
+                    move |resume, reason| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        assert_eq!(resume.request().effective_peer(), peer);
+                        assert_eq!(resume.criteria().pull_from_offset(), 7);
+                        reread_count.fetch_add(1, Ordering::SeqCst);
+                        let body =
+                            Bytes::from_owner(CountingBodyOwner::new(RESPONSE_BODY.to_vec(), response_owner_drops));
+                        let _ = plan_ready_tx.send(());
+                        release_plan_rx
+                            .await
+                            .map_err(|_| RocketMQError::illegal_argument("Pull response plan release closed"))?;
+                        ResponsePlan::bytes(
+                            RemotingCommand::create_response_command_with_code(ResponseCode::PullNotFound),
+                            body,
+                        )
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn owned Pull resume");
+    plan_ready_rx.await.expect("owner-backed Pull response plan ready");
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 0);
+    let mut receipt_rx = Box::pin(receipt_rx);
+    tokio::select! {
+        biased;
+        result = &mut receipt_rx => panic!("Pull response completed before writer release: {result:?}"),
+        _ = tokio::task::yield_now() => {}
+    }
+    release_plan_tx
+        .send(())
+        .expect("release owner-backed Pull response plan");
+
+    let response = client
+        .receive_command()
+        .await
+        .expect("Pull V2 connection remains open")
+        .expect("one Pull response frame");
+    receipt_rx
+        .await
+        .expect("Pull resume receipt channel")
+        .expect("canonical Pull resume/write");
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(response.code(), ResponseCode::PullNotFound as i32);
+    assert_eq!(response.body().map(|body| body.as_ref()), Some(RESPONSE_BODY));
+    assert_eq!(rereads.load(Ordering::SeqCst), 1);
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 1);
+    assert_released(&service);
+    let _ = service.shutdown();
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "strictly one Pull response frame"
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(
+    windows,
+    ignore = "Windows loopback accepts the maximum legal frame before user-space can RST; covered by deterministic transport partial-write tests"
+)]
+async fn tcp_partial_write_drops_owner_once_without_retrying() {
+    const ORIGINAL_OPAQUE: i32 = 9_832;
+    const PARTIAL_BODY_BYTES: usize = 16 * 1024 * 1024 - 4 * 1024;
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = PullDeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (address, running) = start_running_server(processor, Arc::clone(&controller)).await;
+    let connector = TcpSocket::new_v4().expect("create raw Pull V2 socket");
+    disable_loopback_fast_path(&connector).expect("disable Windows loopback fast path");
+    connector
+        .set_recv_buffer_size(4 * 1024)
+        .expect("bound partial-write receive buffer");
+    let raw_client = connector.connect(address).await.expect("connect raw Pull V2 client");
+    configure_abortive_close(&raw_client).expect("configure deterministic partial-write reset");
+    let mut framed = Framed::new(raw_client, RemotingCommandCodec::new());
+    framed
+        .send(request_command(ORIGINAL_OPAQUE))
+        .await
+        .expect("send partial-write Pull request");
+    framed
+        .send(
+            RemotingCommand::create_remoting_command(SENTINEL_CODE)
+                .set_opaque(ORIGINAL_OPAQUE + 1)
+                .mark_oneway_rpc(),
+        )
+        .await
+        .expect("send partial-write commit sentinel");
+    barrier.commit_observed.notified().await;
+    let registered = registrations.recv().await.expect("observe partial-write registration");
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let mut cursor = PullScanCursor::new();
+    let mut candidates = service.reserve_arrival_batch(&PullArrivalView::new(&topic, 0, 8), &mut cursor);
+    let candidate = candidates.pop().expect("one partial-write Pull candidate");
+    assert!(candidates.is_empty());
+    let claim = service
+        .claim_candidate(candidate, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("claim partial-write Pull");
+
+    let owner_drops = Arc::new(AtomicUsize::new(0));
+    let response_owner_drops = Arc::clone(&owner_drops);
+    let rereads = Arc::new(AtomicUsize::new(0));
+    let reread_count = Arc::clone(&rereads);
+    let (plan_ready_tx, plan_ready_rx) = oneshot::channel();
+    let (release_plan_tx, release_plan_rx) = oneshot::channel();
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    let service_for_resume = Arc::clone(&service);
+    running
+        .actions
+        .spawn_service("pull-deferred-partial-write", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    rocketmq_transport::api::v2::DeferredResumeRetainedSize::default(),
+                    move |resume, reason| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        assert_eq!(resume.request().effective_peer(), registered.peer);
+                        reread_count.fetch_add(1, Ordering::SeqCst);
+                        let body = Bytes::from_owner(CountingBodyOwner::new(
+                            vec![b'x'; PARTIAL_BODY_BYTES],
+                            response_owner_drops,
+                        ));
+                        let _ = plan_ready_tx.send(());
+                        release_plan_rx
+                            .await
+                            .map_err(|_| RocketMQError::illegal_argument("partial Pull plan release closed"))?;
+                        ResponsePlan::bytes(
+                            RemotingCommand::create_response_command_with_code(ResponseCode::Success),
+                            body,
+                        )
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn owned partial-write Pull resume");
+
+    plan_ready_rx.await.expect("partial Pull response plan ready");
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 0);
+    release_plan_tx.send(()).expect("release partial Pull response plan");
+    let mut socket = framed.into_inner();
+    let mut prefix = [0_u8; 64];
+    socket
+        .read_exact(&mut prefix)
+        .await
+        .expect("read a canonical Pull frame prefix");
+    assert_ne!(prefix, [0_u8; 64]);
+    assert_eq!(
+        owner_drops.load(Ordering::SeqCst),
+        0,
+        "owner must remain live while the canonical write is incomplete"
+    );
+    drop(socket);
+
+    let error = receipt_rx
+        .await
+        .expect("partial Pull resume receipt channel")
+        .expect_err("peer close must fail the incomplete canonical write");
+    assert_eq!(error.write_progress(), Some(WriteProgress::PossiblyPartial));
+    assert_eq!(rereads.load(Ordering::SeqCst), 1, "partial writes are never retried");
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 1);
+    assert_released(&service);
+    let _ = service.shutdown();
+    running.finish().await;
+}
+
+#[test]
+fn retained_index_estimate_is_checked_and_non_zero() {
+    assert!(PullCriteriaIndex::<DeferredId>::try_retained_bytes_per_entry().is_some_and(|bytes| bytes > 0));
+}

--- a/rocketmq-broker/src/long_polling/pull_deferred/acceptance_tests/lifecycle_tests.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/acceptance_tests/lifecycle_tests.rs
@@ -1,0 +1,233 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_transport::api::v2::DeferredClaimErrorKind;
+
+use super::*;
+
+fn processor(
+    service: &Arc<PullDeferredService>,
+    registrations: mpsc::UnboundedSender<RegistrationObservation>,
+    barrier: &Arc<ProcessorBarrier>,
+    hold_before_outcome: bool,
+    rollback_registration: bool,
+) -> PullDeferredTestProcessor {
+    PullDeferredTestProcessor {
+        service: Arc::clone(service),
+        registrations,
+        barrier: Arc::clone(barrier),
+        hold_before_outcome,
+        rollback_registration,
+    }
+}
+
+#[tokio::test]
+async fn message_arrival_and_timeout_have_exactly_one_claim_winner() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let (mut client, _address, running) = start_server(
+        processor(&service, registration_tx, &barrier, false, false),
+        Arc::clone(&controller),
+    )
+    .await;
+    client
+        .send_command(request_command(71))
+        .await
+        .expect("send claim race waiter");
+    let registration = registrations.recv().await.expect("claim race registration");
+    commit_barrier(&mut client, &barrier, 72).await;
+
+    let (arrival, timeout) = tokio::join!(
+        service.claim(registration.id, DeferredWakeReason::MessageArrived),
+        service.claim(registration.id, DeferredWakeReason::Timeout),
+    );
+    match (arrival, timeout) {
+        (Ok(winner), Err(loser)) => {
+            assert_eq!(winner.reason(), DeferredWakeReason::MessageArrived);
+            assert_eq!(loser.kind(), DeferredClaimErrorKind::AlreadyClaimed);
+            drop(winner);
+        }
+        (Err(loser), Ok(winner)) => {
+            assert_eq!(winner.reason(), DeferredWakeReason::Timeout);
+            assert_eq!(loser.kind(), DeferredClaimErrorKind::AlreadyClaimed);
+            drop(winner);
+        }
+        (arrival, timeout) => panic!("one Pull claim must win: {arrival:?}, {timeout:?}"),
+    }
+    assert_released(&service);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn stale_arrival_bounded_continuation_claims_every_matching_waiter() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let (mut client, _address, running) = start_server(
+        processor(&service, registration_tx, &barrier, false, false),
+        Arc::clone(&controller),
+    )
+    .await;
+    for opaque in [81, 82, 83] {
+        client
+            .send_command(request_command(opaque))
+            .await
+            .expect("send all-match Pull waiter");
+        registrations.recv().await.expect("all-match Pull registration");
+    }
+    commit_barrier(&mut client, &barrier, 84).await;
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let refreshes = AtomicUsize::new(0);
+    let mut submitted = Vec::new();
+    let stats = service
+        .produce_arrival(
+            PullArrivalView::new(&topic, 0, 7),
+            || {
+                refreshes.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(8)
+            },
+            |batch| {
+                submitted.push(batch);
+                Ok::<_, ()>(())
+            },
+        )
+        .expect("bounded Pull arrival producer");
+    assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+    assert_eq!(stats.inspected(), 3);
+    assert_eq!(stats.candidates(), 3);
+    assert_eq!(stats.batches(), 3);
+    assert_eq!(service.index_snapshot().candidates(), 3);
+
+    let mut claims = Vec::new();
+    for candidate in submitted.into_iter().flatten() {
+        claims.push(
+            service
+                .claim_candidate(candidate, DeferredWakeReason::MessageArrived)
+                .await
+                .expect("each affine candidate claims once"),
+        );
+    }
+    assert_eq!(claims.len(), 3);
+    assert_eq!(service.index_snapshot(), PullIndexSnapshot::default());
+    drop(claims);
+    assert_released(&service);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn producer_rejection_restores_candidate_without_spinning() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let (mut client, _address, running) = start_server(
+        processor(&service, registration_tx, &barrier, false, false),
+        Arc::clone(&controller),
+    )
+    .await;
+    client
+        .send_command(request_command(91))
+        .await
+        .expect("send producer rejection waiter");
+    let registration = registrations.recv().await.expect("producer rejection registration");
+    commit_barrier(&mut client, &barrier, 92).await;
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let mut calls = 0;
+    let result = service.produce_arrival(
+        PullArrivalView::new(&topic, 0, 8),
+        || Ok::<_, &'static str>(8),
+        |_batch| {
+            calls += 1;
+            Err("executor sealed")
+        },
+    );
+    assert_eq!(result, Err("executor sealed"));
+    assert_eq!(calls, 1);
+    assert_eq!(service.index_snapshot().live(), 1);
+    assert_eq!(service.index_snapshot().candidates(), 0);
+    let claim = service
+        .claim(registration.id, DeferredWakeReason::ForcedRefresh)
+        .await
+        .expect("restored waiter remains claimable for shutdown owner");
+    drop(claim);
+    assert_released(&service);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn shutdown_before_dispatch_commit_releases_every_affine_owner() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let (mut client, _address, running) = start_server(
+        processor(&service, registration_tx, &barrier, true, false),
+        Arc::clone(&controller),
+    )
+    .await;
+    client
+        .send_command(request_command(101))
+        .await
+        .expect("send shutdown-before-commit waiter");
+    registrations.recv().await.expect("shutdown-before-commit registration");
+    barrier.before_outcome.notified().await;
+    assert_eq!(service.index_snapshot().live(), 1);
+    assert!(matches!(
+        service.shutdown(),
+        rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome::Completed(_)
+    ));
+    assert_released(&service);
+    barrier.release_outcome.notify_one();
+    running.finish().await;
+    assert!(client.receive_command().await.is_none(), "shutdown emits no Pull frame");
+}
+
+#[tokio::test]
+async fn session_close_and_registration_rollback_release_index_wait_and_bytes() {
+    for (opaque, rollback) in [(111, false), (112, true)] {
+        let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+        let service = service(controller.as_ref());
+        let barrier = Arc::new(ProcessorBarrier::default());
+        let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+        let (mut client, _address, running) = start_server(
+            processor(&service, registration_tx, &barrier, false, rollback),
+            Arc::clone(&controller),
+        )
+        .await;
+        client
+            .send_command(request_command(opaque))
+            .await
+            .expect("send session-close/rollback waiter");
+        registrations.recv().await.expect("session-close/rollback registration");
+        if !rollback {
+            commit_barrier(&mut client, &barrier, opaque + 10).await;
+            client.shutdown().await.expect("close Pull client session");
+        }
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while service.admission_snapshot().waiting_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("Pull cleanup releases wait admission");
+        assert_released(&service);
+        running.finish().await;
+        assert!(client.receive_command().await.is_none(), "cleanup emits no Pull frame");
+    }
+}

--- a/rocketmq-broker/src/long_polling/pull_deferred/acceptance_tests/p1_tests.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/acceptance_tests/p1_tests.rs
@@ -1,0 +1,253 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+fn prepared(
+    service: &PullDeferredService,
+    request: &RemotingRequest,
+    timing: PullSuspendTiming,
+    retained: PullRetainedEstimate,
+) -> Result<PreparedPullRegistration, super::PullDeferredPrepareError> {
+    let header = request
+        .command()
+        .decode_command_custom_header::<PullMessageRequestHeader>()
+        .expect("valid Pull pre-take test header");
+    let criteria = PullMatchCriteria::new(
+        header.topic.clone(),
+        header.queue_id,
+        header.queue_offset,
+        SubscriptionData::default(),
+        Arc::new(MatchAll),
+    );
+    let fallback = ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+        ResponseCode::PullNotFound,
+    ))
+    .expect("valid PullNotFound fallback");
+    service.prepare(request, criteria, fallback, timing, retained)
+}
+
+#[derive(Default)]
+struct ProvenanceState {
+    prepared: Option<PreparedPullRegistration>,
+}
+
+#[derive(Clone)]
+struct ProvenanceProcessor {
+    service: Arc<PullDeferredService>,
+    state: Arc<Mutex<ProvenanceState>>,
+}
+
+impl RequestProcessorV2 for ProvenanceProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prior = self.state.lock().prepared.take();
+        if let Some(prior) = prior {
+            let error = self
+                .service
+                .register(prior, request)
+                .expect_err("prepared Pull proof is bound to its original request/session");
+            assert_eq!(error.kind(), PullDeferredRegisterErrorKind::ProvenanceMismatch);
+            let candidate = error
+                .into_candidate()
+                .expect("pre-take failure returns the complete affine candidate");
+            assert_eq!(candidate.request().request_code(), RequestCode::PullMessage);
+            assert_eq!(candidate.criteria().physical_topic().as_str(), "TopicA");
+            assert_eq!(candidate.criteria().pull_from_offset(), 7);
+            assert_eq!(candidate.timing().effective_timeout_millis(), TEST_TIMEOUT_MILLIS);
+            assert_eq!(candidate.retained(), PullRetainedEstimate::new(17, 23));
+            let fallback = candidate.into_fallback();
+            assert_eq!(fallback.response_code(), ResponseCode::PullNotFound as i32);
+            assert_eq!(fallback.body_len(), 0);
+            return success_reply();
+        }
+        let header = request
+            .command()
+            .decode_command_custom_header::<PullMessageRequestHeader>()?;
+        let registration = prepared(
+            &self.service,
+            request,
+            PullSuspendTiming::new(
+                current_millis(),
+                tokio::time::Instant::now(),
+                header.suspend_timeout_millis,
+            ),
+            PullRetainedEstimate::new(17, 23),
+        )
+        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.state.lock().prepared = Some(registration);
+        success_reply()
+    }
+}
+
+#[tokio::test]
+async fn cross_request_and_session_provenance_fails_before_responder_take() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service_with_limits(controller.as_ref(), 2, 16 * 1024 * 1024, 2, 2);
+    let state = Arc::new(Mutex::new(ProvenanceState::default()));
+    let processor = ProvenanceProcessor {
+        service: Arc::clone(&service),
+        state: Arc::clone(&state),
+    };
+    let (mut first, address, running) = start_server(processor, Arc::clone(&controller)).await;
+    first
+        .send_command(request_command(41))
+        .await
+        .expect("send provenance source");
+    assert_eq!(
+        first
+            .receive_command()
+            .await
+            .expect("source connection")
+            .expect("source inline response")
+            .code(),
+        ResponseCode::Success as i32
+    );
+    assert_eq!(service.index_snapshot().reserved(), 1);
+    assert_eq!(service.admission_snapshot().waiting_count(), 1);
+
+    let mut second = Connection::new(TcpStream::connect(address).await.expect("connect second Pull session"));
+    second
+        .send_command(request_command(42))
+        .await
+        .expect("send provenance target from another session");
+    let response = second
+        .receive_command()
+        .await
+        .expect("target connection")
+        .expect("target request retains its inline responder");
+    assert_eq!(response.code(), ResponseCode::Success as i32);
+    assert_eq!(response.opaque(), 42);
+    assert!(state.lock().prepared.is_none());
+    assert_released(&service);
+
+    drop(second);
+    running.finish().await;
+}
+
+#[derive(Clone)]
+struct PreTakeProbeProcessor {
+    service: Arc<PullDeferredService>,
+    held: Arc<Mutex<Vec<PreparedPullRegistration>>>,
+    observed: Arc<Mutex<Vec<PullDeferredPrepareErrorKind>>>,
+    zero_timeout: bool,
+    retained: PullRetainedEstimate,
+}
+
+impl RequestProcessorV2 for PreTakeProbeProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let header = request
+            .command()
+            .decode_command_custom_header::<PullMessageRequestHeader>()?;
+        let timeout = if self.zero_timeout {
+            0
+        } else {
+            header.suspend_timeout_millis
+        };
+        match prepared(
+            &self.service,
+            request,
+            PullSuspendTiming::new(current_millis(), tokio::time::Instant::now(), timeout),
+            self.retained,
+        ) {
+            Ok(prepared) => {
+                self.held.lock().push(prepared);
+                success_reply()
+            }
+            Err(error) => {
+                self.observed.lock().push(error.kind());
+                Ok(HandlerOutcome::Reply(error.into_fallback()))
+            }
+        }
+    }
+}
+
+async fn exercise_second_pre_take_rejection(
+    service: Arc<PullDeferredService>,
+    controller: Arc<AdmissionController>,
+    expected: PullDeferredPrepareErrorKind,
+) {
+    let held = Arc::new(Mutex::new(Vec::new()));
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let processor = PreTakeProbeProcessor {
+        service: Arc::clone(&service),
+        held: Arc::clone(&held),
+        observed: Arc::clone(&observed),
+        zero_timeout: false,
+        retained: PullRetainedEstimate::default(),
+    };
+    let (mut client, _address, running) = start_server(processor, controller).await;
+    for opaque in [51, 52] {
+        client
+            .send_command(request_command(opaque))
+            .await
+            .expect("send Pull pre-take probe");
+        let response = client
+            .receive_command()
+            .await
+            .expect("pre-take probe connection")
+            .expect("inline pre-take probe response");
+        assert_eq!(response.opaque(), opaque);
+    }
+    assert_eq!(&*observed.lock(), &[expected]);
+    assert_eq!(held.lock().len(), 1);
+    held.lock().clear();
+    assert_released(&service);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn index_and_wait_capacity_reject_before_responder_transfer() {
+    let index_controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let index_service = service_with_limits(index_controller.as_ref(), 2, 16 * 1024 * 1024, 1, 1);
+    exercise_second_pre_take_rejection(index_service, index_controller, PullDeferredPrepareErrorKind::Index).await;
+
+    let wait_controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let wait_service = service_with_limits(wait_controller.as_ref(), 1, 16 * 1024 * 1024, 2, 2);
+    exercise_second_pre_take_rejection(wait_service, wait_controller, PullDeferredPrepareErrorKind::Admission).await;
+}
+
+#[tokio::test]
+async fn retained_bytes_and_inclusive_zero_deadline_fallback_inline() {
+    for (retained_bytes, zero_timeout, expected, opaque) in [
+        (1, false, PullDeferredPrepareErrorKind::Admission, 61),
+        (16 * 1024 * 1024, true, PullDeferredPrepareErrorKind::Deadline, 62),
+    ] {
+        let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+        let service = service_with_limits(controller.as_ref(), 1, retained_bytes, 1, 1);
+        let held = Arc::new(Mutex::new(Vec::new()));
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let processor = PreTakeProbeProcessor {
+            service: Arc::clone(&service),
+            held,
+            observed: Arc::clone(&observed),
+            zero_timeout,
+            retained: PullRetainedEstimate::default(),
+        };
+        let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+        client
+            .send_command(request_command(opaque))
+            .await
+            .expect("send Pull pre-take deadline/byte probe");
+        let response = client
+            .receive_command()
+            .await
+            .expect("probe connection")
+            .expect("pre-take fallback response");
+        assert_eq!(response.opaque(), opaque);
+        assert_eq!(response.code(), ResponseCode::PullNotFound as i32);
+        assert_eq!(&*observed.lock(), &[expected]);
+        assert_released(&service);
+        running.finish().await;
+    }
+}

--- a/rocketmq-broker/src/long_polling/pull_deferred/acceptance_tests/session_close_tests.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/acceptance_tests/session_close_tests.rs
@@ -1,0 +1,135 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_transport::api::v2::DeferredResumeErrorKind;
+
+use super::*;
+
+#[cfg(windows)]
+#[tokio::test]
+async fn tcp_session_close_drops_prepared_owner_once_without_retrying() {
+    const ORIGINAL_OPAQUE: i32 = 9_833;
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = PullDeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (address, running) = start_running_server(processor, Arc::clone(&controller)).await;
+    let raw_client = TcpStream::connect(address)
+        .await
+        .expect("connect closing Pull V2 client");
+    configure_abortive_close(&raw_client).expect("configure deterministic session reset");
+    let mut framed = Framed::new(raw_client, RemotingCommandCodec::new());
+    framed
+        .send(request_command(ORIGINAL_OPAQUE))
+        .await
+        .expect("send session-close Pull request");
+    framed
+        .send(
+            RemotingCommand::create_remoting_command(SENTINEL_CODE)
+                .set_opaque(ORIGINAL_OPAQUE + 1)
+                .mark_oneway_rpc(),
+        )
+        .await
+        .expect("send session-close commit sentinel");
+    barrier.commit_observed.notified().await;
+    let registered = registrations.recv().await.expect("observe session-close registration");
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let mut cursor = PullScanCursor::new();
+    let mut candidates = service.reserve_arrival_batch(&PullArrivalView::new(&topic, 0, 8), &mut cursor);
+    let claim = service
+        .claim_candidate(
+            candidates.pop().expect("one session-close Pull candidate"),
+            DeferredWakeReason::MessageArrived,
+        )
+        .await
+        .expect("claim session-close Pull");
+    assert!(candidates.is_empty());
+
+    let owner_drops = Arc::new(AtomicUsize::new(0));
+    let response_owner_drops = Arc::clone(&owner_drops);
+    let rereads = Arc::new(AtomicUsize::new(0));
+    let reread_count = Arc::clone(&rereads);
+    let (plan_ready_tx, plan_ready_rx) = oneshot::channel();
+    let (release_plan_tx, release_plan_rx) = oneshot::channel();
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    let service_for_resume = Arc::clone(&service);
+    running
+        .actions
+        .spawn_service("pull-deferred-session-close-write", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    rocketmq_transport::api::v2::DeferredResumeRetainedSize::default(),
+                    move |resume, reason| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        assert_eq!(resume.request().effective_peer(), registered.peer);
+                        reread_count.fetch_add(1, Ordering::SeqCst);
+                        let body = Bytes::from_owner(CountingBodyOwner::new(
+                            b"owner-held-across-session-close".to_vec(),
+                            response_owner_drops,
+                        ));
+                        let _ = plan_ready_tx.send(());
+                        release_plan_rx
+                            .await
+                            .map_err(|_| RocketMQError::illegal_argument("session-close plan release closed"))?;
+                        ResponsePlan::bytes(
+                            RemotingCommand::create_response_command_with_code(ResponseCode::Success),
+                            body,
+                        )
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn owned session-close Pull resume");
+
+    plan_ready_rx.await.expect("session-close Pull response plan ready");
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 0);
+    drop(framed);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while owner_drops.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("session close reaches the accepted resume owner");
+    assert_eq!(
+        owner_drops.load(Ordering::SeqCst),
+        1,
+        "session close cancels the accepted resume and releases its prepared owner"
+    );
+    assert!(
+        release_plan_tx.send(()).is_err(),
+        "session close must cancel the in-flight response builder"
+    );
+    let error = receipt_rx
+        .await
+        .expect("session-close Pull receipt channel")
+        .expect_err("closed session rejects the prepared response owner");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::SessionClosed);
+    assert_eq!(rereads.load(Ordering::SeqCst), 1, "closed sessions are never retried");
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 1);
+    assert_released(&service);
+    let _ = service.shutdown();
+    running.finish().await;
+}

--- a/rocketmq-broker/src/long_polling/pull_deferred/data.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/data.rs
@@ -1,0 +1,262 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_store::ArcMessageFilter;
+use rocketmq_store::BrokerStatsManager;
+use rocketmq_transport::api::v2::SessionId;
+
+/// Named request metadata consumed by the existing Pull consume hooks.
+#[derive(Default)]
+pub(crate) struct PullHookMetadata {
+    commercial_owner: Option<CheetahString>,
+    account_auth_type: Option<CheetahString>,
+    account_owner_parent: Option<CheetahString>,
+    account_owner_self: Option<CheetahString>,
+}
+
+impl PullHookMetadata {
+    pub(crate) fn from_fields(fields: Option<&std::collections::HashMap<CheetahString, CheetahString>>) -> Self {
+        let value = |key: &str| fields.and_then(|fields| fields.get(key)).cloned();
+        Self {
+            commercial_owner: value(BrokerStatsManager::COMMERCIAL_OWNER),
+            account_auth_type: value(BrokerStatsManager::ACCOUNT_AUTH_TYPE),
+            account_owner_parent: value(BrokerStatsManager::ACCOUNT_OWNER_PARENT),
+            account_owner_self: value(BrokerStatsManager::ACCOUNT_OWNER_SELF),
+        }
+    }
+
+    pub(crate) fn from_command(command: &RemotingCommand) -> Self {
+        Self::from_fields(command.get_ext_fields())
+    }
+
+    #[must_use]
+    pub(crate) const fn commercial_owner(&self) -> Option<&CheetahString> {
+        self.commercial_owner.as_ref()
+    }
+
+    #[must_use]
+    pub(crate) const fn account_auth_type(&self) -> Option<&CheetahString> {
+        self.account_auth_type.as_ref()
+    }
+
+    #[must_use]
+    pub(crate) const fn account_owner_parent(&self) -> Option<&CheetahString> {
+        self.account_owner_parent.as_ref()
+    }
+
+    #[must_use]
+    pub(crate) const fn account_owner_self(&self) -> Option<&CheetahString> {
+        self.account_owner_self.as_ref()
+    }
+
+    pub(super) fn dynamic_bytes(&self) -> Option<usize> {
+        [
+            self.commercial_owner.as_ref(),
+            self.account_auth_type.as_ref(),
+            self.account_owner_parent.as_ref(),
+            self.account_owner_self.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .try_fold(0usize, |total, value| total.checked_add(value.len()))
+    }
+}
+
+/// Typed Pull request facts retained without a command, body, or write capability.
+pub(crate) struct PullRequestData {
+    request_code: RequestCode,
+    original_header: PullMessageRequestHeader,
+    effective_peer: SocketAddr,
+    session_id: SessionId,
+    hook_metadata: PullHookMetadata,
+}
+
+impl PullRequestData {
+    pub(super) const fn new(
+        request_code: RequestCode,
+        original_header: PullMessageRequestHeader,
+        effective_peer: SocketAddr,
+        session_id: SessionId,
+        hook_metadata: PullHookMetadata,
+    ) -> Self {
+        Self {
+            request_code,
+            original_header,
+            effective_peer,
+            session_id,
+            hook_metadata,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn from_test_parts(
+        request_code: RequestCode,
+        original_header: PullMessageRequestHeader,
+        effective_peer: SocketAddr,
+        session_id: SessionId,
+        hook_metadata: PullHookMetadata,
+    ) -> Self {
+        Self::new(request_code, original_header, effective_peer, session_id, hook_metadata)
+    }
+
+    #[must_use]
+    pub(crate) const fn request_code(&self) -> RequestCode {
+        self.request_code
+    }
+
+    #[must_use]
+    pub(crate) const fn original_header(&self) -> &PullMessageRequestHeader {
+        &self.original_header
+    }
+
+    #[must_use]
+    pub(crate) const fn effective_peer(&self) -> SocketAddr {
+        self.effective_peer
+    }
+
+    #[must_use]
+    pub(crate) const fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+
+    #[must_use]
+    pub(crate) const fn hook_metadata(&self) -> &PullHookMetadata {
+        &self.hook_metadata
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        RequestCode,
+        PullMessageRequestHeader,
+        SocketAddr,
+        SessionId,
+        PullHookMetadata,
+    ) {
+        (
+            self.request_code,
+            self.original_header,
+            self.effective_peer,
+            self.session_id,
+            self.hook_metadata,
+        )
+    }
+
+    pub(super) fn dynamic_bytes(&self) -> Option<usize> {
+        let header = &self.original_header;
+        let mut total = [
+            header.consumer_group.len(),
+            header.topic.len(),
+            header.lite_topic.as_ref().map_or(0, CheetahString::len),
+            header.subscription.as_ref().map_or(0, CheetahString::len),
+            header.expression_type.as_ref().map_or(0, CheetahString::len),
+            header.proxy_forward_client_id.as_ref().map_or(0, CheetahString::len),
+            self.hook_metadata.dynamic_bytes()?,
+        ]
+        .into_iter()
+        .try_fold(0usize, |sum, value| sum.checked_add(value))?;
+        if let Some(rpc) = header.topic_request.as_ref().and_then(|topic| topic.rpc.as_ref()) {
+            for value in [rpc.namespace.as_ref(), rpc.broker_name.as_ref()].into_iter().flatten() {
+                total = total.checked_add(value.len())?;
+            }
+        }
+        Some(total)
+    }
+}
+
+/// Immutable physical matching facts shared by the index and resume owner.
+pub(crate) struct PullMatchCriteria {
+    physical_topic: CheetahString,
+    physical_queue_id: i32,
+    pull_from_offset: i64,
+    subscription: SubscriptionData,
+    filter: ArcMessageFilter,
+}
+
+impl PullMatchCriteria {
+    pub(crate) fn new(
+        physical_topic: CheetahString,
+        physical_queue_id: i32,
+        pull_from_offset: i64,
+        subscription: SubscriptionData,
+        filter: ArcMessageFilter,
+    ) -> Self {
+        Self {
+            physical_topic,
+            physical_queue_id,
+            pull_from_offset,
+            subscription,
+            filter,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn physical_topic(&self) -> &CheetahString {
+        &self.physical_topic
+    }
+
+    #[must_use]
+    pub(crate) const fn physical_queue_id(&self) -> i32 {
+        self.physical_queue_id
+    }
+
+    #[must_use]
+    pub(crate) const fn pull_from_offset(&self) -> i64 {
+        self.pull_from_offset
+    }
+
+    #[must_use]
+    pub(crate) const fn subscription(&self) -> &SubscriptionData {
+        &self.subscription
+    }
+
+    #[must_use]
+    pub(crate) const fn filter(&self) -> &ArcMessageFilter {
+        &self.filter
+    }
+
+    pub(super) fn dynamic_bytes(&self) -> Option<usize> {
+        let fixed_strings = [
+            self.physical_topic.len(),
+            self.subscription.topic.len(),
+            self.subscription.sub_string.len(),
+            self.subscription.expression_type.len(),
+            self.subscription.filter_class_source.len(),
+        ];
+        let mut total = fixed_strings
+            .into_iter()
+            .try_fold(0usize, |sum, value| sum.checked_add(value))?;
+        for value in &self.subscription.tags_set {
+            total = total.checked_add(value.len())?;
+        }
+        total.checked_add(
+            self.subscription
+                .code_set
+                .len()
+                .checked_mul(std::mem::size_of::<i32>())?,
+        )
+    }
+}
+
+/// Dynamic session-to-client lookup used by resumed broadcast pulls.
+pub(crate) trait PullSessionClientLookup: Send + Sync {
+    fn client_id(&self, session_id: SessionId, consumer_group: &CheetahString) -> Option<CheetahString>;
+}

--- a/rocketmq-broker/src/long_polling/pull_deferred/deadline.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/deadline.rs
@@ -1,0 +1,108 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+use std::time::Duration;
+
+/// Broker-owned Pull protocol deadline, distinct from the response owner deadline.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PullWaitDeadline {
+    protocol_end_millis: u64,
+    protocol_at: tokio::time::Instant,
+}
+
+impl PullWaitDeadline {
+    /// Preserves the legacy inclusive `now >= suspend_start + timeout` rule.
+    pub(crate) fn checked(
+        suspend_wall_millis: u64,
+        suspend_monotonic: tokio::time::Instant,
+        effective_timeout_millis: u64,
+        wall_now_millis: u64,
+        monotonic_now: tokio::time::Instant,
+    ) -> Result<Self, PullWaitDeadlineError> {
+        let protocol_end_millis = suspend_wall_millis
+            .checked_add(effective_timeout_millis)
+            .ok_or_else(|| PullWaitDeadlineError::new(PullWaitDeadlineErrorKind::ProtocolOverflow))?;
+        let protocol_at = suspend_monotonic
+            .checked_add(Duration::from_millis(effective_timeout_millis))
+            .ok_or_else(|| PullWaitDeadlineError::new(PullWaitDeadlineErrorKind::MonotonicOverflow))?;
+        if wall_now_millis >= protocol_end_millis || monotonic_now >= protocol_at {
+            return Err(PullWaitDeadlineError::new(PullWaitDeadlineErrorKind::AlreadyExpired));
+        }
+        Ok(Self {
+            protocol_end_millis,
+            protocol_at,
+        })
+    }
+
+    #[must_use]
+    pub(crate) const fn protocol_end_millis(self) -> u64 {
+        self.protocol_end_millis
+    }
+
+    #[must_use]
+    pub(crate) const fn protocol_at(self) -> tokio::time::Instant {
+        self.protocol_at
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PullWaitDeadlineErrorKind {
+    ProtocolOverflow,
+    AlreadyExpired,
+    MonotonicOverflow,
+}
+
+impl PullWaitDeadlineErrorKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::ProtocolOverflow => "protocol_overflow",
+            Self::AlreadyExpired => "already_expired",
+            Self::MonotonicOverflow => "monotonic_overflow",
+        }
+    }
+}
+
+pub(crate) struct PullWaitDeadlineError {
+    kind: PullWaitDeadlineErrorKind,
+}
+
+impl PullWaitDeadlineError {
+    const fn new(kind: PullWaitDeadlineErrorKind) -> Self {
+        Self { kind }
+    }
+
+    #[must_use]
+    pub(crate) const fn kind(&self) -> PullWaitDeadlineErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for PullWaitDeadlineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PullWaitDeadlineError")
+            .field("kind", &self.kind.as_str())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PullWaitDeadlineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Pull wait deadline failed: {}", self.kind.as_str())
+    }
+}
+
+impl Error for PullWaitDeadlineError {}

--- a/rocketmq-broker/src/long_polling/pull_deferred/index.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/index.rs
@@ -1,0 +1,708 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::alloc::Layout;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Weak;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_store::CqExtUnit;
+use rocketmq_transport::api::v2::DeferredId;
+
+use super::data::PullMatchCriteria;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PullCriteriaLimits {
+    max_entries: NonZeroUsize,
+    max_entries_per_key: NonZeroUsize,
+}
+
+impl PullCriteriaLimits {
+    pub(crate) const fn new(max_entries: NonZeroUsize, max_entries_per_key: NonZeroUsize) -> Self {
+        Self {
+            max_entries,
+            max_entries_per_key,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct PullCriteriaKey {
+    topic: CheetahString,
+    queue_id: i32,
+}
+
+impl PullCriteriaKey {
+    pub(crate) fn new(topic: CheetahString, queue_id: i32) -> Self {
+        Self { topic, queue_id }
+    }
+
+    pub(super) fn from_criteria(criteria: &PullMatchCriteria) -> Self {
+        Self::new(criteria.physical_topic().clone(), criteria.physical_queue_id())
+    }
+}
+
+/// Borrowed listener metadata. Nothing in this view may cross an async boundary.
+#[derive(Clone, Copy)]
+pub(crate) struct PullArrivalView<'a> {
+    topic: &'a CheetahString,
+    queue_id: i32,
+    max_offset: i64,
+    tags_code: Option<i64>,
+    message_store_time: i64,
+    filter_bitmap: Option<&'a [u8]>,
+    properties: Option<&'a HashMap<CheetahString, CheetahString>>,
+    forced: bool,
+}
+
+impl<'a> PullArrivalView<'a> {
+    pub(crate) const fn new(topic: &'a CheetahString, queue_id: i32, max_offset: i64) -> Self {
+        Self {
+            topic,
+            queue_id,
+            max_offset,
+            tags_code: None,
+            message_store_time: 0,
+            filter_bitmap: None,
+            properties: None,
+            forced: false,
+        }
+    }
+
+    pub(crate) const fn with_filter_metadata(
+        mut self,
+        tags_code: Option<i64>,
+        message_store_time: i64,
+        filter_bitmap: Option<&'a [u8]>,
+        properties: Option<&'a HashMap<CheetahString, CheetahString>>,
+    ) -> Self {
+        self.tags_code = tags_code;
+        self.message_store_time = message_store_time;
+        self.filter_bitmap = filter_bitmap;
+        self.properties = properties;
+        self
+    }
+
+    pub(crate) const fn with_max_offset(mut self, max_offset: i64) -> Self {
+        self.max_offset = max_offset;
+        self
+    }
+
+    #[must_use]
+    pub(crate) const fn forced(mut self) -> Self {
+        self.forced = true;
+        self
+    }
+}
+
+/// Per-callback continuation. A later arrival starts with a fresh cursor.
+#[derive(Default)]
+pub(crate) struct PullScanCursor {
+    after_sequence: Option<u64>,
+}
+
+impl PullScanCursor {
+    pub(crate) const fn new() -> Self {
+        Self { after_sequence: None }
+    }
+}
+
+pub(crate) struct PullCriteriaIndex<I = DeferredId> {
+    inner: Arc<PullCriteriaIndexInner<I>>,
+}
+
+impl<I> Clone for PullCriteriaIndex<I> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<I> PullCriteriaIndex<I>
+where
+    I: Copy + Eq,
+{
+    pub(crate) fn new(limits: PullCriteriaLimits) -> Self {
+        Self {
+            inner: Arc::new(PullCriteriaIndexInner {
+                limits,
+                state: Mutex::new(PullCriteriaIndexState::default()),
+            }),
+        }
+    }
+
+    pub(crate) fn try_retained_bytes_per_entry() -> Option<usize> {
+        let arc_header = Layout::array::<usize>(2).ok()?;
+        let (membership, _) = arc_header.extend(Layout::new::<PullIndexMembership>()).ok()?;
+        [
+            std::mem::size_of::<PullIndexRecord<I>>(),
+            std::mem::size_of::<PullCriteriaKey>() * 2,
+            std::mem::size_of::<VecDeque<PullIndexRecord<I>>>(),
+            membership.pad_to_align().size(),
+            std::mem::size_of::<usize>() * 8,
+        ]
+        .into_iter()
+        .try_fold(0usize, |total, value| total.checked_add(value))
+    }
+
+    pub(crate) fn reserve(&self, key: PullCriteriaKey) -> Result<PullIndexReservation<I>, PullIndexError> {
+        let mut state = self.inner.state.lock();
+        let occupied = state
+            .live
+            .checked_add(state.reserved)
+            .ok_or_else(|| PullIndexError::new(PullIndexErrorKind::GlobalCapacity))?;
+        if occupied >= self.inner.limits.max_entries.get() {
+            return Err(PullIndexError::new(PullIndexErrorKind::GlobalCapacity));
+        }
+        let per_key = state.buckets.get(&key).map_or(0, VecDeque::len);
+        let reserved_for_key = state.reserved_keys.get(&key).copied().unwrap_or_default();
+        let occupied_for_key = per_key
+            .checked_add(reserved_for_key)
+            .ok_or_else(|| PullIndexError::new(PullIndexErrorKind::BucketCapacity))?;
+        if occupied_for_key >= self.inner.limits.max_entries_per_key.get() {
+            return Err(PullIndexError::new(PullIndexErrorKind::BucketCapacity));
+        }
+        let sequence = state.next_sequence;
+        state.next_sequence = sequence
+            .checked_add(1)
+            .ok_or_else(|| PullIndexError::new(PullIndexErrorKind::SequenceExhausted))?;
+        if !state.reserved_keys.contains_key(&key) {
+            state
+                .reserved_keys
+                .try_reserve(1)
+                .map_err(|_| PullIndexError::new(PullIndexErrorKind::Allocation))?;
+        }
+        if !state.buckets.contains_key(&key) {
+            state
+                .buckets
+                .try_reserve(1)
+                .map_err(|_| PullIndexError::new(PullIndexErrorKind::Allocation))?;
+            state.buckets.insert(key.clone(), VecDeque::new());
+        }
+        state
+            .buckets
+            .get_mut(&key)
+            .expect("reserved Pull bucket was inserted")
+            .try_reserve(
+                reserved_for_key
+                    .checked_add(1)
+                    .ok_or_else(|| PullIndexError::new(PullIndexErrorKind::BucketCapacity))?,
+            )
+            .map_err(|_| PullIndexError::new(PullIndexErrorKind::Allocation))?;
+        let reserved_count = state.reserved_keys.entry(key.clone()).or_default();
+        *reserved_count = reserved_count
+            .checked_add(1)
+            .ok_or_else(|| PullIndexError::new(PullIndexErrorKind::BucketCapacity))?;
+        state.reserved = state
+            .reserved
+            .checked_add(1)
+            .ok_or_else(|| PullIndexError::new(PullIndexErrorKind::GlobalCapacity))?;
+        Ok(PullIndexReservation {
+            inner: Some(Arc::clone(&self.inner)),
+            key: Some(key),
+            sequence,
+            membership: Arc::new(PullIndexMembership::default()),
+        })
+    }
+
+    /// Filters a bounded ordered prefix outside the mutex and atomically hides matches.
+    pub(crate) fn reserve_matching(
+        &self,
+        arrival: &PullArrivalView<'_>,
+        cursor: &mut PullScanCursor,
+        scan_limit: NonZeroUsize,
+        candidate_limit: NonZeroUsize,
+    ) -> Vec<PullCandidateReservation<I>> {
+        self.reserve_matching_batch(arrival, cursor, scan_limit, candidate_limit)
+            .into_candidates()
+    }
+
+    pub(crate) fn reserve_matching_batch(
+        &self,
+        arrival: &PullArrivalView<'_>,
+        cursor: &mut PullScanCursor,
+        scan_limit: NonZeroUsize,
+        candidate_limit: NonZeroUsize,
+    ) -> PullCandidateBatch<I> {
+        let key = PullCriteriaKey::new(arrival.topic.clone(), arrival.queue_id);
+        let mut candidates = Vec::new();
+        let mut inspected = 0;
+        let mut exhausted = false;
+        while inspected < scan_limit.get() && candidates.len() < candidate_limit.get() {
+            let Some(snapshot) = self.next_snapshot(&key, cursor.after_sequence) else {
+                exhausted = true;
+                break;
+            };
+            cursor.after_sequence = Some(snapshot.sequence);
+            inspected += 1;
+            if !matches_arrival(&snapshot.criteria, arrival) {
+                continue;
+            }
+            if let Some(candidate) = self.try_reserve_candidate(snapshot) {
+                candidates.push(candidate);
+            }
+        }
+        PullCandidateBatch {
+            candidates,
+            inspected,
+            exhausted,
+        }
+    }
+
+    pub(crate) fn needs_offset_refresh(&self, arrival: &PullArrivalView<'_>) -> bool {
+        if arrival.forced {
+            return false;
+        }
+        let key = PullCriteriaKey::new(arrival.topic.clone(), arrival.queue_id);
+        let state = self.inner.state.lock();
+        state.buckets.get(&key).is_some_and(|bucket| {
+            bucket
+                .iter()
+                .any(|record| arrival.max_offset <= record.criteria.pull_from_offset())
+        })
+    }
+
+    pub(crate) fn reserve_forced_batch(
+        &self,
+        cursor: &mut PullScanCursor,
+        scan_limit: NonZeroUsize,
+        candidate_limit: NonZeroUsize,
+    ) -> PullCandidateBatch<I> {
+        let mut candidates = Vec::new();
+        let mut inspected = 0;
+        let mut exhausted = false;
+        while inspected < scan_limit.get() && candidates.len() < candidate_limit.get() {
+            let Some(snapshot) = self.next_forced_snapshot(cursor.after_sequence) else {
+                exhausted = true;
+                break;
+            };
+            cursor.after_sequence = Some(snapshot.sequence);
+            inspected += 1;
+            if let Some(candidate) = self.try_reserve_candidate(snapshot) {
+                candidates.push(candidate);
+            }
+        }
+        PullCandidateBatch {
+            candidates,
+            inspected,
+            exhausted,
+        }
+    }
+
+    fn next_snapshot(&self, key: &PullCriteriaKey, after: Option<u64>) -> Option<PullCandidateSnapshot<I>> {
+        let state = self.inner.state.lock();
+        state.buckets.get(key)?.iter().find_map(|record| {
+            (after.is_none_or(|after| record.sequence > after)).then(|| PullCandidateSnapshot {
+                key: key.clone(),
+                id: record.id,
+                sequence: record.sequence,
+                criteria: Arc::clone(&record.criteria),
+            })
+        })
+    }
+
+    fn next_forced_snapshot(&self, after: Option<u64>) -> Option<PullCandidateSnapshot<I>> {
+        let state = self.inner.state.lock();
+        state
+            .buckets
+            .iter()
+            .flat_map(|(key, bucket)| bucket.iter().map(move |record| (key, record)))
+            .filter(|(_, record)| after.is_none_or(|after| record.sequence > after))
+            .min_by_key(|(_, record)| record.sequence)
+            .map(|(key, record)| PullCandidateSnapshot {
+                key: key.clone(),
+                id: record.id,
+                sequence: record.sequence,
+                criteria: Arc::clone(&record.criteria),
+            })
+    }
+
+    fn try_reserve_candidate(&self, snapshot: PullCandidateSnapshot<I>) -> Option<PullCandidateReservation<I>> {
+        let mut state = self.inner.state.lock();
+        let bucket = state.buckets.get_mut(&snapshot.key)?;
+        let position = bucket
+            .iter()
+            .position(|record| record.sequence == snapshot.sequence && record.id == snapshot.id)?;
+        let record = bucket.remove(position)?;
+        record.membership.candidate.store(true, Ordering::Release);
+        state.candidates += 1;
+        Some(PullCandidateReservation {
+            inner: Arc::downgrade(&self.inner),
+            key: snapshot.key,
+            record: Some(record),
+        })
+    }
+
+    #[must_use]
+    pub(crate) fn snapshot(&self) -> PullIndexSnapshot {
+        let state = self.inner.state.lock();
+        PullIndexSnapshot {
+            live: state.live,
+            reserved: state.reserved,
+            candidates: state.candidates,
+            buckets: state.buckets.values().filter(|bucket| !bucket.is_empty()).count(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, id: I) -> bool {
+        let state = self.inner.state.lock();
+        state
+            .buckets
+            .values()
+            .any(|bucket| bucket.iter().any(|record| record.id == id))
+    }
+}
+
+#[must_use]
+pub(crate) struct PullCandidateBatch<I = DeferredId>
+where
+    I: Copy + Eq,
+{
+    candidates: Vec<PullCandidateReservation<I>>,
+    inspected: usize,
+    exhausted: bool,
+}
+
+impl<I> PullCandidateBatch<I>
+where
+    I: Copy + Eq,
+{
+    pub(crate) const fn inspected(&self) -> usize {
+        self.inspected
+    }
+
+    pub(crate) const fn exhausted(&self) -> bool {
+        self.exhausted
+    }
+
+    pub(crate) fn into_candidates(self) -> Vec<PullCandidateReservation<I>> {
+        self.candidates
+    }
+}
+
+fn matches_arrival(criteria: &PullMatchCriteria, arrival: &PullArrivalView<'_>) -> bool {
+    if arrival.forced {
+        return true;
+    }
+    if arrival.max_offset <= criteria.pull_from_offset() {
+        return false;
+    }
+    let cq = CqExtUnit::new(
+        arrival.tags_code.unwrap_or_default(),
+        arrival.message_store_time,
+        arrival.filter_bitmap.map(<[u8]>::to_vec),
+    );
+    if !criteria
+        .filter()
+        .is_matched_by_consume_queue(arrival.tags_code, Some(&cq))
+    {
+        return false;
+    }
+    arrival
+        .properties
+        .is_none_or(|properties| criteria.filter().is_matched_by_commit_log(None, Some(properties)))
+}
+
+struct PullCriteriaIndexInner<I> {
+    limits: PullCriteriaLimits,
+    state: Mutex<PullCriteriaIndexState<I>>,
+}
+
+struct PullCriteriaIndexState<I> {
+    buckets: HashMap<PullCriteriaKey, VecDeque<PullIndexRecord<I>>>,
+    reserved_keys: HashMap<PullCriteriaKey, usize>,
+    live: usize,
+    reserved: usize,
+    candidates: usize,
+    next_sequence: u64,
+}
+
+impl<I> Default for PullCriteriaIndexState<I> {
+    fn default() -> Self {
+        Self {
+            buckets: HashMap::new(),
+            reserved_keys: HashMap::new(),
+            live: 0,
+            reserved: 0,
+            candidates: 0,
+            next_sequence: 0,
+        }
+    }
+}
+
+struct PullIndexRecord<I> {
+    id: I,
+    sequence: u64,
+    criteria: Arc<PullMatchCriteria>,
+    membership: Arc<PullIndexMembership>,
+}
+
+#[derive(Default)]
+struct PullIndexMembership {
+    candidate: AtomicBool,
+    detached: AtomicBool,
+}
+
+struct PullCandidateSnapshot<I> {
+    key: PullCriteriaKey,
+    id: I,
+    sequence: u64,
+    criteria: Arc<PullMatchCriteria>,
+}
+
+#[must_use]
+pub(crate) struct PullIndexReservation<I = DeferredId>
+where
+    I: Copy + Eq,
+{
+    inner: Option<Arc<PullCriteriaIndexInner<I>>>,
+    key: Option<PullCriteriaKey>,
+    sequence: u64,
+    membership: Arc<PullIndexMembership>,
+}
+
+impl<I> PullIndexReservation<I>
+where
+    I: Copy + Eq,
+{
+    pub(crate) fn publish(mut self, id: I, criteria: Arc<PullMatchCriteria>) -> PullIndexLease<I> {
+        let inner = self.inner.take().expect("Pull reservation publishes only once");
+        let key = self.key.take().expect("Pull reservation retains its key");
+        let mut state = inner.state.lock();
+        release_reserved_key(&mut state, &key);
+        state.live += 1;
+        let record = PullIndexRecord {
+            id,
+            sequence: self.sequence,
+            criteria,
+            membership: Arc::clone(&self.membership),
+        };
+        let bucket = state.buckets.entry(key.clone()).or_default();
+        let position = bucket
+            .iter()
+            .position(|current| current.sequence > self.sequence)
+            .unwrap_or(bucket.len());
+        bucket.insert(position, record);
+        drop(state);
+        PullIndexLease {
+            inner: Arc::downgrade(&inner),
+            key,
+            id,
+            membership: Arc::clone(&self.membership),
+        }
+    }
+}
+
+impl<I> Drop for PullIndexReservation<I>
+where
+    I: Copy + Eq,
+{
+    fn drop(&mut self) {
+        let (Some(inner), Some(key)) = (self.inner.take(), self.key.take()) else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        release_reserved_key(&mut state, &key);
+    }
+}
+
+fn release_reserved_key<I>(state: &mut PullCriteriaIndexState<I>, key: &PullCriteriaKey) {
+    state.reserved = state.reserved.saturating_sub(1);
+    if let Some(count) = state.reserved_keys.get_mut(key) {
+        *count = count.saturating_sub(1);
+        if *count == 0 {
+            state.reserved_keys.remove(key);
+            if state.buckets.get(key).is_some_and(VecDeque::is_empty) {
+                state.buckets.remove(key);
+            }
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct PullCandidateReservation<I = DeferredId>
+where
+    I: Copy + Eq,
+{
+    inner: Weak<PullCriteriaIndexInner<I>>,
+    key: PullCriteriaKey,
+    record: Option<PullIndexRecord<I>>,
+}
+
+impl<I> PullCandidateReservation<I>
+where
+    I: Copy + Eq,
+{
+    #[must_use]
+    pub(crate) fn id(&self) -> I {
+        self.record.as_ref().expect("candidate owns its record").id
+    }
+
+    /// Permanently hides a candidate after the registry accepts its single claim.
+    pub(crate) fn commit(mut self) {
+        let Some(record) = self.record.take() else {
+            return;
+        };
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        if record.membership.detached.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        record.membership.candidate.store(false, Ordering::Release);
+        state.live -= 1;
+        state.candidates -= 1;
+    }
+}
+
+impl<I> Drop for PullCandidateReservation<I>
+where
+    I: Copy + Eq,
+{
+    fn drop(&mut self) {
+        let Some(record) = self.record.take() else {
+            return;
+        };
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        if record.membership.detached.load(Ordering::Acquire) {
+            return;
+        }
+        record.membership.candidate.store(false, Ordering::Release);
+        state.candidates -= 1;
+        let bucket = state.buckets.entry(self.key.clone()).or_default();
+        let position = bucket
+            .iter()
+            .position(|current| current.sequence > record.sequence)
+            .unwrap_or(bucket.len());
+        bucket.insert(position, record);
+    }
+}
+
+#[must_use]
+pub(crate) struct PullIndexLease<I = DeferredId>
+where
+    I: Copy + Eq,
+{
+    inner: Weak<PullCriteriaIndexInner<I>>,
+    key: PullCriteriaKey,
+    id: I,
+    membership: Arc<PullIndexMembership>,
+}
+
+impl<I> Drop for PullIndexLease<I>
+where
+    I: Copy + Eq,
+{
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        if self.membership.detached.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        state.live -= 1;
+        if self.membership.candidate.load(Ordering::Acquire) {
+            state.candidates -= 1;
+            return;
+        }
+        if let Some(bucket) = state.buckets.get_mut(&self.key) {
+            if let Some(position) = bucket.iter().position(|record| record.id == self.id) {
+                bucket.remove(position);
+            }
+            if bucket.is_empty() {
+                state.buckets.remove(&self.key);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PullIndexSnapshot {
+    live: usize,
+    reserved: usize,
+    candidates: usize,
+    buckets: usize,
+}
+
+impl PullIndexSnapshot {
+    pub(crate) const fn live(self) -> usize {
+        self.live
+    }
+
+    pub(crate) const fn reserved(self) -> usize {
+        self.reserved
+    }
+
+    pub(crate) const fn candidates(self) -> usize {
+        self.candidates
+    }
+
+    pub(crate) const fn buckets(self) -> usize {
+        self.buckets
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PullIndexErrorKind {
+    GlobalCapacity,
+    BucketCapacity,
+    SequenceExhausted,
+    Allocation,
+}
+
+pub(crate) struct PullIndexError {
+    kind: PullIndexErrorKind,
+}
+
+impl PullIndexError {
+    const fn new(kind: PullIndexErrorKind) -> Self {
+        Self { kind }
+    }
+
+    pub(crate) const fn kind(&self) -> PullIndexErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for PullIndexError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PullIndexError")
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PullIndexError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Pull criteria index failed: {:?}", self.kind)
+    }
+}
+
+impl Error for PullIndexError {}

--- a/rocketmq-broker/src/long_polling/pull_deferred/service.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/service.rs
@@ -1,0 +1,1010 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::Infallible;
+use std::error::Error;
+use std::fmt;
+use std::future::Future;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_transport::api::v2::ClaimedDeferred;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredAdmissionAcquireError;
+use rocketmq_transport::api::v2::DeferredAdmissionSnapshot;
+use rocketmq_transport::api::v2::DeferredClaimError;
+use rocketmq_transport::api::v2::DeferredExpiryBatch;
+use rocketmq_transport::api::v2::DeferredExpiryBatchStats;
+use rocketmq_transport::api::v2::DeferredExpiryErrorKind;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredId;
+use rocketmq_transport::api::v2::DeferredParts;
+use rocketmq_transport::api::v2::DeferredRegistration;
+use rocketmq_transport::api::v2::DeferredRegistry;
+use rocketmq_transport::api::v2::DeferredRegistryErrorKind;
+use rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome;
+use rocketmq_transport::api::v2::DeferredResumeError;
+use rocketmq_transport::api::v2::DeferredResumeRetainedSize;
+use rocketmq_transport::api::v2::DeferredRetainedSizeParts;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestId;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponseReceipt;
+use rocketmq_transport::api::v2::SessionId;
+use rocketmq_transport::api::v2::TakeDeferredResponderError;
+
+use super::data::PullHookMetadata;
+use super::data::PullMatchCriteria;
+use super::data::PullRequestData;
+use super::deadline::PullWaitDeadline;
+use super::deadline::PullWaitDeadlineError;
+use super::index::PullArrivalView;
+use super::index::PullCandidateBatch;
+use super::index::PullCandidateReservation;
+use super::index::PullCriteriaIndex;
+use super::index::PullCriteriaKey;
+use super::index::PullCriteriaLimits;
+use super::index::PullIndexError;
+use super::index::PullIndexLease;
+use super::index::PullIndexReservation;
+use super::index::PullIndexSnapshot;
+use super::index::PullScanCursor;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PullSuspendTiming {
+    suspend_wall_millis: u64,
+    suspend_monotonic: tokio::time::Instant,
+    effective_timeout_millis: u64,
+}
+
+impl PullSuspendTiming {
+    pub(crate) const fn new(
+        suspend_wall_millis: u64,
+        suspend_monotonic: tokio::time::Instant,
+        effective_timeout_millis: u64,
+    ) -> Self {
+        Self {
+            suspend_wall_millis,
+            suspend_monotonic,
+            effective_timeout_millis,
+        }
+    }
+
+    pub(crate) const fn from_policy(
+        suspend_wall_millis: u64,
+        suspend_monotonic: tokio::time::Instant,
+        long_polling_enabled: bool,
+        header_timeout_millis: u64,
+        short_polling_time_millis: u64,
+    ) -> Self {
+        Self::new(
+            suspend_wall_millis,
+            suspend_monotonic,
+            if long_polling_enabled {
+                header_timeout_millis
+            } else {
+                short_polling_time_millis
+            },
+        )
+    }
+
+    pub(crate) const fn suspend_wall_millis(self) -> u64 {
+        self.suspend_wall_millis
+    }
+
+    pub(crate) const fn suspend_monotonic(self) -> tokio::time::Instant {
+        self.suspend_monotonic
+    }
+
+    pub(crate) const fn effective_timeout_millis(self) -> u64 {
+        self.effective_timeout_millis
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PullRetainedEstimate {
+    filter_bytes: usize,
+    hook_metadata_bytes: usize,
+}
+
+impl PullRetainedEstimate {
+    pub(crate) const fn new(filter_bytes: usize, hook_metadata_bytes: usize) -> Self {
+        Self {
+            filter_bytes,
+            hook_metadata_bytes,
+        }
+    }
+}
+
+/// Affine fallback and business data retained until responder transfer succeeds.
+#[must_use]
+pub(crate) struct PullSuspensionCandidate {
+    request: PullRequestData,
+    criteria: Arc<PullMatchCriteria>,
+    fallback: ResponsePlan,
+    timing: PullSuspendTiming,
+    retained: PullRetainedEstimate,
+    provenance: PreparedRequestProvenance,
+}
+
+impl PullSuspensionCandidate {
+    pub(crate) fn from_request(
+        request: &RemotingRequest,
+        criteria: PullMatchCriteria,
+        fallback: ResponsePlan,
+        timing: PullSuspendTiming,
+        retained: PullRetainedEstimate,
+    ) -> Result<Self, PullCandidateBuildError> {
+        let original = request.original_identity();
+        let request_code = RequestCode::from(original.original_code());
+        if !matches!(request_code, RequestCode::PullMessage | RequestCode::LitePullMessage) {
+            return Err(PullCandidateBuildError::new(
+                PullCandidateBuildErrorKind::UnsupportedRequestCode,
+                fallback,
+                None,
+            ));
+        }
+        if original.is_one_way() {
+            return Err(PullCandidateBuildError::new(
+                PullCandidateBuildErrorKind::OneWayRequest,
+                fallback,
+                None,
+            ));
+        }
+        let effective_peer = match request.origin() {
+            RequestOrigin::Network { peer } => peer.address(),
+            RequestOrigin::Embedded { .. } => {
+                return Err(PullCandidateBuildError::new(
+                    PullCandidateBuildErrorKind::EmbeddedOrigin,
+                    fallback,
+                    None,
+                ));
+            }
+            _ => {
+                return Err(PullCandidateBuildError::new(
+                    PullCandidateBuildErrorKind::EmbeddedOrigin,
+                    fallback,
+                    None,
+                ));
+            }
+        };
+        let header = match request
+            .command()
+            .decode_command_custom_header::<PullMessageRequestHeader>()
+        {
+            Ok(header) => header,
+            Err(source) => {
+                return Err(PullCandidateBuildError::new(
+                    PullCandidateBuildErrorKind::Header,
+                    fallback,
+                    Some(source),
+                ));
+            }
+        };
+        let request_data = PullRequestData::new(
+            request_code,
+            header,
+            effective_peer,
+            request.session().id(),
+            PullHookMetadata::from_command(request.command()),
+        );
+        Ok(Self {
+            request: request_data,
+            criteria: Arc::new(criteria),
+            fallback,
+            timing,
+            retained,
+            provenance: PreparedRequestProvenance::capture(request),
+        })
+    }
+
+    #[cfg(test)]
+    fn from_test_parts(
+        request: PullRequestData,
+        criteria: Arc<PullMatchCriteria>,
+        fallback: ResponsePlan,
+        timing: PullSuspendTiming,
+        retained: PullRetainedEstimate,
+        provenance: PreparedRequestProvenance,
+    ) -> Self {
+        Self {
+            request,
+            criteria,
+            fallback,
+            timing,
+            retained,
+            provenance,
+        }
+    }
+
+    pub(crate) fn into_fallback(self) -> ResponsePlan {
+        self.fallback
+    }
+
+    pub(crate) const fn request(&self) -> &PullRequestData {
+        &self.request
+    }
+
+    pub(crate) const fn criteria(&self) -> &Arc<PullMatchCriteria> {
+        &self.criteria
+    }
+
+    pub(crate) const fn timing(&self) -> PullSuspendTiming {
+        self.timing
+    }
+
+    pub(crate) const fn retained(&self) -> PullRetainedEstimate {
+        self.retained
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PreparedRequestProvenance {
+    request_id: RequestId,
+    session_id: SessionId,
+}
+
+impl PreparedRequestProvenance {
+    fn capture(request: &RemotingRequest) -> Self {
+        Self {
+            request_id: request.original_identity().request_id(),
+            session_id: request.session().id(),
+        }
+    }
+
+    fn matches(self, request: &RemotingRequest) -> bool {
+        self.request_id == request.original_identity().request_id() && self.session_id == request.session().id()
+    }
+}
+
+/// Affine business ownership carried from registry claim into Pull recovery.
+#[must_use]
+pub(crate) struct ResumePull {
+    request: PullRequestData,
+    criteria: Arc<PullMatchCriteria>,
+    protocol_wait_deadline: PullWaitDeadline,
+    index_lease: Option<PullIndexLease>,
+}
+
+impl ResumePull {
+    fn new(
+        request: PullRequestData,
+        criteria: Arc<PullMatchCriteria>,
+        protocol_wait_deadline: PullWaitDeadline,
+        index_lease: PullIndexLease,
+    ) -> Self {
+        Self {
+            request,
+            criteria,
+            protocol_wait_deadline,
+            index_lease: Some(index_lease),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn without_index_for_test(
+        request: PullRequestData,
+        criteria: Arc<PullMatchCriteria>,
+        protocol_wait_deadline: PullWaitDeadline,
+    ) -> Self {
+        Self {
+            request,
+            criteria,
+            protocol_wait_deadline,
+            index_lease: None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn request(&self) -> &PullRequestData {
+        &self.request
+    }
+
+    #[must_use]
+    pub(crate) const fn criteria(&self) -> &Arc<PullMatchCriteria> {
+        &self.criteria
+    }
+
+    #[must_use]
+    pub(crate) const fn protocol_wait_deadline(&self) -> PullWaitDeadline {
+        self.protocol_wait_deadline
+    }
+
+    pub(super) fn take_index_lease(&mut self) -> Option<PullIndexLease> {
+        self.index_lease.take()
+    }
+
+    pub(crate) fn into_parts(self) -> (PullRequestData, Arc<PullMatchCriteria>, PullWaitDeadline) {
+        let Self {
+            request,
+            criteria,
+            protocol_wait_deadline,
+            index_lease,
+        } = self;
+        drop(index_lease);
+        (request, criteria, protocol_wait_deadline)
+    }
+}
+
+#[must_use]
+pub(crate) struct PreparedPullRegistration {
+    candidate: PullSuspensionCandidate,
+    deadline: PullWaitDeadline,
+    reservation: PullIndexReservation,
+    permit: rocketmq_transport::api::v2::DeferredWaitPermit,
+}
+
+impl PreparedPullRegistration {
+    #[must_use]
+    pub(crate) const fn deadline(&self) -> PullWaitDeadline {
+        self.deadline
+    }
+
+    #[must_use]
+    pub(crate) const fn retained_bytes(&self) -> usize {
+        self.permit.retained_bytes()
+    }
+
+    pub(crate) fn into_candidate(self) -> PullSuspensionCandidate {
+        self.candidate
+    }
+}
+
+pub(crate) struct PullDeferredService {
+    admission: DeferredAdmission,
+    registry: DeferredRegistry<ResumePull>,
+    index: PullCriteriaIndex,
+    expiry_margins: DeferredExpiryMargins,
+    scan_limit: NonZeroUsize,
+    candidate_limit: NonZeroUsize,
+    closed: AtomicBool,
+}
+
+impl PullDeferredService {
+    pub(crate) fn new(
+        admission: DeferredAdmission,
+        index_limits: PullCriteriaLimits,
+        expiry_margins: DeferredExpiryMargins,
+        scan_limit: NonZeroUsize,
+        candidate_limit: NonZeroUsize,
+    ) -> Self {
+        Self {
+            admission,
+            registry: DeferredRegistry::new(),
+            index: PullCriteriaIndex::new(index_limits),
+            expiry_margins,
+            scan_limit,
+            candidate_limit,
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn prepare(
+        &self,
+        request: &RemotingRequest,
+        criteria: PullMatchCriteria,
+        fallback: ResponsePlan,
+        timing: PullSuspendTiming,
+        retained: PullRetainedEstimate,
+    ) -> Result<PreparedPullRegistration, PullDeferredPrepareError> {
+        let candidate = PullSuspensionCandidate::from_request(request, criteria, fallback, timing, retained)
+            .map_err(PullDeferredPrepareError::Build)?;
+        self.prepare_candidate_at(candidate, current_millis(), tokio::time::Instant::now())
+    }
+
+    fn prepare_candidate_at(
+        &self,
+        candidate: PullSuspensionCandidate,
+        wall_now: u64,
+        monotonic_now: tokio::time::Instant,
+    ) -> Result<PreparedPullRegistration, PullDeferredPrepareError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PullDeferredPrepareError::rejected(
+                PullDeferredPrepareErrorKind::ServiceClosed,
+                candidate,
+                None,
+            ));
+        }
+        if self.expiry_margins.recovery().is_zero() || self.expiry_margins.write().is_zero() {
+            return Err(PullDeferredPrepareError::rejected(
+                PullDeferredPrepareErrorKind::InvalidExpiryMargins,
+                candidate,
+                None,
+            ));
+        }
+        let deadline = match PullWaitDeadline::checked(
+            candidate.timing.suspend_wall_millis,
+            candidate.timing.suspend_monotonic,
+            candidate.timing.effective_timeout_millis,
+            wall_now,
+            monotonic_now,
+        ) {
+            Ok(deadline) => deadline,
+            Err(source) => {
+                return Err(PullDeferredPrepareError::Deadline { source, candidate });
+            }
+        };
+        let key = PullCriteriaKey::from_criteria(&candidate.criteria);
+        let reservation = match self.index.reserve(key) {
+            Ok(reservation) => reservation,
+            Err(source) => {
+                return Err(PullDeferredPrepareError::Index { source, candidate });
+            }
+        };
+        let retained_size = match try_retained_size(&candidate) {
+            Ok(size) => size,
+            Err(PullRetainedSizeError::Overflow) => {
+                drop(reservation);
+                return Err(PullDeferredPrepareError::RetainedSizeOverflow { candidate });
+            }
+            Err(PullRetainedSizeError::Admission(source)) => {
+                drop(reservation);
+                return Err(PullDeferredPrepareError::Admission { source, candidate });
+            }
+        };
+        let permit = match self.admission.try_reserve(retained_size) {
+            Ok(permit) => permit,
+            Err(source) => {
+                drop(reservation);
+                return Err(PullDeferredPrepareError::Admission { source, candidate });
+            }
+        };
+        let prepared = PreparedPullRegistration {
+            candidate,
+            deadline,
+            reservation,
+            permit,
+        };
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PullDeferredPrepareError::rejected(
+                PullDeferredPrepareErrorKind::ServiceClosed,
+                prepared.into_candidate(),
+                None,
+            ));
+        }
+        Ok(prepared)
+    }
+
+    pub(crate) fn register(
+        &self,
+        prepared: PreparedPullRegistration,
+        request: &mut RemotingRequest,
+    ) -> Result<DeferredRegistration, PullDeferredRegisterError> {
+        if !prepared.candidate.provenance.matches(request) {
+            return Err(PullDeferredRegisterError::pre_take(
+                PullDeferredRegisterErrorKind::ProvenanceMismatch,
+                prepared,
+                None,
+            ));
+        }
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PullDeferredRegisterError::pre_take(
+                PullDeferredRegisterErrorKind::ServiceClosed,
+                prepared,
+                None,
+            ));
+        }
+        let responder = match request.take_deferred_responder() {
+            Ok(responder) => responder,
+            Err(source) => {
+                return Err(PullDeferredRegisterError::pre_take(
+                    PullDeferredRegisterErrorKind::Responder,
+                    prepared,
+                    Some(source),
+                ));
+            }
+        };
+        let PreparedPullRegistration {
+            candidate,
+            deadline,
+            reservation,
+            permit,
+        } = prepared;
+        let PullSuspensionCandidate {
+            request,
+            criteria,
+            fallback,
+            timing: _,
+            retained: _,
+            provenance: _,
+        } = candidate;
+        let parts =
+            match DeferredParts::new(responder, permit).try_with_expiry(deadline.protocol_at(), self.expiry_margins) {
+                Ok(parts) => parts,
+                Err(source) => {
+                    let kind = source.kind();
+                    let request_id = source.request_id();
+                    drop(source.into_parts());
+                    return Err(PullDeferredRegisterError::Expiry { kind, request_id });
+                }
+            };
+        drop(fallback);
+        match self.registry.register_with(parts, move |id| {
+            let lease = reservation.publish(id, Arc::clone(&criteria));
+            Ok::<_, Infallible>(ResumePull::new(request, criteria, deadline, lease))
+        }) {
+            Ok(registration) => Ok(registration),
+            Err(source) => {
+                let kind = source.kind();
+                let request_id = source.request_id();
+                drop(source);
+                Err(PullDeferredRegisterError::Registry { kind, request_id })
+            }
+        }
+    }
+
+    pub(crate) fn reserve_arrival_batch(
+        &self,
+        arrival: &PullArrivalView<'_>,
+        cursor: &mut PullScanCursor,
+    ) -> Vec<PullCandidateReservation> {
+        if self.closed.load(Ordering::Acquire) {
+            return Vec::new();
+        }
+        self.index
+            .reserve_matching(arrival, cursor, self.scan_limit, self.candidate_limit)
+    }
+
+    /// Selects every waiter matching one borrowed arrival in bounded batches.
+    ///
+    /// `submit` must synchronously transfer the affine candidates to a
+    /// lifecycle-owned task. If it rejects a batch, dropping that batch restores
+    /// index visibility and this callback stops without spinning.
+    pub(crate) fn produce_arrival<E, R, S>(
+        &self,
+        arrival: PullArrivalView<'_>,
+        resolve_current_max_offset: R,
+        mut submit: S,
+    ) -> Result<PullProducerStats, E>
+    where
+        R: FnOnce() -> Result<i64, E>,
+        S: FnMut(Vec<PullCandidateReservation>) -> Result<(), E>,
+    {
+        if self.closed.load(Ordering::Acquire) {
+            return Ok(PullProducerStats::default());
+        }
+        let arrival = if self.index.needs_offset_refresh(&arrival) {
+            arrival.with_max_offset(resolve_current_max_offset()?)
+        } else {
+            arrival
+        };
+        self.produce_batches(
+            |cursor| {
+                self.index
+                    .reserve_matching_batch(&arrival, cursor, self.scan_limit, self.candidate_limit)
+            },
+            &mut submit,
+        )
+    }
+
+    /// Selects every currently indexed waiter for master-online refresh.
+    pub(crate) fn produce_forced<S, E>(&self, mut submit: S) -> Result<PullProducerStats, E>
+    where
+        S: FnMut(Vec<PullCandidateReservation>) -> Result<(), E>,
+    {
+        if self.closed.load(Ordering::Acquire) {
+            return Ok(PullProducerStats::default());
+        }
+        self.produce_batches(
+            |cursor| {
+                self.index
+                    .reserve_forced_batch(cursor, self.scan_limit, self.candidate_limit)
+            },
+            &mut submit,
+        )
+    }
+
+    fn produce_batches<E, N, S>(&self, mut next: N, submit: &mut S) -> Result<PullProducerStats, E>
+    where
+        N: FnMut(&mut PullScanCursor) -> PullCandidateBatch,
+        S: FnMut(Vec<PullCandidateReservation>) -> Result<(), E>,
+    {
+        let mut cursor = PullScanCursor::new();
+        let mut stats = PullProducerStats::default();
+        loop {
+            if self.closed.load(Ordering::Acquire) {
+                break;
+            }
+            let batch = next(&mut cursor);
+            stats.inspected += batch.inspected();
+            let exhausted = batch.exhausted();
+            let candidates = batch.into_candidates();
+            if !candidates.is_empty() {
+                stats.candidates += candidates.len();
+                stats.batches += 1;
+                submit(candidates)?;
+            }
+            if exhausted {
+                break;
+            }
+        }
+        Ok(stats)
+    }
+
+    pub(crate) async fn claim_candidate(
+        &self,
+        candidate: PullCandidateReservation,
+        reason: DeferredWakeReason,
+    ) -> Result<ClaimedDeferred<ResumePull>, DeferredClaimError> {
+        let id = candidate.id();
+        let mut claimed = self.registry.claim(id, reason).await?;
+        candidate.commit();
+        drop(claimed.resume_data_mut().take_index_lease());
+        Ok(claimed)
+    }
+
+    pub(crate) async fn claim(
+        &self,
+        id: DeferredId,
+        reason: DeferredWakeReason,
+    ) -> Result<ClaimedDeferred<ResumePull>, DeferredClaimError> {
+        let mut claimed = self.registry.claim(id, reason).await?;
+        drop(claimed.resume_data_mut().take_index_lease());
+        Ok(claimed)
+    }
+
+    pub(crate) fn sweep_expired(&self) -> PullDeferredSweepBatch {
+        PullDeferredSweepBatch::from_transport(self.registry.sweep_expired(self.candidate_limit))
+    }
+
+    pub(crate) async fn resume_claimed<F, Fut>(
+        &self,
+        claimed: ClaimedDeferred<ResumePull>,
+        retained: DeferredResumeRetainedSize,
+        handler: F,
+    ) -> Result<ResponseReceipt, DeferredResumeError>
+    where
+        F: FnOnce(ResumePull, DeferredWakeReason) -> Fut + Send + 'static,
+        Fut: Future<Output = rocketmq_error::RocketMQResult<ResponsePlan>> + Send + 'static,
+    {
+        claimed.resume(retained, handler).await
+    }
+
+    #[must_use]
+    pub(crate) fn shutdown(&self) -> DeferredRegistryShutdownOutcome {
+        self.closed.store(true, Ordering::Release);
+        self.registry.shutdown()
+    }
+
+    #[must_use]
+    pub(crate) fn admission_snapshot(&self) -> DeferredAdmissionSnapshot {
+        self.admission.snapshot()
+    }
+
+    #[must_use]
+    pub(crate) fn index_snapshot(&self) -> PullIndexSnapshot {
+        self.index.snapshot()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PullProducerStats {
+    inspected: usize,
+    candidates: usize,
+    batches: usize,
+}
+
+impl PullProducerStats {
+    pub(crate) const fn inspected(self) -> usize {
+        self.inspected
+    }
+
+    pub(crate) const fn candidates(self) -> usize {
+        self.candidates
+    }
+
+    pub(crate) const fn batches(self) -> usize {
+        self.batches
+    }
+}
+
+fn try_retained_size(
+    candidate: &PullSuspensionCandidate,
+) -> Result<rocketmq_transport::api::v2::DeferredRetainedSize, PullRetainedSizeError> {
+    let request_bytes = candidate
+        .request
+        .dynamic_bytes()
+        .ok_or(PullRetainedSizeError::Overflow)?;
+    let criteria_bytes = candidate
+        .criteria
+        .dynamic_bytes()
+        .ok_or(PullRetainedSizeError::Overflow)?;
+    let filter_bytes = candidate
+        .retained
+        .filter_bytes
+        .checked_add(criteria_bytes)
+        .ok_or(PullRetainedSizeError::Overflow)?;
+    let index_bytes =
+        PullCriteriaIndex::<DeferredId>::try_retained_bytes_per_entry().ok_or(PullRetainedSizeError::Overflow)?;
+    DeferredRegistry::<ResumePull>::try_retained_size(
+        DeferredRetainedSizeParts::new(request_bytes)
+            .with_filter_bytes(filter_bytes)
+            .with_secondary_index_bytes(index_bytes)
+            .with_metadata_bytes(candidate.retained.hook_metadata_bytes),
+    )
+    .map_err(PullRetainedSizeError::Admission)
+}
+
+enum PullRetainedSizeError {
+    Overflow,
+    Admission(DeferredAdmissionAcquireError),
+}
+
+#[must_use]
+pub(crate) struct PullDeferredSweepBatch {
+    stats: DeferredExpiryBatchStats,
+    claims: Vec<ClaimedDeferred<ResumePull>>,
+}
+
+impl PullDeferredSweepBatch {
+    fn from_transport(batch: DeferredExpiryBatch<ResumePull>) -> Self {
+        let stats = batch.stats();
+        let mut claims = batch.into_claims();
+        for claim in &mut claims {
+            drop(claim.resume_data_mut().take_index_lease());
+        }
+        Self { stats, claims }
+    }
+
+    pub(crate) const fn stats(&self) -> DeferredExpiryBatchStats {
+        self.stats
+    }
+
+    pub(crate) fn into_claims(self) -> Vec<ClaimedDeferred<ResumePull>> {
+        self.claims
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PullCandidateBuildErrorKind {
+    UnsupportedRequestCode,
+    OneWayRequest,
+    EmbeddedOrigin,
+    Header,
+}
+
+pub(crate) struct PullCandidateBuildError {
+    kind: PullCandidateBuildErrorKind,
+    fallback: ResponsePlan,
+    source: Option<rocketmq_error::RocketMQError>,
+}
+
+impl PullCandidateBuildError {
+    fn new(
+        kind: PullCandidateBuildErrorKind,
+        fallback: ResponsePlan,
+        source: Option<rocketmq_error::RocketMQError>,
+    ) -> Self {
+        Self { kind, fallback, source }
+    }
+
+    pub(crate) const fn kind(&self) -> PullCandidateBuildErrorKind {
+        self.kind
+    }
+
+    pub(crate) fn into_fallback(self) -> ResponsePlan {
+        self.fallback
+    }
+}
+
+impl fmt::Debug for PullCandidateBuildError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PullCandidateBuildError")
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PullCandidateBuildError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Pull suspension candidate failed: {:?}", self.kind)
+    }
+}
+
+impl Error for PullCandidateBuildError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source.as_ref().map(|source| source as &(dyn Error + 'static))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PullDeferredPrepareErrorKind {
+    Build(PullCandidateBuildErrorKind),
+    ServiceClosed,
+    InvalidExpiryMargins,
+    Deadline,
+    Index,
+    RetainedSizeOverflow,
+    Admission,
+}
+
+pub(crate) enum PullDeferredPrepareError {
+    Build(PullCandidateBuildError),
+    Rejected {
+        kind: PullDeferredPrepareErrorKind,
+        candidate: PullSuspensionCandidate,
+    },
+    Deadline {
+        source: PullWaitDeadlineError,
+        candidate: PullSuspensionCandidate,
+    },
+    Index {
+        source: PullIndexError,
+        candidate: PullSuspensionCandidate,
+    },
+    RetainedSizeOverflow {
+        candidate: PullSuspensionCandidate,
+    },
+    Admission {
+        source: DeferredAdmissionAcquireError,
+        candidate: PullSuspensionCandidate,
+    },
+}
+
+impl PullDeferredPrepareError {
+    fn rejected(
+        kind: PullDeferredPrepareErrorKind,
+        candidate: PullSuspensionCandidate,
+        _source: Option<Infallible>,
+    ) -> Self {
+        Self::Rejected { kind, candidate }
+    }
+
+    pub(crate) const fn kind(&self) -> PullDeferredPrepareErrorKind {
+        match self {
+            Self::Build(source) => PullDeferredPrepareErrorKind::Build(source.kind()),
+            Self::Rejected { kind, .. } => *kind,
+            Self::Deadline { .. } => PullDeferredPrepareErrorKind::Deadline,
+            Self::Index { .. } => PullDeferredPrepareErrorKind::Index,
+            Self::RetainedSizeOverflow { .. } => PullDeferredPrepareErrorKind::RetainedSizeOverflow,
+            Self::Admission { .. } => PullDeferredPrepareErrorKind::Admission,
+        }
+    }
+
+    pub(crate) fn into_fallback(self) -> ResponsePlan {
+        match self {
+            Self::Build(source) => source.into_fallback(),
+            Self::Rejected { candidate, .. }
+            | Self::Deadline { candidate, .. }
+            | Self::Index { candidate, .. }
+            | Self::RetainedSizeOverflow { candidate }
+            | Self::Admission { candidate, .. } => candidate.into_fallback(),
+        }
+    }
+}
+
+impl fmt::Debug for PullDeferredPrepareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PullDeferredPrepareError")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PullDeferredPrepareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Pull deferred preparation failed: {:?}", self.kind())
+    }
+}
+
+impl Error for PullDeferredPrepareError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Build(source) => Some(source),
+            Self::Deadline { source, .. } => Some(source),
+            Self::Index { source, .. } => Some(source),
+            Self::Admission { source, .. } => Some(source),
+            Self::Rejected { .. } | Self::RetainedSizeOverflow { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PullDeferredRegisterErrorKind {
+    ServiceClosed,
+    ProvenanceMismatch,
+    Responder,
+    Expiry(DeferredExpiryErrorKind),
+    Registry(DeferredRegistryErrorKind),
+}
+
+pub(crate) enum PullDeferredRegisterError {
+    PreTake {
+        kind: PullDeferredRegisterErrorKind,
+        prepared: Box<PreparedPullRegistration>,
+        source: Option<TakeDeferredResponderError>,
+    },
+    Expiry {
+        kind: DeferredExpiryErrorKind,
+        request_id: RequestId,
+    },
+    Registry {
+        kind: DeferredRegistryErrorKind,
+        request_id: RequestId,
+    },
+}
+
+impl PullDeferredRegisterError {
+    fn pre_take(
+        kind: PullDeferredRegisterErrorKind,
+        prepared: PreparedPullRegistration,
+        source: Option<TakeDeferredResponderError>,
+    ) -> Self {
+        Self::PreTake {
+            kind,
+            prepared: Box::new(prepared),
+            source,
+        }
+    }
+
+    pub(crate) const fn kind(&self) -> PullDeferredRegisterErrorKind {
+        match self {
+            Self::PreTake { kind, .. } => *kind,
+            Self::Expiry { kind, .. } => PullDeferredRegisterErrorKind::Expiry(*kind),
+            Self::Registry { kind, .. } => PullDeferredRegisterErrorKind::Registry(*kind),
+        }
+    }
+
+    pub(crate) const fn request_id(&self) -> Option<RequestId> {
+        match self {
+            Self::PreTake { .. } => None,
+            Self::Expiry { request_id, .. } | Self::Registry { request_id, .. } => Some(*request_id),
+        }
+    }
+
+    pub(crate) fn into_pre_take_fallback(self) -> Result<ResponsePlan, Self> {
+        self.into_candidate().map(PullSuspensionCandidate::into_fallback)
+    }
+
+    /// Recovers the exact affine suspension candidate from every pre-take failure.
+    pub(crate) fn into_candidate(self) -> Result<PullSuspensionCandidate, Self> {
+        match self {
+            Self::PreTake { prepared, .. } => Ok((*prepared).into_candidate()),
+            error => Err(error),
+        }
+    }
+}
+
+impl fmt::Debug for PullDeferredRegisterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PullDeferredRegisterError")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PullDeferredRegisterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Pull deferred registration failed: {:?}", self.kind())
+    }
+}
+
+impl Error for PullDeferredRegisterError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::PreTake { source, .. } => source.as_ref().map(|source| source as &(dyn Error + 'static)),
+            Self::Expiry { .. } | Self::Registry { .. } => None,
+        }
+    }
+}

--- a/rocketmq-broker/src/long_polling/pull_deferred/tests.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/tests.rs
@@ -1,0 +1,443 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_store::CqExtUnit;
+use rocketmq_store::MessageFilter;
+
+use super::deadline::PullWaitDeadline;
+use super::deadline::PullWaitDeadlineErrorKind;
+use super::index::PullArrivalView;
+use super::index::PullCriteriaIndex;
+use super::index::PullCriteriaKey;
+use super::index::PullCriteriaLimits;
+use super::index::PullIndexErrorKind;
+use super::index::PullIndexSnapshot;
+use super::index::PullScanCursor;
+use super::service::PullSuspendTiming;
+use super::PullMatchCriteria;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value is non-zero")
+}
+
+struct ToggleFilter(Arc<AtomicBool>);
+
+impl MessageFilter for ToggleFilter {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+struct SplitFilter {
+    consume: bool,
+    commit: bool,
+}
+
+impl MessageFilter for SplitFilter {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        self.consume
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        self.commit
+    }
+}
+
+fn criteria(offset: i64, matches: Arc<AtomicBool>) -> Arc<PullMatchCriteria> {
+    Arc::new(PullMatchCriteria::new(
+        CheetahString::from_static_str("TopicA"),
+        3,
+        offset,
+        SubscriptionData::default(),
+        Arc::new(ToggleFilter(matches)),
+    ))
+}
+
+fn key() -> PullCriteriaKey {
+    PullCriteriaKey::new(CheetahString::from_static_str("TopicA"), 3)
+}
+
+#[test]
+fn pull_deadline_preserves_inclusive_legacy_boundary() {
+    let suspend_monotonic = tokio::time::Instant::now();
+    let before = PullWaitDeadline::checked(
+        1_000,
+        suspend_monotonic,
+        100,
+        1_099,
+        suspend_monotonic + Duration::from_millis(99),
+    )
+    .expect("one millisecond remains");
+    assert_eq!(before.protocol_end_millis(), 1_100);
+    assert_eq!(before.protocol_at(), suspend_monotonic + Duration::from_millis(100));
+
+    let equal = PullWaitDeadline::checked(
+        1_000,
+        suspend_monotonic,
+        100,
+        1_100,
+        suspend_monotonic + Duration::from_millis(99),
+    )
+    .expect_err("equal wall boundary expires");
+    assert_eq!(equal.kind(), PullWaitDeadlineErrorKind::AlreadyExpired);
+    let monotonic_equal = PullWaitDeadline::checked(
+        1_000,
+        suspend_monotonic,
+        100,
+        1_099,
+        suspend_monotonic + Duration::from_millis(100),
+    )
+    .expect_err("equal monotonic boundary expires");
+    assert_eq!(monotonic_equal.kind(), PullWaitDeadlineErrorKind::AlreadyExpired);
+    let zero = PullWaitDeadline::checked(1_000, suspend_monotonic, 0, 1_000, suspend_monotonic)
+        .expect_err("zero timeout is immediate");
+    assert_eq!(zero.kind(), PullWaitDeadlineErrorKind::AlreadyExpired);
+}
+
+#[test]
+fn pull_deadline_checks_wall_and_monotonic_addition() {
+    let monotonic = tokio::time::Instant::now();
+    let overflow =
+        PullWaitDeadline::checked(u64::MAX, monotonic, 1, 0, monotonic).expect_err("wall addition overflows");
+    assert_eq!(overflow.kind(), PullWaitDeadlineErrorKind::ProtocolOverflow);
+
+    let mut representable_seconds = 0u64;
+    let mut upper = u64::MAX;
+    while representable_seconds < upper {
+        let midpoint = representable_seconds + (upper - representable_seconds) / 2 + 1;
+        if monotonic.checked_add(Duration::from_secs(midpoint)).is_some() {
+            representable_seconds = midpoint;
+        } else {
+            upper = midpoint - 1;
+        }
+    }
+    let overflow_base = monotonic
+        .checked_add(Duration::from_secs(representable_seconds))
+        .expect("binary search retains a representable monotonic instant");
+    let monotonic_overflow = PullWaitDeadline::checked(0, overflow_base, u64::MAX, 0, monotonic)
+        .expect_err("monotonic addition overflows before registration");
+    assert_eq!(monotonic_overflow.kind(), PullWaitDeadlineErrorKind::MonotonicOverflow);
+}
+
+#[test]
+fn pull_suspend_timing_selects_long_or_short_policy_at_suspend_start() {
+    let monotonic = tokio::time::Instant::now();
+    assert_eq!(
+        PullSuspendTiming::from_policy(10, monotonic, true, 30_000, 1_000),
+        PullSuspendTiming::new(10, monotonic, 30_000)
+    );
+    assert_eq!(
+        PullSuspendTiming::from_policy(10, monotonic, false, 30_000, 1_000),
+        PullSuspendTiming::new(10, monotonic, 1_000)
+    );
+    let timing = PullSuspendTiming::from_policy(10, monotonic, false, 30_000, 1_000);
+    assert_eq!(timing.suspend_wall_millis(), 10);
+    assert_eq!(timing.suspend_monotonic(), monotonic);
+    assert_eq!(timing.effective_timeout_millis(), 1_000);
+}
+
+#[test]
+fn index_reservations_enforce_global_and_per_key_capacity() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(2), nonzero(1)));
+    let first = index.reserve(key()).expect("first reservation");
+    let per_key = match index.reserve(key()) {
+        Ok(_) => panic!("per-key capacity must reject"),
+        Err(error) => error,
+    };
+    assert_eq!(per_key.kind(), PullIndexErrorKind::BucketCapacity);
+    let second_key = PullCriteriaKey::new(CheetahString::from_static_str("TopicB"), 3);
+    let second = index.reserve(second_key.clone()).expect("second reservation");
+    let global = match index.reserve(second_key) {
+        Ok(_) => panic!("global capacity must reject"),
+        Err(error) => error,
+    };
+    assert_eq!(global.kind(), PullIndexErrorKind::GlobalCapacity);
+    assert_eq!(index.snapshot().reserved(), 2);
+    drop((first, second));
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}
+
+#[test]
+fn stale_offset_and_filter_miss_remain_visible_for_later_arrival() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(2), nonzero(2)));
+    let matches = Arc::new(AtomicBool::new(false));
+    let lease = index
+        .reserve(key())
+        .expect("reservation")
+        .publish(7, criteria(10, Arc::clone(&matches)));
+    let topic = CheetahString::from_static_str("TopicA");
+
+    let mut stale_cursor = PullScanCursor::new();
+    assert!(index
+        .reserve_matching(
+            &PullArrivalView::new(&topic, 3, 10),
+            &mut stale_cursor,
+            nonzero(2),
+            nonzero(2),
+        )
+        .is_empty());
+    let mut miss_cursor = PullScanCursor::new();
+    assert!(index
+        .reserve_matching(
+            &PullArrivalView::new(&topic, 3, 11),
+            &mut miss_cursor,
+            nonzero(2),
+            nonzero(2),
+        )
+        .is_empty());
+    assert!(index.contains(7));
+
+    matches.store(true, Ordering::SeqCst);
+    let mut match_cursor = PullScanCursor::new();
+    let candidates = index.reserve_matching(
+        &PullArrivalView::new(&topic, 3, 11),
+        &mut match_cursor,
+        nonzero(2),
+        nonzero(2),
+    );
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].id(), 7);
+    drop(candidates);
+    assert!(index.contains(7), "losing candidate restores the waiter");
+    drop(lease);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}
+
+#[test]
+fn bounded_continuation_advances_every_current_match_in_sequence_order() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(4), nonzero(4)));
+    let matches = Arc::new(AtomicBool::new(true));
+    let leases = (1..=3)
+        .map(|id| {
+            index
+                .reserve(key())
+                .expect("reservation")
+                .publish(id, criteria(0, Arc::clone(&matches)))
+        })
+        .collect::<Vec<_>>();
+    let topic = CheetahString::from_static_str("TopicA");
+    let arrival = PullArrivalView::new(&topic, 3, 1);
+    let mut cursor = PullScanCursor::new();
+    let mut candidates = Vec::new();
+    loop {
+        let batch = index.reserve_matching(&arrival, &mut cursor, nonzero(1), nonzero(1));
+        if batch.is_empty() {
+            break;
+        }
+        candidates.extend(batch);
+    }
+    assert_eq!(
+        candidates.iter().map(|candidate| candidate.id()).collect::<Vec<_>>(),
+        [1, 2, 3]
+    );
+    assert_eq!(index.snapshot().candidates(), 3);
+    drop(candidates);
+    assert_eq!(index.snapshot().live(), 3);
+    drop(leases);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}
+
+#[test]
+fn bounded_scan_continues_past_an_empty_filtered_prefix() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(4), nonzero(4)));
+    let miss = Arc::new(AtomicBool::new(false));
+    let hit = Arc::new(AtomicBool::new(true));
+    let leases = [
+        index
+            .reserve(key())
+            .expect("miss reservation")
+            .publish(1, criteria(0, miss)),
+        index
+            .reserve(key())
+            .expect("hit reservation")
+            .publish(2, criteria(0, hit)),
+    ];
+    let topic = CheetahString::from_static_str("TopicA");
+    let arrival = PullArrivalView::new(&topic, 3, 1);
+    let mut cursor = PullScanCursor::new();
+    let first = index.reserve_matching_batch(&arrival, &mut cursor, nonzero(1), nonzero(1));
+    assert_eq!(first.inspected(), 1);
+    assert!(!first.exhausted());
+    assert!(first.into_candidates().is_empty());
+    let second = index.reserve_matching_batch(&arrival, &mut cursor, nonzero(1), nonzero(1));
+    assert_eq!(second.into_candidates()[0].id(), 2);
+    drop(leases);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}
+
+#[test]
+fn stale_offset_requires_one_current_max_offset_refresh() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(2), nonzero(2)));
+    let lease = index
+        .reserve(key())
+        .expect("reservation")
+        .publish(3, criteria(10, Arc::new(AtomicBool::new(true))));
+    let topic = CheetahString::from_static_str("TopicA");
+    let stale = PullArrivalView::new(&topic, 3, 10);
+    assert!(index.needs_offset_refresh(&stale));
+    let current = stale.with_max_offset(11);
+    assert!(!index.needs_offset_refresh(&current));
+    let mut cursor = PullScanCursor::new();
+    assert_eq!(
+        index.reserve_matching(&current, &mut cursor, nonzero(1), nonzero(1))[0].id(),
+        3
+    );
+    drop(lease);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}
+
+#[test]
+fn absent_properties_preserve_legacy_consume_queue_match() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(1), nonzero(1)));
+    let criteria = Arc::new(PullMatchCriteria::new(
+        CheetahString::from_static_str("TopicA"),
+        3,
+        0,
+        SubscriptionData::default(),
+        Arc::new(SplitFilter {
+            consume: true,
+            commit: false,
+        }),
+    ));
+    let lease = index.reserve(key()).expect("reservation").publish(4, criteria);
+    let topic = CheetahString::from_static_str("TopicA");
+    let mut no_properties_cursor = PullScanCursor::new();
+    assert_eq!(
+        index.reserve_matching(
+            &PullArrivalView::new(&topic, 3, 1),
+            &mut no_properties_cursor,
+            nonzero(1),
+            nonzero(1),
+        )[0]
+        .id(),
+        4
+    );
+    let properties = HashMap::new();
+    let mut properties_cursor = PullScanCursor::new();
+    assert!(index
+        .reserve_matching(
+            &PullArrivalView::new(&topic, 3, 1).with_filter_metadata(None, 0, None, Some(&properties)),
+            &mut properties_cursor,
+            nonzero(1),
+            nonzero(1),
+        )
+        .is_empty());
+    drop(lease);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}
+
+#[test]
+fn forced_refresh_bypasses_offset_and_filter_without_retaining_arrival_data() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(1), nonzero(1)));
+    let matches = Arc::new(AtomicBool::new(false));
+    let lease = index
+        .reserve(key())
+        .expect("reservation")
+        .publish(9, criteria(100, matches));
+    let topic = CheetahString::from_static_str("TopicA");
+    let bitmap = [1, 2, 3];
+    let properties = HashMap::new();
+    let arrival = PullArrivalView::new(&topic, 3, 0)
+        .with_filter_metadata(Some(7), 8, Some(&bitmap), Some(&properties))
+        .forced();
+    let mut cursor = PullScanCursor::new();
+    let candidates = index.reserve_matching(&arrival, &mut cursor, nonzero(1), nonzero(1));
+    assert_eq!(candidates[0].id(), 9);
+    drop(candidates);
+    drop(lease);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}
+
+#[test]
+fn forced_cursor_advances_all_keys_in_bounded_sequence_order() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(3), nonzero(2)));
+    let matches = Arc::new(AtomicBool::new(false));
+    let other_key = PullCriteriaKey::new(CheetahString::from_static_str("TopicB"), 7);
+    let leases = [
+        index
+            .reserve(key())
+            .expect("first reservation")
+            .publish(1, criteria(100, Arc::clone(&matches))),
+        index
+            .reserve(other_key)
+            .expect("second reservation")
+            .publish(2, criteria(100, matches)),
+    ];
+    let mut cursor = PullScanCursor::new();
+    let first = index.reserve_forced_batch(&mut cursor, nonzero(1), nonzero(1));
+    assert_eq!(first.into_candidates()[0].id(), 1);
+    let second = index.reserve_forced_batch(&mut cursor, nonzero(1), nonzero(1));
+    assert_eq!(second.into_candidates()[0].id(), 2);
+    let exhausted = index.reserve_forced_batch(&mut cursor, nonzero(1), nonzero(1));
+    assert!(exhausted.exhausted());
+    drop(leases);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}
+
+#[test]
+fn successful_candidate_commit_detaches_record_before_lease_drop() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(1), nonzero(1)));
+    let lease = index
+        .reserve(key())
+        .expect("reservation")
+        .publish(12, criteria(0, Arc::new(AtomicBool::new(true))));
+    let topic = CheetahString::from_static_str("TopicA");
+    let mut cursor = PullScanCursor::new();
+    let candidate = index
+        .reserve_matching(&PullArrivalView::new(&topic, 3, 1), &mut cursor, nonzero(1), nonzero(1))
+        .pop()
+        .expect("candidate");
+    candidate.commit();
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+    drop(lease);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}
+
+#[test]
+fn dropping_lease_while_candidate_is_reserved_releases_exactly_once() {
+    let index = PullCriteriaIndex::<u64>::new(PullCriteriaLimits::new(nonzero(1), nonzero(1)));
+    let lease = index
+        .reserve(key())
+        .expect("reservation")
+        .publish(13, criteria(0, Arc::new(AtomicBool::new(true))));
+    let topic = CheetahString::from_static_str("TopicA");
+    let mut cursor = PullScanCursor::new();
+    let candidates = index.reserve_matching(&PullArrivalView::new(&topic, 3, 1), &mut cursor, nonzero(1), nonzero(1));
+    assert_eq!(index.snapshot().candidates(), 1);
+    drop(lease);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+    drop(candidates);
+    assert_eq!(index.snapshot(), PullIndexSnapshot::default());
+}

--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -39,27 +39,26 @@ use rocketmq_protocol::protocol::topic::OffsetMovedEvent;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store::ArcMessageFilter;
 use rocketmq_store::BrokerReadStore;
-use rocketmq_store::BrokerStatsManager;
 use rocketmq_store::GetMessageResult;
 use rocketmq_store::GetMessageStatus;
 use rocketmq_store::StatsType;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
 
-use crate::long_polling::pull_request::PullRequest;
+use crate::long_polling::pull_deferred::PullHookMetadata;
+use crate::long_polling::pull_deferred::PullSuspendTiming;
 use crate::metrics::broker_metrics_manager::BrokerMetricsManager;
 use crate::mqtrace::consume_message_context::ConsumeMessageContext;
 use crate::mqtrace::consume_message_hook::ConsumeMessageHook;
 use crate::processor::pull_message_processor::capability::PullMessageProcessorContext;
-use crate::processor::pull_message_processor::is_broadcast;
 use crate::processor::pull_message_processor::rewrite_response_for_static_topic;
 use crate::processor::pull_message_processor::static_topic_rewrite_error_response;
 use crate::processor::pull_message_processor::StaticTopicRewriteError;
 use crate::processor::pull_message_result_handler::PullMessageResult;
 use crate::processor::pull_message_result_handler::PullMessageResultHandler;
+use crate::processor::pull_message_result_handler::PullResponseContext;
+use crate::processor::pull_message_result_handler::PullSuspension;
 use crate::processor::response_plan::store_response_parts;
 use crate::processor::response_plan::BrokerResponseParts;
 
@@ -87,19 +86,15 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
     async fn handle(
         &self,
         get_message_result: GetMessageResult,
-        request: &mut RemotingCommand,
         request_header: PullMessageRequestHeader,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
         subscription_data: SubscriptionData,
         subscription_group_config: &SubscriptionGroupConfig,
-        broker_allow_suspend: bool,
         message_filter: ArcMessageFilter,
         mut response: RemotingCommand,
         mut mapping_context: TopicQueueMappingContext,
-        _begin_time_mills: u64,
+        response_context: PullResponseContext<'_>,
     ) -> rocketmq_error::RocketMQResult<PullMessageResult> {
-        let client_address = channel.remote_address().to_string();
+        let client_address = response_context.effective_peer.to_string();
         let policy = self.context.policy();
         let topic_config = self.context.topics().select_topic_config(request_header.topic.as_ref());
         let topic_sys_flag = topic_config.as_ref().map(|tc| tc.topic_sys_flag as i32).unwrap_or(0);
@@ -114,10 +109,10 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
         );
         let code = From::from(response.code());
         self.execute_consume_message_hook_before(
-            request,
+            response_context.hook_metadata,
             &request_header,
             &get_message_result,
-            broker_allow_suspend,
+            response_context.allow_legacy_suspend,
             code,
         );
         {
@@ -151,15 +146,15 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
             request_header.consumer_group.as_ref(),
             request_header.queue_id,
             &request_header,
-            &channel,
+            response_context.broadcast_client_resolver,
             Some(&mut response),
             get_message_result.next_begin_offset(),
-        );
+        )?;
         self.try_commit_offset(
-            broker_allow_suspend,
+            response_context.allow_legacy_suspend,
             &request_header,
             get_message_result.next_begin_offset(),
-            channel.remote_address(),
+            response_context.effective_peer,
         );
 
         match code {
@@ -206,7 +201,7 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
                         request_header.queue_id,
                     );
                     // Record group get latency
-                    let latency = (current_millis() - _begin_time_mills) as i32;
+                    let latency = (current_millis() - response_context.begin_time_millis) as i32;
                     self.context.broker_stats().inc_group_get_latency(
                         request_header.consumer_group.as_str(),
                         request_header.topic.as_str(),
@@ -225,29 +220,21 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
                 } else {
                     0
                 };
-                if broker_allow_suspend && has_suspend_flag {
-                    let mut polling_time_mills = suspend_timeout_millis_long;
-                    if !policy.long_polling_enable {
-                        polling_time_mills = policy.short_polling_time_millis;
-                    }
-                    let topic = request_header.topic.as_str();
-                    let queue_id = request_header.queue_id;
-                    let offset = request_header.queue_offset;
-
-                    let pull_request = PullRequest::new(
-                        request.clone(),
-                        channel,
-                        ctx,
-                        polling_time_mills,
+                if response_context.allow_legacy_suspend && has_suspend_flag {
+                    let timing = PullSuspendTiming::from_policy(
                         current_millis(),
-                        offset,
+                        tokio::time::Instant::now(),
+                        policy.long_polling_enable,
+                        suspend_timeout_millis_long,
+                        policy.short_polling_time_millis,
+                    );
+                    return Ok(PullMessageResult::Suspend(Box::new(PullSuspension {
+                        timing,
+                        request_header,
                         subscription_data,
                         message_filter,
-                    );
-                    let suspended = self.context.suspend_pull_request(topic, queue_id, pull_request);
-                    if suspended {
-                        return Ok(PullMessageResult::Suspended);
-                    }
+                        fallback: BrokerResponseParts::command(response)?,
+                    })));
                 }
                 command_result(response)
             }
@@ -417,18 +404,17 @@ impl<MS: BrokerReadStore> DefaultPullMessageResultHandler<MS> {
 
     fn execute_consume_message_hook_before(
         &self,
-        request: &RemotingCommand,
+        hook_metadata: &PullHookMetadata,
         request_header: &PullMessageRequestHeader,
         get_message_result: &GetMessageResult,
         broker_allow_suspend: bool,
         response_code: ResponseCode,
     ) {
         if self.has_consume_message_hook() {
-            let ext_fields = request.get_ext_fields().unwrap();
-            let owner = ext_fields.get(BrokerStatsManager::COMMERCIAL_OWNER);
-            let auth_type = ext_fields.get(BrokerStatsManager::ACCOUNT_AUTH_TYPE);
-            let owner_parent = ext_fields.get(BrokerStatsManager::ACCOUNT_OWNER_PARENT);
-            let owner_self = ext_fields.get(BrokerStatsManager::ACCOUNT_OWNER_SELF);
+            let owner = hook_metadata.commercial_owner();
+            let auth_type = hook_metadata.account_auth_type();
+            let owner_parent = hook_metadata.account_owner_parent();
+            let owner_self = hook_metadata.account_owner_self();
 
             let namespace =
                 CheetahString::from_string(NamespaceUtil::get_namespace_from_resource(&request_header.topic));
@@ -650,44 +636,26 @@ impl<MS: BrokerReadStore> DefaultPullMessageResultHandler<MS> {
         group: &CheetahString,
         queue_id: i32,
         request_header: &PullMessageRequestHeader,
-        channel: &Channel,
+        client_resolver: &crate::processor::pull_message_result_handler::PullBroadcastClientResolver<'_>,
         response: Option<&mut RemotingCommand>,
         next_begin_offset: i64,
-    ) {
+    ) -> rocketmq_error::RocketMQResult<()> {
         if response.is_none() || !self.context.policy().enable_broadcast_offset_store {
-            return;
+            return Ok(());
         }
         let proxy_pull_broadcast = request_header.request_source == Some(RequestSource::ProxyForBroadcast.get_value());
-        let consumer_group_info = self.context.consumers().get_consumer_group_info(group);
-
-        if is_broadcast(proxy_pull_broadcast, consumer_group_info.as_ref()) {
-            let mut offset = request_header.queue_offset;
-            if let Some(response) = response {
-                if ResponseCode::from(response.code()) == ResponseCode::PullOffsetMoved {
-                    offset = next_begin_offset;
-                }
+        let Some(client_id) = client_resolver(request_header)? else {
+            return Ok(());
+        };
+        let mut offset = request_header.queue_offset;
+        if let Some(response) = response {
+            if ResponseCode::from(response.code()) == ResponseCode::PullOffsetMoved {
+                offset = next_begin_offset;
             }
-
-            let client_id = if proxy_pull_broadcast {
-                request_header.proxy_forward_client_id.clone().unwrap_or_default()
-            } else if let Some(ref consumer_group_info) = consumer_group_info {
-                if let Some(ref client_channel_info) = consumer_group_info.find_channel_by_channel(channel) {
-                    client_channel_info.client_id().clone()
-                } else {
-                    return;
-                }
-            } else {
-                return;
-            };
-            self.context.update_broadcast_offset(
-                topic,
-                group,
-                queue_id,
-                offset,
-                client_id.as_str(),
-                proxy_pull_broadcast,
-            );
         }
+        self.context
+            .update_broadcast_offset(topic, group, queue_id, offset, client_id.as_str(), proxy_pull_broadcast);
+        Ok(())
     }
 }
 
@@ -716,7 +684,7 @@ mod tests {
     }
 
     #[test]
-    fn pull_result_distinguishes_immediate_reply_from_suspension() {
+    fn pull_result_preserves_explicit_immediate_reply() {
         let immediate = command_result(response_head()).expect("valid immediate Pull result");
         assert!(matches!(&immediate, PullMessageResult::Reply(_)));
         let PullMessageResult::Reply(parts) = immediate else {
@@ -725,10 +693,7 @@ mod tests {
         let HandlerOutcome::Reply(plan) = parts.into_handler_outcome().expect("valid empty Pull plan") else {
             panic!("immediate Pull parts must map to a Reply outcome");
         };
-        let suspended = PullMessageResult::Suspended;
-
         assert_eq!(plan.body_kind(), ResponseBodyKind::Empty);
-        assert!(matches!(suspended, PullMessageResult::Suspended));
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub(crate) mod capability;
+mod resume;
 
 use std::future::Future;
 use std::sync::Arc;
@@ -57,6 +58,7 @@ use rocketmq_transport::api::v1::RequestProcessor;
 use rocketmq_transport::api::v1::RpcClient;
 use rocketmq_transport::api::v1::RpcClientUtils;
 use rocketmq_transport::api::v1::RpcRequest;
+use rocketmq_transport::api::v2::SessionId;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -66,10 +68,16 @@ use crate::filter::consumer_filter_data::ConsumerFilterData;
 use crate::filter::expression_for_retry_message_filter::ExpressionForRetryMessageFilter;
 use crate::filter::expression_message_filter::ExpressionMessageFilter;
 use crate::long_polling::long_polling_service::pull_request_hold_service::PullRequestProcessor;
+use crate::long_polling::pull_deferred::PullHookMetadata;
+use crate::long_polling::pull_deferred::PullSessionClientLookup;
+use crate::long_polling::pull_request::PullRequest;
 use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
 use crate::processor::pull_message_processor::capability::PullMessageProcessorContext;
+use crate::processor::pull_message_result_handler::PullBroadcastClientResolver;
 use crate::processor::pull_message_result_handler::PullMessageResult;
 use crate::processor::pull_message_result_handler::PullMessageResultHandler;
+use crate::processor::pull_message_result_handler::PullResponseContext;
+use crate::processor::response_plan::BrokerResponseParts;
 use crate::processor::response_plan::LegacyResponseDelivery;
 
 fn store_read_max_msg_bytes(max_msg_bytes: Option<i32>) -> i32 {
@@ -101,6 +109,19 @@ pub struct PullMessageProcessor<MS: BrokerReadStore> {
     pull_message_result_handler: Arc<DefaultPullMessageResultHandler<MS>>,
     context: Arc<PullMessageProcessorContext<MS>>,
     wakeup_task_group: OnceLock<TaskGroup>,
+    session_client_lookup: OnceLock<Arc<dyn PullSessionClientLookup>>,
+}
+
+fn pull_command(response: RemotingCommand) -> rocketmq_error::RocketMQResult<PullMessageResult> {
+    Ok(PullMessageResult::Reply(BrokerResponseParts::command(response)?))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum PullClientIdentityError {
+    #[error("the Pull session client lookup is not installed")]
+    LookupUnavailable,
+    #[error("the resumed Pull session has no current client registration")]
+    RegistrationMissing,
 }
 
 impl<MS> RequestProcessor for PullMessageProcessor<MS>
@@ -291,7 +312,16 @@ where
             pull_message_result_handler,
             context,
             wakeup_task_group: OnceLock::new(),
+            session_client_lookup: OnceLock::new(),
         }
+    }
+
+    #[allow(dead_code, reason = "installed by the forthcoming V2 Pull composition root")]
+    pub(crate) fn install_session_client_lookup(
+        &self,
+        lookup: Arc<dyn PullSessionClientLookup>,
+    ) -> Result<(), Arc<dyn PullSessionClientLookup>> {
+        self.session_client_lookup.set(lookup)
     }
 
     pub(crate) fn set_wakeup_task_group(&self, task_group: TaskGroup) {
@@ -793,35 +823,97 @@ where
         request: &mut RemotingCommand,
         broker_allow_suspend: bool,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_header =
+            request.decode_required_header_fast::<PullMessageRequestHeader>("decode pull-message request header")?;
+        let hook_metadata = PullHookMetadata::from_command(request);
+        let broadcast_client_resolver = |request_header: &PullMessageRequestHeader| {
+            self.resolve_broadcast_client_id_with(request_header, || {
+                Ok(self.legacy_broadcast_client_id(&request_header.consumer_group, &channel))
+            })
+        };
+        let result = self
+            .execute_pull(
+                request_code,
+                request_header,
+                channel.remote_address(),
+                &hook_metadata,
+                &broadcast_client_resolver,
+                broker_allow_suspend,
+                Some(request.opaque()),
+            )
+            .await?;
+        match result {
+            PullMessageResult::Reply(parts) => Ok(legacy_pull_delivery_response(parts.deliver_legacy(&channel).await)),
+            PullMessageResult::Suspend(suspension) => {
+                let suspension = *suspension;
+                let topic = suspension.request_header.topic.clone();
+                let queue_id = suspension.request_header.queue_id;
+                let offset = suspension.request_header.queue_offset;
+                let pull_request = PullRequest::new(
+                    request.clone(),
+                    channel.clone(),
+                    ctx,
+                    suspension.timing.effective_timeout_millis(),
+                    suspension.timing.suspend_wall_millis(),
+                    offset,
+                    suspension.subscription_data,
+                    suspension.message_filter,
+                );
+                if self
+                    .context
+                    .suspend_pull_request(topic.as_str(), queue_id, pull_request)
+                {
+                    Ok(None)
+                } else {
+                    Ok(legacy_pull_delivery_response(
+                        suspension.fallback.deliver_legacy(&channel).await,
+                    ))
+                }
+            }
+        }
+    }
+
+    #[allow(unused_assignments)]
+    #[allow(clippy::too_many_arguments, reason = "typed Pull execution inputs are kept explicit")]
+    async fn execute_pull(
+        &self,
+        request_code: RequestCode,
+        mut request_header: PullMessageRequestHeader,
+        effective_peer: std::net::SocketAddr,
+        hook_metadata: &PullHookMetadata,
+        broadcast_client_resolver: &PullBroadcastClientResolver<'_>,
+        broker_allow_suspend: bool,
+        legacy_opaque: Option<i32>,
+    ) -> rocketmq_error::RocketMQResult<PullMessageResult> {
         let begin_time_mills = current_millis();
         let mut response = self
             .context
             .command_factory
             .create_java_default_error_response_command();
-        response.set_opaque_mut(request.opaque());
-        let mut request_header =
-            request.decode_required_header_fast::<PullMessageRequestHeader>("decode pull-message request header")?;
+        if let Some(opaque) = legacy_opaque {
+            response.set_opaque_mut(opaque);
+        }
         //info!("receive pull message request: {:?}", request_header);
         let mut response_header = PullMessageResponseHeader::default();
         let policy = self.context.policy();
 
         if !PermName::is_readable(policy.broker_permission) {
             response_header.forbidden_type = Some(ForbiddenType::BROKER_FORBIDDEN);
-            return Ok(Some(
+            return pull_command(
                 response
                     .set_code(ResponseCode::NoPermission)
                     .set_command_custom_header(response_header)
                     .set_remark(format!("the broker[{}] pulling message is forbidden", policy.broker_ip)),
-            ));
+            );
         }
         if RequestCode::LitePullMessage == request_code && !policy.lite_pull_message_enable {
             response_header.forbidden_type = Some(ForbiddenType::BROKER_FORBIDDEN);
-            return Ok(Some(
+            return pull_command(
                 response
                     .set_code(ResponseCode::NoPermission)
                     .set_command_custom_header(response_header)
                     .set_remark(format!("the broker[{}] pulling message is forbidden", policy.broker_ip)),
-            ));
+            );
         }
         let subscription_group_config = self
             .context
@@ -829,7 +921,7 @@ where
             .find_subscription_group_config(request_header.consumer_group.as_ref());
 
         if subscription_group_config.is_none() {
-            return Ok(Some(
+            return pull_command(
                 response
                     .set_code(ResponseCode::SubscriptionGroupNotExist)
                     .set_remark(format!(
@@ -837,12 +929,12 @@ where
                         request_header.consumer_group,
                         FAQUrl::suggest_todo(FAQUrl::SUBSCRIPTION_GROUP_NOT_EXIST)
                     )),
-            ));
+            );
         }
 
         if !subscription_group_config.as_ref().unwrap().consume_enable() {
             response_header.forbidden_type = Some(ForbiddenType::GROUP_FORBIDDEN);
-            return Ok(Some(
+            return pull_command(
                 response
                     .set_code(ResponseCode::NoPermission)
                     .set_command_custom_header(response_header)
@@ -850,26 +942,23 @@ where
                         "subscription group no permission, {}",
                         request_header.consumer_group,
                     )),
-            ));
+            );
         }
         let topic_config = self.context.topics().select_topic_config(request_header.topic.as_ref());
         if topic_config.is_none() {
             error!(
                 "the topic {} not exist, consumer: {}",
-                request_header.topic,
-                channel.remote_address()
+                request_header.topic, effective_peer
             );
-            return Ok(Some(response.set_code(ResponseCode::TopicNotExist).set_remark(
-                format!(
-                    "topic[{}] not exist, apply first please! {}",
-                    request_header.topic,
-                    FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
-                ),
+            return pull_command(response.set_code(ResponseCode::TopicNotExist).set_remark(format!(
+                "topic[{}] not exist, apply first please! {}",
+                request_header.topic,
+                FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
             )));
         }
         if !PermName::is_readable(topic_config.as_ref().unwrap().perm) {
             response_header.forbidden_type = Some(ForbiddenType::TOPIC_FORBIDDEN);
-            return Ok(Some(
+            return pull_command(
                 response
                     .set_code(ResponseCode::NoPermission)
                     .set_command_custom_header(response_header)
@@ -877,7 +966,7 @@ where
                         "the topic[{}] pulling message is forbidden",
                         request_header.topic,
                     )),
-            ));
+            );
         }
         let mut topic_queue_mapping_context = self
             .context
@@ -887,12 +976,12 @@ where
             .rewrite_request_for_static_topic(&mut request_header, &mut topic_queue_mapping_context)
             .await
         {
-            return Ok(Some(resp));
+            return pull_command(resp);
         }
         if request_header.queue_id < 0
             || request_header.queue_id >= topic_config.as_ref().unwrap().read_queue_nums as i32
         {
-            return Ok(Some(
+            return pull_command(
                 response
                     .set_code(RemotingSysResponseCode::SystemError)
                     .set_remark(format!(
@@ -900,9 +989,9 @@ where
                         request_header.queue_id,
                         request_header.topic,
                         topic_config.as_ref().unwrap().read_queue_nums,
-                        channel.remote_address()
+                        effective_peer
                     )),
-            ));
+            );
         }
         let (consume_type, message_model) =
             consumer_compensation_for_request_source(RequestSource::parse_integer(request_header.request_source));
@@ -930,20 +1019,20 @@ where
             consumer_filter_data,
         } = match subscription_result {
             Ok(result) => result,
-            Err(err_response) => return Ok(Some(err_response)),
+            Err(err_response) => return pull_command(err_response),
         };
 
         if !ExpressionType::is_tag_type(Some(subscription_data.expression_type.as_str()))
             && !policy.enable_property_filter
         {
-            return Ok(Some(
+            return pull_command(
                 response
                     .set_code(RemotingSysResponseCode::SystemError)
                     .set_remark(format!(
                         "The broker does not support consumer to filter message by {}",
                         subscription_data.expression_type
                     )),
-            ));
+            );
         }
 
         // Build message filter using helper method
@@ -970,11 +1059,11 @@ where
                             if let Some(ref cg_info) = consumer_group_info {
                                 match cg_info.get_consume_type() {
                                     ConsumeType::ConsumePassively => {
-                                        return Ok(Some(
+                                        return pull_command(
                                             response
                                                 .set_code(ResponseCode::SystemBusy)
                                                 .set_remark("This consumer group is reading cold data. It has been flow control"),
-                                        ));
+                                        );
                                     }
                                     ConsumeType::ConsumeActively => {
                                         if broker_allow_suspend
@@ -983,11 +1072,11 @@ where
                                                 .await
                                                 == crate::coldctr::cold_data_cg_ctr_service::ColdDataShortSuspendOutcome::QueueFull
                                         {
-                                            return Ok(Some(
+                                            return pull_command(
                                                 response
                                                     .set_code(ResponseCode::SystemBusy)
                                                     .set_remark("Cold-data pull suspension queue is full"),
-                                            ));
+                                            );
                                         }
                                         request_header.max_msg_nums = 1;
                                     }
@@ -1010,11 +1099,11 @@ where
                 self.context.store().min_offset(topic, queue_id),
                 self.context.store().max_offset(topic, queue_id),
             ) else {
-                return Ok(Some(
+                return pull_command(
                     response
                         .set_code(ResponseCode::SystemError)
                         .set_remark("message store is unavailable"),
-                ));
+                );
             };
             let mut get_message_result = GetMessageResult::new();
             get_message_result.set_status(Some(GetMessageStatus::OffsetReset));
@@ -1024,8 +1113,15 @@ where
             get_message_result.set_suggest_pulling_from_slave(false);
             Some(get_message_result)
         } else {
-            let broadcast_init_offset =
-                self.query_broadcast_pull_init_offset(topic, group, queue_id, &request_header, &channel);
+            let broadcast_init_client_id = broadcast_client_resolver(&request_header)?;
+            let broadcast_init_offset = self.query_broadcast_pull_init_offset(
+                topic,
+                group,
+                queue_id,
+                &request_header,
+                broadcast_init_client_id.as_ref(),
+            );
+            drop(broadcast_init_client_id);
             if broadcast_init_offset >= 0 {
                 let mut get_message_result = GetMessageResult::new();
                 get_message_result.set_status(Some(GetMessageStatus::OffsetReset));
@@ -1048,19 +1144,19 @@ where
                 {
                     Ok(result) => result,
                     Err(_) => {
-                        return Ok(Some(
+                        return pull_command(
                             response
                                 .set_code(ResponseCode::SystemError)
                                 .set_remark("message store is unavailable"),
-                        ));
+                        );
                     }
                 };
                 if result.is_none() {
-                    return Ok(Some(
+                    return pull_command(
                         response
                             .set_code(ResponseCode::SystemError)
                             .set_remark("store getMessage return None"),
-                    ));
+                    );
                 }
                 // Accumulate cold data read bytes for flow control
                 if let Some(ref result) = result {
@@ -1076,27 +1172,28 @@ where
                 .pull_message_result_handler
                 .handle(
                     get_message_result,
-                    request,
                     request_header,
-                    channel.clone(),
-                    ctx,
                     subscription_data,
                     &subscription_group_config.unwrap(),
-                    broker_allow_suspend,
                     message_filter,
                     response,
                     topic_queue_mapping_context,
-                    begin_time_mills,
+                    PullResponseContext {
+                        effective_peer,
+                        hook_metadata,
+                        broadcast_client_resolver,
+                        allow_legacy_suspend: broker_allow_suspend,
+                        begin_time_millis: begin_time_mills,
+                    },
                 )
                 .await?;
-            return match result {
-                PullMessageResult::Reply(parts) => {
-                    Ok(legacy_pull_delivery_response(parts.deliver_legacy(&channel).await))
-                }
-                PullMessageResult::Suspended => Ok(None),
-            };
+            return Ok(result);
         }
-        Ok(None)
+        pull_command(
+            response
+                .set_code(ResponseCode::SystemError)
+                .set_remark("store getMessage return None"),
+        )
     }
 
     fn query_broadcast_pull_init_offset(
@@ -1105,7 +1202,7 @@ where
         group: &CheetahString,
         queue_id: i32,
         request_header: &PullMessageRequestHeader,
-        channel: &Channel,
+        client_id: Option<&CheetahString>,
     ) -> i64 {
         if !self.context.policy().enable_broadcast_offset_store {
             return -1;
@@ -1116,25 +1213,77 @@ where
 
         if is_broadcast(proxy_pull_broadcast, consumer_group_info.as_ref()) {
             let client_id = if proxy_pull_broadcast {
-                request_header.proxy_forward_client_id.as_ref().cloned()
+                request_header.proxy_forward_client_id.as_ref()
             } else {
-                match consumer_group_info.as_ref().unwrap().find_channel_by_channel(channel) {
-                    None => {
-                        return -1;
-                    }
-                    Some(value) => Some(value.client_id().clone()),
-                }
+                client_id
+            };
+            let Some(client_id) = client_id else {
+                return -1;
             };
             return self.context.query_broadcast_offset(
                 topic,
                 group,
                 queue_id,
-                client_id.as_ref().unwrap().as_str(),
+                client_id.as_str(),
                 request_header.queue_offset,
                 proxy_pull_broadcast,
             );
         }
         -1
+    }
+
+    fn resolve_session_broadcast_client_id(
+        &self,
+        request_header: &PullMessageRequestHeader,
+        session_id: SessionId,
+    ) -> rocketmq_error::RocketMQResult<Option<CheetahString>> {
+        self.resolve_broadcast_client_id_with(request_header, || {
+            let lookup = self.session_client_lookup.get().ok_or_else(|| {
+                rocketmq_error::RocketMQError::internal(
+                    "resume-pull-client-lookup",
+                    PullClientIdentityError::LookupUnavailable,
+                )
+            })?;
+            lookup
+                .client_id(session_id, &request_header.consumer_group)
+                .map(Some)
+                .ok_or_else(|| {
+                    rocketmq_error::RocketMQError::internal(
+                        "resume-pull-client-lookup",
+                        PullClientIdentityError::RegistrationMissing,
+                    )
+                })
+        })
+    }
+
+    fn resolve_broadcast_client_id_with(
+        &self,
+        request_header: &PullMessageRequestHeader,
+        resolve_normal_client: impl FnOnce() -> rocketmq_error::RocketMQResult<Option<CheetahString>>,
+    ) -> rocketmq_error::RocketMQResult<Option<CheetahString>> {
+        if !self.context.policy().enable_broadcast_offset_store {
+            return Ok(None);
+        }
+        let proxy = RequestSource::ProxyForBroadcast == From::from(request_header.request_source.unwrap_or(-2));
+        if proxy {
+            return Ok(request_header.proxy_forward_client_id.clone());
+        }
+        let consumer_group_info = self
+            .context
+            .consumers()
+            .get_consumer_group_info(request_header.consumer_group.as_ref());
+        if !is_broadcast(false, consumer_group_info.as_ref()) {
+            return Ok(None);
+        }
+        resolve_normal_client()
+    }
+
+    fn legacy_broadcast_client_id(&self, consumer_group: &CheetahString, channel: &Channel) -> Option<CheetahString> {
+        self.context
+            .consumers()
+            .get_consumer_group_info(consumer_group.as_ref())?
+            .find_channel_by_channel(channel)
+            .map(|info| info.client_id().clone())
     }
 
     pub fn execute_request_when_wakeup(
@@ -1236,6 +1385,10 @@ fn legacy_pull_delivery_response(
         }
     }
 }
+
+#[cfg(test)]
+#[path = "pull_message_processor/resume_store_tests.rs"]
+mod resume_store_tests;
 
 #[cfg(test)]
 mod tests {

--- a/rocketmq-broker/src/processor/pull_message_processor/capability.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor/capability.rs
@@ -18,10 +18,17 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::Weak;
 
+#[cfg(test)]
+use std::any::Any;
+#[cfg(test)]
+use tokio::sync::Notify;
+
 use crate::config::broker_config::BrokerConfig;
 use arc_swap::ArcSwap;
 use cheetah_string::CheetahString;
 use rocketmq_model::common::broker::broker_role::BrokerRole;
+#[cfg(test)]
+use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_store::ArcMessageFilter;
@@ -29,6 +36,10 @@ use rocketmq_store::BrokerReadStore;
 use rocketmq_store::BrokerStatsManager;
 use rocketmq_store::GetMessageResult;
 use rocketmq_store::MessageStoreConfig;
+#[cfg(test)]
+use rocketmq_store::PutMessageResult;
+#[cfg(test)]
+use rocketmq_store::StorePorts;
 use rocketmq_transport::api::v1::RpcClientImpl;
 
 use crate::broker::broker_pre_online_capability::BrokerOnlineRoleState;
@@ -170,6 +181,8 @@ trait PullMessageStorePort: Send + Sync {
         max_msg_bytes: i32,
         message_filter: ArcMessageFilter,
     ) -> Pin<Box<dyn Future<Output = Result<Option<GetMessageResult>, MessageStoreUnavailable>> + Send + 'a>>;
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn Any;
     #[cfg(feature = "local_file_store")]
     fn is_message_in_cold_area(
         &self,
@@ -214,6 +227,11 @@ impl<MS: BrokerReadStore> PullMessageStorePort for EscapeBridge<MS> {
         ))
     }
 
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     #[cfg(feature = "local_file_store")]
     fn is_message_in_cold_area(
         &self,
@@ -229,6 +247,32 @@ impl<MS: BrokerReadStore> PullMessageStorePort for EscapeBridge<MS> {
 /// Non-owning access to the local Store operations used by pull paths.
 pub(crate) struct PullMessageStoreCapability {
     provider: Weak<dyn PullMessageStorePort>,
+    #[cfg(test)]
+    read_barrier: OnceLock<Arc<PullStoreReadBarrier>>,
+}
+
+#[cfg(test)]
+pub(crate) struct PullStoreReadBarrier {
+    entered: Notify,
+    release: Notify,
+}
+
+#[cfg(test)]
+impl PullStoreReadBarrier {
+    pub(crate) fn new() -> Self {
+        Self {
+            entered: Notify::new(),
+            release: Notify::new(),
+        }
+    }
+
+    pub(crate) async fn wait_until_entered(&self) {
+        self.entered.notified().await;
+    }
+
+    pub(crate) fn release(&self) {
+        self.release.notify_one();
+    }
 }
 
 impl PullMessageStoreCapability {
@@ -236,6 +280,8 @@ impl PullMessageStoreCapability {
         let provider: Arc<dyn PullMessageStorePort> = provider.clone();
         Self {
             provider: Arc::downgrade(&provider),
+            #[cfg(test)]
+            read_barrier: std::sync::OnceLock::new(),
         }
     }
 
@@ -265,6 +311,11 @@ impl PullMessageStoreCapability {
         max_msg_bytes: i32,
         message_filter: ArcMessageFilter,
     ) -> Result<Option<GetMessageResult>, MessageStoreUnavailable> {
+        #[cfg(test)]
+        if let Some(barrier) = self.read_barrier.get() {
+            barrier.entered.notify_one();
+            barrier.release.notified().await;
+        }
         self.provider()?
             .get_message(
                 group,
@@ -276,6 +327,24 @@ impl PullMessageStoreCapability {
                 message_filter,
             )
             .await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_read_barrier_for_test(&self, barrier: Arc<PullStoreReadBarrier>) -> bool {
+        self.read_barrier.set(barrier).is_ok()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn put_message_for_test(
+        &self,
+        message: MessageExtBrokerInner,
+    ) -> Result<PutMessageResult, MessageStoreUnavailable> {
+        let provider = self.provider()?;
+        let bridge = provider
+            .as_any()
+            .downcast_ref::<EscapeBridge<StorePorts>>()
+            .ok_or(MessageStoreUnavailable)?;
+        bridge.put_message_to_local_store(message).await
     }
 
     #[cfg(feature = "local_file_store")]
@@ -523,7 +592,10 @@ mod tests {
     #[test]
     fn pull_store_capability_fails_closed_without_provider() {
         let provider: Weak<dyn PullMessageStorePort> = Weak::<EscapeBridge<StorePorts>>::new();
-        let capability = PullMessageStoreCapability { provider };
+        let capability = PullMessageStoreCapability {
+            provider,
+            read_barrier: std::sync::OnceLock::new(),
+        };
 
         assert!(capability
             .max_offset(&CheetahString::from_static_str("topic"), 0)

--- a/rocketmq-broker/src/processor/pull_message_processor/resume.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor/resume.rs
@@ -1,0 +1,93 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_store::BrokerReadStore;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::ResponsePlan;
+
+use super::PullMessageProcessor;
+use crate::long_polling::pull_deferred::PullHookMetadata;
+use crate::long_polling::pull_deferred::ResumePull;
+use crate::processor::pull_message_result_handler::PullBroadcastClientResolver;
+use crate::processor::pull_message_result_handler::PullMessageResult;
+
+#[derive(Debug, thiserror::Error)]
+enum PullResumeError {
+    #[error("a resumed Pull unexpectedly requested legacy suspension")]
+    UnexpectedSuspension,
+}
+
+impl<MS> PullMessageProcessor<MS>
+where
+    MS: BrokerReadStore,
+{
+    /// Re-runs the canonical Pull business path for an already-claimed deferred request.
+    #[allow(dead_code, reason = "called by the forthcoming V2 Pull leaf")]
+    pub(crate) async fn resume_pull(
+        &self,
+        resume: ResumePull,
+        reason: DeferredWakeReason,
+    ) -> RocketMQResult<ResponsePlan> {
+        let (request, criteria, _wait_deadline) = resume.into_parts();
+        drop(criteria);
+        let (request_code, header, effective_peer, session_id, hook_metadata) = request.into_parts();
+        let broadcast_client_resolver =
+            |header: &PullMessageRequestHeader| self.resolve_session_broadcast_client_id(header, session_id);
+        self.resume_pull_parts(
+            request_code,
+            header,
+            effective_peer,
+            &hook_metadata,
+            &broadcast_client_resolver,
+            reason,
+        )
+        .await
+    }
+
+    pub(super) async fn resume_pull_parts(
+        &self,
+        request_code: RequestCode,
+        header: PullMessageRequestHeader,
+        effective_peer: std::net::SocketAddr,
+        hook_metadata: &PullHookMetadata,
+        broadcast_client_resolver: &PullBroadcastClientResolver<'_>,
+        reason: DeferredWakeReason,
+    ) -> RocketMQResult<ResponsePlan> {
+        match reason {
+            DeferredWakeReason::MessageArrived | DeferredWakeReason::Timeout | DeferredWakeReason::ForcedRefresh => {}
+        }
+        match self
+            .execute_pull(
+                request_code,
+                header,
+                effective_peer,
+                hook_metadata,
+                broadcast_client_resolver,
+                false,
+                None,
+            )
+            .await?
+        {
+            PullMessageResult::Reply(parts) => parts.into_response_plan(),
+            PullMessageResult::Suspend(_) => Err(RocketMQError::internal(
+                "resume-pull",
+                PullResumeError::UnexpectedSuspension,
+            )),
+        }
+    }
+}

--- a/rocketmq-broker/src/processor/pull_message_processor/resume_store_tests.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor/resume_store_tests.rs
@@ -1,0 +1,398 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_model::common::filter::expression_type::ExpressionType;
+use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_model::common::message::MessageTrait;
+use rocketmq_model::common::sys_flag::pull_sys_flag::PullSysFlag;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::common::message::message_decoder::message_properties_to_string;
+use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType;
+use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::request_source::RequestSource;
+use rocketmq_protocol::protocol::LanguageCode;
+use rocketmq_store::MessageStoreConfig;
+use rocketmq_store::PutMessageStatus;
+use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::ResponseBodyKind;
+use rocketmq_transport::test_support::Connection;
+use rocketmq_transport::test_support::TestChannelBuilder;
+
+use super::PullMessageProcessor;
+use crate::broker_runtime::BrokerMessageStore;
+use crate::broker_runtime::BrokerRuntime;
+use crate::client::client_channel_info::ClientChannelInfo;
+use crate::config::broker_config::BrokerConfig;
+use crate::long_polling::long_polling_service::pull_request_hold_service::PullRequestHoldService;
+use crate::long_polling::pull_deferred::PullHookMetadata;
+use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
+use crate::processor::pull_message_processor::capability::PullMessageProcessorContext;
+use crate::processor::pull_message_processor::capability::PullStoreReadBarrier;
+
+fn temp_test_root(label: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("rocketmq-rust-pull-resume-{}-{label}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path).expect("create Pull resume test root");
+    path
+}
+
+fn available_ha_port() -> usize {
+    std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .expect("reserve an ephemeral Pull resume HA port")
+        .local_addr()
+        .expect("read the ephemeral Pull resume HA port")
+        .port() as usize
+}
+
+async fn runtime(label: &str) -> (BrokerRuntime, PathBuf) {
+    let root = temp_test_root(label);
+    let broker_config = Arc::new(BrokerConfig {
+        store_path_root_dir: root.to_string_lossy().into_owned().into(),
+        auth_config_path: root.join("auth.json").to_string_lossy().into_owned().into(),
+        enable_broadcast_offset_store: true,
+        ..BrokerConfig::default()
+    });
+    let message_store_config = Arc::new(MessageStoreConfig {
+        store_path_root_dir: root.to_string_lossy().into_owned().into(),
+        ha_listen_port: available_ha_port(),
+        ..MessageStoreConfig::default()
+    });
+    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    runtime.initialize().await.expect("initialize Pull resume runtime");
+    runtime.seed_pop_topic_and_group_for_test("topic-a", "group-a");
+    runtime
+        .start_message_store_for_test()
+        .await
+        .expect("start Pull resume message store");
+    (runtime, root)
+}
+
+fn processor(
+    context: Arc<PullMessageProcessorContext<BrokerMessageStore>>,
+) -> Arc<PullMessageProcessor<BrokerMessageStore>> {
+    let handler = Arc::new(DefaultPullMessageResultHandler::new(
+        Arc::new(Vec::new()),
+        Arc::clone(&context),
+        None,
+    ));
+    Arc::new(PullMessageProcessor::new(handler, context))
+}
+
+fn request_header(queue_offset: i64, suspend: bool) -> PullMessageRequestHeader {
+    PullMessageRequestHeader {
+        consumer_group: CheetahString::from_static_str("group-a"),
+        topic: CheetahString::from_static_str("topic-a"),
+        queue_id: 0,
+        queue_offset,
+        max_msg_nums: 1,
+        sys_flag: PullSysFlag::build_sys_flag(false, suspend, true, false) as i32,
+        commit_offset: 0,
+        suspend_timeout_millis: 60_000,
+        sub_version: 1,
+        subscription: Some(CheetahString::from_static_str("*")),
+        expression_type: Some(CheetahString::from_static_str(ExpressionType::TAG)),
+        ..PullMessageRequestHeader::default()
+    }
+}
+
+fn stored_message() -> MessageExtBrokerInner {
+    let mut message = MessageExtBrokerInner::default();
+    message.set_topic(CheetahString::from_static_str("topic-a"));
+    message.message_ext_inner.set_queue_id(0);
+    message.set_body(Bytes::from_static(b"deferred-pull-message"));
+    message.set_wait_store_msg_ok(false);
+    message.properties_string = message_properties_to_string(message.get_properties());
+    message
+}
+
+async fn test_channel() -> Channel {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind Pull V1 listener");
+    let server_addr = listener.local_addr().expect("Pull V1 listener address");
+    let accept = tokio::spawn(async move { listener.accept().await.expect("accept Pull V1 stream").0 });
+    let stream = tokio::net::TcpStream::connect(server_addr)
+        .await
+        .expect("connect Pull V1 stream");
+    let local_addr = stream.local_addr().expect("Pull V1 local address");
+    let remote_addr = stream.peer_addr().expect("Pull V1 remote address");
+    let peer = accept.await.expect("join Pull V1 accept task");
+    drop(peer);
+    TestChannelBuilder::new(
+        Connection::new(stream),
+        crate::test_task_group("pull-v1-suspension-channel"),
+    )
+    .addresses(local_addr, remote_addr)
+    .build()
+    .expect("build Pull V1 channel")
+}
+
+#[tokio::test]
+async fn real_store_core_rereads_for_each_wake_reason_and_v1_suspension_stays_none() {
+    let (mut runtime, root) = runtime("real-store-v1-parity").await;
+    let context = runtime.pull_message_context_for_test();
+    let processor = processor(Arc::clone(&context));
+    let hold = Arc::new(PullRequestHoldService::new(Arc::downgrade(&processor)));
+    assert!(context.install_pull_request_hold_service(Arc::clone(&hold)));
+
+    let channel = test_channel().await;
+    let ctx = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+    let mut fallback_request =
+        RemotingCommand::create_request_command(RequestCode::PullMessage, request_header(0, true)).set_opaque(731);
+    fallback_request.make_custom_header_to_net();
+    let fallback = processor
+        .process_request_shared(channel.clone(), Arc::clone(&ctx), &mut fallback_request)
+        .await
+        .expect("empty V1 Pull before hold-service start")
+        .expect("inactive V1 hold service must return the PullNotFound fallback");
+    assert_eq!(fallback.code(), ResponseCode::PullNotFound as i32);
+    assert_eq!(fallback.opaque(), 731);
+    assert!(fallback.body().is_none());
+
+    PullRequestHoldService::start(&hold, crate::test_task_group("pull-v1-suspension-hold")).await;
+    let mut suspended_request =
+        RemotingCommand::create_request_command(RequestCode::PullMessage, request_header(0, true)).set_opaque(732);
+    suspended_request.make_custom_header_to_net();
+    let suspended = processor
+        .process_request_shared(channel, ctx, &mut suspended_request)
+        .await
+        .expect("empty V1 Pull with active hold service");
+    assert!(suspended.is_none(), "legacy admitted suspension must remain Ok(None)");
+    hold.shutdown().await;
+
+    let hook_metadata = PullHookMetadata::default();
+    let effective_peer = "127.0.0.1:19001".parse().expect("Pull effective peer");
+    let no_broadcast_client = |_header: &PullMessageRequestHeader| Ok(None);
+    let empty = processor
+        .resume_pull_parts(
+            RequestCode::PullMessage,
+            request_header(0, false),
+            effective_peer,
+            &hook_metadata,
+            &no_broadcast_client,
+            DeferredWakeReason::Timeout,
+        )
+        .await
+        .expect("empty Pull timeout reread");
+    assert_eq!(empty.response_code(), ResponseCode::PullNotFound as i32);
+    assert_eq!(empty.body_kind(), ResponseBodyKind::Empty);
+    assert_eq!(empty.body_len(), 0);
+    drop(empty);
+
+    let put = context
+        .store()
+        .put_message_for_test(stored_message())
+        .await
+        .expect("append Pull resume message");
+    assert_eq!(put.put_message_status(), PutMessageStatus::PutOk);
+    runtime.reput_message_store_once_for_test().await;
+
+    let found = processor
+        .resume_pull_parts(
+            RequestCode::PullMessage,
+            request_header(0, false),
+            effective_peer,
+            &hook_metadata,
+            &no_broadcast_client,
+            DeferredWakeReason::MessageArrived,
+        )
+        .await
+        .expect("message-arrived Pull reread");
+    assert_eq!(found.response_code(), ResponseCode::Success as i32);
+    assert_ne!(found.body_kind(), ResponseBodyKind::Empty);
+    assert!(found.body_len() > 0);
+    drop(found);
+
+    let forced = processor
+        .resume_pull_parts(
+            RequestCode::PullMessage,
+            request_header(1, false),
+            effective_peer,
+            &hook_metadata,
+            &no_broadcast_client,
+            DeferredWakeReason::ForcedRefresh,
+        )
+        .await
+        .expect("forced-refresh Pull reread");
+    assert_eq!(forced.response_code(), ResponseCode::PullNotFound as i32);
+    assert_eq!(forced.body_kind(), ResponseBodyKind::Empty);
+    drop(forced);
+
+    runtime.shutdown_message_store_for_test().await;
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn broadcast_client_resolution_requires_normal_session_lookup_and_proxy_bypasses_it() {
+    let (mut runtime, root) = runtime("broadcast-client-resolution").await;
+    let context = runtime.pull_message_context_for_test();
+    let processor = processor(Arc::clone(&context));
+    let channel = test_channel().await;
+    context.consumers().register_consumer_without_sub(
+        &CheetahString::from_static_str("group-a"),
+        ClientChannelInfo::new(
+            channel,
+            CheetahString::from_static_str("registered-client"),
+            LanguageCode::JAVA,
+            1,
+        ),
+        ConsumeType::ConsumePassively,
+        MessageModel::Broadcasting,
+        ConsumeFromWhere::ConsumeFromLastOffset,
+        false,
+    );
+
+    let normal = request_header(0, false);
+    let lookup = RwLock::new(Some(CheetahString::from_static_str("session-client")));
+    let calls = AtomicUsize::new(0);
+    let resolve_current = || {
+        calls.fetch_add(1, Ordering::SeqCst);
+        lookup
+            .read()
+            .expect("session client test lock")
+            .clone()
+            .map(Some)
+            .ok_or_else(|| {
+                rocketmq_error::RocketMQError::invariant_violated("current Pull session registration is missing")
+            })
+    };
+    let present = processor
+        .resolve_broadcast_client_id_with(&normal, resolve_current)
+        .expect("normal broadcast client lookup");
+    assert_eq!(present.as_deref(), Some("session-client"));
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    *lookup.write().expect("session client test lock") = None;
+    let missing = processor.resolve_broadcast_client_id_with(&normal, resolve_current);
+    assert!(
+        missing.is_err(),
+        "normal broadcast must fail closed when session lookup misses"
+    );
+
+    *lookup.write().expect("session client test lock") = Some(CheetahString::from_static_str("replacement-client"));
+    let replacement = processor
+        .resolve_broadcast_client_id_with(&normal, resolve_current)
+        .expect("replacement session registration");
+    assert_eq!(replacement.as_deref(), Some("replacement-client"));
+
+    let mut proxy = request_header(0, false);
+    proxy.request_source = Some(RequestSource::ProxyForBroadcast.get_value());
+    proxy.proxy_forward_client_id = Some(CheetahString::from_static_str("forwarded-client"));
+    let forwarded = processor
+        .resolve_broadcast_client_id_with(&proxy, resolve_current)
+        .expect("proxy broadcast client id");
+    assert_eq!(forwarded.as_deref(), Some("forwarded-client"));
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+
+    runtime.shutdown_message_store_for_test().await;
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn v1_broadcast_reresolves_client_after_store_await_before_offset_update() {
+    let (mut runtime, root) = runtime("broadcast-reregister-during-store").await;
+    let context = runtime.pull_message_context_for_test();
+    let processor = processor(Arc::clone(&context));
+
+    for _ in 0..2 {
+        let put = context
+            .store()
+            .put_message_for_test(stored_message())
+            .await
+            .expect("append broadcast Pull message");
+        assert_eq!(put.put_message_status(), PutMessageStatus::PutOk);
+    }
+    runtime.reput_message_store_once_for_test().await;
+
+    let channel = test_channel().await;
+    let old_registration = ClientChannelInfo::new(
+        channel.clone(),
+        CheetahString::from_static_str("old-client"),
+        LanguageCode::JAVA,
+        1,
+    );
+    context.consumers().register_consumer_without_sub(
+        &CheetahString::from_static_str("group-a"),
+        old_registration.clone(),
+        ConsumeType::ConsumePassively,
+        MessageModel::Broadcasting,
+        ConsumeFromWhere::ConsumeFromLastOffset,
+        false,
+    );
+    context.update_broadcast_offset("topic-a", "group-a", 0, 0, "old-client", false);
+
+    let barrier = Arc::new(PullStoreReadBarrier::new());
+    assert!(context.store().install_read_barrier_for_test(Arc::clone(&barrier)));
+    let ctx = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+    let mut request =
+        RemotingCommand::create_request_command(RequestCode::PullMessage, request_header(1, false)).set_opaque(913);
+    request.make_custom_header_to_net();
+    let request_task = {
+        let processor = Arc::clone(&processor);
+        let channel = channel.clone();
+        tokio::spawn(async move { processor.process_request_shared(channel, ctx, &mut request).await })
+    };
+
+    barrier.wait_until_entered().await;
+    context
+        .consumers()
+        .unregister_consumer("group-a", &old_registration, false);
+    context.consumers().register_consumer_without_sub(
+        &CheetahString::from_static_str("group-a"),
+        ClientChannelInfo::new(
+            channel,
+            CheetahString::from_static_str("new-client"),
+            LanguageCode::JAVA,
+            1,
+        ),
+        ConsumeType::ConsumePassively,
+        MessageModel::Broadcasting,
+        ConsumeFromWhere::ConsumeFromLastOffset,
+        false,
+    );
+    barrier.release();
+
+    request_task
+        .await
+        .expect("join broadcast Pull request")
+        .expect("broadcast Pull request after re-registration");
+    let new_client_offset = context.query_broadcast_offset("topic-a", "group-a", 0, "new-client", -1, true);
+    let old_client_offset = context.query_broadcast_offset("topic-a", "group-a", 0, "old-client", -1, true);
+    assert_eq!(
+        new_client_offset, 1,
+        "the current registration owns the post-store update"
+    );
+    assert_eq!(
+        old_client_offset, 0,
+        "the stale registration must not receive the post-store update"
+    );
+
+    runtime.shutdown_message_store_for_test().await;
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/rocketmq-broker/src/processor/pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/pull_message_result_handler.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::net::SocketAddr;
 
+use cheetah_string::CheetahString;
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
@@ -21,17 +23,38 @@ use rocketmq_protocol::protocol::static_topic::topic_queue_mapping_context::Topi
 use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use rocketmq_store::ArcMessageFilter;
 use rocketmq_store::GetMessageResult;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
+use crate::long_polling::pull_deferred::PullHookMetadata;
+use crate::long_polling::pull_deferred::PullSuspendTiming;
 use crate::processor::response_plan::BrokerResponseParts;
+
+pub(crate) type PullBroadcastClientResolver<'a> =
+    dyn Fn(&PullMessageRequestHeader) -> rocketmq_error::RocketMQResult<Option<CheetahString>> + Send + Sync + 'a;
+
+/// Channel-free facts required to compose one Pull response.
+pub(crate) struct PullResponseContext<'a> {
+    pub(crate) effective_peer: SocketAddr,
+    pub(crate) hook_metadata: &'a PullHookMetadata,
+    pub(crate) broadcast_client_resolver: &'a PullBroadcastClientResolver<'a>,
+    pub(crate) allow_legacy_suspend: bool,
+    pub(crate) begin_time_millis: u64,
+}
+
+/// Affine data returned to the V1 wrapper when the existing hold service owns the request.
+pub(crate) struct PullSuspension {
+    pub(crate) timing: PullSuspendTiming,
+    pub(crate) request_header: PullMessageRequestHeader,
+    pub(crate) subscription_data: SubscriptionData,
+    pub(crate) message_filter: ArcMessageFilter,
+    pub(crate) fallback: BrokerResponseParts,
+}
 
 /// The explicit outcome of composing a Pull response.
 pub(crate) enum PullMessageResult {
     /// An immediate response whose head and affine body are ready for delivery.
     Reply(BrokerResponseParts),
     /// The request was admitted to the existing long-poll owner.
-    Suspended,
+    Suspend(Box<PullSuspension>),
 }
 
 /// Trait defining the behavior for handling the result of a pull message request.
@@ -71,17 +94,13 @@ pub(crate) trait PullMessageResultHandler: Sync + Send + Any + 'static {
     async fn handle(
         &self,
         get_message_result: GetMessageResult,
-        request: &mut RemotingCommand,
         request_header: PullMessageRequestHeader,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
         subscription_data: SubscriptionData,
         subscription_group_config: &SubscriptionGroupConfig,
-        broker_allow_suspend: bool,
         message_filter: ArcMessageFilter,
         response: RemotingCommand,
         mapping_context: TopicQueueMappingContext,
-        begin_time_mills: u64,
+        response_context: PullResponseContext<'_>,
     ) -> rocketmq_error::RocketMQResult<PullMessageResult>;
 
     /// Returns a mutable reference to `self` as a trait object of type `Any`.


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9831

### Brief Description

- Add broker-private Pull deferred request data, exact suspend-time deadlines, checked retained admission, a bounded criteria index, affine registration/claim ownership, and registry-backed resume lifecycle handling.
- Extract one Channel-free typed Pull execution path shared by legacy V1 and future V2 resume processing while preserving V1 suspension, opaque, response-body ownership, static-topic, hook, offset, and broadcast semantics.
- Resolve broadcast client identity at each use so V1 registration changes during an asynchronous store read and V2 session lookups remain current; proxy broadcast continues to use only the forwarded client identity.
- Add real store, dispatcher/TCP, pending-wake, race, capacity, deadline, shutdown, session-close, owner-backed response, and compatibility coverage without changing the production V1 waiter, listener, route, or Transport API.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check`
- `cargo test -p rocketmq-broker --all-features pull_deferred --lib` (24 passed, 1 Windows-only partial-write case ignored because loopback accepts the maximum legal frame before user-space can inject RST; the Unix test remains active and a Windows session-close lifecycle test passed)
- `cargo test -p rocketmq-broker --all-features pull_message_processor::resume_store_tests --lib` (3 passed)
- `cargo test -p rocketmq-broker --all-features static_topic_ --lib` (11 passed)
- `cargo test -p rocketmq-broker --all-features default_pull_message_result_handler::tests --lib` (4 passed)
- `cargo test -p rocketmq-broker --all-features get_subscription_data_ --lib` (4 passed)
- Three focused `rocketmq-transport` partial-write classification tests (3 passed)
- `cargo clippy -p rocketmq-broker --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo +nightly-2026-07-05 check --manifest-path fuzz/Cargo.toml --locked --all-targets --all-features`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deferred long-polling support for pull requests.
  * Pull requests can resume after message arrival, timeout, or forced refresh while preserving request context.
  * Added matching by topic, queue, offset, tags, filters, and properties.
  * Added admission controls for pending requests and retained response data.

* **Bug Fixes**
  * Improved cleanup when registrations roll back, sessions close, or the broker shuts down.
  * Prevented duplicate responses and retries after failed or interrupted deliveries.

* **Tests**
  * Added comprehensive coverage for concurrency, lifecycle, timeout, capacity, and session-close scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->