### PR TITLE
[ISSUE #9838]🚀Migrate async Send and fast-failure paths to structured V2 execution

### DIFF
--- a/rocketmq-broker/src/config/broker_config.rs
+++ b/rocketmq-broker/src/config/broker_config.rs
@@ -841,6 +841,12 @@ pub struct BrokerConfig {
     #[serde(default = "defaults::broker_fast_failure_pending_max_bytes")]
     pub broker_fast_failure_pending_max_bytes: usize,
 
+    /// Retained for configuration compatibility only.
+    ///
+    /// Structured fast-failure dispatch never transfers a request, channel,
+    /// or connection context to a detached writer. A configured `true` value
+    /// is ignored with a startup warning until the V2 deferred cutover owns
+    /// genuinely post-return Send work.
     #[serde(default = "defaults::send_request_executor_detached_enable")]
     pub send_request_executor_detached_enable: bool,
 

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -545,7 +545,7 @@ impl BrokerFastFailure {
         self.inner.broker_config.broker_fast_failure_enable
     }
 
-    pub(crate) fn send_request_executor_detached_enabled(&self) -> bool {
+    pub(crate) fn legacy_send_detach_requested(&self) -> bool {
         self.inner.broker_config.send_request_executor_detached_enable
     }
 

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -21,7 +21,6 @@ use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_runtime::TaskGroup;
-use rocketmq_runtime::TaskKind;
 use rocketmq_store::BrokerStorePort;
 use rocketmq_transport::api::v1::command_from_error_with_factory_and_opaque;
 use rocketmq_transport::api::v1::command_from_error_with_factory_remark_and_opaque;
@@ -38,7 +37,6 @@ use tracing::warn;
 use self::client_manage_processor::ClientManageProcessor;
 use crate::latency::broker_fast_failure::BrokerFastFailure;
 use crate::latency::broker_fast_failure::FastFailureQueueKind;
-use crate::latency::broker_fast_failure::FastFailureTask;
 use crate::processor::ack_message_processor::AckMessageProcessor;
 use crate::processor::admin_broker_processor::AdminBrokerProcessor;
 use crate::processor::change_invisible_time_processor::ChangeInvisibleTimeProcessor;
@@ -68,6 +66,7 @@ pub(crate) mod client_manage_processor;
 pub(crate) mod consumer_manage_processor;
 pub(crate) mod default_pull_message_result_handler;
 pub(crate) mod end_transaction_processor;
+mod fast_failure_dispatch;
 pub(crate) mod lite_manager_processor;
 pub(crate) mod lite_subscription_ctl_processor;
 pub(crate) mod maintenance_request_processor;
@@ -269,7 +268,7 @@ pub struct BrokerRequestProcessor<MS: BrokerStorePort, TS> {
     default_request_processor: Option<Arc<BrokerProcessorType<MS, TS>>>,
     auth_runtime: Option<Arc<AuthRuntime>>,
     broker_fast_failure: Option<BrokerFastFailure>,
-    request_task_group: Option<TaskGroup>,
+    _request_task_group: Option<TaskGroup>,
 }
 
 impl<MS, TS> BrokerRequestProcessor<MS, TS>
@@ -288,7 +287,7 @@ where
             default_request_processor: None,
             auth_runtime: None,
             broker_fast_failure: None,
-            request_task_group: None,
+            _request_task_group: None,
         }
     }
 
@@ -305,11 +304,17 @@ where
     }
 
     pub fn set_broker_fast_failure(&mut self, broker_fast_failure: BrokerFastFailure) {
+        if broker_fast_failure.legacy_send_detach_requested() {
+            warn!(
+                "sendRequestExecutorDetachedEnable is deprecated and ignored by structured fast-failure dispatch; \
+                 Send requests remain in the admitted handler future until the V2 deferred cutover"
+            );
+        }
         self.broker_fast_failure = Some(broker_fast_failure);
     }
 
     pub fn set_request_task_group(&mut self, request_task_group: TaskGroup) {
-        self.request_task_group = Some(request_task_group);
+        self._request_task_group = Some(request_task_group);
     }
 }
 
@@ -338,7 +343,7 @@ impl<MS: BrokerStorePort, TS> Clone for BrokerRequestProcessor<MS, TS> {
             default_request_processor: self.default_request_processor.clone(),
             auth_runtime: self.auth_runtime.clone(),
             broker_fast_failure: self.broker_fast_failure.clone(),
-            request_task_group: self.request_task_group.clone(),
+            _request_task_group: self._request_task_group.clone(),
         }
     }
 }
@@ -480,231 +485,40 @@ where
         }
 
         let opaque = request.opaque();
