### PR TITLE
[ISSUE #9833]🚀Introduce registry-backed Notification and PopLite deferred infrastructure

### DIFF
--- a/rocketmq-broker/src/lite/lite_event_dispatcher.rs
+++ b/rocketmq-broker/src/lite/lite_event_dispatcher.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -34,6 +35,16 @@ use rocketmq_runtime::ResourceBudgetTree;
 use rocketmq_runtime::ResourcePermit;
 use tokio::sync::Notify;
 
+pub(crate) use self::reservation::LiteEventBatch;
+pub(crate) use self::reservation::LiteEventBatchExecution;
+pub(crate) use self::reservation::LiteEventBatchReservation;
+pub(crate) use self::reservation::LiteEventBatchTerminal;
+use self::reservation::LiteEventReservationMetrics;
+pub(crate) use self::reservation::LiteEventReservationSnapshot;
+use self::reservation::ReservedEventBatch;
+
+mod reservation;
+
 const DEFAULT_CLIENT_EVENT_LIMIT: usize = 10_000;
 const DEFAULT_EVENT_MEMORY_BYTES: usize = 16 * 1024 * 1024;
 const MAX_EVENT_AGE: Duration = Duration::from_secs(30);
@@ -51,9 +62,12 @@ struct ClientEventState {
     group: CheetahString,
     events: VecDeque<CheetahString>,
     event_set: HashSet<CheetahString>,
+    committed_events: HashSet<CheetahString>,
+    committed_redispatches: HashSet<CheetahString>,
     permits: HashMap<CheetahString, Arc<ResourcePermit>>,
     enqueued_at: HashMap<CheetahString, Duration>,
     max_event_count: usize,
+    reserved: Option<ReservedEventBatch>,
 }
 
 impl Default for ClientEventState {
@@ -62,9 +76,12 @@ impl Default for ClientEventState {
             group: CheetahString::new(),
             events: VecDeque::new(),
             event_set: HashSet::new(),
+            committed_events: HashSet::new(),
+            committed_redispatches: HashSet::new(),
             permits: HashMap::new(),
             enqueued_at: HashMap::new(),
             max_event_count: DEFAULT_CLIENT_EVENT_LIMIT,
+            reserved: None,
         }
     }
 }
@@ -78,7 +95,7 @@ impl ClientEventState {
         if self.event_set.contains(&event) {
             return true;
         }
-        if self.events.len() >= self.max_event_count {
+        if self.event_set.len() >= self.max_event_count {
             return false;
         }
         self.event_set.insert(event.clone());
@@ -88,20 +105,19 @@ impl ClientEventState {
         true
     }
 
-    fn drain(&mut self) -> Vec<CheetahString> {
-        let drained = self.events.drain(..).collect::<Vec<_>>();
-        self.event_set.clear();
-        self.permits.clear();
-        self.enqueued_at.clear();
-        drained
-    }
-
     fn pending_events(&self) -> Vec<CheetahString> {
         self.events.iter().cloned().collect()
     }
 
     fn is_empty(&self) -> bool {
         self.events.is_empty()
+    }
+
+    fn is_fully_empty(&self) -> bool {
+        self.events.is_empty()
+            && self.reserved.is_none()
+            && self.committed_events.is_empty()
+            && self.committed_redispatches.is_empty()
     }
 
     fn drop_stale(&mut self, now: Duration, max_age: Duration) -> usize {
@@ -184,6 +200,8 @@ pub(crate) struct LiteEventDispatcher {
     wakeup_notify: Arc<Mutex<Option<Arc<Notify>>>>,
     event_budget: ResourceBudget,
     client_access_budget: ResourceBudget,
+    next_reservation_id: Arc<AtomicU64>,
+    reservation_metrics: Arc<LiteEventReservationMetrics>,
 }
 
 impl Default for LiteEventDispatcher {
@@ -240,6 +258,8 @@ impl LiteEventDispatcher {
             wakeup_notify: Arc::new(Mutex::new(None)),
             event_budget,
             client_access_budget,
+            next_reservation_id: Arc::new(AtomicU64::new(1)),
+            reservation_metrics: Arc::new(LiteEventReservationMetrics::default()),
         })
     }
 
@@ -346,6 +366,9 @@ impl LiteEventDispatcher {
             let original_len = entry.events.len();
             for lmq_name in ordered_lmq_names {
                 if entry.event_set.contains(&lmq_name) || deferred_snapshot.contains(&lmq_name) {
+                    if entry.committed_events.contains(&lmq_name) {
+                        entry.committed_redispatches.insert(lmq_name);
+                    }
                     self.event_budget.record_coalesced(1);
                     continue;
                 }
@@ -425,16 +448,13 @@ impl LiteEventDispatcher {
     }
 
     pub(crate) fn take_pending_events(&self, client_id: &CheetahString) -> Vec<CheetahString> {
-        let now = current_millis();
-        self.scan(now);
-        self.touch_client(client_id);
-
-        let mut drained = self.drain_client_events(client_id);
-        if self.promote_deferred_events(client_id, now, true) > 0 {
-            drained.extend(self.drain_client_events(client_id));
-        }
-        self.cleanup_client_state(client_id);
-        drained
+        let Some(reservation) = self.reserve_pending_events(client_id) else {
+            return Vec::new();
+        };
+        let batch = reservation.commit();
+        let events = batch.event_names();
+        batch.complete(&HashSet::new());
+        events
     }
 
     fn scan(&self, now: u64) {
@@ -475,11 +495,12 @@ impl LiteEventDispatcher {
         let empty_clients = self
             .client_events
             .iter()
-            .filter(|entry| entry.is_empty() && !self.deferred_dispatches.contains_key(entry.key()))
+            .filter(|entry| entry.is_fully_empty() && !self.deferred_dispatches.contains_key(entry.key()))
             .map(|entry| entry.key().clone())
             .collect::<Vec<_>>();
         for client_id in empty_clients {
-            self.client_events.remove_if(&client_id, |_, state| state.is_empty());
+            self.client_events
+                .remove_if(&client_id, |_, state| state.is_fully_empty());
         }
         if dropped > 0 {
             self.event_budget.record_dropped(dropped);
@@ -510,13 +531,6 @@ impl LiteEventDispatcher {
         self.client_access_budget.record_dropped(removed);
     }
 
-    fn drain_client_events(&self, client_id: &CheetahString) -> Vec<CheetahString> {
-        self.client_events
-            .get_mut(client_id)
-            .map(|mut entry| entry.drain())
-            .unwrap_or_default()
-    }
-
     fn promote_deferred_events(&self, client_id: &CheetahString, now: u64, force: bool) -> usize {
         let Some(mut state) = self.deferred_dispatches.get_mut(client_id) else {
             return 0;
@@ -533,6 +547,9 @@ impl LiteEventDispatcher {
             let candidates = state.events.iter().cloned().collect::<Vec<_>>();
             for lmq_name in candidates {
                 if entry.event_set.contains(&lmq_name) {
+                    if entry.committed_events.contains(&lmq_name) {
+                        entry.committed_redispatches.insert(lmq_name.clone());
+                    }
                     state.events.remove(&lmq_name);
                     state.permits.remove(&lmq_name);
                     state.enqueued_at.remove(&lmq_name);
@@ -597,11 +614,14 @@ impl LiteEventDispatcher {
         let mut retained = 0;
         let mut coalesced = 0;
         for (lmq_name, permit) in lmq_names {
-            let already_pending = entry.events.contains(lmq_name)
-                || self
-                    .client_events
-                    .get(client_id)
-                    .is_some_and(|state| state.event_set.contains(lmq_name));
+            let pending_in_client = self.client_events.get_mut(client_id).is_some_and(|mut state| {
+                let pending = state.event_set.contains(lmq_name);
+                if pending && state.committed_events.contains(lmq_name) {
+                    state.committed_redispatches.insert(lmq_name.clone());
+                }
+                pending
+            });
+            let already_pending = entry.events.contains(lmq_name) || pending_in_client;
             if already_pending {
                 coalesced += 1;
                 continue;
@@ -628,9 +648,10 @@ impl LiteEventDispatcher {
         let should_remove = self
             .client_events
             .get(client_id)
-            .is_some_and(|entry| entry.is_empty() && !has_deferred);
+            .is_some_and(|entry| entry.is_fully_empty() && !has_deferred);
         if should_remove {
-            self.client_events.remove_if(client_id, |_, state| state.is_empty());
+            self.client_events
+                .remove_if(client_id, |_, state| state.is_fully_empty());
         }
     }
 

--- a/rocketmq-broker/src/lite/lite_event_dispatcher/reservation.rs
+++ b/rocketmq-broker/src/lite/lite_event_dispatcher/reservation.rs
@@ -1,0 +1,562 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::collections::VecDeque;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::ResourcePermit;
+
+use super::event_retained_bytes;
+use super::ClientEventState;
+use super::LiteEventDispatcher;
+use super::DEFAULT_CLIENT_EVENT_LIMIT;
+
+#[derive(Debug)]
+pub(super) struct LiteEventRecord {
+    event: CheetahString,
+    permit: Arc<ResourcePermit>,
+    enqueued_at: Duration,
+}
+
+#[derive(Debug)]
+pub(super) struct ReservedEventBatch {
+    id: u64,
+    group: CheetahString,
+    records: VecDeque<LiteEventRecord>,
+}
+
+#[derive(Default)]
+pub(super) struct LiteEventReservationMetrics {
+    batches: AtomicUsize,
+    events: AtomicUsize,
+    retained_bytes: AtomicUsize,
+}
+
+/// Low-cardinality ownership snapshot for in-flight Lite event batches.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct LiteEventReservationSnapshot {
+    pub(crate) batches: usize,
+    pub(crate) events: usize,
+    pub(crate) permits: usize,
+    pub(crate) retained_bytes: usize,
+}
+
+struct LiteEventReservationObservation {
+    metrics: Arc<LiteEventReservationMetrics>,
+    events: usize,
+    retained_bytes: usize,
+}
+
+impl LiteEventReservationObservation {
+    fn new(metrics: Arc<LiteEventReservationMetrics>, records: &VecDeque<LiteEventRecord>) -> Self {
+        let events = records.len();
+        let retained_bytes = records.iter().fold(0usize, |total, record| {
+            total.saturating_add(event_retained_bytes(&record.event))
+        });
+        metrics.batches.fetch_add(1, Ordering::AcqRel);
+        metrics.events.fetch_add(events, Ordering::AcqRel);
+        metrics.retained_bytes.fetch_add(retained_bytes, Ordering::AcqRel);
+        Self {
+            metrics,
+            events,
+            retained_bytes,
+        }
+    }
+}
+
+impl Drop for LiteEventReservationObservation {
+    fn drop(&mut self) {
+        self.metrics.batches.fetch_sub(1, Ordering::AcqRel);
+        self.metrics.events.fetch_sub(self.events, Ordering::AcqRel);
+        self.metrics
+            .retained_bytes
+            .fetch_sub(self.retained_bytes, Ordering::AcqRel);
+    }
+}
+
+impl ClientEventState {
+    fn reserve(&mut self, id: u64) -> bool {
+        if self.reserved.is_some() || self.events.is_empty() {
+            return false;
+        }
+        let records = self.drain_records();
+        self.reserved = Some(ReservedEventBatch {
+            id,
+            group: self.group.clone(),
+            records,
+        });
+        true
+    }
+
+    fn append_pending_to_reservation(&mut self, id: u64) {
+        if self.events.is_empty() {
+            return;
+        }
+        let records = self.drain_records();
+        let reserved = self
+            .reserved
+            .as_mut()
+            .filter(|reserved| reserved.id == id)
+            .expect("active Lite event reservation remains installed");
+        reserved.records.extend(records);
+    }
+
+    fn drain_records(&mut self) -> VecDeque<LiteEventRecord> {
+        self.events
+            .drain(..)
+            .map(|event| {
+                let permit = self
+                    .permits
+                    .remove(&event)
+                    .expect("queued Lite event owns its resource permit");
+                let enqueued_at = self
+                    .enqueued_at
+                    .remove(&event)
+                    .expect("queued Lite event owns its enqueue timestamp");
+                LiteEventRecord {
+                    event,
+                    permit,
+                    enqueued_at,
+                }
+            })
+            .collect()
+    }
+
+    fn commit(&mut self, id: u64) -> Option<ReservedEventBatch> {
+        if self.reserved.as_ref().is_none_or(|reserved| reserved.id != id) {
+            return None;
+        }
+        let reserved = self.reserved.take()?;
+        for record in &reserved.records {
+            self.committed_events.insert(record.event.clone());
+        }
+        Some(reserved)
+    }
+
+    fn rollback(&mut self, id: u64) -> bool {
+        if self.reserved.as_ref().is_none_or(|reserved| reserved.id != id) {
+            return false;
+        }
+        let reserved = self.reserved.take().expect("matching Lite event reservation exists");
+        let mut restored = VecDeque::with_capacity(reserved.records.len().saturating_add(self.events.len()));
+        for record in reserved.records {
+            self.permits.insert(record.event.clone(), record.permit);
+            self.enqueued_at.insert(record.event.clone(), record.enqueued_at);
+            restored.push_back(record.event);
+        }
+        restored.append(&mut self.events);
+        self.events = restored;
+        true
+    }
+}
+
+impl LiteEventDispatcher {
+    pub(crate) fn reservation_snapshot(&self) -> LiteEventReservationSnapshot {
+        let events = self.reservation_metrics.events.load(Ordering::Acquire);
+        LiteEventReservationSnapshot {
+            batches: self.reservation_metrics.batches.load(Ordering::Acquire),
+            events,
+            permits: events,
+            retained_bytes: self.reservation_metrics.retained_bytes.load(Ordering::Acquire),
+        }
+    }
+
+    /// Reserves the currently consumable batch without releasing its permits.
+    ///
+    /// An uncommitted reservation restores its records ahead of events that
+    /// arrived while the reservation was in flight. Only one reservation may
+    /// exist for a client, so compatibility drains cannot steal a V2 batch.
+    pub(crate) fn reserve_pending_events(&self, client_id: &CheetahString) -> Option<LiteEventBatchReservation> {
+        let now = current_millis();
+        self.scan(now);
+        self.touch_client(client_id);
+        let id = self.next_reservation_id.fetch_add(1, Ordering::AcqRel);
+        if id == 0 {
+            return None;
+        }
+        {
+            let mut entry = self.client_events.get_mut(client_id)?;
+            if entry.reserved.is_some() || !entry.reserve(id) {
+                return None;
+            }
+        }
+        if self.promote_deferred_events(client_id, now, true) > 0 {
+            let mut entry = self
+                .client_events
+                .get_mut(client_id)
+                .expect("reserved Lite event client remains installed");
+            entry.append_pending_to_reservation(id);
+        }
+        let observation = {
+            let entry = self
+                .client_events
+                .get(client_id)
+                .expect("reserved Lite event client remains installed");
+            let records = &entry
+                .reserved
+                .as_ref()
+                .filter(|reserved| reserved.id == id)
+                .expect("new Lite event reservation remains installed")
+                .records;
+            LiteEventReservationObservation::new(Arc::clone(&self.reservation_metrics), records)
+        };
+        Some(LiteEventBatchReservation {
+            dispatcher: self.clone(),
+            client_id: client_id.clone(),
+            id,
+            observation: Some(observation),
+            armed: true,
+        })
+    }
+
+    fn commit_reservation(&self, client_id: &CheetahString, id: u64) -> Option<ReservedEventBatch> {
+        let mut entry = self.client_events.get_mut(client_id)?;
+        entry.commit(id)
+    }
+
+    fn rollback_reservation(&self, client_id: &CheetahString, id: u64) {
+        if let Some(mut entry) = self.client_events.get_mut(client_id) {
+            entry.rollback(id);
+        }
+    }
+
+    fn settle_committed_records(
+        &self,
+        client_id: &CheetahString,
+        group: &CheetahString,
+        mut records: VecDeque<LiteEventRecord>,
+        requeue_events: &HashSet<CheetahString>,
+        max_event_count: usize,
+        _full_dispatch_delay_millis: u64,
+    ) {
+        if records.is_empty() {
+            self.cleanup_client_state(client_id);
+            return;
+        }
+        let mut inserted = 0usize;
+        {
+            let mut entry = self.client_events.entry(client_id.clone()).or_default();
+            if entry.group.is_empty() {
+                entry.group = group.clone();
+            }
+            entry.set_limit(max_event_count);
+            while let Some(record) = records.pop_front() {
+                entry.committed_events.remove(&record.event);
+                let redispatched = entry.committed_redispatches.remove(&record.event);
+                if !redispatched && !requeue_events.contains(&record.event) {
+                    entry.event_set.remove(&record.event);
+                    continue;
+                }
+                // The committed marker retained this event's logical slot and
+                // permit. Converting it back to queued ownership is therefore
+                // an in-place transfer, not a fresh capacity acquisition.
+                entry.events.push_back(record.event.clone());
+                entry.permits.insert(record.event.clone(), record.permit);
+                entry.enqueued_at.insert(record.event, record.enqueued_at);
+                inserted += 1;
+            }
+        }
+        if inserted > 0 {
+            self.notify_client(client_id);
+        }
+        self.cleanup_client_state(client_id);
+    }
+}
+
+/// Affine ownership of a not-yet-consumed Lite event batch.
+///
+/// Dropping this value before `commit` restores the batch in its original
+/// relative order and keeps the original resource permits alive.
+#[must_use]
+pub(crate) struct LiteEventBatchReservation {
+    dispatcher: LiteEventDispatcher,
+    client_id: CheetahString,
+    id: u64,
+    observation: Option<LiteEventReservationObservation>,
+    armed: bool,
+}
+
+impl LiteEventBatchReservation {
+    pub(crate) fn event_count(&self) -> usize {
+        self.dispatcher
+            .client_events
+            .get(&self.client_id)
+            .and_then(|entry| {
+                entry
+                    .reserved
+                    .as_ref()
+                    .filter(|reserved| reserved.id == self.id)
+                    .map(|reserved| reserved.records.len())
+            })
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.observation
+            .as_ref()
+            .map_or(0, |observation| observation.retained_bytes)
+    }
+
+    pub(crate) fn commit(mut self) -> LiteEventBatch {
+        let reserved = self
+            .dispatcher
+            .commit_reservation(&self.client_id, self.id)
+            .expect("armed Lite event reservation remains installed until commit");
+        self.armed = false;
+        LiteEventBatch {
+            dispatcher: self.dispatcher.clone(),
+            client_id: self.client_id.clone(),
+            group: reserved.group,
+            records: reserved.records,
+            observation: self.observation.take(),
+            completed: false,
+        }
+    }
+
+    /// Splits this affine reservation into an execution handle and a terminal owner.
+    ///
+    /// The execution handle may commit and stage a consume/requeue decision, but the
+    /// terminal owner alone settles records and releases their permits. This lets a
+    /// deferred response keep event ownership through canonical socket completion.
+    pub(crate) fn into_terminal_ownership(self) -> (LiteEventBatchExecution, LiteEventBatchTerminal) {
+        let state = Arc::new(Mutex::new(LiteEventBatchTerminalState::Reserved(self)));
+        (
+            LiteEventBatchExecution {
+                state: Arc::clone(&state),
+            },
+            LiteEventBatchTerminal { state: Some(state) },
+        )
+    }
+}
+
+impl Drop for LiteEventBatchReservation {
+    fn drop(&mut self) {
+        if self.armed {
+            self.dispatcher.rollback_reservation(&self.client_id, self.id);
+        }
+    }
+}
+
+/// A committed Lite event batch whose permits remain owned until completion.
+#[must_use]
+pub(crate) struct LiteEventBatch {
+    dispatcher: LiteEventDispatcher,
+    client_id: CheetahString,
+    group: CheetahString,
+    records: VecDeque<LiteEventRecord>,
+    observation: Option<LiteEventReservationObservation>,
+    completed: bool,
+}
+
+impl LiteEventBatch {
+    pub(crate) fn event_names(&self) -> Vec<CheetahString> {
+        self.records.iter().map(|record| record.event.clone()).collect()
+    }
+
+    pub(crate) fn event_count(&self) -> usize {
+        self.records.len()
+    }
+
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.observation
+            .as_ref()
+            .map_or(0, |observation| observation.retained_bytes)
+    }
+
+    /// Completes the batch, consuming unlisted records and transferring the
+    /// original permits for listed records back to the dispatcher.
+    pub(crate) fn complete(self, requeue_events: &HashSet<CheetahString>) {
+        let max_event_count = self
+            .dispatcher
+            .client_events
+            .get(&self.client_id)
+            .map_or(DEFAULT_CLIENT_EVENT_LIMIT, |entry| entry.max_event_count);
+        self.complete_with_limit(requeue_events, max_event_count, 0);
+    }
+
+    pub(crate) fn complete_with_limit(
+        mut self,
+        requeue_events: &HashSet<CheetahString>,
+        max_event_count: usize,
+        full_dispatch_delay_millis: u64,
+    ) {
+        let records = std::mem::take(&mut self.records);
+        self.completed = true;
+        self.dispatcher.settle_committed_records(
+            &self.client_id,
+            &self.group,
+            records,
+            requeue_events,
+            max_event_count,
+            full_dispatch_delay_millis,
+        );
+    }
+}
+
+impl Drop for LiteEventBatch {
+    fn drop(&mut self) {
+        if self.completed || self.records.is_empty() {
+            return;
+        }
+        let records = std::mem::take(&mut self.records);
+        let max_event_count = self
+            .dispatcher
+            .client_events
+            .get(&self.client_id)
+            .map_or(DEFAULT_CLIENT_EVENT_LIMIT, |entry| entry.max_event_count);
+        let requeue_events = records.iter().map(|record| record.event.clone()).collect();
+        self.dispatcher.settle_committed_records(
+            &self.client_id,
+            &self.group,
+            records,
+            &requeue_events,
+            max_event_count,
+            0,
+        );
+    }
+}
+
+struct LiteEventBatchCompletion {
+    requeue_events: HashSet<CheetahString>,
+    max_event_count: usize,
+    full_dispatch_delay_millis: u64,
+}
+
+enum LiteEventBatchTerminalState {
+    Reserved(LiteEventBatchReservation),
+    Committed {
+        batch: LiteEventBatch,
+        completion: Option<LiteEventBatchCompletion>,
+    },
+    Settled,
+}
+
+/// Affine handler-side access to an event batch retained by a terminal owner.
+#[must_use]
+pub(crate) struct LiteEventBatchExecution {
+    state: Arc<Mutex<LiteEventBatchTerminalState>>,
+}
+
+impl LiteEventBatchExecution {
+    pub(crate) fn commit(self) -> LiteEventBatchCommit {
+        let mut state = self.state.lock();
+        let reserved = match std::mem::replace(&mut *state, LiteEventBatchTerminalState::Settled) {
+            LiteEventBatchTerminalState::Reserved(reserved) => reserved,
+            LiteEventBatchTerminalState::Committed { .. } | LiteEventBatchTerminalState::Settled => {
+                panic!("Lite event terminal reservation commits exactly once")
+            }
+        };
+        let batch = reserved.commit();
+        *state = LiteEventBatchTerminalState::Committed {
+            batch,
+            completion: None,
+        };
+        drop(state);
+        LiteEventBatchCommit { state: self.state }
+    }
+}
+
+/// A committed event-batch view whose settlement is deferred to response terminal.
+#[must_use]
+pub(crate) struct LiteEventBatchCommit {
+    state: Arc<Mutex<LiteEventBatchTerminalState>>,
+}
+
+impl LiteEventBatchCommit {
+    pub(crate) fn event_names(&self) -> Vec<CheetahString> {
+        let state = self.state.lock();
+        match &*state {
+            LiteEventBatchTerminalState::Committed { batch, .. } => batch.event_names(),
+            LiteEventBatchTerminalState::Reserved(_) | LiteEventBatchTerminalState::Settled => Vec::new(),
+        }
+    }
+
+    pub(crate) fn complete(self, requeue_events: &HashSet<CheetahString>) {
+        let max_event_count = {
+            let state = self.state.lock();
+            match &*state {
+                LiteEventBatchTerminalState::Committed { batch, .. } => batch
+                    .dispatcher
+                    .client_events
+                    .get(&batch.client_id)
+                    .map_or(DEFAULT_CLIENT_EVENT_LIMIT, |entry| entry.max_event_count),
+                LiteEventBatchTerminalState::Reserved(_) | LiteEventBatchTerminalState::Settled => return,
+            }
+        };
+        self.complete_with_limit(requeue_events, max_event_count, 0);
+    }
+
+    pub(crate) fn complete_with_limit(
+        self,
+        requeue_events: &HashSet<CheetahString>,
+        max_event_count: usize,
+        full_dispatch_delay_millis: u64,
+    ) {
+        let mut state = self.state.lock();
+        let LiteEventBatchTerminalState::Committed { completion, .. } = &mut *state else {
+            return;
+        };
+        debug_assert!(completion.is_none(), "Lite event batch completion is staged once");
+        *completion = Some(LiteEventBatchCompletion {
+            requeue_events: requeue_events.clone(),
+            max_event_count,
+            full_dispatch_delay_millis,
+        });
+    }
+}
+
+/// Terminal owner that settles a committed batch only when canonical response ownership ends.
+#[must_use]
+pub(crate) struct LiteEventBatchTerminal {
+    state: Option<Arc<Mutex<LiteEventBatchTerminalState>>>,
+}
+
+impl Drop for LiteEventBatchTerminal {
+    fn drop(&mut self) {
+        let Some(state) = self.state.take() else {
+            return;
+        };
+        let terminal = {
+            let mut state = state.lock();
+            std::mem::replace(&mut *state, LiteEventBatchTerminalState::Settled)
+        };
+        match terminal {
+            LiteEventBatchTerminalState::Reserved(reservation) => drop(reservation),
+            LiteEventBatchTerminalState::Committed {
+                batch,
+                completion: Some(completion),
+            } => batch.complete_with_limit(
+                &completion.requeue_events,
+                completion.max_event_count,
+                completion.full_dispatch_delay_millis,
+            ),
+            LiteEventBatchTerminalState::Committed {
+                batch,
+                completion: None,
+            } => drop(batch),
+            LiteEventBatchTerminalState::Settled => {}
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "reservation/tests.rs"]
+mod tests;

--- a/rocketmq-broker/src/lite/lite_event_dispatcher/reservation/tests.rs
+++ b/rocketmq-broker/src/lite/lite_event_dispatcher/reservation/tests.rs
@@ -1,0 +1,210 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use cheetah_string::CheetahString;
+
+use super::LiteEventReservationSnapshot;
+use crate::lite::lite_event_dispatcher::LiteEventDispatcher;
+
+#[test]
+fn lite_event_batch_reservation_rollback_restores_order_and_original_permits() {
+    let dispatcher = LiteEventDispatcher::default();
+    let client_id = CheetahString::from_static_str("client-a");
+    let group = CheetahString::from_static_str("group-a");
+    let first = HashSet::from([
+        CheetahString::from_static_str("%LMQ%$parent$child-a"),
+        CheetahString::from_static_str("%LMQ%$parent$child-b"),
+    ]);
+    dispatcher.do_full_dispatch(&client_id, &group, &first);
+    let reservation = dispatcher
+        .reserve_pending_events(&client_id)
+        .expect("pending events should reserve");
+    let later = HashSet::from([
+        CheetahString::from_static_str("%LMQ%$parent$child-b"),
+        CheetahString::from_static_str("%LMQ%$parent$child-c"),
+    ]);
+
+    assert_eq!(dispatcher.do_full_dispatch(&client_id, &group, &later), 1);
+    assert!(dispatcher.reserve_pending_events(&client_id).is_none());
+    drop(reservation);
+
+    assert_eq!(
+        dispatcher.pending_events(&client_id),
+        vec![
+            CheetahString::from_static_str("%LMQ%$parent$child-a"),
+            CheetahString::from_static_str("%LMQ%$parent$child-b"),
+            CheetahString::from_static_str("%LMQ%$parent$child-c"),
+        ]
+    );
+    assert_eq!(dispatcher.budget_snapshot().current_count, 3);
+    assert_eq!(
+        dispatcher.reservation_snapshot(),
+        LiteEventReservationSnapshot::default()
+    );
+}
+
+#[test]
+fn lite_event_batch_reservation_commit_requeues_with_original_permit_once() {
+    let dispatcher = LiteEventDispatcher::default();
+    let client_id = CheetahString::from_static_str("client-a");
+    let group = CheetahString::from_static_str("group-a");
+    let first = HashSet::from([
+        CheetahString::from_static_str("%LMQ%$parent$child-a"),
+        CheetahString::from_static_str("%LMQ%$parent$child-b"),
+    ]);
+    dispatcher.do_full_dispatch(&client_id, &group, &first);
+    let reservation = dispatcher
+        .reserve_pending_events(&client_id)
+        .expect("pending events should reserve");
+    assert_eq!(reservation.event_count(), 2);
+    assert!(reservation.retained_bytes() > 0);
+    let snapshot = dispatcher.reservation_snapshot();
+    assert_eq!(snapshot.events, 2);
+    assert_eq!(snapshot.permits, 2);
+    let batch = reservation.commit();
+    let duplicate = HashSet::from([CheetahString::from_static_str("%LMQ%$parent$child-b")]);
+    assert_eq!(dispatcher.do_full_dispatch(&client_id, &group, &duplicate), 0);
+
+    batch.complete(&HashSet::from([
+        CheetahString::from_static_str("%LMQ%$parent$child-a"),
+        CheetahString::from_static_str("%LMQ%$parent$child-b"),
+    ]));
+
+    assert_eq!(
+        dispatcher.pending_events(&client_id),
+        vec![
+            CheetahString::from_static_str("%LMQ%$parent$child-a"),
+            CheetahString::from_static_str("%LMQ%$parent$child-b"),
+        ]
+    );
+    assert_eq!(dispatcher.budget_snapshot().current_count, 2);
+    assert_eq!(
+        dispatcher.reservation_snapshot(),
+        LiteEventReservationSnapshot::default()
+    );
+}
+
+#[test]
+fn lite_event_batch_reservation_drop_after_commit_requeues_every_event() {
+    let dispatcher = LiteEventDispatcher::default();
+    let client_id = CheetahString::from_static_str("client-a");
+    let group = CheetahString::from_static_str("group-a");
+    let events = HashSet::from([CheetahString::from_static_str("%LMQ%$parent$child-a")]);
+    dispatcher.do_full_dispatch(&client_id, &group, &events);
+
+    let batch = dispatcher
+        .reserve_pending_events(&client_id)
+        .expect("pending event should reserve")
+        .commit();
+    assert_eq!(batch.event_count(), 1);
+    assert!(batch.retained_bytes() > 0);
+    drop(batch);
+
+    assert_eq!(dispatcher.pending_events(&client_id).len(), 1);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+    assert_eq!(
+        dispatcher.reservation_snapshot(),
+        LiteEventReservationSnapshot::default()
+    );
+}
+
+#[test]
+fn lite_event_batch_reservation_redispatch_after_commit_reuses_permit_and_stays_pending() {
+    let dispatcher = LiteEventDispatcher::default();
+    let client_id = CheetahString::from_static_str("client-a");
+    let group = CheetahString::from_static_str("group-a");
+    let first = CheetahString::from_static_str("%LMQ%$parent$child-a");
+    let second = CheetahString::from_static_str("%LMQ%$parent$child-b");
+    dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([first.clone(), second.clone()]));
+    let batch = dispatcher
+        .reserve_pending_events(&client_id)
+        .expect("pending events should reserve")
+        .commit();
+
+    assert_eq!(
+        dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([second.clone()])),
+        0,
+        "redispatch is deduplicated without acquiring another permit"
+    );
+    assert_eq!(dispatcher.budget_snapshot().current_count, 2);
+    batch.complete(&HashSet::new());
+
+    assert_eq!(dispatcher.pending_events(&client_id), vec![second]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+    assert_eq!(
+        dispatcher.reservation_snapshot(),
+        LiteEventReservationSnapshot::default()
+    );
+}
+
+#[test]
+fn lite_event_terminal_owner_drop_rolls_back_reserved_batch_in_original_order() {
+    let dispatcher = LiteEventDispatcher::default();
+    let client_id = CheetahString::from_static_str("terminal-reserved");
+    let group = CheetahString::from_static_str("group-a");
+    let first = CheetahString::from_static_str("%LMQ%$parent$child-a");
+    let second = CheetahString::from_static_str("%LMQ%$parent$child-b");
+    let later = CheetahString::from_static_str("%LMQ%$parent$child-c");
+    dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([first.clone(), second.clone()]));
+    let reservation = dispatcher
+        .reserve_pending_events(&client_id)
+        .expect("terminal-owned reserved batch");
+    let (execution, terminal) = reservation.into_terminal_ownership();
+    drop(execution);
+    assert_eq!(
+        dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([second.clone(), later.clone()]),),
+        1,
+        "duplicate reserved event does not acquire a second permit"
+    );
+
+    drop(terminal);
+
+    assert_eq!(dispatcher.pending_events(&client_id), vec![first, second, later]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 3);
+    assert_eq!(
+        dispatcher.reservation_snapshot(),
+        LiteEventReservationSnapshot::default()
+    );
+}
+
+#[test]
+fn lite_event_terminal_owner_drop_applies_staged_completion_exactly_once() {
+    let dispatcher = LiteEventDispatcher::default();
+    let client_id = CheetahString::from_static_str("terminal-committed");
+    let group = CheetahString::from_static_str("group-a");
+    let first = CheetahString::from_static_str("%LMQ%$parent$child-a");
+    let second = CheetahString::from_static_str("%LMQ%$parent$child-b");
+    dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([first.clone(), second.clone()]));
+    let reservation = dispatcher
+        .reserve_pending_events(&client_id)
+        .expect("terminal-owned committed batch");
+    let (execution, terminal) = reservation.into_terminal_ownership();
+    execution.commit().complete(&HashSet::from([first.clone()]));
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+    assert_eq!(dispatcher.budget_snapshot().current_count, 2);
+    assert!(dispatcher.reservation_snapshot().retained_bytes > 0);
+
+    drop(terminal);
+
+    assert_eq!(dispatcher.pending_events(&client_id), vec![first.clone()]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+    assert_eq!(dispatcher.take_pending_events(&client_id), vec![first]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+    assert_eq!(
+        dispatcher.reservation_snapshot(),
+        LiteEventReservationSnapshot::default()
+    );
+}

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
@@ -208,29 +208,14 @@ impl<RP: PopLiteLongPollingRequestProcessor + Sync + 'static> PopLiteLongPolling
                     if queue.is_empty() {
                         continue;
                     }
-                    loop {
-                        let Some(first) = queue.pop_front() else {
-                            break;
-                        };
-                        let first = first.value().clone();
-                        if !first.is_timeout() {
-                            queue.insert(first);
-                            break;
-                        }
-                        service.total_polling_num.fetch_sub(1, Ordering::AcqRel);
-                        service.wake_up(first);
-                    }
+                    service.wake_up_expired_requests(queue);
                 }
                 prune_empty_polling_queues(&service.polling_map);
             }
 
             if let Some(service) = service.upgrade() {
                 for entry in service.polling_map.iter() {
-                    let queue = entry.value();
-                    while let Some(first) = queue.pop_front() {
-                        service.total_polling_num.fetch_sub(1, Ordering::AcqRel);
-                        service.wake_up(first.value().clone());
-                    }
+                    service.drain_polling_queue(entry.value());
                 }
                 service.polling_map.clear();
                 service.running.store(false, Ordering::Release);
@@ -353,6 +338,7 @@ impl<RP: PopLiteLongPollingRequestProcessor + Sync + 'static> PopLiteLongPolling
     }
 
     fn wake_up_with_claim(&self, pop_request: Arc<PopRequest>, client_wakeup_claim: Option<ClientWakeupClaim>) -> bool {
+        pop_request.release_resource_permit();
         if !pop_request.complete() {
             return false;
         }
@@ -405,9 +391,32 @@ impl<RP: PopLiteLongPollingRequestProcessor + Sync + 'static> PopLiteLongPolling
             let pop_request = remoting_commands.pop_front().map(|entry| entry.value().clone())?;
             self.total_polling_num.fetch_sub(1, Ordering::AcqRel);
             if !pop_request.get_channel().connection_ref().is_healthy() {
+                pop_request.release_resource_permit();
                 continue;
             }
             return Some(pop_request);
+        }
+    }
+
+    fn wake_up_expired_requests(&self, queue: &SkipSet<Arc<PopRequest>>) {
+        loop {
+            let Some(first) = queue.pop_front() else {
+                break;
+            };
+            let first = first.value().clone();
+            if !first.is_timeout() {
+                queue.insert(first);
+                break;
+            }
+            self.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+            self.wake_up(first);
+        }
+    }
+
+    fn drain_polling_queue(&self, queue: &SkipSet<Arc<PopRequest>>) {
+        while let Some(first) = queue.pop_front() {
+            self.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+            self.wake_up(first.value().clone());
         }
     }
 
@@ -443,7 +452,202 @@ impl<RP: PopLiteLongPollingRequestProcessor + Sync + 'static> PopLiteLongPolling
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_runtime::MonotonicClock;
+    use rocketmq_runtime::ResourceBudgetTree;
+    use rocketmq_transport::api::v1::Channel;
+    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
+    use rocketmq_transport::test_support::Connection;
+
     use super::*;
+
+    #[derive(Default)]
+    struct ManualClock {
+        millis: AtomicU64,
+    }
+
+    impl ManualClock {
+        fn advance(&self, duration: Duration) {
+            self.millis.fetch_add(
+                duration.as_millis().try_into().expect("test duration fits u64"),
+                Ordering::AcqRel,
+            );
+        }
+    }
+
+    impl MonotonicClock for ManualClock {
+        fn now(&self) -> Duration {
+            Duration::from_millis(self.millis.load(Ordering::Acquire))
+        }
+    }
+
+    struct TestProcessor;
+
+    impl PopLiteLongPollingRequestProcessor for TestProcessor {
+        async fn process_request_when_wakeup(
+            &self,
+            _channel: Channel,
+            _ctx: ConnectionHandlerContext,
+            _request: RemotingCommand,
+        ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+            Ok(None)
+        }
+    }
+
+    fn budgeted_service() -> (PopLiteLongPollingService<TestProcessor>, Arc<ManualClock>) {
+        let clock = Arc::new(ManualClock::default());
+        let tree = ResourceBudgetTree::with_clock(
+            "pop-lite-pinned-node",
+            BudgetLimit::new(1, 64 * 1024, FullPolicy::Reject),
+            clock.clone(),
+        )
+        .expect("root budget");
+        let context = PopLiteLongPollingServiceContext::try_with_resource_budget(
+            PopLiteLongPollingPolicy {
+                pop_polling_map_size: 1,
+                max_pop_polling_size: 1,
+                pop_polling_size: 1,
+            },
+            LiteEventDispatcher::default(),
+            None,
+            &tree.root(),
+        )
+        .expect("PopLite request budget");
+        let service = PopLiteLongPollingService::new(context, Weak::new());
+        service.running.store(true, Ordering::Release);
+        (service, clock)
+    }
+
+    async fn test_context() -> ConnectionHandlerContext {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
+        let local_addr = listener.local_addr().expect("local listener address");
+        let stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
+        stream.set_nonblocking(true).expect("set nonblocking");
+        let stream = tokio::net::TcpStream::from_std(stream).expect("convert TCP stream");
+        let connection = Connection::new(stream);
+        let channel = rocketmq_transport::test_support::TestChannelBuilder::new(
+            connection,
+            crate::test_task_group("pop-lite-pinned-node-channel"),
+        )
+        .addresses(local_addr, local_addr)
+        .build()
+        .expect("build test channel");
+        Arc::new(ConnectionHandlerContextWrapper::new(channel))
+    }
+
+    async fn insert_budgeted_request(
+        service: &PopLiteLongPollingService<TestProcessor>,
+        client_id: &CheetahString,
+        expired: u64,
+    ) -> usize {
+        let command = RemotingCommand::create_remoting_command(0);
+        let retained_bytes = PopRequest::estimated_retained_bytes(&command);
+        let permit = service
+            .context
+            .request_budget
+            .try_acquire_data(retained_bytes)
+            .expect("first suspended request should fit");
+        let request = Arc::new(PopRequest::new_with_resource_permit(
+            command,
+            test_context().await,
+            expired,
+            None,
+            None,
+            permit,
+        ));
+        service
+            .polling_map
+            .entry(client_id.clone())
+            .or_default()
+            .insert(request);
+        service.total_polling_num.fetch_add(1, Ordering::AcqRel);
+        retained_bytes
+    }
+
+    fn assert_budget_released_and_readmits(
+        service: &PopLiteLongPollingService<TestProcessor>,
+        clock: &ManualClock,
+        retained_bytes: usize,
+    ) {
+        let terminal = service.resource_snapshot().requests;
+        assert_eq!(terminal.current_count, 0);
+        assert_eq!(terminal.current_bytes, 0);
+
+        clock.advance(Duration::from_secs(1));
+        let readmitted = service
+            .context
+            .request_budget
+            .try_acquire_data(retained_bytes)
+            .expect("terminal request must immediately return its capacity");
+        let admitted = service.resource_snapshot().requests;
+        assert_eq!(admitted.current_count, 1);
+        assert_eq!(admitted.current_bytes, retained_bytes);
+        drop(readmitted);
+        assert_eq!(service.resource_snapshot().requests.current_count, 0);
+        assert_eq!(service.resource_snapshot().requests.current_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn arrival_terminal_releases_budget_while_removed_skipset_node_stays_pinned() {
+        let (service, clock) = budgeted_service();
+        let client_id = CheetahString::from_static_str("arrival-client");
+        let mut command = RemotingCommand::create_remoting_command(0);
+        let retained_bytes = PopRequest::estimated_retained_bytes(&command);
+
+        assert_eq!(
+            service.polling(
+                test_context().await,
+                &mut command,
+                &client_id,
+                i64::try_from(current_millis()).expect("test clock fits i64"),
+                30_000,
+            ),
+            PollingResult::PollingSuc
+        );
+        let queue = service.polling_map.get(&client_id).expect("client queue");
+        let pinned_node = queue.value().front().expect("suspended request node");
+        assert_eq!(service.resource_snapshot().requests.current_count, 1);
+        assert_eq!(service.resource_snapshot().requests.current_bytes, retained_bytes);
+
+        let request = service.poll_request(queue.value()).expect("arrival claims request");
+        let duplicate = Arc::clone(&request);
+        assert!(!service.wake_up(request));
+        assert!(!service.wake_up(duplicate));
+
+        assert_budget_released_and_readmits(&service, clock.as_ref(), retained_bytes);
+        assert!(pinned_node.is_removed(), "guard must still pin the removed node");
+    }
+
+    #[tokio::test]
+    async fn timeout_terminal_releases_budget_while_removed_skipset_node_stays_pinned() {
+        let (service, clock) = budgeted_service();
+        let client_id = CheetahString::from_static_str("timeout-client");
+        let retained_bytes = insert_budgeted_request(&service, &client_id, 0).await;
+        let queue = service.polling_map.get(&client_id).expect("client queue");
+        let pinned_node = queue.value().front().expect("suspended request node");
+
+        service.wake_up_expired_requests(queue.value());
+
+        assert_eq!(service.total_polling_num.load(Ordering::Acquire), 0);
+        assert_budget_released_and_readmits(&service, clock.as_ref(), retained_bytes);
+        assert!(pinned_node.is_removed(), "guard must still pin the removed node");
+    }
+
+    #[tokio::test]
+    async fn cancellation_drain_releases_budget_while_removed_skipset_node_stays_pinned() {
+        let (service, clock) = budgeted_service();
+        let client_id = CheetahString::from_static_str("cancel-client");
+        let retained_bytes =
+            insert_budgeted_request(&service, &client_id, current_millis().saturating_add(30_000)).await;
+        let queue = service.polling_map.get(&client_id).expect("client queue");
+        let pinned_node = queue.value().front().expect("suspended request node");
+        service.running.store(false, Ordering::Release);
+
+        service.drain_polling_queue(queue.value());
+
+        assert_eq!(service.total_polling_num.load(Ordering::Acquire), 0);
+        assert_budget_released_and_readmits(&service, clock.as_ref(), retained_bytes);
+        assert!(pinned_node.is_removed(), "guard must still pin the removed node");
+    }
 
     #[test]
     fn overload_rejects_excess_long_poll_requests_and_releases_permits() {

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -56,6 +56,11 @@ pub(crate) trait PollingCountProvider: Send + Sync {
     fn polling_count(&self, key: &str) -> i32;
 }
 
+#[cfg(test)]
+mod notification_v1_acceptance_tests;
+#[cfg(test)]
+mod permit_release_tests;
+
 #[derive(Clone)]
 pub(crate) struct PopLongPollingPolicy {
     pop_polling_map_size: usize,
@@ -211,24 +216,11 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
                     continue;
                 }
                 for entry in service.polling_map.iter() {
-                    let key = entry.key();
                     let value = entry.value();
                     if value.is_empty() {
                         continue;
                     }
-                    loop {
-                        let first = value.pop_front();
-                        if first.is_none() {
-                            break;
-                        }
-                        let first = first.unwrap().value().clone();
-                        if !first.is_timeout() {
-                            value.insert(first);
-                            break;
-                        }
-                        service.total_polling_num.fetch_sub(1, Ordering::AcqRel);
-                        service.wake_up(first);
-                    }
+                    service.wake_up_expired_requests(value);
                 }
 
                 let last_clean_time = service.last_clean_time.load(Ordering::Acquire);
@@ -240,11 +232,7 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
             if let Some(service) = service.upgrade() {
                 // Clean all suspended requests before the owned scan task exits.
                 for entry in service.polling_map.iter() {
-                    let value = entry.value();
-                    while let Some(first) = value.pop_front() {
-                        service.total_polling_num.fetch_sub(1, Ordering::AcqRel);
-                        service.wake_up(first.value().clone());
-                    }
+                    service.drain_polling_queue(entry.value());
                 }
                 service.running.store(false, Ordering::Release);
             }
@@ -342,7 +330,9 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
 
             // Remove polling entries outside the iteration
             for key in polling_keys_to_remove {
-                self.polling_map.remove(&key);
+                if let Some((_, queue)) = self.polling_map.remove(&key) {
+                    self.discard_polling_queue(&queue);
+                }
             }
         }
         self.last_clean_time.store(current_millis(), Ordering::Release);
@@ -608,6 +598,7 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
     }
 
     fn wake_up_inner(&self, pop_request: Arc<PopRequest>, completion: Option<PopWakeupObserver>) -> bool {
+        pop_request.release_resource_permit();
         if !pop_request.complete() {
             if let Some(completion) = completion {
                 completion.complete(PopWakeupOutcome::AlreadyCompleted);
@@ -677,31 +668,50 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
             return None;
         }
 
-        let mut pop_request: Option<Arc<PopRequest>>;
-
         //maybe need to optimize
         loop {
-            if self.notify_last {
-                pop_request = remoting_commands.pop_back().map(|entry| entry.value().clone());
+            let pop_request = if self.notify_last {
+                remoting_commands.pop_back().map(|entry| entry.value().clone())
             } else {
-                pop_request = remoting_commands.pop_front().map(|entry| entry.value().clone());
-            }
+                remoting_commands.pop_front().map(|entry| entry.value().clone())
+            }?;
 
             self.total_polling_num.fetch_sub(1, Ordering::AcqRel);
-            if pop_request.is_some()
-                && !pop_request
-                    .as_ref()
-                    .unwrap()
-                    .get_channel()
-                    .connection_ref()
-                    .is_healthy()
-            {
+            if !pop_request.get_channel().connection_ref().is_healthy() {
+                pop_request.release_resource_permit();
                 continue;
-            } else {
+            }
+            return Some(pop_request);
+        }
+    }
+
+    fn wake_up_expired_requests(&self, queue: &SkipSet<Arc<PopRequest>>) {
+        loop {
+            let Some(first) = queue.pop_front() else {
+                break;
+            };
+            let first = first.value().clone();
+            if !first.is_timeout() {
+                queue.insert(first);
                 break;
             }
+            self.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+            self.wake_up(first);
         }
-        pop_request
+    }
+
+    fn drain_polling_queue(&self, queue: &SkipSet<Arc<PopRequest>>) {
+        while let Some(first) = queue.pop_front() {
+            self.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+            self.wake_up(first.value().clone());
+        }
+    }
+
+    fn discard_polling_queue(&self, queue: &SkipSet<Arc<PopRequest>>) {
+        while let Some(first) = queue.pop_front() {
+            self.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+            first.value().release_resource_permit();
+        }
     }
 
     /// Gets the number of polling requests for a given key
@@ -961,7 +971,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn notification_filter_requeues_a_miss_then_wakes_on_a_match() {
+    async fn notification_v1_wake_compatibility_filter_requeues_a_miss_then_wakes_on_a_match() {
         let processor = Arc::new(FailingProcessor {
             calls: AtomicUsize::new(0),
         });

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service/notification_v1_acceptance_tests.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service/notification_v1_acceptance_tests.rs
@@ -1,0 +1,304 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
+use rocketmq_protocol::protocol::header::notification_response_header::NotificationResponseHeader;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_store::CqExtUnit;
+use rocketmq_store::MessageFilter;
+use rocketmq_store::MessageStoreConfig;
+use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v1::ConnectionHandlerContext;
+use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
+use rocketmq_transport::test_support::Connection;
+use rocketmq_transport::test_support::TestChannelBuilder;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+
+use super::PopLongPollingRequestProcessor;
+use super::PopLongPollingService;
+use super::PopLongPollingServiceContext;
+use crate::broker_runtime::BrokerRuntime;
+use crate::config::broker_config::BrokerConfig;
+use crate::long_polling::long_polling_service::pop_long_polling_service::PopLongPollingPolicy;
+use crate::long_polling::polling_header::PollingHeader;
+use crate::long_polling::polling_result::PollingResult;
+
+const ARRIVAL_OPAQUE: i32 = 19_833;
+const TIMEOUT_OPAQUE: i32 = 19_834;
+
+struct MatchTagFilter(i64);
+
+impl MessageFilter for MatchTagFilter {
+    fn is_matched_by_consume_queue(&self, tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        tags_code == Some(self.0)
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&std::collections::HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        true
+    }
+}
+
+struct LegacyNotificationProcessor {
+    calls: AtomicUsize,
+    observed: mpsc::UnboundedSender<(i32, NotificationRequestHeader)>,
+}
+
+impl PopLongPollingRequestProcessor for LegacyNotificationProcessor {
+    async fn process_request_when_wakeup(
+        &self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        request: RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        let opaque = request.opaque();
+        let header = request.decode_command_custom_header::<NotificationRequestHeader>()?;
+        self.observed
+            .send((opaque, header))
+            .map_err(|_| rocketmq_error::RocketMQError::illegal_argument("legacy Notification observer closed"))?;
+        let response = application_remoting_command_factory()
+            .create_success_response_command_with_header(NotificationResponseHeader {
+                has_msg: opaque == ARRIVAL_OPAQUE,
+                polling_full: false,
+            })
+            .set_opaque(-1);
+        Ok(Some(response))
+    }
+}
+
+struct LegacySocketHarness {
+    owner: RuntimeOwner,
+    context: ConnectionHandlerContext,
+    peer: Connection,
+    shutdown: std::net::TcpStream,
+}
+
+impl LegacySocketHarness {
+    async fn new(label: &'static str) -> Self {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default(label)).expect("legacy Notification runtime");
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind legacy Notification listener");
+        let address = listener.local_addr().expect("legacy Notification listener address");
+        let (client, accepted) = tokio::join!(TcpStream::connect(address), listener.accept());
+        let client = client.expect("connect legacy Notification channel");
+        let client = client.into_std().expect("recover legacy Notification socket");
+        let shutdown = client.try_clone().expect("clone legacy Notification shutdown handle");
+        let client = TcpStream::from_std(client).expect("restore legacy Notification socket");
+        let (peer, peer_address) = accepted.expect("accept legacy Notification peer");
+        let channel_context = owner.root_context().component("notification-v1.channel");
+        let channel = TestChannelBuilder::new(Connection::new(client), channel_context.task_group().clone())
+            .addresses(address, peer_address)
+            .build()
+            .expect("build legacy Notification channel");
+        Self {
+            owner,
+            context: Arc::new(ConnectionHandlerContextWrapper::new(channel)),
+            peer: Connection::new(peer),
+            shutdown,
+        }
+    }
+
+    async fn receive_one(&mut self) -> RemotingCommand {
+        tokio::time::timeout(Duration::from_secs(2), self.peer.receive_command())
+            .await
+            .expect("legacy Notification raw frame write remains bounded")
+            .expect("legacy Notification connection remains open")
+            .expect("decode legacy Notification raw frame")
+    }
+
+    async fn finish(mut self) {
+        let writer = self.context.channel().close_with_report(Duration::from_secs(1)).await;
+        assert!(writer.is_healthy(), "{}", writer.to_json());
+        drop(self.context);
+        let tasks = self.owner.shutdown_tasks().await;
+        assert!(tasks.is_healthy(), "{}", tasks.to_json());
+        self.shutdown
+            .shutdown(std::net::Shutdown::Both)
+            .expect("shutdown legacy Notification socket");
+        assert!(
+            tokio::time::timeout(Duration::from_secs(2), self.peer.receive_command())
+                .await
+                .expect("legacy Notification EOF remains bounded")
+                .is_none(),
+            "EOF proves the legacy wake emitted exactly one frame"
+        );
+        let background = self.owner.shutdown_background();
+        assert!(background.is_healthy(), "{}", background.to_json());
+    }
+}
+
+fn service<RP>(processor: &Arc<RP>) -> Arc<PopLongPollingService<RP>>
+where
+    RP: PopLongPollingRequestProcessor + Sync + 'static,
+{
+    let mut runtime = BrokerRuntime::new(
+        Arc::new(BrokerConfig::default()),
+        Arc::new(MessageStoreConfig::default()),
+    );
+    let state = runtime.runtime_state_mut();
+    let context = PopLongPollingServiceContext::new(
+        PopLongPollingPolicy::from_config(&state.broker_config()),
+        state.topic_config_manager_handle(),
+        state.subscription_group_manager().config_lookup(),
+        state.broker_service_context(),
+    );
+    Arc::new(PopLongPollingService::new(context, true, Arc::downgrade(processor)))
+}
+
+fn notification_header(
+    topic: &CheetahString,
+    group: &CheetahString,
+    born_time: i64,
+    poll_time: i64,
+) -> NotificationRequestHeader {
+    NotificationRequestHeader {
+        consumer_group: group.clone(),
+        topic: topic.clone(),
+        queue_id: 0,
+        born_time,
+        order: false,
+        attempt_id: None,
+        exp_type: None,
+        exp: None,
+        is_lite_consumer: false,
+        client_id: None,
+        poll_time,
+        topic_request_header: None,
+    }
+}
+
+fn request(header: NotificationRequestHeader, opaque: i32) -> RemotingCommand {
+    let mut request = RemotingCommand::create_request_command(RequestCode::Notification, header).set_opaque(opaque);
+    request.make_custom_header_to_net();
+    request
+}
+
+fn assert_response(response: RemotingCommand, opaque: i32, has_msg: bool) {
+    assert_eq!(response.opaque(), opaque);
+    assert_eq!(response.code(), ResponseCode::Success as i32);
+    assert_eq!(response.remark(), None);
+    assert!(response.body().is_none());
+    let header = response
+        .decode_command_custom_header::<NotificationResponseHeader>()
+        .expect("legacy Notification response header");
+    assert_eq!(header.has_msg, has_msg);
+    assert!(!header.polling_full);
+}
+
+#[tokio::test]
+async fn notification_v1_suspension_filter_arrival_task_group_wake_writes_one_raw_frame() {
+    let (observed_tx, mut observed_rx) = mpsc::unbounded_channel();
+    let processor = Arc::new(LegacyNotificationProcessor {
+        calls: AtomicUsize::new(0),
+        observed: observed_tx,
+    });
+    let service = service(&processor);
+    PopLongPollingService::start(&service).await;
+    let mut harness = LegacySocketHarness::new("notification-v1-arrival-acceptance").await;
+    let topic = CheetahString::from_static_str("notification-v1-topic");
+    let group = CheetahString::from_static_str("notification-v1-group");
+    let born_time = i64::try_from(current_millis()).expect("legacy Notification wall clock fits i64");
+    let header = notification_header(&topic, &group, born_time, 60_000);
+    let polling_header = PollingHeader::new_from_notification_request_header(&header);
+    let mut command = request(header, ARRIVAL_OPAQUE);
+    assert_eq!(
+        service.polling(
+            harness.context.clone(),
+            &mut command,
+            polling_header,
+            Some(SubscriptionData::default()),
+            Some(Arc::new(MatchTagFilter(7))),
+        ),
+        PollingResult::PollingSuc
+    );
+
+    assert!(!service.notify_message_arriving(&topic, 0, &group, Some(6), 0, None, None));
+    assert_eq!(processor.calls.load(Ordering::Acquire), 0);
+    assert!(service.notify_message_arriving(&topic, 0, &group, Some(7), 0, None, None));
+    let (opaque, observed_header) = tokio::time::timeout(Duration::from_secs(2), observed_rx.recv())
+        .await
+        .expect("legacy Notification arrival wake remains bounded")
+        .expect("observe legacy Notification arrival wake");
+    assert_eq!(opaque, ARRIVAL_OPAQUE);
+    assert_eq!(observed_header.consumer_group, group);
+    assert_eq!(observed_header.topic, topic);
+    assert_eq!(processor.calls.load(Ordering::Acquire), 1);
+
+    let response = harness.receive_one().await;
+    assert_response(response, ARRIVAL_OPAQUE, true);
+    service.shutdown().await;
+    drop(service);
+    harness.finish().await;
+}
+
+#[tokio::test]
+async fn notification_v1_suspension_timeout_task_group_wake_writes_one_raw_frame() {
+    let (observed_tx, mut observed_rx) = mpsc::unbounded_channel();
+    let processor = Arc::new(LegacyNotificationProcessor {
+        calls: AtomicUsize::new(0),
+        observed: observed_tx,
+    });
+    let service = service(&processor);
+    PopLongPollingService::start(&service).await;
+    let mut harness = LegacySocketHarness::new("notification-v1-timeout-acceptance").await;
+    let topic = CheetahString::from_static_str("notification-v1-timeout-topic");
+    let group = CheetahString::from_static_str("notification-v1-timeout-group");
+    let born_time = i64::try_from(current_millis()).expect("legacy Notification wall clock fits i64");
+    let header = notification_header(&topic, &group, born_time, 51);
+    let polling_header = PollingHeader::new_from_notification_request_header(&header);
+    let mut command = request(header, TIMEOUT_OPAQUE);
+    assert_eq!(
+        service.polling(harness.context.clone(), &mut command, polling_header, None, None,),
+        PollingResult::PollingSuc
+    );
+    let cutoff = u64::try_from(born_time + 1).expect("positive legacy Notification cutoff");
+    while current_millis() <= cutoff {
+        tokio::task::yield_now().await;
+    }
+
+    let (opaque, observed_header) = tokio::time::timeout(Duration::from_secs(1), observed_rx.recv())
+        .await
+        .expect("legacy Notification timeout scan remains bounded")
+        .expect("observe legacy Notification timeout wake");
+    assert_eq!(opaque, TIMEOUT_OPAQUE);
+    assert_eq!(observed_header.consumer_group, group);
+    assert_eq!(observed_header.topic, topic);
+    assert_eq!(processor.calls.load(Ordering::Acquire), 1);
+
+    let response = harness.receive_one().await;
+    assert_response(response, TIMEOUT_OPAQUE, false);
+    service.shutdown().await;
+    drop(service);
+    harness.finish().await;
+}

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service/permit_release_tests.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service/permit_release_tests.rs
@@ -1,0 +1,214 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crossbeam_skiplist::SkipSet;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudget;
+use rocketmq_runtime::ResourceBudgetTree;
+use rocketmq_store::MessageStoreConfig;
+use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v1::ConnectionHandlerContext;
+use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
+use rocketmq_transport::test_support::Connection;
+
+use super::PopLongPollingPolicy;
+use super::PopLongPollingRequestProcessor;
+use super::PopLongPollingService;
+use super::PopLongPollingServiceContext;
+use crate::broker_runtime::BrokerRuntime;
+use crate::config::broker_config::BrokerConfig;
+use crate::long_polling::pop_request::PopRequest;
+
+struct TestProcessor;
+
+impl PopLongPollingRequestProcessor for TestProcessor {
+    async fn process_request_when_wakeup(
+        &self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request: RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        Ok(None)
+    }
+}
+
+fn test_service(processor: &Arc<TestProcessor>) -> PopLongPollingService<TestProcessor> {
+    let mut runtime = BrokerRuntime::new(
+        Arc::new(BrokerConfig::default()),
+        Arc::new(MessageStoreConfig::default()),
+    );
+    let state = runtime.runtime_state_mut();
+    let context = PopLongPollingServiceContext::new(
+        PopLongPollingPolicy::from_config(&state.broker_config()),
+        state.topic_config_manager_handle(),
+        state.subscription_group_manager().config_lookup(),
+        state.broker_service_context(),
+    );
+    PopLongPollingService::new(context, false, Arc::downgrade(processor))
+}
+
+fn request_budget() -> ResourceBudget {
+    ResourceBudgetTree::new(
+        "pop-long-pinned-node",
+        BudgetLimit::new(1, 64 * 1024, FullPolicy::Reject),
+    )
+    .expect("request budget")
+    .root()
+}
+
+async fn test_context() -> ConnectionHandlerContext {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
+    let local_addr = listener.local_addr().expect("local listener address");
+    let stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
+    stream.set_nonblocking(true).expect("set nonblocking");
+    let stream = tokio::net::TcpStream::from_std(stream).expect("convert TCP stream");
+    let channel = rocketmq_transport::test_support::TestChannelBuilder::new(
+        Connection::new(stream),
+        crate::test_task_group("pop-long-pinned-node-channel"),
+    )
+    .addresses(local_addr, local_addr)
+    .build()
+    .expect("build test channel");
+    Arc::new(ConnectionHandlerContextWrapper::new(channel))
+}
+
+async fn budgeted_request(budget: &ResourceBudget, expired: u64) -> (Arc<PopRequest>, usize) {
+    let command = RemotingCommand::create_remoting_command(0);
+    let retained_bytes = PopRequest::estimated_retained_bytes(&command);
+    let permit = budget
+        .try_acquire_data(retained_bytes)
+        .expect("first suspended request should fit");
+    (
+        Arc::new(PopRequest::new_with_resource_permit(
+            command,
+            test_context().await,
+            expired,
+            None,
+            None,
+            permit,
+        )),
+        retained_bytes,
+    )
+}
+
+fn assert_released_and_readmits(budget: &ResourceBudget, retained_bytes: usize) {
+    let terminal = budget.snapshot();
+    assert_eq!(terminal.current_count, 0);
+    assert_eq!(terminal.current_bytes, 0);
+
+    let readmitted = budget
+        .try_acquire_data(retained_bytes)
+        .expect("logical terminal must return capacity while the removed node remains pinned");
+    assert_eq!(budget.snapshot().current_count, 1);
+    assert_eq!(budget.snapshot().current_bytes, retained_bytes);
+    drop(readmitted);
+    assert_eq!(budget.snapshot().current_count, 0);
+    assert_eq!(budget.snapshot().current_bytes, 0);
+}
+
+#[tokio::test]
+async fn arrival_and_duplicate_terminals_release_shared_permit_while_node_stays_pinned() {
+    let processor = Arc::new(TestProcessor);
+    let service = test_service(&processor);
+    let budget = request_budget();
+    let (request, retained_bytes) = budgeted_request(&budget, current_millis().saturating_add(30_000)).await;
+    let queue = SkipSet::new();
+    queue.insert(request);
+    service.total_polling_num.store(1, std::sync::atomic::Ordering::Release);
+    let pinned_node = queue.front().expect("suspended request node");
+
+    let request = service
+        .poll_remoting_commands(&queue)
+        .expect("arrival claims suspended request");
+    let duplicate = Arc::clone(&request);
+    assert!(!service.wake_up(request));
+    assert!(!service.wake_up(duplicate));
+
+    assert_released_and_readmits(&budget, retained_bytes);
+    assert!(pinned_node.is_removed(), "entry guard must still pin the removed node");
+}
+
+#[tokio::test]
+async fn timeout_terminal_releases_shared_permit_while_node_stays_pinned() {
+    let processor = Arc::new(TestProcessor);
+    let service = test_service(&processor);
+    let budget = request_budget();
+    let (request, retained_bytes) = budgeted_request(&budget, 0).await;
+    let queue = SkipSet::new();
+    queue.insert(request);
+    service.total_polling_num.store(1, std::sync::atomic::Ordering::Release);
+    let pinned_node = queue.front().expect("suspended request node");
+
+    service.wake_up_expired_requests(&queue);
+
+    assert_released_and_readmits(&budget, retained_bytes);
+    assert!(pinned_node.is_removed(), "entry guard must still pin the removed node");
+}
+
+#[tokio::test]
+async fn cancellation_drain_releases_shared_permit_while_node_stays_pinned() {
+    let processor = Arc::new(TestProcessor);
+    let service = test_service(&processor);
+    let budget = request_budget();
+    let (request, retained_bytes) = budgeted_request(&budget, current_millis().saturating_add(30_000)).await;
+    let queue = SkipSet::new();
+    queue.insert(request);
+    service.total_polling_num.store(1, std::sync::atomic::Ordering::Release);
+    let pinned_node = queue.front().expect("suspended request node");
+
+    service.drain_polling_queue(&queue);
+
+    assert_released_and_readmits(&budget, retained_bytes);
+    assert!(pinned_node.is_removed(), "entry guard must still pin the removed node");
+}
+
+#[tokio::test]
+async fn inactive_terminal_releases_shared_permit_while_node_stays_pinned() {
+    let processor = Arc::new(TestProcessor);
+    let service = test_service(&processor);
+    let budget = request_budget();
+    let (request, retained_bytes) = budgeted_request(&budget, current_millis().saturating_add(30_000)).await;
+    request.get_channel().connection_ref().close();
+    let queue = SkipSet::new();
+    queue.insert(request);
+    service.total_polling_num.store(1, std::sync::atomic::Ordering::Release);
+    let pinned_node = queue.front().expect("suspended request node");
+
+    assert!(service.poll_remoting_commands(&queue).is_none());
+
+    assert_released_and_readmits(&budget, retained_bytes);
+    assert!(pinned_node.is_removed(), "entry guard must still pin the removed node");
+}
+
+#[tokio::test]
+async fn resource_removal_releases_shared_permit_while_node_stays_pinned() {
+    let processor = Arc::new(TestProcessor);
+    let service = test_service(&processor);
+    let budget = request_budget();
+    let (request, retained_bytes) = budgeted_request(&budget, current_millis().saturating_add(30_000)).await;
+    let queue = SkipSet::new();
+    queue.insert(request);
+    service.total_polling_num.store(1, std::sync::atomic::Ordering::Release);
+    let pinned_node = queue.front().expect("suspended request node");
+
+    service.discard_polling_queue(&queue);
+
+    assert_released_and_readmits(&budget, retained_bytes);
+    assert!(pinned_node.is_removed(), "entry guard must still pin the removed node");
+}

--- a/rocketmq-broker/src/long_polling/notification_deferred.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The RocketMQ Rust Authors
+// Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod long_polling_service;
-pub(crate) mod many_pull_request;
-pub(crate) mod notification_deferred;
-pub(crate) mod notify_message_arriving_listener;
-pub(crate) mod polling_header;
-pub(crate) mod polling_result;
-pub(crate) mod pop_deferred;
-pub(crate) mod pop_lite_deferred;
-pub(crate) mod pop_request;
-pub(crate) mod pull_deferred;
-pub(crate) mod pull_request;
+pub(crate) mod deadline;
+pub(crate) mod index;
+pub(crate) mod service;
+
+#[cfg(test)]
+mod acceptance_tests;
+#[cfg(test)]
+mod tests;

--- a/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests.rs
@@ -1,0 +1,632 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
+use rocketmq_protocol::protocol::header::notification_response_header::NotificationResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ShutdownReport;
+use rocketmq_store::ArcMessageFilter;
+use rocketmq_store::CqExtUnit;
+use rocketmq_store::MessageFilter;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::FileTransferMode;
+use rocketmq_transport::api::v1::ServerConfig;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome;
+use rocketmq_transport::api::v2::DeferredResumeRetainedSize;
+use rocketmq_transport::api::v2::DeferredWaitLimits;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrdering;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::TransportServerV2;
+use rocketmq_transport::test_support::Connection;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+use super::index::NotificationArrivalView;
+use super::index::NotificationCriteriaLimits;
+use super::service::NotificationDeferredService;
+use super::service::NotificationRetainedEstimate;
+
+const ORIGINAL_OPAQUE: i32 = 9_833;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test limit is non-zero")
+}
+
+fn service(controller: &AdmissionController) -> Arc<NotificationDeferredService> {
+    service_with_scan(controller, 4)
+}
+
+fn service_with_scan(controller: &AdmissionController, scan_limit: usize) -> Arc<NotificationDeferredService> {
+    let admission = DeferredAdmission::try_configure(controller, DeferredWaitLimits::new(4, 4 * 1024 * 1024))
+        .expect("Notification deferred admission");
+    Arc::new(NotificationDeferredService::new(
+        admission,
+        NotificationCriteriaLimits::new(nonzero(4), 3, 1),
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        nonzero(scan_limit),
+        nonzero(4),
+        nonzero(2),
+        nonzero(1024 * 1024),
+    ))
+}
+
+fn request_command() -> RemotingCommand {
+    request_command_for("GroupA", ORIGINAL_OPAQUE, 60_000)
+}
+
+fn request_command_for(group: &str, opaque: i32, poll_time: i64) -> RemotingCommand {
+    let born_time = i64::try_from(current_millis()).expect("current wall time fits the signed protocol field");
+    let header = NotificationRequestHeader {
+        consumer_group: CheetahString::from_string(group.to_owned()),
+        topic: CheetahString::from_static_str("TopicA"),
+        queue_id: 0,
+        poll_time,
+        born_time,
+        order: false,
+        attempt_id: None,
+        exp_type: None,
+        exp: None,
+        is_lite_consumer: false,
+        client_id: Some(CheetahString::from_string(opaque.to_string())),
+        topic_request_header: None,
+    };
+    let mut command = RemotingCommand::create_request_command(RequestCode::Notification, header).set_opaque(opaque);
+    command.make_custom_header_to_net();
+    command
+}
+
+#[derive(Clone, Copy)]
+struct Registration {
+    peer: SocketAddr,
+}
+
+#[derive(Clone)]
+struct DeferredProcessor {
+    service: Arc<NotificationDeferredService>,
+    registrations: mpsc::UnboundedSender<Registration>,
+    filter: Option<ArcMessageFilter>,
+}
+
+impl RequestProcessorV2 for DeferredProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prepared = self
+            .service
+            .prepare(
+                request,
+                None,
+                self.filter.clone(),
+                NotificationRetainedEstimate::default(),
+            )
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let peer = match request.origin() {
+            RequestOrigin::Network { peer } => peer.address(),
+            _ => return Err(RocketMQError::illegal_argument("trusted network origin required")),
+        };
+        let registration = self
+            .service
+            .register(prepared, request)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.registrations
+            .send(Registration { peer })
+            .map_err(|_| RocketMQError::illegal_argument("Notification registration observer closed"))?;
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+
+    fn request_ordering(&self, _ingress: rocketmq_transport::api::v2::IngressRequestView<'_>) -> RequestOrdering {
+        RequestOrdering::Concurrent
+    }
+}
+
+struct ToggleFilter(Arc<AtomicBool>);
+
+impl MessageFilter for ToggleFilter {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+struct RunningServer {
+    owner: RuntimeOwner,
+    server_context: ChildServiceContext,
+    action_context: ChildServiceContext,
+    shutdown: Option<oneshot::Sender<()>>,
+    result: oneshot::Receiver<ShutdownReport>,
+}
+
+impl RunningServer {
+    fn cancel_server_parent(&self) {
+        self.server_context.task_group().cancel();
+    }
+
+    fn begin_shutdown(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
+
+    async fn finish(mut self) {
+        self.begin_shutdown();
+        let report = self.result.await.expect("owned server report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        let tasks = self.owner.shutdown_tasks().await;
+        assert!(tasks.is_healthy(), "{}", tasks.to_json());
+        let final_report = self.owner.shutdown_background();
+        assert!(final_report.is_healthy(), "{}", final_report.to_json());
+    }
+}
+
+async fn start_server<P>(processor: P, controller: Arc<AdmissionController>) -> (Connection, RunningServer)
+where
+    P: RequestProcessorV2 + Clone + Send + Sync + 'static,
+{
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("notification-deferred-acceptance"))
+        .expect("Notification V2 runtime owner");
+    let server_context = owner.root_context().component("notification.server");
+    let runner_context = owner.root_context().component("notification.runner");
+    let action_context = owner.root_context().component("notification.actions");
+    let server = TransportServerV2::new(
+        Arc::new(ServerConfig {
+            bind_address: "127.0.0.1".to_owned(),
+            listen_port: 0,
+            file_transfer_mode: FileTransferMode::Portable,
+            ..ServerConfig::default()
+        }),
+        server_context.clone(),
+        processor,
+    )
+    .with_admission_controller(controller);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    runner_context
+        .spawn_service("notification-deferred-v2-server", async move {
+            let report = server
+                .try_run_with_shutdown_report_and_startup(
+                    async move {
+                        let _ = shutdown_rx.await;
+                    },
+                    startup_tx,
+                )
+                .await
+                .expect("owned Notification server shutdown report");
+            let _ = result_tx.send(report);
+        })
+        .expect("spawn Notification V2 server");
+    let address = startup_rx
+        .await
+        .expect("Notification startup channel")
+        .expect("Notification server startup");
+    let client = Connection::new(TcpStream::connect(address).await.expect("connect Notification client"));
+    (
+        client,
+        RunningServer {
+            owner,
+            server_context,
+            action_context,
+            shutdown: Some(shutdown_tx),
+            result: result_rx,
+        },
+    )
+}
+
+#[tokio::test]
+async fn notification_deferred_v2_tcp_prepare_register_claim_resume_writes_one_canonical_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command())
+        .await
+        .expect("send deferred Notification request");
+    let registration = registrations.recv().await.expect("observe Notification registration");
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let prepared = service.prepare_arrival_batch(NotificationArrivalView::new(&topic, 0), None);
+    let batch = service.claim_prepared_arrival(prepared).await;
+    let (mut claims, cursor) = batch.into_parts();
+    assert!(cursor.is_complete());
+    assert_eq!(claims.len(), 1);
+    let claim = claims.pop().expect("one claimed Notification waiter");
+    let service_for_resume = Arc::clone(&service);
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .action_context
+        .spawn_service("notification-deferred-resume", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    DeferredResumeRetainedSize::default(),
+                    move |resume, reason| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        assert_eq!(resume.request().effective_peer(), registration.peer);
+                        let head = application_remoting_command_factory().create_success_response_command_with_header(
+                            NotificationResponseHeader {
+                                has_msg: false,
+                                polling_full: false,
+                            },
+                        );
+                        ResponsePlan::command(head).map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn Notification resume");
+    receipt_rx
+        .await
+        .expect("Notification receipt channel")
+        .expect("canonical Notification write");
+
+    let response = client
+        .receive_command()
+        .await
+        .expect("connection remains open")
+        .expect("one Notification response frame");
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(response.code(), ResponseCode::Success as i32);
+    assert!(response.remark().is_none());
+    assert!(response.body().is_none());
+    let header = response
+        .decode_command_custom_header::<NotificationResponseHeader>()
+        .expect("Notification response header");
+    assert!(!header.has_msg);
+    assert!(!header.polling_full);
+    assert_eq!(service.snapshot().index().live(), 0);
+    assert_eq!(service.snapshot().admission().waiting_count(), 0);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "EOF proves exactly one response frame"
+    );
+}
+
+#[tokio::test]
+async fn notification_deferred_filter_miss_stays_registered_then_later_match_claims() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let matches = Arc::new(AtomicBool::new(false));
+    let filter: ArcMessageFilter = Arc::new(ToggleFilter(Arc::clone(&matches)));
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: Some(filter),
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command())
+        .await
+        .expect("send filtered Notification request");
+    registrations.recv().await.expect("observe filtered registration");
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let missed = service.prepare_arrival_batch(NotificationArrivalView::new(&topic, 0), None);
+    let missed = service.claim_prepared_arrival(missed).await;
+    let (missed_claims, missed_cursor) = missed.into_parts();
+    assert!(missed_claims.is_empty());
+    assert!(missed_cursor.is_complete());
+    assert_eq!(service.snapshot().index().live(), 1);
+    assert_eq!(service.snapshot().index().candidates(), 0);
+    assert_eq!(service.snapshot().admission().waiting_count(), 1);
+
+    matches.store(true, Ordering::Release);
+    let matched = service.prepare_arrival_batch(NotificationArrivalView::new(&topic, 0), None);
+    let matched = service.claim_prepared_arrival(matched).await;
+    let (mut claims, cursor) = matched.into_parts();
+    assert!(cursor.is_complete());
+    assert_eq!(claims.len(), 1);
+    let claim = claims.pop().expect("later matching arrival claims the waiter");
+    let service_for_resume = Arc::clone(&service);
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .action_context
+        .spawn_service("notification-deferred-filter-resume", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    DeferredResumeRetainedSize::default(),
+                    |_resume, reason| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        let head = application_remoting_command_factory().create_success_response_command_with_header(
+                            NotificationResponseHeader {
+                                has_msg: true,
+                                polling_full: false,
+                            },
+                        );
+                        ResponsePlan::command(head).map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn filtered Notification resume");
+    receipt_rx
+        .await
+        .expect("filtered Notification receipt channel")
+        .expect("canonical filtered Notification write");
+    let response = client
+        .receive_command()
+        .await
+        .expect("filtered connection remains open")
+        .expect("filtered Notification response frame");
+    let header = response
+        .decode_command_custom_header::<NotificationResponseHeader>()
+        .expect("filtered Notification response header");
+    assert!(header.has_msg);
+    assert!(!header.polling_full);
+    assert_eq!(service.snapshot().index().live(), 0);
+    assert_eq!(service.snapshot().admission().waiting_count(), 0);
+
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn notification_deferred_session_close_drains_registry_permit_and_index() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command())
+        .await
+        .expect("send Notification request before session close");
+    registrations.recv().await.expect("observe Notification registration");
+    assert_eq!(service.snapshot().admission().waiting_count(), 1);
+    assert_eq!(service.snapshot().index().live(), 1);
+
+    client.shutdown().await.expect("close Notification client session");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let snapshot = service.snapshot();
+            if snapshot.admission().waiting_count() == 0 && snapshot.index().live() == 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("session close drains Notification deferred state");
+    let DeferredRegistryShutdownOutcome::Completed(stats) = service.shutdown() else {
+        panic!("session-close verification should win service shutdown");
+    };
+    assert_eq!(
+        stats.detached_entries(),
+        0,
+        "session close already removed the registry entry"
+    );
+    assert_eq!(stats.invariant_failures(), 0);
+    let snapshot = service.snapshot();
+    assert_eq!(snapshot.admission().waiting_count(), 0);
+    assert_eq!(snapshot.admission().retained_bytes(), 0);
+    assert_eq!(snapshot.index().live(), 0);
+    assert_eq!(snapshot.index().reserved(), 0);
+    assert_eq!(snapshot.index().candidates(), 0);
+    assert_eq!(snapshot.index().keys(), 0);
+    assert_eq!(snapshot.index().oldest_waiter_age_millis(), None);
+    assert_eq!(snapshot.prepared(), 0);
+    assert_eq!(snapshot.pending_claims(), 0);
+    assert_eq!(snapshot.resume_executions(), 0);
+    assert_eq!(snapshot.resume_execution_bytes(), 0);
+    assert_eq!(snapshot.active_continuations(), 0);
+    assert_eq!(snapshot.continuation_bytes(), 0);
+
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn notification_deferred_timeout_winner_excludes_prepared_arrival_and_duplicate_claims() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("GroupA", 4, 250))
+        .await
+        .expect("send short Notification waiter");
+    registrations
+        .recv()
+        .await
+        .expect("observe short Notification registration");
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let arrival = NotificationArrivalView::new(&topic, 0);
+    let prepared_arrival = service.prepare_arrival_batch(arrival, None);
+    assert_eq!(prepared_arrival.candidate_count(), 1);
+    let duplicate_arrival = service.prepare_arrival_batch(arrival, None);
+    assert_eq!(
+        duplicate_arrival.candidate_count(),
+        0,
+        "candidate ownership excludes duplicate arrival"
+    );
+
+    let mut timeout_claims = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let claims = service.sweep_expired().into_claims();
+            if !claims.is_empty() {
+                break claims;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("protocol timeout becomes due");
+    assert_eq!(timeout_claims.len(), 1);
+    let timeout_claim = timeout_claims.pop().expect("one timeout claim");
+    assert_eq!(timeout_claim.reason(), DeferredWakeReason::Timeout);
+
+    let arrival_after_timeout = service.claim_prepared_arrival(prepared_arrival).await;
+    assert!(arrival_after_timeout.into_parts().0.is_empty());
+    let duplicate_after_timeout = service.claim_prepared_arrival(duplicate_arrival).await;
+    assert!(duplicate_after_timeout.into_parts().0.is_empty());
+    drop(timeout_claim);
+    assert_eq!(service.snapshot().index().live(), 0);
+    assert_eq!(service.snapshot().admission().waiting_count(), 0);
+
+    client.shutdown().await.expect("close timeout Notification client");
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn notification_deferred_newest_first_bounded_batch_continuation_advances_other_key() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service_with_scan(controller.as_ref(), 1);
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    for command in [
+        request_command_for("GroupA", 1, 60_000),
+        request_command_for("GroupA", 2, 60_000),
+        request_command_for("GroupB", 3, 60_000),
+    ] {
+        client.send_command(command).await.expect("send Notification waiter");
+        registrations
+            .recv()
+            .await
+            .expect("observe Notification waiter registration");
+    }
+    assert_eq!(service.snapshot().index().live(), 3);
+    assert_eq!(service.snapshot().admission().waiting_count(), 3);
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let arrival = NotificationArrivalView::new(&topic, 0);
+    let first = service.prepare_arrival_batch(arrival, None);
+    assert_eq!(first.inspected(), 1, "callback executes one bounded synchronous batch");
+    let first = service.claim_prepared_arrival(first).await;
+    let (mut first_claims, cursor) = first.into_parts();
+    assert_eq!(first_claims.len(), 1);
+    assert!(
+        !cursor.is_complete(),
+        "the second matching key remains for continuation"
+    );
+    let first_claim = first_claims.pop().expect("newest GroupA waiter claimed");
+    assert_eq!(
+        first_claim.resume_data().request().header().client_id.as_deref(),
+        Some("2"),
+        "same-key selection is newest-first"
+    );
+
+    let continuation = service
+        .admit_continuation(arrival, cursor)
+        .expect("admit bounded continuation");
+    let (claims_tx, mut claims_rx) = mpsc::unbounded_channel();
+    let handle_claims = Arc::new(move |claims| {
+        let claims_tx = claims_tx.clone();
+        async move {
+            let _ = claims_tx.send(claims);
+        }
+    });
+    service
+        .spawn_continuation(running.action_context.task_group(), continuation, handle_claims)
+        .expect("spawn lifecycle-owned Notification continuation");
+    let mut continued_claims = tokio::time::timeout(Duration::from_secs(2), claims_rx.recv())
+        .await
+        .expect("bounded continuation completes")
+        .expect("continuation claim batch");
+    assert_eq!(continued_claims.len(), 1);
+    let continued_claim = continued_claims.pop().expect("GroupB waiter claimed by continuation");
+    assert_eq!(
+        continued_claim.resume_data().request().consumer_group().as_str(),
+        "GroupB"
+    );
+
+    drop((first_claim, continued_claim));
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while service.snapshot().active_continuations() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("continuation permit released");
+    assert_eq!(
+        service.snapshot().index().live(),
+        1,
+        "older GroupA waiter remains registered"
+    );
+    assert_eq!(service.snapshot().admission().waiting_count(), 1);
+
+    client
+        .shutdown()
+        .await
+        .expect("close multi-waiter Notification session");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while service.snapshot().admission().waiting_count() != 0 || service.snapshot().index().live() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("session close drains final older waiter");
+    assert_eq!(service.snapshot().continuation_bytes(), 0);
+    running.finish().await;
+}
+
+mod body_owner_audit_tests;
+mod filter_audit_tests;
+mod registration_audit_tests;
+mod snapshot_audit_tests;
+mod terminal_audit_tests;

--- a/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/body_owner_audit_tests.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/body_owner_audit_tests.rs
@@ -1,0 +1,323 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io::Write;
+use std::sync::atomic::AtomicUsize;
+
+use bytes::Bytes;
+use rocketmq_transport::api::v1::FileRegionLease;
+use rocketmq_transport::api::v2::ClaimedDeferred;
+use rocketmq_transport::api::v2::DeferredResumeErrorKind;
+use rocketmq_transport::api::v2::FileRegion;
+use rocketmq_transport::api::v2::FileRegionSequence;
+use rocketmq_transport::api::v2::WriteProgress;
+
+use super::super::service::ResumeNotification;
+use super::*;
+
+const OWNER_BODY: &[u8] = b"notification-owner-body";
+const ONE_OVER_FRAME_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+struct CountingBodyOwner {
+    body: Vec<u8>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl CountingBodyOwner {
+    fn new(body: Vec<u8>, drops: Arc<AtomicUsize>) -> Self {
+        Self { body, drops }
+    }
+}
+
+impl AsRef<[u8]> for CountingBodyOwner {
+    fn as_ref(&self) -> &[u8] {
+        &self.body
+    }
+}
+
+impl Drop for CountingBodyOwner {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct CountingFileOwner {
+    file: File,
+    drops: Arc<AtomicUsize>,
+}
+
+impl FileRegionLease for CountingFileOwner {
+    fn file(&self) -> &File {
+        &self.file
+    }
+}
+
+impl Drop for CountingFileOwner {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn notification_head() -> RemotingCommand {
+    application_remoting_command_factory().create_success_response_command_with_header(NotificationResponseHeader {
+        has_msg: false,
+        polling_full: false,
+    })
+}
+
+async fn register_and_claim(
+    client: &mut Connection,
+    registrations: &mut mpsc::UnboundedReceiver<Registration>,
+    service: &NotificationDeferredService,
+) -> (Registration, ClaimedDeferred<ResumeNotification>) {
+    client
+        .send_command(request_command())
+        .await
+        .expect("send owner-backed Notification request");
+    let registration = registrations
+        .recv()
+        .await
+        .expect("observe owner-backed Notification registration");
+    let topic = CheetahString::from_static_str("TopicA");
+    let prepared = service.prepare_arrival_batch(NotificationArrivalView::new(&topic, 0), None);
+    let batch = service.claim_prepared_arrival(prepared).await;
+    let (mut claims, cursor) = batch.into_parts();
+    assert!(cursor.is_complete());
+    assert_eq!(claims.len(), 1);
+    (registration, claims.pop().expect("one owner-backed Notification claim"))
+}
+
+fn assert_service_released(service: &NotificationDeferredService) {
+    let snapshot = service.snapshot();
+    assert_eq!(snapshot.admission().waiting_count(), 0);
+    assert_eq!(snapshot.admission().retained_bytes(), 0);
+    assert_eq!(snapshot.index().live(), 0);
+    assert_eq!(snapshot.index().reserved(), 0);
+    assert_eq!(snapshot.index().candidates(), 0);
+    assert_eq!(snapshot.pending_claims(), 0);
+    assert_eq!(snapshot.resume_executions(), 0);
+    assert_eq!(snapshot.resume_execution_bytes(), 0);
+}
+
+#[tokio::test]
+async fn notification_deferred_owner_backed_body_success_releases_once_without_retry() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    let (registration, claim) = register_and_claim(&mut client, &mut registrations, &service).await;
+    let owner_drops = Arc::new(AtomicUsize::new(0));
+    let response_owner_drops = Arc::clone(&owner_drops);
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let response_attempts = Arc::clone(&attempts);
+
+    service
+        .resume_claimed(
+            claim,
+            DeferredResumeRetainedSize::default(),
+            move |resume, reason| async move {
+                assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                assert_eq!(resume.request().effective_peer(), registration.peer);
+                response_attempts.fetch_add(1, Ordering::SeqCst);
+                let body = Bytes::from_owner(CountingBodyOwner::new(OWNER_BODY.to_vec(), response_owner_drops));
+                ResponsePlan::bytes(notification_head(), body)
+                    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+            },
+        )
+        .await
+        .expect("write owner-backed Notification body");
+
+    let response = client
+        .receive_command()
+        .await
+        .expect("owner-backed Notification connection remains open")
+        .expect("owner-backed Notification response frame");
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(response.body().map(|body| body.as_ref()), Some(OWNER_BODY));
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 1);
+    assert_service_released(&service);
+
+    running.finish().await;
+    assert!(client.receive_command().await.is_none());
+}
+
+#[tokio::test]
+async fn notification_deferred_prewrite_failure_releases_owner_once_without_retry() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    let (_, claim) = register_and_claim(&mut client, &mut registrations, &service).await;
+    let owner_drops = Arc::new(AtomicUsize::new(0));
+    let response_owner_drops = Arc::clone(&owner_drops);
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let response_attempts = Arc::clone(&attempts);
+
+    let error = service
+        .resume_claimed(
+            claim,
+            DeferredResumeRetainedSize::default(),
+            move |_resume, reason| async move {
+                assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                response_attempts.fetch_add(1, Ordering::SeqCst);
+                let body = Bytes::from_owner(CountingBodyOwner::new(
+                    vec![b'x'; ONE_OVER_FRAME_BODY_BYTES],
+                    response_owner_drops,
+                ));
+                ResponsePlan::bytes(notification_head(), body)
+                    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+            },
+        )
+        .await
+        .expect_err("frame-limit failure rejects the owner-backed Notification body");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::Response);
+    assert_eq!(error.write_progress(), Some(WriteProgress::NotStarted));
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 1);
+    assert_service_released(&service);
+
+    client.shutdown().await.expect("close prewrite-failure client");
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn notification_deferred_parent_cancel_releases_prepared_owner_once_without_retry() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    let (_, claim) = register_and_claim(&mut client, &mut registrations, &service).await;
+    let owner_drops = Arc::new(AtomicUsize::new(0));
+    let response_owner_drops = Arc::clone(&owner_drops);
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let response_attempts = Arc::clone(&attempts);
+    let (plan_ready_tx, plan_ready_rx) = oneshot::channel();
+    let (release_plan_tx, release_plan_rx) = oneshot::channel();
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    let service_for_resume = Arc::clone(&service);
+    running
+        .action_context
+        .spawn_service("notification-owner-parent-cancel", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    DeferredResumeRetainedSize::default(),
+                    move |_resume, reason| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        response_attempts.fetch_add(1, Ordering::SeqCst);
+                        let body = Bytes::from_owner(CountingBodyOwner::new(OWNER_BODY.to_vec(), response_owner_drops));
+                        let plan = ResponsePlan::bytes(notification_head(), body)
+                            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+                        let _ = plan_ready_tx.send(());
+                        release_plan_rx
+                            .await
+                            .map_err(|_| RocketMQError::illegal_argument("cancelled Notification plan release"))?;
+                        Ok(plan)
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn owner-backed Notification cancellation");
+
+    plan_ready_rx
+        .await
+        .expect("owner-backed Notification plan reaches the accepted handler");
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 0);
+    running.cancel_server_parent();
+    let error = receipt_rx
+        .await
+        .expect("cancelled Notification receipt channel")
+        .expect_err("parent cancellation must reject the owner-backed Notification plan");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::Cancelled);
+    assert!(release_plan_tx.send(()).is_err());
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 1);
+    assert_service_released(&service);
+
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn notification_deferred_post_writer_claim_partial_releases_file_owner_once_without_retry() {
+    const REGION_BYTES: &[u8] = b"leased-notification-region";
+
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    let (_, claim) = register_and_claim(&mut client, &mut registrations, &service).await;
+    let owner_drops = Arc::new(AtomicUsize::new(0));
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let response_attempts = Arc::clone(&attempts);
+    let mut file = tempfile::tempfile().expect("temporary Notification region");
+    file.write_all(REGION_BYTES).expect("write Notification region");
+    file.flush().expect("flush Notification region");
+    let owner = Arc::new(CountingFileOwner {
+        file,
+        drops: Arc::clone(&owner_drops),
+    });
+    let lease: Arc<dyn FileRegionLease> = owner.clone();
+    let region = FileRegion::try_new(lease, 0, REGION_BYTES.len() as u64).expect("validated Notification region");
+    let regions = FileRegionSequence::try_new(vec![region]).expect("Notification region sequence");
+    owner
+        .file
+        .set_len(0)
+        .expect("inject deterministic body EOF after region validation");
+    drop(owner);
+
+    let error = service
+        .resume_claimed(
+            claim,
+            DeferredResumeRetainedSize::default(),
+            move |_resume, reason| async move {
+                assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                response_attempts.fetch_add(1, Ordering::SeqCst);
+                ResponsePlan::file_regions(notification_head(), regions)
+                    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+            },
+        )
+        .await
+        .expect_err("truncated leased body fails after the canonical frame head");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::Response);
+    assert_eq!(error.write_progress(), Some(WriteProgress::PossiblyPartial));
+    assert_eq!(attempts.load(Ordering::SeqCst), 1, "partial writes are never retried");
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 1);
+    assert_service_released(&service);
+
+    drop(client);
+    running.finish().await;
+}

--- a/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/filter_audit_tests.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/filter_audit_tests.rs
@@ -1,0 +1,228 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+use std::sync::atomic::AtomicUsize;
+
+use super::*;
+
+struct FixedFilter {
+    matched: bool,
+    commit_calls: Option<Arc<AtomicUsize>>,
+}
+
+impl MessageFilter for FixedFilter {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        self.matched
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        if let Some(calls) = self.commit_calls.as_ref() {
+            calls.fetch_add(1, Ordering::AcqRel);
+        }
+        false
+    }
+}
+
+#[derive(Clone)]
+struct PerRequestFilterProcessor {
+    service: Arc<NotificationDeferredService>,
+    registrations: mpsc::UnboundedSender<()>,
+    commit_calls: Option<Arc<AtomicUsize>>,
+}
+
+impl RequestProcessorV2 for PerRequestFilterProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let header = request
+            .command()
+            .decode_command_custom_header::<NotificationRequestHeader>()?;
+        let matched = header.client_id.as_deref() != Some("8102");
+        let filter: ArcMessageFilter = Arc::new(FixedFilter {
+            matched,
+            commit_calls: self.commit_calls.clone(),
+        });
+        let prepared = self
+            .service
+            .prepare(request, None, Some(filter), NotificationRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let registration = self
+            .service
+            .register(prepared, request)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let _ = self.registrations.send(());
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+
+    fn request_ordering(&self, _ingress: rocketmq_transport::api::v2::IngressRequestView<'_>) -> RequestOrdering {
+        RequestOrdering::Concurrent
+    }
+}
+
+fn success_plan(has_msg: bool) -> rocketmq_error::RocketMQResult<ResponsePlan> {
+    let head = application_remoting_command_factory().create_success_response_command_with_header(
+        NotificationResponseHeader {
+            has_msg,
+            polling_full: false,
+        },
+    );
+    ResponsePlan::command(head).map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+}
+
+#[tokio::test]
+async fn notification_deferred_miss_prefix_beyond_callback_batch_continuation_claims_and_resumes_match() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service_with_scan(controller.as_ref(), 1);
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = PerRequestFilterProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        commit_calls: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    for opaque in [8_101, 8_102] {
+        client
+            .send_command(request_command_for("GroupA", opaque, 60_000))
+            .await
+            .expect("send filtered Notification waiter");
+        registrations.recv().await.expect("observe filtered registration");
+    }
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let arrival = NotificationArrivalView::new(&topic, 0);
+    let first = service.prepare_arrival_batch(arrival, None);
+    assert_eq!(first.inspected(), 1);
+    assert_eq!(first.candidate_count(), 0, "newest filter miss restores its entry");
+    let first = service.claim_prepared_arrival(first).await;
+    let (claims, cursor) = first.into_parts();
+    assert!(claims.is_empty());
+    assert!(!cursor.is_complete(), "older matching prefix remains for continuation");
+    assert_eq!(service.snapshot().index().live(), 2);
+    assert_eq!(service.snapshot().admission().waiting_count(), 2);
+
+    let continuation = service
+        .admit_continuation(arrival, cursor)
+        .expect("admit miss-prefix continuation");
+    let service_for_handler = Arc::clone(&service);
+    let (resumed_tx, mut resumed_rx) = mpsc::unbounded_channel();
+    let handle_claims = Arc::new(move |claims| {
+        let service = Arc::clone(&service_for_handler);
+        let resumed = resumed_tx.clone();
+        async move {
+            for claim in claims {
+                let result = service
+                    .resume_claimed(
+                        claim,
+                        DeferredResumeRetainedSize::default(),
+                        |_resume, reason| async move {
+                            assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                            success_plan(true)
+                        },
+                    )
+                    .await;
+                let _ = resumed.send(result);
+            }
+        }
+    });
+    service
+        .spawn_continuation(running.action_context.task_group(), continuation, handle_claims)
+        .expect("spawn miss-prefix continuation");
+    resumed_rx
+        .recv()
+        .await
+        .expect("continuation resumes matching waiter")
+        .expect("matching continuation writes canonically");
+    let response = client
+        .receive_command()
+        .await
+        .expect("filtered connection")
+        .expect("matching continuation frame");
+    assert_eq!(
+        response.opaque(),
+        8_101,
+        "older matching waiter, not newest miss, resumes"
+    );
+    assert_eq!(service.snapshot().index().live(), 1);
+    assert_eq!(service.snapshot().admission().waiting_count(), 1);
+
+    client.shutdown().await.expect("close filtered Notification session");
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn notification_deferred_properties_absent_matches_and_one_arrival_claims_wildcard_then_exact() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let commit_calls = Arc::new(AtomicUsize::new(0));
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = PerRequestFilterProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        commit_calls: Some(Arc::clone(&commit_calls)),
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    let mut wildcard = request_command_for("GroupA", 8_201, 60_000);
+    wildcard.add_ext_field("queueId", "-1");
+    for command in [wildcard, request_command_for("GroupA", 8_202, 60_000)] {
+        client
+            .send_command(command)
+            .await
+            .expect("send wildcard/exact Notification waiter");
+        registrations.recv().await.expect("observe wildcard/exact registration");
+    }
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let prepared = service.prepare_arrival_batch(NotificationArrivalView::new(&topic, 0), None);
+    assert_eq!(
+        prepared.candidate_count(),
+        2,
+        "wildcard and exact keys both match one arrival"
+    );
+    assert_eq!(
+        commit_calls.load(Ordering::Acquire),
+        0,
+        "absent properties skip commit-log filter"
+    );
+    let (claims, cursor) = service.claim_prepared_arrival(prepared).await.into_parts();
+    assert!(cursor.is_complete());
+    assert_eq!(claims.len(), 2);
+    for claim in claims {
+        service
+            .resume_claimed(
+                claim,
+                DeferredResumeRetainedSize::default(),
+                |_resume, _reason| async move { success_plan(true) },
+            )
+            .await
+            .expect("wildcard/exact canonical resume");
+    }
+    let mut opaque = BTreeSet::new();
+    for _ in 0..2 {
+        opaque.insert(
+            client
+                .receive_command()
+                .await
+                .expect("wildcard/exact connection")
+                .expect("wildcard/exact response")
+                .opaque(),
+        );
+    }
+    assert_eq!(opaque, BTreeSet::from([8_201, 8_202]));
+    assert_eq!(service.snapshot().index().live(), 0);
+    assert_eq!(service.snapshot().admission().waiting_count(), 0);
+    running.finish().await;
+}

--- a/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/registration_audit_tests.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/registration_audit_tests.rs
@@ -1,0 +1,415 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use parking_lot::Mutex;
+use rocketmq_security_api::AuthenticatedRequestContext;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::RequestPolicy;
+use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+use rocketmq_transport::api::v2::DeferredExpiryErrorKind;
+use rocketmq_transport::api::v2::DeferredRegistryErrorKind;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+use super::*;
+use crate::long_polling::notification_deferred::service::NotificationDeferredPrepareErrorKind;
+use crate::long_polling::notification_deferred::service::NotificationDeferredRegisterErrorKind;
+use crate::long_polling::notification_deferred::service::NotificationRegisterFault;
+use crate::long_polling::notification_deferred::service::PreparedNotificationRegistration;
+
+fn success_reply(polling_full: bool) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+    let header = NotificationResponseHeader {
+        has_msg: false,
+        polling_full,
+    };
+    ResponsePlan::command(application_remoting_command_factory().create_success_response_command_with_header(header))
+        .map(HandlerOutcome::Reply)
+        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+}
+
+fn limited_service(
+    controller: &AdmissionController,
+    wait_limits: DeferredWaitLimits,
+    index_limits: NotificationCriteriaLimits,
+) -> Arc<NotificationDeferredService> {
+    let admission = DeferredAdmission::try_configure(controller, wait_limits).expect("limited Notification admission");
+    Arc::new(NotificationDeferredService::new(
+        admission,
+        index_limits,
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        nonzero(4),
+        nonzero(4),
+        nonzero(2),
+        nonzero(1024 * 1024),
+    ))
+}
+
+fn assert_empty(service: &NotificationDeferredService) {
+    let snapshot = service.snapshot();
+    assert_eq!(snapshot.admission().waiting_count(), 0);
+    assert_eq!(snapshot.admission().retained_bytes(), 0);
+    assert_eq!(snapshot.index().live(), 0);
+    assert_eq!(snapshot.index().reserved(), 0);
+    assert_eq!(snapshot.prepared(), 0);
+    assert_eq!(snapshot.pending_claims(), 0);
+    assert_eq!(snapshot.resume_executions(), 0);
+    assert_eq!(snapshot.resume_execution_bytes(), 0);
+}
+
+#[derive(Default)]
+struct ProvenanceState {
+    prepared: Option<PreparedNotificationRegistration>,
+}
+
+#[derive(Clone)]
+struct ProvenanceProcessor {
+    service: Arc<NotificationDeferredService>,
+    state: Arc<Mutex<ProvenanceState>>,
+}
+
+impl RequestProcessorV2 for ProvenanceProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        if let Some(prepared) = self.state.lock().prepared.take() {
+            let error = self
+                .service
+                .register(prepared, request)
+                .expect_err("a prepared Notification proof cannot move to another request");
+            assert_eq!(error.kind(), NotificationDeferredRegisterErrorKind::ProvenanceMismatch);
+            return success_reply(false);
+        }
+        let prepared = self
+            .service
+            .prepare(request, None, None, NotificationRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.state.lock().prepared = Some(prepared);
+        success_reply(false)
+    }
+}
+
+#[derive(Clone)]
+struct EmbeddedOriginProcessor {
+    service: Arc<NotificationDeferredService>,
+    observed: Arc<Mutex<Option<NotificationDeferredPrepareErrorKind>>>,
+}
+
+impl RequestProcessorV2 for EmbeddedOriginProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let error = match self
+            .service
+            .prepare(request, None, None, NotificationRetainedEstimate::default())
+        {
+            Err(error) => error,
+            Ok(_) => panic!("embedded Notification must fail before allocating deferred resources"),
+        };
+        *self.observed.lock() = Some(error.kind());
+        success_reply(false)
+    }
+}
+
+struct AllowEmbeddedPolicy;
+
+impl RequestPolicy for AllowEmbeddedPolicy {
+    fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+        Decision::Allow
+    }
+}
+
+#[derive(Clone)]
+struct CapacityProcessor {
+    service: Arc<NotificationDeferredService>,
+    held: Arc<Mutex<Vec<PreparedNotificationRegistration>>>,
+    observed: Arc<Mutex<Vec<NotificationDeferredPrepareErrorKind>>>,
+}
+
+impl RequestProcessorV2 for CapacityProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let polling_full = match self
+            .service
+            .prepare(request, None, None, NotificationRetainedEstimate::default())
+        {
+            Ok(prepared) => {
+                self.held.lock().push(prepared);
+                false
+            }
+            Err(error) => {
+                self.observed.lock().push(error.kind());
+                true
+            }
+        };
+        success_reply(polling_full)
+    }
+}
+
+#[derive(Clone)]
+struct OneWayProcessor {
+    service: Arc<NotificationDeferredService>,
+    observed: mpsc::UnboundedSender<NotificationDeferredPrepareErrorKind>,
+}
+
+#[derive(Clone)]
+struct PostTakeFaultProcessor {
+    service: Arc<NotificationDeferredService>,
+    fault: NotificationRegisterFault,
+    observed: mpsc::UnboundedSender<NotificationDeferredRegisterErrorKind>,
+}
+
+impl RequestProcessorV2 for PostTakeFaultProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prepared = self
+            .service
+            .prepare(request, None, None, NotificationRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.service.force_register_fault(self.fault);
+        let error = match self.service.register(prepared, request) {
+            Err(error) => error,
+            Ok(_) => panic!("injected post-take Notification fault must fail registration"),
+        };
+        let kind = error.kind();
+        let message = error.to_string();
+        drop(error);
+        self.observed
+            .send(kind)
+            .map_err(|_| RocketMQError::illegal_argument("post-take observer closed"))?;
+        Err(RocketMQError::illegal_argument(message))
+    }
+}
+
+impl RequestProcessorV2 for OneWayProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let error = match self
+            .service
+            .prepare(request, None, None, NotificationRetainedEstimate::default())
+        {
+            Err(error) => error,
+            Ok(_) => panic!("one-way Notification must fail before deferred allocation"),
+        };
+        self.observed
+            .send(error.kind())
+            .map_err(|_| RocketMQError::illegal_argument("one-way observer closed"))?;
+        success_reply(false)
+    }
+}
+
+#[tokio::test]
+async fn notification_deferred_one_way_is_rejected_before_capacity_take_and_writes_nothing() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (observed_tx, mut observed_rx) = mpsc::unbounded_channel();
+    let processor = OneWayProcessor {
+        service: Arc::clone(&service),
+        observed: observed_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command().mark_oneway_rpc())
+        .await
+        .expect("send one-way Notification");
+    assert_eq!(
+        observed_rx.recv().await,
+        Some(NotificationDeferredPrepareErrorKind::OneWay)
+    );
+    assert_empty(&service);
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "one-way request emits no frame"
+    );
+}
+
+#[tokio::test]
+async fn notification_deferred_cross_request_provenance_fails_before_responder_take() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let state = Arc::new(Mutex::new(ProvenanceState::default()));
+    let processor = ProvenanceProcessor {
+        service: Arc::clone(&service),
+        state: Arc::clone(&state),
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+
+    for opaque in [10_101, 10_102] {
+        client
+            .send_command(request_command_for("provenance-group", opaque, 60_000))
+            .await
+            .expect("send Notification provenance request");
+        let reply = client
+            .receive_command()
+            .await
+            .expect("provenance connection")
+            .expect("inline provenance response");
+        assert_eq!(reply.opaque(), opaque);
+    }
+    assert!(state.lock().prepared.is_none());
+    assert_empty(&service);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn notification_deferred_embedded_origin_is_rejected_before_capacity_take() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let observed = Arc::new(Mutex::new(None));
+    let processor = EmbeddedOriginProcessor {
+        service: Arc::clone(&service),
+        observed: Arc::clone(&observed),
+    };
+    let runtime = RuntimeOwner::new(RuntimeConfig::server_default("notification-embedded-origin"))
+        .expect("embedded Notification runtime");
+    let context = runtime.root_context().component("notification.embedded-origin");
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        Vec::new(),
+        Arc::new(TransportSecurity::secure_enforced(
+            Some(Arc::new(AllowEmbeddedPolicy)),
+            None,
+        )),
+        Arc::clone(&controller),
+    ));
+    let harness = EmbeddedRequestHarnessV2::new(
+        dispatcher,
+        context.task_group().clone(),
+        Principal::new("notification-embedded-test"),
+    );
+
+    let outcome = harness
+        .dispatch(None, request_command_for("embedded-group", 10_103, 60_000))
+        .await
+        .expect("embedded Notification inline response");
+    assert!(matches!(outcome, EmbeddedDispatchOutcome::Reply(_)));
+    assert_eq!(
+        *observed.lock(),
+        Some(NotificationDeferredPrepareErrorKind::EmbeddedOrigin)
+    );
+    assert_empty(&service);
+
+    drop(harness);
+    drop(context);
+    assert!(runtime.shutdown_tasks().await.is_healthy());
+    assert!(runtime.shutdown_background().is_healthy());
+}
+
+#[tokio::test]
+async fn notification_deferred_global_per_key_wait_and_bytes_full_map_to_polling_full() {
+    let cases = [
+        (
+            "global",
+            DeferredWaitLimits::new(4, 1024 * 1024),
+            NotificationCriteriaLimits::new(nonzero(1), 3, 1),
+            vec![("GroupA", 10_201), ("GroupB", 10_202)],
+            NotificationDeferredPrepareErrorKind::Index,
+        ),
+        (
+            "per-key",
+            DeferredWaitLimits::new(4, 1024 * 1024),
+            NotificationCriteriaLimits::new(nonzero(4), 0, 1),
+            vec![("GroupA", 10_203), ("GroupA", 10_204)],
+            NotificationDeferredPrepareErrorKind::Index,
+        ),
+        (
+            "wait-count",
+            DeferredWaitLimits::new(1, 1024 * 1024),
+            NotificationCriteriaLimits::new(nonzero(4), 3, 1),
+            vec![("GroupA", 10_205), ("GroupB", 10_206)],
+            NotificationDeferredPrepareErrorKind::Admission,
+        ),
+        (
+            "wait-bytes",
+            DeferredWaitLimits::new(4, 1),
+            NotificationCriteriaLimits::new(nonzero(4), 3, 1),
+            vec![("GroupA", 10_207)],
+            NotificationDeferredPrepareErrorKind::Admission,
+        ),
+    ];
+
+    for (label, wait_limits, index_limits, requests, expected_kind) in cases {
+        let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+        let service = limited_service(controller.as_ref(), wait_limits, index_limits);
+        let held = Arc::new(Mutex::new(Vec::new()));
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let processor = CapacityProcessor {
+            service: Arc::clone(&service),
+            held: Arc::clone(&held),
+            observed: Arc::clone(&observed),
+        };
+        let (mut client, running) = start_server(processor, controller).await;
+        let mut polling_full = Vec::new();
+        for (group, opaque) in requests {
+            client
+                .send_command(request_command_for(group, opaque, 60_000))
+                .await
+                .expect("send Notification capacity probe");
+            let reply = client
+                .receive_command()
+                .await
+                .expect("capacity connection")
+                .expect("capacity inline response");
+            let header = reply
+                .decode_command_custom_header::<NotificationResponseHeader>()
+                .expect("Notification capacity response header");
+            polling_full.push(header.polling_full);
+        }
+        assert_eq!(observed.lock().as_slice(), &[expected_kind], "{label}");
+        assert_eq!(polling_full.last(), Some(&true), "{label}");
+        held.lock().clear();
+        assert_empty(&service);
+        running.finish().await;
+    }
+}
+
+#[tokio::test]
+async fn notification_deferred_post_take_close_expiry_and_registry_fail_closed_without_a_frame() {
+    let cases = [
+        (
+            "service-close",
+            NotificationRegisterFault::Close,
+            NotificationDeferredRegisterErrorKind::ServiceClosedAfterTake,
+        ),
+        (
+            "expiry",
+            NotificationRegisterFault::Expiry,
+            NotificationDeferredRegisterErrorKind::Expiry(DeferredExpiryErrorKind::ProtocolAlreadyExpired),
+        ),
+        (
+            "registry",
+            NotificationRegisterFault::Builder,
+            NotificationDeferredRegisterErrorKind::Registry(DeferredRegistryErrorKind::ParentCancelled),
+        ),
+    ];
+
+    for (label, fault, expected) in cases {
+        let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+        let service = service(controller.as_ref());
+        let (observed_tx, mut observed_rx) = mpsc::unbounded_channel();
+        let processor = PostTakeFaultProcessor {
+            service: Arc::clone(&service),
+            fault,
+            observed: observed_tx,
+        };
+        let (mut client, running) = start_server(processor, controller).await;
+        client
+            .send_command(request_command_for("post-take-group", 10_300, 60_000))
+            .await
+            .expect("send post-take Notification probe");
+        assert_eq!(observed_rx.recv().await, Some(expected), "{label}");
+        assert_empty(&service);
+        let _ = service.shutdown();
+        running.finish().await;
+        assert!(
+            client.receive_command().await.is_none(),
+            "{label} emitted a response frame"
+        );
+    }
+}

--- a/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/snapshot_audit_tests.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/snapshot_audit_tests.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[tokio::test]
+async fn notification_deferred_snapshot_tracks_accepted_resume_count_and_bytes_until_terminal() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("GroupA", 7_001, 60_000))
+        .await
+        .expect("send observed Notification waiter");
+    registrations.recv().await.expect("observe Notification registration");
+
+    let registered = service.snapshot();
+    assert_eq!(registered.admission().waiting_count(), 1);
+    assert!(registered.admission().retained_bytes() > 0);
+    assert_eq!(registered.index().live(), 1);
+    assert_eq!(registered.index().reserved(), 0);
+    assert_eq!(registered.index().candidates(), 0);
+    assert_eq!(registered.index().keys(), 1);
+    assert!(registered.index().oldest_waiter_age_millis().is_some());
+    let manual_now = tokio::time::Instant::now();
+    let initial_age = service
+        .index
+        .snapshot_at_for_test(manual_now)
+        .oldest_waiter_age_millis()
+        .expect("registered waiter has an age");
+    let normalized_age = |now| {
+        service
+            .index
+            .snapshot_at_for_test(now)
+            .oldest_waiter_age_millis()
+            .expect("registered waiter remains indexed")
+            .checked_sub(initial_age)
+            .expect("manual observation cannot move backwards")
+    };
+    assert_eq!(normalized_age(manual_now), 0);
+    assert_eq!(
+        normalized_age(manual_now + Duration::from_millis(7)),
+        7,
+        "the manual monotonic clock reports the exact positive registered-age delta"
+    );
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let prepared = service.prepare_arrival_batch(NotificationArrivalView::new(&topic, 0), None);
+    let (mut claims, cursor) = service.claim_prepared_arrival(prepared).await.into_parts();
+    assert!(cursor.is_complete());
+    let claim = claims.pop().expect("claim observed Notification waiter");
+    let started = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let started_in_handler = Arc::clone(&started);
+    let release_in_handler = Arc::clone(&release);
+    let service_for_resume = Arc::clone(&service);
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .action_context
+        .spawn_service("notification-deferred-observed-resume", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    DeferredResumeRetainedSize::new(321),
+                    move |_resume, reason| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        started_in_handler.notify_one();
+                        release_in_handler.notified().await;
+                        let head = application_remoting_command_factory().create_success_response_command_with_header(
+                            NotificationResponseHeader {
+                                has_msg: false,
+                                polling_full: false,
+                            },
+                        );
+                        ResponsePlan::command(head).map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn observed Notification resume");
+
+    started.notified().await;
+    let active = service.snapshot();
+    assert_eq!(active.resume_executions(), 1);
+    assert_eq!(active.resume_execution_bytes(), 321);
+    assert_eq!(
+        active.admission().waiting_count(),
+        0,
+        "wait permit precedes execution admission release"
+    );
+    assert_eq!(active.index().live(), 0);
+
+    release.notify_one();
+    receipt_rx
+        .await
+        .expect("observed resume receipt channel")
+        .expect("observed resume writes canonically");
+    let response = client
+        .receive_command()
+        .await
+        .expect("observed resume connection")
+        .expect("observed resume frame");
+    assert_eq!(response.opaque(), 7_001);
+    let terminal = service.snapshot();
+    assert_eq!(terminal.admission().waiting_count(), 0);
+    assert_eq!(terminal.admission().retained_bytes(), 0);
+    assert_eq!(terminal.index().live(), 0);
+    assert_eq!(terminal.index().reserved(), 0);
+    assert_eq!(terminal.index().candidates(), 0);
+    assert_eq!(terminal.index().keys(), 0);
+    assert_eq!(terminal.index().oldest_waiter_age_millis(), None);
+    assert_eq!(terminal.resume_executions(), 0);
+    assert_eq!(terminal.resume_execution_bytes(), 0);
+    assert_eq!(terminal.pending_claims(), 0);
+    assert_eq!(terminal.prepared(), 0);
+    assert_eq!(terminal.active_continuations(), 0);
+    assert_eq!(terminal.continuation_bytes(), 0);
+
+    running.finish().await;
+}

--- a/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/terminal_audit_tests.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/acceptance_tests/terminal_audit_tests.rs
@@ -1,0 +1,317 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use rocketmq_transport::api::v2::ClaimedDeferred;
+use rocketmq_transport::api::v2::DeferredResumeErrorKind;
+use rocketmq_transport::api::v2::DeferredTerminalReason;
+use tokio::sync::Notify;
+
+use super::*;
+use crate::long_polling::notification_deferred::service::ResumeNotification;
+
+struct DropSignal(Arc<Notify>);
+
+impl Drop for DropSignal {
+    fn drop(&mut self) {
+        self.0.notify_one();
+    }
+}
+
+fn assert_terminal(service: &NotificationDeferredService) {
+    let snapshot = service.snapshot();
+    assert_eq!(snapshot.admission().waiting_count(), 0);
+    assert_eq!(snapshot.admission().retained_bytes(), 0);
+    assert_eq!(snapshot.index().live(), 0);
+    assert_eq!(snapshot.index().reserved(), 0);
+    assert_eq!(snapshot.index().candidates(), 0);
+    assert_eq!(snapshot.index().keys(), 0);
+    assert_eq!(snapshot.index().oldest_waiter_age_millis(), None);
+    assert_eq!(snapshot.prepared(), 0);
+    assert_eq!(snapshot.pending_claims(), 0);
+    assert_eq!(snapshot.resume_executions(), 0);
+    assert_eq!(snapshot.resume_execution_bytes(), 0);
+    assert_eq!(snapshot.active_continuations(), 0);
+    assert_eq!(snapshot.continuation_bytes(), 0);
+}
+
+async fn registered_waiter(
+    service: &Arc<NotificationDeferredService>,
+    controller: Arc<AdmissionController>,
+    opaque: i32,
+) -> (Connection, RunningServer) {
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredProcessor {
+        service: Arc::clone(service),
+        registrations: registration_tx,
+        filter: None,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("GroupA", opaque, 60_000))
+        .await
+        .expect("send terminal-audit Notification waiter");
+    registrations
+        .recv()
+        .await
+        .expect("observe terminal-audit Notification registration");
+    (client, running)
+}
+
+async fn claim_one(service: &NotificationDeferredService) -> ClaimedDeferred<ResumeNotification> {
+    let topic = CheetahString::from_static_str("TopicA");
+    let prepared = service.prepare_arrival_batch(NotificationArrivalView::new(&topic, 0), None);
+    let (mut claims, cursor) = service.claim_prepared_arrival(prepared).await.into_parts();
+    assert!(cursor.is_complete());
+    assert_eq!(claims.len(), 1);
+    claims.pop().expect("one Notification waiter is claimed")
+}
+
+#[tokio::test]
+async fn notification_deferred_execution_admission_rejects_before_handler_and_writes_one_error() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (mut client, running) = registered_waiter(&service, Arc::clone(&controller), 8_101).await;
+    let claim = claim_one(&service).await;
+    assert_eq!(service.snapshot().admission().waiting_count(), 1);
+
+    let handler_calls = Arc::new(AtomicUsize::new(0));
+    let handler_calls_for_resume = Arc::clone(&handler_calls);
+    service
+        .resume_claimed(
+            claim,
+            DeferredResumeRetainedSize::new(AdmissionLimits::default().queued.bytes),
+            move |_resume, _reason| async move {
+                handler_calls_for_resume.fetch_add(1, Ordering::SeqCst);
+                ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                    ResponseCode::Success,
+                ))
+                .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+            },
+        )
+        .await
+        .expect("execution rejection writes one canonical overload response");
+
+    let response = client
+        .receive_command()
+        .await
+        .expect("execution-reject session remains open")
+        .expect("execution rejection emits one response frame");
+    assert_eq!(response.opaque(), 8_101);
+    assert_eq!(response.code(), ResponseCode::SystemBusy as i32);
+    assert_eq!(handler_calls.load(Ordering::SeqCst), 0);
+    assert_terminal(&service);
+    let admission = controller.snapshot();
+    assert_eq!(admission.queued.current_count, 0);
+    assert_eq!(admission.inflight.current_count, 0);
+    assert_eq!(admission.processors.current_count, 0);
+    assert_eq!(admission.queued.rejected_count, 1);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "execution admission rejection has one terminal frame"
+    );
+}
+
+#[tokio::test]
+async fn notification_deferred_service_shutdown_drains_registered_candidate_without_handler_or_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (mut client, running) = registered_waiter(&service, controller, 8_102).await;
+    let topic = CheetahString::from_static_str("TopicA");
+    let prepared = service.prepare_arrival_batch(NotificationArrivalView::new(&topic, 0), None);
+    assert_eq!(prepared.candidate_count(), 1);
+    assert_eq!(service.snapshot().index().candidates(), 1);
+
+    let DeferredRegistryShutdownOutcome::Completed(stats) = service.shutdown() else {
+        panic!("terminal audit owns Notification service shutdown");
+    };
+    assert_eq!(stats.detached_entries(), 1);
+    assert_eq!(stats.invariant_failures(), 0);
+    let claimed_after_shutdown = service.claim_prepared_arrival(prepared).await;
+    assert!(claimed_after_shutdown.into_parts().0.is_empty());
+    assert_terminal(&service);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "service shutdown emits no Notification frame"
+    );
+}
+
+#[tokio::test]
+async fn notification_deferred_inactive_session_cannot_claim_execute_or_write() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (mut client, running) = registered_waiter(&service, controller, 8_103).await;
+    client.shutdown().await.expect("close inactive Notification session");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let snapshot = service.snapshot();
+            if snapshot.admission().waiting_count() == 0 && snapshot.index().live() == 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("inactive session cleanup drains Notification waiter");
+
+    let topic = CheetahString::from_static_str("TopicA");
+    let prepared = service.prepare_arrival_batch(NotificationArrivalView::new(&topic, 0), None);
+    assert_eq!(prepared.candidate_count(), 0);
+    assert!(service.claim_prepared_arrival(prepared).await.into_parts().0.is_empty());
+    assert_terminal(&service);
+
+    running.finish().await;
+    assert!(client.receive_command().await.is_none());
+}
+
+#[tokio::test]
+async fn notification_deferred_service_shutdown_stops_accepted_handler_without_a_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (mut client, running) = registered_waiter(&service, controller, 8_104).await;
+    let claim = claim_one(&service).await;
+    let handler_calls = Arc::new(AtomicUsize::new(0));
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let dropped = Arc::new(Notify::new());
+    let calls_for_handler = Arc::clone(&handler_calls);
+    let started_for_handler = Arc::clone(&started);
+    let release_for_handler = Arc::clone(&release);
+    let dropped_for_handler = Arc::clone(&dropped);
+    let service_for_resume = Arc::clone(&service);
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .action_context
+        .spawn_service("notification-terminal-service-shutdown", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    DeferredResumeRetainedSize::new(257),
+                    move |_resume, _reason| async move {
+                        calls_for_handler.fetch_add(1, Ordering::SeqCst);
+                        let _drop_signal = DropSignal(dropped_for_handler);
+                        started_for_handler.notify_one();
+                        release_for_handler.notified().await;
+                        ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::Success,
+                        ))
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn accepted Notification resume");
+    started.notified().await;
+    let active = service.snapshot();
+    assert_eq!(active.admission().waiting_count(), 0);
+    assert_eq!(active.resume_executions(), 1);
+    assert_eq!(active.resume_execution_bytes(), 257);
+
+    assert!(matches!(
+        service.shutdown(),
+        DeferredRegistryShutdownOutcome::Completed(_)
+    ));
+    release.notify_one();
+    dropped.notified().await;
+    let error = receipt_rx
+        .await
+        .expect("service-shutdown receipt channel")
+        .expect_err("service shutdown stops an accepted Notification resume");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::Cancelled);
+    assert_eq!(
+        error.prior_terminal_reason(),
+        Some(DeferredTerminalReason::ParentCancelled)
+    );
+    assert_eq!(error.write_progress(), None);
+    assert_eq!(handler_calls.load(Ordering::SeqCst), 1);
+    assert_terminal(&service);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "service shutdown cancels the accepted handler before write"
+    );
+}
+
+#[tokio::test]
+async fn notification_deferred_parent_cancel_stops_accepted_handler_without_a_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref());
+    let (mut client, mut running) = registered_waiter(&service, controller, 8_105).await;
+    let claim = claim_one(&service).await;
+    let handler_calls = Arc::new(AtomicUsize::new(0));
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let dropped = Arc::new(Notify::new());
+    let calls_for_handler = Arc::clone(&handler_calls);
+    let started_for_handler = Arc::clone(&started);
+    let release_for_handler = Arc::clone(&release);
+    let dropped_for_handler = Arc::clone(&dropped);
+    let service_for_resume = Arc::clone(&service);
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .action_context
+        .spawn_service("notification-terminal-parent-cancel", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    DeferredResumeRetainedSize::new(193),
+                    move |_resume, _reason| async move {
+                        calls_for_handler.fetch_add(1, Ordering::SeqCst);
+                        let _drop_signal = DropSignal(dropped_for_handler);
+                        started_for_handler.notify_one();
+                        release_for_handler.notified().await;
+                        ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::Success,
+                        ))
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn parent-cancelled Notification resume");
+    started.notified().await;
+    assert_eq!(service.snapshot().admission().waiting_count(), 0);
+    assert_eq!(service.snapshot().resume_executions(), 1);
+
+    running.begin_shutdown();
+    dropped.notified().await;
+    let error = receipt_rx
+        .await
+        .expect("parent-cancel receipt channel")
+        .expect_err("parent cancellation stops accepted Notification resume");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::Cancelled);
+    assert_eq!(
+        error.prior_terminal_reason(),
+        Some(DeferredTerminalReason::ParentCancelled)
+    );
+    assert_eq!(error.write_progress(), None);
+    assert_eq!(handler_calls.load(Ordering::SeqCst), 1);
+    assert_terminal(&service);
+    drop(release);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "parent cancellation drains without a Notification frame"
+    );
+}

--- a/rocketmq-broker/src/long_polling/notification_deferred/deadline.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/deadline.rs
@@ -1,0 +1,128 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+use std::time::Duration;
+
+const EARLY_WAKE_MILLIS: i64 = 50;
+
+/// Checked Notification protocol deadline, separate from transport ownership.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct NotificationWaitDeadline {
+    protocol_millis: i64,
+    protocol_at: tokio::time::Instant,
+}
+
+impl NotificationWaitDeadline {
+    /// Freezes `now > (born + poll).saturating_sub(50)` as a monotonic instant.
+    pub(crate) fn checked(
+        born_time: i64,
+        poll_time: i64,
+        wall_now: i64,
+        monotonic_now: tokio::time::Instant,
+    ) -> Result<Self, NotificationWaitDeadlineError> {
+        if born_time < 0 {
+            return Err(NotificationWaitDeadlineError::new(
+                NotificationWaitDeadlineErrorKind::NegativeBornTime,
+            ));
+        }
+        if poll_time <= 0 {
+            return Err(NotificationWaitDeadlineError::new(
+                NotificationWaitDeadlineErrorKind::NonPositivePollTime,
+            ));
+        }
+        if wall_now < 0 {
+            return Err(NotificationWaitDeadlineError::new(
+                NotificationWaitDeadlineErrorKind::NegativeWallTime,
+            ));
+        }
+        let requested_end = born_time
+            .checked_add(poll_time)
+            .ok_or_else(|| NotificationWaitDeadlineError::new(NotificationWaitDeadlineErrorKind::ProtocolOverflow))?;
+        let cutoff = requested_end.saturating_sub(EARLY_WAKE_MILLIS);
+        if wall_now > cutoff {
+            return Err(NotificationWaitDeadlineError::new(
+                NotificationWaitDeadlineErrorKind::AlreadyExpired,
+            ));
+        }
+        let protocol_millis = cutoff
+            .checked_add(1)
+            .ok_or_else(|| NotificationWaitDeadlineError::new(NotificationWaitDeadlineErrorKind::ProtocolOverflow))?;
+        let remaining = protocol_millis
+            .checked_sub(wall_now)
+            .ok_or_else(|| NotificationWaitDeadlineError::new(NotificationWaitDeadlineErrorKind::ProtocolOverflow))?;
+        let remaining = u64::try_from(remaining)
+            .map_err(|_| NotificationWaitDeadlineError::new(NotificationWaitDeadlineErrorKind::ProtocolOverflow))?;
+        let protocol_at = monotonic_now
+            .checked_add(Duration::from_millis(remaining))
+            .ok_or_else(|| NotificationWaitDeadlineError::new(NotificationWaitDeadlineErrorKind::MonotonicOverflow))?;
+        Ok(Self {
+            protocol_millis,
+            protocol_at,
+        })
+    }
+
+    #[must_use]
+    pub(crate) const fn protocol_millis(self) -> i64 {
+        self.protocol_millis
+    }
+
+    #[must_use]
+    pub(crate) const fn protocol_at(self) -> tokio::time::Instant {
+        self.protocol_at
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum NotificationWaitDeadlineErrorKind {
+    NegativeBornTime,
+    NonPositivePollTime,
+    NegativeWallTime,
+    ProtocolOverflow,
+    AlreadyExpired,
+    MonotonicOverflow,
+}
+
+pub(crate) struct NotificationWaitDeadlineError {
+    kind: NotificationWaitDeadlineErrorKind,
+}
+
+impl NotificationWaitDeadlineError {
+    const fn new(kind: NotificationWaitDeadlineErrorKind) -> Self {
+        Self { kind }
+    }
+
+    #[must_use]
+    pub(crate) const fn kind(&self) -> NotificationWaitDeadlineErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for NotificationWaitDeadlineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NotificationWaitDeadlineError")
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for NotificationWaitDeadlineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Notification wait deadline failed: {:?}", self.kind)
+    }
+}
+
+impl Error for NotificationWaitDeadlineError {}

--- a/rocketmq-broker/src/long_polling/notification_deferred/index.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/index.rs
@@ -1,0 +1,807 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicU8;
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Weak;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_model::common::key_builder::KeyBuilder;
+use rocketmq_model::common::key_builder::POP_RETRY_SEPARATOR_V2;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_store::ArcMessageFilter;
+use rocketmq_store::CqExtUnit;
+use rocketmq_transport::api::v2::DeferredId;
+
+use super::deadline::NotificationWaitDeadline;
+
+const INDEXED: u8 = 0;
+const CANDIDATE: u8 = 1;
+const REMOVED: u8 = 2;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct NotificationCriteriaLimits {
+    max_entries: NonZeroUsize,
+    max_entries_per_key: NonZeroUsize,
+    allocation_hint: usize,
+}
+
+impl NotificationCriteriaLimits {
+    pub(crate) fn new(max_entries: NonZeroUsize, legacy_pop_polling_size: usize, allocation_hint: usize) -> Self {
+        // Legacy rejects only when `queue.len() > pop_polling_size`.
+        let compatible_per_key = legacy_pop_polling_size.saturating_add(1);
+        Self {
+            max_entries,
+            max_entries_per_key: NonZeroUsize::new(compatible_per_key).unwrap_or(NonZeroUsize::MIN),
+            allocation_hint,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn direct(max_entries: NonZeroUsize, max_entries_per_key: NonZeroUsize) -> Self {
+        Self {
+            max_entries,
+            max_entries_per_key,
+            allocation_hint: 0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct NotificationCriteriaKey {
+    topic: CheetahString,
+    consumer_group: CheetahString,
+    queue_id: i32,
+}
+
+impl NotificationCriteriaKey {
+    pub(crate) fn new(topic: CheetahString, consumer_group: CheetahString, queue_id: i32) -> Self {
+        Self {
+            topic,
+            consumer_group,
+            queue_id,
+        }
+    }
+
+    pub(crate) fn from_parts(topic: &CheetahString, consumer_group: &CheetahString, queue_id: i32) -> Self {
+        Self::new(topic.clone(), consumer_group.clone(), queue_id)
+    }
+}
+
+/// Borrowed message-arrival metadata. It cannot escape the producer callback.
+#[derive(Clone, Copy)]
+pub(crate) struct NotificationArrivalView<'a> {
+    pub(super) topic: &'a CheetahString,
+    pub(super) queue_id: i32,
+    pub(super) tags_code: Option<i64>,
+    pub(super) msg_store_time: i64,
+    pub(super) filter_bit_map: Option<&'a [u8]>,
+    pub(super) properties: Option<&'a HashMap<CheetahString, CheetahString>>,
+}
+
+impl<'a> NotificationArrivalView<'a> {
+    pub(crate) const fn new(topic: &'a CheetahString, queue_id: i32) -> Self {
+        Self {
+            topic,
+            queue_id,
+            tags_code: None,
+            msg_store_time: 0,
+            filter_bit_map: None,
+            properties: None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn with_filter_metadata(
+        mut self,
+        tags_code: Option<i64>,
+        msg_store_time: i64,
+        filter_bit_map: Option<&'a [u8]>,
+        properties: Option<&'a HashMap<CheetahString, CheetahString>>,
+    ) -> Self {
+        self.tags_code = tags_code;
+        self.msg_store_time = msg_store_time;
+        self.filter_bit_map = filter_bit_map;
+        self.properties = properties;
+        self
+    }
+
+    #[must_use]
+    pub(crate) const fn topic(&self) -> &CheetahString {
+        self.topic
+    }
+
+    #[must_use]
+    pub(crate) const fn queue_id(&self) -> i32 {
+        self.queue_id
+    }
+
+    pub(super) fn cq_ext_unit(&self) -> CqExtUnit {
+        CqExtUnit::new(
+            self.tags_code.unwrap_or_default(),
+            self.msg_store_time,
+            self.filter_bit_map.map(<[u8]>::to_vec),
+        )
+    }
+}
+
+/// Immutable subscription/filter snapshot shared by index and resume data.
+pub(crate) struct NotificationMatchCriteria {
+    subscription: Option<SubscriptionData>,
+    filter: Option<ArcMessageFilter>,
+}
+
+impl NotificationMatchCriteria {
+    pub(crate) fn new(subscription: Option<SubscriptionData>, filter: Option<ArcMessageFilter>) -> Self {
+        Self { subscription, filter }
+    }
+
+    #[must_use]
+    pub(crate) const fn subscription(&self) -> Option<&SubscriptionData> {
+        self.subscription.as_ref()
+    }
+
+    #[must_use]
+    pub(crate) const fn filter(&self) -> Option<&ArcMessageFilter> {
+        self.filter.as_ref()
+    }
+
+    pub(super) fn matches(&self, arrival: &NotificationArrivalView<'_>, cq: &CqExtUnit) -> bool {
+        let Some(filter) = self.filter.as_ref() else {
+            return true;
+        };
+        if !filter.is_matched_by_consume_queue(arrival.tags_code, Some(cq)) {
+            return false;
+        }
+        arrival
+            .properties
+            .is_none_or(|properties| filter.is_matched_by_commit_log(None, Some(properties)))
+    }
+}
+
+/// Frozen fanout and newest-first position for one arrival.
+#[must_use]
+pub(crate) struct NotificationScanCursor {
+    keys: Vec<NotificationKeyCursor>,
+    key_position: usize,
+    conflicts_spent: usize,
+}
+
+impl NotificationScanCursor {
+    #[cfg(test)]
+    pub(crate) fn for_test(remaining_keys: usize) -> Self {
+        let key = NotificationCriteriaKey::new(
+            CheetahString::from_static_str("test-topic"),
+            CheetahString::from_static_str("test-group"),
+            0,
+        );
+        Self {
+            keys: (0..remaining_keys)
+                .map(|_| NotificationKeyCursor {
+                    key: key.clone(),
+                    before_sequence: u64::MAX,
+                })
+                .collect(),
+            key_position: 0,
+            conflicts_spent: 0,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn is_complete(&self) -> bool {
+        self.key_position >= self.keys.len()
+    }
+
+    pub(super) fn try_retained_bytes(&self) -> Option<usize> {
+        let mut bytes = self
+            .keys
+            .capacity()
+            .checked_mul(std::mem::size_of::<NotificationKeyCursor>())?;
+        for cursor in &self.keys {
+            bytes = bytes
+                .checked_add(cursor.key.topic.len())?
+                .checked_add(cursor.key.consumer_group.len())?;
+        }
+        Some(bytes)
+    }
+
+    fn current(&self) -> Option<&NotificationKeyCursor> {
+        self.keys.get(self.key_position)
+    }
+
+    fn advance_before(&mut self, sequence: u64) {
+        if let Some(key) = self.keys.get_mut(self.key_position) {
+            key.before_sequence = sequence;
+        }
+    }
+
+    pub(super) fn advance_key(&mut self) {
+        self.key_position = self.key_position.saturating_add(1);
+    }
+
+    pub(super) fn record_conflict(&mut self) {
+        self.conflicts_spent = self.conflicts_spent.saturating_add(1);
+    }
+
+    pub(super) const fn conflicts_spent(&self) -> usize {
+        self.conflicts_spent
+    }
+}
+
+struct NotificationKeyCursor {
+    key: NotificationCriteriaKey,
+    before_sequence: u64,
+}
+
+pub(crate) struct NotificationCriteriaIndex<I = DeferredId> {
+    inner: Arc<NotificationCriteriaIndexInner<I>>,
+}
+
+impl<I> Clone for NotificationCriteriaIndex<I> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<I> NotificationCriteriaIndex<I>
+where
+    I: Copy + Eq,
+{
+    pub(crate) fn new(limits: NotificationCriteriaLimits) -> Self {
+        let state = NotificationIndexState::with_hint(limits.allocation_hint);
+        Self {
+            inner: Arc::new(NotificationCriteriaIndexInner {
+                limits,
+                state: Mutex::new(state),
+                #[cfg(test)]
+                forced_conflicts: AtomicUsize::new(0),
+            }),
+        }
+    }
+
+    pub(crate) const fn retained_bytes_per_entry() -> usize {
+        std::mem::size_of::<NotificationRecord<I>>()
+            + std::mem::size_of::<NotificationCriteriaKey>()
+            + std::mem::size_of::<NotificationIndexLease<I>>()
+    }
+
+    pub(crate) fn reserve(
+        &self,
+        key: NotificationCriteriaKey,
+    ) -> Result<NotificationIndexReservation<I>, NotificationIndexError> {
+        self.reserve_at(key, tokio::time::Instant::now())
+    }
+
+    pub(crate) fn reserve_at(
+        &self,
+        key: NotificationCriteriaKey,
+        admitted_at: tokio::time::Instant,
+    ) -> Result<NotificationIndexReservation<I>, NotificationIndexError> {
+        let mut state = self.inner.state.lock();
+        if state.live.saturating_add(state.reserved) >= self.inner.limits.max_entries.get() {
+            return Err(NotificationIndexError::new(NotificationIndexErrorKind::GlobalCapacity));
+        }
+        let occupied = state.buckets.get(&key).map_or(0, |bucket| {
+            bucket
+                .records
+                .len()
+                .saturating_add(bucket.reserved)
+                .saturating_add(bucket.candidates)
+        });
+        if occupied >= self.inner.limits.max_entries_per_key.get() {
+            return Err(NotificationIndexError::new(NotificationIndexErrorKind::PerKeyCapacity));
+        }
+        let sequence = state
+            .next_sequence
+            .checked_add(1)
+            .ok_or_else(|| NotificationIndexError::new(NotificationIndexErrorKind::SequenceExhausted))?;
+        if !state.buckets.contains_key(&key) {
+            state
+                .buckets
+                .try_reserve(1)
+                .map_err(|_| NotificationIndexError::new(NotificationIndexErrorKind::Allocation))?;
+        }
+        let bucket = state.buckets.entry(key.clone()).or_default();
+        bucket
+            .records
+            .try_reserve(1)
+            .map_err(|_| NotificationIndexError::new(NotificationIndexErrorKind::Allocation))?;
+        bucket.reserved += 1;
+        state.reserved += 1;
+        state.next_sequence = sequence;
+        drop(state);
+        Ok(NotificationIndexReservation {
+            inner: Some(Arc::clone(&self.inner)),
+            key: Some(key),
+            sequence,
+            admitted_at,
+        })
+    }
+
+    /// Freezes groups, wildcard-before-exact key order, and sequence ceilings.
+    pub(crate) fn scan_cursor(&self, arrival: &NotificationArrivalView<'_>) -> NotificationScanCursor {
+        let normalized = if KeyBuilder::is_pop_retry_topic_v2(arrival.topic.as_str()) {
+            let normal_topic = arrival
+                .topic
+                .as_str()
+                .split_once(POP_RETRY_SEPARATOR_V2)
+                .map_or(arrival.topic.as_str(), |(_, topic)| topic);
+            CheetahString::from_slice(normal_topic)
+        } else {
+            arrival.topic.clone()
+        };
+        let state = self.inner.state.lock();
+        let mut groups = state
+            .buckets
+            .keys()
+            .filter(|key| key.topic == normalized && (key.queue_id == -1 || key.queue_id == arrival.queue_id))
+            .map(|key| key.consumer_group.clone())
+            .collect::<Vec<_>>();
+        groups.sort_unstable();
+        groups.dedup();
+        let mut keys = Vec::with_capacity(groups.len().saturating_mul(2));
+        for group in groups {
+            for queue_id in [-1, arrival.queue_id] {
+                if queue_id == -1
+                    && arrival.queue_id == -1
+                    && keys.last().is_some_and(|cursor: &NotificationKeyCursor| {
+                        cursor.key.topic == normalized
+                            && cursor.key.consumer_group == group
+                            && cursor.key.queue_id == -1
+                    })
+                {
+                    continue;
+                }
+                let key = NotificationCriteriaKey::from_parts(&normalized, &group, queue_id);
+                let Some(bucket) = state.buckets.get(&key) else {
+                    continue;
+                };
+                let before_sequence = bucket
+                    .records
+                    .last()
+                    .map_or(state.next_sequence.saturating_add(1), |record| {
+                        record.sequence.saturating_add(1)
+                    });
+                keys.push(NotificationKeyCursor { key, before_sequence });
+            }
+        }
+        NotificationScanCursor {
+            keys,
+            key_position: 0,
+            conflicts_spent: 0,
+        }
+    }
+
+    /// Reserves one newest candidate without retaining arrival payload.
+    pub(crate) fn reserve_next(&self, cursor: &mut NotificationScanCursor) -> NotificationCandidateSelection<I> {
+        loop {
+            let Some(current) = cursor.current() else {
+                return NotificationCandidateSelection::Complete;
+            };
+            #[cfg(test)]
+            if self
+                .inner
+                .forced_conflicts
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return NotificationCandidateSelection::Conflict;
+            }
+            let snapshot = {
+                let state = self.inner.state.lock();
+                state.buckets.get(&current.key).and_then(|bucket| {
+                    bucket
+                        .records
+                        .iter()
+                        .rev()
+                        .find(|record| record.sequence < current.before_sequence)
+                        .map(|record| (record.id, record.sequence))
+                })
+            };
+            let Some((id, sequence)) = snapshot else {
+                cursor.advance_key();
+                continue;
+            };
+            let mut state = self.inner.state.lock();
+            let Some(bucket) = state.buckets.get_mut(&current.key) else {
+                return NotificationCandidateSelection::Conflict;
+            };
+            let Some(position) = bucket
+                .records
+                .iter()
+                .position(|record| record.id == id && record.sequence == sequence)
+            else {
+                return NotificationCandidateSelection::Conflict;
+            };
+            let record = bucket.records.remove(position);
+            record.membership.store(CANDIDATE, Ordering::Release);
+            bucket.candidates += 1;
+            let candidate_key = current.key.clone();
+            drop(state);
+            cursor.advance_before(sequence);
+            return NotificationCandidateSelection::Candidate(NotificationCandidateReservation {
+                inner: Arc::downgrade(&self.inner),
+                key: candidate_key,
+                record: Some(record),
+            });
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn snapshot(&self) -> NotificationIndexSnapshot {
+        self.snapshot_at(tokio::time::Instant::now())
+    }
+
+    fn snapshot_at(&self, now: tokio::time::Instant) -> NotificationIndexSnapshot {
+        let state = self.inner.state.lock();
+        NotificationIndexSnapshot {
+            live: state.live,
+            reserved: state.reserved,
+            candidates: state.buckets.values().map(|bucket| bucket.candidates).sum(),
+            keys: state.buckets.len(),
+            oldest_waiter_age_millis: state
+                .buckets
+                .values()
+                .flat_map(|bucket| bucket.records.iter())
+                .map(|record| now.saturating_duration_since(record.admitted_at).as_millis())
+                .max()
+                .and_then(|age| u64::try_from(age).ok()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn snapshot_at_for_test(&self, now: tokio::time::Instant) -> NotificationIndexSnapshot {
+        self.snapshot_at(now)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, id: I) -> bool {
+        self.inner
+            .state
+            .lock()
+            .buckets
+            .values()
+            .any(|bucket| bucket.records.iter().any(|record| record.id == id))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_conflicts(&self, count: usize) {
+        self.inner.forced_conflicts.store(count, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn forced_conflicts_remaining(&self) -> usize {
+        self.inner.forced_conflicts.load(Ordering::Acquire)
+    }
+}
+
+struct NotificationCriteriaIndexInner<I> {
+    limits: NotificationCriteriaLimits,
+    state: Mutex<NotificationIndexState<I>>,
+    #[cfg(test)]
+    forced_conflicts: AtomicUsize,
+}
+
+struct NotificationIndexState<I> {
+    buckets: HashMap<NotificationCriteriaKey, NotificationBucket<I>>,
+    live: usize,
+    reserved: usize,
+    next_sequence: u64,
+}
+
+impl<I> NotificationIndexState<I> {
+    fn with_hint(hint: usize) -> Self {
+        Self {
+            buckets: HashMap::with_capacity(hint),
+            live: 0,
+            reserved: 0,
+            next_sequence: 0,
+        }
+    }
+}
+
+struct NotificationBucket<I> {
+    records: Vec<NotificationRecord<I>>,
+    reserved: usize,
+    candidates: usize,
+}
+
+impl<I> Default for NotificationBucket<I> {
+    fn default() -> Self {
+        Self {
+            records: Vec::new(),
+            reserved: 0,
+            candidates: 0,
+        }
+    }
+}
+
+struct NotificationRecord<I> {
+    id: I,
+    sequence: u64,
+    _deadline: NotificationWaitDeadline,
+    admitted_at: tokio::time::Instant,
+    criteria: Arc<NotificationMatchCriteria>,
+    membership: Arc<AtomicU8>,
+}
+
+#[must_use]
+pub(crate) struct NotificationIndexReservation<I = DeferredId> {
+    inner: Option<Arc<NotificationCriteriaIndexInner<I>>>,
+    key: Option<NotificationCriteriaKey>,
+    sequence: u64,
+    admitted_at: tokio::time::Instant,
+}
+
+impl<I> NotificationIndexReservation<I>
+where
+    I: Copy + Eq,
+{
+    pub(crate) fn publish(
+        mut self,
+        id: I,
+        deadline: NotificationWaitDeadline,
+        criteria: Arc<NotificationMatchCriteria>,
+    ) -> NotificationIndexLease<I> {
+        let inner = self
+            .inner
+            .take()
+            .expect("Notification index reservation owns its index");
+        let key = self.key.take().expect("Notification index reservation owns its key");
+        let membership = Arc::new(AtomicU8::new(INDEXED));
+        let mut state = inner.state.lock();
+        debug_assert!(state.reserved > 0);
+        state.reserved = state.reserved.saturating_sub(1);
+        state.live = state.live.saturating_add(1);
+        {
+            let bucket = state.buckets.entry(key.clone()).or_default();
+            debug_assert!(bucket.reserved > 0);
+            bucket.reserved = bucket.reserved.saturating_sub(1);
+            bucket.records.push(NotificationRecord {
+                id,
+                sequence: self.sequence,
+                _deadline: deadline,
+                admitted_at: self.admitted_at,
+                criteria,
+                membership: Arc::clone(&membership),
+            });
+        }
+        drop(state);
+        NotificationIndexLease {
+            inner: Arc::downgrade(&inner),
+            key: Some(key),
+            id,
+            membership,
+        }
+    }
+}
+
+impl<I> Drop for NotificationIndexReservation<I> {
+    fn drop(&mut self) {
+        let (Some(inner), Some(key)) = (self.inner.take(), self.key.take()) else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        if let Some(bucket) = state.buckets.get_mut(&key) {
+            bucket.reserved = bucket.reserved.saturating_sub(1);
+        }
+        state.reserved = state.reserved.saturating_sub(1);
+        let remove = state
+            .buckets
+            .get(&key)
+            .is_some_and(|bucket| bucket.records.is_empty() && bucket.reserved == 0 && bucket.candidates == 0);
+        if remove {
+            state.buckets.remove(&key);
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct NotificationIndexLease<I: Eq = DeferredId> {
+    inner: Weak<NotificationCriteriaIndexInner<I>>,
+    key: Option<NotificationCriteriaKey>,
+    id: I,
+    membership: Arc<AtomicU8>,
+}
+
+impl<I> Drop for NotificationIndexLease<I>
+where
+    I: Eq,
+{
+    fn drop(&mut self) {
+        let previous = self.membership.swap(REMOVED, Ordering::AcqRel);
+        if previous != INDEXED {
+            return;
+        }
+        let (Some(inner), Some(key)) = (self.inner.upgrade(), self.key.take()) else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        let mut removed = false;
+        if let Some(bucket) = state.buckets.get_mut(&key) {
+            if let Some(position) = bucket.records.iter().position(|record| record.id == self.id) {
+                bucket.records.remove(position);
+                removed = true;
+            }
+        }
+        if removed {
+            state.live = state.live.saturating_sub(1);
+        }
+        let remove = state
+            .buckets
+            .get(&key)
+            .is_some_and(|bucket| bucket.records.is_empty() && bucket.reserved == 0 && bucket.candidates == 0);
+        if remove {
+            state.buckets.remove(&key);
+        }
+    }
+}
+
+pub(crate) enum NotificationCandidateSelection<I = DeferredId> {
+    Candidate(NotificationCandidateReservation<I>),
+    Conflict,
+    Complete,
+}
+
+#[must_use]
+pub(crate) struct NotificationCandidateReservation<I = DeferredId> {
+    inner: Weak<NotificationCriteriaIndexInner<I>>,
+    key: NotificationCriteriaKey,
+    record: Option<NotificationRecord<I>>,
+}
+
+impl<I> NotificationCandidateReservation<I>
+where
+    I: Copy,
+{
+    #[must_use]
+    pub(crate) fn id(&self) -> I {
+        self.record.as_ref().expect("candidate owns its record").id
+    }
+
+    #[must_use]
+    pub(crate) fn sequence(&self) -> u64 {
+        self.record.as_ref().expect("candidate owns its record").sequence
+    }
+
+    #[must_use]
+    pub(crate) fn criteria(&self) -> &Arc<NotificationMatchCriteria> {
+        &self.record.as_ref().expect("candidate owns its record").criteria
+    }
+}
+
+impl<I> Drop for NotificationCandidateReservation<I> {
+    fn drop(&mut self) {
+        let Some(record) = self.record.take() else {
+            return;
+        };
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        let restored = record
+            .membership
+            .compare_exchange(CANDIDATE, INDEXED, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+        {
+            let bucket = state.buckets.entry(self.key.clone()).or_default();
+            bucket.candidates = bucket.candidates.saturating_sub(1);
+            if restored {
+                let position = bucket
+                    .records
+                    .binary_search_by_key(&record.sequence, |record| record.sequence)
+                    .unwrap_or_else(|position| position);
+                bucket.records.insert(position, record);
+            }
+        }
+        if !restored {
+            state.live = state.live.saturating_sub(1);
+        }
+        let remove = state
+            .buckets
+            .get(&self.key)
+            .is_some_and(|bucket| bucket.records.is_empty() && bucket.reserved == 0 && bucket.candidates == 0);
+        if remove {
+            state.buckets.remove(&self.key);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct NotificationIndexSnapshot {
+    live: usize,
+    reserved: usize,
+    candidates: usize,
+    keys: usize,
+    oldest_waiter_age_millis: Option<u64>,
+}
+
+impl NotificationIndexSnapshot {
+    #[must_use]
+    pub(crate) const fn live(self) -> usize {
+        self.live
+    }
+
+    #[must_use]
+    pub(crate) const fn reserved(self) -> usize {
+        self.reserved
+    }
+
+    #[must_use]
+    pub(crate) const fn candidates(self) -> usize {
+        self.candidates
+    }
+
+    #[must_use]
+    pub(crate) const fn keys(self) -> usize {
+        self.keys
+    }
+
+    #[must_use]
+    pub(crate) const fn oldest_waiter_age_millis(self) -> Option<u64> {
+        self.oldest_waiter_age_millis
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum NotificationIndexErrorKind {
+    GlobalCapacity,
+    PerKeyCapacity,
+    SequenceExhausted,
+    Allocation,
+}
+
+pub(crate) struct NotificationIndexError {
+    kind: NotificationIndexErrorKind,
+}
+
+impl NotificationIndexError {
+    const fn new(kind: NotificationIndexErrorKind) -> Self {
+        Self { kind }
+    }
+
+    #[must_use]
+    pub(crate) const fn kind(&self) -> NotificationIndexErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for NotificationIndexError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NotificationIndexError")
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for NotificationIndexError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Notification criteria index failed: {:?}", self.kind)
+    }
+}
+
+impl Error for NotificationIndexError {}

--- a/rocketmq-broker/src/long_polling/notification_deferred/service.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/service.rs
@@ -1,0 +1,843 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::Infallible;
+use std::error::Error;
+use std::fmt;
+use std::future::Future;
+use std::num::NonZeroU64;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+#[cfg(test)]
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::RuntimeResult;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskId;
+use rocketmq_store::ArcMessageFilter;
+use rocketmq_transport::api::v2::ClaimedDeferred;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredAdmissionAcquireError;
+use rocketmq_transport::api::v2::DeferredAdmissionSnapshot;
+use rocketmq_transport::api::v2::DeferredClaimError;
+use rocketmq_transport::api::v2::DeferredClaimErrorKind;
+use rocketmq_transport::api::v2::DeferredExpiryBatch;
+use rocketmq_transport::api::v2::DeferredExpiryBatchStats;
+use rocketmq_transport::api::v2::DeferredExpiryError;
+use rocketmq_transport::api::v2::DeferredExpiryErrorKind;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredId;
+use rocketmq_transport::api::v2::DeferredParts;
+use rocketmq_transport::api::v2::DeferredRegistration;
+use rocketmq_transport::api::v2::DeferredRegistry;
+use rocketmq_transport::api::v2::DeferredRegistryError;
+use rocketmq_transport::api::v2::DeferredRegistryErrorKind;
+use rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome;
+use rocketmq_transport::api::v2::DeferredResumeError;
+use rocketmq_transport::api::v2::DeferredResumeRetainedSize;
+use rocketmq_transport::api::v2::DeferredRetainedSizeParts;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponseReceipt;
+use rocketmq_transport::api::v2::TakeDeferredResponderError;
+
+use super::deadline::NotificationWaitDeadline;
+use super::deadline::NotificationWaitDeadlineError;
+use super::index::NotificationArrivalView;
+use super::index::NotificationCandidateReservation;
+use super::index::NotificationCandidateSelection;
+use super::index::NotificationCriteriaIndex;
+use super::index::NotificationCriteriaKey;
+use super::index::NotificationCriteriaLimits;
+use super::index::NotificationIndexError;
+use super::index::NotificationIndexSnapshot;
+use super::index::NotificationMatchCriteria;
+use super::index::NotificationScanCursor;
+
+mod continuation;
+mod data;
+
+use continuation::ContinuationAdmission;
+pub(crate) use continuation::NotificationArrivalContinuation;
+use continuation::OwnedNotificationArrival;
+use data::CounterObservation;
+pub(crate) use data::NotificationRequestData;
+pub(crate) use data::NotificationRetainedEstimate;
+pub(crate) use data::PreparedNotificationRegistration;
+use data::PreparedObservation;
+use data::PreparedRequestProvenance;
+pub(crate) use data::ResumeNotification;
+
+pub(crate) struct NotificationDeferredService {
+    admission: DeferredAdmission,
+    registry: DeferredRegistry<ResumeNotification>,
+    pub(super) index: NotificationCriteriaIndex,
+    expiry_margins: DeferredExpiryMargins,
+    scan_limit: NonZeroUsize,
+    conflict_limit: NonZeroUsize,
+    continuation_admission: Arc<ContinuationAdmission>,
+    prepared: Arc<AtomicUsize>,
+    pending_claims: Arc<AtomicUsize>,
+    resume_executions: Arc<AtomicUsize>,
+    resume_execution_bytes: Arc<AtomicUsize>,
+    closed: AtomicBool,
+    #[cfg(test)]
+    register_fault: AtomicU8,
+}
+
+impl NotificationDeferredService {
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "constructor exposes each independent bounded resource"
+    )]
+    pub(crate) fn new(
+        admission: DeferredAdmission,
+        index_limits: NotificationCriteriaLimits,
+        expiry_margins: DeferredExpiryMargins,
+        scan_limit: NonZeroUsize,
+        conflict_limit: NonZeroUsize,
+        continuation_count: NonZeroUsize,
+        continuation_bytes: NonZeroUsize,
+    ) -> Self {
+        Self {
+            admission,
+            registry: DeferredRegistry::new(),
+            index: NotificationCriteriaIndex::new(index_limits),
+            expiry_margins,
+            scan_limit,
+            conflict_limit,
+            continuation_admission: Arc::new(ContinuationAdmission::new(
+                continuation_count.get(),
+                continuation_bytes.get(),
+            )),
+            prepared: Arc::new(AtomicUsize::new(0)),
+            pending_claims: Arc::new(AtomicUsize::new(0)),
+            resume_executions: Arc::new(AtomicUsize::new(0)),
+            resume_execution_bytes: Arc::new(AtomicUsize::new(0)),
+            closed: AtomicBool::new(false),
+            #[cfg(test)]
+            register_fault: AtomicU8::new(0),
+        }
+    }
+
+    pub(crate) fn prepare(
+        &self,
+        request: &RemotingRequest,
+        subscription: Option<SubscriptionData>,
+        filter: Option<ArcMessageFilter>,
+        retained: NotificationRetainedEstimate,
+    ) -> Result<PreparedNotificationRegistration, NotificationDeferredPrepareError> {
+        if request.command().is_oneway_rpc() {
+            return Err(NotificationDeferredPrepareError::OneWay);
+        }
+        let header = request
+            .command()
+            .decode_command_custom_header::<NotificationRequestHeader>()
+            .map_err(NotificationDeferredPrepareError::Header)?;
+        let effective_peer = match request.origin() {
+            RequestOrigin::Network { peer } => peer.address(),
+            RequestOrigin::Embedded { .. } => return Err(NotificationDeferredPrepareError::EmbeddedOrigin),
+            _ => return Err(NotificationDeferredPrepareError::EmbeddedOrigin),
+        };
+        let wall_now =
+            i64::try_from(current_millis()).map_err(|_| NotificationDeferredPrepareError::WallTimeOverflow)?;
+        self.prepare_data_at(
+            NotificationRequestData::new(header, effective_peer),
+            subscription,
+            filter,
+            retained,
+            wall_now,
+            tokio::time::Instant::now(),
+            Some(PreparedRequestProvenance::capture(request)),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn prepare_at(
+        &self,
+        request: NotificationRequestData,
+        subscription: Option<SubscriptionData>,
+        filter: Option<ArcMessageFilter>,
+        retained: NotificationRetainedEstimate,
+        wall_now: i64,
+        monotonic_now: tokio::time::Instant,
+    ) -> Result<PreparedNotificationRegistration, NotificationDeferredPrepareError> {
+        self.prepare_data_at(request, subscription, filter, retained, wall_now, monotonic_now, None)
+    }
+
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "manual clock and provenance are explicit preparation inputs"
+    )]
+    fn prepare_data_at(
+        &self,
+        request: NotificationRequestData,
+        subscription: Option<SubscriptionData>,
+        filter: Option<ArcMessageFilter>,
+        retained: NotificationRetainedEstimate,
+        wall_now: i64,
+        monotonic_now: tokio::time::Instant,
+        provenance: Option<PreparedRequestProvenance>,
+    ) -> Result<PreparedNotificationRegistration, NotificationDeferredPrepareError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(NotificationDeferredPrepareError::ServiceClosed);
+        }
+        if self.expiry_margins.recovery().is_zero() || self.expiry_margins.write().is_zero() {
+            return Err(NotificationDeferredPrepareError::InvalidExpiryMargins);
+        }
+        let deadline = NotificationWaitDeadline::checked(
+            request.header.born_time,
+            request.header.poll_time,
+            wall_now,
+            monotonic_now,
+        )
+        .map_err(NotificationDeferredPrepareError::Deadline)?;
+        let resume_bytes = retained
+            .resume_bytes
+            .checked_add(request.estimated_dynamic_bytes()?)
+            .ok_or(NotificationDeferredPrepareError::RetainedSizeOverflow)?;
+        let filter_bytes = retained
+            .filter_bytes
+            .checked_add(std::mem::size_of::<NotificationMatchCriteria>())
+            .ok_or(NotificationDeferredPrepareError::RetainedSizeOverflow)?;
+        let retained_size = DeferredRegistry::<ResumeNotification>::try_retained_size(
+            DeferredRetainedSizeParts::new(resume_bytes)
+                .with_filter_bytes(filter_bytes)
+                .with_secondary_index_bytes(NotificationCriteriaIndex::<DeferredId>::retained_bytes_per_entry())
+                .with_metadata_bytes(retained.metadata_bytes),
+        )
+        .map_err(NotificationDeferredPrepareError::Admission)?;
+        let key = NotificationCriteriaKey::from_parts(request.topic(), request.consumer_group(), request.queue_id());
+        let reservation = self
+            .index
+            .reserve_at(key, monotonic_now)
+            .map_err(NotificationDeferredPrepareError::Index)?;
+        let permit = self
+            .admission
+            .try_reserve(retained_size)
+            .map_err(NotificationDeferredPrepareError::Admission)?;
+        let observation = PreparedObservation::new(Arc::clone(&self.prepared));
+        let prepared = PreparedNotificationRegistration {
+            request,
+            criteria: Arc::new(NotificationMatchCriteria::new(subscription, filter)),
+            deadline,
+            reservation,
+            permit,
+            provenance,
+            observation,
+        };
+        if self.closed.load(Ordering::Acquire) {
+            drop(prepared);
+            return Err(NotificationDeferredPrepareError::ServiceClosed);
+        }
+        Ok(prepared)
+    }
+
+    /// Takes the responder only after every recoverable reservation succeeds.
+    pub(crate) fn register(
+        &self,
+        prepared: PreparedNotificationRegistration,
+        request: &mut RemotingRequest,
+    ) -> Result<DeferredRegistration, NotificationDeferredRegisterError> {
+        if !prepared
+            .provenance
+            .is_some_and(|provenance| provenance.matches(request))
+        {
+            return Err(NotificationDeferredRegisterError::ProvenanceMismatch);
+        }
+        if self.closed.load(Ordering::Acquire) {
+            return Err(NotificationDeferredRegisterError::ServiceClosedBeforeTake);
+        }
+        let responder = request
+            .take_deferred_responder()
+            .map_err(NotificationDeferredRegisterError::Responder)?;
+        #[cfg(test)]
+        let register_fault = self.register_fault.swap(0, Ordering::AcqRel);
+        #[cfg(test)]
+        if register_fault == REGISTER_FAULT_CLOSE_AFTER_TAKE {
+            let _ = self.shutdown();
+        }
+        if self.closed.load(Ordering::Acquire) {
+            drop(responder);
+            return Err(NotificationDeferredRegisterError::ServiceClosedAfterTake);
+        }
+        let PreparedNotificationRegistration {
+            request,
+            criteria,
+            deadline,
+            reservation,
+            permit,
+            provenance: _,
+            observation,
+        } = prepared;
+        #[cfg(test)]
+        let protocol_at = if register_fault == REGISTER_FAULT_EXPIRY_AFTER_TAKE {
+            tokio::time::Instant::now()
+                .checked_sub(Duration::from_millis(1))
+                .unwrap_or_else(tokio::time::Instant::now)
+        } else {
+            deadline.protocol_at()
+        };
+        #[cfg(not(test))]
+        let protocol_at = deadline.protocol_at();
+        let parts = DeferredParts::new(responder, permit)
+            .try_with_expiry(protocol_at, self.expiry_margins)
+            .map_err(NotificationDeferredRegisterError::Expiry)?;
+        #[cfg(test)]
+        if register_fault == REGISTER_FAULT_BUILDER_AFTER_TAKE {
+            self.closed.store(true, Ordering::Release);
+            let _ = self.registry.shutdown();
+        }
+        let registration = self
+            .registry
+            .register_with(parts, move |id| {
+                let index_lease = reservation.publish(id, deadline, Arc::clone(&criteria));
+                Ok::<_, Infallible>(ResumeNotification::new(request, criteria, deadline, index_lease))
+            })
+            .map_err(NotificationDeferredRegisterError::Registry);
+        drop(observation);
+        registration
+    }
+
+    /// Performs the one synchronous, bounded, borrow-only filtering batch.
+    pub(crate) fn prepare_arrival_batch<'a>(
+        &self,
+        arrival: NotificationArrivalView<'a>,
+        cursor: Option<NotificationScanCursor>,
+    ) -> NotificationPreparedArrivalBatch {
+        self.prepare_arrival_batch_with_conflict_budget(
+            arrival,
+            cursor,
+            self.conflict_limit.get().min(self.scan_limit.get()),
+        )
+    }
+
+    fn prepare_arrival_batch_with_conflict_budget<'a>(
+        &self,
+        arrival: NotificationArrivalView<'a>,
+        cursor: Option<NotificationScanCursor>,
+        conflict_budget: usize,
+    ) -> NotificationPreparedArrivalBatch {
+        let mut cursor = cursor.unwrap_or_else(|| self.index.scan_cursor(&arrival));
+        let cq = arrival.cq_ext_unit();
+        let mut candidates = Vec::new();
+        let mut inspected = 0;
+        let mut conflicts = 0;
+        while inspected < self.scan_limit.get() && conflicts < conflict_budget && !cursor.is_complete() {
+            match self.index.reserve_next(&mut cursor) {
+                NotificationCandidateSelection::Candidate(candidate) => {
+                    inspected += 1;
+                    if candidate.criteria().matches(&arrival, &cq) {
+                        cursor.advance_key();
+                        candidates.push(candidate);
+                    }
+                }
+                NotificationCandidateSelection::Conflict => {
+                    conflicts += 1;
+                    cursor.record_conflict();
+                }
+                NotificationCandidateSelection::Complete => break,
+            }
+        }
+        NotificationPreparedArrivalBatch {
+            candidates,
+            cursor,
+            inspected,
+            conflicts,
+        }
+    }
+
+    /// Claims only already-filtered affine candidates; no arrival borrow crosses await.
+    pub(crate) async fn claim_prepared_arrival(
+        &self,
+        prepared: NotificationPreparedArrivalBatch,
+    ) -> NotificationClaimBatch {
+        let _observation = CounterObservation::new(Arc::clone(&self.pending_claims));
+        let NotificationPreparedArrivalBatch {
+            candidates,
+            cursor,
+            inspected,
+            conflicts,
+        } = prepared;
+        let mut claims = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            let id = candidate.id();
+            match self.claim(id, DeferredWakeReason::MessageArrived).await {
+                Ok(claim) => claims.push(claim),
+                Err(error) if is_candidate_race(error.kind()) => {}
+                Err(_) => {}
+            }
+            drop(candidate);
+        }
+        NotificationClaimBatch {
+            claims,
+            cursor,
+            inspected,
+            conflicts,
+        }
+    }
+
+    async fn claim(
+        &self,
+        id: DeferredId,
+        reason: DeferredWakeReason,
+    ) -> Result<ClaimedDeferred<ResumeNotification>, DeferredClaimError> {
+        let mut claimed = self.registry.claim(id, reason).await?;
+        drop(claimed.resume_data_mut().take_index_lease());
+        Ok(claimed)
+    }
+
+    pub(crate) fn admit_continuation(
+        &self,
+        arrival: NotificationArrivalView<'_>,
+        cursor: NotificationScanCursor,
+    ) -> Result<NotificationArrivalContinuation, NotificationContinuationError> {
+        if cursor.is_complete() {
+            return Err(NotificationContinuationError::Complete);
+        }
+        let remaining_conflicts = self.conflict_limit.get().saturating_sub(cursor.conflicts_spent());
+        if remaining_conflicts == 0 {
+            return Err(NotificationContinuationError::ConflictBudgetExhausted);
+        }
+        let retained_bytes = OwnedNotificationArrival::retained_bytes(arrival, &cursor)?;
+        let permit = self.continuation_admission.reserve(retained_bytes)?;
+        let owned = OwnedNotificationArrival::try_from_view(arrival)?;
+        Ok(NotificationArrivalContinuation {
+            owned,
+            cursor,
+            remaining_conflicts,
+            _permit: permit,
+        })
+    }
+
+    /// Runs all post-callback batches in one injected, lifecycle-owned task.
+    pub(crate) fn spawn_continuation<F, Fut>(
+        self: &Arc<Self>,
+        task_group: &TaskGroup,
+        mut continuation: NotificationArrivalContinuation,
+        handle_claims: Arc<F>,
+    ) -> RuntimeResult<TaskId>
+    where
+        F: Fn(Vec<ClaimedDeferred<ResumeNotification>>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let service = Arc::clone(self);
+        task_group.spawn_service("broker.notification-deferred.arrival", async move {
+            loop {
+                let prepared = {
+                    let view = continuation.owned.view();
+                    let batch_conflicts = continuation.remaining_conflicts.min(service.scan_limit.get());
+                    service.prepare_arrival_batch_with_conflict_budget(view, Some(continuation.cursor), batch_conflicts)
+                };
+                let batch = service.claim_prepared_arrival(prepared).await;
+                continuation.remaining_conflicts = continuation.remaining_conflicts.saturating_sub(batch.conflicts());
+                let (claims, cursor) = batch.into_parts();
+                handle_claims(claims).await;
+                continuation.cursor = cursor;
+                if continuation.cursor.is_complete()
+                    || continuation.remaining_conflicts == 0
+                    || service.closed.load(Ordering::Acquire)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+    }
+
+    pub(crate) fn sweep_expired(&self) -> NotificationDeferredSweepBatch {
+        NotificationDeferredSweepBatch::from_transport(self.registry.sweep_expired(self.scan_limit))
+    }
+
+    pub(crate) fn start_sweeper<F, Fut>(
+        self: &Arc<Self>,
+        task_group: &TaskGroup,
+        interval_millis: NonZeroU64,
+        handle_claims: F,
+    ) -> RuntimeResult<TaskId>
+    where
+        F: Fn(Vec<ClaimedDeferred<ResumeNotification>>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let service = Arc::clone(self);
+        let cancellation = task_group.cancellation_token();
+        let interval = Duration::from_millis(interval_millis.get());
+        task_group.spawn_service("broker.notification-deferred.sweep", async move {
+            loop {
+                if service.closed.load(Ordering::Acquire)
+                    || tokio::time::timeout(interval, cancellation.cancelled()).await.is_ok()
+                {
+                    break;
+                }
+                let claims = service.sweep_expired().into_claims();
+                if !claims.is_empty() {
+                    handle_claims(claims).await;
+                }
+            }
+        })
+    }
+
+    pub(crate) async fn resume_claimed<F, Fut>(
+        &self,
+        claimed: ClaimedDeferred<ResumeNotification>,
+        handler_retained: DeferredResumeRetainedSize,
+        handler: F,
+    ) -> Result<ResponseReceipt, DeferredResumeError>
+    where
+        F: FnOnce(ResumeNotification, DeferredWakeReason) -> Fut + Send + 'static,
+        Fut: Future<Output = rocketmq_error::RocketMQResult<ResponsePlan>> + Send + 'static,
+    {
+        let resume_executions = Arc::clone(&self.resume_executions);
+        let resume_execution_bytes = Arc::clone(&self.resume_execution_bytes);
+        let dynamic_bytes = handler_retained.dynamic_bytes();
+        let result = claimed
+            .resume(handler_retained, move |resume, reason| async move {
+                let _observation =
+                    CounterObservation::new_with_bytes(resume_executions, resume_execution_bytes, dynamic_bytes);
+                handler(resume, reason).await
+            })
+            .await;
+        result
+    }
+
+    #[must_use]
+    pub(crate) fn snapshot(&self) -> NotificationDeferredSnapshot {
+        let continuation = self.continuation_admission.snapshot();
+        NotificationDeferredSnapshot {
+            admission: self.admission.snapshot(),
+            index: self.index.snapshot(),
+            prepared: self.prepared.load(Ordering::Acquire),
+            pending_claims: self.pending_claims.load(Ordering::Acquire),
+            resume_executions: self.resume_executions.load(Ordering::Acquire),
+            resume_execution_bytes: self.resume_execution_bytes.load(Ordering::Acquire),
+            active_continuations: continuation.count,
+            continuation_bytes: continuation.bytes,
+            continuation_rejected: continuation.rejected,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn shutdown(&self) -> DeferredRegistryShutdownOutcome {
+        self.closed.store(true, Ordering::Release);
+        self.registry.shutdown()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_register_fault(&self, fault: NotificationRegisterFault) {
+        self.register_fault.store(fault as u8, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+const REGISTER_FAULT_CLOSE_AFTER_TAKE: u8 = 1;
+#[cfg(test)]
+const REGISTER_FAULT_EXPIRY_AFTER_TAKE: u8 = 2;
+#[cfg(test)]
+const REGISTER_FAULT_BUILDER_AFTER_TAKE: u8 = 3;
+
+#[cfg(test)]
+#[repr(u8)]
+#[derive(Clone, Copy)]
+pub(crate) enum NotificationRegisterFault {
+    Close = REGISTER_FAULT_CLOSE_AFTER_TAKE,
+    Expiry = REGISTER_FAULT_EXPIRY_AFTER_TAKE,
+    Builder = REGISTER_FAULT_BUILDER_AFTER_TAKE,
+}
+
+#[must_use]
+pub(crate) struct NotificationPreparedArrivalBatch {
+    pub(super) candidates: Vec<NotificationCandidateReservation>,
+    pub(super) cursor: NotificationScanCursor,
+    inspected: usize,
+    conflicts: usize,
+}
+
+impl NotificationPreparedArrivalBatch {
+    #[must_use]
+    pub(crate) const fn inspected(&self) -> usize {
+        self.inspected
+    }
+
+    #[must_use]
+    pub(crate) const fn conflicts(&self) -> usize {
+        self.conflicts
+    }
+
+    #[must_use]
+    pub(crate) fn candidate_count(&self) -> usize {
+        self.candidates.len()
+    }
+
+    pub(crate) const fn cursor(&self) -> &NotificationScanCursor {
+        &self.cursor
+    }
+}
+
+#[must_use]
+pub(crate) struct NotificationClaimBatch {
+    claims: Vec<ClaimedDeferred<ResumeNotification>>,
+    cursor: NotificationScanCursor,
+    inspected: usize,
+    conflicts: usize,
+}
+
+impl NotificationClaimBatch {
+    #[must_use]
+    pub(crate) const fn inspected(&self) -> usize {
+        self.inspected
+    }
+
+    #[must_use]
+    pub(crate) const fn conflicts(&self) -> usize {
+        self.conflicts
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<ClaimedDeferred<ResumeNotification>>, NotificationScanCursor) {
+        (self.claims, self.cursor)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct NotificationDeferredSnapshot {
+    admission: DeferredAdmissionSnapshot,
+    index: NotificationIndexSnapshot,
+    prepared: usize,
+    pending_claims: usize,
+    resume_executions: usize,
+    resume_execution_bytes: usize,
+    active_continuations: usize,
+    continuation_bytes: usize,
+    continuation_rejected: usize,
+}
+
+impl NotificationDeferredSnapshot {
+    #[must_use]
+    pub(crate) const fn admission(self) -> DeferredAdmissionSnapshot {
+        self.admission
+    }
+
+    #[must_use]
+    pub(crate) const fn index(self) -> NotificationIndexSnapshot {
+        self.index
+    }
+
+    #[must_use]
+    pub(crate) const fn prepared(self) -> usize {
+        self.prepared
+    }
+
+    #[must_use]
+    pub(crate) const fn pending_claims(self) -> usize {
+        self.pending_claims
+    }
+
+    #[must_use]
+    pub(crate) const fn resume_executions(self) -> usize {
+        self.resume_executions
+    }
+
+    #[must_use]
+    pub(crate) const fn resume_execution_bytes(self) -> usize {
+        self.resume_execution_bytes
+    }
+
+    #[must_use]
+    pub(crate) const fn active_continuations(self) -> usize {
+        self.active_continuations
+    }
+
+    #[must_use]
+    pub(crate) const fn continuation_bytes(self) -> usize {
+        self.continuation_bytes
+    }
+
+    #[must_use]
+    pub(crate) const fn continuation_rejected(self) -> usize {
+        self.continuation_rejected
+    }
+}
+
+#[must_use]
+pub(crate) struct NotificationDeferredSweepBatch {
+    stats: DeferredExpiryBatchStats,
+    claims: Vec<ClaimedDeferred<ResumeNotification>>,
+}
+
+impl NotificationDeferredSweepBatch {
+    fn from_transport(batch: DeferredExpiryBatch<ResumeNotification>) -> Self {
+        let stats = batch.stats();
+        let mut claims = batch.into_claims();
+        for claim in &mut claims {
+            drop(claim.resume_data_mut().take_index_lease());
+        }
+        Self { stats, claims }
+    }
+
+    #[must_use]
+    pub(crate) const fn stats(&self) -> DeferredExpiryBatchStats {
+        self.stats
+    }
+
+    #[must_use]
+    pub(crate) fn into_claims(self) -> Vec<ClaimedDeferred<ResumeNotification>> {
+        self.claims
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NotificationContinuationError {
+    Complete,
+    ConflictBudgetExhausted,
+    CountFull,
+    BytesFull,
+    SizeOverflow,
+    Allocation,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NotificationDeferredPrepareErrorKind {
+    ServiceClosed,
+    OneWay,
+    EmbeddedOrigin,
+    Header,
+    WallTimeOverflow,
+    InvalidExpiryMargins,
+    RetainedSizeOverflow,
+    Deadline,
+    Index,
+    Admission,
+}
+
+pub(crate) enum NotificationDeferredPrepareError {
+    ServiceClosed,
+    OneWay,
+    EmbeddedOrigin,
+    Header(RocketMQError),
+    WallTimeOverflow,
+    InvalidExpiryMargins,
+    RetainedSizeOverflow,
+    Deadline(NotificationWaitDeadlineError),
+    Index(NotificationIndexError),
+    Admission(DeferredAdmissionAcquireError),
+}
+
+impl NotificationDeferredPrepareError {
+    #[must_use]
+    pub(crate) const fn kind(&self) -> NotificationDeferredPrepareErrorKind {
+        match self {
+            Self::ServiceClosed => NotificationDeferredPrepareErrorKind::ServiceClosed,
+            Self::OneWay => NotificationDeferredPrepareErrorKind::OneWay,
+            Self::EmbeddedOrigin => NotificationDeferredPrepareErrorKind::EmbeddedOrigin,
+            Self::Header(_) => NotificationDeferredPrepareErrorKind::Header,
+            Self::WallTimeOverflow => NotificationDeferredPrepareErrorKind::WallTimeOverflow,
+            Self::InvalidExpiryMargins => NotificationDeferredPrepareErrorKind::InvalidExpiryMargins,
+            Self::RetainedSizeOverflow => NotificationDeferredPrepareErrorKind::RetainedSizeOverflow,
+            Self::Deadline(_) => NotificationDeferredPrepareErrorKind::Deadline,
+            Self::Index(_) => NotificationDeferredPrepareErrorKind::Index,
+            Self::Admission(_) => NotificationDeferredPrepareErrorKind::Admission,
+        }
+    }
+}
+
+impl fmt::Debug for NotificationDeferredPrepareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NotificationDeferredPrepareError")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for NotificationDeferredPrepareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Notification deferred preparation failed: {:?}", self.kind())
+    }
+}
+
+impl Error for NotificationDeferredPrepareError {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NotificationDeferredRegisterErrorKind {
+    ServiceClosedBeforeTake,
+    ServiceClosedAfterTake,
+    ProvenanceMismatch,
+    Responder,
+    Expiry(DeferredExpiryErrorKind),
+    Registry(DeferredRegistryErrorKind),
+}
+
+pub(crate) enum NotificationDeferredRegisterError {
+    ServiceClosedBeforeTake,
+    ServiceClosedAfterTake,
+    ProvenanceMismatch,
+    Responder(TakeDeferredResponderError),
+    Expiry(DeferredExpiryError),
+    Registry(DeferredRegistryError<ResumeNotification, Infallible>),
+}
+
+impl NotificationDeferredRegisterError {
+    #[must_use]
+    pub(crate) const fn kind(&self) -> NotificationDeferredRegisterErrorKind {
+        match self {
+            Self::ServiceClosedBeforeTake => NotificationDeferredRegisterErrorKind::ServiceClosedBeforeTake,
+            Self::ServiceClosedAfterTake => NotificationDeferredRegisterErrorKind::ServiceClosedAfterTake,
+            Self::ProvenanceMismatch => NotificationDeferredRegisterErrorKind::ProvenanceMismatch,
+            Self::Responder(_) => NotificationDeferredRegisterErrorKind::Responder,
+            Self::Expiry(error) => NotificationDeferredRegisterErrorKind::Expiry(error.kind()),
+            Self::Registry(error) => NotificationDeferredRegisterErrorKind::Registry(error.kind()),
+        }
+    }
+}
+
+impl fmt::Debug for NotificationDeferredRegisterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NotificationDeferredRegisterError")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for NotificationDeferredRegisterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "Notification deferred registration failed: {:?}",
+            self.kind()
+        )
+    }
+}
+
+impl Error for NotificationDeferredRegisterError {}
+
+const fn is_candidate_race(kind: DeferredClaimErrorKind) -> bool {
+    matches!(
+        kind,
+        DeferredClaimErrorKind::NotFound
+            | DeferredClaimErrorKind::AlreadyClaimed
+            | DeferredClaimErrorKind::AlreadyCompleted
+            | DeferredClaimErrorKind::SessionClosed
+            | DeferredClaimErrorKind::DeadlineExpired
+    )
+}

--- a/rocketmq-broker/src/long_polling/notification_deferred/service/continuation.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/service/continuation.rs
@@ -1,0 +1,223 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::mem::size_of;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+
+use super::NotificationContinuationError;
+use crate::long_polling::notification_deferred::index::NotificationArrivalView;
+use crate::long_polling::notification_deferred::index::NotificationScanCursor;
+
+pub(super) struct OwnedNotificationArrival {
+    topic: CheetahString,
+    queue_id: i32,
+    tags_code: Option<i64>,
+    msg_store_time: i64,
+    filter_bit_map: Option<Vec<u8>>,
+    properties: Option<HashMap<CheetahString, CheetahString>>,
+}
+
+impl OwnedNotificationArrival {
+    pub(super) fn retained_bytes(
+        arrival: NotificationArrivalView<'_>,
+        cursor: &NotificationScanCursor,
+    ) -> Result<usize, NotificationContinuationError> {
+        let mut bytes = size_of::<NotificationArrivalContinuation>()
+            .checked_add(
+                cursor
+                    .try_retained_bytes()
+                    .ok_or(NotificationContinuationError::SizeOverflow)?,
+            )
+            .and_then(|total| total.checked_add(string_allocation_bound(arrival.topic.len())?))
+            .ok_or(NotificationContinuationError::SizeOverflow)?;
+        if let Some(bitmap) = arrival.filter_bit_map {
+            let bitmap_bytes =
+                byte_allocation_bound(bitmap.len()).ok_or(NotificationContinuationError::SizeOverflow)?;
+            bytes = bytes
+                .checked_add(bitmap_bytes)
+                .ok_or(NotificationContinuationError::SizeOverflow)?;
+        }
+        if let Some(properties) = arrival.properties {
+            let bucket_count = properties
+                .len()
+                .checked_mul(2)
+                .and_then(|count| count.checked_add(1))
+                .ok_or(NotificationContinuationError::SizeOverflow)?;
+            let bucket_bytes = bucket_count
+                .checked_mul(
+                    size_of::<(CheetahString, CheetahString)>()
+                        .checked_add(size_of::<u64>())
+                        .and_then(|bytes| bytes.checked_add(1))
+                        .ok_or(NotificationContinuationError::SizeOverflow)?,
+                )
+                .ok_or(NotificationContinuationError::SizeOverflow)?;
+            bytes = bytes
+                .checked_add(bucket_bytes)
+                .ok_or(NotificationContinuationError::SizeOverflow)?;
+            for (key, value) in properties {
+                let key_bytes =
+                    string_allocation_bound(key.len()).ok_or(NotificationContinuationError::SizeOverflow)?;
+                let value_bytes =
+                    string_allocation_bound(value.len()).ok_or(NotificationContinuationError::SizeOverflow)?;
+                bytes = bytes
+                    .checked_add(key_bytes)
+                    .and_then(|total| total.checked_add(value_bytes))
+                    .ok_or(NotificationContinuationError::SizeOverflow)?;
+            }
+        }
+        Ok(bytes.max(1))
+    }
+
+    pub(super) fn try_from_view(arrival: NotificationArrivalView<'_>) -> Result<Self, NotificationContinuationError> {
+        let filter_bit_map = match arrival.filter_bit_map {
+            Some(bitmap) => {
+                let mut owned = Vec::new();
+                owned
+                    .try_reserve_exact(bitmap.len())
+                    .map_err(|_| NotificationContinuationError::Allocation)?;
+                owned.extend_from_slice(bitmap);
+                Some(owned)
+            }
+            None => None,
+        };
+        let properties = match arrival.properties {
+            Some(properties) => {
+                let mut owned = HashMap::new();
+                owned
+                    .try_reserve(properties.len())
+                    .map_err(|_| NotificationContinuationError::Allocation)?;
+                owned.extend(properties.iter().map(|(key, value)| (key.clone(), value.clone())));
+                Some(owned)
+            }
+            None => None,
+        };
+        Ok(Self {
+            topic: arrival.topic.clone(),
+            queue_id: arrival.queue_id,
+            tags_code: arrival.tags_code,
+            msg_store_time: arrival.msg_store_time,
+            filter_bit_map,
+            properties,
+        })
+    }
+
+    pub(super) fn view(&self) -> NotificationArrivalView<'_> {
+        NotificationArrivalView::new(&self.topic, self.queue_id).with_filter_metadata(
+            self.tags_code,
+            self.msg_store_time,
+            self.filter_bit_map.as_deref(),
+            self.properties.as_ref(),
+        )
+    }
+}
+
+#[must_use]
+pub(crate) struct NotificationArrivalContinuation {
+    pub(super) owned: OwnedNotificationArrival,
+    pub(super) cursor: NotificationScanCursor,
+    pub(super) remaining_conflicts: usize,
+    pub(super) _permit: ContinuationPermit,
+}
+
+fn byte_allocation_bound(len: usize) -> Option<usize> {
+    len.checked_mul(2)?.checked_add(size_of::<usize>())
+}
+
+fn string_allocation_bound(len: usize) -> Option<usize> {
+    byte_allocation_bound(len)
+}
+
+pub(super) struct ContinuationAdmission {
+    max_count: usize,
+    max_bytes: usize,
+    count: AtomicUsize,
+    bytes: AtomicUsize,
+    rejected: AtomicUsize,
+}
+
+impl ContinuationAdmission {
+    pub(super) const fn new(max_count: usize, max_bytes: usize) -> Self {
+        Self {
+            max_count,
+            max_bytes,
+            count: AtomicUsize::new(0),
+            bytes: AtomicUsize::new(0),
+            rejected: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) fn reserve(self: &Arc<Self>, bytes: usize) -> Result<ContinuationPermit, NotificationContinuationError> {
+        let count = self.count.fetch_add(1, Ordering::AcqRel);
+        if count >= self.max_count {
+            self.count.fetch_sub(1, Ordering::AcqRel);
+            self.rejected.fetch_add(1, Ordering::Relaxed);
+            return Err(NotificationContinuationError::CountFull);
+        }
+        let mut current = self.bytes.load(Ordering::Acquire);
+        loop {
+            let Some(next) = current.checked_add(bytes) else {
+                self.count.fetch_sub(1, Ordering::AcqRel);
+                self.rejected.fetch_add(1, Ordering::Relaxed);
+                return Err(NotificationContinuationError::SizeOverflow);
+            };
+            if next > self.max_bytes {
+                self.count.fetch_sub(1, Ordering::AcqRel);
+                self.rejected.fetch_add(1, Ordering::Relaxed);
+                return Err(NotificationContinuationError::BytesFull);
+            }
+            match self
+                .bytes
+                .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
+        Ok(ContinuationPermit {
+            admission: Arc::clone(self),
+            bytes,
+        })
+    }
+
+    pub(super) fn snapshot(&self) -> ContinuationSnapshot {
+        ContinuationSnapshot {
+            count: self.count.load(Ordering::Acquire),
+            bytes: self.bytes.load(Ordering::Acquire),
+            rejected: self.rejected.load(Ordering::Acquire),
+        }
+    }
+}
+
+pub(super) struct ContinuationPermit {
+    admission: Arc<ContinuationAdmission>,
+    bytes: usize,
+}
+
+impl Drop for ContinuationPermit {
+    fn drop(&mut self) {
+        self.admission.count.fetch_sub(1, Ordering::AcqRel);
+        self.admission.bytes.fetch_sub(self.bytes, Ordering::AcqRel);
+    }
+}
+
+pub(super) struct ContinuationSnapshot {
+    pub(super) count: usize,
+    pub(super) bytes: usize,
+    pub(super) rejected: usize,
+}

--- a/rocketmq-broker/src/long_polling/notification_deferred/service/data.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/service/data.rs
@@ -1,0 +1,287 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_store::ArcMessageFilter;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestId;
+use rocketmq_transport::api::v2::SessionId;
+
+use super::NotificationDeferredPrepareError;
+use crate::long_polling::notification_deferred::deadline::NotificationWaitDeadline;
+use crate::long_polling::notification_deferred::index::NotificationIndexLease;
+use crate::long_polling::notification_deferred::index::NotificationIndexReservation;
+use crate::long_polling::notification_deferred::index::NotificationMatchCriteria;
+
+pub(crate) struct NotificationRequestData {
+    pub(super) header: NotificationRequestHeader,
+    effective_peer: SocketAddr,
+}
+
+impl NotificationRequestData {
+    pub(crate) const fn new(header: NotificationRequestHeader, effective_peer: SocketAddr) -> Self {
+        Self { header, effective_peer }
+    }
+
+    #[must_use]
+    pub(crate) const fn header(&self) -> &NotificationRequestHeader {
+        &self.header
+    }
+
+    #[must_use]
+    pub(crate) const fn effective_peer(&self) -> SocketAddr {
+        self.effective_peer
+    }
+
+    #[must_use]
+    pub(crate) const fn topic(&self) -> &CheetahString {
+        &self.header.topic
+    }
+
+    #[must_use]
+    pub(crate) const fn consumer_group(&self) -> &CheetahString {
+        &self.header.consumer_group
+    }
+
+    #[must_use]
+    pub(crate) const fn queue_id(&self) -> i32 {
+        self.header.queue_id
+    }
+
+    pub(crate) fn into_parts(self) -> (NotificationRequestHeader, SocketAddr) {
+        (self.header, self.effective_peer)
+    }
+
+    pub(super) fn estimated_dynamic_bytes(&self) -> Result<usize, NotificationDeferredPrepareError> {
+        let mut bytes = self
+            .header
+            .topic
+            .len()
+            .checked_add(self.header.consumer_group.len())
+            .ok_or(NotificationDeferredPrepareError::RetainedSizeOverflow)?;
+        for value in [
+            self.header.attempt_id.as_ref(),
+            self.header.exp_type.as_ref(),
+            self.header.exp.as_ref(),
+            self.header.client_id.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            bytes = bytes
+                .checked_add(value.len())
+                .ok_or(NotificationDeferredPrepareError::RetainedSizeOverflow)?;
+        }
+        if let Some(rpc) = self
+            .header
+            .topic_request_header
+            .as_ref()
+            .and_then(|topic| topic.rpc.as_ref())
+        {
+            for value in [rpc.namespace.as_ref(), rpc.broker_name.as_ref()].into_iter().flatten() {
+                bytes = bytes
+                    .checked_add(value.len())
+                    .ok_or(NotificationDeferredPrepareError::RetainedSizeOverflow)?;
+            }
+        }
+        Ok(bytes)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct PreparedRequestProvenance {
+    request_id: RequestId,
+    session_id: SessionId,
+}
+
+impl PreparedRequestProvenance {
+    pub(super) fn capture(request: &RemotingRequest) -> Self {
+        Self {
+            request_id: request.original_identity().request_id(),
+            session_id: request.session().id(),
+        }
+    }
+
+    pub(super) fn matches(self, request: &RemotingRequest) -> bool {
+        self.request_id == request.original_identity().request_id() && self.session_id == request.session().id()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct NotificationRetainedEstimate {
+    pub(super) resume_bytes: usize,
+    pub(super) filter_bytes: usize,
+    pub(super) metadata_bytes: usize,
+}
+
+impl NotificationRetainedEstimate {
+    pub(crate) const fn new(resume_bytes: usize, filter_bytes: usize, metadata_bytes: usize) -> Self {
+        Self {
+            resume_bytes,
+            filter_bytes,
+            metadata_bytes,
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct ResumeNotification {
+    request: NotificationRequestData,
+    criteria: Arc<NotificationMatchCriteria>,
+    wait_deadline: NotificationWaitDeadline,
+    index_lease: Option<NotificationIndexLease>,
+}
+
+impl ResumeNotification {
+    pub(super) fn new(
+        request: NotificationRequestData,
+        criteria: Arc<NotificationMatchCriteria>,
+        wait_deadline: NotificationWaitDeadline,
+        index_lease: NotificationIndexLease,
+    ) -> Self {
+        Self {
+            request,
+            criteria,
+            wait_deadline,
+            index_lease: Some(index_lease),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        request: NotificationRequestData,
+        criteria: Arc<NotificationMatchCriteria>,
+        wait_deadline: NotificationWaitDeadline,
+    ) -> Self {
+        Self {
+            request,
+            criteria,
+            wait_deadline,
+            index_lease: None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn request(&self) -> &NotificationRequestData {
+        &self.request
+    }
+
+    #[must_use]
+    pub(crate) fn subscription(&self) -> Option<&SubscriptionData> {
+        self.criteria.subscription()
+    }
+
+    #[must_use]
+    pub(crate) fn filter(&self) -> Option<&ArcMessageFilter> {
+        self.criteria.filter()
+    }
+
+    #[must_use]
+    pub(crate) const fn wait_deadline(&self) -> NotificationWaitDeadline {
+        self.wait_deadline
+    }
+
+    pub(super) fn take_index_lease(&mut self) -> Option<NotificationIndexLease> {
+        self.index_lease.take()
+    }
+
+    pub(crate) fn into_execution_parts(
+        self,
+    ) -> (
+        NotificationRequestData,
+        Option<SubscriptionData>,
+        Option<ArcMessageFilter>,
+    ) {
+        let subscription = self.criteria.subscription().cloned();
+        let filter = self.criteria.filter().cloned();
+        (self.request, subscription, filter)
+    }
+}
+
+#[must_use]
+pub(crate) struct PreparedNotificationRegistration {
+    pub(super) request: NotificationRequestData,
+    pub(super) criteria: Arc<NotificationMatchCriteria>,
+    pub(super) deadline: NotificationWaitDeadline,
+    pub(super) reservation: NotificationIndexReservation,
+    pub(super) permit: rocketmq_transport::api::v2::DeferredWaitPermit,
+    pub(super) provenance: Option<PreparedRequestProvenance>,
+    pub(super) observation: PreparedObservation,
+}
+
+impl PreparedNotificationRegistration {
+    #[must_use]
+    pub(crate) const fn deadline(&self) -> NotificationWaitDeadline {
+        self.deadline
+    }
+
+    #[must_use]
+    pub(crate) const fn retained_bytes(&self) -> usize {
+        self.permit.retained_bytes()
+    }
+}
+
+pub(super) struct PreparedObservation {
+    counter: Arc<AtomicUsize>,
+}
+
+impl PreparedObservation {
+    pub(super) fn new(counter: Arc<AtomicUsize>) -> Self {
+        counter.fetch_add(1, Ordering::AcqRel);
+        Self { counter }
+    }
+}
+
+impl Drop for PreparedObservation {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+pub(super) struct CounterObservation {
+    counter: Arc<AtomicUsize>,
+    bytes: Option<(Arc<AtomicUsize>, usize)>,
+}
+
+impl CounterObservation {
+    pub(super) fn new(counter: Arc<AtomicUsize>) -> Self {
+        counter.fetch_add(1, Ordering::AcqRel);
+        Self { counter, bytes: None }
+    }
+
+    pub(super) fn new_with_bytes(counter: Arc<AtomicUsize>, bytes: Arc<AtomicUsize>, retained_bytes: usize) -> Self {
+        counter.fetch_add(1, Ordering::AcqRel);
+        bytes.fetch_add(retained_bytes, Ordering::AcqRel);
+        Self {
+            counter,
+            bytes: Some((bytes, retained_bytes)),
+        }
+    }
+}
+
+impl Drop for CounterObservation {
+    fn drop(&mut self) {
+        if let Some((bytes, retained_bytes)) = self.bytes.take() {
+            bytes.fetch_sub(retained_bytes, Ordering::AcqRel);
+        }
+        self.counter.fetch_sub(1, Ordering::AcqRel);
+    }
+}

--- a/rocketmq-broker/src/long_polling/notification_deferred/tests.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/tests.rs
@@ -1,0 +1,430 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_store::CqExtUnit;
+use rocketmq_store::MessageFilter;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredWaitLimits;
+
+use super::deadline::NotificationWaitDeadline;
+use super::deadline::NotificationWaitDeadlineErrorKind;
+use super::index::NotificationArrivalView;
+use super::index::NotificationCandidateSelection;
+use super::index::NotificationCriteriaIndex;
+use super::index::NotificationCriteriaKey;
+use super::index::NotificationCriteriaLimits;
+use super::index::NotificationIndexErrorKind;
+use super::index::NotificationIndexSnapshot;
+use super::index::NotificationMatchCriteria;
+use super::index::NotificationScanCursor;
+use super::service::NotificationContinuationError;
+use super::service::NotificationDeferredPrepareErrorKind;
+use super::service::NotificationDeferredService;
+use super::service::NotificationRequestData;
+use super::service::NotificationRetainedEstimate;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test limit is non-zero")
+}
+
+fn key(group: &str, queue_id: i32) -> NotificationCriteriaKey {
+    NotificationCriteriaKey::new(
+        CheetahString::from_static_str("topic"),
+        CheetahString::from_string(group.to_owned()),
+        queue_id,
+    )
+}
+
+fn request(born_time: i64, poll_time: i64, group: &str, queue_id: i32) -> NotificationRequestData {
+    NotificationRequestData::new(
+        NotificationRequestHeader {
+            consumer_group: CheetahString::from_string(group.to_owned()),
+            topic: CheetahString::from_static_str("topic"),
+            queue_id,
+            poll_time,
+            born_time,
+            order: false,
+            attempt_id: None,
+            exp_type: None,
+            exp: None,
+            is_lite_consumer: false,
+            client_id: None,
+            topic_request_header: None,
+        },
+        "127.0.0.1:10911".parse::<SocketAddr>().expect("test socket address"),
+    )
+}
+
+fn service(
+    scan_limit: usize,
+    conflicts: usize,
+    continuation_count: usize,
+    continuation_bytes: usize,
+) -> NotificationDeferredService {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = DeferredAdmission::try_configure(&controller, DeferredWaitLimits::new(16, 16 * 1024 * 1024))
+        .expect("Notification wait admission");
+    NotificationDeferredService::new(
+        admission,
+        NotificationCriteriaLimits::new(nonzero(16), 7, 1),
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        nonzero(scan_limit),
+        nonzero(conflicts),
+        nonzero(continuation_count),
+        nonzero(continuation_bytes),
+    )
+}
+
+struct ToggleFilter(Arc<AtomicBool>);
+
+impl MessageFilter for ToggleFilter {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+#[test]
+fn notification_deferred_deadline_preserves_signed_strict_fifty_millisecond_boundary() {
+    let monotonic = tokio::time::Instant::now();
+    let live = NotificationWaitDeadline::checked(1_000, 100, 1_050, monotonic).expect("cutoff equality is live");
+    assert_eq!(live.protocol_millis(), 1_051);
+    assert_eq!(live.protocol_at(), monotonic + Duration::from_millis(1));
+    assert_eq!(
+        NotificationWaitDeadline::checked(1_000, 100, 1_051, monotonic)
+            .expect_err("the next integer millisecond expires")
+            .kind(),
+        NotificationWaitDeadlineErrorKind::AlreadyExpired
+    );
+    assert_eq!(
+        NotificationWaitDeadline::checked(-1, 100, 0, monotonic)
+            .expect_err("negative born time is rejected")
+            .kind(),
+        NotificationWaitDeadlineErrorKind::NegativeBornTime
+    );
+    assert_eq!(
+        NotificationWaitDeadline::checked(i64::MAX, 1, 0, monotonic)
+            .expect_err("signed end overflow is rejected")
+            .kind(),
+        NotificationWaitDeadlineErrorKind::ProtocolOverflow
+    );
+    assert_eq!(
+        NotificationWaitDeadline::checked(1_000, 0, 0, monotonic)
+            .expect_err("non-positive poll time is immediate")
+            .kind(),
+        NotificationWaitDeadlineErrorKind::NonPositivePollTime
+    );
+}
+
+#[test]
+fn notification_deferred_index_uses_legacy_plus_one_per_key_and_hint_is_not_a_key_limit() {
+    let index = NotificationCriteriaIndex::<u64>::new(NotificationCriteriaLimits::new(nonzero(4), 1, 1));
+    let criteria = Arc::new(NotificationMatchCriteria::new(None, None));
+    let deadline = NotificationWaitDeadline::checked(0, 1_000, 0, tokio::time::Instant::now()).expect("test deadline");
+    let first =
+        index
+            .reserve(key("group-a", 0))
+            .expect("legacy length zero")
+            .publish(1, deadline, Arc::clone(&criteria));
+    let second =
+        index
+            .reserve(key("group-a", 0))
+            .expect("legacy length one")
+            .publish(2, deadline, Arc::clone(&criteria));
+    let full = match index.reserve(key("group-a", 0)) {
+        Ok(_) => panic!("third entry exceeds pop_polling_size + 1"),
+        Err(error) => error,
+    };
+    assert_eq!(full.kind(), NotificationIndexErrorKind::PerKeyCapacity);
+    let other = index
+        .reserve(key("group-b", 0))
+        .expect("allocation hint is not a key cap")
+        .publish(3, deadline, Arc::clone(&criteria));
+    let fourth = index
+        .reserve(key("group-c", 0))
+        .expect("fourth global entry")
+        .publish(4, deadline, criteria);
+    let global = match index.reserve(key("group-d", 0)) {
+        Ok(_) => panic!("fifth entry exceeds the global live+reserved cap"),
+        Err(error) => error,
+    };
+    assert_eq!(global.kind(), NotificationIndexErrorKind::GlobalCapacity);
+    assert_eq!(index.snapshot().keys(), 3);
+    drop((first, second, other, fourth));
+    assert_eq!(index.snapshot(), NotificationIndexSnapshot::default());
+}
+
+#[test]
+fn notification_deferred_cursor_is_wildcard_first_and_newest_first_without_revisiting_miss() {
+    let index = NotificationCriteriaIndex::<u64>::new(NotificationCriteriaLimits::direct(nonzero(8), nonzero(8)));
+    let deadline = NotificationWaitDeadline::checked(0, 1_000, 0, tokio::time::Instant::now()).expect("test deadline");
+    let toggle = Arc::new(AtomicBool::new(false));
+    let filtered = Arc::new(NotificationMatchCriteria::new(
+        Some(SubscriptionData::default()),
+        Some(Arc::new(ToggleFilter(Arc::clone(&toggle)))),
+    ));
+    let wildcard = index.reserve(key("group", -1)).expect("wildcard").publish(
+        1,
+        deadline,
+        Arc::new(NotificationMatchCriteria::new(None, None)),
+    );
+    let exact_old = index.reserve(key("group", 3)).expect("exact old").publish(
+        2,
+        deadline,
+        Arc::new(NotificationMatchCriteria::new(None, None)),
+    );
+    let exact_new = index
+        .reserve(key("group", 3))
+        .expect("exact new")
+        .publish(3, deadline, filtered);
+    let topic = CheetahString::from_static_str("topic");
+    let arrival = NotificationArrivalView::new(&topic, 3).with_filter_metadata(Some(7), 10, None, None);
+    let mut cursor = index.scan_cursor(&arrival);
+
+    let NotificationCandidateSelection::Candidate(first) = index.reserve_next(&mut cursor) else {
+        panic!("wildcard candidate expected");
+    };
+    assert_eq!(first.id(), 1);
+    cursor.advance_key();
+    drop(first);
+
+    let NotificationCandidateSelection::Candidate(miss) = index.reserve_next(&mut cursor) else {
+        panic!("newest exact candidate expected");
+    };
+    assert_eq!(miss.id(), 3);
+    assert!(!miss.criteria().matches(&arrival, &arrival.cq_ext_unit()));
+    drop(miss);
+    let NotificationCandidateSelection::Candidate(next) = index.reserve_next(&mut cursor) else {
+        panic!("older exact candidate expected after miss");
+    };
+    assert_eq!(next.id(), 2);
+    drop(next);
+
+    toggle.store(true, Ordering::SeqCst);
+    let mut fresh = index.scan_cursor(&arrival);
+    let NotificationCandidateSelection::Candidate(retry_wildcard) = index.reserve_next(&mut fresh) else {
+        panic!("fresh arrival starts at wildcard");
+    };
+    fresh.advance_key();
+    drop(retry_wildcard);
+    let NotificationCandidateSelection::Candidate(retry_exact) = index.reserve_next(&mut fresh) else {
+        panic!("fresh arrival sees newest exact again");
+    };
+    assert_eq!(retry_exact.id(), 3);
+    drop(retry_exact);
+    drop((wildcard, exact_old, exact_new));
+    assert_eq!(index.snapshot(), NotificationIndexSnapshot::default());
+}
+
+#[test]
+fn notification_deferred_retry_v2_arrival_normalizes_before_fanout_snapshot() {
+    let index = NotificationCriteriaIndex::<u64>::new(NotificationCriteriaLimits::direct(nonzero(2), nonzero(2)));
+    let deadline = NotificationWaitDeadline::checked(0, 1_000, 0, tokio::time::Instant::now()).expect("test deadline");
+    let lease = index.reserve(key("group", 3)).expect("normal topic key").publish(
+        7,
+        deadline,
+        Arc::new(NotificationMatchCriteria::new(None, None)),
+    );
+    let retry = CheetahString::from_string(
+        rocketmq_model::common::key_builder::KeyBuilder::build_pop_retry_topic_v2("topic", "group"),
+    );
+    let arrival = NotificationArrivalView::new(&retry, 3);
+    let mut cursor = index.scan_cursor(&arrival);
+    let NotificationCandidateSelection::Candidate(candidate) = index.reserve_next(&mut cursor) else {
+        panic!("retry-v2 arrival resolves the normal topic key");
+    };
+    assert_eq!(candidate.id(), 7);
+    drop(candidate);
+    drop(lease);
+    assert_eq!(index.snapshot(), NotificationIndexSnapshot::default());
+}
+
+#[test]
+fn notification_deferred_prepare_failures_release_index_and_wait_capacity() {
+    let service = service(2, 2, 1, 1024);
+    let monotonic = tokio::time::Instant::now();
+    let invalid = match service.prepare_at(
+        request(-1, 100, "group", 0),
+        None,
+        None,
+        NotificationRetainedEstimate::default(),
+        0,
+        monotonic,
+    ) {
+        Ok(_) => panic!("invalid signed deadline stays pre-take"),
+        Err(error) => error,
+    };
+    assert_eq!(invalid.kind(), NotificationDeferredPrepareErrorKind::Deadline);
+    assert_eq!(service.snapshot().index(), NotificationIndexSnapshot::default());
+    assert_eq!(service.snapshot().admission().waiting_count(), 0);
+
+    let prepared = service
+        .prepare_at(
+            request(1_000, 1_000, "group", 0),
+            None,
+            None,
+            NotificationRetainedEstimate::default(),
+            1_100,
+            monotonic,
+        )
+        .expect("valid prepared registration");
+    assert!(prepared.retained_bytes() > 0);
+    assert_eq!(service.snapshot().prepared(), 1);
+    assert_eq!(service.snapshot().index().reserved(), 1);
+    drop(prepared);
+    assert_eq!(service.snapshot().prepared(), 0);
+    assert_eq!(service.snapshot().index(), NotificationIndexSnapshot::default());
+    assert_eq!(service.snapshot().admission().waiting_count(), 0);
+}
+
+#[test]
+fn notification_deferred_continuation_has_independent_count_and_bytes_admission() {
+    let deferred_service = service(1, 1, 1, 4096);
+    let topic = CheetahString::from_static_str("topic");
+    let arrival = NotificationArrivalView::new(&topic, 0);
+    let continuation = deferred_service
+        .admit_continuation(arrival, NotificationScanCursor::for_test(1))
+        .expect("first continuation is admitted");
+    assert_eq!(deferred_service.snapshot().active_continuations(), 1);
+    let second = match deferred_service.admit_continuation(arrival, NotificationScanCursor::for_test(1)) {
+        Ok(_) => panic!("second continuation exceeds the count cap"),
+        Err(error) => error,
+    };
+    assert_eq!(second, NotificationContinuationError::CountFull);
+    drop(continuation);
+    assert_eq!(deferred_service.snapshot().active_continuations(), 0);
+    assert_eq!(deferred_service.snapshot().continuation_bytes(), 0);
+    assert_eq!(deferred_service.snapshot().continuation_rejected(), 1);
+
+    let bytes_limited = service(1, 1, 2, 4);
+    let large_topic = CheetahString::from_static_str("topic-larger-than-four-bytes");
+    let bytes_error = match bytes_limited.admit_continuation(
+        NotificationArrivalView::new(&large_topic, 0),
+        NotificationScanCursor::for_test(1),
+    ) {
+        Ok(_) => panic!("arrival payload exceeds continuation byte capacity"),
+        Err(error) => error,
+    };
+    assert_eq!(bytes_error, NotificationContinuationError::BytesFull);
+    assert_eq!(bytes_limited.snapshot().active_continuations(), 0);
+    assert_eq!(bytes_limited.snapshot().continuation_bytes(), 0);
+}
+
+#[test]
+fn notification_deferred_continuation_charges_fixed_cursor_and_property_storage_before_copy() {
+    let topic = CheetahString::from_string("topic".repeat(32));
+    let properties = (0..32)
+        .map(|index| {
+            (
+                CheetahString::from_string(format!("k{index}")),
+                CheetahString::from_string(format!("v{index}")),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let arrival = NotificationArrivalView::new(&topic, 0).with_filter_metadata(None, 0, None, Some(&properties));
+    let constrained = service(1, 1, 1, 4096);
+    let error = match constrained.admit_continuation(arrival, NotificationScanCursor::for_test(64)) {
+        Ok(_) => panic!("fixed owners, cursor backing, buckets, and short properties exceed the byte cap"),
+        Err(error) => error,
+    };
+    assert_eq!(error, NotificationContinuationError::BytesFull);
+    assert_eq!(constrained.snapshot().active_continuations(), 0);
+    assert_eq!(constrained.snapshot().continuation_bytes(), 0);
+
+    let admitted = service(1, 1, 1, 1024 * 1024);
+    let continuation = admitted
+        .admit_continuation(arrival, NotificationScanCursor::for_test(64))
+        .expect("the conservative retained oracle fits the generous cap");
+    assert!(
+        admitted.snapshot().continuation_bytes() > topic.len() + properties.len(),
+        "the charge includes fixed owners and collection backing, not only string payload bytes"
+    );
+    drop(continuation);
+    assert_eq!(admitted.snapshot().active_continuations(), 0);
+    assert_eq!(admitted.snapshot().continuation_bytes(), 0);
+}
+
+#[tokio::test]
+async fn notification_deferred_continuation_spends_one_conflict_budget_across_batches() {
+    let service = Arc::new(service(1, 2, 1, 1024 * 1024));
+    service.index.force_conflicts(8);
+    let topic = CheetahString::from_static_str("topic");
+    let arrival = NotificationArrivalView::new(&topic, 0);
+    let initial = service.prepare_arrival_batch(arrival, Some(NotificationScanCursor::for_test(1)));
+    assert_eq!(initial.conflicts(), 1);
+    let initial = service.claim_prepared_arrival(initial).await;
+    let (initial_claims, cursor) = initial.into_parts();
+    assert!(initial_claims.is_empty());
+    let continuation = service
+        .admit_continuation(arrival, cursor)
+        .expect("conflict continuation admission");
+    assert_eq!(service.snapshot().active_continuations(), 1);
+    let runtime = RuntimeOwner::new(RuntimeConfig::server_default("notification-conflict-budget"))
+        .expect("conflict-budget runtime owner");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&calls);
+    service
+        .spawn_continuation(
+            runtime.root_context().component("notification.conflict").task_group(),
+            continuation,
+            Arc::new(
+                move |claims: Vec<rocketmq_transport::api::v2::ClaimedDeferred<super::service::ResumeNotification>>| {
+                    let observed = Arc::clone(&observed);
+                    async move {
+                        assert!(claims.is_empty());
+                        observed.fetch_add(1, Ordering::AcqRel);
+                    }
+                },
+            ),
+        )
+        .expect("spawn conflict continuation");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while calls.load(Ordering::Acquire) != 1 || service.snapshot().active_continuations() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("continuation terminates when its shared conflict budget is exhausted");
+    assert_eq!(calls.load(Ordering::Acquire), 1);
+    assert_eq!(service.index.forced_conflicts_remaining(), 6);
+    assert_eq!(service.snapshot().continuation_bytes(), 0);
+    let report = runtime.shutdown_tasks().await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+    let final_report = runtime.shutdown_background();
+    assert!(final_report.is_healthy(), "{}", final_report.to_json());
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The RocketMQ Rust Authors
+// Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod long_polling_service;
-pub(crate) mod many_pull_request;
-pub(crate) mod notification_deferred;
-pub(crate) mod notify_message_arriving_listener;
-pub(crate) mod polling_header;
-pub(crate) mod polling_result;
-pub(crate) mod pop_deferred;
-pub(crate) mod pop_lite_deferred;
-pub(crate) mod pop_request;
-pub(crate) mod pull_deferred;
-pub(crate) mod pull_request;
+pub(crate) mod data;
+pub(crate) mod deadline;
+pub(crate) mod gate;
+pub(crate) mod index;
+pub(crate) mod prepare;
+pub(crate) mod service;
+
+#[cfg(test)]
+mod acceptance_tests;
+#[cfg(test)]
+mod tests;

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests.rs
@@ -1,0 +1,438 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Barrier;
+use std::time::Duration;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_model::common::key_builder::POP_ORDER_REVIVE_QUEUE;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
+use rocketmq_protocol::protocol::header::pop_lite_message_response_header::PopLiteMessageResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ShutdownReport;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::ServerConfig;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredId;
+use rocketmq_transport::api::v2::DeferredResumeErrorKind;
+use rocketmq_transport::api::v2::DeferredResumeRetainedSize;
+use rocketmq_transport::api::v2::DeferredTerminalReason;
+use rocketmq_transport::api::v2::DeferredWaitLimits;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrdering;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::TransportServerV2;
+use rocketmq_transport::test_support::Connection;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+use super::index::PopLiteIndexLimits;
+use super::prepare::PopLiteRetainedEstimate;
+use super::service::PopLiteDeferredService;
+use crate::lite::lite_event_dispatcher::LiteEventDispatcher;
+
+const ORIGINAL_OPAQUE: i32 = 9_833;
+
+struct CountingBodyOwner {
+    body: Vec<u8>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl AsRef<[u8]> for CountingBodyOwner {
+    fn as_ref(&self) -> &[u8] {
+        &self.body
+    }
+}
+
+impl Drop for CountingBodyOwner {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+mod concurrency_tests;
+mod deadline_tests;
+mod lifecycle_tests;
+mod owner_tests;
+mod post_take_fault_tests;
+mod provenance_tests;
+mod resource_wire_tests;
+mod terminal_session_tests;
+
+pub(super) fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test limit is non-zero")
+}
+
+pub(super) fn service(
+    controller: &AdmissionController,
+    dispatcher: LiteEventDispatcher,
+) -> Arc<PopLiteDeferredService> {
+    let admission = DeferredAdmission::try_configure(controller, DeferredWaitLimits::new(4, 4 * 1024 * 1024))
+        .expect("PopLite deferred admission");
+    Arc::new(PopLiteDeferredService::new(
+        admission,
+        PopLiteIndexLimits::new(nonzero(4), nonzero(4), nonzero(2)),
+        dispatcher,
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        Duration::from_secs(30),
+        nonzero(4),
+    ))
+}
+
+pub(super) fn request_command() -> RemotingCommand {
+    request_command_for("client-a", ORIGINAL_OPAQUE, 60_000)
+}
+
+pub(super) fn request_command_for(client_id: &str, opaque: i32, poll_time: i64) -> RemotingCommand {
+    let header = PopLiteMessageRequestHeader {
+        client_id: CheetahString::from_string(client_id.to_owned()),
+        consumer_group: CheetahString::from_static_str("group-a"),
+        topic: CheetahString::from_static_str("parent-topic"),
+        max_msg_num: 1,
+        invisible_time: 30_000,
+        poll_time,
+        born_time: i64::try_from(current_millis()).expect("wall time fits signed protocol field"),
+        attempt_id: None,
+        rpc: None,
+    };
+    let mut command = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, header).set_opaque(opaque);
+    command.make_custom_header_to_net();
+    command
+}
+
+#[derive(Clone)]
+struct DeferredTestProcessor {
+    service: Arc<PopLiteDeferredService>,
+    registrations: mpsc::UnboundedSender<DeferredId>,
+}
+
+impl RequestProcessorV2 for DeferredTestProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prepared = self
+            .service
+            .prepare(request, PopLiteRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let registration = self
+            .service
+            .register(prepared, request)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let id = registration.deferred_id();
+        self.registrations
+            .send(id)
+            .map_err(|_| RocketMQError::illegal_argument("PopLite registration observer closed"))?;
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+
+    fn request_ordering(&self, _ingress: rocketmq_transport::api::v2::IngressRequestView<'_>) -> RequestOrdering {
+        RequestOrdering::Concurrent
+    }
+}
+
+pub(super) struct RunningServer {
+    owner: RuntimeOwner,
+    pub(super) action_context: ChildServiceContext,
+    shutdown: Option<oneshot::Sender<()>>,
+    result: oneshot::Receiver<ShutdownReport>,
+}
+
+impl RunningServer {
+    pub(super) async fn finish(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        let report = self.result.await.expect("owned PopLite server report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        let tasks = self.owner.shutdown_tasks().await;
+        assert!(tasks.is_healthy(), "{}", tasks.to_json());
+        let final_report = self.owner.shutdown_background();
+        assert!(final_report.is_healthy(), "{}", final_report.to_json());
+    }
+}
+
+pub(super) async fn start_server<P>(processor: P, controller: Arc<AdmissionController>) -> (Connection, RunningServer)
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("pop-lite-deferred-acceptance"))
+        .expect("PopLite V2 runtime owner");
+    let server_context = owner.root_context().component("pop-lite.server");
+    let runner_context = owner.root_context().component("pop-lite.runner");
+    let action_context = owner.root_context().component("pop-lite.actions");
+    let server = TransportServerV2::new(
+        Arc::new(ServerConfig {
+            bind_address: "127.0.0.1".to_owned(),
+            listen_port: 0,
+            ..ServerConfig::default()
+        }),
+        server_context,
+        processor,
+    )
+    .with_admission_controller(controller);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    runner_context
+        .spawn_service("pop-lite-deferred-v2-server", async move {
+            let report = server
+                .try_run_with_shutdown_report_and_startup(
+                    async move {
+                        let _ = shutdown_rx.await;
+                    },
+                    startup_tx,
+                )
+                .await
+                .expect("owned PopLite server shutdown report");
+            let _ = result_tx.send(report);
+        })
+        .expect("spawn PopLite V2 server");
+    let address = startup_rx
+        .await
+        .expect("PopLite startup channel")
+        .expect("PopLite server startup");
+    let client = Connection::new(TcpStream::connect(address).await.expect("connect PopLite client"));
+    (
+        client,
+        RunningServer {
+            owner,
+            action_context,
+            shutdown: Some(shutdown_tx),
+            result: result_rx,
+        },
+    )
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_v2_event_claim_writes_one_canonical_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let client_id = CheetahString::from_static_str("client-a");
+    let event = CheetahString::from_static_str("%LMQ%$parent-topic$child-a");
+    assert_eq!(
+        dispatcher.do_full_dispatch(
+            &client_id,
+            &CheetahString::from_static_str("group-a"),
+            &HashSet::from([event.clone()]),
+        ),
+        1
+    );
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command())
+        .await
+        .expect("send deferred PopLite request");
+    let _id = registrations.recv().await.expect("observe PopLite registration");
+    assert_eq!(
+        service.take_pending_replays(nonzero(1)),
+        vec![client_id.clone()],
+        "post-registration observation replays an arrival-before-register event"
+    );
+    let registered = service.resource_snapshot();
+    assert_eq!(registered.admission.waiting_count(), 1);
+    assert!(registered.admission.retained_bytes() > 0);
+    assert_eq!(registered.index.live, 1);
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim PopLite event")
+        .expect("registered client has a claim");
+    assert_eq!(service.resource_snapshot().active_client_gates, 1);
+
+    let service_for_resume = Arc::clone(&service);
+    let service_for_handler = Arc::clone(&service);
+    let resumed_client_id = client_id.clone();
+    let body_drops = Arc::new(AtomicUsize::new(0));
+    let body_drops_for_handler = Arc::clone(&body_drops);
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .action_context
+        .spawn_service("pop-lite-deferred-resume", async move {
+            let result = service_for_resume
+                .resume_event_claim(
+                    claim,
+                    DeferredResumeRetainedSize::default(),
+                    move |resume, reason, reservation| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        assert_eq!(resume.request().client_id(), &resumed_client_id);
+                        let accepted = service_for_handler.resource_snapshot();
+                        assert_eq!(accepted.active_client_gates, 1);
+                        assert_eq!(accepted.event_reservations.events, 1);
+                        assert_eq!(accepted.accepted_resumes, 1);
+                        let batch = reservation.commit();
+                        assert_eq!(batch.event_names(), vec![event]);
+                        batch.complete(&HashSet::new());
+                        let head = application_remoting_command_factory().create_success_response_command_with_header(
+                            PopLiteMessageResponseHeader {
+                                pop_time: current_millis() as i64,
+                                invisible_time: resume.request().header().invisible_time,
+                                revive_qid: POP_ORDER_REVIVE_QUEUE,
+                                start_offset_info: None,
+                                msg_offset_info: None,
+                                order_count_info: None,
+                            },
+                        );
+                        let body = Bytes::from_owner(CountingBodyOwner {
+                            body: b"owner-backed-pop-lite-success".to_vec(),
+                            drops: body_drops_for_handler,
+                        });
+                        ResponsePlan::bytes(head, body)
+                            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn PopLite resume");
+    receipt_rx
+        .await
+        .expect("PopLite receipt channel")
+        .expect("canonical PopLite write");
+
+    let response = client
+        .receive_command()
+        .await
+        .expect("connection remains open")
+        .expect("one PopLite response frame");
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(response.code(), ResponseCode::Success as i32);
+    assert_eq!(
+        response.body().map(|body| body.as_ref()),
+        Some(b"owner-backed-pop-lite-success".as_slice())
+    );
+    assert_eq!(body_drops.load(Ordering::SeqCst), 1);
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+    let snapshot = service.resource_snapshot();
+    assert_eq!(snapshot.admission.waiting_count(), 0);
+    assert_eq!(snapshot.index.live, 0);
+    assert_eq!(snapshot.event_reservations.events, 0);
+    assert_eq!(snapshot.active_client_gates, 0);
+    assert_eq!(snapshot.accepted_resumes, 0);
+
+    running.finish().await;
+    assert!(client.receive_command().await.is_none(), "EOF proves exactly one frame");
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_claim_failure_rolls_back_event_order_and_permits() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command())
+        .await
+        .expect("send deferred PopLite request");
+    let id = registrations.recv().await.expect("observe PopLite registration");
+
+    let client_id = CheetahString::from_static_str("client-a");
+    assert!(
+        service
+            .claim_event(&client_id)
+            .await
+            .expect("pending-event miss is not a claim failure")
+            .is_none(),
+        "pending-event miss must leave the registered waiter claimable"
+    );
+    assert_eq!(service.resource_snapshot().index.live, 1);
+    let first = CheetahString::from_static_str("%LMQ%$parent-topic$child-a");
+    let second = CheetahString::from_static_str("%LMQ%$parent-topic$child-b");
+    assert_eq!(
+        dispatcher.do_full_dispatch(
+            &client_id,
+            &CheetahString::from_static_str("group-a"),
+            &HashSet::from([first.clone(), second.clone()]),
+        ),
+        2
+    );
+    let claimed_elsewhere = service
+        .registry
+        .claim(id, DeferredWakeReason::Timeout)
+        .await
+        .expect("test owner claims registry entry first");
+
+    match service.claim_event(&client_id).await {
+        Err(_) => {}
+        Ok(_) => panic!("stale PopLite index claim must fail at the registry"),
+    }
+    assert_eq!(dispatcher.pending_events(&client_id), vec![first, second]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 2);
+    assert_eq!(dispatcher.reservation_snapshot().events, 0);
+    assert_eq!(service.resource_snapshot().active_client_gates, 0);
+    assert_eq!(
+        service.take_pending_replays(nonzero(1)),
+        vec![client_id.clone()],
+        "registry-claim rollback must schedule the restored event without another arrival"
+    );
+    drop(claimed_elsewhere);
+    assert_eq!(service.resource_snapshot().index.live, 0);
+
+    assert_eq!(dispatcher.take_pending_events(&client_id).len(), 2);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_shutdown_cannot_reinsert_a_checked_pending_replay() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(&controller, dispatcher.clone());
+    let client_id = CheetahString::from_static_str("shutdown-client");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([CheetahString::from_static_str("%LMQ%$parent-topic$shutdown-child")]),
+    );
+    let checked = Arc::new(Barrier::new(2));
+    let resume = Arc::new(Barrier::new(2));
+    service.set_replay_insert_hook(Arc::clone(&checked), Arc::clone(&resume));
+    let observing_service = Arc::clone(&service);
+    let observing_client = client_id.clone();
+    let observer = std::thread::spawn(move || observing_service.observe_pending_event(&observing_client));
+    checked.wait();
+    service.shutdown();
+    resume.wait();
+    assert!(!observer.join().expect("pending replay observer thread"));
+    assert_eq!(service.resource_snapshot().pending_replays, 0);
+    assert_eq!(dispatcher.take_pending_events(&client_id).len(), 1);
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/concurrency_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/concurrency_tests.rs
@@ -1,0 +1,374 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use tokio::sync::Notify;
+use tokio::sync::Semaphore;
+
+use super::*;
+
+fn assert_terminal_snapshot(service: &PopLiteDeferredService) {
+    let snapshot = service.resource_snapshot();
+    assert_eq!(snapshot.admission.waiting_count(), 0);
+    assert_eq!(snapshot.admission.retained_bytes(), 0);
+    assert_eq!(snapshot.index.live, 0);
+    assert_eq!(snapshot.index.reserved, 0);
+    assert_eq!(snapshot.index.candidates, 0);
+    assert_eq!(snapshot.event_reservations.batches, 0);
+    assert_eq!(snapshot.event_reservations.events, 0);
+    assert_eq!(snapshot.event_reservations.permits, 0);
+    assert_eq!(snapshot.event_reservations.retained_bytes, 0);
+    assert_eq!(snapshot.active_client_gates, 0);
+    assert_eq!(snapshot.prepared_registrations, 0);
+    assert_eq!(snapshot.pending_claims, 0);
+    assert_eq!(snapshot.resume_execution_count, 0);
+    assert_eq!(snapshot.resume_execution_bytes, 0);
+    assert_eq!(snapshot.pending_replays, 0);
+}
+
+#[derive(Clone)]
+struct OpaqueRegistrationProcessor {
+    service: Arc<PopLiteDeferredService>,
+    registrations: mpsc::UnboundedSender<(i32, DeferredId)>,
+}
+
+impl RequestProcessorV2 for OpaqueRegistrationProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let opaque = request.command().opaque();
+        let prepared = self
+            .service
+            .prepare(request, PopLiteRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let registration = self
+            .service
+            .register(prepared, request)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.registrations
+            .send((opaque, registration.deferred_id()))
+            .map_err(|_| RocketMQError::illegal_argument("opaque registration observer closed"))?;
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+
+    fn request_ordering(&self, _ingress: rocketmq_transport::api::v2::IngressRequestView<'_>) -> RequestOrdering {
+        RequestOrdering::Concurrent
+    }
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_different_clients_resume_and_write_in_parallel() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+
+    let clients = [("parallel-a", 201), ("parallel-b", 202)];
+    let mut claims = Vec::new();
+    for (client_name, opaque) in clients {
+        client
+            .send_command(request_command_for(client_name, opaque, 60_000))
+            .await
+            .expect("send parallel PopLite waiter");
+        registrations.recv().await.expect("observe parallel registration");
+        let client_id = CheetahString::from_string(client_name.to_owned());
+        let event = CheetahString::from_string(format!("%LMQ%$parent-topic${client_name}"));
+        assert_eq!(
+            dispatcher.do_full_dispatch(
+                &client_id,
+                &CheetahString::from_static_str("group-a"),
+                &HashSet::from([event]),
+            ),
+            1
+        );
+        claims.push(
+            service
+                .claim_event(&client_id)
+                .await
+                .expect("claim parallel PopLite event")
+                .expect("parallel client has a waiter"),
+        );
+    }
+
+    let started = Arc::new(AtomicUsize::new(0));
+    let release = Arc::new(Semaphore::new(0));
+    let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+    let (receipt_tx, mut receipt_rx) = mpsc::unbounded_channel();
+    for claim in claims {
+        let service_for_resume = Arc::clone(&service);
+        let started_count = Arc::clone(&started);
+        let release_handler = Arc::clone(&release);
+        let started_sender = started_tx.clone();
+        let receipt_sender = receipt_tx.clone();
+        running
+            .action_context
+            .spawn_service("pop-lite-parallel-resume", async move {
+                let result = service_for_resume
+                    .resume_event_claim(
+                        claim,
+                        DeferredResumeRetainedSize::new(97),
+                        move |_resume, reason, reservation| async move {
+                            assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                            started_count.fetch_add(1, Ordering::SeqCst);
+                            let _ = started_sender.send(());
+                            release_handler
+                                .acquire()
+                                .await
+                                .map_err(|_| RocketMQError::illegal_argument("parallel release closed"))?
+                                .forget();
+                            let batch = reservation.commit();
+                            batch.complete(&HashSet::new());
+                            ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                                ResponseCode::Success,
+                            ))
+                            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                        },
+                    )
+                    .await;
+                let _ = receipt_sender.send(result);
+            })
+            .expect("spawn parallel PopLite resume");
+    }
+    drop(started_tx);
+    drop(receipt_tx);
+    started_rx.recv().await.expect("first parallel handler starts");
+    started_rx.recv().await.expect("second parallel handler starts");
+    assert_eq!(started.load(Ordering::SeqCst), 2);
+    let active = service.resource_snapshot();
+    assert_eq!(active.active_client_gates, 2);
+    assert_eq!(active.resume_execution_count, 2);
+    assert!(active.resume_execution_bytes >= 194);
+
+    release.add_permits(2);
+    for _ in 0..2 {
+        receipt_rx
+            .recv()
+            .await
+            .expect("parallel receipt")
+            .expect("parallel canonical write");
+    }
+    let mut opaqueness = HashSet::new();
+    for _ in 0..2 {
+        let response = client
+            .receive_command()
+            .await
+            .expect("parallel connection")
+            .expect("parallel response frame");
+        opaqueness.insert(response.opaque());
+    }
+    assert_eq!(opaqueness, HashSet::from([201, 202]));
+    assert_terminal_snapshot(&service);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_same_client_timeout_is_not_serialized_by_event_gate() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = OpaqueRegistrationProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+
+    for (opaque, poll_time) in [(204, 10_000), (205, 60_000)] {
+        client
+            .send_command(request_command_for("same-client-timeout", opaque, poll_time))
+            .await
+            .expect("send same-client PopLite waiter");
+    }
+    let mut timeout_id = None;
+    for _ in 0..2 {
+        let (opaque, id) = registrations.recv().await.expect("observe same-client waiter");
+        if opaque == 205 {
+            timeout_id = Some(id);
+        }
+    }
+    let timeout_id = timeout_id.expect("map timeout waiter by original opaque");
+
+    let client_id = CheetahString::from_static_str("same-client-timeout");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([CheetahString::from_static_str("%LMQ%$parent-topic$same-client-timeout")]),
+    );
+    let event_claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim same-client event")
+        .expect("event waiter is claimable");
+
+    let event_started = Arc::new(Notify::new());
+    let event_release = Arc::new(Notify::new());
+    let event_started_for_handler = Arc::clone(&event_started);
+    let event_release_for_handler = Arc::clone(&event_release);
+    let (event_receipt_tx, event_receipt_rx) = oneshot::channel();
+    let service_for_event = Arc::clone(&service);
+    running
+        .action_context
+        .spawn_service("pop-lite-same-client-event", async move {
+            let result = service_for_event
+                .resume_event_claim(
+                    event_claim,
+                    DeferredResumeRetainedSize::new(101),
+                    move |_resume, reason, reservation| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        event_started_for_handler.notify_one();
+                        event_release_for_handler.notified().await;
+                        reservation.commit().complete(&HashSet::new());
+                        ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::Success,
+                        ))
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = event_receipt_tx.send(result);
+        })
+        .expect("spawn same-client event resume");
+    event_started.notified().await;
+    assert_eq!(service.resource_snapshot().active_client_gates, 1);
+
+    let mut timeout_claim = service
+        .registry
+        .claim(timeout_id, DeferredWakeReason::Timeout)
+        .await
+        .expect("claim same-client timeout independently of event gate");
+    drop(timeout_claim.resume_data_mut().take_index_lease());
+    service
+        .resume_claimed(
+            timeout_claim,
+            DeferredResumeRetainedSize::new(41),
+            move |_resume, reason| async move {
+                assert_eq!(reason, DeferredWakeReason::Timeout);
+                ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                    ResponseCode::PollingTimeout,
+                ))
+                .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+            },
+        )
+        .await
+        .expect("same-client timeout writes while event remains active");
+
+    let timeout_response = client
+        .receive_command()
+        .await
+        .expect("same-client timeout connection")
+        .expect("timeout response precedes blocked event response");
+    assert_eq!(timeout_response.opaque(), 205);
+    assert_eq!(timeout_response.code(), ResponseCode::PollingTimeout as i32);
+    let while_event_is_blocked = service.resource_snapshot();
+    assert_eq!(while_event_is_blocked.active_client_gates, 1);
+    assert_eq!(while_event_is_blocked.resume_execution_count, 1);
+
+    event_release.notify_one();
+    event_receipt_rx
+        .await
+        .expect("event receipt observer")
+        .expect("event response writes after release");
+    let event_response = client
+        .receive_command()
+        .await
+        .expect("same-client event connection")
+        .expect("event response frame");
+    assert_eq!(event_response.opaque(), 204);
+    assert_eq!(event_response.code(), ResponseCode::Success as i32);
+    assert_terminal_snapshot(&service);
+    running.finish().await;
+}
+
+#[derive(Clone)]
+struct CommitWindowProcessor {
+    service: Arc<PopLiteDeferredService>,
+    registrations: mpsc::UnboundedSender<DeferredId>,
+    release: Arc<Semaphore>,
+}
+
+impl RequestProcessorV2 for CommitWindowProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prepared = self
+            .service
+            .prepare(request, PopLiteRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let registration = self
+            .service
+            .register(prepared, request)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.registrations
+            .send(registration.deferred_id())
+            .map_err(|_| RocketMQError::illegal_argument("commit-window observer closed"))?;
+        self.release
+            .acquire()
+            .await
+            .map_err(|_| RocketMQError::illegal_argument("commit-window release closed"))?
+            .forget();
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_registration_commit_window_blocks_claim_until_activation() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let release = Arc::new(Semaphore::new(0));
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = CommitWindowProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        release: Arc::clone(&release),
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("commit-window", 203, 60_000))
+        .await
+        .expect("send commit-window PopLite waiter");
+    registrations
+        .recv()
+        .await
+        .expect("registration exists before outcome commit");
+
+    let client_id = CheetahString::from_static_str("commit-window");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([CheetahString::from_static_str("%LMQ%$parent-topic$commit-window")]),
+    );
+    let service_for_claim = Arc::clone(&service);
+    let claim_client_id = client_id.clone();
+    let claim_task = tokio::spawn(async move { service_for_claim.claim_event(&claim_client_id).await });
+    tokio::task::yield_now().await;
+    assert!(
+        !claim_task.is_finished(),
+        "claim waits for HandlerOutcome::Deferred commit"
+    );
+
+    release.add_permits(1);
+    let claim = claim_task
+        .await
+        .expect("commit-window claim task")
+        .expect("commit-window registry claim")
+        .expect("activation makes the candidate claimable");
+    drop(claim);
+    assert_eq!(dispatcher.take_pending_events(&client_id).len(), 1);
+    client.shutdown().await.expect("close commit-window session");
+    running.finish().await;
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/deadline_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/deadline_tests.rs
@@ -1,0 +1,119 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredWaitLimits;
+
+use super::*;
+use crate::long_polling::pop_lite_deferred::deadline::PopLiteWaitDeadline;
+
+#[derive(Clone)]
+struct DeadlineProcessor {
+    service: Arc<PopLiteDeferredService>,
+    deadlines: mpsc::UnboundedSender<PopLiteWaitDeadline>,
+}
+
+impl RequestProcessorV2 for DeadlineProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prepared = self
+            .service
+            .prepare(request, PopLiteRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.deadlines
+            .send(prepared.deadline())
+            .map_err(|_| RocketMQError::illegal_argument("PopLite deadline observer closed"))?;
+        let registration = self
+            .service
+            .register(prepared, request)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+}
+
+fn capped_service(controller: &AdmissionController) -> Arc<PopLiteDeferredService> {
+    let admission = DeferredAdmission::try_configure(controller, DeferredWaitLimits::new(4, 4 * 1024 * 1024))
+        .expect("capped PopLite admission");
+    Arc::new(PopLiteDeferredService::new(
+        admission,
+        PopLiteIndexLimits::new(nonzero(4), nonzero(4), nonzero(2)),
+        LiteEventDispatcher::default(),
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        Duration::from_millis(100),
+        nonzero(4),
+    ))
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_max_age_expires_as_business_timeout_and_drains() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = capped_service(controller.as_ref());
+    let (deadline_tx, mut deadlines) = mpsc::unbounded_channel();
+    let processor = DeadlineProcessor {
+        service: Arc::clone(&service),
+        deadlines: deadline_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("deadline-client", 301, 60_000))
+        .await
+        .expect("send capped PopLite waiter");
+    let deadline = deadlines.recv().await.expect("observe capped PopLite deadline");
+    assert!(deadline.effective_end_millis() <= current_millis().saturating_add(100));
+    tokio::time::sleep_until(deadline.protocol_at()).await;
+
+    let mut claims = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let claims = service.sweep_expired().into_claims();
+            if !claims.is_empty() {
+                break claims;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("protocol deadline becomes sweepable");
+    assert_eq!(claims.len(), 1);
+    let claim = claims.pop().expect("one capped timeout claim");
+    assert_eq!(claim.reason(), DeferredWakeReason::Timeout);
+
+    service
+        .resume_claimed(
+            claim,
+            DeferredResumeRetainedSize::new(43),
+            move |_resume, reason| async move {
+                assert_eq!(reason, DeferredWakeReason::Timeout);
+                ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                    ResponseCode::PollingTimeout,
+                ))
+                .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+            },
+        )
+        .await
+        .expect("business timeout writes canonically");
+    let response = client
+        .receive_command()
+        .await
+        .expect("deadline connection")
+        .expect("business timeout response");
+    assert_eq!(response.opaque(), 301);
+    assert_eq!(response.code(), ResponseCode::PollingTimeout as i32);
+    let terminal = service.resource_snapshot();
+    assert_eq!(terminal.admission.waiting_count(), 0);
+    assert_eq!(terminal.admission.retained_bytes(), 0);
+    assert_eq!(terminal.index.live, 0);
+    assert_eq!(terminal.resume_execution_count, 0);
+    assert_eq!(terminal.resume_execution_bytes, 0);
+    running.finish().await;
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/lifecycle_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/lifecycle_tests.rs
@@ -1,0 +1,294 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use crate::long_polling::pop_lite_deferred::prepare::PopLiteDeferredPrepareErrorKind;
+use crate::long_polling::pop_lite_deferred::prepare::PopLiteDeferredRegisterErrorKind;
+
+#[derive(Clone)]
+struct AfterTakeCloseProcessor {
+    service: Arc<PopLiteDeferredService>,
+    observed: mpsc::UnboundedSender<PopLiteDeferredRegisterErrorKind>,
+}
+
+impl RequestProcessorV2 for AfterTakeCloseProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prepared = self
+            .service
+            .prepare(request, PopLiteRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let error = self
+            .service
+            .register(prepared, request)
+            .expect_err("the service closes after responder transfer");
+        let kind = error.kind();
+        let message = error.to_string();
+        drop(error);
+        self.observed
+            .send(kind)
+            .map_err(|_| RocketMQError::illegal_argument("after-take observer closed"))?;
+        Err(RocketMQError::illegal_argument(message))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pop_lite_deferred_close_after_responder_take_rolls_back_builder_resources() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), LiteEventDispatcher::default());
+    let taken = Arc::new(Barrier::new(2));
+    let resume = Arc::new(Barrier::new(2));
+    service.set_register_after_take_hook(Arc::clone(&taken), Arc::clone(&resume));
+    let (observed_tx, mut observed_rx) = mpsc::unbounded_channel();
+    let processor = AfterTakeCloseProcessor {
+        service: Arc::clone(&service),
+        observed: observed_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("after-take-close", 401, 60_000))
+        .await
+        .expect("send after-take close request");
+
+    tokio::task::spawn_blocking(move || taken.wait())
+        .await
+        .expect("observe responder transfer");
+    service.shutdown();
+    tokio::task::spawn_blocking(move || resume.wait())
+        .await
+        .expect("release after-take registration");
+    assert_eq!(
+        observed_rx.recv().await.expect("after-take close result"),
+        PopLiteDeferredRegisterErrorKind::ServiceClosedAfterTake
+    );
+    let snapshot = service.resource_snapshot();
+    assert_eq!(snapshot.admission.waiting_count(), 0);
+    assert_eq!(snapshot.admission.retained_bytes(), 0);
+    assert_eq!(snapshot.index.live, 0);
+    assert_eq!(snapshot.index.reserved, 0);
+    assert_eq!(snapshot.prepared_registrations, 0);
+    assert_eq!(snapshot.resume_execution_count, 0);
+    assert_eq!(snapshot.resume_execution_bytes, 0);
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "sealed service after responder take emits no fallback frame"
+    );
+}
+
+#[derive(Clone)]
+struct OneWayProbeProcessor {
+    service: Arc<PopLiteDeferredService>,
+    observed: mpsc::UnboundedSender<PopLiteDeferredPrepareErrorKind>,
+}
+
+impl RequestProcessorV2 for OneWayProbeProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let error = match self.service.prepare(request, PopLiteRetainedEstimate::default()) {
+            Err(error) => error,
+            Ok(_) => panic!("one-way PopLite must fail before allocating deferred resources"),
+        };
+        self.observed
+            .send(error.kind())
+            .map_err(|_| RocketMQError::illegal_argument("one-way observer closed"))?;
+        ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+            ResponseCode::Success,
+        ))
+        .map(HandlerOutcome::Reply)
+        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+    }
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_one_way_is_rejected_before_capacity_and_emits_no_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), LiteEventDispatcher::default());
+    let (observed_tx, mut observed_rx) = mpsc::unbounded_channel();
+    let processor = OneWayProbeProcessor {
+        service: Arc::clone(&service),
+        observed: observed_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    let command = request_command_for("one-way-client", 402, 60_000).mark_oneway_rpc();
+    client.send_command(command).await.expect("send one-way PopLite probe");
+    assert_eq!(
+        observed_rx.recv().await.expect("one-way PopLite prepare result"),
+        PopLiteDeferredPrepareErrorKind::OneWay
+    );
+    let snapshot = service.resource_snapshot();
+    assert_eq!(snapshot.admission.waiting_count(), 0);
+    assert_eq!(snapshot.admission.retained_bytes(), 0);
+    assert_eq!(snapshot.index.live, 0);
+    assert_eq!(snapshot.index.reserved, 0);
+    assert_eq!(snapshot.prepared_registrations, 0);
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "one-way PopLite emits no frame"
+    );
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_shutdown_drains_registered_waiter_without_processor_or_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), LiteEventDispatcher::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("shutdown-waiter", 403, 60_000))
+        .await
+        .expect("send shutdown PopLite waiter");
+    registrations.recv().await.expect("observe shutdown PopLite waiter");
+    let registered = service.resource_snapshot();
+    assert_eq!(registered.admission.waiting_count(), 1);
+    assert_eq!(registered.index.live, 1);
+
+    assert!(matches!(
+        service.shutdown(),
+        rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome::Completed(_)
+    ));
+    // The registration observer runs before the dispatcher commits
+    // `HandlerOutcome::Deferred`. Registry shutdown drains registry-owned
+    // entries synchronously, while a concurrently finishing handler may still
+    // own the provisional builder. Await the test-owned server task group so
+    // that either commit or rollback has reached its canonical terminal before
+    // asserting the complete admission snapshot.
+    running.finish().await;
+    let drained = service.resource_snapshot();
+    assert_eq!(drained.admission.waiting_count(), 0);
+    assert_eq!(drained.admission.retained_bytes(), 0);
+    assert_eq!(drained.index.live, 0);
+    assert_eq!(drained.index.reserved, 0);
+    assert_eq!(drained.index.candidates, 0);
+    assert_eq!(drained.event_reservations.events, 0);
+    assert_eq!(drained.active_client_gates, 0);
+    assert_eq!(drained.pending_claims, 0);
+    assert_eq!(drained.resume_execution_count, 0);
+    assert_eq!(drained.resume_execution_bytes, 0);
+
+    assert!(
+        client.receive_command().await.is_none(),
+        "service shutdown emits no synthetic PopLite response"
+    );
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_service_close_drops_claim_and_restores_event_batch_exactly_once() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("service-close-claim", 404, 60_000))
+        .await
+        .expect("send service-close PopLite waiter");
+    registrations.recv().await.expect("observe service-close waiter");
+
+    let client_id = CheetahString::from_static_str("service-close-claim");
+    let first = CheetahString::from_static_str("%LMQ%$parent-topic$close-a");
+    let second = CheetahString::from_static_str("%LMQ%$parent-topic$close-b");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([first.clone(), second.clone()]),
+    );
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim event before service close")
+        .expect("service-close waiter is claimable");
+    let claimed = service.resource_snapshot();
+    assert_eq!(claimed.event_reservations.events, 2);
+    assert_eq!(claimed.event_reservations.permits, 2);
+    assert_eq!(claimed.active_client_gates, 1);
+
+    let _ = service.shutdown();
+    drop(claim);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![first, second]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 2);
+    assert_eq!(dispatcher.reservation_snapshot().events, 0);
+    let drained = service.resource_snapshot();
+    assert_eq!(drained.admission.waiting_count(), 0);
+    assert_eq!(drained.index.live, 0);
+    assert_eq!(drained.event_reservations.events, 0);
+    assert_eq!(drained.active_client_gates, 0);
+    assert_eq!(drained.resume_execution_count, 0);
+    assert_eq!(drained.resume_execution_bytes, 0);
+
+    assert_eq!(dispatcher.take_pending_events(&client_id).len(), 2);
+    running.finish().await;
+    assert!(client.receive_command().await.is_none());
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_inactive_session_cannot_claim_execute_or_write() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("inactive-session", 405, 60_000))
+        .await
+        .expect("send inactive-session PopLite waiter");
+    registrations.recv().await.expect("observe inactive-session waiter");
+    client.shutdown().await.expect("close inactive PopLite session");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let snapshot = service.resource_snapshot();
+            if snapshot.admission.waiting_count() == 0 && snapshot.index.live == 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("session cleanup drains inactive PopLite waiter");
+
+    let client_id = CheetahString::from_static_str("inactive-session");
+    let event = CheetahString::from_static_str("%LMQ%$parent-topic$inactive");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([event.clone()]),
+    );
+    assert!(service
+        .claim_event(&client_id)
+        .await
+        .expect("inactive-session miss is not a claim error")
+        .is_none());
+    let terminal = service.resource_snapshot();
+    assert_eq!(terminal.pending_claims, 0);
+    assert_eq!(terminal.active_client_gates, 0);
+    assert_eq!(terminal.event_reservations.events, 0);
+    assert_eq!(terminal.resume_execution_count, 0);
+    assert_eq!(terminal.resume_execution_bytes, 0);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![event]);
+    assert_eq!(dispatcher.take_pending_events(&client_id).len(), 1);
+
+    running.finish().await;
+    assert!(client.receive_command().await.is_none());
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/owner_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/owner_tests.rs
@@ -1,0 +1,188 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v2::DeferredResumeRetainedSize;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::ResponsePlan;
+use tokio::sync::mpsc;
+
+use super::request_command;
+use super::service;
+use super::start_server;
+use super::CountingBodyOwner;
+use super::DeferredTestProcessor;
+use super::ORIGINAL_OPAQUE;
+
+#[tokio::test]
+async fn pop_lite_deferred_execution_admission_rejects_before_processor_and_writes_one_error() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = crate::lite::lite_event_dispatcher::LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(request_command())
+        .await
+        .expect("send execution-reject PopLite request");
+    registrations
+        .recv()
+        .await
+        .expect("observe execution-reject registration");
+
+    let client_id = CheetahString::from_static_str("client-a");
+    let event = CheetahString::from_static_str("%LMQ%$parent-topic$child-a");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([event.clone()]),
+    );
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("execution-reject event claim")
+        .expect("execution-reject waiter is claimable");
+    let executions = Arc::new(AtomicUsize::new(0));
+    let executions_for_handler = Arc::clone(&executions);
+    service
+        .resume_event_claim(
+            claim,
+            DeferredResumeRetainedSize::new(AdmissionLimits::default().queued.bytes),
+            move |_resume, _reason, reservation| async move {
+                executions_for_handler.fetch_add(1, Ordering::SeqCst);
+                let batch = reservation.commit();
+                batch.complete(&HashSet::new());
+                ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                    ResponseCode::Success,
+                ))
+                .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+            },
+        )
+        .await
+        .expect("bounded execution rejection writes its canonical error response");
+
+    let response = client
+        .receive_command()
+        .await
+        .expect("execution-reject connection remains open")
+        .expect("one execution-reject response frame");
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(response.code(), ResponseCode::SystemBusy as i32);
+    assert_eq!(executions.load(Ordering::SeqCst), 0);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![event.clone()]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+    let snapshot = service.resource_snapshot();
+    assert_eq!(snapshot.active_client_gates, 0);
+    assert_eq!(snapshot.accepted_resumes, 0);
+    assert_eq!(snapshot.resume_execution_count, 0);
+    assert_eq!(snapshot.resume_execution_bytes, 0);
+    let admission = controller.snapshot();
+    assert_eq!(admission.queued.current_count, 0);
+    assert_eq!(admission.inflight.current_count, 0);
+    assert_eq!(admission.processors.current_count, 0);
+    assert_eq!(admission.queued.rejected_count, 1);
+
+    assert_eq!(dispatcher.take_pending_events(&client_id), vec![event]);
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "admission rejection emits exactly one frame"
+    );
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_handler_failure_drops_body_owner_once_and_rolls_back_event() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = crate::lite::lite_event_dispatcher::LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command())
+        .await
+        .expect("send owner-failure PopLite request");
+    registrations.recv().await.expect("observe owner-failure registration");
+
+    let client_id = CheetahString::from_static_str("client-a");
+    let event = CheetahString::from_static_str("%LMQ%$parent-topic$child-a");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([event.clone()]),
+    );
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("owner-failure event claim")
+        .expect("owner-failure waiter is claimable");
+    let owner_drops = Arc::new(AtomicUsize::new(0));
+    let owner_drops_for_handler = Arc::clone(&owner_drops);
+    service
+        .resume_event_claim(
+            claim,
+            DeferredResumeRetainedSize::default(),
+            move |_resume, reason, _reservation| async move {
+                assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                let _body = Bytes::from_owner(CountingBodyOwner {
+                    body: b"owner-backed-pop-lite-failure".to_vec(),
+                    drops: owner_drops_for_handler,
+                });
+                Err::<ResponsePlan, _>(RocketMQError::illegal_argument("PopLite owner failure"))
+            },
+        )
+        .await
+        .expect("handler failure writes its canonical typed error response");
+
+    let response = client
+        .receive_command()
+        .await
+        .expect("owner-failure connection remains open")
+        .expect("one owner-failure response frame");
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(response.code(), ResponseCode::InvalidParameter as i32);
+    assert_eq!(owner_drops.load(Ordering::SeqCst), 1);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![event.clone()]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+    let snapshot = service.resource_snapshot();
+    assert_eq!(snapshot.active_client_gates, 0);
+    assert_eq!(snapshot.accepted_resumes, 0);
+    assert_eq!(snapshot.resume_execution_count, 0);
+    assert_eq!(snapshot.resume_execution_bytes, 0);
+
+    assert_eq!(dispatcher.take_pending_events(&client_id), vec![event]);
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "handler failure emits exactly one frame"
+    );
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/post_take_fault_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/post_take_fault_tests.rs
@@ -1,0 +1,103 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_transport::api::v2::DeferredExpiryErrorKind;
+
+use super::*;
+use crate::long_polling::pop_lite_deferred::prepare::PopLiteDeferredRegisterErrorKind;
+
+#[derive(Clone)]
+struct ExpiryAttachmentFaultProcessor {
+    service: Arc<PopLiteDeferredService>,
+    observed: mpsc::UnboundedSender<PopLiteDeferredRegisterErrorKind>,
+}
+
+impl RequestProcessorV2 for ExpiryAttachmentFaultProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prepared = self
+            .service
+            .prepare(request, PopLiteRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let error = self
+            .service
+            .register(prepared, request)
+            .expect_err("the injected post-take expiry attachment must fail closed");
+        let kind = error.kind();
+        let message = error.to_string();
+        drop(error);
+        self.observed
+            .send(kind)
+            .map_err(|_| RocketMQError::illegal_argument("post-take expiry observer closed"))?;
+        Err(RocketMQError::illegal_argument(message))
+    }
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_expiry_attach_after_take_cancels_without_handler_or_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    service.fail_next_expiry_attachment_after_take();
+    let client_id = CheetahString::from_static_str("post-take-expiry");
+    let event = CheetahString::from_static_str("%LMQ%$parent-topic$post-take-expiry");
+    assert_eq!(
+        dispatcher.do_full_dispatch(
+            &client_id,
+            &CheetahString::from_static_str("group-a"),
+            &HashSet::from([event.clone()]),
+        ),
+        1
+    );
+    let (observed_tx, mut observed_rx) = mpsc::unbounded_channel();
+    let (mut client, running) = start_server(
+        ExpiryAttachmentFaultProcessor {
+            service: Arc::clone(&service),
+            observed: observed_tx,
+        },
+        controller,
+    )
+    .await;
+
+    client
+        .send_command(request_command_for(client_id.as_str(), 406, 60_000))
+        .await
+        .expect("send post-take expiry attachment request");
+    assert_eq!(
+        observed_rx.recv().await.expect("post-take expiry result"),
+        PopLiteDeferredRegisterErrorKind::Expiry(DeferredExpiryErrorKind::ProtocolAlreadyExpired)
+    );
+    let terminal = service.resource_snapshot();
+    assert_eq!(terminal.admission.waiting_count(), 0);
+    assert_eq!(terminal.admission.retained_bytes(), 0);
+    assert_eq!(terminal.index.live, 0);
+    assert_eq!(terminal.index.reserved, 0);
+    assert_eq!(terminal.index.candidates, 0);
+    assert_eq!(terminal.index.clients, 0);
+    assert_eq!(terminal.prepared_registrations, 0);
+    assert_eq!(terminal.pending_claims, 0);
+    assert_eq!(terminal.resume_execution_count, 0);
+    assert_eq!(terminal.resume_execution_bytes, 0);
+    assert_eq!(terminal.event_reservations.events, 0);
+    assert_eq!(terminal.active_client_gates, 0);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![event]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+
+    assert_eq!(dispatcher.take_pending_events(&client_id).len(), 1);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "post-take expiry attachment failure emits no fallback frame"
+    );
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/provenance_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/provenance_tests.rs
@@ -1,0 +1,240 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use parking_lot::Mutex;
+use rocketmq_security_api::AuthenticatedRequestContext;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::RequestPolicy;
+use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredWaitLimits;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+use super::*;
+use crate::long_polling::pop_lite_deferred::prepare::PopLiteDeferredPrepareErrorKind;
+use crate::long_polling::pop_lite_deferred::prepare::PopLiteDeferredRegisterErrorKind;
+use crate::long_polling::pop_lite_deferred::prepare::PreparedPopLiteRegistration;
+
+fn success_reply() -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+    ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+        ResponseCode::Success,
+    ))
+    .map(HandlerOutcome::Reply)
+    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+}
+
+#[derive(Default)]
+struct ProvenanceState {
+    prepared: Option<PreparedPopLiteRegistration>,
+}
+
+#[derive(Clone)]
+struct ProvenanceProcessor {
+    service: Arc<PopLiteDeferredService>,
+    state: Arc<Mutex<ProvenanceState>>,
+}
+
+impl RequestProcessorV2 for ProvenanceProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        if let Some(prepared) = self.state.lock().prepared.take() {
+            let error = self
+                .service
+                .register(prepared, request)
+                .expect_err("a prepared PopLite proof cannot move to another request");
+            assert_eq!(error.kind(), PopLiteDeferredRegisterErrorKind::ProvenanceMismatch);
+            return success_reply();
+        }
+        let prepared = self
+            .service
+            .prepare(request, PopLiteRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.state.lock().prepared = Some(prepared);
+        success_reply()
+    }
+}
+
+#[derive(Clone)]
+struct EmbeddedOriginProcessor {
+    service: Arc<PopLiteDeferredService>,
+    observed: Arc<Mutex<Option<PopLiteDeferredPrepareErrorKind>>>,
+}
+
+impl RequestProcessorV2 for EmbeddedOriginProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let error = match self.service.prepare(request, PopLiteRetainedEstimate::default()) {
+            Err(error) => error,
+            Ok(_) => panic!("embedded PopLite must fail before allocating deferred resources"),
+        };
+        *self.observed.lock() = Some(error.kind());
+        success_reply()
+    }
+}
+
+struct AllowEmbeddedPolicy;
+
+impl RequestPolicy for AllowEmbeddedPolicy {
+    fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+        Decision::Allow
+    }
+}
+
+fn assert_empty(service: &PopLiteDeferredService) {
+    let snapshot = service.resource_snapshot();
+    assert_eq!(snapshot.admission.waiting_count(), 0);
+    assert_eq!(snapshot.admission.retained_bytes(), 0);
+    assert_eq!(snapshot.index.live, 0);
+    assert_eq!(snapshot.index.reserved, 0);
+    assert_eq!(snapshot.prepared_registrations, 0);
+    assert_eq!(snapshot.resume_execution_count, 0);
+    assert_eq!(snapshot.resume_execution_bytes, 0);
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_cross_request_provenance_fails_before_responder_take() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), LiteEventDispatcher::default());
+    let state = Arc::new(Mutex::new(ProvenanceState::default()));
+    let processor = ProvenanceProcessor {
+        service: Arc::clone(&service),
+        state: Arc::clone(&state),
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+
+    for opaque in [101, 102] {
+        client
+            .send_command(request_command_for("provenance-client", opaque, 60_000))
+            .await
+            .expect("send PopLite provenance request");
+        let reply = client
+            .receive_command()
+            .await
+            .expect("provenance connection")
+            .expect("inline provenance response");
+        assert_eq!(reply.opaque(), opaque);
+    }
+    assert!(state.lock().prepared.is_none());
+    assert_empty(&service);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_embedded_origin_is_rejected_before_capacity_take() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), LiteEventDispatcher::default());
+    let observed = Arc::new(Mutex::new(None));
+    let processor = EmbeddedOriginProcessor {
+        service: Arc::clone(&service),
+        observed: Arc::clone(&observed),
+    };
+    let runtime =
+        RuntimeOwner::new(RuntimeConfig::server_default("pop-lite-embedded-origin")).expect("embedded PopLite runtime");
+    let context = runtime.root_context().component("pop-lite.embedded-origin");
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        Vec::new(),
+        Arc::new(TransportSecurity::secure_enforced(
+            Some(Arc::new(AllowEmbeddedPolicy)),
+            None,
+        )),
+        Arc::clone(&controller),
+    ));
+    let harness = EmbeddedRequestHarnessV2::new(
+        dispatcher,
+        context.task_group().clone(),
+        Principal::new("pop-lite-embedded-test"),
+    );
+
+    let outcome = harness
+        .dispatch(None, request_command_for("embedded-client", 103, 60_000))
+        .await
+        .expect("embedded PopLite inline response");
+    assert!(matches!(outcome, EmbeddedDispatchOutcome::Reply(_)));
+    assert_eq!(*observed.lock(), Some(PopLiteDeferredPrepareErrorKind::EmbeddedOrigin));
+    assert_empty(&service);
+
+    drop(harness);
+    drop(context);
+    assert!(runtime.shutdown_tasks().await.is_healthy());
+    assert!(runtime.shutdown_background().is_healthy());
+}
+
+#[derive(Clone)]
+struct CapacityProbeProcessor {
+    service: Arc<PopLiteDeferredService>,
+    held: Arc<Mutex<Vec<PreparedPopLiteRegistration>>>,
+    observed: Arc<Mutex<Vec<PopLiteDeferredPrepareErrorKind>>>,
+}
+
+impl RequestProcessorV2 for CapacityProbeProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        match self.service.prepare(request, PopLiteRetainedEstimate::default()) {
+            Ok(prepared) => self.held.lock().push(prepared),
+            Err(error) => self.observed.lock().push(error.kind()),
+        }
+        success_reply()
+    }
+}
+
+fn limited_service(controller: &AdmissionController, limits: DeferredWaitLimits) -> Arc<PopLiteDeferredService> {
+    let admission = DeferredAdmission::try_configure(controller, limits).expect("limited PopLite admission");
+    Arc::new(PopLiteDeferredService::new(
+        admission,
+        PopLiteIndexLimits::new(nonzero(4), nonzero(4), nonzero(2)),
+        LiteEventDispatcher::default(),
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        Duration::from_secs(30),
+        nonzero(4),
+    ))
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_wait_admission_enforces_count_and_bytes_before_take() {
+    for (limits, requests) in [
+        (DeferredWaitLimits::new(1, 1024 * 1024), 2_usize),
+        (DeferredWaitLimits::new(4, 1), 1_usize),
+    ] {
+        let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+        let service = limited_service(controller.as_ref(), limits);
+        let held = Arc::new(Mutex::new(Vec::new()));
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let processor = CapacityProbeProcessor {
+            service: Arc::clone(&service),
+            held: Arc::clone(&held),
+            observed: Arc::clone(&observed),
+        };
+        let (mut client, running) = start_server(processor, controller).await;
+        for index in 0..requests {
+            client
+                .send_command(request_command_for("capacity-client", 110 + index as i32, 60_000))
+                .await
+                .expect("send PopLite capacity probe");
+            client
+                .receive_command()
+                .await
+                .expect("capacity connection")
+                .expect("capacity inline response");
+        }
+        assert_eq!(
+            observed.lock().as_slice(),
+            &[PopLiteDeferredPrepareErrorKind::Admission]
+        );
+        held.lock().clear();
+        assert_empty(&service);
+        running.finish().await;
+    }
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/resource_wire_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/resource_wire_tests.rs
@@ -1,0 +1,227 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use parking_lot::Mutex;
+use rocketmq_protocol::protocol::header::pop_lite_message_response_header::PopLiteMessageResponseHeader;
+use rocketmq_transport::api::v2::DeferredAdmissionAcquireErrorKind;
+
+use super::*;
+use crate::long_polling::pop_lite_deferred::index::PopLiteIndexErrorKind;
+use crate::long_polling::pop_lite_deferred::prepare::PopLiteDeferredPrepareError;
+use crate::long_polling::pop_lite_deferred::prepare::PreparedPopLiteRegistration;
+use crate::processor::pop_lite_message_processor::core::PopLiteCoreResult;
+use crate::processor::pop_lite_message_processor::response::compose_pop_lite_response_plan;
+use crate::processor::pop_lite_message_processor::response::PopLiteResponseKind;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CapacityFailure {
+    Index(PopLiteIndexErrorKind),
+    Admission(DeferredAdmissionAcquireErrorKind),
+}
+
+fn capacity_failure(error: PopLiteDeferredPrepareError) -> CapacityFailure {
+    match error {
+        PopLiteDeferredPrepareError::Index(error) => CapacityFailure::Index(error.kind()),
+        PopLiteDeferredPrepareError::Admission(error) => CapacityFailure::Admission(error.kind()),
+        error => panic!("unexpected PopLite capacity failure: {error:?}"),
+    }
+}
+
+fn polling_full_reply(request: &RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+    let request_header = request
+        .command()
+        .decode_command_custom_header::<PopLiteMessageRequestHeader>()?;
+    compose_pop_lite_response_plan(
+        &application_remoting_command_factory(),
+        &request_header,
+        PopLiteCoreResult {
+            body: None,
+            fetched_count: 0,
+            order_count_info: None,
+        },
+        PopLiteResponseKind::PollingFull,
+    )
+    .map(HandlerOutcome::Reply)
+}
+
+fn held_reply() -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+    ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+        ResponseCode::Success,
+    ))
+    .map(HandlerOutcome::Reply)
+    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+}
+
+#[derive(Clone)]
+struct CapacityWireProcessor {
+    service: Arc<PopLiteDeferredService>,
+    held: Arc<Mutex<Vec<PreparedPopLiteRegistration>>>,
+    failures: Arc<Mutex<Vec<CapacityFailure>>>,
+}
+
+impl RequestProcessorV2 for CapacityWireProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        match self.service.prepare(request, PopLiteRetainedEstimate::default()) {
+            Ok(prepared) => {
+                self.held.lock().push(prepared);
+                held_reply()
+            }
+            Err(error) => {
+                self.failures.lock().push(capacity_failure(error));
+                polling_full_reply(request)
+            }
+        }
+    }
+}
+
+fn matrix_service(
+    controller: &AdmissionController,
+    index_limits: PopLiteIndexLimits,
+    wait_limits: DeferredWaitLimits,
+) -> Arc<PopLiteDeferredService> {
+    let admission = DeferredAdmission::try_configure(controller, wait_limits).expect("matrix deferred admission");
+    Arc::new(PopLiteDeferredService::new(
+        admission,
+        index_limits,
+        LiteEventDispatcher::default(),
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        Duration::from_secs(30),
+        nonzero(4),
+    ))
+}
+
+struct CapacityCase {
+    index_limits: PopLiteIndexLimits,
+    wait_limits: DeferredWaitLimits,
+    clients: &'static [&'static str],
+    expected: CapacityFailure,
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_v2_capacity_matrix_writes_exact_polling_full_frame() {
+    let cases = [
+        CapacityCase {
+            index_limits: PopLiteIndexLimits::new(nonzero(1), nonzero(4), nonzero(4)),
+            wait_limits: DeferredWaitLimits::new(4, 4 * 1024 * 1024),
+            clients: &["global-a", "global-b"],
+            expected: CapacityFailure::Index(PopLiteIndexErrorKind::GlobalCapacity),
+        },
+        CapacityCase {
+            index_limits: PopLiteIndexLimits::new(nonzero(4), nonzero(1), nonzero(4)),
+            wait_limits: DeferredWaitLimits::new(4, 4 * 1024 * 1024),
+            clients: &["client-a", "client-b"],
+            expected: CapacityFailure::Index(PopLiteIndexErrorKind::ClientCapacity),
+        },
+        CapacityCase {
+            index_limits: PopLiteIndexLimits::new(nonzero(4), nonzero(4), nonzero(1)),
+            wait_limits: DeferredWaitLimits::new(4, 4 * 1024 * 1024),
+            clients: &["per-client", "per-client"],
+            expected: CapacityFailure::Index(PopLiteIndexErrorKind::PerClientCapacity),
+        },
+        CapacityCase {
+            index_limits: PopLiteIndexLimits::new(nonzero(4), nonzero(4), nonzero(4)),
+            wait_limits: DeferredWaitLimits::new(1, 4 * 1024 * 1024),
+            clients: &["wait-count-a", "wait-count-b"],
+            expected: CapacityFailure::Admission(DeferredAdmissionAcquireErrorKind::WaiterCapacityExhausted),
+        },
+        CapacityCase {
+            index_limits: PopLiteIndexLimits::new(nonzero(4), nonzero(4), nonzero(4)),
+            wait_limits: DeferredWaitLimits::new(4, 1),
+            clients: &["wait-bytes"],
+            expected: CapacityFailure::Admission(DeferredAdmissionAcquireErrorKind::RetainedByteCapacityExhausted),
+        },
+    ];
+
+    for (case_index, case) in cases.into_iter().enumerate() {
+        let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+        let service = matrix_service(controller.as_ref(), case.index_limits, case.wait_limits);
+        let held = Arc::new(Mutex::new(Vec::new()));
+        let failures = Arc::new(Mutex::new(Vec::new()));
+        let (mut client, running) = start_server(
+            CapacityWireProcessor {
+                service: Arc::clone(&service),
+                held: Arc::clone(&held),
+                failures: Arc::clone(&failures),
+            },
+            controller,
+        )
+        .await;
+
+        for (request_index, client_id) in case.clients.iter().enumerate() {
+            let opaque = 20_000 + (case_index as i32 * 10) + request_index as i32;
+            client
+                .send_command(request_command_for(client_id, opaque, 60_000))
+                .await
+                .expect("send PopLite capacity request");
+            let mut response = client
+                .receive_command()
+                .await
+                .expect("capacity connection remains open")
+                .expect("capacity response frame");
+            assert_eq!(response.opaque(), opaque);
+            if request_index + 1 == case.clients.len() {
+                assert_eq!(response.code(), ResponseCode::PollingFull as i32);
+                assert_eq!(
+                    response.remark().map(CheetahString::as_str),
+                    Some("POP_LITE_POLLING_FULL")
+                );
+                assert!(response.body().is_none());
+                response.make_custom_header_to_net();
+                let header = response
+                    .decode_command_custom_header::<PopLiteMessageResponseHeader>()
+                    .expect("decode PollingFull response header");
+                assert!(header.pop_time > 0);
+                assert_eq!(header.invisible_time, 30_000);
+                assert_eq!(header.revive_qid, POP_ORDER_REVIVE_QUEUE);
+                assert_eq!(header.start_offset_info, None);
+                assert_eq!(header.msg_offset_info, None);
+                assert_eq!(header.order_count_info, None);
+            } else {
+                assert_eq!(response.code(), ResponseCode::Success as i32);
+            }
+        }
+
+        assert_eq!(failures.lock().as_slice(), &[case.expected]);
+        let rejected = service.resource_snapshot();
+        match case.expected {
+            CapacityFailure::Index(_) => assert_eq!(rejected.admission.rejected_count(), 0),
+            CapacityFailure::Admission(_) => assert_eq!(rejected.admission.rejected_count(), 1),
+        }
+        if case.clients.len() > 1 {
+            assert_eq!(rejected.prepared_registrations, 1);
+            assert_eq!(rejected.index.reserved, 1);
+            assert_eq!(rejected.admission.waiting_count(), 1);
+            assert!(rejected.admission.retained_bytes() > 0);
+        } else {
+            assert_eq!(rejected.prepared_registrations, 0);
+            assert_eq!(rejected.index.reserved, 0);
+            assert_eq!(rejected.admission.waiting_count(), 0);
+            assert_eq!(rejected.admission.retained_bytes(), 0);
+        }
+
+        held.lock().clear();
+        let terminal = service.resource_snapshot();
+        assert_eq!(terminal.admission.waiting_count(), 0);
+        assert_eq!(terminal.admission.retained_bytes(), 0);
+        assert_eq!(terminal.index.live, 0);
+        assert_eq!(terminal.index.reserved, 0);
+        assert_eq!(terminal.index.candidates, 0);
+        assert_eq!(terminal.index.clients, 0);
+        assert_eq!(terminal.index.oldest_waiter_age, None);
+        assert_eq!(terminal.prepared_registrations, 0);
+        assert_eq!(terminal.resume_execution_count, 0);
+        assert_eq!(terminal.resume_execution_bytes, 0);
+        running.finish().await;
+    }
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/terminal_session_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/acceptance_tests/terminal_session_tests.rs
@@ -1,0 +1,562 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[tokio::test]
+async fn pop_lite_deferred_caller_drop_keeps_gate_until_canonical_terminal_and_replays_next_event() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    for _ in 0..2 {
+        client
+            .send_command(request_command())
+            .await
+            .expect("send same-client PopLite waiter");
+        registrations.recv().await.expect("observe same-client registration");
+    }
+
+    let client_id = CheetahString::from_static_str("client-a");
+    let first = CheetahString::from_static_str("%LMQ%$parent-topic$child-a");
+    let second = CheetahString::from_static_str("%LMQ%$parent-topic$child-b");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([first.clone()]),
+    );
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim first PopLite event")
+        .expect("first same-client waiter");
+    let (handler_started_tx, handler_started_rx) = oneshot::channel();
+    let (release_handler_tx, release_handler_rx) = oneshot::channel();
+    let service_for_resume = Arc::clone(&service);
+    let caller = tokio::spawn(async move {
+        service_for_resume
+            .resume_event_claim(
+                claim,
+                DeferredResumeRetainedSize::default(),
+                move |_resume, reason, reservation| async move {
+                    assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                    let _ = handler_started_tx.send(());
+                    release_handler_rx
+                        .await
+                        .map_err(|_| RocketMQError::illegal_argument("terminal handler release closed"))?;
+                    let batch = reservation.commit();
+                    batch.complete(&HashSet::new());
+                    ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                        ResponseCode::Success,
+                    ))
+                    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                },
+            )
+            .await
+    });
+    handler_started_rx.await.expect("first PopLite handler accepted");
+
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([second.clone()]),
+    );
+    assert!(service.observe_pending_event(&client_id));
+    caller.abort();
+    assert!(caller.await.expect_err("caller future is cancelled").is_cancelled());
+    assert_eq!(service.resource_snapshot().active_client_gates, 1);
+    assert_eq!(service.resource_snapshot().accepted_resumes, 1);
+    assert!(
+        service
+            .claim_event(&client_id)
+            .await
+            .expect("active-gate observation is not an error")
+            .is_none(),
+        "the second same-client waiter cannot claim while the first canonical job is active"
+    );
+
+    release_handler_tx
+        .send(())
+        .expect("release network-owned PopLite handler");
+    let response = client
+        .receive_command()
+        .await
+        .expect("same-client connection remains open")
+        .expect("first canonical response frame");
+    assert_eq!(response.code(), ResponseCode::Success as i32);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while service.resource_snapshot().active_client_gates != 0 || service.resource_snapshot().accepted_resumes != 0
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("canonical write terminal releases the first gate");
+    assert_eq!(
+        service.take_pending_replays(nonzero(1)),
+        vec![client_id.clone()],
+        "the event observed during the first wake is replayed after its canonical terminal"
+    );
+    let second_claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim replayed PopLite event")
+        .expect("second same-client waiter wakes after the first terminal");
+    drop(second_claim);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![second]);
+    assert_eq!(dispatcher.take_pending_events(&client_id).len(), 1);
+
+    client.shutdown().await.expect("close same-client PopLite session");
+    running.finish().await;
+}
+#[tokio::test]
+async fn pop_lite_deferred_requeue_stays_affine_until_canonical_writer_terminal() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    for opaque in [ORIGINAL_OPAQUE, ORIGINAL_OPAQUE + 1] {
+        client
+            .send_command(request_command_for("client-a", opaque, 60_000))
+            .await
+            .expect("send terminal-owned PopLite waiter");
+        registrations
+            .recv()
+            .await
+            .expect("observe terminal-owned PopLite registration");
+    }
+
+    let client_id = CheetahString::from_static_str("client-a");
+    let event = CheetahString::from_static_str("%LMQ%$parent-topic$terminal-child");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([event.clone()]),
+    );
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim terminal-owned PopLite event")
+        .expect("first terminal-owned waiter is claimable");
+    let handler_ready = Arc::new(Barrier::new(2));
+    let release_writer = Arc::new(Barrier::new(2));
+    service.set_terminal_ready_hook(Arc::clone(&handler_ready), Arc::clone(&release_writer));
+    let service_for_resume = Arc::clone(&service);
+    let requeued_event = event.clone();
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .action_context
+        .spawn_service("pop-lite-terminal-owned-requeue", async move {
+            let result = service_for_resume
+                .resume_event_claim(
+                    claim,
+                    DeferredResumeRetainedSize::default(),
+                    move |_resume, reason, reservation| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        reservation.commit().complete(&HashSet::from([requeued_event]));
+                        ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::Success,
+                        ))
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn terminal-owned PopLite resume");
+
+    handler_ready.wait();
+    let pre_writer = service.resource_snapshot();
+    assert_eq!(pre_writer.event_reservations.events, 1);
+    assert_eq!(pre_writer.event_reservations.permits, 1);
+    assert!(pre_writer.event_reservations.retained_bytes > 0);
+    assert_eq!(pre_writer.active_client_gates, 1);
+    assert!(pre_writer.resume_execution_bytes > 0);
+    assert!(
+        dispatcher.reserve_pending_events(&client_id).is_none(),
+        "the V1 compatibility seam cannot steal a V2 requeue before writer terminal"
+    );
+    assert!(
+        service
+            .claim_event(&client_id)
+            .await
+            .expect("active terminal gate observation is not an error")
+            .is_none(),
+        "a second same-client wake cannot consume the staged requeue"
+    );
+    release_writer.wait();
+
+    receipt_rx
+        .await
+        .expect("terminal-owned receipt channel")
+        .expect("terminal-owned canonical response");
+    let response = client
+        .receive_command()
+        .await
+        .expect("terminal-owned connection remains open")
+        .expect("terminal-owned canonical frame");
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![event.clone()]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+    let terminal = service.resource_snapshot();
+    assert_eq!(terminal.event_reservations.events, 0);
+    assert_eq!(terminal.event_reservations.retained_bytes, 0);
+    assert_eq!(terminal.active_client_gates, 0);
+    assert_eq!(terminal.accepted_resumes, 0);
+    assert_eq!(terminal.resume_execution_bytes, 0);
+    assert_eq!(service.take_pending_replays(nonzero(1)), vec![client_id.clone()]);
+
+    let second = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim terminal requeue exactly once")
+        .expect("second waiter resumes after terminal");
+    drop(second);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![event.clone()]);
+    assert_eq!(dispatcher.take_pending_events(&client_id), vec![event]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+
+    client.shutdown().await.expect("close terminal-owned PopLite client");
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_staged_requeue_rolls_back_once_when_session_closes_before_write() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("staged-cancel", ORIGINAL_OPAQUE, 60_000))
+        .await
+        .expect("send staged-cancel PopLite waiter");
+    registrations
+        .recv()
+        .await
+        .expect("observe staged-cancel PopLite registration");
+
+    let client_id = CheetahString::from_static_str("staged-cancel");
+    let event = CheetahString::from_static_str("%LMQ%$parent-topic$staged-cancel-child");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([event.clone()]),
+    );
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim staged-cancel PopLite event")
+        .expect("staged-cancel waiter is claimable");
+    let service_for_resume = Arc::clone(&service);
+    let requeued_event = event.clone();
+    let (staged_tx, staged_rx) = oneshot::channel();
+    let (release_handler_tx, release_handler_rx) = oneshot::channel();
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .action_context
+        .spawn_service("pop-lite-staged-cancel", async move {
+            let result = service_for_resume
+                .resume_event_claim(
+                    claim,
+                    DeferredResumeRetainedSize::default(),
+                    move |_resume, reason, reservation| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        reservation.commit().complete(&HashSet::from([requeued_event]));
+                        let _ = staged_tx.send(());
+                        release_handler_rx
+                            .await
+                            .map_err(|_| RocketMQError::illegal_argument("staged-cancel handler release closed"))?;
+                        ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::Success,
+                        ))
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn staged-cancel PopLite resume");
+
+    staged_rx.await.expect("staged completion reached before cancellation");
+    let staged = service.resource_snapshot();
+    assert_eq!(staged.event_reservations.events, 1);
+    assert!(staged.event_reservations.retained_bytes > 0);
+    assert_eq!(staged.active_client_gates, 1);
+    assert_eq!(staged.accepted_resumes, 1);
+    assert!(staged.resume_execution_bytes > 0);
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+
+    client
+        .shutdown()
+        .await
+        .expect("close staged-cancel PopLite session before writer handoff");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let snapshot = service.resource_snapshot();
+            if snapshot.event_reservations.events == 0
+                && snapshot.active_client_gates == 0
+                && snapshot.accepted_resumes == 0
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("session close cancels staged PopLite ownership");
+    assert!(
+        release_handler_tx.send(()).is_err(),
+        "session close drops the staged handler before it can produce a plan"
+    );
+    let error = receipt_rx
+        .await
+        .expect("staged-cancel receipt channel")
+        .expect_err("closed session rejects staged PopLite response");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::SessionClosed);
+    let terminal = service.resource_snapshot();
+    assert_eq!(terminal.event_reservations.events, 0);
+    assert_eq!(terminal.event_reservations.retained_bytes, 0);
+    assert_eq!(terminal.active_client_gates, 0);
+    assert_eq!(terminal.accepted_resumes, 0);
+    assert_eq!(terminal.resume_execution_bytes, 0);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![event.clone()]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+    assert_eq!(service.take_pending_replays(nonzero(1)), vec![client_id.clone()]);
+    assert_eq!(dispatcher.take_pending_events(&client_id), vec![event]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_parent_shutdown_settles_staged_requeue_without_a_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command_for("parent-cancel", ORIGINAL_OPAQUE, 60_000))
+        .await
+        .expect("send parent-cancel PopLite waiter");
+    registrations
+        .recv()
+        .await
+        .expect("observe parent-cancel PopLite registration");
+
+    let client_id = CheetahString::from_static_str("parent-cancel");
+    let first = CheetahString::from_static_str("%LMQ%$parent-topic$parent-a");
+    let second = CheetahString::from_static_str("%LMQ%$parent-topic$parent-b");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([first.clone(), second.clone()]),
+    );
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim parent-cancel PopLite event")
+        .expect("parent-cancel waiter is claimable");
+    let handler_ready = Arc::new(Barrier::new(2));
+    let release_writer = Arc::new(Barrier::new(2));
+    service.set_terminal_ready_hook(Arc::clone(&handler_ready), Arc::clone(&release_writer));
+    let service_for_resume = Arc::clone(&service);
+    let first_for_requeue = first.clone();
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    running
+        .action_context
+        .spawn_service("pop-lite-parent-cancel-staged", async move {
+            let result = service_for_resume
+                .resume_event_claim(
+                    claim,
+                    DeferredResumeRetainedSize::new(73),
+                    move |_resume, _reason, reservation| async move {
+                        reservation.commit().complete(&HashSet::from([first_for_requeue]));
+                        ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::Success,
+                        ))
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn parent-cancel staged PopLite resume");
+
+    handler_ready.wait();
+    let staged = service.resource_snapshot();
+    assert_eq!(staged.event_reservations.events, 2);
+    assert_eq!(staged.active_client_gates, 1);
+    assert_eq!(staged.resume_execution_count, 1);
+    assert!(staged.resume_execution_bytes > 73);
+    let _ = service.shutdown();
+    release_writer.wait();
+
+    let error = receipt_rx
+        .await
+        .expect("parent-cancel receipt channel")
+        .expect_err("parent shutdown rejects the staged response");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::Cancelled);
+    assert_eq!(
+        error.prior_terminal_reason(),
+        Some(DeferredTerminalReason::ParentCancelled)
+    );
+    assert_eq!(error.write_progress(), None);
+    let terminal = service.resource_snapshot();
+    assert_eq!(terminal.event_reservations.events, 0);
+    assert_eq!(terminal.active_client_gates, 0);
+    assert_eq!(terminal.resume_execution_count, 0);
+    assert_eq!(terminal.resume_execution_bytes, 0);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![first.clone()]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+    assert_eq!(service.take_pending_replays(nonzero(1)), Vec::<CheetahString>::new());
+    assert_eq!(dispatcher.take_pending_events(&client_id), vec![first]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "parent cancellation emits no PopLite response frame"
+    );
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_v2_session_close_rolls_back_claimed_events_and_gate() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = LiteEventDispatcher::default();
+    let service = service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+    };
+    let (mut client, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command())
+        .await
+        .expect("send session-close PopLite request");
+    registrations.recv().await.expect("observe session-close registration");
+
+    let client_id = CheetahString::from_static_str("client-a");
+    let first = CheetahString::from_static_str("%LMQ%$parent-topic$child-a");
+    let second = CheetahString::from_static_str("%LMQ%$parent-topic$child-b");
+    dispatcher.do_full_dispatch(
+        &client_id,
+        &CheetahString::from_static_str("group-a"),
+        &HashSet::from([first.clone(), second.clone()]),
+    );
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim session-close PopLite event")
+        .expect("registered client has a claim");
+
+    let (handler_started_tx, handler_started_rx) = oneshot::channel();
+    let (release_handler_tx, release_handler_rx) = oneshot::channel();
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    let body_drops = Arc::new(AtomicUsize::new(0));
+    let body_drops_for_handler = Arc::clone(&body_drops);
+    let service_for_resume = Arc::clone(&service);
+    running
+        .action_context
+        .spawn_service("pop-lite-deferred-session-close-resume", async move {
+            let result = service_for_resume
+                .resume_event_claim(
+                    claim,
+                    DeferredResumeRetainedSize::default(),
+                    move |_resume, reason, reservation| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        let body = Bytes::from_owner(CountingBodyOwner {
+                            body: b"owner-backed-pop-lite-cancel".to_vec(),
+                            drops: body_drops_for_handler,
+                        });
+                        let _ = handler_started_tx.send(());
+                        release_handler_rx
+                            .await
+                            .map_err(|_| RocketMQError::illegal_argument("session-close handler release closed"))?;
+                        let batch = reservation.commit();
+                        batch.complete(&HashSet::new());
+                        ResponsePlan::bytes(
+                            RemotingCommand::create_response_command_with_code(ResponseCode::Success),
+                            body,
+                        )
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn session-close PopLite resume");
+    handler_started_rx.await.expect("PopLite resume handler started");
+    let accepted = service.resource_snapshot();
+    assert_eq!(accepted.admission.waiting_count(), 0);
+    assert_eq!(accepted.index.live, 0);
+    assert_eq!(accepted.event_reservations.events, 2);
+    assert_eq!(accepted.event_reservations.permits, 2);
+    assert_eq!(accepted.active_client_gates, 1);
+    assert_eq!(accepted.accepted_resumes, 1);
+
+    client.shutdown().await.expect("close PopLite client session");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let snapshot = service.resource_snapshot();
+            if snapshot.event_reservations.events == 0
+                && snapshot.active_client_gates == 0
+                && snapshot.accepted_resumes == 0
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("session close cancels accepted PopLite resume ownership");
+    assert!(
+        release_handler_tx.send(()).is_err(),
+        "session close cancels the handler before event commit"
+    );
+    let error = receipt_rx
+        .await
+        .expect("session-close PopLite receipt channel")
+        .expect_err("closed session rejects the accepted PopLite response");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::SessionClosed);
+    assert_eq!(body_drops.load(Ordering::SeqCst), 1);
+    assert_eq!(dispatcher.pending_events(&client_id), vec![first, second]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 2);
+    let terminal = service.resource_snapshot();
+    assert_eq!(terminal.admission.waiting_count(), 0);
+    assert_eq!(terminal.index.live, 0);
+    assert_eq!(terminal.active_client_gates, 0);
+
+    assert_eq!(dispatcher.take_pending_events(&client_id).len(), 2);
+    running.finish().await;
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/data.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/data.rs
@@ -1,0 +1,126 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
+
+use crate::config::broker_config::BrokerConfig;
+
+use super::deadline::PopLiteWaitDeadline;
+use super::deadline::DEFAULT_POP_LITE_MAX_AGE;
+use super::index::PopLiteIndexLease;
+use super::index::PopLiteIndexLimits;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PopLiteDeferredPolicy {
+    pub(crate) index_limits: PopLiteIndexLimits,
+    pub(crate) max_age: Duration,
+}
+
+impl PopLiteDeferredPolicy {
+    pub(crate) fn from_config(config: &BrokerConfig) -> Option<Self> {
+        let max_entries = usize::try_from(config.max_pop_polling_size).unwrap_or(usize::MAX);
+        Some(Self {
+            index_limits: PopLiteIndexLimits::new(
+                NonZeroUsize::new(max_entries)?,
+                NonZeroUsize::new(config.pop_polling_map_size)?,
+                NonZeroUsize::new(config.pop_polling_size)?,
+            ),
+            max_age: DEFAULT_POP_LITE_MAX_AGE,
+        })
+    }
+}
+
+/// Typed PopLite request ownership retained without a command or connection.
+pub(crate) struct PopLiteRequestData {
+    header: PopLiteMessageRequestHeader,
+}
+
+impl PopLiteRequestData {
+    pub(crate) const fn new(header: PopLiteMessageRequestHeader) -> Self {
+        Self { header }
+    }
+
+    pub(crate) const fn header(&self) -> &PopLiteMessageRequestHeader {
+        &self.header
+    }
+
+    pub(crate) const fn client_id(&self) -> &cheetah_string::CheetahString {
+        &self.header.client_id
+    }
+
+    pub(crate) fn try_estimated_dynamic_bytes(&self) -> Option<usize> {
+        let mut total = [
+            self.header.client_id.len(),
+            self.header.consumer_group.len(),
+            self.header.topic.len(),
+        ]
+        .into_iter()
+        .try_fold(0usize, usize::checked_add)?;
+        if let Some(attempt_id) = &self.header.attempt_id {
+            total = total.checked_add(attempt_id.len())?;
+        }
+        if let Some(rpc) = &self.header.rpc {
+            for value in [rpc.namespace.as_ref(), rpc.broker_name.as_ref()].into_iter().flatten() {
+                total = total.checked_add(value.len())?;
+            }
+        }
+        Some(total)
+    }
+
+    pub(crate) fn into_header(self) -> PopLiteMessageRequestHeader {
+        self.header
+    }
+}
+
+/// Affine PopLite business ownership moved from registry claim into resume.
+#[must_use]
+pub(crate) struct ResumePopLite {
+    request: PopLiteRequestData,
+    wait_deadline: PopLiteWaitDeadline,
+    index_lease: Option<PopLiteIndexLease>,
+}
+
+impl ResumePopLite {
+    pub(super) fn new(
+        request: PopLiteRequestData,
+        wait_deadline: PopLiteWaitDeadline,
+        index_lease: PopLiteIndexLease,
+    ) -> Self {
+        Self {
+            request,
+            wait_deadline,
+            index_lease: Some(index_lease),
+        }
+    }
+
+    pub(crate) const fn request(&self) -> &PopLiteRequestData {
+        &self.request
+    }
+
+    pub(crate) const fn wait_deadline(&self) -> PopLiteWaitDeadline {
+        self.wait_deadline
+    }
+
+    pub(super) fn take_index_lease(&mut self) -> Option<PopLiteIndexLease> {
+        self.index_lease.take()
+    }
+
+    pub(crate) fn into_request(mut self) -> PopLiteRequestData {
+        drop(self.index_lease.take());
+        self.request
+    }
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/deadline.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/deadline.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+use std::time::Duration;
+
+const EARLY_WAKE_MILLIS: u64 = 50;
+pub(crate) const DEFAULT_POP_LITE_MAX_AGE: Duration = Duration::from_secs(30);
+
+/// Checked PopLite business deadline with the legacy strict 50 ms cutoff.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PopLiteWaitDeadline {
+    effective_end_millis: u64,
+    protocol_millis: u64,
+    protocol_at: tokio::time::Instant,
+}
+
+impl PopLiteWaitDeadline {
+    pub(crate) fn checked(
+        born_time: i64,
+        poll_time: i64,
+        admission_wall_now: u64,
+        monotonic_now: tokio::time::Instant,
+        max_age: Duration,
+    ) -> Result<Self, PopLiteWaitDeadlineError> {
+        if born_time < 0 {
+            return Err(PopLiteWaitDeadlineError::new(
+                PopLiteWaitDeadlineErrorKind::NegativeBornTime,
+            ));
+        }
+        if poll_time <= 0 {
+            return Err(PopLiteWaitDeadlineError::new(
+                PopLiteWaitDeadlineErrorKind::NonPositivePollTime,
+            ));
+        }
+        let requested_end = born_time
+            .checked_add(poll_time)
+            .ok_or_else(|| PopLiteWaitDeadlineError::new(PopLiteWaitDeadlineErrorKind::RequestedEndOverflow))?;
+        let requested_end = u64::try_from(requested_end)
+            .map_err(|_| PopLiteWaitDeadlineError::new(PopLiteWaitDeadlineErrorKind::RequestedEndOverflow))?;
+        let max_age_millis = u64::try_from(max_age.as_millis()).unwrap_or(u64::MAX);
+        let cap_end = admission_wall_now.saturating_add(max_age_millis);
+        let effective_end_millis = requested_end.min(cap_end);
+        let cutoff = effective_end_millis.saturating_sub(EARLY_WAKE_MILLIS);
+        if admission_wall_now > cutoff {
+            return Err(PopLiteWaitDeadlineError::new(
+                PopLiteWaitDeadlineErrorKind::AlreadyExpired,
+            ));
+        }
+        let remaining_millis = cutoff
+            .checked_sub(admission_wall_now)
+            .and_then(|remaining| remaining.checked_add(1))
+            .ok_or_else(|| PopLiteWaitDeadlineError::new(PopLiteWaitDeadlineErrorKind::ProtocolOverflow))?;
+        let protocol_millis = cutoff
+            .checked_add(1)
+            .ok_or_else(|| PopLiteWaitDeadlineError::new(PopLiteWaitDeadlineErrorKind::ProtocolOverflow))?;
+        let protocol_at = monotonic_now
+            .checked_add(Duration::from_millis(remaining_millis))
+            .ok_or_else(|| PopLiteWaitDeadlineError::new(PopLiteWaitDeadlineErrorKind::MonotonicOverflow))?;
+        Ok(Self {
+            effective_end_millis,
+            protocol_millis,
+            protocol_at,
+        })
+    }
+
+    pub(crate) const fn effective_end_millis(self) -> u64 {
+        self.effective_end_millis
+    }
+
+    pub(crate) const fn protocol_millis(self) -> u64 {
+        self.protocol_millis
+    }
+
+    pub(crate) const fn protocol_at(self) -> tokio::time::Instant {
+        self.protocol_at
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PopLiteWaitDeadlineErrorKind {
+    NegativeBornTime,
+    NonPositivePollTime,
+    RequestedEndOverflow,
+    AlreadyExpired,
+    ProtocolOverflow,
+    MonotonicOverflow,
+}
+
+impl PopLiteWaitDeadlineErrorKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::NegativeBornTime => "negative_born_time",
+            Self::NonPositivePollTime => "non_positive_poll_time",
+            Self::RequestedEndOverflow => "requested_end_overflow",
+            Self::AlreadyExpired => "already_expired",
+            Self::ProtocolOverflow => "protocol_overflow",
+            Self::MonotonicOverflow => "monotonic_overflow",
+        }
+    }
+}
+
+pub(crate) struct PopLiteWaitDeadlineError {
+    kind: PopLiteWaitDeadlineErrorKind,
+}
+
+impl PopLiteWaitDeadlineError {
+    const fn new(kind: PopLiteWaitDeadlineErrorKind) -> Self {
+        Self { kind }
+    }
+
+    pub(crate) const fn kind(&self) -> PopLiteWaitDeadlineErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for PopLiteWaitDeadlineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PopLiteWaitDeadlineError")
+            .field("kind", &self.kind.as_str())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PopLiteWaitDeadlineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "PopLite wait deadline failed: {}", self.kind.as_str())
+    }
+}
+
+impl Error for PopLiteWaitDeadlineError {}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/gate.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/gate.rs
@@ -1,0 +1,64 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::Weak;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+
+/// Per-client single-flight gate for message-arrival claims.
+#[derive(Clone, Default)]
+pub(crate) struct PopLiteEventGate {
+    inner: Arc<PopLiteEventGateInner>,
+}
+
+#[derive(Default)]
+struct PopLiteEventGateInner {
+    active_clients: Mutex<HashSet<CheetahString>>,
+}
+
+impl PopLiteEventGate {
+    pub(crate) fn try_reserve(&self, client_id: &CheetahString) -> Option<PopLiteEventGateReservation> {
+        let mut active = self.inner.active_clients.lock();
+        if !active.insert(client_id.clone()) {
+            return None;
+        }
+        Some(PopLiteEventGateReservation {
+            inner: Arc::downgrade(&self.inner),
+            client_id: Some(client_id.clone()),
+        })
+    }
+
+    pub(crate) fn active_count(&self) -> usize {
+        self.inner.active_clients.lock().len()
+    }
+}
+
+/// Affine gate ownership held through canonical resume and write completion.
+#[must_use]
+pub(crate) struct PopLiteEventGateReservation {
+    inner: Weak<PopLiteEventGateInner>,
+    client_id: Option<CheetahString>,
+}
+
+impl Drop for PopLiteEventGateReservation {
+    fn drop(&mut self) {
+        let (Some(inner), Some(client_id)) = (self.inner.upgrade(), self.client_id.take()) else {
+            return;
+        };
+        inner.active_clients.lock().remove(&client_id);
+    }
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/index.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/index.rs
@@ -1,0 +1,453 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::alloc::Layout;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Weak;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_transport::api::v2::DeferredId;
+
+use super::deadline::PopLiteWaitDeadline;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PopLiteIndexLimits {
+    pub(crate) max_entries: NonZeroUsize,
+    pub(crate) max_clients: NonZeroUsize,
+    pub(crate) max_entries_per_client: NonZeroUsize,
+}
+
+impl PopLiteIndexLimits {
+    pub(crate) const fn new(
+        max_entries: NonZeroUsize,
+        max_clients: NonZeroUsize,
+        max_entries_per_client: NonZeroUsize,
+    ) -> Self {
+        Self {
+            max_entries,
+            max_clients,
+            max_entries_per_client,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PopLiteIndexSnapshot {
+    pub(crate) live: usize,
+    pub(crate) reserved: usize,
+    pub(crate) candidates: usize,
+    pub(crate) clients: usize,
+    pub(crate) oldest_waiter_age: Option<Duration>,
+}
+
+pub(crate) struct PopLiteCriteriaIndex<I = DeferredId> {
+    inner: Arc<PopLiteCriteriaIndexInner<I>>,
+}
+
+impl<I> Clone for PopLiteCriteriaIndex<I> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<I> PopLiteCriteriaIndex<I>
+where
+    I: Copy + Eq,
+{
+    pub(crate) fn new(limits: PopLiteIndexLimits) -> Self {
+        Self {
+            inner: Arc::new(PopLiteCriteriaIndexInner {
+                limits,
+                state: Mutex::new(PopLiteCriteriaIndexState::default()),
+            }),
+        }
+    }
+
+    pub(crate) fn try_retained_bytes_per_entry() -> Option<usize> {
+        let (membership, _) = Layout::new::<AtomicBool>().extend(Layout::new::<AtomicBool>()).ok()?;
+        [
+            std::mem::size_of::<PopLiteIndexRecord<I>>(),
+            std::mem::size_of::<CheetahString>(),
+            std::mem::size_of::<PopLiteClientBucket<I>>(),
+            membership.pad_to_align().size(),
+        ]
+        .into_iter()
+        .try_fold(0usize, usize::checked_add)
+    }
+
+    pub(crate) fn reserve(
+        &self,
+        client_id: CheetahString,
+        registered_at: tokio::time::Instant,
+    ) -> Result<PopLiteIndexReservation<I>, PopLiteIndexError> {
+        let mut state = self.inner.state.lock();
+        let occupied = state
+            .live
+            .checked_add(state.reserved)
+            .ok_or_else(|| PopLiteIndexError::new(PopLiteIndexErrorKind::GlobalCapacity))?;
+        if occupied >= self.inner.limits.max_entries.get() {
+            return Err(PopLiteIndexError::new(PopLiteIndexErrorKind::GlobalCapacity));
+        }
+        let bucket_missing = !state.clients.contains_key(&client_id);
+        if bucket_missing && state.clients.len() >= self.inner.limits.max_clients.get() {
+            return Err(PopLiteIndexError::new(PopLiteIndexErrorKind::ClientCapacity));
+        }
+        let client_occupied = state.clients.get(&client_id).map_or(0, |bucket| {
+            bucket
+                .entries
+                .len()
+                .saturating_add(bucket.candidates)
+                .saturating_add(bucket.reserved)
+        });
+        if client_occupied >= self.inner.limits.max_entries_per_client.get() {
+            return Err(PopLiteIndexError::new(PopLiteIndexErrorKind::PerClientCapacity));
+        }
+        let next_sequence = state
+            .next_sequence
+            .checked_add(1)
+            .ok_or_else(|| PopLiteIndexError::new(PopLiteIndexErrorKind::SequenceExhausted))?;
+        if bucket_missing {
+            state
+                .clients
+                .try_reserve(1)
+                .map_err(|_| PopLiteIndexError::new(PopLiteIndexErrorKind::Allocation))?;
+        }
+        let bucket = state.clients.entry(client_id.clone()).or_default();
+        bucket
+            .entries
+            .try_reserve(1)
+            .map_err(|_| PopLiteIndexError::new(PopLiteIndexErrorKind::Allocation))?;
+        bucket.reserved += 1;
+        state.reserved += 1;
+        state.next_sequence = next_sequence;
+        drop(state);
+        Ok(PopLiteIndexReservation {
+            inner: Some(Arc::clone(&self.inner)),
+            client_id: Some(client_id),
+            sequence: next_sequence - 1,
+            registered_at,
+            membership: Arc::new(PopLiteIndexMembership::default()),
+        })
+    }
+
+    pub(crate) fn reserve_oldest(&self, client_id: &CheetahString) -> Option<PopLiteCandidateReservation<I>> {
+        let mut state = self.inner.state.lock();
+        let bucket = state.clients.get_mut(client_id)?;
+        let record = bucket.entries.pop_front()?;
+        record.membership.candidate.store(true, Ordering::Release);
+        bucket.candidates += 1;
+        state.candidates += 1;
+        Some(PopLiteCandidateReservation {
+            inner: Arc::downgrade(&self.inner),
+            client_id: client_id.clone(),
+            record: Some(record),
+        })
+    }
+
+    pub(crate) fn snapshot(&self) -> PopLiteIndexSnapshot {
+        let state = self.inner.state.lock();
+        let now = tokio::time::Instant::now();
+        let oldest_registered = state
+            .clients
+            .values()
+            .flat_map(|bucket| bucket.entries.iter())
+            .map(|record| record.registered_at)
+            .min();
+        PopLiteIndexSnapshot {
+            live: state.live,
+            reserved: state.reserved,
+            candidates: state.candidates,
+            clients: state.clients.len(),
+            oldest_waiter_age: oldest_registered.map(|registered| now.saturating_duration_since(registered)),
+        }
+    }
+}
+
+struct PopLiteCriteriaIndexInner<I> {
+    limits: PopLiteIndexLimits,
+    state: Mutex<PopLiteCriteriaIndexState<I>>,
+}
+
+struct PopLiteCriteriaIndexState<I> {
+    clients: HashMap<CheetahString, PopLiteClientBucket<I>>,
+    live: usize,
+    reserved: usize,
+    candidates: usize,
+    next_sequence: u64,
+}
+
+impl<I> Default for PopLiteCriteriaIndexState<I> {
+    fn default() -> Self {
+        Self {
+            clients: HashMap::new(),
+            live: 0,
+            reserved: 0,
+            candidates: 0,
+            next_sequence: 0,
+        }
+    }
+}
+
+struct PopLiteClientBucket<I> {
+    entries: VecDeque<PopLiteIndexRecord<I>>,
+    reserved: usize,
+    candidates: usize,
+}
+
+impl<I> Default for PopLiteClientBucket<I> {
+    fn default() -> Self {
+        Self {
+            entries: VecDeque::new(),
+            reserved: 0,
+            candidates: 0,
+        }
+    }
+}
+
+struct PopLiteIndexRecord<I> {
+    id: I,
+    deadline: PopLiteWaitDeadline,
+    sequence: u64,
+    registered_at: tokio::time::Instant,
+    membership: Arc<PopLiteIndexMembership>,
+}
+
+impl<I> PopLiteIndexRecord<I> {
+    const fn order_key(&self) -> (tokio::time::Instant, u64) {
+        (self.deadline.protocol_at(), self.sequence)
+    }
+}
+
+#[derive(Default)]
+struct PopLiteIndexMembership {
+    live: AtomicBool,
+    candidate: AtomicBool,
+}
+
+fn insert_ordered<I>(entries: &mut VecDeque<PopLiteIndexRecord<I>>, record: PopLiteIndexRecord<I>) {
+    let position = entries
+        .binary_search_by_key(&record.order_key(), PopLiteIndexRecord::order_key)
+        .unwrap_or_else(|position| position);
+    entries.insert(position, record);
+}
+
+fn bucket_is_empty<I>(bucket: &PopLiteClientBucket<I>) -> bool {
+    bucket.entries.is_empty() && bucket.reserved == 0 && bucket.candidates == 0
+}
+
+#[must_use]
+pub(crate) struct PopLiteIndexReservation<I = DeferredId> {
+    inner: Option<Arc<PopLiteCriteriaIndexInner<I>>>,
+    client_id: Option<CheetahString>,
+    sequence: u64,
+    registered_at: tokio::time::Instant,
+    membership: Arc<PopLiteIndexMembership>,
+}
+
+impl<I> PopLiteIndexReservation<I>
+where
+    I: Copy + Eq,
+{
+    pub(crate) fn publish(mut self, id: I, deadline: PopLiteWaitDeadline) -> PopLiteIndexLease<I> {
+        let inner = self.inner.take().expect("armed PopLite index reservation owns index");
+        let client_id = self
+            .client_id
+            .take()
+            .expect("armed PopLite index reservation owns client id");
+        {
+            let mut state = inner.state.lock();
+            let bucket = state
+                .clients
+                .get_mut(&client_id)
+                .expect("armed PopLite reservation retains client bucket");
+            bucket.reserved -= 1;
+            insert_ordered(
+                &mut bucket.entries,
+                PopLiteIndexRecord {
+                    id,
+                    deadline,
+                    sequence: self.sequence,
+                    registered_at: self.registered_at,
+                    membership: Arc::clone(&self.membership),
+                },
+            );
+            state.reserved -= 1;
+            state.live += 1;
+            self.membership.live.store(true, Ordering::Release);
+        }
+        PopLiteIndexLease {
+            inner: Arc::downgrade(&inner),
+            client_id,
+            id,
+            order: (deadline.protocol_at(), self.sequence),
+            membership: Arc::clone(&self.membership),
+        }
+    }
+}
+
+impl<I> Drop for PopLiteIndexReservation<I> {
+    fn drop(&mut self) {
+        let (Some(inner), Some(client_id)) = (self.inner.take(), self.client_id.take()) else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        let remove = if let Some(bucket) = state.clients.get_mut(&client_id) {
+            bucket.reserved -= 1;
+            bucket_is_empty(bucket)
+        } else {
+            false
+        };
+        state.reserved -= 1;
+        if remove {
+            state.clients.remove(&client_id);
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct PopLiteIndexLease<I: Eq = DeferredId> {
+    inner: Weak<PopLiteCriteriaIndexInner<I>>,
+    client_id: CheetahString,
+    id: I,
+    order: (tokio::time::Instant, u64),
+    membership: Arc<PopLiteIndexMembership>,
+}
+
+impl<I> Drop for PopLiteIndexLease<I>
+where
+    I: Eq,
+{
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        if !self.membership.live.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        let mut remove_client = false;
+        let mut candidate_removed = false;
+        if let Some(bucket) = state.clients.get_mut(&self.client_id) {
+            if self.membership.candidate.swap(false, Ordering::AcqRel) {
+                bucket.candidates -= 1;
+                candidate_removed = true;
+            } else if let Ok(position) = bucket
+                .entries
+                .binary_search_by_key(&self.order, PopLiteIndexRecord::order_key)
+            {
+                if bucket.entries.get(position).is_some_and(|record| record.id == self.id) {
+                    bucket.entries.remove(position);
+                }
+            }
+            remove_client = bucket_is_empty(bucket);
+        }
+        if candidate_removed {
+            state.candidates -= 1;
+        }
+        state.live -= 1;
+        if remove_client {
+            state.clients.remove(&self.client_id);
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct PopLiteCandidateReservation<I: Eq = DeferredId> {
+    inner: Weak<PopLiteCriteriaIndexInner<I>>,
+    client_id: CheetahString,
+    record: Option<PopLiteIndexRecord<I>>,
+}
+
+impl<I> PopLiteCandidateReservation<I>
+where
+    I: Copy + Eq,
+{
+    pub(crate) fn id(&self) -> I {
+        self.record.as_ref().expect("live PopLite candidate owns record").id
+    }
+}
+
+impl<I> Drop for PopLiteCandidateReservation<I>
+where
+    I: Eq,
+{
+    fn drop(&mut self) {
+        let Some(record) = self.record.take() else {
+            return;
+        };
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        let Some(bucket) = state.clients.get_mut(&self.client_id) else {
+            return;
+        };
+        if !record.membership.candidate.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        bucket.candidates -= 1;
+        if record.membership.live.load(Ordering::Acquire) {
+            insert_ordered(&mut bucket.entries, record);
+        }
+        state.candidates -= 1;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PopLiteIndexErrorKind {
+    GlobalCapacity,
+    ClientCapacity,
+    PerClientCapacity,
+    SequenceExhausted,
+    Allocation,
+}
+
+pub(crate) struct PopLiteIndexError {
+    kind: PopLiteIndexErrorKind,
+}
+
+impl PopLiteIndexError {
+    const fn new(kind: PopLiteIndexErrorKind) -> Self {
+        Self { kind }
+    }
+
+    pub(crate) const fn kind(&self) -> PopLiteIndexErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for PopLiteIndexError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_tuple("PopLiteIndexError").field(&self.kind).finish()
+    }
+}
+
+impl fmt::Display for PopLiteIndexError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "PopLite deferred index failed: {:?}", self.kind)
+    }
+}
+
+impl Error for PopLiteIndexError {}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/prepare.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/prepare.rs
@@ -1,0 +1,348 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::Infallible;
+use std::error::Error;
+use std::fmt;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_transport::api::v2::DeferredAdmissionAcquireError;
+use rocketmq_transport::api::v2::DeferredExpiryError;
+use rocketmq_transport::api::v2::DeferredExpiryErrorKind;
+use rocketmq_transport::api::v2::DeferredId;
+use rocketmq_transport::api::v2::DeferredParts;
+use rocketmq_transport::api::v2::DeferredRegistration;
+use rocketmq_transport::api::v2::DeferredRegistry;
+use rocketmq_transport::api::v2::DeferredRegistryError;
+use rocketmq_transport::api::v2::DeferredRegistryErrorKind;
+use rocketmq_transport::api::v2::DeferredRetainedSizeParts;
+use rocketmq_transport::api::v2::DeferredWaitPermit;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestId;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::SessionId;
+use rocketmq_transport::api::v2::TakeDeferredResponderError;
+
+use super::data::PopLiteRequestData;
+use super::data::ResumePopLite;
+use super::deadline::PopLiteWaitDeadline;
+use super::deadline::PopLiteWaitDeadlineError;
+use super::index::PopLiteCriteriaIndex;
+use super::index::PopLiteIndexError;
+use super::index::PopLiteIndexErrorKind;
+use super::index::PopLiteIndexReservation;
+use super::service::ObservationGuard;
+use super::service::ObservationKind;
+use super::service::PopLiteDeferredService;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PopLiteRetainedEstimate {
+    pub(crate) resume_bytes: usize,
+    pub(crate) metadata_bytes: usize,
+}
+
+impl PopLiteRetainedEstimate {
+    pub(crate) const fn new(resume_bytes: usize, metadata_bytes: usize) -> Self {
+        Self {
+            resume_bytes,
+            metadata_bytes,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PreparedRequestProvenance {
+    request_id: RequestId,
+    session_id: SessionId,
+}
+
+impl PreparedRequestProvenance {
+    fn capture(request: &RemotingRequest) -> Self {
+        Self {
+            request_id: request.original_identity().request_id(),
+            session_id: request.session().id(),
+        }
+    }
+
+    fn matches(self, request: &RemotingRequest) -> bool {
+        self.request_id == request.original_identity().request_id() && self.session_id == request.session().id()
+    }
+}
+
+#[must_use]
+pub(crate) struct PreparedPopLiteRegistration {
+    request: PopLiteRequestData,
+    deadline: PopLiteWaitDeadline,
+    reservation: PopLiteIndexReservation,
+    permit: DeferredWaitPermit,
+    provenance: PreparedRequestProvenance,
+    _observation: ObservationGuard,
+}
+
+impl PreparedPopLiteRegistration {
+    pub(crate) const fn deadline(&self) -> PopLiteWaitDeadline {
+        self.deadline
+    }
+
+    pub(crate) const fn retained_bytes(&self) -> usize {
+        self.permit.retained_bytes()
+    }
+}
+
+impl PopLiteDeferredService {
+    pub(crate) fn prepare(
+        &self,
+        request: &RemotingRequest,
+        retained: PopLiteRetainedEstimate,
+    ) -> Result<PreparedPopLiteRegistration, PopLiteDeferredPrepareError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PopLiteDeferredPrepareError::ServiceClosed);
+        }
+        if request.command().is_oneway_rpc() {
+            return Err(PopLiteDeferredPrepareError::OneWay);
+        }
+        match request.origin() {
+            RequestOrigin::Network { .. } => {}
+            _ => return Err(PopLiteDeferredPrepareError::EmbeddedOrigin),
+        }
+        if self.expiry_margins.recovery().is_zero() || self.expiry_margins.write().is_zero() {
+            return Err(PopLiteDeferredPrepareError::InvalidExpiryMargins);
+        }
+        let header = request
+            .command()
+            .decode_command_custom_header::<PopLiteMessageRequestHeader>()
+            .map_err(PopLiteDeferredPrepareError::Header)?;
+        validate_header(&header)?;
+        let wall_now = current_millis();
+        let monotonic_now = tokio::time::Instant::now();
+        let deadline = PopLiteWaitDeadline::checked(
+            header.born_time,
+            header.poll_time,
+            wall_now,
+            monotonic_now,
+            self.max_age,
+        )
+        .map_err(PopLiteDeferredPrepareError::Deadline)?;
+        let provenance = PreparedRequestProvenance::capture(request);
+        let request = PopLiteRequestData::new(header);
+        let dynamic_bytes = request
+            .try_estimated_dynamic_bytes()
+            .ok_or(PopLiteDeferredPrepareError::RetainedSizeOverflow)?;
+        let resume_bytes = retained
+            .resume_bytes
+            .checked_add(dynamic_bytes)
+            .ok_or(PopLiteDeferredPrepareError::RetainedSizeOverflow)?;
+        let index_bytes = PopLiteCriteriaIndex::<DeferredId>::try_retained_bytes_per_entry()
+            .ok_or(PopLiteDeferredPrepareError::RetainedSizeOverflow)?;
+        let retained_parts = DeferredRetainedSizeParts::new(resume_bytes)
+            .with_secondary_index_bytes(index_bytes)
+            .with_metadata_bytes(retained.metadata_bytes);
+        let retained_size = DeferredRegistry::<ResumePopLite>::try_retained_size(retained_parts)
+            .map_err(PopLiteDeferredPrepareError::Admission)?;
+        let reservation = self
+            .index
+            .reserve(request.client_id().clone(), monotonic_now)
+            .map_err(PopLiteDeferredPrepareError::Index)?;
+        let permit = self
+            .admission
+            .try_reserve(retained_size)
+            .map_err(PopLiteDeferredPrepareError::Admission)?;
+        let prepared = PreparedPopLiteRegistration {
+            request,
+            deadline,
+            reservation,
+            permit,
+            provenance,
+            _observation: ObservationGuard::new(Arc::clone(&self.observations), ObservationKind::Prepared),
+        };
+        if self.closed.load(Ordering::Acquire) {
+            drop(prepared);
+            return Err(PopLiteDeferredPrepareError::ServiceClosed);
+        }
+        Ok(prepared)
+    }
+
+    pub(crate) fn register(
+        &self,
+        prepared: PreparedPopLiteRegistration,
+        request: &mut RemotingRequest,
+    ) -> Result<DeferredRegistration, PopLiteDeferredRegisterError> {
+        if !prepared.provenance.matches(request) {
+            return Err(PopLiteDeferredRegisterError::ProvenanceMismatch);
+        }
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PopLiteDeferredRegisterError::ServiceClosed);
+        }
+        let client_id = prepared.request.client_id().clone();
+        let responder = request
+            .take_deferred_responder()
+            .map_err(PopLiteDeferredRegisterError::Responder)?;
+        #[cfg(test)]
+        self.wait_register_after_take_hook();
+        if self.closed.load(Ordering::Acquire) {
+            drop(responder);
+            return Err(PopLiteDeferredRegisterError::ServiceClosedAfterTake);
+        }
+        let PreparedPopLiteRegistration {
+            request,
+            deadline,
+            reservation,
+            permit,
+            provenance: _,
+            _observation,
+        } = prepared;
+        #[cfg(test)]
+        let protocol_at = if self.fail_next_expiry_attachment.swap(false, Ordering::AcqRel) {
+            tokio::time::Instant::now()
+        } else {
+            deadline.protocol_at()
+        };
+        #[cfg(not(test))]
+        let protocol_at = deadline.protocol_at();
+        let parts = DeferredParts::new(responder, permit)
+            .try_with_expiry(protocol_at, self.expiry_margins)
+            .map_err(PopLiteDeferredRegisterError::Expiry)?;
+        let registration = self
+            .registry
+            .register_with(parts, move |id| {
+                let index_lease = reservation.publish(id, deadline);
+                Ok::<_, Infallible>(ResumePopLite::new(request, deadline, index_lease))
+            })
+            .map_err(PopLiteDeferredRegisterError::Registry)?;
+        drop(_observation);
+        self.observe_pending_event(&client_id);
+        Ok(registration)
+    }
+}
+
+fn validate_header(header: &PopLiteMessageRequestHeader) -> Result<(), PopLiteDeferredPrepareError> {
+    if header.client_id.is_empty() || header.consumer_group.is_empty() || header.topic.is_empty() {
+        return Err(PopLiteDeferredPrepareError::InvalidHeader);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PopLiteDeferredPrepareErrorKind {
+    ServiceClosed,
+    OneWay,
+    EmbeddedOrigin,
+    InvalidExpiryMargins,
+    Header,
+    InvalidHeader,
+    Deadline,
+    RetainedSizeOverflow,
+    Index(PopLiteIndexErrorKind),
+    Admission,
+}
+
+pub(crate) enum PopLiteDeferredPrepareError {
+    ServiceClosed,
+    OneWay,
+    EmbeddedOrigin,
+    InvalidExpiryMargins,
+    Header(RocketMQError),
+    InvalidHeader,
+    Deadline(PopLiteWaitDeadlineError),
+    RetainedSizeOverflow,
+    Index(PopLiteIndexError),
+    Admission(DeferredAdmissionAcquireError),
+}
+
+impl PopLiteDeferredPrepareError {
+    pub(crate) const fn kind(&self) -> PopLiteDeferredPrepareErrorKind {
+        match self {
+            Self::ServiceClosed => PopLiteDeferredPrepareErrorKind::ServiceClosed,
+            Self::OneWay => PopLiteDeferredPrepareErrorKind::OneWay,
+            Self::EmbeddedOrigin => PopLiteDeferredPrepareErrorKind::EmbeddedOrigin,
+            Self::InvalidExpiryMargins => PopLiteDeferredPrepareErrorKind::InvalidExpiryMargins,
+            Self::Header(_) => PopLiteDeferredPrepareErrorKind::Header,
+            Self::InvalidHeader => PopLiteDeferredPrepareErrorKind::InvalidHeader,
+            Self::Deadline(_) => PopLiteDeferredPrepareErrorKind::Deadline,
+            Self::RetainedSizeOverflow => PopLiteDeferredPrepareErrorKind::RetainedSizeOverflow,
+            Self::Index(source) => PopLiteDeferredPrepareErrorKind::Index(source.kind()),
+            Self::Admission(_) => PopLiteDeferredPrepareErrorKind::Admission,
+        }
+    }
+}
+
+impl fmt::Debug for PopLiteDeferredPrepareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("PopLiteDeferredPrepareError")
+            .field(&self.kind())
+            .finish()
+    }
+}
+
+impl fmt::Display for PopLiteDeferredPrepareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "PopLite deferred preparation failed: {:?}", self.kind())
+    }
+}
+
+impl Error for PopLiteDeferredPrepareError {}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PopLiteDeferredRegisterErrorKind {
+    ServiceClosed,
+    ServiceClosedAfterTake,
+    ProvenanceMismatch,
+    Responder,
+    Expiry(DeferredExpiryErrorKind),
+    Registry(DeferredRegistryErrorKind),
+}
+
+pub(crate) enum PopLiteDeferredRegisterError {
+    ServiceClosed,
+    ServiceClosedAfterTake,
+    ProvenanceMismatch,
+    Responder(TakeDeferredResponderError),
+    Expiry(DeferredExpiryError),
+    Registry(DeferredRegistryError<ResumePopLite, Infallible>),
+}
+
+impl PopLiteDeferredRegisterError {
+    pub(crate) const fn kind(&self) -> PopLiteDeferredRegisterErrorKind {
+        match self {
+            Self::ServiceClosed => PopLiteDeferredRegisterErrorKind::ServiceClosed,
+            Self::ServiceClosedAfterTake => PopLiteDeferredRegisterErrorKind::ServiceClosedAfterTake,
+            Self::ProvenanceMismatch => PopLiteDeferredRegisterErrorKind::ProvenanceMismatch,
+            Self::Responder(_) => PopLiteDeferredRegisterErrorKind::Responder,
+            Self::Expiry(source) => PopLiteDeferredRegisterErrorKind::Expiry(source.kind()),
+            Self::Registry(source) => PopLiteDeferredRegisterErrorKind::Registry(source.kind()),
+        }
+    }
+}
+
+impl fmt::Debug for PopLiteDeferredRegisterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("PopLiteDeferredRegisterError")
+            .field(&self.kind())
+            .finish()
+    }
+}
+
+impl fmt::Display for PopLiteDeferredRegisterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "PopLite deferred registration failed: {:?}", self.kind())
+    }
+}
+
+impl Error for PopLiteDeferredRegisterError {}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/service.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/service.rs
@@ -1,0 +1,515 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::future::Future;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Barrier;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_transport::api::v2::ClaimedDeferred;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredAdmissionSnapshot;
+use rocketmq_transport::api::v2::DeferredClaimError;
+use rocketmq_transport::api::v2::DeferredExpiryBatch;
+use rocketmq_transport::api::v2::DeferredExpiryBatchStats;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredRegistry;
+use rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome;
+use rocketmq_transport::api::v2::DeferredResumeError;
+use rocketmq_transport::api::v2::DeferredResumeRetainedSize;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponseReceipt;
+
+use crate::lite::lite_event_dispatcher::LiteEventBatchExecution;
+use crate::lite::lite_event_dispatcher::LiteEventBatchReservation;
+use crate::lite::lite_event_dispatcher::LiteEventBatchTerminal;
+use crate::lite::lite_event_dispatcher::LiteEventDispatcher;
+use crate::lite::lite_event_dispatcher::LiteEventReservationSnapshot;
+
+use super::data::ResumePopLite;
+use super::gate::PopLiteEventGate;
+use super::gate::PopLiteEventGateReservation;
+use super::index::PopLiteCriteriaIndex;
+use super::index::PopLiteIndexLimits;
+use super::index::PopLiteIndexSnapshot;
+
+#[derive(Default)]
+pub(super) struct PopLiteServiceObservations {
+    prepared: AtomicUsize,
+    pending_claims: AtomicUsize,
+    accepted_resumes: AtomicUsize,
+    resume_execution_bytes: AtomicUsize,
+}
+
+pub(super) enum ObservationKind {
+    Prepared,
+    PendingClaim,
+    AcceptedResume,
+}
+
+pub(super) struct ObservationGuard {
+    observations: Arc<PopLiteServiceObservations>,
+    kind: ObservationKind,
+    retained_bytes: usize,
+}
+
+impl ObservationGuard {
+    pub(super) fn new(observations: Arc<PopLiteServiceObservations>, kind: ObservationKind) -> Self {
+        match kind {
+            ObservationKind::Prepared => observations.prepared.fetch_add(1, Ordering::AcqRel),
+            ObservationKind::PendingClaim => observations.pending_claims.fetch_add(1, Ordering::AcqRel),
+            ObservationKind::AcceptedResume => observations.accepted_resumes.fetch_add(1, Ordering::AcqRel),
+        };
+        Self {
+            observations,
+            kind,
+            retained_bytes: 0,
+        }
+    }
+
+    pub(super) fn accepted(observations: Arc<PopLiteServiceObservations>, retained_bytes: usize) -> Self {
+        observations.accepted_resumes.fetch_add(1, Ordering::AcqRel);
+        observations
+            .resume_execution_bytes
+            .fetch_add(retained_bytes, Ordering::AcqRel);
+        Self {
+            observations,
+            kind: ObservationKind::AcceptedResume,
+            retained_bytes,
+        }
+    }
+}
+
+impl Drop for ObservationGuard {
+    fn drop(&mut self) {
+        match self.kind {
+            ObservationKind::Prepared => self.observations.prepared.fetch_sub(1, Ordering::AcqRel),
+            ObservationKind::PendingClaim => self.observations.pending_claims.fetch_sub(1, Ordering::AcqRel),
+            ObservationKind::AcceptedResume => {
+                self.observations.accepted_resumes.fetch_sub(1, Ordering::AcqRel);
+                self.observations
+                    .resume_execution_bytes
+                    .fetch_sub(self.retained_bytes, Ordering::AcqRel)
+            }
+        };
+    }
+}
+
+pub(crate) struct PopLiteDeferredService {
+    pub(super) admission: DeferredAdmission,
+    pub(super) registry: DeferredRegistry<ResumePopLite>,
+    pub(super) index: PopLiteCriteriaIndex,
+    event_gate: PopLiteEventGate,
+    pub(super) dispatcher: LiteEventDispatcher,
+    pub(super) expiry_margins: DeferredExpiryMargins,
+    pub(super) max_age: Duration,
+    sweep_limit: NonZeroUsize,
+    pub(super) closed: Arc<AtomicBool>,
+    pub(super) pending_replays: Arc<Mutex<HashSet<CheetahString>>>,
+    pub(super) observations: Arc<PopLiteServiceObservations>,
+    #[cfg(test)]
+    replay_insert_hook: Arc<Mutex<Option<ReplayInsertHook>>>,
+    #[cfg(test)]
+    register_after_take_hook: Arc<Mutex<Option<RegisterAfterTakeHook>>>,
+    #[cfg(test)]
+    terminal_ready_hook: Arc<Mutex<Option<TerminalReadyHook>>>,
+    #[cfg(test)]
+    pub(super) fail_next_expiry_attachment: AtomicBool,
+}
+
+impl PopLiteDeferredService {
+    pub(crate) fn new(
+        admission: DeferredAdmission,
+        index_limits: PopLiteIndexLimits,
+        dispatcher: LiteEventDispatcher,
+        expiry_margins: DeferredExpiryMargins,
+        max_age: Duration,
+        sweep_limit: NonZeroUsize,
+    ) -> Self {
+        Self {
+            admission,
+            registry: DeferredRegistry::new(),
+            index: PopLiteCriteriaIndex::new(index_limits),
+            event_gate: PopLiteEventGate::default(),
+            dispatcher,
+            expiry_margins,
+            max_age,
+            sweep_limit,
+            closed: Arc::new(AtomicBool::new(false)),
+            pending_replays: Arc::new(Mutex::new(HashSet::new())),
+            observations: Arc::new(PopLiteServiceObservations::default()),
+            #[cfg(test)]
+            replay_insert_hook: Arc::new(Mutex::new(None)),
+            #[cfg(test)]
+            register_after_take_hook: Arc::new(Mutex::new(None)),
+            #[cfg(test)]
+            terminal_ready_hook: Arc::new(Mutex::new(None)),
+            #[cfg(test)]
+            fail_next_expiry_attachment: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn observe_pending_event(&self, client_id: &CheetahString) -> bool {
+        observe_replay(
+            &self.closed,
+            &self.pending_replays,
+            &self.dispatcher,
+            client_id,
+            #[cfg(test)]
+            &self.replay_insert_hook,
+        )
+    }
+
+    pub(crate) fn take_pending_replays(&self, limit: NonZeroUsize) -> Vec<CheetahString> {
+        let mut pending = self.pending_replays.lock();
+        let clients = pending.iter().take(limit.get()).cloned().collect::<Vec<_>>();
+        for client in &clients {
+            pending.remove(client);
+        }
+        clients
+    }
+
+    pub(crate) async fn claim_event(
+        &self,
+        client_id: &CheetahString,
+    ) -> Result<Option<PopLiteEventClaim>, DeferredClaimError> {
+        let _pending = ObservationGuard::new(Arc::clone(&self.observations), ObservationKind::PendingClaim);
+        let Some(gate) = self.event_gate.try_reserve(client_id) else {
+            return Ok(None);
+        };
+        let Some(candidate) = self.index.reserve_oldest(client_id) else {
+            drop(gate);
+            return Ok(None);
+        };
+        let Some(events) = self.dispatcher.reserve_pending_events(client_id) else {
+            drop(candidate);
+            drop(gate);
+            return Ok(None);
+        };
+        self.pending_replays.lock().remove(client_id);
+        let id = candidate.id();
+        match self.registry.claim(id, DeferredWakeReason::MessageArrived).await {
+            Ok(mut claimed) => {
+                drop(claimed.resume_data_mut().take_index_lease());
+                drop(candidate);
+                Ok(Some(PopLiteEventClaim {
+                    claimed,
+                    gate,
+                    events,
+                    client_id: client_id.clone(),
+                }))
+            }
+            Err(error) => {
+                drop(events);
+                drop(candidate);
+                drop(gate);
+                self.observe_pending_event(client_id);
+                Err(error)
+            }
+        }
+    }
+
+    pub(crate) async fn resume_event_claim<F, Fut>(
+        &self,
+        event_claim: PopLiteEventClaim,
+        handler_retained: DeferredResumeRetainedSize,
+        handler: F,
+    ) -> Result<ResponseReceipt, DeferredResumeError>
+    where
+        F: FnOnce(ResumePopLite, DeferredWakeReason, LiteEventBatchExecution) -> Fut + Send + 'static,
+        Fut: Future<Output = rocketmq_error::RocketMQResult<ResponsePlan>> + Send + 'static,
+    {
+        let PopLiteEventClaim {
+            claimed,
+            gate,
+            events,
+            client_id,
+        } = event_claim;
+        let retained = handler_retained.dynamic_bytes().saturating_add(events.retained_bytes());
+        let (event_execution, event_terminal) = events.into_terminal_ownership();
+        let observations = Arc::clone(&self.observations);
+        let terminal = PopLiteEventTerminal {
+            events: Some(event_terminal),
+            gate: Some(gate),
+            client_id,
+            dispatcher: self.dispatcher.clone(),
+            pending_replays: Arc::clone(&self.pending_replays),
+            closed: Arc::clone(&self.closed),
+            accepted: None,
+            #[cfg(test)]
+            replay_insert_hook: Arc::clone(&self.replay_insert_hook),
+            #[cfg(test)]
+            terminal_ready_hook: Arc::clone(&self.terminal_ready_hook),
+        };
+        claimed
+            .resume(DeferredResumeRetainedSize::new(retained), move |resume, reason| {
+                let mut terminal = terminal;
+                terminal.accepted = Some(ObservationGuard::accepted(observations, retained));
+                PopLiteEventTerminalFuture {
+                    inner: handler(resume, reason, event_execution),
+                    _terminal: terminal,
+                }
+            })
+            .await
+    }
+
+    pub(crate) async fn resume_claimed<F, Fut>(
+        &self,
+        claimed: ClaimedDeferred<ResumePopLite>,
+        handler_retained: DeferredResumeRetainedSize,
+        handler: F,
+    ) -> Result<ResponseReceipt, DeferredResumeError>
+    where
+        F: FnOnce(ResumePopLite, DeferredWakeReason) -> Fut + Send + 'static,
+        Fut: Future<Output = rocketmq_error::RocketMQResult<ResponsePlan>> + Send + 'static,
+    {
+        let retained = handler_retained.dynamic_bytes();
+        let observations = Arc::clone(&self.observations);
+        claimed
+            .resume(handler_retained, move |resume, reason| PopLiteAcceptedFuture {
+                inner: handler(resume, reason),
+                _accepted: ObservationGuard::accepted(observations, retained),
+            })
+            .await
+    }
+
+    pub(crate) fn sweep_expired(&self) -> PopLiteDeferredSweepBatch {
+        PopLiteDeferredSweepBatch::from_transport(self.registry.sweep_expired(self.sweep_limit))
+    }
+
+    pub(crate) fn resource_snapshot(&self) -> PopLiteDeferredResourceSnapshot {
+        PopLiteDeferredResourceSnapshot {
+            admission: self.admission.snapshot(),
+            index: self.index.snapshot(),
+            event_reservations: self.dispatcher.reservation_snapshot(),
+            active_client_gates: self.event_gate.active_count(),
+            prepared_registrations: self.observations.prepared.load(Ordering::Acquire),
+            pending_claims: self.observations.pending_claims.load(Ordering::Acquire),
+            accepted_resumes: self.observations.accepted_resumes.load(Ordering::Acquire),
+            resume_execution_count: self.observations.accepted_resumes.load(Ordering::Acquire),
+            resume_execution_bytes: self.observations.resume_execution_bytes.load(Ordering::Acquire),
+            pending_replays: self.pending_replays.lock().len(),
+        }
+    }
+
+    pub(crate) fn shutdown(&self) -> DeferredRegistryShutdownOutcome {
+        self.closed.store(true, Ordering::Release);
+        self.pending_replays.lock().clear();
+        self.registry.shutdown()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_replay_insert_hook(&self, checked: Arc<Barrier>, resume: Arc<Barrier>) {
+        *self.replay_insert_hook.lock() = Some(ReplayInsertHook { checked, resume });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_register_after_take_hook(&self, taken: Arc<Barrier>, resume: Arc<Barrier>) {
+        *self.register_after_take_hook.lock() = Some(RegisterAfterTakeHook { taken, resume });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_terminal_ready_hook(&self, ready: Arc<Barrier>, resume: Arc<Barrier>) {
+        *self.terminal_ready_hook.lock() = Some(TerminalReadyHook { ready, resume });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_expiry_attachment_after_take(&self) {
+        self.fail_next_expiry_attachment.store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(super) fn wait_register_after_take_hook(&self) {
+        if let Some(hook) = self.register_after_take_hook.lock().take() {
+            hook.taken.wait();
+            hook.resume.wait();
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct PopLiteEventClaim {
+    claimed: ClaimedDeferred<ResumePopLite>,
+    gate: PopLiteEventGateReservation,
+    events: LiteEventBatchReservation,
+    client_id: CheetahString,
+}
+
+struct PopLiteEventTerminal {
+    events: Option<LiteEventBatchTerminal>,
+    gate: Option<PopLiteEventGateReservation>,
+    client_id: CheetahString,
+    dispatcher: LiteEventDispatcher,
+    pending_replays: Arc<Mutex<HashSet<CheetahString>>>,
+    closed: Arc<AtomicBool>,
+    accepted: Option<ObservationGuard>,
+    #[cfg(test)]
+    replay_insert_hook: Arc<Mutex<Option<ReplayInsertHook>>>,
+    #[cfg(test)]
+    terminal_ready_hook: Arc<Mutex<Option<TerminalReadyHook>>>,
+}
+
+impl Drop for PopLiteEventTerminal {
+    fn drop(&mut self) {
+        drop(self.events.take());
+        drop(self.gate.take());
+        observe_replay(
+            &self.closed,
+            &self.pending_replays,
+            &self.dispatcher,
+            &self.client_id,
+            #[cfg(test)]
+            &self.replay_insert_hook,
+        );
+        drop(self.accepted.take());
+    }
+}
+
+fn observe_replay(
+    closed: &AtomicBool,
+    pending_replays: &Mutex<HashSet<CheetahString>>,
+    dispatcher: &LiteEventDispatcher,
+    client_id: &CheetahString,
+    #[cfg(test)] replay_insert_hook: &Mutex<Option<ReplayInsertHook>>,
+) -> bool {
+    if closed.load(Ordering::Acquire) || dispatcher.pending_events(client_id).is_empty() {
+        return false;
+    }
+    #[cfg(test)]
+    if let Some(hook) = replay_insert_hook.lock().take() {
+        hook.checked.wait();
+        hook.resume.wait();
+    }
+    let mut pending = pending_replays.lock();
+    if closed.load(Ordering::Acquire) || dispatcher.pending_events(client_id).is_empty() {
+        return false;
+    }
+    pending.insert(client_id.clone());
+    true
+}
+
+#[cfg(test)]
+struct ReplayInsertHook {
+    checked: Arc<Barrier>,
+    resume: Arc<Barrier>,
+}
+
+#[cfg(test)]
+struct RegisterAfterTakeHook {
+    taken: Arc<Barrier>,
+    resume: Arc<Barrier>,
+}
+
+#[cfg(test)]
+struct TerminalReadyHook {
+    ready: Arc<Barrier>,
+    resume: Arc<Barrier>,
+}
+
+#[must_use]
+struct PopLiteEventTerminalFuture<F> {
+    inner: F,
+    _terminal: PopLiteEventTerminal,
+}
+
+#[must_use]
+struct PopLiteAcceptedFuture<F> {
+    inner: F,
+    _accepted: ObservationGuard,
+}
+
+impl<F> Future for PopLiteAcceptedFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: `inner` is structurally pinned with `self`; it is never moved
+        // after the wrapper is pinned and is dropped in place with the wrapper.
+        unsafe { self.as_mut().map_unchecked_mut(|future| &mut future.inner) }.poll(context)
+    }
+}
+
+impl<F> Future for PopLiteEventTerminalFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: `inner` is structurally pinned with `self`; it is never moved
+        // after the wrapper is pinned and is dropped in place with the wrapper.
+        let result = unsafe { self.as_mut().map_unchecked_mut(|future| &mut future.inner) }.poll(context);
+        #[cfg(test)]
+        if result.is_ready() {
+            if let Some(hook) = self._terminal.terminal_ready_hook.lock().take() {
+                hook.ready.wait();
+                hook.resume.wait();
+            }
+        }
+        result
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PopLiteDeferredResourceSnapshot {
+    pub(crate) admission: DeferredAdmissionSnapshot,
+    pub(crate) index: PopLiteIndexSnapshot,
+    pub(crate) event_reservations: LiteEventReservationSnapshot,
+    pub(crate) active_client_gates: usize,
+    pub(crate) prepared_registrations: usize,
+    pub(crate) pending_claims: usize,
+    pub(crate) accepted_resumes: usize,
+    pub(crate) resume_execution_count: usize,
+    pub(crate) resume_execution_bytes: usize,
+    pub(crate) pending_replays: usize,
+}
+
+#[must_use]
+pub(crate) struct PopLiteDeferredSweepBatch {
+    stats: DeferredExpiryBatchStats,
+    claims: Vec<ClaimedDeferred<ResumePopLite>>,
+}
+
+impl PopLiteDeferredSweepBatch {
+    fn from_transport(batch: DeferredExpiryBatch<ResumePopLite>) -> Self {
+        let stats = batch.stats();
+        let mut claims = batch.into_claims();
+        for claim in &mut claims {
+            drop(claim.resume_data_mut().take_index_lease());
+        }
+        Self { stats, claims }
+    }
+
+    pub(crate) const fn stats(&self) -> DeferredExpiryBatchStats {
+        self.stats
+    }
+
+    pub(crate) fn into_claims(self) -> Vec<ClaimedDeferred<ResumePopLite>> {
+        self.claims
+    }
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The RocketMQ Rust Authors
+// Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod long_polling_service;
-pub(crate) mod many_pull_request;
-pub(crate) mod notification_deferred;
-pub(crate) mod notify_message_arriving_listener;
-pub(crate) mod polling_header;
-pub(crate) mod polling_result;
-pub(crate) mod pop_deferred;
-pub(crate) mod pop_lite_deferred;
-pub(crate) mod pop_request;
-pub(crate) mod pull_deferred;
-pub(crate) mod pull_request;
+#[path = "tests/deadline.rs"]
+mod deadline;
+#[path = "tests/gate.rs"]
+mod gate;
+#[path = "tests/index.rs"]
+mod index;

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/tests/deadline.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/tests/deadline.rs
@@ -1,0 +1,70 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use crate::long_polling::pop_lite_deferred::deadline::PopLiteWaitDeadline;
+use crate::long_polling::pop_lite_deferred::deadline::PopLiteWaitDeadlineErrorKind;
+
+#[test]
+fn pop_lite_deferred_deadline_applies_30_second_business_cap() {
+    let monotonic = tokio::time::Instant::now();
+    let deadline = PopLiteWaitDeadline::checked(1_000, 90_000, 1_000, monotonic, Duration::from_secs(30))
+        .expect("30 second cap should be representable");
+
+    assert_eq!(deadline.effective_end_millis(), 31_000);
+    assert_eq!(deadline.protocol_millis(), 30_951);
+    assert_eq!(deadline.protocol_at(), monotonic + Duration::from_millis(29_951));
+}
+
+#[test]
+fn pop_lite_deferred_deadline_preserves_strict_50ms_boundary() {
+    let monotonic = tokio::time::Instant::now();
+    let equal = PopLiteWaitDeadline::checked(1_000, 1_000, 1_950, monotonic, Duration::from_secs(30))
+        .expect("equal cutoff remains live for one millisecond");
+    let expired = PopLiteWaitDeadline::checked(1_000, 1_000, 1_951, monotonic, Duration::from_secs(30))
+        .expect_err("first millisecond after cutoff is expired");
+
+    assert_eq!(equal.protocol_at(), monotonic + Duration::from_millis(1));
+    assert_eq!(expired.kind(), PopLiteWaitDeadlineErrorKind::AlreadyExpired);
+}
+
+#[test]
+fn pop_lite_deferred_deadline_rejects_signed_invalid_and_overflow_inputs() {
+    let now = tokio::time::Instant::now();
+    assert_eq!(
+        PopLiteWaitDeadline::checked(-1, 1, 0, now, Duration::from_secs(30))
+            .expect_err("negative born time")
+            .kind(),
+        PopLiteWaitDeadlineErrorKind::NegativeBornTime
+    );
+    assert_eq!(
+        PopLiteWaitDeadline::checked(0, 0, 0, now, Duration::from_secs(30))
+            .expect_err("zero poll time")
+            .kind(),
+        PopLiteWaitDeadlineErrorKind::NonPositivePollTime
+    );
+    assert_eq!(
+        PopLiteWaitDeadline::checked(i64::MAX, 1, 0, now, Duration::from_secs(30))
+            .expect_err("signed requested end overflow")
+            .kind(),
+        PopLiteWaitDeadlineErrorKind::RequestedEndOverflow
+    );
+    assert_eq!(
+        PopLiteWaitDeadline::checked(i64::MAX - 1, 1, u64::MAX - 5, now, Duration::from_secs(30),)
+            .expect_err("saturating admission cap still observes an expired requested end")
+            .kind(),
+        PopLiteWaitDeadlineErrorKind::AlreadyExpired
+    );
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/tests/gate.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/tests/gate.rs
@@ -1,0 +1,32 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+
+use crate::long_polling::pop_lite_deferred::gate::PopLiteEventGate;
+
+#[test]
+fn pop_lite_deferred_gate_is_single_flight_per_client_and_parallel_across_clients() {
+    let gate = PopLiteEventGate::default();
+    let client_a = CheetahString::from_static_str("client-a");
+    let client_b = CheetahString::from_static_str("client-b");
+    let first = gate.try_reserve(&client_a).expect("first client-a gate");
+    let other = gate.try_reserve(&client_b).expect("client-b gate is independent");
+
+    assert!(gate.try_reserve(&client_a).is_none());
+    assert_eq!(gate.active_count(), 2);
+    drop(first);
+    assert!(gate.try_reserve(&client_a).is_some());
+    drop(other);
+}

--- a/rocketmq-broker/src/long_polling/pop_lite_deferred/tests/index.rs
+++ b/rocketmq-broker/src/long_polling/pop_lite_deferred/tests/index.rs
@@ -1,0 +1,104 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+
+use crate::config::broker_config::BrokerConfig;
+use crate::long_polling::pop_lite_deferred::data::PopLiteDeferredPolicy;
+use crate::long_polling::pop_lite_deferred::deadline::PopLiteWaitDeadline;
+use crate::long_polling::pop_lite_deferred::index::PopLiteCriteriaIndex;
+use crate::long_polling::pop_lite_deferred::index::PopLiteIndexErrorKind;
+use crate::long_polling::pop_lite_deferred::index::PopLiteIndexLimits;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test limit is non-zero")
+}
+
+fn deadline(base: tokio::time::Instant, end_millis: i64) -> PopLiteWaitDeadline {
+    PopLiteWaitDeadline::checked(0, end_millis + 49, 0, base, Duration::from_secs(300)).expect("test deadline")
+}
+
+#[test]
+fn pop_lite_deferred_index_selects_earliest_expiry_then_oldest_sequence() {
+    let base = tokio::time::Instant::now();
+    let index = PopLiteCriteriaIndex::<u64>::new(PopLiteIndexLimits::new(nonzero(4), nonzero(2), nonzero(4)));
+    let client = CheetahString::from_static_str("client-a");
+    let late = index
+        .reserve(client.clone(), base)
+        .expect("late reservation")
+        .publish(1, deadline(base, 200));
+    let first_equal = index
+        .reserve(client.clone(), base)
+        .expect("first equal reservation")
+        .publish(2, deadline(base, 100));
+    let second_equal = index
+        .reserve(client.clone(), base)
+        .expect("second equal reservation")
+        .publish(3, deadline(base, 100));
+
+    let first = index.reserve_oldest(&client).expect("earliest candidate");
+    assert_eq!(first.id(), 2);
+    drop(first);
+    let first_again = index
+        .reserve_oldest(&client)
+        .expect("released candidate restores order");
+    assert_eq!(first_again.id(), 2);
+    drop((first_again, late, first_equal, second_equal));
+    assert_eq!(index.snapshot().live, 0);
+    assert_eq!(index.snapshot().clients, 0);
+}
+
+#[test]
+fn pop_lite_deferred_index_maps_global_client_and_per_client_capacities() {
+    let base = tokio::time::Instant::now();
+    let client_a = CheetahString::from_static_str("client-a");
+    let client_b = CheetahString::from_static_str("client-b");
+    let index = PopLiteCriteriaIndex::<u64>::new(PopLiteIndexLimits::new(nonzero(2), nonzero(1), nonzero(1)));
+    let first = index.reserve(client_a.clone(), base).expect("first reservation");
+
+    assert_eq!(
+        index.reserve(client_a, base).err().expect("per-client full").kind(),
+        PopLiteIndexErrorKind::PerClientCapacity
+    );
+    assert_eq!(
+        index
+            .reserve(client_b, base)
+            .err()
+            .expect("distinct client full")
+            .kind(),
+        PopLiteIndexErrorKind::ClientCapacity
+    );
+    drop(first);
+    assert_eq!(index.snapshot().reserved, 0);
+    assert_eq!(index.snapshot().clients, 0);
+}
+
+#[test]
+fn pop_lite_deferred_policy_preserves_legacy_capacity_mapping() {
+    let config = BrokerConfig {
+        max_pop_polling_size: 17,
+        pop_polling_map_size: 5,
+        pop_polling_size: 3,
+        ..Default::default()
+    };
+    let policy = PopLiteDeferredPolicy::from_config(&config).expect("positive legacy limits");
+
+    assert_eq!(policy.index_limits.max_entries.get(), 17);
+    assert_eq!(policy.index_limits.max_clients.get(), 5);
+    assert_eq!(policy.index_limits.max_entries_per_client.get(), 3);
+    assert_eq!(policy.max_age, Duration::from_secs(30));
+}

--- a/rocketmq-broker/src/long_polling/pop_request.rs
+++ b/rocketmq-broker/src/long_polling/pop_request.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
 
+use parking_lot::Mutex;
 use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::common::time_utils::current_millis;
@@ -26,6 +27,28 @@ use rocketmq_runtime::ResourcePermit;
 use rocketmq_store::ArcMessageFilter;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
+
+struct PopRequestPermit {
+    permit: Mutex<Option<ResourcePermit>>,
+}
+
+impl PopRequestPermit {
+    fn empty() -> Self {
+        Self {
+            permit: Mutex::new(None),
+        }
+    }
+
+    fn new(permit: ResourcePermit) -> Self {
+        Self {
+            permit: Mutex::new(Some(permit)),
+        }
+    }
+
+    fn release(&self) -> bool {
+        self.permit.lock().take().is_some()
+    }
+}
 
 pub struct PopRequest {
     remoting_command: RemotingCommand,
@@ -36,7 +59,7 @@ pub struct PopRequest {
     expired: u64,
     subscription_data: Option<SubscriptionData>,
     message_filter: Option<ArcMessageFilter>,
-    _resource_permit: Option<ResourcePermit>,
+    resource_permit: PopRequestPermit,
 }
 
 impl PopRequest {
@@ -76,7 +99,7 @@ impl PopRequest {
             expired,
             subscription_data,
             message_filter,
-            _resource_permit: None,
+            resource_permit: PopRequestPermit::empty(),
         }
     }
 
@@ -89,8 +112,13 @@ impl PopRequest {
         resource_permit: ResourcePermit,
     ) -> Self {
         let mut request = Self::new(remoting_command, ctx, expired, subscription_data, message_filter);
-        request._resource_permit = Some(resource_permit);
+        request.resource_permit = PopRequestPermit::new(resource_permit);
         request
+    }
+
+    /// Releases retained-request budget at the logical terminal, independently of node reclamation.
+    pub(crate) fn release_resource_permit(&self) -> bool {
+        self.resource_permit.release()
     }
 
     pub fn get_channel(&self) -> &Channel {

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -432,6 +432,47 @@ where
             map.insert(queue_id, offset);
         }
 
+        self.record_offset_change_with_locked();
+    }
+
+    /// Replaces a Store-rejected consumer offset only while it is still the value that was read.
+    ///
+    /// Unlike normal commits, a correction may move backwards. The expected-current comparison is
+    /// performed under the offset-table write lock so a concurrent forward commit cannot be
+    /// overwritten by a stale Store correction. The topic/group must still exist; `-1` denotes a
+    /// queue offset that was absent within that existing topic/group when the Store read began.
+    pub(crate) fn correct_offset_if_current(
+        &self,
+        group: &CheetahString,
+        topic: &CheetahString,
+        queue_id: i32,
+        expected_current: i64,
+        corrected_offset: i64,
+    ) -> bool {
+        if corrected_offset < 0 {
+            return false;
+        }
+
+        let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
+        let key = build_topic_group_key(topic, group);
+
+        {
+            let mut write_guard = self.consumer_offset_wrapper.offset_table.write();
+            let Some(map) = write_guard.get_mut(&key) else {
+                return false;
+            };
+            let current = map.get(&queue_id).copied().unwrap_or(-1);
+            if current != expected_current || current == corrected_offset {
+                return false;
+            }
+            map.insert(queue_id, corrected_offset);
+        }
+
+        self.record_offset_change_with_locked();
+        true
+    }
+
+    fn record_offset_change_with_locked(&self) {
         let committed_updates = self
             .consumer_offset_wrapper
             .version_change_counter
@@ -1468,6 +1509,148 @@ mod tests {
                 .load(Ordering::Acquire),
             after_first + 1
         );
+    }
+
+    #[test]
+    fn missing_and_cleaned_offsets_are_not_recreated_by_correction() {
+        let manager = new_manager();
+        let topic = CheetahString::from_static_str("topic-a");
+        let group = CheetahString::from_static_str("group-a");
+        let key = build_topic_group_key(&topic, &group);
+        let initial_change_count = manager
+            .consumer_offset_wrapper
+            .version_change_counter
+            .load(Ordering::Acquire);
+
+        assert!(!manager.correct_offset_if_current(&group, &topic, 0, -1, 2));
+        assert!(!manager.consumer_offset_wrapper.offset_table.read().contains_key(&key));
+        assert_eq!(
+            manager
+                .consumer_offset_wrapper
+                .version_change_counter
+                .load(Ordering::Acquire),
+            initial_change_count
+        );
+
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 100);
+        manager.clean_offset_by_group(&group);
+        let before_stale_correction = manager
+            .consumer_offset_wrapper
+            .version_change_counter
+            .load(Ordering::Acquire);
+
+        assert!(!manager.correct_offset_if_current(&group, &topic, 0, 100, 2));
+        assert!(!manager.consumer_offset_wrapper.offset_table.read().contains_key(&key));
+        assert_eq!(
+            manager
+                .consumer_offset_wrapper
+                .version_change_counter
+                .load(Ordering::Acquire),
+            before_stale_correction
+        );
+    }
+
+    #[test]
+    fn concurrent_forward_commit_makes_correction_stale_without_rollback_or_phantom() {
+        let manager = Arc::new(new_manager());
+        let topic = CheetahString::from_static_str("topic-a");
+        let group = CheetahString::from_static_str("group-a");
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 40);
+
+        let forward_commit = {
+            let manager = Arc::clone(&manager);
+            let barrier = Arc::new(Barrier::new(2));
+            let worker_barrier = Arc::clone(&barrier);
+            let worker = std::thread::spawn(move || {
+                worker_barrier.wait();
+                manager.commit_offset(
+                    "127.0.0.1:10911".into(),
+                    &CheetahString::from_static_str("group-a"),
+                    &CheetahString::from_static_str("topic-a"),
+                    0,
+                    41,
+                );
+                worker_barrier.wait();
+            });
+            (barrier, worker)
+        };
+
+        forward_commit.0.wait();
+        forward_commit.0.wait();
+        let before_stale_correction = manager
+            .consumer_offset_wrapper
+            .version_change_counter
+            .load(Ordering::Acquire);
+
+        assert!(!manager.correct_offset_if_current(&group, &topic, 0, 40, 2));
+        forward_commit
+            .1
+            .join()
+            .expect("forward offset commit worker should finish");
+
+        assert_eq!(manager.query_offset(&group, &topic, 0), 41);
+        assert_eq!(
+            manager.offset_table_snapshot(),
+            HashMap::from([(build_topic_group_key(&topic, &group), HashMap::from([(0, 41)]))])
+        );
+        assert_eq!(
+            manager
+                .consumer_offset_wrapper
+                .version_change_counter
+                .load(Ordering::Acquire),
+            before_stale_correction
+        );
+    }
+
+    #[test]
+    fn offset_correction_advances_version_exactly_once_and_false_paths_do_not() {
+        let mut manager = new_manager();
+        Arc::get_mut(&mut manager.broker_config)
+            .expect("test manager should own its broker config")
+            .consumer_offset_update_version_step = 1;
+        let topic = CheetahString::from_static_str("topic-a");
+        let group = CheetahString::from_static_str("group-a");
+
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 99);
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 100);
+        let before_stale_correction = manager
+            .consumer_offset_wrapper
+            .version_change_counter
+            .load(Ordering::Acquire);
+        let version_before_stale_correction = manager.data_version().counter();
+
+        assert!(!manager.correct_offset_if_current(&group, &topic, 0, 99, 2));
+        assert_eq!(manager.query_offset(&group, &topic, 0), 100);
+        assert_eq!(
+            manager
+                .consumer_offset_wrapper
+                .version_change_counter
+                .load(Ordering::Acquire),
+            before_stale_correction
+        );
+        assert_eq!(manager.data_version().counter(), version_before_stale_correction);
+
+        assert!(manager.correct_offset_if_current(&group, &topic, 0, 100, 2));
+        assert_eq!(manager.query_offset(&group, &topic, 0), 2);
+        assert_eq!(
+            manager
+                .consumer_offset_wrapper
+                .version_change_counter
+                .load(Ordering::Acquire),
+            before_stale_correction + 1
+        );
+        assert_eq!(manager.data_version().counter(), version_before_stale_correction + 1);
+
+        assert!(!manager.correct_offset_if_current(&group, &topic, 0, 2, 2));
+        assert!(!manager.correct_offset_if_current(&group, &topic, 0, 2, -1));
+        assert_eq!(
+            manager
+                .consumer_offset_wrapper
+                .version_change_counter
+                .load(Ordering::Acquire),
+            before_stale_correction + 1
+        );
+        assert_eq!(manager.data_version().counter(), version_before_stale_correction + 1);
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/notification_processor.rs
+++ b/rocketmq-broker/src/processor/notification_processor.rs
@@ -12,23 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod core;
+mod response;
+mod resume;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Weak;
 
 use crate::config::broker_config::BrokerConfig;
 use cheetah_string::CheetahString;
-use rand::RngExt;
 use rocketmq_model::common::config::TopicConfig;
-use rocketmq_model::common::constant::PermName;
 use rocketmq_model::common::filter::expression_type::ExpressionType;
 #[cfg(any(test, feature = "test-support"))]
 use rocketmq_model::common::hasher::string_hasher::JavaStringHasher;
-use rocketmq_model::common::FAQUrl;
-use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::filter::filter_api::FilterAPI;
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
-use rocketmq_protocol::protocol::header::notification_response_header::NotificationResponseHeader;
 use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
@@ -40,8 +39,6 @@ use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RequestProcessor;
 use tokio::sync::Mutex as AsyncMutex;
-use tracing::error;
-use tracing::warn;
 
 use crate::failover::escape_bridge::EscapeBridge;
 use crate::failover::escape_bridge::MessageStoreUnavailable;
@@ -530,164 +527,26 @@ where
         }
         let channel = ctx.channel();
 
-        let mut response = self
-            .context
-            .command_factory
-            .create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header::<NotificationRequestHeader>()?;
-
-        response.set_opaque_mut(request.opaque());
-
-        if !PermName::is_readable(self.context.policy.broker_permission) {
-            response.set_code_ref(ResponseCode::NoPermission);
-            response.set_remark_mut(format!(
-                "the broker[{}] peeking message is forbidden",
-                self.context.policy.broker_ip1
-            ));
-            return Ok(Some(response));
-        }
-
-        let topic_config = self
-            .context
-            .topic_config_manager
-            .select_topic_config(&request_header.topic);
-        if topic_config.is_none() {
-            error!(
-                "The topic {} not exist, consumer: {}",
-                request_header.topic,
-                channel.remote_address()
-            );
-            response.set_code_ref(ResponseCode::TopicNotExist);
-            response.set_remark_mut(format!(
-                "topic[{}] not exist, apply first please! {}",
-                request_header.topic,
-                FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
-            ));
-            return Ok(Some(response));
-        }
-        let topic_config = topic_config.unwrap();
-
-        if !PermName::is_readable(topic_config.perm) {
-            response.set_code_ref(ResponseCode::NoPermission);
-            response.set_remark_mut(format!(
-                "the topic[{}] peeking message is forbidden",
-                request_header.topic
-            ));
-            return Ok(Some(response));
-        }
-
-        if request_header.queue_id >= topic_config.get_read_queue_nums() as i32 {
-            let error_info = format!(
-                "queueId[{}] is illegal, topic:[{}] topicConfig.readQueueNums:[{}] consumer:[{:?}]",
-                request_header.queue_id,
-                request_header.topic,
-                topic_config.get_read_queue_nums(),
-                channel.remote_address()
-            );
-            warn!("{}", error_info);
-            response.set_code_ref(ResponseCode::InvalidParameter);
-            response.set_remark_mut(&error_info);
-            return Ok(Some(response));
-        }
-
-        let subscription_group_config = match self
-            .context
-            .subscription_group_lookup
-            .find_subscription_group_config(&request_header.consumer_group)
-        {
-            Some(config) => config,
-            None => {
-                response.set_code_ref(ResponseCode::SubscriptionGroupNotExist);
-                response.set_remark_mut(format!(
-                    "subscription group [{}] does not exist, {}",
-                    request_header.consumer_group,
-                    FAQUrl::suggest_todo(FAQUrl::SUBSCRIPTION_GROUP_NOT_EXIST)
-                ));
-                return Ok(Some(response));
-            }
+        let effective_peer = channel.remote_address();
+        let core = self
+            .execute_notification_core(&request_header, effective_peer, request.opaque(), None)
+            .await;
+        let core = match core {
+            core::NotificationCoreOutcome::Reply(response) => return Ok(Some(response)),
+            core::NotificationCoreOutcome::Ready(core) => core,
         };
-
-        if !subscription_group_config.consume_enable() {
-            response.set_code_ref(ResponseCode::NoPermission);
-            response.set_remark_mut(format!(
-                "subscription group no permission, {}",
-                request_header.consumer_group
-            ));
-            return Ok(Some(response));
-        }
-
-        let filter_contract = match build_notification_filter_contract(
-            self.context.policy.use_message_filter_for_notification,
-            &self.context.consumer_filter_manager,
-            &request_header,
-        ) {
-            Ok(contract) => contract,
-            Err(()) => {
-                warn!(
-                    "Parse the consumer's subscription[{:?}] failed, group: {}",
-                    request_header.exp, request_header.consumer_group
-                );
-                response.set_code_ref(ResponseCode::SubscriptionParseFailed);
-                response.set_remark_mut("parse the consumer's subscription failed");
-                return Ok(Some(response));
-            }
-        };
-
-        let random_q: i32 = rand::rng().random_range(0..100);
-        let mut has_msg = false;
-        let need_retry = random_q % 5 == 0;
-        let retry_policy = self.context.retry_policies.retry_policy(&request_header.consumer_group);
-
-        if need_retry {
-            for retry_topic in
-                retry_policy.read_topics(request_header.topic.as_str(), request_header.consumer_group.as_str())
-            {
-                let retry_topic = retry_topic.into();
-                has_msg = self
-                    .has_msg_from_topic_name(&retry_topic, random_q, &request_header, None)
-                    .await;
-                if has_msg {
-                    break;
-                }
-            }
-        }
-        if !has_msg {
-            if request_header.queue_id < 0 {
-                has_msg = self
-                    .has_msg_from_topic(Some(&topic_config), random_q, &request_header, filter_contract.as_ref())
-                    .await;
-            } else if let Some(topic_name) = topic_config.topic_name.as_ref() {
-                let queue_id = request_header.queue_id;
-                has_msg = self
-                    .has_msg_from_queue(topic_name, &request_header, queue_id, filter_contract.as_ref())
-                    .await;
-            }
-            // if it doesn't have message, fetch retry again
-            if !need_retry && !has_msg {
-                for retry_topic in
-                    retry_policy.read_topics(request_header.topic.as_str(), request_header.consumer_group.as_str())
-                {
-                    let retry_topic = retry_topic.into();
-                    has_msg = self
-                        .has_msg_from_topic_name(&retry_topic, random_q, &request_header, None)
-                        .await;
-                    if has_msg {
-                        break;
-                    }
-                }
-            }
-        }
 
         let mut polling_full = false;
-        if !has_msg {
+        if !core.has_msg {
             match self.pop_long_polling_service.polling(
                 ctx,
                 request,
                 PollingHeader::new_from_notification_request_header(&request_header),
-                filter_contract
+                core.filter_contract
                     .as_ref()
                     .map(|contract| contract.subscription_data.clone()),
-                filter_contract.map(|contract| contract.message_filter),
+                core.filter_contract.map(|contract| contract.message_filter),
             ) {
                 PollingResult::PollingSuc => return Ok(None),
                 PollingResult::PollingFull => polling_full = true,
@@ -695,12 +554,12 @@ where
             }
         }
 
-        Ok(Some(
-            self.context
-                .command_factory
-                .create_success_response_command_with_header(NotificationResponseHeader { has_msg, polling_full })
-                .set_opaque(request.opaque()),
-        ))
+        Ok(Some(response::compose_notification_response(
+            &self.context.command_factory,
+            core.has_msg,
+            polling_full,
+            request.opaque(),
+        )))
     }
 }
 

--- a/rocketmq-broker/src/processor/notification_processor/core.rs
+++ b/rocketmq-broker/src/processor/notification_processor/core.rs
@@ -1,0 +1,202 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+
+use rand::RngExt;
+use rocketmq_model::common::constant::PermName;
+use rocketmq_model::common::FAQUrl;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_store::BrokerReadWriteStore;
+use tracing::error;
+use tracing::warn;
+
+use super::build_notification_filter_contract;
+use super::NotificationFilterContract;
+use super::NotificationProcessor;
+
+pub(super) struct NotificationCoreReady {
+    pub(super) has_msg: bool,
+    pub(super) filter_contract: Option<NotificationFilterContract>,
+}
+
+pub(super) enum NotificationCoreOutcome {
+    Reply(RemotingCommand),
+    Ready(NotificationCoreReady),
+}
+
+impl<MS> NotificationProcessor<MS>
+where
+    MS: BrokerReadWriteStore,
+{
+    /// Executes validation and the one real store read without a Channel/context.
+    pub(super) async fn execute_notification_core(
+        &self,
+        request_header: &NotificationRequestHeader,
+        effective_peer: SocketAddr,
+        opaque: i32,
+        frozen_filter: Option<NotificationFilterContract>,
+    ) -> NotificationCoreOutcome {
+        let mut response = self
+            .context
+            .command_factory
+            .create_java_default_error_response_command();
+        response.set_opaque_mut(opaque);
+
+        if !PermName::is_readable(self.context.policy.broker_permission) {
+            response.set_code_ref(ResponseCode::NoPermission);
+            response.set_remark_mut(format!(
+                "the broker[{}] peeking message is forbidden",
+                self.context.policy.broker_ip1
+            ));
+            return NotificationCoreOutcome::Reply(response);
+        }
+
+        let Some(topic_config) = self
+            .context
+            .topic_config_manager
+            .select_topic_config(&request_header.topic)
+        else {
+            error!(
+                "The topic {} not exist, consumer: {}",
+                request_header.topic, effective_peer
+            );
+            response.set_code_ref(ResponseCode::TopicNotExist);
+            response.set_remark_mut(format!(
+                "topic[{}] not exist, apply first please! {}",
+                request_header.topic,
+                FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
+            ));
+            return NotificationCoreOutcome::Reply(response);
+        };
+
+        if !PermName::is_readable(topic_config.perm) {
+            response.set_code_ref(ResponseCode::NoPermission);
+            response.set_remark_mut(format!(
+                "the topic[{}] peeking message is forbidden",
+                request_header.topic
+            ));
+            return NotificationCoreOutcome::Reply(response);
+        }
+
+        if request_header.queue_id >= topic_config.get_read_queue_nums() as i32 {
+            let error_info = format!(
+                "queueId[{}] is illegal, topic:[{}] topicConfig.readQueueNums:[{}] consumer:[{}]",
+                request_header.queue_id,
+                request_header.topic,
+                topic_config.get_read_queue_nums(),
+                effective_peer
+            );
+            warn!("{}", error_info);
+            response.set_code_ref(ResponseCode::InvalidParameter);
+            response.set_remark_mut(&error_info);
+            return NotificationCoreOutcome::Reply(response);
+        }
+
+        let Some(subscription_group_config) = self
+            .context
+            .subscription_group_lookup
+            .find_subscription_group_config(&request_header.consumer_group)
+        else {
+            response.set_code_ref(ResponseCode::SubscriptionGroupNotExist);
+            response.set_remark_mut(format!(
+                "subscription group [{}] does not exist, {}",
+                request_header.consumer_group,
+                FAQUrl::suggest_todo(FAQUrl::SUBSCRIPTION_GROUP_NOT_EXIST)
+            ));
+            return NotificationCoreOutcome::Reply(response);
+        };
+
+        if !subscription_group_config.consume_enable() {
+            response.set_code_ref(ResponseCode::NoPermission);
+            response.set_remark_mut(format!(
+                "subscription group no permission, {}",
+                request_header.consumer_group
+            ));
+            return NotificationCoreOutcome::Reply(response);
+        }
+
+        let filter_contract = match frozen_filter {
+            Some(contract) => Some(contract),
+            None => match build_notification_filter_contract(
+                self.context.policy.use_message_filter_for_notification,
+                &self.context.consumer_filter_manager,
+                request_header,
+            ) {
+                Ok(contract) => contract,
+                Err(()) => {
+                    warn!(
+                        "Parse the consumer's subscription[{:?}] failed, group: {}",
+                        request_header.exp, request_header.consumer_group
+                    );
+                    response.set_code_ref(ResponseCode::SubscriptionParseFailed);
+                    response.set_remark_mut("parse the consumer's subscription failed");
+                    return NotificationCoreOutcome::Reply(response);
+                }
+            },
+        };
+
+        let random_q: i32 = rand::rng().random_range(0..100);
+        let need_retry = random_q % 5 == 0;
+        let retry_policy = self.context.retry_policies.retry_policy(&request_header.consumer_group);
+        let mut has_msg = false;
+        if need_retry {
+            for retry_topic in
+                retry_policy.read_topics(request_header.topic.as_str(), request_header.consumer_group.as_str())
+            {
+                has_msg = self
+                    .has_msg_from_topic_name(&retry_topic.into(), random_q, request_header, None)
+                    .await;
+                if has_msg {
+                    break;
+                }
+            }
+        }
+        if !has_msg {
+            if request_header.queue_id < 0 {
+                has_msg = self
+                    .has_msg_from_topic(Some(&topic_config), random_q, request_header, filter_contract.as_ref())
+                    .await;
+            } else if let Some(topic_name) = topic_config.topic_name.as_ref() {
+                has_msg = self
+                    .has_msg_from_queue(
+                        topic_name,
+                        request_header,
+                        request_header.queue_id,
+                        filter_contract.as_ref(),
+                    )
+                    .await;
+            }
+            if !need_retry && !has_msg {
+                for retry_topic in
+                    retry_policy.read_topics(request_header.topic.as_str(), request_header.consumer_group.as_str())
+                {
+                    has_msg = self
+                        .has_msg_from_topic_name(&retry_topic.into(), random_q, request_header, None)
+                        .await;
+                    if has_msg {
+                        break;
+                    }
+                }
+            }
+        }
+
+        NotificationCoreOutcome::Ready(NotificationCoreReady {
+            has_msg,
+            filter_contract,
+        })
+    }
+}

--- a/rocketmq-broker/src/processor/notification_processor/response.rs
+++ b/rocketmq-broker/src/processor/notification_processor/response.rs
@@ -1,0 +1,58 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_protocol::protocol::header::notification_response_header::NotificationResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+
+pub(super) fn compose_notification_response(
+    command_factory: &RemotingCommandFactory,
+    has_msg: bool,
+    polling_full: bool,
+    opaque: i32,
+) -> RemotingCommand {
+    command_factory
+        .create_success_response_command_with_header(NotificationResponseHeader { has_msg, polling_full })
+        .set_opaque(opaque)
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_protocol::protocol::header::notification_response_header::NotificationResponseHeader;
+    use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+
+    use super::*;
+
+    #[test]
+    fn notification_v1_wake_compatibility_response_composer_preserves_opaque_and_header() {
+        let mut response = compose_notification_response(&application_remoting_command_factory(), false, false, 9833);
+        response.make_custom_header_to_net();
+        let header = response
+            .decode_command_custom_header::<NotificationResponseHeader>()
+            .expect("Notification response header");
+
+        assert_eq!(response.opaque(), 9833);
+        assert!(!header.has_msg);
+        assert!(!header.polling_full);
+        assert!(response.body().is_none());
+
+        let mut full = compose_notification_response(&application_remoting_command_factory(), false, true, 9834);
+        full.make_custom_header_to_net();
+        let full_header = full
+            .decode_command_custom_header::<NotificationResponseHeader>()
+            .expect("Notification polling-full header");
+        assert!(!full_header.has_msg);
+        assert!(full_header.polling_full);
+    }
+}

--- a/rocketmq-broker/src/processor/notification_processor/resume.rs
+++ b/rocketmq-broker/src/processor/notification_processor/resume.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_store::BrokerReadWriteStore;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::ResponsePlan;
+
+use super::core::NotificationCoreOutcome;
+use super::NotificationFilterContract;
+use super::NotificationProcessor;
+use crate::long_polling::notification_deferred::service::ResumeNotification;
+
+#[cfg(test)]
+mod tests;
+
+impl<MS> NotificationProcessor<MS>
+where
+    MS: BrokerReadWriteStore,
+{
+    /// Performs one real reread after a canonical claim; the request is never re-registered.
+    pub(crate) async fn resume_notification(
+        &self,
+        resume: ResumeNotification,
+        reason: DeferredWakeReason,
+    ) -> rocketmq_error::RocketMQResult<ResponsePlan> {
+        let command = self.resume_notification_command(resume, reason).await?;
+        ResponsePlan::command(command)
+            .map_err(|_| rocketmq_error::RocketMQError::invariant_violated("invalid Notification response plan"))
+    }
+
+    async fn resume_notification_command(
+        &self,
+        resume: ResumeNotification,
+        reason: DeferredWakeReason,
+    ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+        match reason {
+            DeferredWakeReason::MessageArrived | DeferredWakeReason::Timeout | DeferredWakeReason::ForcedRefresh => {}
+        }
+        let (request, subscription, filter) = resume.into_execution_parts();
+        let frozen_filter = match (subscription, filter) {
+            (Some(subscription_data), Some(message_filter)) => Some(NotificationFilterContract {
+                subscription_data,
+                message_filter,
+            }),
+            _ => None,
+        };
+        let (header, effective_peer) = request.into_parts();
+        let outcome = self
+            .execute_notification_core(&header, effective_peer, 0, frozen_filter)
+            .await;
+        match outcome {
+            NotificationCoreOutcome::Reply(command) => Ok(command),
+            NotificationCoreOutcome::Ready(ready) => Ok(super::response::compose_notification_response(
+                &self.context.command_factory,
+                ready.has_msg,
+                false,
+                0,
+            )),
+        }
+    }
+}

--- a/rocketmq-broker/src/processor/notification_processor/resume/tests.rs
+++ b/rocketmq-broker/src/processor/notification_processor/resume/tests.rs
@@ -1,0 +1,470 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Weak;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_model::common::config::TopicConfig;
+use rocketmq_model::common::constant::PermName;
+use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_model::common::message::MessageTrait;
+use rocketmq_model::common::FAQUrl;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::common::message::message_decoder::message_properties_to_string;
+use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
+use rocketmq_protocol::protocol::header::notification_response_header::NotificationResponseHeader;
+use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_store::MessageStoreConfig;
+use rocketmq_store::PutMessageStatus;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+
+use super::super::core::NotificationCoreOutcome;
+use super::super::NotificationPolicy;
+use super::super::NotificationPopOffsetCapability;
+use super::super::NotificationProcessor;
+use super::super::NotificationProcessorContext;
+use super::super::NotificationStoreCapability;
+use crate::broker_runtime::BrokerMessageStore;
+use crate::broker_runtime::BrokerRuntime;
+use crate::failover::escape_bridge::EscapeBridge;
+use crate::long_polling::long_polling_service::pop_long_polling_service::PopLongPollingPolicy;
+use crate::long_polling::long_polling_service::pop_long_polling_service::PopLongPollingServiceContext;
+use crate::long_polling::notification_deferred::deadline::NotificationWaitDeadline;
+use crate::long_polling::notification_deferred::index::NotificationMatchCriteria;
+use crate::long_polling::notification_deferred::service::NotificationRequestData;
+use crate::long_polling::notification_deferred::service::ResumeNotification;
+
+fn temp_test_root(label: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "rocketmq-rust-notification-resume-{}-{label}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path).expect("create Notification resume test root");
+    path
+}
+
+fn available_ha_port() -> usize {
+    std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .expect("reserve an ephemeral Notification resume HA port")
+        .local_addr()
+        .expect("read the ephemeral Notification resume HA port")
+        .port() as usize
+}
+
+async fn runtime(label: &str) -> (BrokerRuntime, PathBuf) {
+    let root = temp_test_root(label);
+    let broker_config = Arc::new(crate::config::broker_config::BrokerConfig {
+        store_path_root_dir: root.to_string_lossy().into_owned().into(),
+        auth_config_path: root.join("auth.json").to_string_lossy().into_owned().into(),
+        auto_create_subscription_group: false,
+        ..Default::default()
+    });
+    let message_store_config = Arc::new(MessageStoreConfig {
+        store_path_root_dir: root.to_string_lossy().into_owned().into(),
+        ha_listen_port: available_ha_port(),
+        ..MessageStoreConfig::default()
+    });
+    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    runtime
+        .initialize()
+        .await
+        .expect("initialize Notification resume runtime");
+    runtime.seed_pop_topic_and_group_for_test("topic-a", "group-a");
+    runtime
+        .start_message_store_for_test()
+        .await
+        .expect("start Notification resume message store");
+    (runtime, root)
+}
+
+fn processor(
+    runtime: &mut BrokerRuntime,
+) -> (
+    Arc<NotificationProcessor<BrokerMessageStore>>,
+    Arc<EscapeBridge<BrokerMessageStore>>,
+) {
+    let inner = runtime.runtime_state_mut();
+    let policy = NotificationPolicy::from_config(&inner.broker_config());
+    processor_with_policy(inner, policy)
+}
+
+fn processor_with_policy(
+    inner: &mut crate::broker_runtime::BrokerRuntimeState<BrokerMessageStore>,
+    policy: NotificationPolicy,
+) -> (
+    Arc<NotificationProcessor<BrokerMessageStore>>,
+    Arc<EscapeBridge<BrokerMessageStore>>,
+) {
+    let long_polling_policy = PopLongPollingPolicy::from_config(&inner.broker_config());
+    let topic_config_manager = inner.topic_config_manager_handle();
+    let subscription_group_lookup = inner.subscription_group_manager().config_lookup();
+    let consumer_filter_manager = Arc::new(inner.consumer_filter_manager().clone());
+    let long_polling = PopLongPollingServiceContext::new(
+        long_polling_policy,
+        Arc::clone(&topic_config_manager),
+        subscription_group_lookup.clone(),
+        inner.broker_service_context(),
+    );
+    let escape_bridge = inner.escape_bridge();
+    let processor = NotificationProcessor::new(NotificationProcessorContext::new(
+        policy,
+        inner.pop_policy_state(),
+        topic_config_manager,
+        subscription_group_lookup,
+        consumer_filter_manager,
+        inner.consumer_order_info_manager_handle(),
+        inner.consumer_offset_manager_handle().query_capability(),
+        NotificationStoreCapability::new(&escape_bridge),
+        NotificationPopOffsetCapability {
+            merge_service: Weak::new(),
+        },
+        long_polling,
+    ));
+    (processor, escape_bridge)
+}
+
+fn core_header(topic: &str, group: &str, queue_id: i32) -> NotificationRequestHeader {
+    let now = i64::try_from(current_millis()).expect("current wall time fits Notification protocol");
+    NotificationRequestHeader {
+        consumer_group: CheetahString::from_string(group.to_owned()),
+        topic: CheetahString::from_string(topic.to_owned()),
+        queue_id,
+        poll_time: 0,
+        born_time: now,
+        order: false,
+        attempt_id: None,
+        exp_type: None,
+        exp: None,
+        is_lite_consumer: false,
+        client_id: None,
+        topic_request_header: None,
+    }
+}
+
+fn resume_request() -> ResumeNotification {
+    let now = i64::try_from(current_millis()).expect("current wall time fits Notification protocol");
+    let header = NotificationRequestHeader {
+        consumer_group: CheetahString::from_static_str("group-a"),
+        topic: CheetahString::from_static_str("topic-a"),
+        queue_id: 0,
+        poll_time: 60_000,
+        born_time: now,
+        order: false,
+        attempt_id: None,
+        exp_type: None,
+        exp: None,
+        is_lite_consumer: false,
+        client_id: None,
+        topic_request_header: None,
+    };
+    let deadline = NotificationWaitDeadline::checked(now, 60_000, now, tokio::time::Instant::now())
+        .expect("live Notification test deadline");
+    ResumeNotification::for_test(
+        NotificationRequestData::new(header, "127.0.0.1:19001".parse().expect("test peer")),
+        Arc::new(NotificationMatchCriteria::new(None, None)),
+        deadline,
+    )
+}
+
+fn stored_message() -> MessageExtBrokerInner {
+    stored_message_for("topic-a")
+}
+
+fn stored_message_for(topic: &str) -> MessageExtBrokerInner {
+    let mut message = MessageExtBrokerInner::default();
+    message.set_topic(CheetahString::from_string(topic.to_owned()));
+    message.message_ext_inner.set_queue_id(0);
+    message.set_body(Bytes::from_static(b"deferred-notification-message"));
+    message.set_wait_store_msg_ok(false);
+    message.properties_string = message_properties_to_string(message.get_properties());
+    message
+}
+
+#[tokio::test]
+async fn notification_core_finds_message_from_configured_retry_topic() {
+    let (mut runtime, root) = runtime("retry-found").await;
+    let (processor, escape_bridge) = processor(&mut runtime);
+    let retry_topic = processor
+        .context
+        .retry_policies
+        .retry_policy(&CheetahString::from_static_str("group-a"))
+        .read_topics("topic-a", "group-a")
+        .into_iter()
+        .next()
+        .expect("Notification retry policy has a readable topic");
+    let _ = runtime
+        .runtime_state_mut()
+        .topic_config_manager_handle()
+        .update_topic_config(TopicConfig::with_queues(retry_topic.clone(), 1, 1), 0);
+    let put = escape_bridge
+        .put_message_to_local_store(stored_message_for(&retry_topic))
+        .await
+        .expect("append Notification retry message");
+    assert_eq!(put.put_message_status(), PutMessageStatus::PutOk);
+    runtime.reput_message_store_once_for_test().await;
+
+    let peer = "127.0.0.1:19003".parse().expect("Notification retry peer");
+    let ready = match processor
+        .execute_notification_core(&core_header("topic-a", "group-a", 0), peer, 20_005, None)
+        .await
+    {
+        NotificationCoreOutcome::Ready(ready) => ready,
+        NotificationCoreOutcome::Reply(response) => {
+            panic!("retry-store Notification core failed with code {}", response.code())
+        }
+    };
+    assert!(ready.has_msg);
+
+    drop((processor, escape_bridge));
+    runtime.shutdown_message_store_for_test().await;
+    let _ = std::fs::remove_dir_all(root);
+}
+
+fn assert_notification_header(
+    mut command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+    has_msg: bool,
+) {
+    assert_eq!(command.code(), ResponseCode::Success as i32);
+    assert!(command.body().is_none());
+    command.make_custom_header_to_net();
+    let header = command
+        .decode_command_custom_header::<NotificationResponseHeader>()
+        .expect("Notification response header");
+    assert_eq!(header.has_msg, has_msg);
+    assert!(!header.polling_full);
+}
+
+#[tokio::test]
+async fn notification_deferred_actual_store_reread_builds_empty_then_found_response_headers() {
+    let (mut runtime, root) = runtime("empty-then-found").await;
+    let (processor, escape_bridge) = processor(&mut runtime);
+
+    let empty = processor
+        .resume_notification_command(resume_request(), DeferredWakeReason::Timeout)
+        .await
+        .expect("empty Notification resume reread");
+    assert_notification_header(empty, false);
+
+    let put = escape_bridge
+        .put_message_to_local_store(stored_message())
+        .await
+        .expect("append Notification resume message");
+    assert_eq!(put.put_message_status(), PutMessageStatus::PutOk);
+    runtime.reput_message_store_once_for_test().await;
+
+    let found = processor
+        .resume_notification_command(resume_request(), DeferredWakeReason::MessageArrived)
+        .await
+        .expect("found Notification resume reread");
+    assert_notification_header(found, true);
+
+    drop((processor, escape_bridge));
+    runtime.shutdown_message_store_for_test().await;
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn notification_core_characterizes_permission_topic_group_queue_filter_and_order() {
+    let (mut runtime, root) = runtime("core-characterization").await;
+    let peer = "127.0.0.1:19002".parse().expect("Notification core peer");
+
+    let mut denied_policy = NotificationPolicy::from_config(&runtime.runtime_state_mut().broker_config());
+    denied_policy.broker_permission = 0;
+    denied_policy.broker_ip1 = CheetahString::from_static_str("127.0.0.1");
+    let (denied, denied_bridge) = processor_with_policy(runtime.runtime_state_mut(), denied_policy);
+    let denied_response = match denied
+        .execute_notification_core(&core_header("topic-a", "group-a", 0), peer, 20_001, None)
+        .await
+    {
+        NotificationCoreOutcome::Reply(response) => response,
+        NotificationCoreOutcome::Ready(_) => panic!("broker permission denial must be terminal"),
+    };
+    assert_eq!(denied_response.code(), ResponseCode::NoPermission as i32);
+    assert_eq!(denied_response.opaque(), 20_001);
+    assert_eq!(
+        denied_response.remark().map(CheetahString::as_str),
+        Some("the broker[127.0.0.1] peeking message is forbidden")
+    );
+    assert!(denied_response.body().is_none());
+    drop((denied, denied_bridge));
+
+    let (processor, escape_bridge) = processor(&mut runtime);
+    let cases = [
+        (
+            core_header("missing-topic", "group-a", 0),
+            ResponseCode::TopicNotExist,
+            format!(
+                "topic[missing-topic] not exist, apply first please! {}",
+                FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
+            ),
+        ),
+        (
+            core_header("topic-a", "missing-group", 0),
+            ResponseCode::SubscriptionGroupNotExist,
+            format!(
+                "subscription group [missing-group] does not exist, {}",
+                FAQUrl::suggest_todo(FAQUrl::SUBSCRIPTION_GROUP_NOT_EXIST)
+            ),
+        ),
+        (
+            core_header("topic-a", "group-a", 99),
+            ResponseCode::InvalidParameter,
+            format!("queueId[99] is illegal, topic:[topic-a] topicConfig.readQueueNums:[1] consumer:[{peer}]"),
+        ),
+    ];
+    for (header, expected, expected_remark) in cases {
+        let response = match processor.execute_notification_core(&header, peer, 20_002, None).await {
+            NotificationCoreOutcome::Reply(response) => response,
+            NotificationCoreOutcome::Ready(_) => panic!("Notification validation failure must be terminal"),
+        };
+        assert_eq!(response.code(), expected as i32);
+        assert_eq!(response.opaque(), 20_002);
+        assert_eq!(
+            response.remark().map(CheetahString::as_str),
+            Some(expected_remark.as_str())
+        );
+        assert!(response.body().is_none());
+    }
+
+    let _ = runtime
+        .runtime_state_mut()
+        .topic_config_manager_handle()
+        .update_topic_config(TopicConfig::with_perm("topic-a", 1, 1, PermName::PERM_WRITE), 0);
+    let topic_denied = match processor
+        .execute_notification_core(&core_header("topic-a", "group-a", 0), peer, 20_003, None)
+        .await
+    {
+        NotificationCoreOutcome::Reply(response) => response,
+        NotificationCoreOutcome::Ready(_) => panic!("unreadable topic must be terminal"),
+    };
+    assert_eq!(topic_denied.code(), ResponseCode::NoPermission as i32);
+    assert_eq!(topic_denied.opaque(), 20_003);
+    assert_eq!(
+        topic_denied.remark().map(CheetahString::as_str),
+        Some("the topic[topic-a] peeking message is forbidden")
+    );
+    assert!(topic_denied.body().is_none());
+    let _ = runtime
+        .runtime_state_mut()
+        .topic_config_manager_handle()
+        .update_topic_config(TopicConfig::with_queues("topic-a", 1, 1), 0);
+
+    let mut disabled_group = SubscriptionGroupConfig::new(CheetahString::from_static_str("group-a"));
+    disabled_group.set_consume_enable(false);
+    assert!(runtime
+        .runtime_state_mut()
+        .subscription_group_manager()
+        .update_subscription_group_config(&mut disabled_group));
+    let group_denied = match processor
+        .execute_notification_core(&core_header("topic-a", "group-a", 0), peer, 20_004, None)
+        .await
+    {
+        NotificationCoreOutcome::Reply(response) => response,
+        NotificationCoreOutcome::Ready(_) => panic!("disabled group must be terminal"),
+    };
+    assert_eq!(group_denied.code(), ResponseCode::NoPermission as i32);
+    assert_eq!(group_denied.opaque(), 20_004);
+    assert_eq!(
+        group_denied.remark().map(CheetahString::as_str),
+        Some("subscription group no permission, group-a")
+    );
+    assert!(group_denied.body().is_none());
+    disabled_group.set_consume_enable(true);
+    assert!(runtime
+        .runtime_state_mut()
+        .subscription_group_manager()
+        .update_subscription_group_config(&mut disabled_group));
+
+    let put = escape_bridge
+        .put_message_to_local_store(stored_message())
+        .await
+        .expect("append ordered Notification core message");
+    assert_eq!(put.put_message_status(), PutMessageStatus::PutOk);
+    runtime.reput_message_store_once_for_test().await;
+    let topic = CheetahString::from_static_str("topic-a");
+    let group = CheetahString::from_static_str("group-a");
+    let attempt = CheetahString::from_static_str("attempt-1");
+    let mut order_info = String::new();
+    assert!(runtime.runtime_state_mut().consumer_order_info_manager().update(
+        attempt.clone(),
+        false,
+        &topic,
+        &group,
+        0,
+        current_millis(),
+        60_000,
+        vec![0],
+        &mut order_info,
+    ));
+    assert!(!order_info.is_empty());
+
+    let mut ordered = core_header("topic-a", "group-a", 0);
+    ordered.order = true;
+    let ready = match processor.execute_notification_core(&ordered, peer, 20_005, None).await {
+        NotificationCoreOutcome::Ready(ready) => ready,
+        NotificationCoreOutcome::Reply(response) => {
+            panic!("unblocked order request failed with code {}", response.code())
+        }
+    };
+    assert!(ready.has_msg, "a missing attempt id intentionally skips order blocking");
+
+    ordered.attempt_id = Some(attempt);
+    let same_attempt = match processor.execute_notification_core(&ordered, peer, 20_006, None).await {
+        NotificationCoreOutcome::Ready(ready) => ready,
+        NotificationCoreOutcome::Reply(response) => {
+            panic!("same-attempt order request failed with code {}", response.code())
+        }
+    };
+    assert!(same_attempt.has_msg, "the active order attempt remains readable");
+
+    ordered.attempt_id = Some(CheetahString::from_static_str("attempt-2"));
+    let blocked_attempt = match processor.execute_notification_core(&ordered, peer, 20_007, None).await {
+        NotificationCoreOutcome::Ready(ready) => ready,
+        NotificationCoreOutcome::Reply(response) => {
+            panic!("blocked order request failed with code {}", response.code())
+        }
+    };
+    assert!(!blocked_attempt.has_msg, "a competing order attempt is blocked");
+
+    drop((processor, escape_bridge));
+    let mut filter_policy = NotificationPolicy::from_config(&runtime.runtime_state_mut().broker_config());
+    filter_policy.use_message_filter_for_notification = true;
+    let (filtered, filtered_bridge) = processor_with_policy(runtime.runtime_state_mut(), filter_policy);
+    let mut invalid_filter = core_header("topic-a", "group-a", 0);
+    invalid_filter.exp_type = Some(CheetahString::from_static_str("TAG"));
+    invalid_filter.exp = Some(CheetahString::from_static_str("||"));
+    let response = match filtered
+        .execute_notification_core(&invalid_filter, peer, 20_008, None)
+        .await
+    {
+        NotificationCoreOutcome::Reply(response) => response,
+        NotificationCoreOutcome::Ready(_) => panic!("enabled invalid Notification filter must be terminal"),
+    };
+    assert_eq!(response.code(), ResponseCode::SubscriptionParseFailed as i32);
+    assert_eq!(response.opaque(), 20_008);
+    assert_eq!(
+        response.remark().map(CheetahString::as_str),
+        Some("parse the consumer's subscription failed")
+    );
+    assert!(response.body().is_none());
+    drop((filtered, filtered_bridge));
+    runtime.shutdown_message_store_for_test().await;
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -22,11 +22,9 @@ use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use rocketmq_model::common::attribute::topic_message_type::TopicMessageType;
 use rocketmq_model::common::constant::PermName;
-use rocketmq_model::common::key_builder::POP_ORDER_REVIVE_QUEUE;
 use rocketmq_model::common::message::MessageConst;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
-use rocketmq_protocol::protocol::header::pop_lite_message_response_header::PopLiteMessageResponseHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
@@ -52,6 +50,10 @@ use crate::offset::manager::consumer_offset_manager::ConsumerOffsetManager;
 use crate::processor::pop_message_processor::QueueLockManager;
 use crate::subscription::manager::subscription_group_manager::SubscriptionGroupConfigLookup;
 use crate::topic::manager::topic_config_manager::TopicConfigManager;
+
+pub(crate) mod core;
+pub(crate) mod response;
+mod resume;
 
 #[derive(Clone)]
 pub(crate) struct PopLiteMessagePolicy {
@@ -105,6 +107,42 @@ impl<MS: BrokerReadWriteStore> PopLiteOffsetCapability<MS> {
         }
     }
 
+    fn correct_offset_if_current(
+        &self,
+        group: &CheetahString,
+        topic: &CheetahString,
+        expected_current: i64,
+        corrected_offset: i64,
+    ) -> bool {
+        self.manager.upgrade().is_some_and(|manager| {
+            manager.correct_offset_if_current(group, topic, 0, expected_current, corrected_offset)
+        })
+    }
+
+    fn apply_store_offset_correction(
+        &self,
+        group: &CheetahString,
+        topic: &CheetahString,
+        expected_current: i64,
+        corrected_offset: i64,
+    ) -> Option<i64> {
+        let manager = self.manager.upgrade()?;
+        if expected_current == -1 {
+            manager.commit_offset(
+                CheetahString::from_static_str("PopLiteInitialOffset"),
+                group,
+                topic,
+                0,
+                corrected_offset,
+            );
+            let effective = manager.query_offset(group, topic, 0);
+            return (effective >= 0).then_some(effective);
+        }
+        manager
+            .correct_offset_if_current(group, topic, 0, expected_current, corrected_offset)
+            .then_some(corrected_offset)
+    }
+
     pub(crate) fn assign_reset_offset(&self, topic: &CheetahString, group: &CheetahString, offset: i64) -> bool {
         let Some(manager) = self.manager.upgrade() else {
             return false;
@@ -116,13 +154,29 @@ impl<MS: BrokerReadWriteStore> PopLiteOffsetCapability<MS> {
 
 pub(crate) struct PopLiteMessageStoreCapability<MS: BrokerReadWriteStore> {
     escape_bridge: Weak<EscapeBridge<MS>>,
+    #[cfg(test)]
+    store_await_hook: parking_lot::Mutex<Option<PopLiteStoreAwaitHook>>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct PopLiteStoreAwaitHook {
+    entered: Arc<tokio::sync::Barrier>,
+    release: Arc<tokio::sync::Barrier>,
 }
 
 impl<MS: BrokerReadWriteStore> PopLiteMessageStoreCapability<MS> {
     pub(crate) fn new(escape_bridge: &Arc<EscapeBridge<MS>>) -> Self {
         Self {
             escape_bridge: Arc::downgrade(escape_bridge),
+            #[cfg(test)]
+            store_await_hook: parking_lot::Mutex::new(None),
         }
+    }
+
+    #[cfg(test)]
+    fn set_store_await_hook(&self, entered: Arc<tokio::sync::Barrier>, release: Arc<tokio::sync::Barrier>) {
+        *self.store_await_hook.lock() = Some(PopLiteStoreAwaitHook { entered, release });
     }
 
     fn is_available(&self) -> bool {
@@ -136,6 +190,13 @@ impl<MS: BrokerReadWriteStore> PopLiteMessageStoreCapability<MS> {
         offset: i64,
         batch_size: i32,
     ) -> Option<GetMessageResult> {
+        #[cfg(test)]
+        let store_await_hook = self.store_await_hook.lock().clone();
+        #[cfg(test)]
+        if let Some(hook) = store_await_hook {
+            hook.entered.wait().await;
+            hook.release.wait().await;
+        }
         self.escape_bridge
             .upgrade()?
             .get_message_from_local_store(group, topic, 0, offset, batch_size)
@@ -461,20 +522,15 @@ impl<MS: BrokerReadWriteStore> PopLiteMessageProcessor<MS> {
                 &request_header.consumer_group,
                 0,
             ));
-            if !self
-                .context
-                .queue_lock_manager
-                .try_lock_with_key(lock_key.clone())
-                .await
-            {
+            let Some(queue_lock) = self.context.queue_lock_manager.try_acquire_with_key(lock_key).await else {
                 requeue_events.insert(lmq_name);
                 continue;
-            }
+            };
 
             let result = self
                 .pop_from_lmq(request_header, &attempt_id, &lmq_name, remaining)
                 .await;
-            self.context.queue_lock_manager.unlock_with_key(lock_key).await;
+            drop(queue_lock);
 
             match result {
                 PopLmqResult::Fetched {
@@ -532,9 +588,15 @@ impl<MS: BrokerReadWriteStore> PopLiteMessageProcessor<MS> {
             return PopLmqResult::Requeue;
         }
 
-        let consume_offset = self.get_pop_offset(&request_header.consumer_group, lmq_name);
+        let (consume_offset, expected_current_offset) = self.get_pop_offset(&request_header.consumer_group, lmq_name);
         let Some(get_message_result) = self
-            .get_message(&request_header.consumer_group, lmq_name, consume_offset, remaining)
+            .get_message(
+                &request_header.consumer_group,
+                lmq_name,
+                consume_offset,
+                expected_current_offset,
+                remaining,
+            )
             .await
         else {
             return PopLmqResult::Skip;
@@ -565,20 +627,27 @@ impl<MS: BrokerReadWriteStore> PopLiteMessageProcessor<MS> {
         }
     }
 
-    fn get_pop_offset(&self, group: &CheetahString, lmq_name: &CheetahString) -> i64 {
-        let mut offset = self.context.consumer_offset.query_offset(group, lmq_name).max(0);
-        if let Some(reset_offset) = self
+    fn get_pop_offset(&self, group: &CheetahString, lmq_name: &CheetahString) -> (i64, i64) {
+        let reset_offset = self
             .context
             .consumer_offset
-            .query_then_erase_reset_offset(lmq_name, group)
-        {
+            .query_then_erase_reset_offset(lmq_name, group);
+        let expected_current = self.context.consumer_offset.query_offset(group, lmq_name);
+        if let Some(reset_offset) = reset_offset {
             self.consumer_order_info_manager.clear_block(lmq_name, group, 0);
-            self.context
-                .consumer_offset
-                .commit_offset("ResetOffset", group, lmq_name, reset_offset);
-            offset = reset_offset;
+            if reset_offset >= expected_current {
+                self.context
+                    .consumer_offset
+                    .commit_offset("ResetOffset", group, lmq_name, reset_offset);
+            } else {
+                self.context
+                    .consumer_offset
+                    .correct_offset_if_current(group, lmq_name, expected_current, reset_offset);
+            }
+            let effective_offset = self.context.consumer_offset.query_offset(group, lmq_name);
+            return (effective_offset.max(0), effective_offset);
         }
-        offset
+        (expected_current.max(0), expected_current)
     }
 
     async fn get_message(
@@ -586,6 +655,7 @@ impl<MS: BrokerReadWriteStore> PopLiteMessageProcessor<MS> {
         group: &CheetahString,
         lmq_name: &CheetahString,
         offset: i64,
+        expected_current_offset: i64,
         batch_size: i32,
     ) -> Option<GetMessageResult> {
         let result = self
@@ -606,14 +676,18 @@ impl<MS: BrokerReadWriteStore> PopLiteMessageProcessor<MS> {
         ) && result.next_begin_offset() >= 0
         {
             let correct_offset = result.next_begin_offset();
-            self.context
-                .consumer_offset
-                .commit_offset("CorrectOffset", group, lmq_name, correct_offset);
-            return self
-                .context
-                .message_store
-                .get_message(group, lmq_name, correct_offset, batch_size)
-                .await;
+            if let Some(effective_offset) = self.context.consumer_offset.apply_store_offset_correction(
+                group,
+                lmq_name,
+                expected_current_offset,
+                correct_offset,
+            ) {
+                return self
+                    .context
+                    .message_store
+                    .get_message(group, lmq_name, effective_offset, batch_size)
+                    .await;
+            }
         }
         Some(result)
     }
@@ -674,41 +748,14 @@ impl<MS: BrokerReadWriteStore> PopLiteMessageProcessor<MS> {
 
         let dispatcher = &self.context.lite_event_dispatcher;
         dispatcher.touch_client(&request_header.client_id);
-        let pending_events = dispatcher.take_pending_events(&request_header.client_id);
-        let (body, requeue_events, fetched_count, order_count_info) =
-            self.pop_from_events(&request_header, pending_events).await;
-        if !requeue_events.is_empty() {
-            let (max_event_count, dispatch_delay_millis) = self.lite_dispatch_policy(&request_header.consumer_group);
-            dispatcher.do_full_dispatch_with_limit(
-                &request_header.client_id,
-                &request_header.consumer_group,
-                &requeue_events,
-                max_event_count,
-                dispatch_delay_millis,
-            );
-        }
-
-        let response_header = PopLiteMessageResponseHeader {
-            pop_time: current_millis() as i64,
-            invisible_time: request_header.invisible_time,
-            revive_qid: POP_ORDER_REVIVE_QUEUE,
-            start_offset_info: None,
-            msg_offset_info: None,
-            order_count_info: (fetched_count > 0).then_some(order_count_info).flatten(),
+        let result = match dispatcher.reserve_pending_events(&request_header.client_id) {
+            Some(reservation) => self.execute_pop_lite_batch(&request_header, reservation.commit()).await,
+            None => self.execute_pop_lite_without_events(&request_header).await,
         };
-        let mut response = self
-            .context
-            .command_factory
-            .create_success_response_command_with_header(response_header)
-            .set_opaque(request.opaque());
-
-        match body {
-            Some(body) => {
-                response.set_code_ref(ResponseCode::Success);
-                response.set_remark_mut("FOUND");
-                response.set_body_mut_ref(body);
-            }
-            None => match self.pop_lite_long_polling_service.polling(
+        let response_kind = if result.body.is_some() {
+            response::PopLiteResponseKind::Found
+        } else {
+            match self.pop_lite_long_polling_service.polling(
                 ctx,
                 request,
                 &request_header.client_id,
@@ -722,16 +769,11 @@ impl<MS: BrokerReadWriteStore> PopLiteMessageProcessor<MS> {
                     }
                     return Ok(None);
                 }
-                PollingResult::PollingFull => {
-                    response.set_code_ref(ResponseCode::PollingFull);
-                    response.set_remark_mut("POP_LITE_POLLING_FULL");
-                }
-                _ => {
-                    response.set_code_ref(ResponseCode::PollingTimeout);
-                    response.set_remark_mut("NO_MESSAGE_IN_QUEUE");
-                }
-            },
-        }
+                PollingResult::PollingFull => response::PopLiteResponseKind::PollingFull,
+                _ => response::PopLiteResponseKind::PollingTimeout,
+            }
+        };
+        let response = self.compose_pop_lite_command(request.opaque(), &request_header, result, response_kind);
 
         Ok(Some(response))
     }
@@ -760,226 +802,4 @@ impl<MS: BrokerReadWriteStore> PopLiteLongPollingRequestProcessor for PopLiteMes
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::sync::Weak;
-    use std::time::Duration;
-
-    use crate::config::broker_config::BrokerConfig;
-    use cheetah_string::CheetahString;
-    use rocketmq_runtime::RuntimeContext;
-    use rocketmq_store::MessageStoreConfig;
-    use rocketmq_store::StorePorts;
-
-    use super::PopLiteMessagePolicy;
-    use super::PopLiteMessageProcessor;
-    use super::PopLiteMessageProcessorContext;
-    use super::PopLiteMessageStoreCapability;
-    use super::PopLiteOffsetCapability;
-    use crate::broker_runtime::BrokerMessageStore;
-    use crate::broker_runtime::BrokerRuntime;
-    use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingPolicy;
-    use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingService;
-    use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingServiceContext;
-    use crate::processor::pop_message_processor::QueueLockManager;
-
-    fn pop_lite_processor_for_test(runtime: &mut BrokerRuntime) -> Arc<PopLiteMessageProcessor<BrokerMessageStore>> {
-        let inner = runtime.runtime_state_mut();
-        let topic_config_manager = inner.topic_config_manager_handle();
-        let subscription_group_lookup = inner.subscription_group_manager().config_lookup();
-        let lite_event_dispatcher = inner.lite_event_dispatcher().clone();
-        let service_context = inner.broker_service_context();
-        let queue_lock_manager = service_context
-            .clone()
-            .map(QueueLockManager::new_with_service_context)
-            .unwrap_or_else(QueueLockManager::new);
-        let long_polling = PopLiteLongPollingServiceContext::try_with_resource_budget(
-            PopLiteLongPollingPolicy::from_config(&inner.broker_config()),
-            lite_event_dispatcher.clone(),
-            service_context,
-            inner.resource_budget(),
-        )
-        .expect("test Broker resource budget");
-        let consumer_offset_manager = inner.consumer_offset_manager_handle();
-
-        PopLiteMessageProcessor::new(PopLiteMessageProcessorContext::new(
-            PopLiteMessagePolicy::from_config(&inner.broker_config()),
-            topic_config_manager,
-            subscription_group_lookup,
-            PopLiteOffsetCapability::new(&consumer_offset_manager),
-            PopLiteMessageStoreCapability {
-                escape_bridge: Weak::new(),
-            },
-            lite_event_dispatcher,
-            queue_lock_manager,
-            long_polling,
-        ))
-    }
-
-    #[test]
-    fn transform_order_count_info_drops_queue_level_suffix_when_offset_entries_exist() {
-        let result = PopLiteMessageProcessor::<StorePorts>::transform_order_count_info("0 qo0%100 1;0 0 1", 1);
-
-        assert_eq!(result, "0 qo0%100 1");
-    }
-
-    #[test]
-    fn pop_lite_message_policy_captures_only_required_startup_values() {
-        let broker_config = BrokerConfig {
-            broker_ip1: CheetahString::from_static_str("192.0.2.10"),
-            broker_permission: 4,
-            max_client_event_count: 17,
-            lite_event_full_dispatch_delay_time: 29,
-            ..Default::default()
-        };
-
-        let policy = PopLiteMessagePolicy::from_config(&broker_config);
-
-        assert_eq!(policy.broker_ip1, "192.0.2.10");
-        assert_eq!(policy.broker_permission, 4);
-        assert_eq!(policy.max_client_event_count, 17);
-        assert_eq!(policy.lite_event_full_dispatch_delay_time, 29);
-    }
-
-    #[test]
-    fn pop_lite_message_processor_source_uses_only_explicit_capabilities() {
-        let source = include_str!("pop_lite_message_processor.rs");
-
-        assert!(!source.contains(concat!("rocketmq_rust::", "ArcMut")));
-        assert!(!source.contains(concat!("BrokerRuntime", "Inner")));
-        assert!(!source.contains(concat!("broker_runtime", "_inner")));
-        assert!(source.contains("context: PopLiteMessageProcessorContext<MS>"));
-        assert!(source.contains("consumer_offset: PopLiteOffsetCapability<MS>"));
-        assert!(source.contains("message_store: PopLiteMessageStoreCapability<MS>"));
-    }
-
-    #[test]
-    fn pop_lite_message_providers_do_not_keep_runtime_or_store_alive() {
-        let broker_config = Arc::new(BrokerConfig::default());
-        let message_store_config = Arc::new(MessageStoreConfig::default());
-        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
-        let inner = runtime.runtime_state_mut();
-        let offset_manager = inner.consumer_offset_manager_handle();
-        let offset = PopLiteOffsetCapability::new(&offset_manager);
-        let escape_bridge = inner.escape_bridge();
-        let store = PopLiteMessageStoreCapability::new(&escape_bridge);
-        let group = CheetahString::from_static_str("group");
-        let topic = CheetahString::from_static_str("topic");
-
-        assert!(store.is_available());
-        drop(offset_manager);
-        drop(escape_bridge);
-        drop(runtime);
-
-        assert!(!store.is_available());
-        assert_eq!(offset.query_offset(&group, &topic), -1);
-        assert_eq!(offset.query_then_erase_reset_offset(&topic, &group), None);
-        offset.commit_offset("provider-shutdown-test", &group, &topic, 1);
-    }
-
-    #[tokio::test]
-    async fn pop_lite_long_polling_service_uses_weak_processor_back_reference() {
-        fn assert_send_sync<T: Send + Sync>(_: &T) {}
-
-        let broker_config = Arc::new(BrokerConfig::default());
-        let message_store_config = Arc::new(MessageStoreConfig::default());
-        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
-        let processor = pop_lite_processor_for_test(&mut runtime);
-        let processor_weak = Arc::downgrade(&processor);
-        let service = processor.pop_lite_long_polling_service.clone();
-
-        assert_send_sync(&processor);
-        drop(processor);
-
-        assert!(processor_weak.upgrade().is_none());
-        assert_eq!(Arc::strong_count(&service), 1);
-    }
-
-    #[tokio::test]
-    async fn pop_lite_long_polling_service_start_shutdown_and_restart_are_serialized() {
-        let broker_config = Arc::new(BrokerConfig::default());
-        let message_store_config = Arc::new(MessageStoreConfig::default());
-        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
-        let processor = pop_lite_processor_for_test(&mut runtime);
-        let service = processor.pop_lite_long_polling_service.clone();
-
-        PopLiteLongPollingService::start(&service).await;
-        let first_task_group = service
-            .task_group_for_test()
-            .expect("long-polling task group should be installed");
-        PopLiteLongPollingService::start(&service).await;
-        assert_eq!(
-            service
-                .task_group_for_test()
-                .expect("duplicate start should retain the task group")
-                .task_count(),
-            1
-        );
-        assert_eq!(first_task_group.task_count(), 1);
-        assert!(service.is_running());
-
-        service.shutdown().await;
-        assert!(!service.is_running());
-        assert!(service.task_group_for_test().is_none());
-
-        PopLiteLongPollingService::start(&service).await;
-        let restarted_task_group = service
-            .task_group_for_test()
-            .expect("restart should install a task group");
-        assert_eq!(restarted_task_group.task_count(), 1);
-        assert!(!restarted_task_group.cancellation_token().is_cancelled());
-        service.shutdown().await;
-        assert!(!service.is_running());
-    }
-
-    #[tokio::test]
-    async fn pop_lite_long_polling_service_uses_broker_parent_task_group() {
-        let broker_config = Arc::new(BrokerConfig::default());
-        let message_store_config = Arc::new(MessageStoreConfig::default());
-        let runtime_context = RuntimeContext::from_current("pop-lite-long-polling-parent-test");
-        let broker_service = runtime_context.service_context("broker-service");
-        let mut runtime =
-            BrokerRuntime::new_with_service_context(broker_config, message_store_config, broker_service.clone());
-        let parent_id = runtime
-            .runtime_state_mut()
-            .broker_service_task_group()
-            .expect("broker service task group should exist")
-            .id();
-        let processor = pop_lite_processor_for_test(&mut runtime);
-        let service = processor.pop_lite_long_polling_service.clone();
-
-        PopLiteLongPollingService::start(&service).await;
-        let task_group = service
-            .task_group_for_test()
-            .expect("POP Lite long-polling task group should be installed");
-
-        assert_eq!(task_group.parent_id(), Some(parent_id));
-        service.shutdown().await;
-        let report = broker_service.task_group().shutdown(Duration::from_secs(1)).await;
-        assert!(report.is_healthy(), "{}", report.to_json());
-    }
-
-    #[tokio::test]
-    async fn active_pop_lite_long_polling_scan_does_not_keep_owner_alive() {
-        let broker_config = Arc::new(BrokerConfig::default());
-        let message_store_config = Arc::new(MessageStoreConfig::default());
-        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
-        let processor = pop_lite_processor_for_test(&mut runtime);
-        let service = processor.pop_lite_long_polling_service.clone();
-        let processor_weak = Arc::downgrade(&processor);
-        let service_weak = Arc::downgrade(&service);
-
-        PopLiteLongPollingService::start(&service).await;
-        drop(processor);
-        drop(service);
-
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while service_weak.upgrade().is_some() {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("scan task should release the service owner");
-        assert!(processor_weak.upgrade().is_none());
-    }
-}
+mod tests;

--- a/rocketmq-broker/src/processor/pop_lite_message_processor/core.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor/core.rs
@@ -1,0 +1,88 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
+use rocketmq_store::BrokerReadWriteStore;
+
+use super::PopLiteMessageProcessor;
+use crate::lite::lite_event_dispatcher::LiteEventBatch;
+use crate::lite::lite_event_dispatcher::LiteEventBatchExecution;
+
+pub(crate) struct PopLiteCoreResult {
+    pub(crate) body: Option<Bytes>,
+    pub(crate) fetched_count: i32,
+    pub(crate) order_count_info: Option<CheetahString>,
+}
+
+impl<MS> PopLiteMessageProcessor<MS>
+where
+    MS: BrokerReadWriteStore,
+{
+    pub(crate) async fn execute_pop_lite_batch(
+        &self,
+        request_header: &PopLiteMessageRequestHeader,
+        batch: LiteEventBatch,
+    ) -> PopLiteCoreResult {
+        let events = batch.event_names();
+        let (result, requeue_events) = self.execute_pop_lite_events(request_header, events).await;
+        let (max_event_count, delay_millis) = self.lite_dispatch_policy(&request_header.consumer_group);
+        batch.complete_with_limit(&requeue_events, max_event_count, delay_millis);
+        result
+    }
+
+    /// Executes a deferred batch while staging settlement for canonical response terminal.
+    pub(crate) async fn execute_pop_lite_terminal_batch(
+        &self,
+        request_header: &PopLiteMessageRequestHeader,
+        events: LiteEventBatchExecution,
+    ) -> PopLiteCoreResult {
+        let batch = events.commit();
+        let event_names = batch.event_names();
+        let (result, requeue_events) = self.execute_pop_lite_events(request_header, event_names).await;
+        let (max_event_count, delay_millis) = self.lite_dispatch_policy(&request_header.consumer_group);
+        batch.complete_with_limit(&requeue_events, max_event_count, delay_millis);
+        result
+    }
+
+    pub(super) async fn execute_pop_lite_without_events(
+        &self,
+        request_header: &PopLiteMessageRequestHeader,
+    ) -> PopLiteCoreResult {
+        let (body, _, fetched_count, order_count_info) = self.pop_from_events(request_header, Vec::new()).await;
+        PopLiteCoreResult {
+            body,
+            fetched_count,
+            order_count_info,
+        }
+    }
+
+    async fn execute_pop_lite_events(
+        &self,
+        request_header: &PopLiteMessageRequestHeader,
+        events: Vec<CheetahString>,
+    ) -> (PopLiteCoreResult, std::collections::HashSet<CheetahString>) {
+        let (body, requeue_events, fetched_count, order_count_info) =
+            self.pop_from_events(request_header, events).await;
+        (
+            PopLiteCoreResult {
+                body,
+                fetched_count,
+                order_count_info,
+            },
+            requeue_events,
+        )
+    }
+}

--- a/rocketmq-broker/src/processor/pop_lite_message_processor/response.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor/response.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_model::common::key_builder::POP_ORDER_REVIVE_QUEUE;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
+use rocketmq_protocol::protocol::header::pop_lite_message_response_header::PopLiteMessageResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_store::BrokerReadWriteStore;
+use rocketmq_transport::api::v2::ResponsePlan;
+
+use super::core::PopLiteCoreResult;
+use super::PopLiteMessageProcessor;
+use crate::processor::response_plan::BrokerResponseParts;
+
+#[derive(Clone, Copy)]
+pub(crate) enum PopLiteResponseKind {
+    Found,
+    PollingFull,
+    PollingTimeout,
+}
+
+impl<MS> PopLiteMessageProcessor<MS>
+where
+    MS: BrokerReadWriteStore,
+{
+    pub(super) fn compose_pop_lite_command(
+        &self,
+        opaque: i32,
+        request_header: &PopLiteMessageRequestHeader,
+        result: PopLiteCoreResult,
+        kind: PopLiteResponseKind,
+    ) -> RemotingCommand {
+        let (mut head, body) = self.compose_pop_lite_parts(request_header, result, kind);
+        head.set_opaque_mut(opaque);
+        if let Some(body) = body {
+            head.set_body_mut_ref(body);
+        }
+        head
+    }
+
+    pub(super) fn compose_pop_lite_plan(
+        &self,
+        request_header: &PopLiteMessageRequestHeader,
+        result: PopLiteCoreResult,
+        kind: PopLiteResponseKind,
+    ) -> rocketmq_error::RocketMQResult<ResponsePlan> {
+        compose_pop_lite_response_plan(&self.context.command_factory, request_header, result, kind)
+    }
+
+    fn compose_pop_lite_parts(
+        &self,
+        request_header: &PopLiteMessageRequestHeader,
+        result: PopLiteCoreResult,
+        kind: PopLiteResponseKind,
+    ) -> (RemotingCommand, Option<bytes::Bytes>) {
+        compose_pop_lite_response_parts(&self.context.command_factory, request_header, result, kind)
+    }
+}
+
+pub(crate) fn compose_pop_lite_response_plan(
+    command_factory: &RemotingCommandFactory,
+    request_header: &PopLiteMessageRequestHeader,
+    result: PopLiteCoreResult,
+    kind: PopLiteResponseKind,
+) -> rocketmq_error::RocketMQResult<ResponsePlan> {
+    let (head, body) = compose_pop_lite_response_parts(command_factory, request_header, result, kind);
+    match body {
+        Some(body) => BrokerResponseParts::bytes(head, body)?.into_response_plan(),
+        None => BrokerResponseParts::command(head)?.into_response_plan(),
+    }
+}
+
+fn compose_pop_lite_response_parts(
+    command_factory: &RemotingCommandFactory,
+    request_header: &PopLiteMessageRequestHeader,
+    result: PopLiteCoreResult,
+    kind: PopLiteResponseKind,
+) -> (RemotingCommand, Option<bytes::Bytes>) {
+    let response_header = PopLiteMessageResponseHeader {
+        pop_time: current_millis() as i64,
+        invisible_time: request_header.invisible_time,
+        revive_qid: POP_ORDER_REVIVE_QUEUE,
+        start_offset_info: None,
+        msg_offset_info: None,
+        order_count_info: (result.fetched_count > 0).then_some(result.order_count_info).flatten(),
+    };
+    let mut head = command_factory.create_success_response_command_with_header(response_header);
+    match kind {
+        PopLiteResponseKind::Found => {
+            head.set_code_ref(ResponseCode::Success);
+            head.set_remark_mut("FOUND");
+        }
+        PopLiteResponseKind::PollingFull => {
+            head.set_code_ref(ResponseCode::PollingFull);
+            head.set_remark_mut("POP_LITE_POLLING_FULL");
+        }
+        PopLiteResponseKind::PollingTimeout => {
+            head.set_code_ref(ResponseCode::PollingTimeout);
+            head.set_remark_mut("NO_MESSAGE_IN_QUEUE");
+        }
+    }
+    (head, result.body)
+}

--- a/rocketmq-broker/src/processor/pop_lite_message_processor/resume.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor/resume.rs
@@ -1,0 +1,64 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_store::BrokerReadWriteStore;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::ResponsePlan;
+
+use super::core::PopLiteCoreResult;
+use super::response::PopLiteResponseKind;
+use super::PopLiteMessageProcessor;
+use crate::lite::lite_event_dispatcher::LiteEventBatchExecution;
+use crate::long_polling::pop_lite_deferred::data::ResumePopLite;
+
+impl<MS> PopLiteMessageProcessor<MS>
+where
+    MS: BrokerReadWriteStore,
+{
+    /// Executes one claimed PopLite event using its affine dispatcher batch.
+    pub(crate) async fn resume_pop_lite(
+        &self,
+        resume: ResumePopLite,
+        reason: DeferredWakeReason,
+        events: LiteEventBatchExecution,
+    ) -> rocketmq_error::RocketMQResult<ResponsePlan> {
+        debug_assert_eq!(reason, DeferredWakeReason::MessageArrived);
+        let request_header = resume.into_request().into_header();
+        let result = self.execute_pop_lite_terminal_batch(&request_header, events).await;
+        let kind = if result.body.is_some() {
+            PopLiteResponseKind::Found
+        } else {
+            PopLiteResponseKind::PollingTimeout
+        };
+        self.compose_pop_lite_plan(&request_header, result, kind)
+    }
+
+    pub(crate) fn resume_pop_lite_timeout(
+        &self,
+        resume: ResumePopLite,
+        reason: DeferredWakeReason,
+    ) -> rocketmq_error::RocketMQResult<ResponsePlan> {
+        debug_assert_eq!(reason, DeferredWakeReason::Timeout);
+        let request_header = resume.into_request().into_header();
+        self.compose_pop_lite_plan(
+            &request_header,
+            PopLiteCoreResult {
+                body: None,
+                fetched_count: 0,
+                order_count_info: None,
+            },
+            PopLiteResponseKind::PollingTimeout,
+        )
+    }
+}

--- a/rocketmq-broker/src/processor/pop_lite_message_processor/tests.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor/tests.rs
@@ -1,0 +1,286 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::config::broker_config::BrokerConfig;
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_store::MessageStoreConfig;
+use rocketmq_store::StorePorts;
+
+use crate::broker_runtime::BrokerMessageStore;
+use crate::broker_runtime::BrokerRuntime;
+use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingPolicy;
+use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingService;
+use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingServiceContext;
+use crate::processor::pop_message_processor::QueueLockManager;
+
+fn pop_lite_processor_for_test(runtime: &mut BrokerRuntime) -> Arc<PopLiteMessageProcessor<BrokerMessageStore>> {
+    let inner = runtime.runtime_state_mut();
+    let topic_config_manager = inner.topic_config_manager_handle();
+    let subscription_group_lookup = inner.subscription_group_manager().config_lookup();
+    let lite_event_dispatcher = inner.lite_event_dispatcher().clone();
+    let service_context = inner.broker_service_context();
+    let queue_lock_manager = service_context
+        .clone()
+        .map(QueueLockManager::new_with_service_context)
+        .unwrap_or_else(QueueLockManager::new);
+    let long_polling = PopLiteLongPollingServiceContext::try_with_resource_budget(
+        PopLiteLongPollingPolicy::from_config(&inner.broker_config()),
+        lite_event_dispatcher.clone(),
+        service_context,
+        inner.resource_budget(),
+    )
+    .expect("test Broker resource budget");
+    let consumer_offset_manager = inner.consumer_offset_manager_handle();
+    let escape_bridge = inner.escape_bridge();
+
+    PopLiteMessageProcessor::new(PopLiteMessageProcessorContext::new(
+        PopLiteMessagePolicy::from_config(&inner.broker_config()),
+        topic_config_manager,
+        subscription_group_lookup,
+        PopLiteOffsetCapability::new(&consumer_offset_manager),
+        PopLiteMessageStoreCapability::new(&escape_bridge),
+        lite_event_dispatcher,
+        queue_lock_manager,
+        long_polling,
+    ))
+}
+
+#[test]
+fn transform_order_count_info_drops_queue_level_suffix_when_offset_entries_exist() {
+    let result = PopLiteMessageProcessor::<StorePorts>::transform_order_count_info("0 qo0%100 1;0 0 1", 1);
+
+    assert_eq!(result, "0 qo0%100 1");
+}
+
+#[test]
+fn pop_lite_message_policy_captures_only_required_startup_values() {
+    let broker_config = BrokerConfig {
+        broker_ip1: CheetahString::from_static_str("192.0.2.10"),
+        broker_permission: 4,
+        max_client_event_count: 17,
+        lite_event_full_dispatch_delay_time: 29,
+        ..Default::default()
+    };
+
+    let policy = PopLiteMessagePolicy::from_config(&broker_config);
+
+    assert_eq!(policy.broker_ip1, "192.0.2.10");
+    assert_eq!(policy.broker_permission, 4);
+    assert_eq!(policy.max_client_event_count, 17);
+    assert_eq!(policy.lite_event_full_dispatch_delay_time, 29);
+}
+
+#[test]
+fn pop_lite_message_processor_source_uses_only_explicit_capabilities() {
+    let source = include_str!("../pop_lite_message_processor.rs");
+
+    assert!(!source.contains(concat!("rocketmq_rust::", "ArcMut")));
+    assert!(!source.contains(concat!("BrokerRuntime", "Inner")));
+    assert!(!source.contains(concat!("broker_runtime", "_inner")));
+    assert!(source.contains("context: PopLiteMessageProcessorContext<MS>"));
+    assert!(source.contains("consumer_offset: PopLiteOffsetCapability<MS>"));
+    assert!(source.contains("message_store: PopLiteMessageStoreCapability<MS>"));
+}
+
+#[test]
+fn pop_lite_message_providers_do_not_keep_runtime_or_store_alive() {
+    let broker_config = Arc::new(BrokerConfig::default());
+    let message_store_config = Arc::new(MessageStoreConfig::default());
+    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    let inner = runtime.runtime_state_mut();
+    let offset_manager = inner.consumer_offset_manager_handle();
+    let offset = PopLiteOffsetCapability::new(&offset_manager);
+    let escape_bridge = inner.escape_bridge();
+    let store = PopLiteMessageStoreCapability::new(&escape_bridge);
+    let group = CheetahString::from_static_str("group");
+    let topic = CheetahString::from_static_str("topic");
+
+    assert!(store.is_available());
+    drop(offset_manager);
+    drop(escape_bridge);
+    drop(runtime);
+
+    assert!(!store.is_available());
+    assert_eq!(offset.query_offset(&group, &topic), -1);
+    assert_eq!(offset.query_then_erase_reset_offset(&topic, &group), None);
+    offset.commit_offset("provider-shutdown-test", &group, &topic, 1);
+}
+
+#[tokio::test]
+async fn pop_lite_long_polling_service_uses_weak_processor_back_reference() {
+    fn assert_send_sync<T: Send + Sync>(_: &T) {}
+
+    let broker_config = Arc::new(BrokerConfig::default());
+    let message_store_config = Arc::new(MessageStoreConfig::default());
+    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    let processor = pop_lite_processor_for_test(&mut runtime);
+    let processor_weak = Arc::downgrade(&processor);
+    let service = processor.pop_lite_long_polling_service.clone();
+
+    assert_send_sync(&processor);
+    drop(processor);
+
+    assert!(processor_weak.upgrade().is_none());
+    assert_eq!(Arc::strong_count(&service), 1);
+}
+
+#[tokio::test]
+async fn pop_lite_long_polling_service_start_shutdown_and_restart_are_serialized() {
+    let broker_config = Arc::new(BrokerConfig::default());
+    let message_store_config = Arc::new(MessageStoreConfig::default());
+    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    let processor = pop_lite_processor_for_test(&mut runtime);
+    let service = processor.pop_lite_long_polling_service.clone();
+
+    PopLiteLongPollingService::start(&service).await;
+    let first_task_group = service
+        .task_group_for_test()
+        .expect("long-polling task group should be installed");
+    PopLiteLongPollingService::start(&service).await;
+    assert_eq!(
+        service
+            .task_group_for_test()
+            .expect("duplicate start should retain the task group")
+            .task_count(),
+        1
+    );
+    assert_eq!(first_task_group.task_count(), 1);
+    assert!(service.is_running());
+
+    service.shutdown().await;
+    assert!(!service.is_running());
+    assert!(service.task_group_for_test().is_none());
+
+    PopLiteLongPollingService::start(&service).await;
+    let restarted_task_group = service
+        .task_group_for_test()
+        .expect("restart should install a task group");
+    assert_eq!(restarted_task_group.task_count(), 1);
+    assert!(!restarted_task_group.cancellation_token().is_cancelled());
+    service.shutdown().await;
+    assert!(!service.is_running());
+}
+
+#[tokio::test]
+async fn pop_lite_long_polling_service_uses_broker_parent_task_group() {
+    let broker_config = Arc::new(BrokerConfig::default());
+    let message_store_config = Arc::new(MessageStoreConfig::default());
+    let runtime_context = RuntimeContext::from_current("pop-lite-long-polling-parent-test");
+    let broker_service = runtime_context.service_context("broker-service");
+    let mut runtime =
+        BrokerRuntime::new_with_service_context(broker_config, message_store_config, broker_service.clone());
+    let parent_id = runtime
+        .runtime_state_mut()
+        .broker_service_task_group()
+        .expect("broker service task group should exist")
+        .id();
+    let processor = pop_lite_processor_for_test(&mut runtime);
+    let service = processor.pop_lite_long_polling_service.clone();
+
+    PopLiteLongPollingService::start(&service).await;
+    let task_group = service
+        .task_group_for_test()
+        .expect("POP Lite long-polling task group should be installed");
+
+    assert_eq!(task_group.parent_id(), Some(parent_id));
+    service.shutdown().await;
+    let report = broker_service.task_group().shutdown(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+#[tokio::test]
+async fn active_pop_lite_long_polling_scan_does_not_keep_owner_alive() {
+    let broker_config = Arc::new(BrokerConfig::default());
+    let message_store_config = Arc::new(MessageStoreConfig::default());
+    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    let processor = pop_lite_processor_for_test(&mut runtime);
+    let service = processor.pop_lite_long_polling_service.clone();
+    let processor_weak = Arc::downgrade(&processor);
+    let service_weak = Arc::downgrade(&service);
+
+    PopLiteLongPollingService::start(&service).await;
+    drop(processor);
+    drop(service);
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while service_weak.upgrade().is_some() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("scan task should release the service owner");
+    assert!(processor_weak.upgrade().is_none());
+}
+
+#[tokio::test]
+async fn cancelled_store_read_releases_queue_lock_for_competing_pop_lite_request() {
+    let broker_config = Arc::new(BrokerConfig::default());
+    let message_store_config = Arc::new(MessageStoreConfig::default());
+    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    let processor = pop_lite_processor_for_test(&mut runtime);
+    let entered_store = Arc::new(tokio::sync::Barrier::new(2));
+    let release_store = Arc::new(tokio::sync::Barrier::new(2));
+    processor
+        .context
+        .message_store
+        .set_store_await_hook(Arc::clone(&entered_store), release_store);
+    let lmq_name = CheetahString::from_static_str("%LMQ%$parent-topic$cancelled-store");
+    let consumer_group = CheetahString::from_static_str("group-a");
+    let header = PopLiteMessageRequestHeader {
+        client_id: CheetahString::from_static_str("cancelled-store-client"),
+        consumer_group: consumer_group.clone(),
+        topic: CheetahString::from_static_str("parent-topic"),
+        max_msg_num: 1,
+        invisible_time: 30_000,
+        poll_time: 60_000,
+        born_time: 0,
+        attempt_id: None,
+        rpc: None,
+    };
+    let processor_for_read = Arc::clone(&processor);
+    let lmq_for_read = lmq_name.clone();
+    let read_task = tokio::spawn(async move { processor_for_read.pop_from_events(&header, vec![lmq_for_read]).await });
+
+    entered_store.wait().await;
+    let lock_key = CheetahString::from_string(QueueLockManager::build_lock_key(&lmq_name, &consumer_group, 0));
+    assert!(
+        processor
+            .context
+            .queue_lock_manager
+            .try_acquire_with_key(lock_key.clone())
+            .await
+            .is_none(),
+        "the blocked Store read retains the exact queue lock entry"
+    );
+
+    read_task.abort();
+    assert!(
+        read_task.await.expect_err("cancelled Store read task").is_cancelled(),
+        "the Store read future is cancelled at the deterministic barrier"
+    );
+    let competing = processor
+        .context
+        .queue_lock_manager
+        .try_acquire_with_key(lock_key)
+        .await
+        .expect("cancellation releases the queue lock for a competing request");
+    drop(competing);
+}

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -1488,11 +1488,22 @@ impl TimedLock {
 
 #[derive(Clone)]
 pub struct QueueLockManager {
-    expired_local_cache: Arc<RwLock<HashMap<CheetahString, TimedLock>>>,
+    expired_local_cache: Arc<RwLock<HashMap<CheetahString, Arc<TimedLock>>>>,
     shutdown: Arc<Notify>,
     running: Arc<AtomicBool>,
     task_group: Arc<Mutex<Option<TaskGroup>>>,
     service_context: ChildServiceContext,
+}
+
+#[must_use]
+pub(crate) struct QueueLockLease {
+    lock: Arc<TimedLock>,
+}
+
+impl Drop for QueueLockLease {
+    fn drop(&mut self) {
+        self.lock.unlock();
+    }
 }
 
 impl QueueLockManager {
@@ -1542,8 +1553,20 @@ impl QueueLockManager {
         }
         drop(cache);
         let mut cache = self.expired_local_cache.write().await;
-        let lock = cache.entry(key).or_insert(TimedLock::new());
+        let lock = cache.entry(key).or_insert_with(|| Arc::new(TimedLock::new()));
         lock.try_lock()
+    }
+
+    pub(crate) async fn try_acquire_with_key(&self, key: CheetahString) -> Option<QueueLockLease> {
+        {
+            let cache = self.expired_local_cache.read().await;
+            if let Some(lock) = cache.get(&key) {
+                return lock.try_lock().then(|| QueueLockLease { lock: Arc::clone(lock) });
+            }
+        }
+        let mut cache = self.expired_local_cache.write().await;
+        let lock = cache.entry(key).or_insert_with(|| Arc::new(TimedLock::new()));
+        lock.try_lock().then(|| QueueLockLease { lock: Arc::clone(lock) })
     }
 
     pub async fn unlock(&self, topic: &CheetahString, consumer_group: &CheetahString, queue_id: i32) {
@@ -1561,7 +1584,10 @@ impl QueueLockManager {
     pub async fn clean_unused_locks(&self, used_expire_millis: u64) -> usize {
         let mut cache = self.expired_local_cache.write().await;
         let count = cache.len();
-        cache.retain(|_, lock| current_millis() - lock.get_lock_time() <= used_expire_millis);
+        cache.retain(|_, lock| {
+            let has_affine_holder = lock.is_locked() && Arc::strong_count(lock) > 1;
+            has_affine_holder || current_millis().saturating_sub(lock.get_lock_time()) <= used_expire_millis
+        });
         count
     }
 
@@ -2067,16 +2093,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queue_lock_lease_releases_exact_entry_on_drop() {
+        let manager = QueueLockManager::new();
+        let key = CheetahString::from_static_str("lease-drop");
+        let lease = manager
+            .try_acquire_with_key(key.clone())
+            .await
+            .expect("first affine queue lock lease");
+
+        assert!(manager.try_acquire_with_key(key.clone()).await.is_none());
+        drop(lease);
+
+        assert!(manager.try_acquire_with_key(key).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn queue_lock_cleanup_preserves_held_entry_and_prevents_aba_replacement() {
+        let manager = QueueLockManager::new();
+        let key = CheetahString::from_static_str("lease-cleanup");
+        let lease = manager
+            .try_acquire_with_key(key.clone())
+            .await
+            .expect("held affine queue lock lease");
+        let held = manager
+            .expired_local_cache
+            .read()
+            .await
+            .get(&key)
+            .cloned()
+            .expect("held entry is indexed");
+        held.lock_time.store(0, Ordering::Relaxed);
+
+        assert_eq!(manager.clean_unused_locks(0).await, 1);
+        let after_cleanup = manager
+            .expired_local_cache
+            .read()
+            .await
+            .get(&key)
+            .cloned()
+            .expect("cleanup retains a held entry");
+        assert!(Arc::ptr_eq(&held, &after_cleanup));
+        assert!(manager.try_acquire_with_key(key.clone()).await.is_none());
+
+        drop(after_cleanup);
+        drop(lease);
+        held.lock_time.store(0, Ordering::Relaxed);
+        drop(held);
+        assert_eq!(manager.clean_unused_locks(0).await, 1);
+        assert!(!manager.expired_local_cache.read().await.contains_key(&key));
+        assert!(manager.try_acquire_with_key(key).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn queue_lock_cleanup_preserves_legacy_stale_lock_recovery() {
+        let manager = QueueLockManager::new();
+        let key = CheetahString::from_static_str("legacy-stale-cleanup");
+        assert!(manager.try_lock_with_key(key.clone()).await);
+        manager
+            .expired_local_cache
+            .read()
+            .await
+            .get(&key)
+            .expect("legacy locked entry is indexed")
+            .lock_time
+            .store(0, Ordering::Relaxed);
+
+        assert_eq!(manager.clean_unused_locks(0).await, 1);
+        assert!(!manager.expired_local_cache.read().await.contains_key(&key));
+        assert!(manager.try_lock_with_key(key).await);
+    }
+
+    #[tokio::test]
     async fn clean_unused_locks_removes_expired_locks() {
         let manager = QueueLockManager::new();
         let topic = CheetahString::from_static_str("test_topic");
         let consumer_group = CheetahString::from_static_str("test_group");
         let queue_id = 1;
-        manager.try_lock(&topic, &consumer_group, queue_id).await;
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        let removed_count = manager.clean_unused_locks(5).await;
+        let key = CheetahString::from_string(QueueLockManager::build_lock_key(&topic, &consumer_group, queue_id));
+        manager.try_lock_with_key(key.clone()).await;
+        manager.unlock_with_key(key.clone()).await;
+        manager
+            .expired_local_cache
+            .read()
+            .await
+            .get(&key)
+            .expect("unlocked entry is indexed")
+            .lock_time
+            .store(0, Ordering::Relaxed);
+        let removed_count = manager.clean_unused_locks(0).await;
         assert_eq!(removed_count, 1);
-        let removed_count = manager.clean_unused_locks(15).await;
+        let removed_count = manager.clean_unused_locks(0).await;
         assert_eq!(removed_count, 0);
     }
 }

--- a/rocketmq-broker/tests/broker_runtime/pop_lite_core_causality_tests.rs
+++ b/rocketmq-broker/tests/broker_runtime/pop_lite_core_causality_tests.rs
@@ -1,0 +1,491 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[tokio::test]
+async fn pop_lite_v2_resume_core_real_store_causality_advances_offset_once() {
+    let mut runtime = new_lite_test_runtime("pop-lite-v2-core-consume").await;
+    seed_lite_query_state(&mut runtime);
+    seed_lmq_message(&mut runtime, "child-a", b"lite-v2-body").await;
+    let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+    let client_id = CheetahString::from_static_str("client-1");
+    let group = CheetahString::from_static_str("group-a");
+    runtime.composition.state.lite_event_dispatcher().do_full_dispatch(
+        &client_id,
+        &group,
+        &HashSet::from([lmq_name.clone()]),
+    );
+
+    let _ = runtime.init_processor();
+    let processor = runtime
+        .composition
+        .state
+        .pop_lite_message_processor()
+        .expect("PopLite processor should initialize")
+        .clone();
+    let batch = runtime
+        .composition
+        .state
+        .lite_event_dispatcher()
+        .reserve_pending_events(&client_id)
+        .expect("V2 seam should reserve the dispatched event")
+        .commit();
+    let request_header = PopLiteMessageRequestHeader {
+        client_id: client_id.clone(),
+        consumer_group: group.clone(),
+        topic: CheetahString::from_static_str("parent-topic"),
+        max_msg_num: 1,
+        invisible_time: 60_000,
+        poll_time: 30_000,
+        born_time: current_millis() as i64,
+        attempt_id: None,
+        rpc: None,
+    };
+
+    let result = processor.execute_pop_lite_batch(&request_header, batch).await;
+    let mut body = result.body.expect("V2 shared core should return the stored message");
+    let message =
+        MessageDecoder::decode(&mut body, true, false, false, false, false).expect("decode V2 shared core message");
+    assert_eq!(message.body(), Some(Bytes::from_static(b"lite-v2-body")));
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        1
+    );
+    assert!(runtime
+        .composition
+        .state
+        .lite_event_dispatcher()
+        .pending_events(&client_id)
+        .is_empty());
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .lite_event_dispatcher()
+            .reservation_snapshot()
+            .events,
+        0
+    );
+
+    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+}
+
+#[tokio::test]
+async fn pop_lite_v2_real_store_preserves_attempt_order_and_requeues_until_drained() {
+    let mut runtime = new_lite_test_runtime("pop-lite-v2-attempt-requeue").await;
+    seed_lite_query_state(&mut runtime);
+    seed_lmq_message(&mut runtime, "child-a", b"lite-v2-first").await;
+    seed_lmq_message(&mut runtime, "child-a", b"lite-v2-second").await;
+    let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+    let client_id = CheetahString::from_static_str("client-1");
+    let group = CheetahString::from_static_str("group-a");
+    let dispatcher = runtime.composition.state.lite_event_dispatcher().clone();
+    dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([lmq_name.clone()]));
+
+    let _ = runtime.init_processor();
+    let processor = runtime
+        .composition
+        .state
+        .pop_lite_message_processor()
+        .expect("PopLite processor should initialize")
+        .clone();
+    let header = |attempt_id: &'static str| PopLiteMessageRequestHeader {
+        client_id: client_id.clone(),
+        consumer_group: group.clone(),
+        topic: CheetahString::from_static_str("parent-topic"),
+        max_msg_num: 1,
+        invisible_time: 60_000,
+        poll_time: 30_000,
+        born_time: current_millis() as i64,
+        attempt_id: Some(CheetahString::from_static_str(attempt_id)),
+        rpc: None,
+    };
+
+    let first = processor
+        .execute_pop_lite_batch(
+            &header("attempt-a"),
+            dispatcher
+                .reserve_pending_events(&client_id)
+                .expect("reserve first V2 event")
+                .commit(),
+        )
+        .await;
+    let mut first_body = first.body.expect("first V2 attempt reads the first message");
+    let first_message = MessageDecoder::decode(&mut first_body, true, false, false, false, false)
+        .expect("decode first V2 ordered message");
+    assert_eq!(first_message.body(), Some(Bytes::from_static(b"lite-v2-first")));
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        1
+    );
+    assert_eq!(dispatcher.pending_events(&client_id), vec![lmq_name.clone()]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+
+    let blocked = processor
+        .execute_pop_lite_batch(
+            &header("attempt-b"),
+            dispatcher
+                .reserve_pending_events(&client_id)
+                .expect("reserve event for blocked V2 attempt")
+                .commit(),
+        )
+        .await;
+    assert!(blocked.body.is_none(), "different attempt remains FIFO-blocked");
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        1
+    );
+    assert_eq!(dispatcher.pending_events(&client_id), vec![lmq_name.clone()]);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+
+    let second = processor
+        .execute_pop_lite_batch(
+            &header("attempt-a"),
+            dispatcher
+                .reserve_pending_events(&client_id)
+                .expect("reserve event for matching V2 attempt")
+                .commit(),
+        )
+        .await;
+    let mut second_body = second.body.expect("matching V2 attempt reads the second message");
+    let second_message = MessageDecoder::decode(&mut second_body, true, false, false, false, false)
+        .expect("decode second V2 ordered message");
+    assert_eq!(second_message.body(), Some(Bytes::from_static(b"lite-v2-second")));
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        2
+    );
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+    assert_eq!(dispatcher.reservation_snapshot().events, 0);
+
+    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+}
+
+#[tokio::test]
+async fn pop_lite_v2_real_store_applies_reset_and_consumes_empty_event() {
+    let mut runtime = new_lite_test_runtime("pop-lite-v2-offset-correction").await;
+    seed_lite_query_state(&mut runtime);
+    seed_lmq_message(&mut runtime, "child-a", b"lite-v2-reset-first").await;
+    seed_lmq_message(&mut runtime, "child-a", b"lite-v2-reset-second").await;
+    let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+    let empty_lmq = CheetahString::from_string(to_lmq_name("parent-topic", "child-b").expect("child-b lmq"));
+    let client_id = CheetahString::from_static_str("client-1");
+    let group = CheetahString::from_static_str("group-a");
+    let dispatcher = runtime.composition.state.lite_event_dispatcher().clone();
+
+    let _ = runtime.init_processor();
+    let processor = runtime
+        .composition
+        .state
+        .pop_lite_message_processor()
+        .expect("PopLite processor should initialize")
+        .clone();
+    runtime
+        .composition
+        .state
+        .consumer_offset_manager()
+        .assign_reset_offset(&lmq_name, &group, 0, 1);
+    runtime.composition.state.consumer_offset_manager().commit_offset(
+        CheetahString::from_static_str("PopLiteV2ResetConcurrentAdvance"),
+        &group,
+        &lmq_name,
+        0,
+        99,
+    );
+    let durable_reset_key = CheetahString::from_string(format!("{}@{}", lmq_name, group));
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .offset_table_snapshot()
+            .get(&durable_reset_key)
+            .and_then(|offsets| offsets.get(&0))
+            .copied(),
+        Some(99),
+        "the reset path must conditionally replace the durable high-water mark"
+    );
+    dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([lmq_name.clone()]));
+    let header = PopLiteMessageRequestHeader {
+        client_id: client_id.clone(),
+        consumer_group: group.clone(),
+        topic: CheetahString::from_static_str("parent-topic"),
+        max_msg_num: 1,
+        invisible_time: 60_000,
+        poll_time: 30_000,
+        born_time: current_millis() as i64,
+        attempt_id: None,
+        rpc: None,
+    };
+    let reset = processor
+        .execute_pop_lite_batch(
+            &header,
+            dispatcher
+                .reserve_pending_events(&client_id)
+                .expect("reserve reset-offset V2 event")
+                .commit(),
+        )
+        .await;
+    let mut reset_body = reset.body.expect("reset offset reads the second stored message");
+    let reset_message = MessageDecoder::decode(&mut reset_body, true, false, false, false, false)
+        .expect("decode reset-offset V2 message");
+    assert_eq!(reset_message.body(), Some(Bytes::from_static(b"lite-v2-reset-second")));
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        2
+    );
+
+    dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([empty_lmq]));
+    let empty = processor
+        .execute_pop_lite_batch(
+            &header,
+            dispatcher
+                .reserve_pending_events(&client_id)
+                .expect("reserve empty-store V2 event")
+                .commit(),
+        )
+        .await;
+    assert!(empty.body.is_none());
+    assert_eq!(empty.fetched_count, 0);
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+    assert_eq!(dispatcher.reservation_snapshot().events, 0);
+
+    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+}
+
+#[tokio::test]
+async fn pop_lite_v2_real_store_corrects_bad_offset_before_reread() {
+    let mut runtime = new_lite_test_runtime("pop-lite-v2-bad-offset-correction").await;
+    seed_lite_query_state(&mut runtime);
+    seed_lmq_message(&mut runtime, "child-a", b"lite-v2-first").await;
+    seed_lmq_message(&mut runtime, "child-a", b"lite-v2-second").await;
+    let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+    let client_id = CheetahString::from_static_str("client-1");
+    let group = CheetahString::from_static_str("group-a");
+    let dispatcher = runtime.composition.state.lite_event_dispatcher().clone();
+    runtime.composition.state.consumer_offset_manager().commit_offset(
+        CheetahString::from_static_str("PopLiteV2BadOffsetTest"),
+        &group,
+        &lmq_name,
+        0,
+        99,
+    );
+    let direct_bad_offset = runtime
+        .composition
+        .state
+        .message_store()
+        .expect("message store should remain initialized")
+        .get_message(&group, &lmq_name, 0, 99, 1, None)
+        .await
+        .expect("bad-offset direct read returns a correction result");
+    assert_eq!(direct_bad_offset.status(), Some(GetMessageStatus::OffsetOverflowBadly));
+    assert_eq!(direct_bad_offset.next_begin_offset(), 2);
+
+    let _ = runtime.init_processor();
+    let processor = runtime
+        .composition
+        .state
+        .pop_lite_message_processor()
+        .expect("PopLite processor should initialize")
+        .clone();
+    dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([lmq_name.clone()]));
+    let header = PopLiteMessageRequestHeader {
+        client_id: client_id.clone(),
+        consumer_group: group.clone(),
+        topic: CheetahString::from_static_str("parent-topic"),
+        max_msg_num: 1,
+        invisible_time: 60_000,
+        poll_time: 30_000,
+        born_time: current_millis() as i64,
+        attempt_id: None,
+        rpc: None,
+    };
+    let corrected = processor
+        .execute_pop_lite_batch(
+            &header,
+            dispatcher
+                .reserve_pending_events(&client_id)
+                .expect("reserve bad-offset V2 event")
+                .commit(),
+        )
+        .await;
+
+    assert!(corrected.body.is_none(), "corrected end offset has no unread message");
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        2
+    );
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+    assert_eq!(dispatcher.reservation_snapshot().events, 0);
+
+    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+}
+
+#[tokio::test]
+async fn pop_lite_v2_real_store_initializes_missing_offset_from_retained_minimum() {
+    let mut runtime = new_lite_test_runtime("pop-lite-v2-missing-offset-minimum").await;
+    seed_lite_query_state(&mut runtime);
+    seed_lmq_offsets(&mut runtime, &[("child-a", 5)]);
+    seed_lmq_message(&mut runtime, "child-a", b"lite-v2-retained-minimum").await;
+    let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+    let client_id = CheetahString::from_static_str("client-1");
+    let group = CheetahString::from_static_str("group-a");
+    let direct = runtime
+        .composition
+        .state
+        .message_store()
+        .expect("message store remains initialized")
+        .get_message(&group, &lmq_name, 0, 0, 1, None)
+        .await
+        .expect("retained-minimum read returns a correction result");
+    assert_eq!(direct.status(), Some(GetMessageStatus::OffsetTooSmall));
+    assert_eq!(direct.next_begin_offset(), 5);
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        -1
+    );
+
+    let _ = runtime.init_processor();
+    let processor = runtime
+        .composition
+        .state
+        .pop_lite_message_processor()
+        .expect("PopLite processor should initialize")
+        .clone();
+    let dispatcher = runtime.composition.state.lite_event_dispatcher().clone();
+    dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([lmq_name.clone()]));
+    let result = processor
+        .execute_pop_lite_batch(
+            &PopLiteMessageRequestHeader {
+                client_id: client_id.clone(),
+                consumer_group: group.clone(),
+                topic: CheetahString::from_static_str("parent-topic"),
+                max_msg_num: 1,
+                invisible_time: 60_000,
+                poll_time: 30_000,
+                born_time: current_millis() as i64,
+                attempt_id: None,
+                rpc: None,
+            },
+            dispatcher
+                .reserve_pending_events(&client_id)
+                .expect("reserve retained-minimum event")
+                .commit(),
+        )
+        .await;
+
+    let mut body = result.body.expect("corrected initial read returns retained message");
+    let message = MessageDecoder::decode(&mut body, true, false, false, false, false)
+        .expect("decode retained-minimum V2 message");
+    assert_eq!(message.body(), Some(Bytes::from_static(b"lite-v2-retained-minimum")));
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        6
+    );
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+
+    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+}
+
+#[tokio::test]
+async fn pop_lite_v2_unavailable_store_consumes_event_without_offset_commit() {
+    let mut runtime = new_lite_test_runtime("pop-lite-v2-store-unavailable").await;
+    seed_lite_query_state(&mut runtime);
+    let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+    let client_id = CheetahString::from_static_str("client-1");
+    let group = CheetahString::from_static_str("group-a");
+    let dispatcher = runtime.composition.state.lite_event_dispatcher().clone();
+    let _ = runtime.init_processor();
+    let processor = runtime
+        .composition
+        .state
+        .pop_lite_message_processor()
+        .expect("PopLite processor should initialize")
+        .clone();
+    runtime.shutdown_message_store_for_test().await;
+    dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([lmq_name.clone()]));
+    let header = PopLiteMessageRequestHeader {
+        client_id: client_id.clone(),
+        consumer_group: group.clone(),
+        topic: CheetahString::from_static_str("parent-topic"),
+        max_msg_num: 1,
+        invisible_time: 60_000,
+        poll_time: 30_000,
+        born_time: current_millis() as i64,
+        attempt_id: None,
+        rpc: None,
+    };
+    let unavailable = processor
+        .execute_pop_lite_batch(
+            &header,
+            dispatcher
+                .reserve_pending_events(&client_id)
+                .expect("reserve unavailable-store V2 event")
+                .commit(),
+        )
+        .await;
+
+    assert!(unavailable.body.is_none());
+    assert_eq!(unavailable.fetched_count, 0);
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        -1
+    );
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+    assert_eq!(dispatcher.reservation_snapshot().events, 0);
+
+    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+}

--- a/rocketmq-broker/tests/broker_runtime/pop_lite_deferred_wire_tests.rs
+++ b/rocketmq-broker/tests/broker_runtime/pop_lite_deferred_wire_tests.rs
@@ -1,0 +1,416 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::num::NonZeroUsize;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_model::common::key_builder::POP_ORDER_REVIVE_QUEUE;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ShutdownReport;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredId;
+use rocketmq_transport::api::v2::DeferredResumeRetainedSize;
+use rocketmq_transport::api::v2::DeferredWaitLimits;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrdering;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::TransportServerV2;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+use super::*;
+use crate::long_polling::pop_lite_deferred::index::PopLiteIndexLimits;
+use crate::long_polling::pop_lite_deferred::prepare::PopLiteRetainedEstimate;
+use crate::long_polling::pop_lite_deferred::service::PopLiteDeferredService;
+
+const SUCCESS_OPAQUE: i32 = 98_336;
+const EMPTY_OPAQUE: i32 = 98_337;
+const CLIENT_ID: &str = "client-1";
+const GROUP: &str = "group-a";
+const PARENT_TOPIC: &str = "parent-topic";
+const INVISIBLE_TIME: i64 = 60_000;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test limit is non-zero")
+}
+
+fn deferred_service(controller: &AdmissionController, dispatcher: LiteEventDispatcher) -> Arc<PopLiteDeferredService> {
+    let admission = DeferredAdmission::try_configure(controller, DeferredWaitLimits::new(8, 8 * 1024 * 1024))
+        .expect("configure PopLite real-store deferred admission");
+    Arc::new(PopLiteDeferredService::new(
+        admission,
+        PopLiteIndexLimits::new(nonzero(8), nonzero(8), nonzero(4)),
+        dispatcher,
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        Duration::from_secs(30),
+        nonzero(8),
+    ))
+}
+
+fn deferred_request(opaque: i32) -> RemotingCommand {
+    let header = PopLiteMessageRequestHeader {
+        client_id: CheetahString::from_static_str(CLIENT_ID),
+        consumer_group: CheetahString::from_static_str(GROUP),
+        topic: CheetahString::from_static_str(PARENT_TOPIC),
+        max_msg_num: 1,
+        invisible_time: INVISIBLE_TIME,
+        poll_time: 30_000,
+        born_time: current_millis() as i64,
+        attempt_id: None,
+        rpc: None,
+    };
+    let mut command = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, header).set_opaque(opaque);
+    command.make_custom_header_to_net();
+    command
+}
+
+#[derive(Clone)]
+struct RegisteringProcessor {
+    service: Arc<PopLiteDeferredService>,
+    registrations: mpsc::UnboundedSender<DeferredId>,
+}
+
+impl RequestProcessorV2 for RegisteringProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prepared = self
+            .service
+            .prepare(request, PopLiteRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let registration = self
+            .service
+            .register(prepared, request)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.registrations
+            .send(registration.deferred_id())
+            .map_err(|_| RocketMQError::illegal_argument("PopLite registration observer closed"))?;
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+
+    fn request_ordering(&self, _ingress: rocketmq_transport::api::v2::IngressRequestView<'_>) -> RequestOrdering {
+        RequestOrdering::Concurrent
+    }
+}
+
+struct RunningWireServer {
+    owner: RuntimeOwner,
+    shutdown: Option<oneshot::Sender<()>>,
+    result: oneshot::Receiver<ShutdownReport>,
+}
+
+impl RunningWireServer {
+    async fn finish(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        let report = self.result.await.expect("owned PopLite wire server report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        let tasks = self.owner.shutdown_tasks().await;
+        assert!(tasks.is_healthy(), "{}", tasks.to_json());
+        let background = self.owner.shutdown_background();
+        assert!(background.is_healthy(), "{}", background.to_json());
+    }
+}
+
+async fn start_wire_server(
+    processor: RegisteringProcessor,
+    controller: Arc<AdmissionController>,
+) -> (Connection, RunningWireServer) {
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("pop-lite-real-store-v2-wire"))
+        .expect("PopLite real-store V2 runtime owner");
+    let server_context = owner.root_context().component("pop-lite.real-store.server");
+    let runner_context: ChildServiceContext = owner.root_context().component("pop-lite.real-store.runner");
+    let server = TransportServerV2::new(
+        Arc::new(rocketmq_transport::api::v1::ServerConfig {
+            bind_address: "127.0.0.1".to_owned(),
+            listen_port: 0,
+            ..rocketmq_transport::api::v1::ServerConfig::default()
+        }),
+        server_context,
+        processor,
+    )
+    .with_admission_controller(controller);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    runner_context
+        .spawn_service("pop-lite-real-store-v2-wire-server", async move {
+            let report = server
+                .try_run_with_shutdown_report_and_startup(
+                    async move {
+                        let _ = shutdown_rx.await;
+                    },
+                    startup_tx,
+                )
+                .await
+                .expect("owned PopLite real-store server shutdown report");
+            let _ = result_tx.send(report);
+        })
+        .expect("spawn PopLite real-store V2 server");
+    let address = startup_rx
+        .await
+        .expect("PopLite real-store startup channel")
+        .expect("PopLite real-store server startup");
+    let client = Connection::new(
+        TcpStream::connect(address)
+            .await
+            .expect("connect PopLite real-store client"),
+    );
+    (
+        client,
+        RunningWireServer {
+            owner,
+            shutdown: Some(shutdown_tx),
+            result: result_rx,
+        },
+    )
+}
+
+fn assert_response_header(response: &mut RemotingCommand, expected_order_count: Option<&str>) {
+    response.make_custom_header_to_net();
+    let header = response
+        .decode_command_custom_header::<PopLiteMessageResponseHeader>()
+        .expect("decode PopLite V2 response header");
+    assert!(header.pop_time > 0);
+    assert_eq!(header.invisible_time, INVISIBLE_TIME);
+    assert_eq!(header.revive_qid, POP_ORDER_REVIVE_QUEUE);
+    assert_eq!(header.start_offset_info, None);
+    assert_eq!(header.msg_offset_info, None);
+    assert_eq!(header.order_count_info.as_deref(), expected_order_count);
+}
+
+fn assert_terminal_resources(service: &PopLiteDeferredService, dispatcher: &LiteEventDispatcher) {
+    let snapshot = service.resource_snapshot();
+    assert_eq!(snapshot.admission.waiting_count(), 0);
+    assert_eq!(snapshot.admission.retained_bytes(), 0);
+    assert_eq!(snapshot.index.live, 0);
+    assert_eq!(snapshot.index.reserved, 0);
+    assert_eq!(snapshot.index.candidates, 0);
+    assert_eq!(snapshot.index.clients, 0);
+    assert_eq!(snapshot.index.oldest_waiter_age, None);
+    assert_eq!(snapshot.event_reservations.batches, 0);
+    assert_eq!(snapshot.event_reservations.events, 0);
+    assert_eq!(snapshot.event_reservations.permits, 0);
+    assert_eq!(snapshot.event_reservations.retained_bytes, 0);
+    assert_eq!(snapshot.active_client_gates, 0);
+    assert_eq!(snapshot.prepared_registrations, 0);
+    assert_eq!(snapshot.pending_claims, 0);
+    assert_eq!(snapshot.accepted_resumes, 0);
+    assert_eq!(snapshot.resume_execution_count, 0);
+    assert_eq!(snapshot.resume_execution_bytes, 0);
+    assert_eq!(dispatcher.budget_snapshot().current_count, 0);
+    assert_eq!(dispatcher.budget_snapshot().current_bytes, 0);
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_v2_real_store_single_chain_writes_exact_terminal_frame() {
+    let mut runtime = new_lite_test_runtime("pop-lite-deferred-v2-real-store-wire").await;
+    seed_lite_query_state(&mut runtime);
+    seed_lmq_message(&mut runtime, "child-a", b"lite-deferred-v2-real-store").await;
+    let _ = runtime.init_processor();
+    let pop_lite = runtime
+        .composition
+        .state
+        .pop_lite_message_processor()
+        .expect("PopLite processor should initialize")
+        .clone();
+    let dispatcher = runtime.composition.state.lite_event_dispatcher().clone();
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = deferred_service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let (mut client, running) = start_wire_server(
+        RegisteringProcessor {
+            service: Arc::clone(&service),
+            registrations: registration_tx,
+        },
+        controller,
+    )
+    .await;
+
+    client
+        .send_command(deferred_request(SUCCESS_OPAQUE))
+        .await
+        .expect("send real-store PopLite deferred request");
+    registrations.recv().await.expect("observe real-store registration");
+    let registered = service.resource_snapshot();
+    assert_eq!(registered.admission.waiting_count(), 1);
+    assert!(registered.admission.retained_bytes() > 0);
+    assert_eq!(registered.index.live, 1);
+    assert_eq!(registered.index.clients, 1);
+    assert!(registered.index.oldest_waiter_age.is_some());
+
+    let lmq_name = CheetahString::from_string(to_lmq_name(PARENT_TOPIC, "child-a").expect("child-a lmq"));
+    let client_id = CheetahString::from_static_str(CLIENT_ID);
+    let group = CheetahString::from_static_str(GROUP);
+    assert_eq!(
+        dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([lmq_name.clone()])),
+        1
+    );
+    assert_eq!(dispatcher.budget_snapshot().current_count, 1);
+    assert!(dispatcher.budget_snapshot().current_bytes > 0);
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim real-store PopLite event")
+        .expect("registered real-store client has a claim");
+    let service_during_resume = Arc::clone(&service);
+    let pop_lite_during_resume = Arc::clone(&pop_lite);
+    service
+        .resume_event_claim(
+            claim,
+            DeferredResumeRetainedSize::new(512),
+            move |resume, reason, events| async move {
+                assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                let active = service_during_resume.resource_snapshot();
+                assert_eq!(active.event_reservations.batches, 1);
+                assert_eq!(active.event_reservations.events, 1);
+                assert_eq!(active.event_reservations.permits, 1);
+                assert!(active.event_reservations.retained_bytes > 0);
+                assert_eq!(active.active_client_gates, 1);
+                assert_eq!(active.resume_execution_count, 1);
+                assert!(active.resume_execution_bytes >= 512);
+                pop_lite_during_resume.resume_pop_lite(resume, reason, events).await
+            },
+        )
+        .await
+        .expect("write canonical real-store PopLite response");
+
+    let mut response = client
+        .receive_command()
+        .await
+        .expect("real-store connection remains open")
+        .expect("one real-store PopLite response frame");
+    assert_eq!(response.opaque(), SUCCESS_OPAQUE);
+    assert_eq!(response.code(), ResponseCode::Success as i32);
+    assert_eq!(response.remark().map(CheetahString::as_str), Some("FOUND"));
+    assert_response_header(&mut response, Some("0"));
+    let mut body = response.body().cloned().expect("real-store PopLite response body");
+    let message = MessageDecoder::decode(&mut body, true, false, false, false, false)
+        .expect("decode real-store PopLite response body");
+    assert_eq!(message.body(), Some(Bytes::from_static(b"lite-deferred-v2-real-store")));
+    assert!(body.is_empty(), "response body contains exactly one stored message");
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .consumer_offset_manager()
+            .query_offset(&group, &lmq_name, 0),
+        1
+    );
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+    assert_terminal_resources(&service, &dispatcher);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "EOF proves exactly one response frame"
+    );
+    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+}
+
+#[tokio::test]
+async fn pop_lite_deferred_v2_real_store_claimed_empty_is_exact_terminal_timeout() {
+    let mut runtime = new_lite_test_runtime("pop-lite-deferred-v2-real-store-empty").await;
+    seed_lite_query_state(&mut runtime);
+    let _ = runtime.init_processor();
+    let pop_lite = runtime
+        .composition
+        .state
+        .pop_lite_message_processor()
+        .expect("PopLite processor should initialize")
+        .clone();
+    let dispatcher = runtime.composition.state.lite_event_dispatcher().clone();
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = deferred_service(controller.as_ref(), dispatcher.clone());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let (mut client, running) = start_wire_server(
+        RegisteringProcessor {
+            service: Arc::clone(&service),
+            registrations: registration_tx,
+        },
+        controller,
+    )
+    .await;
+
+    client
+        .send_command(deferred_request(EMPTY_OPAQUE))
+        .await
+        .expect("send empty-store PopLite deferred request");
+    registrations.recv().await.expect("observe empty-store registration");
+    let lmq_name = CheetahString::from_string(to_lmq_name(PARENT_TOPIC, "child-b").expect("child-b lmq"));
+    let client_id = CheetahString::from_static_str(CLIENT_ID);
+    let group = CheetahString::from_static_str(GROUP);
+    assert_eq!(
+        dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([lmq_name.clone()])),
+        1
+    );
+    let claim = service
+        .claim_event(&client_id)
+        .await
+        .expect("claim empty-store PopLite event")
+        .expect("registered empty-store client has a claim");
+    service
+        .resume_event_claim(
+            claim,
+            DeferredResumeRetainedSize::new(128),
+            move |resume, reason, events| async move { pop_lite.resume_pop_lite(resume, reason, events).await },
+        )
+        .await
+        .expect("write canonical empty-store PopLite response");
+
+    let mut response = client
+        .receive_command()
+        .await
+        .expect("empty-store connection remains open")
+        .expect("one empty-store PopLite response frame");
+    assert_eq!(response.opaque(), EMPTY_OPAQUE);
+    assert_eq!(response.code(), ResponseCode::PollingTimeout as i32);
+    assert_eq!(
+        response.remark().map(CheetahString::as_str),
+        Some("NO_MESSAGE_IN_QUEUE")
+    );
+    assert!(response.body().is_none());
+    assert_response_header(&mut response, None);
+    assert!(dispatcher.pending_events(&client_id).is_empty());
+    assert_terminal_resources(&service, &dispatcher);
+
+    assert_eq!(
+        dispatcher.do_full_dispatch(&client_id, &group, &HashSet::from([lmq_name.clone()])),
+        1
+    );
+    assert!(
+        service
+            .claim_event(&client_id)
+            .await
+            .expect("post-terminal claim check")
+            .is_none(),
+        "a claimed-empty responder is terminal and is never re-registered"
+    );
+    assert_eq!(dispatcher.take_pending_events(&client_id), vec![lmq_name]);
+    assert_terminal_resources(&service, &dispatcher);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "EOF proves exactly one timeout frame"
+    );
+    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+}

--- a/rocketmq-broker/tests/broker_runtime/pop_lite_v1_compatibility_tests.rs
+++ b/rocketmq-broker/tests/broker_runtime/pop_lite_v1_compatibility_tests.rs
@@ -1,0 +1,245 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+
+use super::*;
+use rocketmq_model::common::key_builder::POP_ORDER_REVIVE_QUEUE;
+
+async fn create_test_channel_pair(
+    label: &str,
+) -> (
+    Channel,
+    tokio::net::TcpStream,
+    rocketmq_runtime::TaskGroup,
+    std::net::TcpStream,
+) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind paired test listener");
+    let local_addr = listener.local_addr().expect("paired listener address");
+    let peer = tokio::net::TcpStream::connect(local_addr)
+        .await
+        .expect("connect paired test peer");
+    let (server_stream, peer_addr) = listener.accept().await.expect("accept paired test peer");
+    let server_stream = server_stream.into_std().expect("convert paired server stream");
+    let server_shutdown = server_stream.try_clone().expect("clone paired server stream");
+    let server_stream = tokio::net::TcpStream::from_std(server_stream).expect("restore paired server stream");
+    let connection = Connection::new(server_stream);
+    let channel_tasks = crate::test_task_group(label);
+    let channel = rocketmq_transport::test_support::TestChannelBuilder::new(connection, channel_tasks.clone())
+        .addresses(local_addr, peer_addr)
+        .build()
+        .expect("build paired test channel");
+    (channel, peer, channel_tasks, server_shutdown)
+}
+
+async fn read_raw_remoting_frame(stream: &mut tokio::net::TcpStream) -> Vec<u8> {
+    let mut length_prefix = [0_u8; 4];
+    stream
+        .read_exact(&mut length_prefix)
+        .await
+        .expect("read raw RocketMQ frame length");
+    let payload_len = i32::from_be_bytes(length_prefix);
+    assert!(payload_len >= 4, "invalid raw RocketMQ frame length {payload_len}");
+    let payload_len = usize::try_from(payload_len).expect("positive raw RocketMQ frame length");
+    let mut frame = vec![0_u8; payload_len.saturating_add(length_prefix.len())];
+    frame[..length_prefix.len()].copy_from_slice(&length_prefix);
+    stream
+        .read_exact(&mut frame[length_prefix.len()..])
+        .await
+        .expect("read complete raw RocketMQ frame");
+    frame
+}
+
+fn assert_shutdown_tree_drained(report: &rocketmq_runtime::ShutdownReport) {
+    assert_eq!(report.leaked, 0, "{}", report.to_json());
+    assert_eq!(report.blocking_still_running, 0, "{}", report.to_json());
+    assert_eq!(report.detached_still_running, 0, "{}", report.to_json());
+    assert!(report.remaining_tasks.is_empty(), "{}", report.to_json());
+    assert!(report.blocking_tasks.is_empty(), "{}", report.to_json());
+    for child in &report.children {
+        assert_shutdown_tree_drained(child);
+    }
+}
+
+#[tokio::test]
+async fn pop_lite_v1_wake_compatibility_trigger_dispatch_advances_offset() {
+    let mut runtime = new_lite_test_runtime("pop-lite-trigger-wakeup").await;
+    seed_lite_query_state(&mut runtime);
+    seed_lmq_message(&mut runtime, "child-a", b"lite-body").await;
+    let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+
+    let (mut processor, _) = runtime.init_processor();
+    runtime
+        .composition
+        .state
+        .pop_lite_message_processor
+        .as_ref()
+        .expect("pop lite processor should be initialized")
+        .start()
+        .await;
+
+    let (pop_channel, mut pop_peer, pop_channel_tasks, pop_server_shutdown) =
+        create_test_channel_pair("pop-lite-v1-raw-channel").await;
+    let pop_ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(pop_channel.clone()));
+    let pop_header = PopLiteMessageRequestHeader {
+        client_id: CheetahString::from_static_str("client-1"),
+        consumer_group: CheetahString::from_static_str("group-a"),
+        topic: CheetahString::from_static_str("parent-topic"),
+        max_msg_num: 1,
+        invisible_time: 60_000,
+        poll_time: 3_000,
+        born_time: current_millis() as i64,
+        attempt_id: None,
+        rpc: None,
+    };
+    let mut pop_request =
+        RemotingCommand::create_request_command(RequestCode::PopLiteMessage, pop_header).set_opaque(98_335);
+    pop_request.make_custom_header_to_net();
+    let response = processor
+        .process_request(pop_channel.clone(), pop_ctx, &mut pop_request)
+        .await
+        .expect("pop lite should suspend cleanly");
+    assert!(
+        response.is_none(),
+        "suspended pop-lite should not produce an immediate response"
+    );
+
+    let trigger_channel = create_test_channel().await;
+    let trigger_ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(trigger_channel.clone()));
+    let trigger_header = TriggerLiteDispatchRequestHeader {
+        group: CheetahString::from_static_str("group-a"),
+        client_id: Some(CheetahString::from_static_str("client-1")),
+    };
+    let mut trigger_request = RemotingCommand::create_request_command(RequestCode::TriggerLiteDispatch, trigger_header);
+    trigger_request.make_custom_header_to_net();
+    let trigger_response = processor
+        .process_request(trigger_channel, trigger_ctx, &mut trigger_request)
+        .await
+        .expect("trigger lite dispatch should succeed")
+        .expect("trigger lite dispatch should return a response");
+    assert_eq!(ResponseCode::from(trigger_response.code()), ResponseCode::Success);
+
+    let raw_frame = tokio::time::timeout(Duration::from_secs(3), read_raw_remoting_frame(&mut pop_peer))
+        .await
+        .expect("legacy PopLite wake must emit one bounded raw frame");
+    let announced = i32::from_be_bytes(raw_frame[..4].try_into().expect("complete raw PopLite frame prefix"));
+    assert_eq!(
+        usize::try_from(announced).expect("positive raw PopLite frame length"),
+        raw_frame.len() - 4
+    );
+    let mut encoded = BytesMut::from(raw_frame.as_slice());
+    let mut wake_response = RemotingCommand::decode(&mut encoded)
+        .expect("decode legacy PopLite wake frame")
+        .expect("complete legacy PopLite wake frame");
+    assert!(encoded.is_empty(), "legacy PopLite wake emits one frame");
+    assert_eq!(wake_response.opaque(), 98_335);
+    assert_eq!(wake_response.code(), ResponseCode::Success as i32);
+    assert_eq!(wake_response.remark().map(CheetahString::as_str), Some("FOUND"));
+    wake_response.make_custom_header_to_net();
+    let response_header = wake_response
+        .decode_command_custom_header::<PopLiteMessageResponseHeader>()
+        .expect("decode legacy PopLite wake response header");
+    assert!(response_header.pop_time > 0);
+    assert_eq!(response_header.invisible_time, 60_000);
+    assert_eq!(response_header.revive_qid, POP_ORDER_REVIVE_QUEUE);
+    assert_eq!(response_header.start_offset_info, None);
+    assert_eq!(response_header.msg_offset_info, None);
+    assert_eq!(response_header.order_count_info.as_deref(), Some("0"));
+    let mut response_body = wake_response.body().cloned().expect("legacy PopLite wake body");
+    let message = MessageDecoder::decode(&mut response_body, true, false, false, false, false)
+        .expect("decode legacy PopLite wake body");
+    assert_eq!(message.body(), Some(Bytes::from_static(b"lite-body")));
+    assert!(
+        response_body.is_empty(),
+        "legacy PopLite wake body has no trailing bytes after the exact message payload"
+    );
+
+    assert_eq!(
+        runtime.composition.state.consumer_offset_manager().query_offset(
+            &CheetahString::from_static_str("group-a"),
+            &lmq_name,
+            0,
+        ),
+        1,
+        "legacy wake commits the consumed offset before writing"
+    );
+
+    assert_eq!(
+        runtime
+            .composition
+            .state
+            .pop_lite_message_processor
+            .as_ref()
+            .expect("pop lite processor should be initialized")
+            .pop_lite_long_polling_service()
+            .get_polling_num("client-1"),
+        0
+    );
+    assert!(runtime
+        .composition
+        .state
+        .lite_event_dispatcher()
+        .pending_events(&CheetahString::from_static_str("client-1"))
+        .is_empty());
+    runtime
+        .composition
+        .state
+        .pop_lite_message_processor
+        .as_ref()
+        .expect("pop lite processor should be initialized")
+        .shutdown()
+        .await;
+    let broker_tasks = runtime
+        .composition
+        .state
+        .broker_service_task_group()
+        .expect("lite test runtime has an owned broker task group");
+    let broker_report = broker_tasks.shutdown(Duration::from_secs(1)).await;
+    assert_shutdown_tree_drained(&broker_report);
+    let drained = runtime
+        .composition
+        .state
+        .pop_lite_message_processor
+        .as_ref()
+        .expect("pop lite processor should remain initialized until drain assertion")
+        .pop_lite_long_polling_service()
+        .resource_snapshot();
+    assert_eq!(drained.waking_client_count, 0);
+    drop(processor);
+    drop(runtime.composition.state.pop_lite_message_processor.take());
+    pop_peer.shutdown().await.expect("half-close legacy PopLite raw peer");
+    let channel_report = pop_channel.close_with_report(Duration::from_secs(1)).await;
+    assert!(channel_report.is_healthy(), "{}", channel_report.to_json());
+    drop(pop_channel);
+    let channel_tasks_report = pop_channel_tasks.shutdown(Duration::from_secs(1)).await;
+    assert_shutdown_tree_drained(&channel_tasks_report);
+    let store_path_root_dir = runtime.message_store_config().store_path_root_dir.to_string();
+    drop(runtime);
+    // The V1 SkipSet retires removed PopRequest nodes through epoch reclamation, so the
+    // test-owned duplicate socket handle closes the transport deterministically without
+    // claiming that the retired node has already been reclaimed.
+    pop_server_shutdown
+        .shutdown(std::net::Shutdown::Both)
+        .expect("shutdown legacy PopLite server socket");
+    let mut trailing = Vec::new();
+    tokio::time::timeout(Duration::from_secs(1), pop_peer.read_to_end(&mut trailing))
+        .await
+        .expect("legacy PopLite raw peer reaches EOF")
+        .expect("read legacy PopLite trailing bytes");
+    assert!(trailing.is_empty(), "legacy PopLite wake emits no trailing frame");
+    let _ = std::fs::remove_dir_all(store_path_root_dir);
+}

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -162,6 +162,10 @@ use tokio::time::sleep;
 
 use super::*;
 
+mod pop_lite_core_causality_tests;
+mod pop_lite_deferred_wire_tests;
+mod pop_lite_v1_compatibility_tests;
+
 impl BrokerRuntime {
     pub(crate) fn pull_message_context_for_test(&self) -> Arc<PullMessageProcessorContext<BrokerMessageStore>> {
         self.composition.state.build_pull_message_context()
@@ -1642,7 +1646,11 @@ async fn new_lite_test_runtime(label: &str) -> BrokerRuntime {
         read_uncommitted: true,
         ..MessageStoreConfig::default()
     });
-    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    let mut runtime = BrokerRuntime::new_with_service_context(
+        broker_config,
+        message_store_config,
+        crate::test_service_context(format!("broker-runtime.{label}")),
+    );
     assert!(runtime.initialize().await.is_ok());
     runtime
 }
@@ -4911,108 +4919,6 @@ async fn pop_lite_message_without_events_suspends_when_polling_enabled() {
             .get_polling_num("client-1"),
         1
     );
-
-    runtime
-        .composition
-        .state
-        .pop_lite_message_processor
-        .as_ref()
-        .expect("pop lite processor should be initialized")
-        .shutdown()
-        .await;
-    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
-}
-
-#[tokio::test]
-async fn trigger_lite_dispatch_wakes_suspended_pop_lite_request_and_advances_offset() {
-    let mut runtime = new_lite_test_runtime("pop-lite-trigger-wakeup").await;
-    seed_lite_query_state(&mut runtime);
-    seed_lmq_message(&mut runtime, "child-a", b"lite-body").await;
-    let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
-
-    let (mut processor, _) = runtime.init_processor();
-    runtime
-        .composition
-        .state
-        .pop_lite_message_processor
-        .as_ref()
-        .expect("pop lite processor should be initialized")
-        .start()
-        .await;
-
-    let pop_channel = create_test_channel().await;
-    let pop_ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(pop_channel.clone()));
-    let pop_header = PopLiteMessageRequestHeader {
-        client_id: CheetahString::from_static_str("client-1"),
-        consumer_group: CheetahString::from_static_str("group-a"),
-        topic: CheetahString::from_static_str("parent-topic"),
-        max_msg_num: 1,
-        invisible_time: 60_000,
-        poll_time: 3_000,
-        born_time: current_millis() as i64,
-        attempt_id: None,
-        rpc: None,
-    };
-    let mut pop_request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, pop_header);
-    pop_request.make_custom_header_to_net();
-    let response = processor
-        .process_request(pop_channel, pop_ctx, &mut pop_request)
-        .await
-        .expect("pop lite should suspend cleanly");
-    assert!(
-        response.is_none(),
-        "suspended pop-lite should not produce an immediate response"
-    );
-
-    let trigger_channel = create_test_channel().await;
-    let trigger_ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(trigger_channel.clone()));
-    let trigger_header = TriggerLiteDispatchRequestHeader {
-        group: CheetahString::from_static_str("group-a"),
-        client_id: Some(CheetahString::from_static_str("client-1")),
-    };
-    let mut trigger_request = RemotingCommand::create_request_command(RequestCode::TriggerLiteDispatch, trigger_header);
-    trigger_request.make_custom_header_to_net();
-    let trigger_response = processor
-        .process_request(trigger_channel, trigger_ctx, &mut trigger_request)
-        .await
-        .expect("trigger lite dispatch should succeed")
-        .expect("trigger lite dispatch should return a response");
-    assert_eq!(ResponseCode::from(trigger_response.code()), ResponseCode::Success);
-
-    let deadline = std::time::Instant::now() + Duration::from_secs(3);
-    loop {
-        if runtime.composition.state.consumer_offset_manager().query_offset(
-            &CheetahString::from_static_str("group-a"),
-            &lmq_name,
-            0,
-        ) == 1
-        {
-            break;
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "suspended pop-lite request should be woken and advance offset"
-        );
-        sleep(Duration::from_millis(20)).await;
-    }
-
-    assert_eq!(
-        runtime
-            .composition
-            .state
-            .pop_lite_message_processor
-            .as_ref()
-            .expect("pop lite processor should be initialized")
-            .pop_lite_long_polling_service()
-            .get_polling_num("client-1"),
-        0
-    );
-    assert!(runtime
-        .composition
-        .state
-        .lite_event_dispatcher()
-        .pending_events(&CheetahString::from_static_str("client-1"))
-        .is_empty());
 
     runtime
         .composition

--- a/rocketmq-transport/src/dispatch/deferred_expiry.rs
+++ b/rocketmq-transport/src/dispatch/deferred_expiry.rs
@@ -297,6 +297,41 @@ mod tests {
         assert_eq!(expiry.kind(), DeferredExpiryKind::OwnerDeadline);
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn notification_protocol_deadline_owner_early_equal_late_matrix_is_owner_safe() {
+        let now = Instant::now();
+        let (_runtime, control) = control(Some(RequestDeadline::after(Duration::from_secs(10))));
+        let margins = DeferredExpiryMargins::new(Duration::from_secs(3), Duration::from_secs(2));
+        let cases = [
+            (
+                now + Duration::from_secs(4),
+                DeferredExpiryKind::LongPollTimeout,
+                now + Duration::from_secs(4),
+            ),
+            (
+                now + Duration::from_secs(5),
+                DeferredExpiryKind::OwnerDeadline,
+                now + Duration::from_secs(5),
+            ),
+            (
+                now + Duration::from_secs(6),
+                DeferredExpiryKind::OwnerDeadline,
+                now + Duration::from_secs(5),
+            ),
+        ];
+
+        for (protocol_at, expected_kind, expected_next) in cases {
+            let expiry = DeferredExpiry::try_from_control(&control, protocol_at, margins)
+                .expect("Notification owner/protocol boundary remains live");
+            assert_eq!(expiry.resume_cutoff(), Some(now + Duration::from_secs(5)));
+            assert_eq!(expiry.kind(), expected_kind);
+            assert_eq!(expiry.next_at(), expected_next);
+        }
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert_eq!(Instant::now(), now + Duration::from_secs(5));
+    }
+
     #[test]
     fn margins_are_non_zero_even_without_an_owner_deadline() {
         let (_runtime, control) = control(None);

--- a/rocketmq-transport/src/dispatch/deferred_resume.rs
+++ b/rocketmq-transport/src/dispatch/deferred_resume.rs
@@ -482,33 +482,34 @@ where
         Completed(RocketMQResult<T>),
         Stopped(ResumeResult),
     }
-    let outcome = {
-        let handler_future = handler(resume, reason);
-        tokio::pin!(handler_future);
-        tokio::select! {
-            biased;
-            stop = stop_view.wait_before_write() => HandlerOutcome::Stopped(finish_lifecycle(
-                id,
-                request_id,
-                responder.take().expect("stopped handler responder"),
-                marker.take().expect("stopped handler marker"),
-                stop,
-                None,
-            )),
-            result = &mut handler_future => {
-                match stop_view.current_before_write() {
-                    Some(stop) => HandlerOutcome::Stopped(finish_lifecycle(
-                        id,
-                        request_id,
-                        responder.take().expect("post-handler responder"),
-                        marker.take().expect("post-handler marker"),
-                        stop,
-                        None,
-                    )),
-                    None => HandlerOutcome::Completed(result),
-                }
-            },
-        }
+    // Keep the completed handler future alive until response delivery reaches
+    // its canonical terminal. Broker-private handlers use this ownership seam
+    // for affine resources that must span business execution and socket I/O.
+    let handler_future = handler(resume, reason);
+    tokio::pin!(handler_future);
+    let outcome = tokio::select! {
+        biased;
+        stop = stop_view.wait_before_write() => HandlerOutcome::Stopped(finish_lifecycle(
+            id,
+            request_id,
+            responder.take().expect("stopped handler responder"),
+            marker.take().expect("stopped handler marker"),
+            stop,
+            None,
+        )),
+        result = &mut handler_future => {
+            match stop_view.current_before_write() {
+                Some(stop) => HandlerOutcome::Stopped(finish_lifecycle(
+                    id,
+                    request_id,
+                    responder.take().expect("post-handler responder"),
+                    marker.take().expect("post-handler marker"),
+                    stop,
+                    None,
+                )),
+                None => HandlerOutcome::Completed(result),
+            }
+        },
     };
     let result = match outcome {
         HandlerOutcome::Stopped(result) => result,
@@ -695,6 +696,10 @@ impl ResumeCompletion {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "deferred_resume/terminal_ownership_tests.rs"]
+mod terminal_ownership_tests;
 
 #[cfg(test)]
 mod tests {

--- a/rocketmq-transport/src/dispatch/deferred_resume/terminal_ownership_tests.rs
+++ b/rocketmq-transport/src/dispatch/deferred_resume/terminal_ownership_tests.rs
@@ -1,0 +1,136 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Instant;
+
+use rocketmq_error::RocketMQResult;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use tokio::sync::Notify;
+
+use super::execute_work;
+use super::ResumeStopView;
+use crate::admission::AdmissionController;
+use crate::admission::AdmissionLimits;
+use crate::dispatch::DeferredAdmission;
+use crate::dispatch::DeferredParts;
+use crate::dispatch::DeferredRegistry;
+use crate::dispatch::DeferredRequest;
+use crate::dispatch::DeferredRetainedSizeParts;
+use crate::dispatch::DeferredWaitLimits;
+use crate::dispatch::DeferredWakeReason;
+use crate::dispatch::OriginalRequestIdentity;
+use crate::dispatch::RequestControlView;
+use crate::dispatch::RequestMeta;
+use crate::dispatch::ResponsePlan;
+use crate::dispatch::ResponseSink;
+use crate::session_view::EmbeddedSessionRecord;
+use crate::telemetry::TransportTelemetry;
+
+struct ReadyRetainedFuture {
+    output: Option<RocketMQResult<ResponsePlan>>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl Future for ReadyRetainedFuture {
+    type Output = RocketMQResult<ResponsePlan>;
+
+    fn poll(mut self: Pin<&mut Self>, _context: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+        std::task::Poll::Ready(self.output.take().expect("retained future is polled once"))
+    }
+}
+
+impl Drop for ReadyRetainedFuture {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+#[tokio::test]
+async fn completed_handler_future_is_retained_until_canonical_response_handoff_terminal() {
+    let runtime = RuntimeOwner::new(RuntimeConfig::server_default("deferred-resume-handler-owner"))
+        .expect("handler-owner runtime");
+    let parent = runtime.root_context().component("handler-owner").task_group().clone();
+    let session = EmbeddedSessionRecord::new(98_330);
+    let control = RequestControlView::from_meta(
+        &RequestMeta::new(Instant::now(), None),
+        session.view().state().clone(),
+        &parent,
+    );
+    let checked = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let (sink, _receiver, _attempts) =
+        ResponseSink::local_plan_with_handoff_gate(control.clone(), Arc::clone(&checked), Arc::clone(&release));
+    let original = OriginalRequestIdentity::capture(
+        98_330,
+        &AtomicU64::new(1),
+        &RemotingCommand::create_remoting_command(39).set_opaque(833),
+    )
+    .expect("handler-owner identity");
+    let responder = sink
+        .deferred_seed_for_test(TransportTelemetry::noop(), session.view().id(), control)
+        .into_responder(original);
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = DeferredAdmission::try_configure(&controller, DeferredWaitLimits::new(1, 4096))
+        .expect("handler-owner admission");
+    let retained = DeferredRegistry::<()>::try_retained_size(DeferredRetainedSizeParts::new(0))
+        .expect("handler-owner retained size");
+    let permit = admission.try_reserve(retained).expect("handler-owner wait permit");
+    let registry = DeferredRegistry::new();
+    let registration = registry
+        .register(DeferredRequest::new((), DeferredParts::new(responder, permit)))
+        .expect("handler-owner registration");
+    let id = registration.deferred_id();
+    registration.commit().expect("publish handler-owner registration");
+    let claim = registry
+        .claim(id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("claim handler-owner registration");
+    let parts = claim.into_execution_parts();
+    let stop_view = ResumeStopView::from_execution_parts(&parts);
+    let drops = Arc::new(AtomicUsize::new(0));
+    let future_drops = Arc::clone(&drops);
+    let execution = tokio::spawn(execute_work(
+        parts,
+        move |(), _reason| ReadyRetainedFuture {
+            output: Some(Ok(ResponsePlan::command(
+                RemotingCommand::create_response_command_with_code(0),
+            )
+            .expect("handler-owner response plan"))),
+            drops: future_drops,
+        },
+        stop_view,
+    ));
+
+    checked.notified().await;
+    assert_eq!(
+        drops.load(Ordering::Acquire),
+        0,
+        "a ready handler future still owns affine terminal resources while response delivery is blocked"
+    );
+    release.notify_one();
+    execution
+        .await
+        .expect("handler-owner execution task")
+        .expect("canonical local response handoff");
+    assert_eq!(drops.load(Ordering::Acquire), 1);
+    assert_eq!(admission.snapshot().waiting_count(), 0);
+}

--- a/rocketmq-transport/src/dispatch/deferred_resume/tests/stop.rs
+++ b/rocketmq-transport/src/dispatch/deferred_resume/tests/stop.rs
@@ -15,6 +15,53 @@
 use super::*;
 
 #[tokio::test(start_paused = true)]
+async fn owner_cutoff_is_live_early_and_terminal_at_equal_and_late_instants() {
+    let (runtime, _controller, executor) =
+        executor_with_limits("deferred-resume-cutoff-boundary", AdmissionLimits::default());
+    let session = Arc::new(EmbeddedSessionRecord::new(9_820));
+    let lifecycle = runtime
+        .root_context()
+        .component("deferred-resume-cutoff-boundary-owner");
+    let control = RequestControlView::from_meta(
+        &RequestMeta::new(
+            std::time::Instant::now(),
+            Some(RequestDeadline::after(Duration::from_millis(10))),
+        ),
+        session.view().state().clone(),
+        lifecycle.task_group(),
+    );
+    let stop_view = ResumeStopView::new(control, None);
+
+    assert_eq!(stop_view.current_before_resume(), None);
+    assert_eq!(stop_view.current_before_write(), None);
+    tokio::time::advance(Duration::from_millis(9)).await;
+    assert_eq!(stop_view.current_before_resume(), None, "early remains live");
+    assert_eq!(stop_view.current_before_write(), None, "early write remains live");
+
+    tokio::time::advance(Duration::from_millis(1)).await;
+    assert_eq!(
+        stop_view.current_before_resume().map(|stop| stop.terminal_reason()),
+        Some(DeferredTerminalReason::OwnerDeadline),
+        "the equal instant is terminal"
+    );
+    assert_eq!(
+        stop_view.current_before_write().map(|stop| stop.terminal_reason()),
+        Some(DeferredTerminalReason::OwnerDeadline)
+    );
+
+    tokio::time::advance(Duration::from_millis(1)).await;
+    assert_eq!(
+        stop_view.current_before_resume().map(|stop| stop.terminal_reason()),
+        Some(DeferredTerminalReason::OwnerDeadline),
+        "late remains terminal"
+    );
+    let report = executor
+        .drain_until(ShutdownDeadline::after(Duration::from_secs(1)))
+        .await;
+    assert_eq!(report.aborted, 0);
+}
+
+#[tokio::test(start_paused = true)]
 async fn owner_cutoff_cancels_an_ordered_waiter_before_processor_execution() {
     let (runtime, controller, executor) =
         executor_with_limits("deferred-resume-ordering-cutoff", AdmissionLimits::default());

--- a/rocketmq-transport/src/dispatch/response_sink/plan.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan.rs
@@ -245,7 +245,7 @@ impl ResponseSink {
     }
 
     #[cfg(test)]
-    fn local_plan_with_handoff_gate(
+    pub(in crate::dispatch) fn local_plan_with_handoff_gate(
         control: RequestControlView,
         checked: Arc<tokio::sync::Notify>,
         resume: Arc<tokio::sync::Notify>,

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests/deferred_expiry.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests/deferred_expiry.rs
@@ -144,6 +144,7 @@ impl RequestProcessorV2 for TcpDeferredExpiryProcessor {
 struct TcpExpiryHarness {
     runtime: V2TestRuntime,
     admission_controller: Arc<AdmissionController>,
+    admission_events: tokio::sync::mpsc::Receiver<crate::admission::AdmissionEvent>,
     registry: DeferredRegistry<i32>,
     admission: DeferredAdmission,
     state: Arc<ExpiryProcessorState>,
@@ -155,7 +156,11 @@ struct TcpExpiryHarness {
 fn expiry_harness(name: &'static str, policy: ExpiryPolicy) -> TcpExpiryHarness {
     let runtime = V2TestRuntime::new(name);
     let registry = DeferredRegistry::<i32>::new();
-    let admission_controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let (admission_event_tx, admission_events) = tokio::sync::mpsc::channel(64);
+    let admission_controller = Arc::new(AdmissionController::with_observer(
+        AdmissionLimits::default(),
+        admission_event_tx,
+    ));
     let admission = DeferredAdmission::try_configure(
         admission_controller.as_ref(),
         DeferredWaitLimits::new(8, 8 * 1024 * 1024),
@@ -178,6 +183,7 @@ fn expiry_harness(name: &'static str, policy: ExpiryPolicy) -> TcpExpiryHarness 
     TcpExpiryHarness {
         runtime,
         admission_controller,
+        admission_events,
         registry,
         admission,
         state,
@@ -211,6 +217,17 @@ async fn await_commit_barrier(client: &mut crate::connection::Connection, state:
     state.committed.notified().await;
 }
 
+async fn await_inflight_release(events: &mut tokio::sync::mpsc::Receiver<crate::admission::AdmissionEvent>) {
+    loop {
+        let event = events.recv().await.expect("admission observer remains open");
+        if event.resource == crate::admission::AdmissionResource::Inflight
+            && event.outcome == crate::admission::AdmissionOutcome::Released
+        {
+            break;
+        }
+    }
+}
+
 #[tokio::test]
 async fn real_tcp_protocol_timeout_sweeps_and_resumes_exactly_once() {
     let mut harness = expiry_harness(
@@ -227,7 +244,9 @@ async fn real_tcp_protocol_timeout_sweeps_and_resumes_exactly_once() {
     let terminals = Arc::clone(&harness.terminals);
     let (mut client, _address, mut running) = start_server(harness.runtime, harness.server).await;
     let observed = send_deferred_request(&mut client, &mut harness.registrations, 9_001).await;
+    await_inflight_release(&mut harness.admission_events).await;
     await_commit_barrier(&mut client, &state, 9_011).await;
+    await_inflight_release(&mut harness.admission_events).await;
 
     let batch =
         registry.sweep_expired_at_for_test(observed.scheduled_at, NonZeroUsize::new(8).expect("non-zero sweep"));
@@ -306,7 +325,9 @@ async fn real_tcp_owner_cutoff_removes_without_resuming_or_writing() {
     let terminals = Arc::clone(&harness.terminals);
     let (mut client, _address, mut running) = start_server(harness.runtime, harness.server).await;
     let observed = send_deferred_request(&mut client, &mut harness.registrations, 9_002).await;
+    await_inflight_release(&mut harness.admission_events).await;
     await_commit_barrier(&mut client, &state, 9_012).await;
+    await_inflight_release(&mut harness.admission_events).await;
 
     let batch =
         registry.sweep_expired_at_for_test(observed.scheduled_at, NonZeroUsize::new(8).expect("non-zero sweep"));


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #9833

### Brief Description
- add broker-private registry-backed Notification and PopLite deferred services with typed request data, checked deadlines, affine indexes, and terminal resource snapshots
- preserve V1 suspension/direct-write behavior while sharing PopLite event reserve/commit/rollback ownership across V1 and V2
- keep same-client PopLite wake ownership through the canonical writer terminal and make queue-lock cancellation and offset correction fail-safe
- add real Store, TransportServerV2/TCP, raw V1 frame, capacity, lifecycle, owner-backed body, partial-write, and terminal-zero coverage
- retain the production V1 routes; production V2 leaves, lifecycle ownership, and aggregate cutover remain assigned to MIG-04, BRK-06, and MIG-05

### How Did You Test This Change?
- `cargo test -p rocketmq-broker --lib notification_deferred` (31 passed; repeated with `--all-features`)
- `cargo test -p rocketmq-broker --lib pop_lite_deferred` (33 passed; repeated with `--all-features`)
- V1 raw Notification and PopLite compatibility, real-store causality/wire, pinned permit, queue-lock, offset correction, owner cutoff, body-owner and possibly-partial focused tests
- `cargo fmt -p rocketmq-broker -- --check`
- `cargo fmt -p rocketmq-transport -- --check`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example/`
- independent Sol xhigh checklist audit: APPROVE, no P0/P1/P2

Note: the standalone `rocketmq-example` mandatory `cargo fmt --all -- --check` hits Windows error 206 (`The filename or extension is too long`) in both this worktree and the unchanged `origin/main` baseline. The affected broker and transport package format checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deferred long-polling support for Notification and POP Lite requests.
  - Added bounded capacity controls for waiting requests, retained data, and continuation processing.
  - Added reliable event reservation, replay, timeout, and shutdown handling for POP Lite delivery.
  - Added conditional consumer-offset correction to recover from stale or rejected offsets.

- **Bug Fixes**
  - Improved resource release during request completion, expiration, cancellation, and connection failures.
  - Preserved event ordering and prevented duplicate redispatches.

- **Compatibility**
  - Added coverage and safeguards for legacy Notification v1 and POP Lite behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->