-        let retained_bytes = estimate_fast_failure_retained_bytes(request);
-        let (task, response_rx) = match broker_fast_failure.try_enqueue(queue_kind, opaque, retained_bytes) {
-            Ok(admitted) => admitted,
-            Err(response) => return Ok(Some(response)),
+        let metadata = fast_failure_dispatch::FastFailureRequestMetadata::from_command(request);
+        let admission = match fast_failure_dispatch::try_admit(broker_fast_failure, queue_kind, metadata) {
+            Ok(admission) => admission,
+            Err(rejection) => return Ok(Some(rejection.into_legacy_command())),
         };
-        let queued_request = request.clone();
-        let broker_fast_failure = broker_fast_failure.clone();
-        let detach_response = should_detach_fast_failure_response(
-            queue_kind,
-            broker_fast_failure.send_request_executor_detached_enabled(),
-            self.request_task_group.is_some(),
-        );
-
-        if detach_response {
-            let Some(task_group) = &self.request_task_group else {
+        let run = match admission
+            .await_run(fast_failure_dispatch::FastFailureControl::legacy())
+            .await
+        {
+            Ok(run) => run,
+            Err(fast_failure_dispatch::FastFailureAwaitError::Rejected(rejection)) => {
+                return Ok(Some(rejection.into_legacy_command()));
+            }
+            Err(fast_failure_dispatch::FastFailureAwaitError::LifecycleStopped) => {
                 return Ok(Some(system_error_response(
                     &self.command_factory,
                     opaque,
-                    "detached send request executor has no task group",
-                )));
-            };
-            let detached_task = Self::run_detached_fast_failure_request(
-                queue_kind,
-                broker_fast_failure.clone(),
-                task.clone(),
-                processor,
-                channel,
-                ctx,
-                queued_request,
-                opaque,
-                response_rx,
-            );
-            if let Err(error) =
-                task_group.spawn("broker.request.fast-failure.detached", TaskKind::Worker, detached_task)
-            {
-                warn!(?error, "failed to spawn detached fast failure request task");
-                broker_fast_failure.cancel(
-                    queue_kind,
-                    &task,
-                    system_error_response(
-                        &self.command_factory,
-                        opaque,
-                        "detached fast failure request task spawn failed",
-                    ),
-                );
-                return Ok(Some(system_error_response(
-                    &self.command_factory,
-                    opaque,
-                    "detached fast failure request task spawn failed",
+                    "legacy fast-failure dispatch unexpectedly lost its lifecycle owner",
                 )));
             }
-            return Ok(None);
-        }
-
-        let request_task = Self::run_fast_failure_request(
-            queue_kind,
-            broker_fast_failure.clone(),
-            task.clone(),
-            processor,
-            channel,
-            ctx,
-            queued_request,
-            opaque,
-        );
-        if let Some(task_group) = &self.request_task_group {
-            if let Err(error) = task_group.spawn("broker.request.fast-failure", TaskKind::Worker, request_task) {
-                warn!(?error, "failed to spawn fast failure request task");
-                broker_fast_failure.cancel(
-                    queue_kind,
-                    &task,
-                    system_error_response(&self.command_factory, opaque, "fast failure request task spawn failed"),
-                );
-            }
-        } else {
-            request_task.await;
-        }
-
-        match response_rx.await {
-            Ok(response) => Ok(response),
-            Err(_error) => Ok(Some(system_error_response(
-                &self.command_factory,
-                opaque,
-                "fast failure response channel closed before request completed",
-            ))),
-        }
-    }
-
-    async fn run_detached_fast_failure_request(
-        queue_kind: FastFailureQueueKind,
-        broker_fast_failure: BrokerFastFailure,
-        task: Arc<FastFailureTask>,
-        processor: BrokerProcessorType<MS, TS>,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        queued_request: RemotingCommand,
-        opaque: i32,
-        response_rx: tokio::sync::oneshot::Receiver<Option<RemotingCommand>>,
-    ) {
-        let command_factory = broker_fast_failure.command_factory();
-        let request_task = Self::run_fast_failure_request(
-            queue_kind,
-            broker_fast_failure,
-            task,
-            processor,
-            channel,
-            ctx.clone(),
-            queued_request,
-            opaque,
-        );
-        tokio::pin!(request_task);
-        tokio::pin!(response_rx);
-
-        let response_result = tokio::select! {
-            _ = &mut request_task => (&mut response_rx).await,
-            response_result = &mut response_rx => response_result,
         };
-        Self::write_detached_fast_failure_response(&command_factory, response_result, ctx, opaque).await;
-    }
-
-    async fn write_detached_fast_failure_response(
-        command_factory: &RemotingCommandFactory,
-        response_result: Result<Option<RemotingCommand>, tokio::sync::oneshot::error::RecvError>,
-        ctx: ConnectionHandlerContext,
-        opaque: i32,
-    ) {
-        match response_result {
-            Ok(Some(response)) => {
-                if let Err(error) = ctx.try_write_response(response.set_opaque(opaque)).await {
-                    warn!(
-                        kind = error.kind().as_str(),
-                        progress = error.write_progress().map_or("none", |progress| progress.as_str()),
-                        retryable = error.retryable(),
-                        "detached fast failure response write failed; not retrying"
-                    );
-                }
-            }
-            Ok(None) => {}
-            Err(_error) => {
-                if let Err(error) = ctx
-                    .try_write_response(system_error_response(
-                        command_factory,
-                        opaque,
-                        "fast failure response channel closed before detached request completed",
-                    ))
-                    .await
-                {
-                    warn!(
-                        kind = error.kind().as_str(),
-                        progress = error.write_progress().map_or("none", |progress| progress.as_str()),
-                        retryable = error.retryable(),
-                        "detached fast failure response write failed; not retrying"
-                    );
-                }
-            }
-        }
-    }
-
-    async fn run_fast_failure_request(
-        queue_kind: FastFailureQueueKind,
-        broker_fast_failure: BrokerFastFailure,
-        task: Arc<FastFailureTask>,
-        mut processor: BrokerProcessorType<MS, TS>,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        mut queued_request: RemotingCommand,
-        opaque: i32,
-    ) {
-        let Some(_permit) = broker_fast_failure.acquire_permit(queue_kind).await else {
-            warn!("fast failure queue permit acquisition failed: queue={queue_kind:?}");
-            if broker_fast_failure.try_mark_running(queue_kind, &task) {
-                broker_fast_failure.complete(
-                    queue_kind,
-                    &task,
-                    Some(system_error_response(
-                        &broker_fast_failure.command_factory(),
-                        opaque,
-                        "fast failure queue permit acquisition failed",
-                    )),
-                );
-            }
-            return;
-        };
-
-        if !broker_fast_failure.try_mark_running(queue_kind, &task) {
-            return;
-        }
-
-        let response = match processor.process_request(channel, ctx, &mut queued_request).await {
+        let response = match processor.process_request(channel, ctx, request).await {
             Ok(response) => response,
             Err(error) => Some(command_from_error_with_factory_and_opaque(
-                &broker_fast_failure.command_factory(),
+                &self.command_factory,
                 &error,
                 opaque,
             )),
         };
-        broker_fast_failure.complete(queue_kind, &task, response);
+        Ok(match run.complete(response).await {
+            Ok(response) => response,
+            Err(rejection) => Some(rejection.into_legacy_command()),
+        })
     }
-}
-
-fn estimate_fast_failure_retained_bytes(request: &RemotingCommand) -> usize {
-    let mut retained_bytes = std::mem::size_of::<RemotingCommand>();
-    retained_bytes = retained_bytes.saturating_add(request.body().map_or(0, bytes::Bytes::len));
-    retained_bytes = retained_bytes.saturating_add(request.remark().map_or(0, |remark| remark.len()));
-    if let Some(ext_fields) = request.ext_fields() {
-        retained_bytes = retained_bytes.saturating_add(
-            ext_fields
-                .iter()
-                .map(|(key, value)| {
-                    std::mem::size_of_val(key)
-                        .saturating_add(std::mem::size_of_val(value))
-                        .saturating_add(key.len())
-                        .saturating_add(value.len())
-                })
-                .fold(0usize, usize::saturating_add),
-        );
-    }
-    retained_bytes.max(1)
-}
-
-fn should_detach_fast_failure_response(
-    queue_kind: FastFailureQueueKind,
-    send_request_executor_detached_enabled: bool,
-    has_request_task_group: bool,
-) -> bool {
-    queue_kind == FastFailureQueueKind::Send && send_request_executor_detached_enabled && has_request_task_group
 }
 
 fn fast_failure_queue_kind(request_code: i32, default_processor: bool) -> Option<FastFailureQueueKind> {
@@ -862,13 +676,13 @@ mod tests {
     #[test]
     fn fast_failure_retained_bytes_include_body_remark_and_extension_fields() {
         let base = RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(1);
-        let base_bytes = estimate_fast_failure_retained_bytes(&base);
+        let base_bytes = fast_failure_dispatch::estimate_retained_bytes(&base);
         let request = RemotingCommand::new_request(RequestCode::SendMessage, bytes::Bytes::from(vec![1; 1_024]))
             .set_opaque(2)
             .set_remark("busy-budget-test")
             .set_ext_fields(std::collections::HashMap::from([("topic".into(), "orders".into())]));
 
-        let retained_bytes = estimate_fast_failure_retained_bytes(&request);
+        let retained_bytes = fast_failure_dispatch::estimate_retained_bytes(&request);
 
         assert!(retained_bytes >= base_bytes + 1_024 + "busy-budget-test".len() + "topic".len() + "orders".len());
     }
@@ -883,30 +697,6 @@ mod tests {
             fast_failure_queue_kind(RequestCode::UpdateBrokerConfig as i32, false),
             None
         );
-    }
-
-    #[test]
-    fn detach_fast_failure_response_only_applies_to_send_with_task_group() {
-        assert!(should_detach_fast_failure_response(
-            FastFailureQueueKind::Send,
-            true,
-            true
-        ));
-        assert!(!should_detach_fast_failure_response(
-            FastFailureQueueKind::Send,
-            false,
-            true
-        ));
-        assert!(!should_detach_fast_failure_response(
-            FastFailureQueueKind::Send,
-            true,
-            false
-        ));
-        assert!(!should_detach_fast_failure_response(
-            FastFailureQueueKind::Pull,
-            true,
-            true
-        ));
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/fast_failure_dispatch.rs
+++ b/rocketmq-broker/src/processor/fast_failure_dispatch.rs
@@ -1,0 +1,371 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+use rocketmq_transport::api::v2::RequestControlView;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponsePlanError;
+use tokio::sync::OwnedSemaphorePermit;
+
+use crate::latency::broker_fast_failure::BrokerFastFailure;
+use crate::latency::broker_fast_failure::FastFailureQueueKind;
+use crate::latency::broker_fast_failure::FastFailureTask;
+
+#[derive(Clone, Copy)]
+pub(super) struct FastFailureRequestMetadata {
+    opaque: i32,
+    retained_bytes: usize,
+}
+
+impl FastFailureRequestMetadata {
+    pub(super) fn from_command(request: &RemotingCommand) -> Self {
+        Self {
+            opaque: request.opaque(),
+            retained_bytes: estimate_retained_bytes(request),
+        }
+    }
+}
+
+pub(super) enum FastFailureControl<'a> {
+    Legacy,
+    Request(&'a RequestControlView),
+    #[cfg(test)]
+    CancelOnSecondCheck(&'a std::sync::atomic::AtomicUsize),
+}
+
+impl FastFailureControl<'_> {
+    pub(super) const fn legacy() -> Self {
+        Self::Legacy
+    }
+
+    #[cfg(test)]
+    const fn cancel_on_second_check(checks: &std::sync::atomic::AtomicUsize) -> FastFailureControl<'_> {
+        FastFailureControl::CancelOnSecondCheck(checks)
+    }
+
+    fn is_cancelled(&self) -> bool {
+        match self {
+            Self::Legacy => false,
+            Self::Request(control) => control.is_cancelled(),
+            #[cfg(test)]
+            Self::CancelOnSecondCheck(checks) => checks.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 1,
+        }
+    }
+
+    async fn cancelled(&self) {
+        match self {
+            Self::Request(control) => control.cancelled().await,
+            Self::Legacy => std::future::pending().await,
+            #[cfg(test)]
+            Self::CancelOnSecondCheck(_) => std::future::pending().await,
+        }
+    }
+}
+
+impl<'a> From<&'a RequestControlView> for FastFailureControl<'a> {
+    fn from(control: &'a RequestControlView) -> Self {
+        Self::Request(control)
+    }
+}
+
+pub(super) struct FastFailureAdmission {
+    service: BrokerFastFailure,
+    queue_kind: FastFailureQueueKind,
+    task: Arc<FastFailureTask>,
+    response_rx: Option<tokio::sync::oneshot::Receiver<Option<RemotingCommand>>>,
+    opaque: i32,
+    armed: bool,
+}
+
+impl FastFailureAdmission {
+    pub(super) async fn await_run(
+        mut self,
+        control: FastFailureControl<'_>,
+    ) -> Result<FastFailureRunGuard, FastFailureAwaitError> {
+        let Some(mut response_rx) = self.response_rx.take() else {
+            self.armed = false;
+            return Err(FastFailureAwaitError::Rejected(self.missing_response_rejection(
+                FastFailureRejectionKind::Internal,
+                "fast failure admission lost its response receiver before dispatch",
+            )));
+        };
+        if control.is_cancelled() {
+            self.cancel_for_control();
+            self.armed = false;
+            drop(response_rx);
+            return Err(FastFailureAwaitError::LifecycleStopped);
+        }
+
+        // A queue cancellation already owns the response. Bias it ahead of a
+        // simultaneously available permit so cancelled work never reaches the processor.
+        let permit = tokio::select! {
+            biased;
+            response = &mut response_rx => {
+                self.armed = false;
+                return Err(FastFailureAwaitError::Rejected(rejection_from_result(
+                    response,
+                    &self.service.command_factory(),
+                    self.opaque,
+                    FastFailureRejectionKind::QueueCancelled,
+                    "fast failure request was cancelled without a response",
+                )));
+            }
+            () = control.cancelled() => {
+                self.cancel_for_control();
+                self.armed = false;
+                drop(response_rx);
+                return Err(FastFailureAwaitError::LifecycleStopped);
+            }
+            permit = self.service.acquire_permit(self.queue_kind) => permit,
+        };
+
+        let Some(permit) = permit else {
+            self.cancel_with_response(super::system_error_response(
+                &self.service.command_factory(),
+                self.opaque,
+                "fast failure queue permit acquisition failed",
+            ));
+            self.armed = false;
+            return Err(FastFailureAwaitError::Rejected(rejection_from_result(
+                response_rx.await,
+                &self.service.command_factory(),
+                self.opaque,
+                FastFailureRejectionKind::PermitClosed,
+                "fast failure queue permit acquisition failed before a response was produced",
+            )));
+        };
+        if !self.service.try_mark_running(self.queue_kind, &self.task) {
+            self.armed = false;
+            return Err(FastFailureAwaitError::Rejected(rejection_from_result(
+                response_rx.await,
+                &self.service.command_factory(),
+                self.opaque,
+                FastFailureRejectionKind::QueueCancelled,
+                "fast failure request was cancelled before processor execution",
+            )));
+        }
+
+        self.armed = false;
+        let run = FastFailureRunGuard {
+            service: self.service.clone(),
+            queue_kind: self.queue_kind,
+            task: Arc::clone(&self.task),
+            response_rx: Some(response_rx),
+            opaque: self.opaque,
+            _permit: permit,
+            settled: false,
+        };
+        // Cancellation may race the permit/CAS transition. The affine run
+        // owner rolls that transition back before any business future exists.
+        if control.is_cancelled() {
+            drop(run);
+            return Err(FastFailureAwaitError::LifecycleStopped);
+        }
+        Ok(run)
+    }
+
+    fn cancel_for_control(&self) {
+        self.cancel_with_response(super::system_error_response(
+            &self.service.command_factory(),
+            self.opaque,
+            "request lifecycle ended before fast-failure dispatch",
+        ));
+    }
+
+    fn cancel_with_response(&self, response: RemotingCommand) {
+        self.service.cancel(self.queue_kind, &self.task, response);
+    }
+
+    fn missing_response_rejection(&self, kind: FastFailureRejectionKind, remark: &'static str) -> FastFailureRejection {
+        FastFailureRejection::new(
+            kind,
+            super::system_error_response(&self.service.command_factory(), self.opaque, remark),
+        )
+    }
+}
+
+impl Drop for FastFailureAdmission {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.cancel_with_response(super::system_error_response(
+            &self.service.command_factory(),
+            self.opaque,
+            "fast failure admission owner was dropped before processor execution",
+        ));
+    }
+}
+
+pub(super) struct FastFailureRunGuard {
+    service: BrokerFastFailure,
+    queue_kind: FastFailureQueueKind,
+    task: Arc<FastFailureTask>,
+    response_rx: Option<tokio::sync::oneshot::Receiver<Option<RemotingCommand>>>,
+    opaque: i32,
+    _permit: OwnedSemaphorePermit,
+    settled: bool,
+}
+
+impl FastFailureRunGuard {
+    pub(super) async fn complete(
+        mut self,
+        response: Option<RemotingCommand>,
+    ) -> Result<Option<RemotingCommand>, FastFailureRejection> {
+        self.service.complete(self.queue_kind, &self.task, response);
+        self.settled = true;
+        let Some(response_rx) = self.response_rx.take() else {
+            return Err(FastFailureRejection::new(
+                FastFailureRejectionKind::Internal,
+                super::system_error_response(
+                    &self.service.command_factory(),
+                    self.opaque,
+                    "fast failure run owner lost its response receiver",
+                ),
+            ));
+        };
+        response_rx.await.map_err(|_| {
+            FastFailureRejection::new(
+                FastFailureRejectionKind::Internal,
+                super::system_error_response(
+                    &self.service.command_factory(),
+                    self.opaque,
+                    "fast failure response channel closed before request completed",
+                ),
+            )
+        })
+    }
+}
+
+impl Drop for FastFailureRunGuard {
+    fn drop(&mut self) {
+        if !self.settled {
+            // `complete` performs the running-count transition and wakes the
+            // unique receiver; dropping the permit then admits the next waiter.
+            self.service.complete(self.queue_kind, &self.task, None);
+            self.settled = true;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum FastFailureRejectionKind {
+    Budget,
+    QueueCancelled,
+    PermitClosed,
+    Internal,
+}
+
+#[derive(Debug)]
+pub(super) enum FastFailureAwaitError {
+    Rejected(FastFailureRejection),
+    LifecycleStopped,
+}
+
+pub(super) struct FastFailureRejection {
+    kind: FastFailureRejectionKind,
+    response: RemotingCommand,
+}
+
+impl std::fmt::Debug for FastFailureRejection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FastFailureRejection")
+            .field("kind", &self.kind)
+            .field("response_code", &self.response.code())
+            .field("opaque", &self.response.opaque())
+            .finish()
+    }
+}
+
+impl FastFailureRejection {
+    fn new(kind: FastFailureRejectionKind, response: RemotingCommand) -> Self {
+        Self { kind, response }
+    }
+
+    pub(super) const fn kind(&self) -> FastFailureRejectionKind {
+        self.kind
+    }
+
+    pub(super) fn into_legacy_command(self) -> RemotingCommand {
+        self.response
+    }
+
+    pub(super) fn into_response_plan(mut self) -> Result<ResponsePlan, ResponsePlanError> {
+        match self.response.take_body() {
+            Some(body) => ResponsePlan::bytes(self.response, body),
+            None => ResponsePlan::command(self.response),
+        }
+    }
+}
+
+pub(super) fn try_admit(
+    service: &BrokerFastFailure,
+    queue_kind: FastFailureQueueKind,
+    metadata: FastFailureRequestMetadata,
+) -> Result<FastFailureAdmission, FastFailureRejection> {
+    let (task, response_rx) = service
+        .try_enqueue(queue_kind, metadata.opaque, metadata.retained_bytes)
+        .map_err(|response| FastFailureRejection::new(FastFailureRejectionKind::Budget, response))?;
+    Ok(FastFailureAdmission {
+        service: service.clone(),
+        queue_kind,
+        task,
+        response_rx: Some(response_rx),
+        opaque: metadata.opaque,
+        armed: true,
+    })
+}
+
+pub(super) fn estimate_retained_bytes(request: &RemotingCommand) -> usize {
+    let mut retained_bytes = std::mem::size_of::<RemotingCommand>();
+    retained_bytes = retained_bytes.saturating_add(request.body().map_or(0, bytes::Bytes::len));
+    retained_bytes = retained_bytes.saturating_add(request.remark().map_or(0, |remark| remark.len()));
+    if let Some(ext_fields) = request.ext_fields() {
+        retained_bytes = retained_bytes.saturating_add(
+            ext_fields
+                .iter()
+                .map(|(key, value)| {
+                    std::mem::size_of_val(key)
+                        .saturating_add(std::mem::size_of_val(value))
+                        .saturating_add(key.len())
+                        .saturating_add(value.len())
+                })
+                .fold(0usize, usize::saturating_add),
+        );
+    }
+    retained_bytes.max(1)
+}
+
+fn rejection_from_result(
+    result: Result<Option<RemotingCommand>, tokio::sync::oneshot::error::RecvError>,
+    command_factory: &RemotingCommandFactory,
+    opaque: i32,
+    kind: FastFailureRejectionKind,
+    missing_response_remark: &'static str,
+) -> FastFailureRejection {
+    match result {
+        Ok(Some(response)) => FastFailureRejection::new(kind, response),
+        Ok(None) | Err(_) => FastFailureRejection::new(
+            FastFailureRejectionKind::Internal,
+            super::system_error_response(command_factory, opaque, missing_response_remark),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-broker/src/processor/fast_failure_dispatch/tests.rs
+++ b/rocketmq-broker/src/processor/fast_failure_dispatch/tests.rs
@@ -1,0 +1,545 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::poll;
+use parking_lot::Mutex;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_security_api::AuthenticatedRequestContext;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::RequestPolicy;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::ServerConfig;
+use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+use rocketmq_transport::api::v2::EmbeddedDispatchErrorKind;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RejectRequestDecision;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestControlView;
+use rocketmq_transport::api::v2::RequestDeadline;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponseWriteObservationV2;
+use rocketmq_transport::api::v2::TransportServerV2;
+use rocketmq_transport::test_support::Connection;
+use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+use tokio::sync::Notify;
+
+use super::*;
+use crate::config::broker_config::BrokerConfig;
+
+fn fast_failure(max_count: usize) -> BrokerFastFailure {
+    BrokerFastFailure::new(Arc::new(BrokerConfig {
+        broker_fast_failure_enable: true,
+        broker_fast_failure_pending_max_count: max_count,
+        broker_fast_failure_pending_max_bytes: 64 * 1024,
+        wait_time_mills_in_send_queue: 60_000,
+        ..BrokerConfig::default()
+    }))
+}
+
+fn request(opaque: i32) -> RemotingCommand {
+    RemotingCommand::new_request(
+        RequestCode::SendMessage,
+        bytes::Bytes::from_static(b"fast-failure-request"),
+    )
+    .set_opaque(opaque)
+}
+
+fn metadata(opaque: i32) -> FastFailureRequestMetadata {
+    FastFailureRequestMetadata::from_command(&request(opaque))
+}
+
+fn assert_queue_resources_released(service: &BrokerFastFailure) {
+    let budget = service.pending_budget_snapshot();
+    assert_eq!(budget.current_count, 0);
+    assert_eq!(budget.current_bytes, 0);
+    assert!(service.pending_count_snapshot().iter().all(|(_, count)| *count == 0));
+}
+
+#[tokio::test]
+async fn queue_cancellation_wins_the_permit_race_and_returns_one_typed_rejection() {
+    let service = fast_failure(2);
+    let admission = try_admit(&service, FastFailureQueueKind::Send, metadata(71)).expect("admitted request");
+    let cancel_response = service
+        .command_factory()
+        .create_response_command_with_code_remark(ResponseCode::SystemBusy, "cancelled before dispatch")
+        .set_opaque(71);
+    assert!(service.cancel(FastFailureQueueKind::Send, &admission.task, cancel_response));
+
+    let error = match admission.await_run(FastFailureControl::legacy()).await {
+        Err(error) => error,
+        Ok(_) => panic!("cancelled admission must not acquire processor ownership"),
+    };
+    let FastFailureAwaitError::Rejected(rejection) = error else {
+        panic!("queue cancellation must not be reported as lifecycle cancellation");
+    };
+    assert_eq!(rejection.kind(), FastFailureRejectionKind::QueueCancelled);
+    let response = rejection.into_legacy_command();
+    assert_eq!(response.code(), ResponseCode::SystemBusy as i32);
+    assert_eq!(response.opaque(), 71);
+    assert_queue_resources_released(&service);
+}
+
+#[tokio::test]
+async fn dropping_pending_admission_releases_budget_without_a_cleaner_scan() {
+    let service = fast_failure(1);
+    let admission = try_admit(&service, FastFailureQueueKind::Send, metadata(72)).expect("admitted request");
+    assert_eq!(service.pending_budget_snapshot().current_count, 1);
+
+    drop(admission);
+
+    assert_queue_resources_released(&service);
+    let replacement = try_admit(&service, FastFailureQueueKind::Send, metadata(73)).expect("budget was released");
+    drop(replacement);
+    assert_queue_resources_released(&service);
+}
+
+#[tokio::test]
+async fn lifecycle_stop_after_permit_cas_rolls_back_before_business_ownership() {
+    let service = fast_failure(2);
+    let checks = AtomicUsize::new(0);
+    let admission = try_admit(&service, FastFailureQueueKind::Send, metadata(78)).expect("admitted request");
+
+    let error = match admission
+        .await_run(FastFailureControl::cancel_on_second_check(&checks))
+        .await
+    {
+        Err(error) => error,
+        Ok(_) => panic!("post-CAS lifecycle stop must not escape as a run owner"),
+    };
+
+    assert!(matches!(error, FastFailureAwaitError::LifecycleStopped));
+    assert_eq!(checks.load(Ordering::SeqCst), 2);
+    assert_queue_resources_released(&service);
+    let replacement = try_admit(&service, FastFailureQueueKind::Send, metadata(79)).expect("permit was rolled back");
+    let run = replacement
+        .await_run(FastFailureControl::legacy())
+        .await
+        .expect("replacement acquires the released permit");
+    drop(run);
+    assert_queue_resources_released(&service);
+}
+
+#[tokio::test]
+async fn dropping_run_guards_releases_execution_permits_and_running_ownership() {
+    let service = fast_failure(128);
+    let mut guards = Vec::new();
+    let blocked = loop {
+        let admission = try_admit(
+            &service,
+            FastFailureQueueKind::Send,
+            metadata(100 + i32::try_from(guards.len()).expect("bounded guard count")),
+        )
+        .expect("admitted request");
+        let mut wait = Box::pin(admission.await_run(FastFailureControl::legacy()));
+        match poll!(&mut wait) {
+            std::task::Poll::Ready(Ok(guard)) => guards.push(guard),
+            std::task::Poll::Ready(Err(error)) => panic!("unexpected admission failure: {error:?}"),
+            std::task::Poll::Pending => break wait,
+        }
+    };
+    assert!(!guards.is_empty());
+    assert_eq!(service.pending_budget_snapshot().current_count, 1);
+
+    drop(guards);
+    let resumed = blocked.await.expect("dropped run guards release an execution permit");
+    drop(resumed);
+
+    assert_queue_resources_released(&service);
+}
+
+struct AllowEmbeddedPolicy;
+
+impl RequestPolicy for AllowEmbeddedPolicy {
+    fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+        Decision::Allow
+    }
+}
+
+#[derive(Clone)]
+struct ControlCaptureProcessor {
+    sender: Arc<Mutex<Option<oneshot::Sender<RequestControlView>>>>,
+}
+
+impl RequestProcessorV2 for ControlCaptureProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        if let Some(sender) = self.sender.lock().take() {
+            let _ = sender.send(request.control().clone());
+        }
+        let response = RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+            .set_opaque(request.original_identity().original_opaque());
+        Ok(HandlerOutcome::Reply(
+            ResponsePlan::command(response).expect("control capture response plan"),
+        ))
+    }
+}
+
+struct ControlFixture {
+    owner: RuntimeOwner,
+    context: rocketmq_runtime::ChildServiceContext,
+    harness: EmbeddedRequestHarnessV2<ControlCaptureProcessor>,
+    receiver: Option<oneshot::Receiver<RequestControlView>>,
+}
+
+impl ControlFixture {
+    fn new(name: &'static str) -> Self {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default(name)).expect("control fixture runtime");
+        let context = owner.root_context().component(format!("{name}.request"));
+        let (sender, receiver) = oneshot::channel();
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            ControlCaptureProcessor {
+                sender: Arc::new(Mutex::new(Some(sender))),
+            },
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            context.task_group().clone(),
+            Principal::new("fast-failure-control-test"),
+        );
+        Self {
+            owner,
+            context,
+            harness,
+            receiver: Some(receiver),
+        }
+    }
+
+    async fn capture(&mut self, deadline: Option<RequestDeadline>, opaque: i32) -> RequestControlView {
+        let EmbeddedDispatchOutcome::Reply(plan) = self
+            .harness
+            .dispatch(deadline, request(opaque))
+            .await
+            .expect("capture a real V2 request control")
+        else {
+            panic!("control capture must return an inline reply");
+        };
+        drop(plan);
+        self.receiver
+            .take()
+            .expect("one control receiver")
+            .await
+            .expect("processor supplied its V2 control")
+    }
+
+    async fn finish(self) {
+        drop(self.harness);
+        drop(self.context);
+        assert!(self.owner.shutdown_tasks().await.is_healthy());
+        assert!(self.owner.shutdown_background().is_healthy());
+    }
+}
+
+#[tokio::test]
+async fn real_v2_deadline_stops_pending_admission_without_a_processor_owner() {
+    let service = fast_failure(2);
+    let mut fixture = ControlFixture::new("fast-failure-v2-deadline");
+    let control = fixture
+        .capture(Some(RequestDeadline::after(Duration::from_secs(1))), 74)
+        .await;
+    control.cancelled().await;
+    let admission = try_admit(&service, FastFailureQueueKind::Send, metadata(74)).expect("admitted request");
+
+    let error = match admission.await_run(FastFailureControl::from(&control)).await {
+        Err(error) => error,
+        Ok(_) => panic!("expired V2 control must not acquire processor ownership"),
+    };
+    assert!(matches!(error, FastFailureAwaitError::LifecycleStopped));
+    assert_queue_resources_released(&service);
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn real_v2_parent_cancel_stops_pending_admission_without_a_processor_owner() {
+    let service = fast_failure(2);
+    let mut fixture = ControlFixture::new("fast-failure-v2-parent-cancel");
+    let control = fixture.capture(None, 75).await;
+    fixture.context.task_group().cancel();
+    let admission = try_admit(&service, FastFailureQueueKind::Send, metadata(75)).expect("admitted request");
+
+    let error = match admission.await_run(FastFailureControl::from(&control)).await {
+        Err(error) => error,
+        Ok(_) => panic!("cancelled V2 parent must not acquire processor ownership"),
+    };
+    assert!(matches!(error, FastFailureAwaitError::LifecycleStopped));
+    assert_queue_resources_released(&service);
+    fixture.finish().await;
+}
+
+#[derive(Clone)]
+struct PendingFastFailureProcessor {
+    service: BrokerFastFailure,
+    entered: Arc<tokio::sync::Notify>,
+}
+
+impl RequestProcessorV2 for PendingFastFailureProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let admission = match try_admit(
+            &self.service,
+            FastFailureQueueKind::Send,
+            FastFailureRequestMetadata::from_command(request.command()),
+        ) {
+            Ok(admission) => admission,
+            Err(rejection) => {
+                return Ok(HandlerOutcome::Reply(
+                    rejection.into_response_plan().expect("pending rejection plan"),
+                ));
+            }
+        };
+        let _run = match admission.await_run(FastFailureControl::from(request.control())).await {
+            Ok(run) => run,
+            Err(FastFailureAwaitError::Rejected(rejection)) => {
+                return Ok(HandlerOutcome::Reply(
+                    rejection.into_response_plan().expect("queued rejection plan"),
+                ));
+            }
+            Err(FastFailureAwaitError::LifecycleStopped) => {
+                return Err(rocketmq_error::RocketMQError::invariant_violated(
+                    "dispatcher lifecycle stopped before fast-failure execution",
+                ));
+            }
+        };
+        self.entered.notify_one();
+        std::future::pending().await
+    }
+}
+
+#[tokio::test]
+async fn canonical_v2_deadline_drops_post_mark_run_owner_and_releases_resources() {
+    let service = fast_failure(2);
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("fast-failure-post-mark-deadline"))
+        .expect("post-mark V2 runtime");
+    let context = owner
+        .root_context()
+        .component("fast-failure-post-mark-deadline.request");
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        PendingFastFailureProcessor {
+            service: service.clone(),
+            entered: Arc::clone(&entered),
+        },
+        Vec::new(),
+        Arc::new(TransportSecurity::secure_enforced(
+            Some(Arc::new(AllowEmbeddedPolicy)),
+            None,
+        )),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+    ));
+    let harness = EmbeddedRequestHarnessV2::new(
+        dispatcher,
+        context.task_group().clone(),
+        Principal::new("fast-failure-post-mark-test"),
+    );
+    let error = {
+        let entered_wait = entered.notified();
+        let dispatch = harness.dispatch(Some(RequestDeadline::after(Duration::from_secs(1))), request(77));
+        tokio::pin!(dispatch);
+        tokio::select! {
+            () = entered_wait => {}
+            result = &mut dispatch => panic!("post-mark processor completed before deadline: {result:?}"),
+        }
+        dispatch
+            .await
+            .expect_err("canonical V2 deadline cancels the running processor")
+    };
+    assert_eq!(error.kind(), EmbeddedDispatchErrorKind::DeadlineExceeded);
+    assert_queue_resources_released(&service);
+
+    drop(harness);
+    drop(context);
+    assert!(owner.shutdown_tasks().await.is_healthy());
+    assert!(owner.shutdown_background().is_healthy());
+}
+
+#[derive(Clone)]
+struct CanonicalFastFailureProcessor {
+    service: BrokerFastFailure,
+    admissions: Arc<AtomicUsize>,
+    business_executions: Arc<AtomicUsize>,
+    writes: Arc<AtomicUsize>,
+    write_observed: Arc<Notify>,
+}
+
+impl RequestProcessorV2 for CanonicalFastFailureProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.admissions.fetch_add(1, Ordering::SeqCst);
+        let metadata = FastFailureRequestMetadata::from_command(request.command());
+        let plan = match try_admit(&self.service, FastFailureQueueKind::Send, metadata) {
+            Err(rejection) => rejection
+                .into_response_plan()
+                .expect("typed fast-failure rejection plan"),
+            Ok(admission) => match admission.await_run(FastFailureControl::from(request.control())).await {
+                Ok(run) => {
+                    self.business_executions.fetch_add(1, Ordering::SeqCst);
+                    let response = RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                        .set_opaque(request.original_identity().original_opaque());
+                    let response = run
+                        .complete(Some(response))
+                        .await
+                        .map_err(|_| {
+                            rocketmq_error::RocketMQError::invariant_violated("fast-failure completion failed")
+                        })?
+                        .ok_or_else(|| {
+                            rocketmq_error::RocketMQError::invariant_violated(
+                                "fast-failure completion lost its response",
+                            )
+                        })?;
+                    ResponsePlan::command(response).expect("completed response plan")
+                }
+                Err(FastFailureAwaitError::Rejected(rejection)) => {
+                    rejection.into_response_plan().expect("queued rejection plan")
+                }
+                Err(FastFailureAwaitError::LifecycleStopped) => {
+                    return Err(rocketmq_error::RocketMQError::invariant_violated(
+                        "fast-failure V2 request lifecycle stopped",
+                    ));
+                }
+            },
+        };
+        Ok(HandlerOutcome::Reply(plan))
+    }
+
+    fn reject_request(&self, _code: i32) -> RejectRequestDecision {
+        RejectRequestDecision::Proceed
+    }
+
+    fn observe_response_write(&self, _observation: ResponseWriteObservationV2) {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.write_observed.notify_one();
+    }
+}
+
+#[tokio::test]
+async fn v2_typed_budget_rejection_is_driven_and_written_once_by_the_canonical_dispatcher() {
+    const OPAQUE: i32 = 76;
+
+    let service = fast_failure(1);
+    let held = try_admit(&service, FastFailureQueueKind::Send, metadata(70)).expect("fill pending budget");
+    let held_usage = service.pending_budget_snapshot();
+    let admissions = Arc::new(AtomicUsize::new(0));
+    let business_executions = Arc::new(AtomicUsize::new(0));
+    let writes = Arc::new(AtomicUsize::new(0));
+    let write_observed = Arc::new(Notify::new());
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("broker-fast-failure-v2-rejection"))
+        .expect("fast-failure V2 test runtime owner");
+    let server = TransportServerV2::new(
+        Arc::new(ServerConfig {
+            bind_address: "127.0.0.1".to_owned(),
+            listen_port: 0,
+            ..ServerConfig::default()
+        }),
+        owner.root_context().component("fast-failure-v2-server"),
+        CanonicalFastFailureProcessor {
+            service: service.clone(),
+            admissions: Arc::clone(&admissions),
+            business_executions: Arc::clone(&business_executions),
+            writes: Arc::clone(&writes),
+            write_observed: Arc::clone(&write_observed),
+        },
+    );
+    let runner = owner.root_context().component("fast-failure-v2-runner");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    runner
+        .spawn_service("fast-failure-v2-run", async move {
+            let result = server
+                .try_run_with_shutdown_report_and_startup(
+                    async move {
+                        let _ = shutdown_rx.await;
+                    },
+                    startup_tx,
+                )
+                .await;
+            let _ = result_tx.send(result);
+        })
+        .expect("spawn owned fast-failure V2 server");
+
+    let address = startup_rx
+        .await
+        .expect("fast-failure V2 startup channel")
+        .expect("fast-failure V2 server startup");
+    let mut client = Connection::new(
+        TcpStream::connect(address)
+            .await
+            .expect("connect fast-failure V2 client"),
+    );
+    let wire_request = RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(OPAQUE);
+    let rejected_bytes = estimate_retained_bytes(&wire_request);
+    client
+        .send_command(wire_request)
+        .await
+        .expect("send fast-failure V2 request");
+    let response = client
+        .receive_command()
+        .await
+        .expect("fast-failure V2 connection remains open")
+        .expect("canonical busy response frame");
+
+    assert_eq!(response.code(), ResponseCode::SystemBusy as i32);
+    assert_eq!(response.opaque(), OPAQUE);
+    assert_eq!(
+        response.remark().map(AsRef::<str>::as_ref),
+        Some(
+            format!(
+                "[PENDING_BUDGET]broker busy, retry later, queue: send, exhausted: Count, request bytes: \
+                 {rejected_bytes}, pending count: 1, pending bytes: {}",
+                held_usage.current_bytes
+            )
+            .as_str()
+        )
+    );
+    assert!(response.body().is_none());
+    tokio::time::timeout(Duration::from_secs(2), write_observed.notified())
+        .await
+        .expect("canonical write observation deadline");
+    assert_eq!(admissions.load(Ordering::SeqCst), 1);
+    assert_eq!(business_executions.load(Ordering::SeqCst), 0);
+    assert_eq!(writes.load(Ordering::SeqCst), 1);
+
+    client.shutdown().await.expect("shutdown fast-failure V2 client");
+    let _ = shutdown_tx.send(());
+    let report = tokio::time::timeout(Duration::from_secs(2), result_rx)
+        .await
+        .expect("fast-failure V2 shutdown deadline")
+        .expect("fast-failure V2 result channel")
+        .expect("fast-failure V2 shutdown report");
+    assert!(report.is_healthy(), "{}", report.to_json());
+    let task_report = owner.shutdown_tasks().await;
+    assert!(task_report.is_healthy(), "{}", task_report.to_json());
+    let final_report = owner.shutdown_background();
+    assert!(final_report.is_healthy(), "{}", final_report.to_json());
+    drop(held);
+    assert_queue_resources_released(&service);
+}

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use cheetah_string::CheetahString;
 use rocketmq_model::common::attribute::topic_message_type::TopicMessageType;
 use rocketmq_model::common::message::message_accessor::MessageAccessor;
@@ -36,21 +38,44 @@ use rocketmq_store::BrokerWriteStore;
 use rocketmq_store::PutMessageResult;
 use rocketmq_store::PutMessageStatus;
 use rocketmq_store::StatsType;
+use rocketmq_store_api::MessageAppender;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_and_opaque;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::RequestControlView;
 
+use crate::client::manager::producer_manager::ProducerReplyChannelRegistry;
 use crate::client::net::broker_to_client::Broker2Client;
 use tracing::info;
 use tracing::warn;
 
 use crate::mqtrace::send_message_context::SendMessageContext;
 use crate::processor::send_message_processor::capability::SendMessageProcessorContext;
+use crate::processor::send_message_processor::structured_store::append_message_with_control_reply;
+use crate::processor::send_message_processor::structured_store::await_store;
+use crate::processor::send_message_processor::structured_store::StoreAwaitControl;
+use crate::processor::send_message_processor::structured_store::StoreHookCompletion;
+use crate::processor::send_message_processor::structured_store::StructuredStoreReply;
+use crate::processor::send_message_processor::structured_store::StructuredStoreReplyError;
 use crate::processor::send_message_processor::Inner;
 use crate::transaction::transactional_message_service::TransactionalMessageService;
 
 const PUSH_REPLY_MESSAGE_TO_CLIENT_TIMEOUT_MILLIS: u64 = 10_000;
+
+pub(crate) async fn append_reply_message_with_control_reply<S, M, B>(
+    control: RequestControlView,
+    store: &mut S,
+    message: M,
+    build_response: B,
+) -> Result<StructuredStoreReply, StructuredStoreReplyError>
+where
+    S: MessageAppender<M>,
+    M: Send,
+    B: FnOnce(Result<S::Receipt, S::Error>) -> (RemotingCommand, StoreHookCompletion),
+{
+    append_message_with_control_reply(control, store, message, build_response).await
+}
 
 fn add_reply_response_metadata(response: &mut RemotingCommand, region_id: &str, trace_on: bool) {
     response
@@ -60,6 +85,119 @@ fn add_reply_response_metadata(response: &mut RemotingCommand, region_id: &str, 
 
 fn push_reply_call_failed_remark(sender_id: &str) -> String {
     format!("push reply message to {sender_id}fail.")
+}
+
+enum ReplyPushPortError {
+    ChannelNotFound,
+    Call {
+        source: rocketmq_error::RocketMQError,
+        remote_address: SocketAddr,
+    },
+}
+
+trait ReplyPushPort {
+    type Target: Send;
+
+    fn acquire(&mut self, sender_id: &str) -> Result<Self::Target, ReplyPushPortError>;
+
+    async fn push(
+        &mut self,
+        target: Self::Target,
+        header: ReplyMessageRequestHeader,
+        body: Option<Bytes>,
+        timeout_millis: u64,
+    ) -> Result<RemotingCommand, ReplyPushPortError>;
+}
+
+struct BrokerReplyPushPort {
+    channels: ProducerReplyChannelRegistry,
+    broker_to_client: Broker2Client,
+    command_factory: rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory,
+}
+
+impl ReplyPushPort for BrokerReplyPushPort {
+    type Target = Channel;
+
+    fn acquire(&mut self, sender_id: &str) -> Result<Self::Target, ReplyPushPortError> {
+        self.channels
+            .find_channel(sender_id)
+            .ok_or(ReplyPushPortError::ChannelNotFound)
+    }
+
+    async fn push(
+        &mut self,
+        mut channel: Self::Target,
+        header: ReplyMessageRequestHeader,
+        body: Option<Bytes>,
+        timeout_millis: u64,
+    ) -> Result<RemotingCommand, ReplyPushPortError> {
+        let remote_address = channel.remote_address();
+        let mut command = self
+            .command_factory
+            .create_request_command(RequestCode::PushReplyMessageToClient, header);
+        if let Some(body) = body {
+            command.set_body_mut_ref(body);
+        }
+        self.broker_to_client
+            .call_client(&mut channel, command, timeout_millis)
+            .await
+            .map_err(|source| ReplyPushPortError::Call { source, remote_address })
+    }
+}
+
+fn apply_reply_store_result(
+    put_message_result: &PutMessageResult,
+    response_header: &mut SendMessageResponseHeader,
+    queue_id: i32,
+    max_message_size: i32,
+) -> bool {
+    let put_ok = match put_message_result.put_message_status() {
+        PutMessageStatus::PutOk
+        | PutMessageStatus::FlushDiskTimeout
+        | PutMessageStatus::FlushSlaveTimeout
+        | PutMessageStatus::SlaveNotAvailable => true,
+        PutMessageStatus::ServiceNotAvailable => {
+            warn!(
+                "service not available now. It may be caused by one of the following reasons: the broker's disk \
+                 is full, messages are put to the slave, message store has been shut down, etc."
+            );
+            false
+        }
+        PutMessageStatus::CreateMappedFileFailed => {
+            warn!("create mapped file failed, remoting_server is busy or broken.");
+            false
+        }
+        PutMessageStatus::MessageIllegal => {
+            warn!(
+                "the message is illegal, maybe msg body or properties length not matched. msg body length limit \
+                 {}B.",
+                max_message_size
+            );
+            false
+        }
+        PutMessageStatus::PropertiesSizeExceeded => {
+            warn!("the message is illegal, maybe msg properties length limit 32KB.");
+            false
+        }
+        PutMessageStatus::OsPageCacheBusy => {
+            warn!("[PC_SYNCHRONIZED]broker busy, start flow control for a while");
+            false
+        }
+        PutMessageStatus::UnknownError => {
+            warn!("UNKNOWN_ERROR");
+            false
+        }
+        _ => {
+            warn!("UNKNOWN_ERROR DEFAULT");
+            false
+        }
+    };
+    if let (true, Some(append_result)) = (put_ok, put_message_result.append_message_result()) {
+        response_header.set_msg_id(append_result.msg_id.clone().unwrap_or_default());
+        response_header.set_queue_id(queue_id);
+        response_header.set_queue_offset(append_result.logics_offset);
+    }
+    put_ok
 }
 
 /// Processes reply messages in the Request-Reply pattern.
@@ -100,6 +238,23 @@ fn push_reply_call_failed_remark(sender_id: &str) -> String {
 /// ```
 pub struct ReplyMessageProcessor<MS: BrokerWriteStore, TS> {
     inner: Arc<Inner<MS, TS>>,
+}
+
+struct ReplyCompletionFacts {
+    owner: Option<CheetahString>,
+    body_len: usize,
+}
+
+impl ReplyCompletionFacts {
+    fn capture(request: &RemotingCommand) -> Self {
+        Self {
+            owner: request
+                .get_ext_fields()
+                .and_then(|fields| fields.get(BrokerStatsManager::COMMERCIAL_OWNER))
+                .cloned(),
+            body_len: request.get_body().map_or(0, |body| body.len()),
+        }
+    }
 }
 
 impl<MS: BrokerWriteStore, TS> Clone for ReplyMessageProcessor<MS, TS> {
@@ -268,12 +423,24 @@ where
             queue_id_int = self.inner.random_queue_id(topic_config.write_queue_nums) as i32;
         }
 
+        let inbound_peer = channel.remote_address();
         // Build message inner with extracted helper
-        let mut msg_inner = self.build_msg_inner(channel, request, &request_header, queue_id_int);
-
-        let mut push_reply_result = self
-            .push_reply_message(channel, ctx, &request_header, &mut msg_inner)
-            .await;
+        let mut msg_inner = self.build_msg_inner(inbound_peer, request, &request_header, queue_id_int);
+        let completion_facts = ReplyCompletionFacts::capture(request);
+        let store_host = self.inner.context.policy.snapshot().store_host;
+        let mut push_port = BrokerReplyPushPort {
+            channels: self.inner.context.producer_reply_channels.clone(),
+            broker_to_client: self.inner.broker_to_client,
+            command_factory: self.inner.context.command_factory,
+        };
+        let mut push_reply_result = push_reply_message(
+            &mut push_port,
+            inbound_peer,
+            store_host,
+            &request_header,
+            &mut msg_inner,
+        )
+        .await;
 
         // Update properties_string after msg_inner properties are modified
         msg_inner.properties_string = MessageDecoder::message_properties_to_string(msg_inner.get_properties());
@@ -289,9 +456,14 @@ where
         // Preserve push-first semantics: optional persistence happens only after
         // the client push attempt has completed.
         if store_reply_message_enable {
-            let put_message_result = match self.inner.context.store.put_message(msg_inner).await {
-                Ok(result) => result,
-                Err(_) => {
+            let store_result = await_store(
+                StoreAwaitControl::Legacy,
+                self.inner.context.store.put_message(msg_inner),
+            )
+            .await;
+            let put_message_result = match store_result {
+                Ok(Ok(result)) => result,
+                Ok(Err(_)) | Err(_) => {
                     const STORE_ERROR: &str = "message store not available";
                     warn!("process reply message, {}", STORE_ERROR);
                     return response
@@ -301,7 +473,7 @@ where
             };
             self.handle_put_message_result(
                 put_message_result,
-                request,
+                completion_facts,
                 &mut response_header,
                 send_message_context,
                 queue_id_int,
@@ -315,7 +487,7 @@ where
     // Build MessageExtBrokerInner to improve readability
     fn build_msg_inner(
         &self,
-        channel: &Channel,
+        inbound_peer: SocketAddr,
         request: &RemotingCommand,
         request_header: &SendMessageRequestHeader,
         queue_id_int: i32,
@@ -333,7 +505,7 @@ where
         );
         msg_inner.properties_string = request_header.properties.clone().unwrap_or_default();
         msg_inner.message_ext_inner.born_timestamp = request_header.born_timestamp;
-        msg_inner.message_ext_inner.born_host = channel.remote_address();
+        msg_inner.message_ext_inner.born_host = inbound_peer;
         msg_inner.message_ext_inner.store_host = self.inner.context.policy.snapshot().store_host;
         msg_inner.message_ext_inner.reconsume_times = request_header.reconsume_times.unwrap_or(0);
         msg_inner
@@ -342,60 +514,19 @@ where
     fn handle_put_message_result(
         &mut self,
         put_message_result: PutMessageResult,
-        request: &RemotingCommand,
+        completion_facts: ReplyCompletionFacts,
         response_header: &mut SendMessageResponseHeader,
         send_message_context: &mut SendMessageContext,
         queue_id_int: i32,
         _message_type: TopicMessageType,
         topic: &str,
     ) {
-        let put_ok = match put_message_result.put_message_status() {
-            PutMessageStatus::PutOk
-            | PutMessageStatus::FlushDiskTimeout
-            | PutMessageStatus::FlushSlaveTimeout
-            | PutMessageStatus::SlaveNotAvailable => true,
-            PutMessageStatus::ServiceNotAvailable => {
-                warn!(
-                    "service not available now. It may be caused by one of the following reasons: the broker's disk \
-                     is full, messages are put to the slave, message store has been shut down, etc."
-                );
-                false
-            }
-            PutMessageStatus::CreateMappedFileFailed => {
-                warn!("create mapped file failed, remoting_server is busy or broken.");
-                false
-            }
-            PutMessageStatus::MessageIllegal => {
-                let max_size = self.inner.context.policy.snapshot().max_message_size;
-                warn!(
-                    "the message is illegal, maybe msg body or properties length not matched. msg body length limit \
-                     {}B.",
-                    max_size
-                );
-                false
-            }
-            PutMessageStatus::PropertiesSizeExceeded => {
-                warn!("the message is illegal, maybe msg properties length limit 32KB.");
-                false
-            }
-            PutMessageStatus::OsPageCacheBusy => {
-                warn!("[PC_SYNCHRONIZED]broker busy, start flow control for a while");
-                false
-            }
-            PutMessageStatus::UnknownError => {
-                warn!("UNKNOWN_ERROR");
-                false
-            }
-            _ => {
-                warn!("UNKNOWN_ERROR DEFAULT");
-                false
-            }
-        };
-        let owner = request
-            .get_ext_fields()
-            .unwrap()
-            .get(BrokerStatsManager::COMMERCIAL_OWNER)
-            .cloned();
+        let put_ok = apply_reply_store_result(
+            &put_message_result,
+            response_header,
+            queue_id_int,
+            self.inner.context.policy.snapshot().max_message_size,
+        );
         let (commercial_size_per_msg, commercial_base_count) = {
             let policy = self.inner.context.policy.snapshot();
             (policy.commercial_size_per_msg, policy.commercial_base_count)
@@ -409,10 +540,6 @@ where
             stats_manager.inc_topic_put_nums(topic, append_result.msg_num, 1);
             stats_manager.inc_topic_put_size(topic, append_result.wrote_bytes);
             stats_manager.inc_broker_put_nums(topic, append_result.msg_num);
-
-            response_header.set_msg_id(append_result.msg_id.clone().unwrap_or_default());
-            response_header.set_queue_id(queue_id_int);
-            response_header.set_queue_offset(append_result.logics_offset);
 
             if self.inner.has_send_message_hook() {
                 let msg_id = response_header.msg_id().clone();
@@ -428,15 +555,15 @@ where
                 send_message_context.commercial_send_stats = StatsType::SendSuccess;
                 send_message_context.commercial_send_times = inc_value;
                 send_message_context.commercial_send_size = wrote_size;
-                send_message_context.commercial_owner = owner.unwrap_or_default();
+                send_message_context.commercial_owner = completion_facts.owner.unwrap_or_default();
             }
         } else if self.inner.has_send_message_hook() {
-            let wrote_size = request.get_body().map_or(0, |body| body.len());
+            let wrote_size = completion_facts.body_len;
             let inc_value = (wrote_size as f64 / commercial_size_per_msg as f64).ceil() as i32;
             send_message_context.commercial_send_stats = StatsType::SendFailure;
             send_message_context.commercial_send_times = inc_value;
             send_message_context.commercial_send_size = wrote_size as i32;
-            send_message_context.commercial_owner = owner.unwrap_or_default();
+            send_message_context.commercial_owner = completion_facts.owner.unwrap_or_default();
         }
     }
 
@@ -457,36 +584,33 @@ where
             response_header.set_queue_offset(0);
         }
     }
+}
 
-    async fn push_reply_message<M: MessageTrait>(
-        &mut self,
-        channel: &Channel,
-        _ctx: &ConnectionHandlerContext,
-        request_header: &SendMessageRequestHeader,
-        msg: &mut M,
-    ) -> PushReplyResult {
-        let sender_id = msg.property(&CheetahString::from_static_str(
-            MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT,
+async fn push_reply_message<P: ReplyPushPort, M: MessageTrait>(
+    port: &mut P,
+    inbound_peer: SocketAddr,
+    store_host: SocketAddr,
+    request_header: &SendMessageRequestHeader,
+    msg: &mut M,
+) -> PushReplyResult {
+    let sender_id = msg.property(&CheetahString::from_static_str(
+        MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT,
+    ));
+
+    let Some(sender_id) = sender_id else {
+        warn!(
+            "{} is null, can not reply message",
+            MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT
+        );
+        return PushReplyResult::failure(format!(
+            "reply message properties[{}] is null",
+            MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT
         ));
+    };
 
-        let Some(sender_id) = sender_id else {
-            warn!(
-                "{} is null, can not reply message",
-                MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT
-            );
-            return PushReplyResult::failure(format!(
-                "reply message properties[{}] is null",
-                MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT
-            ));
-        };
-
-        let Some(mut reply_channel) = self
-            .inner
-            .context
-            .producer_reply_channels
-            .find_channel(sender_id.as_str())
-        else {
-            // Format once for both logging and error return
+    let target = match port.acquire(sender_id.as_str()) {
+        Ok(target) => target,
+        Err(ReplyPushPortError::ChannelNotFound) => {
             warn!(
                 "push reply message fail, channel of <{}> not found. Topic: {}, QueueId: {}",
                 sender_id,
@@ -497,93 +621,94 @@ where
                 "push reply message fail, channel of <{}> not found.",
                 sender_id
             ));
-        };
-
-        // Add PROPERTY_PUSH_REPLY_TIME to message properties BEFORE building header
-        msg.put_property(
-            CheetahString::from_static_str(MessageConst::PROPERTY_PUSH_REPLY_TIME),
-            CheetahString::from_string(current_millis().to_string()),
-        );
-
-        // Build reply message request header with properties (including PROPERTY_PUSH_REPLY_TIME)
-        let reply_message_request_header = self.build_reply_request_header(channel, request_header, msg);
-        let mut command = self
-            .inner
-            .context
-            .command_factory
-            .create_request_command(RequestCode::PushReplyMessageToClient, reply_message_request_header);
-        if let Some(body) = msg.get_body().cloned() {
-            command.set_body_mut_ref(body);
         }
+        Err(ReplyPushPortError::Call { .. }) => {
+            return PushReplyResult::failure(push_reply_call_failed_remark(sender_id.as_str()));
+        }
+    };
 
-        let mut broker_to_client = self.inner.broker_to_client;
-        match broker_to_client
-            .call_client(&mut reply_channel, command, PUSH_REPLY_MESSAGE_TO_CLIENT_TIMEOUT_MILLIS)
-            .await
-        {
-            Ok(response) if response.code() == ResponseCode::Success as i32 => PushReplyResult::success(),
-            Ok(response) => {
-                let code = response.code();
-                let remark = response.remark().map(|r| r.as_str()).unwrap_or("unknown error");
-                warn!(
-                    "push reply message to <{}> return fail, code: {}, remark: {}. Topic: {}, QueueId: {}, \
+    // Add PROPERTY_PUSH_REPLY_TIME to message properties BEFORE building header
+    msg.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_PUSH_REPLY_TIME),
+        CheetahString::from_string(current_millis().to_string()),
+    );
+
+    // Build reply message request header with properties (including PROPERTY_PUSH_REPLY_TIME)
+    let reply_message_request_header = build_reply_request_header(inbound_peer, store_host, request_header, msg);
+    match port
+        .push(
+            target,
+            reply_message_request_header,
+            msg.get_body().cloned(),
+            PUSH_REPLY_MESSAGE_TO_CLIENT_TIMEOUT_MILLIS,
+        )
+        .await
+    {
+        Ok(response) if response.code() == ResponseCode::Success as i32 => PushReplyResult::success(),
+        Ok(response) => {
+            let code = response.code();
+            let remark = response.remark().map(|r| r.as_str()).unwrap_or("unknown error");
+            warn!(
+                "push reply message to <{}> return fail, code: {}, remark: {}. Topic: {}, QueueId: {}, \
                      CorrelationId: {:?}",
-                    sender_id,
-                    code,
-                    remark,
-                    request_header.topic(),
-                    request_header.queue_id,
-                    msg.property(&CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID))
-                );
-                // Reuse extracted values to avoid duplicate format
-                PushReplyResult::failure(push_reply_call_failed_remark(sender_id.as_str()))
-            }
-            Err(error) => {
-                warn!(
-                    "push reply message to <{}> failed: {}. Channel: {:?}, Topic: {}, QueueId: {}",
-                    sender_id,
-                    error,
-                    reply_channel.remote_address(),
-                    request_header.topic(),
-                    request_header.queue_id
-                );
-                // Use compact error message to reduce allocation
-                PushReplyResult::failure(push_reply_call_failed_remark(sender_id.as_str()))
-            }
+                sender_id,
+                code,
+                remark,
+                request_header.topic(),
+                request_header.queue_id,
+                msg.property(&CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID))
+            );
+            // Reuse extracted values to avoid duplicate format
+            PushReplyResult::failure(push_reply_call_failed_remark(sender_id.as_str()))
+        }
+        Err(ReplyPushPortError::ChannelNotFound) => {
+            PushReplyResult::failure(push_reply_call_failed_remark(sender_id.as_str()))
+        }
+        Err(ReplyPushPortError::Call { source, remote_address }) => {
+            warn!(
+                "push reply message to <{}> failed: {}. Channel: {:?}, Topic: {}, QueueId: {}",
+                sender_id,
+                source,
+                remote_address,
+                request_header.topic(),
+                request_header.queue_id
+            );
+            // Use compact error message to reduce allocation
+            PushReplyResult::failure(push_reply_call_failed_remark(sender_id.as_str()))
         }
     }
+}
 
-    // Build ReplyMessageRequestHeader with message properties
-    fn build_reply_request_header<M: MessageTrait>(
-        &self,
-        channel: &Channel,
-        request_header: &SendMessageRequestHeader,
-        msg: &M,
-    ) -> ReplyMessageRequestHeader {
-        // Use message properties directly (PROPERTY_PUSH_REPLY_TIME already added)
-        let properties_string = MessageDecoder::message_properties_to_string(msg.get_properties());
+// Build ReplyMessageRequestHeader with message properties
+fn build_reply_request_header<M: MessageTrait>(
+    inbound_peer: SocketAddr,
+    store_host: SocketAddr,
+    request_header: &SendMessageRequestHeader,
+    msg: &M,
+) -> ReplyMessageRequestHeader {
+    // Use message properties directly (PROPERTY_PUSH_REPLY_TIME already added)
+    let properties_string = MessageDecoder::message_properties_to_string(msg.get_properties());
 
-        // Cache addresses to avoid repeated .to_string() calls
-        let born_host = CheetahString::from_string(channel.remote_address().to_string());
-        let store_host = CheetahString::from_string(self.inner.context.policy.snapshot().store_host.to_string());
+    // Cache addresses to avoid repeated .to_string() calls
+    let born_host = CheetahString::from_string(inbound_peer.to_string());
+    let store_host = CheetahString::from_string(store_host.to_string());
 
-        ReplyMessageRequestHeader {
-            born_host,
-            store_host,
-            store_timestamp: current_millis() as i64,
-            producer_group: request_header.producer_group.clone(),
-            topic: request_header.topic.clone(),
-            default_topic: request_header.default_topic.clone(),
-            default_topic_queue_nums: request_header.default_topic_queue_nums,
-            queue_id: request_header.queue_id,
-            sys_flag: request_header.sys_flag,
-            born_timestamp: request_header.born_timestamp,
-            flag: request_header.flag,
-            properties: Some(properties_string),
-            reconsume_times: request_header.reconsume_times,
-            unit_mode: request_header.unit_mode,
-            ..Default::default()
-        }
+    ReplyMessageRequestHeader {
+        born_host,
+        store_host,
+        store_timestamp: current_millis() as i64,
+        producer_group: request_header.producer_group.clone(),
+        topic: request_header.topic.clone(),
+        default_topic: request_header.default_topic.clone(),
+        default_topic_queue_nums: request_header.default_topic_queue_nums,
+        queue_id: request_header.queue_id,
+        sys_flag: request_header.sys_flag,
+        born_timestamp: request_header.born_timestamp,
+        flag: request_header.flag,
+        properties: Some(properties_string),
+        reconsume_times: request_header.reconsume_times,
+        unit_mode: request_header.unit_mode,
+        ..Default::default()
     }
 }
 
@@ -775,3 +900,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "reply_message_processor/structured_store_tests.rs"]
+mod structured_store_tests;

--- a/rocketmq-broker/src/processor/reply_message_processor/structured_store_tests.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor/structured_store_tests.rs
@@ -1,0 +1,483 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_error::RocketMQError;
+use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_model::common::message::MessageConst;
+use rocketmq_model::common::message::MessageTrait;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode as ProtocolResponseCode;
+use rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+use rocketmq_protocol::protocol::header::reply_message_request_header::ReplyMessageRequestHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_security_api::AuthenticatedRequestContext;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::RequestPolicy;
+use rocketmq_store::store_append_receipt;
+use rocketmq_store::AppendMessageResult;
+use rocketmq_store::AppendMessageStatus;
+use rocketmq_store::PutMessageResult;
+use rocketmq_store::PutMessageStatus;
+use rocketmq_store::StoreAppendReceipt;
+use rocketmq_store_api::MessageAppender;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponseWriteObservationV2;
+use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+use super::add_reply_response_metadata;
+use super::append_reply_message_with_control_reply;
+use super::apply_reply_store_result;
+use super::push_reply_message;
+use super::ReplyPushPort;
+use super::ReplyPushPortError;
+use crate::processor::send_message_processor::structured_store::StoreHookCompletion;
+
+const OPAQUE: i32 = 98_308;
+
+#[derive(Clone, Copy)]
+enum StoreBehavior {
+    Success,
+    Error,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct BuiltReply {
+    opaque: i32,
+    code: i32,
+    remark: Option<String>,
+    region: Option<String>,
+    trace: Option<String>,
+    msg_id: String,
+    queue_id: i32,
+    queue_offset: i64,
+}
+
+struct State {
+    events: Mutex<Vec<&'static str>>,
+    built: Mutex<Option<BuiltReply>>,
+}
+
+#[derive(Clone, Copy)]
+enum PushBehavior {
+    Success,
+    NonSuccess,
+    MissingChannel,
+    CallError,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct PushCall {
+    sender_id: String,
+    born_host: String,
+    store_host: String,
+    topic: String,
+    body: Option<Bytes>,
+    timeout_millis: u64,
+    properties: Option<String>,
+}
+
+struct ProbePushPort {
+    behavior: PushBehavior,
+    state: Arc<State>,
+    calls: Arc<Mutex<Vec<PushCall>>>,
+}
+
+impl ProbePushPort {
+    fn new(behavior: PushBehavior, state: Arc<State>) -> Self {
+        Self {
+            behavior,
+            state,
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl ReplyPushPort for ProbePushPort {
+    type Target = String;
+
+    fn acquire(&mut self, sender_id: &str) -> Result<Self::Target, ReplyPushPortError> {
+        if matches!(self.behavior, PushBehavior::MissingChannel) {
+            Err(ReplyPushPortError::ChannelNotFound)
+        } else {
+            Ok(sender_id.to_string())
+        }
+    }
+
+    async fn push(
+        &mut self,
+        sender_id: Self::Target,
+        header: ReplyMessageRequestHeader,
+        body: Option<Bytes>,
+        timeout_millis: u64,
+    ) -> Result<RemotingCommand, ReplyPushPortError> {
+        self.state.events.lock().push("push_completed");
+        self.calls.lock().push(PushCall {
+            sender_id,
+            born_host: header.born_host.to_string(),
+            store_host: header.store_host.to_string(),
+            topic: header.topic.to_string(),
+            body,
+            timeout_millis,
+            properties: header.properties.map(|value| value.to_string()),
+        });
+        match self.behavior {
+            PushBehavior::Success => Ok(RemotingCommand::create_response_command_with_code(
+                ProtocolResponseCode::Success,
+            )),
+            PushBehavior::NonSuccess => Ok(crate::processor::system_error_response(
+                &application_remoting_command_factory(),
+                0,
+                "probe remote non-success",
+            )),
+            PushBehavior::MissingChannel => unreachable!("missing channels stop before message mutation"),
+            PushBehavior::CallError => Err(ReplyPushPortError::Call {
+                source: RocketMQError::network_connection_failed("127.0.0.1:10911", "probe"),
+                remote_address: "127.0.0.1:10911".parse().expect("probe address"),
+            }),
+        }
+    }
+}
+
+fn push_message() -> MessageExtBrokerInner {
+    let mut message = MessageExtBrokerInner::default();
+    message.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT),
+        CheetahString::from_static_str("reply-client"),
+    );
+    message.set_body(Bytes::from_static(b"reply-body"));
+    message
+}
+
+fn push_header(
+) -> rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader
+{
+    rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader {
+        producer_group: "reply-producer".into(),
+        topic: "reply-topic".into(),
+        default_topic: "TBW102".into(),
+        default_topic_queue_nums: 4,
+        queue_id: 5,
+        born_timestamp: 83,
+        ..Default::default()
+    }
+}
+
+impl State {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            events: Mutex::new(Vec::new()),
+            built: Mutex::new(None),
+        })
+    }
+}
+
+struct ReplyAppender {
+    behavior: StoreBehavior,
+    state: Arc<State>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct ReplyStoreError(&'static str);
+
+impl MessageAppender<()> for ReplyAppender {
+    type Receipt = StoreAppendReceipt;
+    type Error = ReplyStoreError;
+
+    fn append_message(
+        &mut self,
+        (): (),
+    ) -> impl std::future::Future<Output = Result<Self::Receipt, Self::Error>> + Send {
+        self.state.events.lock().push("store_entered");
+        std::future::ready(match self.behavior {
+            StoreBehavior::Success => {
+                let append_result = AppendMessageResult {
+                    status: AppendMessageStatus::PutOk,
+                    msg_id: Some("RID-9838".to_string()),
+                    logics_offset: 0,
+                    ..AppendMessageResult::default()
+                };
+                Ok(store_append_receipt(
+                    PutMessageResult::new_append_result(PutMessageStatus::PutOk, Some(append_result)),
+                    23,
+                    23,
+                ))
+            }
+            StoreBehavior::Error => Err(ReplyStoreError("reply store not available")),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct ReplyProbeProcessor {
+    behavior: StoreBehavior,
+    state: Arc<State>,
+}
+
+impl RequestProcessorV2 for ReplyProbeProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let control = request.control().clone();
+        let identity = request.original_identity();
+        let opaque = identity.original_opaque();
+        self.state.events.lock().push("before_hook");
+        let mut push_port = ProbePushPort::new(PushBehavior::Success, Arc::clone(&self.state));
+        let mut push_message = push_message();
+        let push_result = push_reply_message(
+            &mut push_port,
+            "127.0.0.1:18080".parse().expect("inbound peer"),
+            "127.0.0.1:10911".parse().expect("store host"),
+            &push_header(),
+            &mut push_message,
+        )
+        .await;
+        assert!(push_result.success);
+        let mut store = ReplyAppender {
+            behavior: self.behavior,
+            state: Arc::clone(&self.state),
+        };
+        let state = Arc::clone(&self.state);
+        let reply = append_reply_message_with_control_reply(control, &mut store, (), move |result| {
+            let (mut response, msg_id, queue_id, queue_offset) = match result {
+                Ok(receipt) => {
+                    let mut header = SendMessageResponseHeader::default();
+                    assert!(apply_reply_store_result(receipt.result(), &mut header, 5, 1024));
+                    let msg_id = header.msg_id().to_string();
+                    let queue_id = header.queue_id();
+                    let queue_offset = header.queue_offset();
+                    (
+                        application_remoting_command_factory().create_success_response_command_with_header(header),
+                        msg_id,
+                        queue_id,
+                        queue_offset,
+                    )
+                }
+                Err(remark) => (
+                    crate::processor::system_error_response(&application_remoting_command_factory(), opaque, remark.0),
+                    String::new(),
+                    0,
+                    0,
+                ),
+            };
+            response.set_opaque_mut(opaque);
+            add_reply_response_metadata(&mut response, "region-r", true);
+            let fields = response.ext_fields().cloned().unwrap_or_default();
+            *state.built.lock() = Some(BuiltReply {
+                opaque: response.opaque(),
+                code: response.code(),
+                remark: response.remark().map(ToString::to_string),
+                region: fields.get(MessageConst::PROPERTY_MSG_REGION).map(ToString::to_string),
+                trace: fields.get(MessageConst::PROPERTY_TRACE_SWITCH).map(ToString::to_string),
+                msg_id,
+                queue_id,
+                queue_offset,
+            });
+            (response, StoreHookCompletion::BeforeReply)
+        })
+        .await
+        .map_err(|_| RocketMQError::invariant_violated("structured Reply conversion failed"))?;
+        let (outcome, completion) = reply.into_parts();
+        assert_eq!(completion, StoreHookCompletion::BeforeReply);
+        self.state.events.lock().push("after_hook");
+        Ok(outcome)
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        assert_eq!(observation.original_code(), RequestCode::SendReplyMessage as i32);
+        self.state.events.lock().push("write_observed");
+    }
+}
+
+struct AllowEmbeddedPolicy;
+
+impl RequestPolicy for AllowEmbeddedPolicy {
+    fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+        Decision::Allow
+    }
+}
+
+async fn dispatch(behavior: StoreBehavior, state: Arc<State>, name: &'static str) -> EmbeddedDispatchOutcome {
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default(name)).expect("structured Reply runtime");
+    let context = owner.root_context().component(format!("{name}.request"));
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        ReplyProbeProcessor { behavior, state },
+        Vec::new(),
+        Arc::new(TransportSecurity::secure_enforced(
+            Some(Arc::new(AllowEmbeddedPolicy)),
+            None,
+        )),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+    ));
+    let harness = EmbeddedRequestHarnessV2::new(
+        dispatcher,
+        context.task_group().clone(),
+        Principal::new("structured-reply-test"),
+    );
+    let outcome = harness
+        .dispatch(
+            None,
+            RemotingCommand::create_remoting_command(RequestCode::SendReplyMessage).set_opaque(OPAQUE),
+        )
+        .await
+        .expect("structured Reply dispatch");
+    drop(harness);
+    drop(context);
+    assert!(owner.shutdown_tasks().await.is_healthy());
+    assert!(owner.shutdown_background().is_healthy());
+    outcome
+}
+
+#[tokio::test]
+async fn structured_reply_store_leaf_preserves_push_hook_metadata_and_error_visibility() {
+    let success = State::new();
+    let EmbeddedDispatchOutcome::Reply(success_plan) =
+        dispatch(StoreBehavior::Success, Arc::clone(&success), "structured-reply-success").await
+    else {
+        panic!("successful Reply store must return one reply")
+    };
+    assert_eq!(success_plan.response_code(), ProtocolResponseCode::Success as i32);
+    assert_eq!(
+        success.events.lock().as_slice(),
+        [
+            "before_hook",
+            "push_completed",
+            "store_entered",
+            "after_hook",
+            "write_observed"
+        ]
+    );
+    assert_eq!(
+        success.built.lock().as_ref(),
+        Some(&BuiltReply {
+            opaque: OPAQUE,
+            code: ProtocolResponseCode::Success as i32,
+            remark: None,
+            region: Some("region-r".to_string()),
+            trace: Some("true".to_string()),
+            msg_id: "RID-9838".to_string(),
+            queue_id: 5,
+            queue_offset: 0,
+        })
+    );
+    drop(success_plan);
+
+    let failed = State::new();
+    let EmbeddedDispatchOutcome::Reply(error_plan) =
+        dispatch(StoreBehavior::Error, Arc::clone(&failed), "structured-reply-error").await
+    else {
+        panic!("failed Reply store must return one visible reply")
+    };
+    assert_eq!(error_plan.response_code(), ProtocolResponseCode::SystemError as i32);
+    {
+        let built = failed.built.lock();
+        let built = built.as_ref().expect("Reply store error response built");
+        assert_eq!(error_plan.response_code(), built.code);
+        assert_eq!(built.opaque, OPAQUE);
+        assert_eq!(built.remark.as_deref(), Some("reply store not available"));
+    }
+    assert_eq!(
+        failed.events.lock().as_slice(),
+        [
+            "before_hook",
+            "push_completed",
+            "store_entered",
+            "after_hook",
+            "write_observed"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn reply_push_capability_covers_success_missing_channel_non_success_and_call_error() {
+    let cases = [
+        (PushBehavior::Success, true, ""),
+        (
+            PushBehavior::MissingChannel,
+            false,
+            "push reply message fail, channel of <reply-client> not found.",
+        ),
+        (
+            PushBehavior::NonSuccess,
+            false,
+            "push reply message to reply-clientfail.",
+        ),
+        (
+            PushBehavior::CallError,
+            false,
+            "push reply message to reply-clientfail.",
+        ),
+    ];
+
+    for (behavior, expected_success, expected_remark) in cases {
+        let state = State::new();
+        let mut port = ProbePushPort::new(behavior, state);
+        let calls = Arc::clone(&port.calls);
+        let mut message = push_message();
+        let result = push_reply_message(
+            &mut port,
+            "127.0.0.1:18080".parse::<SocketAddr>().expect("inbound peer"),
+            "127.0.0.1:10911".parse::<SocketAddr>().expect("store host"),
+            &push_header(),
+            &mut message,
+        )
+        .await;
+
+        assert_eq!(result.success, expected_success);
+        assert_eq!(result.remark, expected_remark);
+        let calls = calls.lock();
+        if matches!(behavior, PushBehavior::MissingChannel) {
+            assert!(calls.is_empty());
+            assert!(
+                message
+                    .property(&CheetahString::from_static_str(MessageConst::PROPERTY_PUSH_REPLY_TIME))
+                    .is_none(),
+                "missing-channel compatibility must not mutate the message before optional storage"
+            );
+            continue;
+        }
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].sender_id, "reply-client");
+        assert_eq!(calls[0].born_host, "127.0.0.1:18080");
+        assert_eq!(calls[0].store_host, "127.0.0.1:10911");
+        assert_eq!(calls[0].topic, "reply-topic");
+        assert_eq!(calls[0].body.as_deref(), Some(b"reply-body".as_slice()));
+        assert_eq!(
+            calls[0].timeout_millis,
+            super::PUSH_REPLY_MESSAGE_TO_CLIENT_TIMEOUT_MILLIS
+        );
+        assert!(
+            calls[0]
+                .properties
+                .as_deref()
+                .is_some_and(|properties| properties.contains(MessageConst::PROPERTY_PUSH_REPLY_TIME)),
+            "push timestamp must be captured before the capability call"
+        );
+    }
+}

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -105,6 +105,7 @@ use crate::transaction::transactional_message_service::TransactionalMessageServi
 
 pub(crate) mod capability;
 mod message_builder;
+pub(super) mod structured_store;
 
 use capability::SendMessagePolicy;
 use capability::SendMessageProcessorContext;
@@ -112,9 +113,36 @@ use message_builder::clear_reserved_properties;
 use message_builder::enrich_parsed_send_message_request_properties;
 use message_builder::recall_handle_topic_and_timestamp;
 use message_builder::should_create_uniq_key;
+use structured_store::await_store;
+use structured_store::StoreAwaitControl;
+use structured_store::StoreAwaitStopped;
 
 pub struct SendMessageProcessor<MS: BrokerWriteStore, TS> {
     inner: Arc<Inner<MS, TS>>,
+}
+
+struct SendCompletionFacts {
+    opaque: i32,
+    body_len: i32,
+    owner: Option<CheetahString>,
+    auth_type: Option<CheetahString>,
+    owner_parent: Option<CheetahString>,
+    owner_self: Option<CheetahString>,
+}
+
+impl SendCompletionFacts {
+    fn capture(request: &RemotingCommand) -> Self {
+        let binding = HashMap::new();
+        let ext_fields = request.ext_fields().unwrap_or(&binding);
+        Self {
+            opaque: request.opaque(),
+            body_len: request.body().as_ref().map_or(0, |body| body.len() as i32),
+            owner: ext_fields.get(BrokerStatsManager::COMMERCIAL_OWNER).cloned(),
+            auth_type: ext_fields.get(BrokerStatsManager::ACCOUNT_AUTH_TYPE).cloned(),
+            owner_parent: ext_fields.get(BrokerStatsManager::ACCOUNT_OWNER_PARENT).cloned(),
+            owner_self: ext_fields.get(BrokerStatsManager::ACCOUNT_OWNER_SELF).cloned(),
+        }
+    }
 }
 
 struct ParsedSendRequest {
@@ -440,6 +468,7 @@ where
         if response.code() != -1 {
             return Ok(Some(response));
         }
+        let inbound_peer = channel.remote_address();
         let topic_config = self
             .inner
             .context
@@ -479,7 +508,7 @@ where
         message_ext.message_ext_inner.message.set_properties(request_properties);
         message_ext.message_ext_inner.message.set_body(request.body().cloned());
         message_ext.message_ext_inner.born_timestamp = request_header.born_timestamp;
-        message_ext.message_ext_inner.born_host = channel.remote_address();
+        message_ext.message_ext_inner.born_host = inbound_peer;
         message_ext.message_ext_inner.store_host = self.inner.context.policy.snapshot().store_host;
         message_ext.message_ext_inner.reconsume_times = request_header.reconsume_times.unwrap_or(0);
         let cluster_name = self.inner.context.policy.snapshot().broker_cluster_name.clone();
@@ -535,37 +564,38 @@ where
             MessageClientIDSetter::get_uniq_id(&batch_message.message_ext_broker_inner.message_ext_inner.message);
         let topic = batch_message.message_ext_broker_inner.message_ext_inner.topic().clone();
         let topic_message_type = crate::metrics::broker_metrics_manager::get_message_type(&request_header);
+        let completion_facts = SendCompletionFacts::capture(request);
         let append_receipt = if is_inner_batch {
             let mut store = self.inner.context.store.clone();
             append_message_with_store(&mut store, batch_message.message_ext_broker_inner)
                 .await
+                .map_err(map_legacy_store_wait_stopped)?
                 .map_err(map_store_api_error)?
         } else {
             let mut store = self.inner.context.store.clone();
             append_message_with_store(&mut store, batch_message)
                 .await
+                .map_err(map_legacy_store_wait_stopped)?
                 .map_err(map_store_api_error)?
         };
-        let result = self
-            .handle_put_message_result(
-                append_receipt,
-                &mut response,
-                request,
-                topic.as_str(),
-                transaction_id,
-                None,
-                &mut send_message_context,
-                ctx,
-                queue_id,
-                start,
-                &mut mapping_context,
-                topic_message_type,
-                MessageType::NormalMsg,
-            )
-            .await;
-        finish_send_message_response(result, response, |response| {
+        let result = self.handle_put_message_result(
+            append_receipt,
+            &mut response,
+            completion_facts,
+            topic.as_str(),
+            transaction_id,
+            None,
+            &mut send_message_context,
+            queue_id,
+            start,
+            &mut mapping_context,
+            topic_message_type,
+            MessageType::NormalMsg,
+        );
+        finish_legacy_send_message_response(result, response, ctx, |response| {
             send_message_callback(&mut send_message_context, response);
         })
+        .await
     }
 
     async fn send_message<F>(
@@ -586,6 +616,7 @@ where
         if response.code() != -1 {
             return Ok(Some(response));
         }
+        let inbound_peer = channel.remote_address();
 
         let mut topic_config = self
             .inner
@@ -653,7 +684,7 @@ where
         );
 
         message_ext.message_ext_inner.born_timestamp = request_header.born_timestamp;
-        message_ext.message_ext_inner.born_host = channel.remote_address();
+        message_ext.message_ext_inner.born_host = inbound_peer;
         message_ext.message_ext_inner.store_host = self.inner.context.policy.snapshot().store_host;
         message_ext.message_ext_inner.reconsume_times = request_header.reconsume_times.unwrap_or(0);
 
@@ -689,11 +720,13 @@ where
         let topic_message_type = crate::metrics::broker_metrics_manager::get_message_type(&request_header);
         let transaction_id = MessageClientIDSetter::get_uniq_id(&message_ext.message_ext_inner.message);
         let recall_handle = self.build_recall_handle(&message_ext);
+        let completion_facts = SendCompletionFacts::capture(request);
         let append_receipt = if send_transaction_prepare_message {
             let result = {
                 let mut store = TransactionalMessageAppender::new(self.inner.transactional_message_service.as_ref());
                 append_message_with_store(&mut store, message_ext)
                     .await
+                    .map_err(map_legacy_store_wait_stopped)?
                     .map_err(map_store_api_error)?
             };
             let (max_phy_offset, flushed_where) = self
@@ -707,34 +740,33 @@ where
             let mut store = self.inner.context.store.clone();
             append_message_with_store(&mut store, message_ext)
                 .await
+                .map_err(map_legacy_store_wait_stopped)?
                 .map_err(map_store_api_error)?
         };
-        let result = self
-            .handle_put_message_result(
-                append_receipt,
-                &mut response,
-                request,
-                topic.as_str(),
-                transaction_id,
-                recall_handle,
-                &mut send_message_context,
-                ctx,
-                queue_id,
-                start,
-                &mut mapping_context,
-                topic_message_type,
-                MessageType::NormalMsg,
-            )
-            .await;
-        finish_send_message_response(result, response, |response| {
+        let result = self.handle_put_message_result(
+            append_receipt,
+            &mut response,
+            completion_facts,
+            topic.as_str(),
+            transaction_id,
+            recall_handle,
+            &mut send_message_context,
+            queue_id,
+            start,
+            &mut mapping_context,
+            topic_message_type,
+            MessageType::NormalMsg,
+        );
+        finish_legacy_send_message_response(result, response, ctx, |response| {
             send_message_callback(&mut send_message_context, response);
         })
+        .await
     }
 }
 
-async fn complete_direct_send_message_response(
+async fn complete_legacy_send_message_response(
     response_write: impl Future<Output = Result<ResponseReceipt, ResponseError>>,
-) -> (Option<RemotingCommand>, bool) {
+) {
     if let Err(error) = response_write.await {
         error!(
             kind = error.kind().as_str(),
@@ -743,18 +775,26 @@ async fn complete_direct_send_message_response(
             "send message response write failed; not retrying"
         );
     }
-    (None, true)
 }
 
-fn finish_send_message_response(
+/// Final V1 compatibility adapter. The store await and response construction
+/// complete before this boundary; only the legacy write capability crosses
+/// the final await so the established write-attempt-before-after-hook ordering
+/// remains unchanged until MIG-04 wires the V2 write observation.
+async fn finish_legacy_send_message_response(
     result: (Option<RemotingCommand>, bool),
     mut response: RemotingCommand,
-    send_message_callback: impl FnOnce(&mut RemotingCommand),
+    ctx: &ConnectionHandlerContext,
+    after_hook: impl FnOnce(&mut RemotingCommand),
 ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-    send_message_callback(&mut response);
     if result.1 {
-        Ok(None)
-    } else if result.0.is_some() {
+        complete_legacy_send_message_response(ctx.try_write_response_ref(&mut response)).await;
+        after_hook(&mut response);
+        return Ok(None);
+    }
+
+    after_hook(&mut response);
+    if result.0.is_some() {
         Ok(result.0)
     } else {
         Ok(Some(response))
@@ -892,31 +932,6 @@ where
         }
     }
 
-    /// Set response header for successful message send
-    #[inline]
-    fn set_success_response_header(
-        &self,
-        response_header: &mut SendMessageResponseHeader,
-        append_receipt: &StoreAppendReceipt,
-        queue_id: i32,
-        transaction_id: Option<CheetahString>,
-        recall_handle: Option<CheetahString>,
-    ) {
-        let append_result = append_receipt
-            .result()
-            .append_message_result()
-            .expect("append result must exist for successful send");
-        response_header.set_msg_id(
-            append_result
-                .get_message_id()
-                .expect("message_id must exist for successful send"),
-        );
-        response_header.set_queue_id(queue_id);
-        response_header.set_queue_offset(append_result.logics_offset);
-        response_header.set_transaction_id(transaction_id);
-        response_header.set_recall_handle(recall_handle);
-    }
-
     /// Update send message context for hooks
     fn update_send_context_on_success(
         &self,
@@ -995,16 +1010,15 @@ where
         clippy::too_many_arguments,
         reason = "existing send result protocol context is tracked by the lint debt registry"
     )]
-    async fn handle_put_message_result(
+    fn handle_put_message_result(
         &self,
         append_receipt: StoreAppendReceipt,
         response: &mut RemotingCommand,
-        request: &RemotingCommand,
+        completion_facts: SendCompletionFacts,
         topic: &str,
         transaction_id: Option<CheetahString>,
         recall_handle: Option<CheetahString>,
         send_message_context: &mut SendMessageContext,
-        ctx: &mut ConnectionHandlerContext,
         queue_id_int: i32,
         begin_time_millis: Instant,
         mapping_context: &mut TopicQueueMappingContext,
@@ -1013,12 +1027,6 @@ where
     ) -> (Option<RemotingCommand>, bool) {
         let send_ok = map_put_status_to_response(append_receipt.result().put_message_status(), response);
 
-        let binding = HashMap::new();
-        let ext_fields = request.ext_fields().unwrap_or(&binding);
-        let owner = ext_fields.get(BrokerStatsManager::COMMERCIAL_OWNER).cloned();
-        let auth_type = ext_fields.get(BrokerStatsManager::ACCOUNT_AUTH_TYPE).cloned();
-        let owner_parent = ext_fields.get(BrokerStatsManager::ACCOUNT_OWNER_PARENT).cloned();
-        let owner_self = ext_fields.get(BrokerStatsManager::ACCOUNT_OWNER_SELF).cloned();
         let has_send_message_hook = self.has_send_message_hook();
 
         if send_ok {
@@ -1035,7 +1043,7 @@ where
                     .read_custom_header_mut::<SendMessageResponseHeader>()
                     .expect("SendMessageResponseHeader must exist");
 
-                self.set_success_response_header(
+                set_success_response_header(
                     response_header,
                     &append_receipt,
                     queue_id_int,
@@ -1057,27 +1065,26 @@ where
                         send_message_context,
                         response_header,
                         &append_receipt,
-                        owner,
-                        auth_type,
-                        owner_parent,
-                        owner_self,
+                        completion_facts.owner,
+                        completion_facts.auth_type,
+                        completion_facts.owner_parent,
+                        completion_facts.owner_self,
                     );
                 }
             }
 
-            response.set_opaque_mut(request.opaque());
-            complete_direct_send_message_response(ctx.try_write_response_ref(response)).await
+            response.set_opaque_mut(completion_facts.opaque);
+            (None, true)
         } else {
             if has_send_message_hook {
-                let request_body_len = request.body().as_ref().map_or(0, |body| body.len() as i32);
                 self.update_send_context_on_failure(
                     send_message_context,
                     &append_receipt,
-                    request_body_len,
-                    owner,
-                    auth_type,
-                    owner_parent,
-                    owner_self,
+                    completion_facts.body_len,
+                    completion_facts.owner,
+                    completion_facts.auth_type,
+                    completion_facts.owner_parent,
+                    completion_facts.owner_self,
                 );
             }
             (None, false)
@@ -1333,15 +1340,45 @@ where
     }
 }
 
+/// Applies the production Send store receipt to the wire response header.
+/// Both legacy completion and the route-neutral structured leaf use this
+/// mapping, so transaction and recall fields cannot drift during MIG-04.
+#[inline]
+fn set_success_response_header(
+    response_header: &mut SendMessageResponseHeader,
+    append_receipt: &StoreAppendReceipt,
+    queue_id: i32,
+    transaction_id: Option<CheetahString>,
+    recall_handle: Option<CheetahString>,
+) {
+    let append_result = append_receipt
+        .result()
+        .append_message_result()
+        .expect("append result must exist for successful send");
+    response_header.set_msg_id(
+        append_result
+            .get_message_id()
+            .expect("message_id must exist for successful send"),
+    );
+    response_header.set_queue_id(queue_id);
+    response_header.set_queue_offset(append_result.logics_offset);
+    response_header.set_transaction_id(transaction_id);
+    response_header.set_recall_handle(recall_handle);
+}
+
 fn append_message_with_store<'a, S, M>(
     store: &'a mut S,
     message: M,
-) -> impl Future<Output = Result<S::Receipt, S::Error>> + Send + 'a
+) -> impl Future<Output = Result<Result<S::Receipt, S::Error>, StoreAwaitStopped>> + Send + 'a
 where
     S: MessageAppender<M> + 'a,
     M: Send + 'a,
 {
-    store.append_message(message)
+    await_store(StoreAwaitControl::Legacy, store.append_message(message))
+}
+
+fn map_legacy_store_wait_stopped(_: StoreAwaitStopped) -> RocketMQError {
+    RocketMQError::invariant_violated("legacy message store await cannot observe request cancellation")
 }
 
 fn map_store_api_error(error: rocketmq_store_api::StoreError) -> RocketMQError {
@@ -1691,11 +1728,9 @@ where
         msg_inner.properties_string = message_properties_to_string(msg_ext.get_properties());
 
         let inner_topic = msg_inner.get_topic().clone();
-        let put_message_result = self
-            .context
-            .store
-            .put_message(msg_inner)
+        let put_message_result = await_store(StoreAwaitControl::Legacy, self.context.store.put_message(msg_inner))
             .await
+            .map_err(map_legacy_store_wait_stopped)?
             .map_err(|_| message_store_not_initialized())?;
         let commercial_owner = request
             .get_ext_fields()
@@ -2047,8 +2082,8 @@ mod tests {
     use super::add_send_response_metadata;
     use super::append_message_with_store;
     use super::broker_send_permission_denied;
-    use super::complete_direct_send_message_response;
-    use super::finish_send_message_response;
+    use super::complete_legacy_send_message_response;
+    use super::finish_legacy_send_message_response;
     use super::has_registered_send_message_hooks;
     use super::has_valid_compaction_key;
     use super::map_put_status_to_response;
@@ -2203,7 +2238,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn direct_send_response_failure_does_not_enable_central_fallback() {
+    async fn legacy_direct_write_failure_runs_after_hook_only_after_write_attempt() {
         let harness = LocalRequestHarness::new(crate::test_task_group("send-message-direct-write-failure"))
             .await
             .expect("local transport harness should start");
@@ -2213,7 +2248,7 @@ mod tests {
         let events = Arc::new(Mutex::new(Vec::new()));
         let mut response = RemotingCommand::create_success_response_command().set_body(b"direct".to_vec());
 
-        let direct_result = {
+        {
             let write_events = Arc::clone(&events);
             let response_write = async {
                 attempts.fetch_add(1, Ordering::Relaxed);
@@ -2225,23 +2260,30 @@ mod tests {
                 assert!(matches!(error, ResponseError::SessionClosed));
                 Err::<ResponseReceipt, ResponseError>(error)
             };
-            complete_direct_send_message_response(response_write).await
-        };
+            complete_legacy_send_message_response(response_write).await;
+        }
 
         assert_eq!(attempts.load(Ordering::Relaxed), 1);
-        assert!(direct_result.0.is_none());
-        assert!(direct_result.1);
         assert!(response.body().is_none(), "the single direct write consumed the body");
-        let callback_events = Arc::clone(&events);
-        let outer = finish_send_message_response(direct_result, response, move |_| {
-            callback_events.lock().expect("callback event lock").push("callback");
-        })
-        .expect("direct write failure remains a successful processor outcome");
+        events.lock().expect("callback event lock").push("callback");
+        assert_eq!(events.lock().expect("event lock").as_slice(), ["write", "callback"]);
+
+        let callback_ran = AtomicUsize::new(0);
+        let outer = finish_legacy_send_message_response(
+            (None, true),
+            RemotingCommand::create_success_response_command().set_body(b"compatibility".to_vec()),
+            &context,
+            |_| {
+                callback_ran.fetch_add(1, Ordering::Relaxed);
+            },
+        )
+        .await
+        .expect("a failed legacy direct write remains a successful processor outcome");
         assert!(
             outer.is_none(),
-            "a failed direct write must not produce a central fallback response"
+            "the compatibility adapter must never schedule a central retry"
         );
-        assert_eq!(events.lock().expect("event lock").as_slice(), ["write", "callback"]);
+        assert_eq!(callback_ran.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -2476,6 +2518,7 @@ mod tests {
 
         let actual = append_message_with_store(&mut store, ())
             .await
+            .expect("legacy append await remains active")
             .expect("append succeeds");
 
         assert_eq!(PutMessageStatus::PutOk, actual.result().put_message_status());

--- a/rocketmq-broker/src/processor/send_message_processor/structured_store.rs
+++ b/rocketmq-broker/src/processor/send_message_processor/structured_store.rs
@@ -1,0 +1,129 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_store_api::MessageAppender;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RequestControlView;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponsePlanError;
+
+#[derive(Clone)]
+pub(crate) enum StoreAwaitControl {
+    Legacy,
+    Request(RequestControlView),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("request lifecycle stopped while awaiting the message store")]
+pub(crate) struct StoreAwaitStopped;
+
+pub(crate) async fn await_store<F>(control: StoreAwaitControl, store_future: F) -> Result<F::Output, StoreAwaitStopped>
+where
+    F: Future + Send,
+{
+    let StoreAwaitControl::Request(control) = control else {
+        return Ok(store_future.await);
+    };
+    if control.is_cancelled() {
+        return Err(StoreAwaitStopped);
+    }
+    let result = tokio::select! {
+        biased;
+        () = control.cancelled() => return Err(StoreAwaitStopped),
+        result = store_future => result,
+    };
+    if control.is_cancelled() {
+        return Err(StoreAwaitStopped);
+    }
+    Ok(result)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub(crate) enum StructuredStoreReplyError {
+    #[error("request lifecycle stopped while awaiting the message store")]
+    Cancelled,
+    #[error("store response plan construction failed: {0}")]
+    ResponsePlan(#[from] ResponsePlanError),
+}
+
+/// Affine hook-completion token owned by exactly one structured store reply.
+/// Consuming the reply makes the caller handle every legacy-compatible timing
+/// class before handing the response plan to the canonical writer.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum StoreHookCompletion {
+    AfterCanonicalWrite,
+    BeforeReply,
+    NoAfterHook,
+}
+
+pub(crate) struct StructuredStoreReply {
+    outcome: HandlerOutcome,
+    hook_completion: StoreHookCompletion,
+}
+
+impl StructuredStoreReply {
+    pub(crate) fn into_parts(self) -> (HandlerOutcome, StoreHookCompletion) {
+        (self.outcome, self.hook_completion)
+    }
+}
+
+/// Awaits one store operation inside the admitted request task and returns one
+/// canonical V2 reply. Cancellation stops waiting and suppresses a reply; it
+/// cannot prove that a store operation already handed to the backend did not
+/// commit. The only request-lifecycle value retained across the await is the
+/// read-only control view.
+async fn await_store_reply<F, T, E, B>(
+    control: RequestControlView,
+    store_future: F,
+    build_response: B,
+) -> Result<StructuredStoreReply, StructuredStoreReplyError>
+where
+    F: Future<Output = Result<T, E>> + Send,
+    B: FnOnce(Result<T, E>) -> (RemotingCommand, StoreHookCompletion),
+{
+    let result = await_store(StoreAwaitControl::Request(control), store_future)
+        .await
+        .map_err(|StoreAwaitStopped| StructuredStoreReplyError::Cancelled)?;
+    let (response, hook_completion) = build_response(result);
+    let outcome = ResponsePlan::command(response)
+        .map(HandlerOutcome::Reply)
+        .map_err(StructuredStoreReplyError::from)?;
+    Ok(StructuredStoreReply {
+        outcome,
+        hook_completion,
+    })
+}
+
+/// Structured V2 leaf for an ordinary message-store append. This is kept
+/// route-neutral so MIG-04 can select it without reintroducing V1 transport
+/// context into the store future.
+pub(crate) async fn append_message_with_control_reply<S, M, B>(
+    control: RequestControlView,
+    store: &mut S,
+    message: M,
+    build_response: B,
+) -> Result<StructuredStoreReply, StructuredStoreReplyError>
+where
+    S: MessageAppender<M>,
+    M: Send,
+    B: FnOnce(Result<S::Receipt, S::Error>) -> (RemotingCommand, StoreHookCompletion),
+{
+    await_store_reply(control, store.append_message(message), build_response).await
+}
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-broker/src/processor/send_message_processor/structured_store/tests.rs
+++ b/rocketmq-broker/src/processor/send_message_processor/structured_store/tests.rs
@@ -1,0 +1,546 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode as ProtocolResponseCode;
+use rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_security_api::AuthenticatedRequestContext;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::RequestPolicy;
+use rocketmq_store::store_append_receipt;
+use rocketmq_store::AppendMessageResult;
+use rocketmq_store::AppendMessageStatus;
+use rocketmq_store::PutMessageResult;
+use rocketmq_store::PutMessageStatus;
+use rocketmq_store::StoreAppendReceipt;
+use rocketmq_store_api::MessageAppender;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+use rocketmq_transport::api::v2::EmbeddedDispatchErrorKind;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestDeadline;
+use rocketmq_transport::api::v2::RequestId;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponseWriteObservationV2;
+use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+use tokio::sync::Notify;
+
+use super::append_message_with_control_reply;
+use super::StoreHookCompletion;
+use crate::processor::send_message_processor::map_put_status_to_response;
+use crate::processor::send_message_processor::set_success_response_header;
+
+const OPAQUE: i32 = 98_307;
+
+#[derive(Clone, Copy)]
+enum StoreBehavior {
+    GatedSuccess,
+    PutRejected,
+    ImmediateError,
+    Pending,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct BuiltResponse {
+    opaque: i32,
+    code: i32,
+    remark: Option<String>,
+    msg_id: String,
+    queue_id: i32,
+    queue_offset: i64,
+    transaction_id: Option<String>,
+    recall_handle: Option<String>,
+}
+
+struct ProbeState {
+    events: Mutex<Vec<&'static str>>,
+    entered: Notify,
+    entered_count: AtomicUsize,
+    release: Notify,
+    store_future_drops: Arc<AtomicUsize>,
+    built: Mutex<Option<BuiltResponse>>,
+    built_replies: Mutex<HashSet<RequestId>>,
+    pending_after_write: Mutex<HashSet<RequestId>>,
+}
+
+impl ProbeState {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            events: Mutex::new(Vec::new()),
+            entered: Notify::new(),
+            entered_count: AtomicUsize::new(0),
+            release: Notify::new(),
+            store_future_drops: Arc::new(AtomicUsize::new(0)),
+            built: Mutex::new(None),
+            built_replies: Mutex::new(HashSet::new()),
+            pending_after_write: Mutex::new(HashSet::new()),
+        })
+    }
+}
+
+struct StoreFutureOwner(Arc<AtomicUsize>);
+
+impl Drop for StoreFutureOwner {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct ProbeAppender {
+    behavior: StoreBehavior,
+    state: Arc<ProbeState>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct ProbeStoreError(&'static str);
+
+impl MessageAppender<()> for ProbeAppender {
+    type Receipt = StoreAppendReceipt;
+    type Error = ProbeStoreError;
+
+    fn append_message(
+        &mut self,
+        (): (),
+    ) -> impl std::future::Future<Output = Result<Self::Receipt, Self::Error>> + Send {
+        let state = Arc::clone(&self.state);
+        let owner = StoreFutureOwner(Arc::clone(&self.state.store_future_drops));
+        let behavior = self.behavior;
+        async move {
+            let _owner = owner;
+            state.events.lock().push("store_entered");
+            state.entered_count.fetch_add(1, Ordering::SeqCst);
+            state.entered.notify_one();
+            match behavior {
+                StoreBehavior::GatedSuccess => {
+                    state.release.notified().await;
+                    state.events.lock().push("store_completed");
+                    let append_result = AppendMessageResult {
+                        status: AppendMessageStatus::PutOk,
+                        msg_id: Some("MID-9837".to_string()),
+                        logics_offset: 71,
+                        ..AppendMessageResult::default()
+                    };
+                    Ok(store_append_receipt(
+                        PutMessageResult::new_append_result(PutMessageStatus::PutOk, Some(append_result)),
+                        11,
+                        11,
+                    ))
+                }
+                StoreBehavior::PutRejected => {
+                    state.events.lock().push("store_rejected");
+                    Ok(store_append_receipt(
+                        PutMessageResult::new_default(PutMessageStatus::MessageIllegal),
+                        0,
+                        0,
+                    ))
+                }
+                StoreBehavior::ImmediateError => {
+                    state.events.lock().push("store_failed");
+                    Err(ProbeStoreError("message store not available"))
+                }
+                StoreBehavior::Pending => std::future::pending::<Result<StoreAppendReceipt, ProbeStoreError>>().await,
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct StoreProbeProcessor {
+    behavior: StoreBehavior,
+    state: Arc<ProbeState>,
+}
+
+impl RequestProcessorV2 for StoreProbeProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let control = request.control().clone();
+        let identity = request.original_identity();
+        let original_opaque = identity.original_opaque();
+        let request_id = identity.request_id();
+        self.state.events.lock().push("before_hook");
+        let mut store = ProbeAppender {
+            behavior: self.behavior,
+            state: Arc::clone(&self.state),
+        };
+        let state_for_response = Arc::clone(&self.state);
+        let reply = append_message_with_control_reply(control, &mut store, (), move |result| {
+            let (mut response, completion, msg_id, queue_id, queue_offset, transaction_id, recall_handle) = match result
+            {
+                Ok(receipt) => {
+                    let mut response = application_remoting_command_factory()
+                        .create_success_response_command_with_header(SendMessageResponseHeader::default());
+                    if !map_put_status_to_response(receipt.result().put_message_status(), &mut response) {
+                        (
+                            response,
+                            StoreHookCompletion::BeforeReply,
+                            String::new(),
+                            0,
+                            0,
+                            None,
+                            None,
+                        )
+                    } else {
+                        let header = response
+                            .read_custom_header_mut::<SendMessageResponseHeader>()
+                            .expect("structured Send response header");
+                        set_success_response_header(
+                            header,
+                            &receipt,
+                            3,
+                            Some("TX-9837".into()),
+                            Some("RECALL-9837".into()),
+                        );
+                        let msg_id = header.msg_id().to_string();
+                        let queue_id = header.queue_id();
+                        let queue_offset = header.queue_offset();
+                        let transaction_id = header.transaction_id().map(ToString::to_string);
+                        let recall_handle = header.recall_handle().map(ToString::to_string);
+                        (
+                            response,
+                            StoreHookCompletion::AfterCanonicalWrite,
+                            msg_id,
+                            queue_id,
+                            queue_offset,
+                            transaction_id,
+                            recall_handle,
+                        )
+                    }
+                }
+                Err(remark) => (
+                    crate::processor::system_error_response(
+                        &application_remoting_command_factory(),
+                        original_opaque,
+                        remark.0,
+                    ),
+                    StoreHookCompletion::NoAfterHook,
+                    String::new(),
+                    0,
+                    0,
+                    None,
+                    None,
+                ),
+            };
+            response.set_opaque_mut(original_opaque);
+            *state_for_response.built.lock() = Some(BuiltResponse {
+                opaque: response.opaque(),
+                code: response.code(),
+                remark: response.remark().map(ToString::to_string),
+                msg_id,
+                queue_id,
+                queue_offset,
+                transaction_id,
+                recall_handle,
+            });
+            (response, completion)
+        })
+        .await
+        .map_err(|_| RocketMQError::invariant_violated("structured Send reply conversion failed"))?;
+        let (outcome, completion) = reply.into_parts();
+        assert!(
+            self.state.built_replies.lock().insert(request_id),
+            "one RequestId owns at most one built reply"
+        );
+        match completion {
+            StoreHookCompletion::AfterCanonicalWrite => assert!(
+                self.state.pending_after_write.lock().insert(request_id),
+                "one RequestId owns at most one pending after-hook"
+            ),
+            StoreHookCompletion::BeforeReply => self.state.events.lock().push("after_hook"),
+            StoreHookCompletion::NoAfterHook => {}
+        }
+        Ok(outcome)
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        assert_eq!(observation.original_code(), RequestCode::SendMessage as i32);
+        let request_id = observation.request_id();
+        if self.state.built_replies.lock().remove(&request_id) {
+            self.state.events.lock().push("write_observed");
+        }
+        if self.state.pending_after_write.lock().remove(&request_id) {
+            self.state.events.lock().push("after_hook");
+        }
+    }
+}
+
+struct AllowEmbeddedPolicy;
+
+impl RequestPolicy for AllowEmbeddedPolicy {
+    fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+        Decision::Allow
+    }
+}
+
+struct Fixture {
+    owner: RuntimeOwner,
+    context: rocketmq_runtime::ChildServiceContext,
+    harness: EmbeddedRequestHarnessV2<StoreProbeProcessor>,
+}
+
+impl Fixture {
+    fn new(name: &'static str, behavior: StoreBehavior, state: Arc<ProbeState>) -> Self {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default(name)).expect("structured store runtime");
+        let context = owner.root_context().component(format!("{name}.request"));
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            StoreProbeProcessor { behavior, state },
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            context.task_group().clone(),
+            Principal::new("structured-store-test"),
+        );
+        Self {
+            owner,
+            context,
+            harness,
+        }
+    }
+
+    async fn finish(self) {
+        drop(self.harness);
+        drop(self.context);
+        assert!(self.owner.shutdown_tasks().await.is_healthy());
+        assert!(self.owner.shutdown_background().is_healthy());
+    }
+}
+
+fn request() -> RemotingCommand {
+    RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(OPAQUE)
+}
+
+#[tokio::test]
+async fn structured_send_store_await_preserves_hook_order_and_response_side_contracts() {
+    let state = ProbeState::new();
+    let fixture = Fixture::new(
+        "structured-send-success",
+        StoreBehavior::GatedSuccess,
+        Arc::clone(&state),
+    );
+    let outcome = {
+        let entered = state.entered.notified();
+        let dispatch = fixture.harness.dispatch(None, request());
+        tokio::pin!(dispatch);
+        tokio::select! {
+            () = entered => {}
+            result = &mut dispatch => panic!("store completed before its explicit release: {result:?}"),
+        }
+        assert_eq!(state.events.lock().as_slice(), ["before_hook", "store_entered"]);
+        state.release.notify_one();
+        dispatch.await.expect("structured Send reply")
+    };
+    let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+        panic!("structured Send must return one reply")
+    };
+    assert_eq!(plan.response_code(), ProtocolResponseCode::Success as i32);
+    assert_eq!(
+        state.events.lock().as_slice(),
+        [
+            "before_hook",
+            "store_entered",
+            "store_completed",
+            "write_observed",
+            "after_hook"
+        ]
+    );
+    assert_eq!(state.store_future_drops.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        state.built.lock().as_ref(),
+        Some(&BuiltResponse {
+            opaque: OPAQUE,
+            code: ProtocolResponseCode::Success as i32,
+            remark: None,
+            msg_id: "MID-9837".to_string(),
+            queue_id: 3,
+            queue_offset: 71,
+            transaction_id: Some("TX-9837".to_string()),
+            recall_handle: Some("RECALL-9837".to_string()),
+        })
+    );
+    drop(plan);
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn structured_send_store_error_is_one_visible_reply() {
+    let state = ProbeState::new();
+    let fixture = Fixture::new(
+        "structured-send-error",
+        StoreBehavior::ImmediateError,
+        Arc::clone(&state),
+    );
+    let EmbeddedDispatchOutcome::Reply(plan) = fixture
+        .harness
+        .dispatch(None, request())
+        .await
+        .expect("structured store error reply")
+    else {
+        panic!("store error must return one reply")
+    };
+    assert_eq!(plan.response_code(), ProtocolResponseCode::SystemError as i32);
+    assert_eq!(state.store_future_drops.load(Ordering::SeqCst), 1);
+    {
+        let built = state.built.lock();
+        let built = built.as_ref().expect("store error response built");
+        assert_eq!(plan.response_code(), built.code);
+        assert_eq!(built.opaque, OPAQUE);
+        assert_eq!(built.remark.as_deref(), Some("message store not available"));
+    }
+    assert_eq!(
+        state.events.lock().as_slice(),
+        ["before_hook", "store_entered", "store_failed", "write_observed"]
+    );
+    drop(plan);
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn structured_send_rejected_status_runs_after_hook_before_canonical_write() {
+    let state = ProbeState::new();
+    let fixture = Fixture::new(
+        "structured-send-rejected",
+        StoreBehavior::PutRejected,
+        Arc::clone(&state),
+    );
+    let EmbeddedDispatchOutcome::Reply(plan) = fixture
+        .harness
+        .dispatch(None, request())
+        .await
+        .expect("structured rejected-status reply")
+    else {
+        panic!("rejected PutMessageStatus must return one reply")
+    };
+    assert_eq!(plan.response_code(), ProtocolResponseCode::MessageIllegal as i32);
+    assert_eq!(
+        state.events.lock().as_slice(),
+        [
+            "before_hook",
+            "store_entered",
+            "store_rejected",
+            "after_hook",
+            "write_observed"
+        ]
+    );
+    assert!(state.pending_after_write.lock().is_empty());
+    drop(plan);
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn structured_send_after_write_completions_are_correlated_by_request_id() {
+    let state = ProbeState::new();
+    let fixture = Fixture::new(
+        "structured-send-request-ids",
+        StoreBehavior::GatedSuccess,
+        Arc::clone(&state),
+    );
+    let (first, second) = {
+        let first = fixture.harness.dispatch(None, request());
+        let second = fixture.harness.dispatch(None, request());
+        let both = async { tokio::join!(first, second) };
+        tokio::pin!(both);
+        while state.entered_count.load(Ordering::SeqCst) < 2 {
+            let entered = state.entered.notified();
+            tokio::select! {
+                () = entered => {}
+                result = &mut both => panic!("stores completed before explicit release: {result:?}"),
+            }
+        }
+        state.release.notify_waiters();
+        both.await
+    };
+    assert!(matches!(
+        first.expect("first structured Send"),
+        EmbeddedDispatchOutcome::Reply(_)
+    ));
+    assert!(matches!(
+        second.expect("second structured Send"),
+        EmbeddedDispatchOutcome::Reply(_)
+    ));
+
+    {
+        let events = state.events.lock();
+        assert_eq!(events.iter().filter(|event| **event == "write_observed").count(), 2);
+        assert_eq!(events.iter().filter(|event| **event == "after_hook").count(), 2);
+    }
+    assert!(state.built_replies.lock().is_empty());
+    assert!(state.pending_after_write.lock().is_empty());
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn structured_send_parent_cancel_stops_waiting_and_suppresses_reply() {
+    let state = ProbeState::new();
+    let fixture = Fixture::new("structured-send-cancel", StoreBehavior::Pending, Arc::clone(&state));
+    let error = {
+        let entered = state.entered.notified();
+        let dispatch = fixture.harness.dispatch(None, request());
+        tokio::pin!(dispatch);
+        tokio::select! {
+            () = entered => {}
+            result = &mut dispatch => panic!("pending store completed before parent cancellation: {result:?}"),
+        }
+        fixture.context.task_group().cancel();
+        dispatch.await.expect_err("parent cancellation stops the store await")
+    };
+    assert_eq!(error.kind(), EmbeddedDispatchErrorKind::Cancelled);
+    // Future ownership is released promptly and no reply is constructed. The
+    // test deliberately makes no assertion that a real backend rolled back an
+    // operation it may already have accepted.
+    assert_eq!(state.store_future_drops.load(Ordering::SeqCst), 1);
+    assert!(state.built.lock().is_none());
+    assert!(state.built_replies.lock().is_empty());
+    assert!(state.pending_after_write.lock().is_empty());
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn structured_send_expired_deadline_suppresses_store_and_reply() {
+    let state = ProbeState::new();
+    let fixture = Fixture::new("structured-send-deadline", StoreBehavior::Pending, Arc::clone(&state));
+    let error = fixture
+        .harness
+        .dispatch(Some(RequestDeadline::after(Duration::ZERO)), request())
+        .await
+        .expect_err("deadline stops the pending store await");
+    assert_eq!(error.kind(), EmbeddedDispatchErrorKind::DeadlineExceeded);
+    assert_eq!(state.store_future_drops.load(Ordering::SeqCst), 0);
+    assert!(state.events.lock().is_empty());
+    assert!(state.built.lock().is_none());
+    assert!(state.built_replies.lock().is_empty());
+    assert!(state.pending_after_write.lock().is_empty());
+    fixture.finish().await;
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9838

### Brief Description

- Route production Send, Reply, transaction, batch, retry, and send-back store futures through one lifecycle-aware await seam, and provide the route-neutral structured leaf that returns `ResponsePlan` without retaining transport capabilities.
- Replace detached fast-failure request copies and direct response writes with affine admission/run owners, typed rejections, request-control cancellation, and one canonical response plan.
- Preserve legacy Send/Reply hook ordering, opaque binding, transaction and recall headers, reply push-before-store behavior, and missing-channel side contracts until the formal V2 route cutover.
- Add deterministic deadline, cancellation, store-error, hook-order, concurrent request identity, reply push matrix, resource-release, and real TCP single-write coverage.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check` (passed)
- `cargo fmt -p rocketmq-transport -- --check` (passed)
- `cargo test -p rocketmq-transport` (passed)
- `cargo test -p rocketmq-broker --lib fast_failure_dispatch --all-features` (8 passed)
- `cargo test -p rocketmq-broker --lib structured_store --all-features` (8 passed)
- `cargo test -p rocketmq-broker --lib reply_message_processor --all-features` (12 passed)
- `cargo test -p rocketmq-broker --lib send_message_processor --all-features` (44 passed before the final test-only synchronization cleanup; affected focused suites were rerun afterward)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- `cargo +nightly-2026-07-05 check --manifest-path fuzz/Cargo.toml --locked --all-targets --all-features` (passed)
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` (passed)
- Error-architecture guard: existing repository baseline still fails in unchanged files; the changed-file comparison reported zero findings.
- Full Broker `all-features` run with an increased Windows test-thread stack: 1051 passed, 3 ignored, and 2 pre-existing Lite event-limit tests failed; both failing source/test paths and feature manifests are unchanged from `origin/main` and both failures reproduce individually.
- Default Send suite: 43 passed and the pre-existing extended-timer capability test failed because that feature is disabled; the test and feature manifests are unchanged from `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved fast-failure request handling with clearer admission, cancellation, budget, and rejection behavior.
  - Requests that are cancelled or exceed available capacity now receive consistent responses without disrupting connections.
  - Improved message storage and reply processing for legacy and structured requests, including cancellation and deadline handling.
  - Standardized success and error responses with consistent metadata and store-result reporting.
- **Documentation**
  - Clarified that the legacy detached-send setting is retained for compatibility and may generate a startup warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->