### PR TITLE
[ISSUE #9841]📝Add a live V2 processor migration inventory

### DIFF
--- a/rocketmq-doc/en/remoting-processor-v2-migration-ledger.md
+++ b/rocketmq-doc/en/remoting-processor-v2-migration-ledger.md
@@ -1,0 +1,208 @@
+# Remoting Processor V2 Migration Ledger
+
+This ledger is the live inventory for removing production dependencies on the
+V1 `RequestProcessor` contract, `ConnectionHandlerContext`, and raw `Channel`
+parameters. It is an implementation aid, not a source fingerprint or a release
+gate. Update the affected rows whenever a migration changes ownership or status.
+
+## Status and ownership model
+
+| Status | Meaning |
+|---|---|
+| `V1` | The production implementation still uses the V1 processor/context contract. |
+| `Dual` | A V2 implementation exists, but a production V1 route or compatibility path remains. |
+| `V2 infrastructure` | The code already uses the V2 contract and supports a later production cutover. |
+| `Compatibility` | The code is retained temporarily to serve or drain an accepted V1 request. |
+
+Migration owners are the implementation batches defined by the connection
+handler context plan:
+
+- `MIG-02`: Transport, Client, Namesrv, and Controller processors.
+- `MIG-03`: ordinary Broker leaf processors and session identity registries.
+- `MIG-04`: response-heavy Broker leaves and their result/deferred seams.
+- `MIG-05`: Broker aggregate/router production cutover and bounded V1 drain.
+- `MIG-06`: Admin nested handlers, Auth, and Proxy.
+- `MIG-07`: final production V1 removal and compatibility cleanup.
+
+## Transport and Client
+
+| Area | Production implementation or consumer | Current state | Owner and completion condition |
+|---|---|---|---|
+| Transport | `rocketmq-transport/src/request_processor/default_request_processor.rs` — `DefaultRequestProcessor` | `V1`; the channel and context parameters are unused. | `MIG-02`; return an explicit V2 reply outcome and migrate its direct tests. |
+| Client | `rocketmq-client/src/implementation/client_remoting_processor.rs` — `ClientRemotingProcessor` | `V1`; dispatch and several callback helpers accept `Channel` or `ConnectionHandlerContext`. | `MIG-02`; map reply, one-way, and protocol-no-response callbacks to explicit V2 outcomes and migrate the inline transport-backed tests. |
+| Transport | `rocketmq-transport/src/clients/` and `rocketmq-transport/src/clients/client.rs` — `TransportClient<PR>`, `RemotingClient<PR>`, and `ClientInner<PR>` | The production client inbound route is generically bound to V1 `RequestProcessor`; it creates a context for each session. | `MIG-02`; provide a V2 inbound client owner/coexistence seam that does not expose raw channel/context authority to the processor. Keep the V1 facade compatibility-only until `MIG-07`. |
+| Transport | `rocketmq-transport/src/remoting.rs` — `RemotingGeneralHandler<RP>` | V1 generic inbound router; invokes the V1 processor and writes through the context channel. | `MIG-07`; retain only as an explicit compatibility owner after application routes move to V2. |
+| Transport | `rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs` and its `launch.rs`/`connection_handler.rs` path | `TransportServer<RP>` is the V1 generic production listener and connection route. | Application owners move to `TransportServerV2` in `MIG-02`/`MIG-05`; remove the unused V1 production route in `MIG-07`. |
+| Transport | `rocketmq-transport/src/dispatch/authorized_dispatcher.rs` and `legacy_processor_adapter.rs` | The V1 dispatcher is bridged through `LegacyProcessorAdapter`; V2 dispatcher/server owners already exist. | Compatibility-only; do not expand the adapter, and remove it in `MIG-07` after all callers move. |
+| Client | `rocketmq-client/src/factory/mq_client_instance.rs`, `implementation/mq_client_api_impl.rs`, and `implementation/mq_client_api_impl/transport.rs` | Production composition constructs `ClientRemotingProcessor` behind the V1 `RemotingClient<PR>` bound. | `MIG-02`; compose the new V2 inbound client owner and retain outbound request behavior. |
+
+Transport already contains `RequestProcessorV2`, `AuthorizedCommandDispatcherV2`,
+`TransportServerV2`, response-plan, and deferred-registration infrastructure.
+Its V2-only unit and network processors are coverage for that infrastructure,
+not pending production leaf migrations. The transport V1 server tests and V1
+adapter tests remain compatibility coverage until `MIG-07` removes the adapter.
+The reserved V2 extension guard must continue rejecting `Channel` and
+`ConnectionHandlerContext`; migration must not bypass it to preserve a V1 side
+contract.
+
+## Namesrv
+
+| Production implementation | Kind | Current state | Owner and completion condition |
+|---|---|---|---|
+| `rocketmq-namesrv/src/processor/default_request_processor.rs` — `DefaultRequestProcessor` | Leaf | `V1`; the context is unused, but broker registration passes the `Channel` to `RouteInfoManager`. | `MIG-02`; migrate before the wrapper/router and replace connection ownership with the narrow session-registration/lifecycle port. |
+| `rocketmq-namesrv/src/processor/client_request_processor.rs` — `ClientRequestProcessor` | Leaf | `V1`; both transport parameters are unused. | `MIG-02`; migrate before the wrapper/router. |
+| `rocketmq-namesrv/src/processor/cluster_test_request_processor.rs` — `ClusterTestRequestProcessor` | Leaf | `V1`; both transport parameters are unused. | `MIG-02`; preserve the route lookup behavior and integration coverage. |
+| `rocketmq-namesrv/src/processor.rs` — `NameServerRequestProcessorWrapper` | Wrapper enum | `V1`; reconstructs child calls with a raw channel and ignores the supplied context. | `MIG-02`; dispatch a typed request to V2 children after every leaf is migrated. |
+| `rocketmq-namesrv/src/processor.rs` — `NameServerRequestProcessor` | Aggregate/router | `V1`; auth/admission consumes the context and remote address, then the router forwards channel/context to a selected wrapper. | `MIG-02`; migrate last and retain real request/response, auth-denial, admission, and metrics tests. |
+| `rocketmq-namesrv/src/bootstrap.rs` | Production composition | Builds `TransportServer<NameServerRequestProcessor>` and registers route/default wrappers. | `MIG-02`; switch the production owner to `TransportServerV2` after leaves and wrapper are V2. |
+
+The `RouteProcessor` and `BlockingRouteProcessor` fixtures in
+`rocketmq-namesrv/src/processor/cluster_test_request_processor/route_lookup.rs`
+implement the separate transport `SessionProcessor` test contract. They do not
+use `ConnectionHandlerContext`; keep them aligned with the route-lookup tests,
+but do not mechanically convert them as V1 production processors.
+
+## Controller
+
+| Production implementation or consumer | Kind | Current state | Owner and completion condition |
+|---|---|---|---|
+| `rocketmq-controller/src/processor/controller_request_processor.rs` — `ControllerRequestProcessor` | Leaf/command router | `V1`; context is unused, but maintenance auth reads channel identity and heartbeat passes the full channel to its manager. | `MIG-02`; replace those side contracts with typed identity and the narrow session-registration/lifecycle port. |
+| `rocketmq-controller/src/processor.rs` — `ControllerRequestProcessorWrapper` | Wrapper enum | `V1`; forwards channel/context to the leaf. | `MIG-02`; migrate after the leaf. |
+| `rocketmq-controller/src/processor.rs` — `ControllerServerRequestProcessor` | Aggregate/default router | `V1`; forwards channel/context to the registered wrapper, but the current production manager does not wire this aggregate. | `MIG-02`; either prove and register a V2 purpose for it or classify it as dead compatibility code for deletion in `MIG-07`; retain its unsupported-request test until that decision. |
+| `rocketmq-controller/src/controller/controller_manager.rs` | Production composition/context forwarding | Builds `TransportServer<ControllerRequestProcessor>` directly; it does not use `ControllerServerRequestProcessor`. | `MIG-02`; register the V2 leaf/server owner without synthesizing a legacy context and preserve heartbeat/session lifecycle behavior. |
+
+Inline tests that construct `ConnectionHandlerContextWrapper` belong to their
+production processor or wrapper and must migrate in the same change.
+
+Namesrv broker registration and Controller heartbeat currently hand a raw
+`Channel` to a longer-lived owner. They must not place that capability in a V2
+request extension. `MIG-02` must move registration/cleanup to a session owner or
+introduce the narrowest typed registration port so disconnect cleanup remains
+correct without leaking arbitrary write authority.
+
+## Broker ordinary leaves and session registries
+
+All rows in this section are owned by `MIG-03`. Their inline tests migrate with
+the production file. A leaf is complete only when it returns an explicit V2
+outcome and no longer receives a raw context solely for dispatch compatibility.
+
+| Production implementation | Current state | Notable migration responsibility |
+|---|---|---|
+| `rocketmq-broker/src/processor/ack_message_processor.rs` — `AckMessageProcessor<MS>` | `V1` generic leaf | Use typed origin/session facts only where required. |
+| `rocketmq-broker/src/processor/change_invisible_time_processor.rs` — `ChangeInvisibleTimeProcessor<MS>` | `V1` generic leaf | Preserve response mapping without direct response writes. |
+| `rocketmq-broker/src/processor/client_manage_processor.rs` — `ClientManageProcessor<MS>` | `V1` generic leaf | Move client identity and registry operations to stable session identities/narrow push handles. |
+| `rocketmq-broker/src/processor/consumer_manage_processor.rs` — `ConsumerManageProcessor<MS>` | `V1` generic leaf | Move consumer registry operations to stable session identities/narrow push handles. |
+| `rocketmq-broker/src/processor/end_transaction_processor.rs` — `EndTransactionProcessor<TM, MS>` | `V1` generic leaf | Return a typed reply/error plan. |
+| `rocketmq-broker/src/processor/lite_manager_processor.rs` — `LiteManagerProcessor<MS>` | `V1` generic leaf | Remove unused transport context and retain protocol behavior. |
+| `rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs` — `LiteSubscriptionCtlProcessor<MS>` | `V1` generic leaf | Remove unused transport context and retain protocol behavior. |
+| `rocketmq-broker/src/processor/maintenance_request_processor.rs` — `MaintenanceRequestProcessor` | `V1` leaf | Replace raw session access with the narrow typed view actually required. |
+| `rocketmq-broker/src/processor/peek_message_processor.rs` — `PeekMessageProcessor<MS>` | `V1` generic leaf | Return a typed response plan. |
+| `rocketmq-broker/src/processor/polling_info_processor.rs` — `PollingInfoProcessor` | `V1` leaf | Remove unused context and return a typed reply. |
+| `rocketmq-broker/src/processor/query_assignment_processor.rs` — `QueryAssignmentProcessor` | `V1` leaf | Remove unused context and return a typed reply. |
+| `rocketmq-broker/src/processor/recall_message_processor.rs` — `RecallMessageProcessor<MS>` | `V1` generic leaf | Preserve typed error mapping and response semantics. |
+| `rocketmq-broker/src/client/manager/producer_manager.rs` | Registry/context consumer | Stores/indexes raw `Channel` values and accepts `ConnectionHandlerContext`. | Establish the canonical `SessionId` to client identity read seam needed by Pull, and retain only an explicit server-push capability where writes are required. |
+
+The manager migration must not retain `RemotingRequest` or `SessionView` as an
+arbitrary send handle. Existing source-text assertions are not completion
+evidence and must not be expanded into a fingerprint gate.
+
+## Broker response-heavy leaves
+
+These rows are owned by `MIG-04`. Existing BRK seams are prerequisites and V2
+infrastructure; they do not by themselves mark a production leaf complete.
+
+| Production implementation or seam | Current state | Completion condition |
+|---|---|---|
+| `rocketmq-broker/src/processor/send_message_processor.rs` — `SendMessageProcessor<MS, TS>` | `V1` production leaf; structured async Send seam exists. | Implement the V2 leaf on the structured seam; every immediate path returns a reply plan. |
+| `rocketmq-broker/src/processor/reply_message_processor.rs` — `ReplyMessageProcessor<MS, TS>` | `V1` production leaf; structured Reply seam exists. | Implement the V2 leaf without a direct write/ambiguous `None` path. |
+| `rocketmq-broker/src/processor/query_message_processor.rs` — `QueryMessageProcessor<S>` | `Dual`; a V2 leaf exists, but the V1 implementation remains reachable. | Complete heap/segments/FileRegion coverage and retain V1 only until the aggregate cutover. |
+| `rocketmq-broker/src/processor/pull_message_processor.rs` — `PullMessageProcessor<MS>` | `V1`; also implements legacy `PullRequestProcessor`. | Use the existing Pull deferred service plus the `MIG-03` session/client seam; successful suspension returns sealed `Deferred`. |
+| `rocketmq-broker/src/processor/pop_message_processor.rs` — `PopMessageProcessor<MS>` | `V1`; also implements legacy `PopLongPollingRequestProcessor`. | Use the existing Pop deferred service and return sealed `Deferred` only for successful suspension. |
+| `rocketmq-broker/src/processor/pop_lite_message_processor.rs` — `PopLiteMessageProcessor<MS>` | `V1`; also implements legacy `PopLiteLongPollingRequestProcessor`. | Use the existing PopLite deferred service, client event gate, reservation, and deadline rules. |
+| `rocketmq-broker/src/processor/notification_processor.rs` — `NotificationProcessor<MS>` | `V1`; also implements legacy `PopLongPollingRequestProcessor`. | Use the existing Notification deferred service and preserve filter-before-claim behavior. |
+| `rocketmq-broker/src/processor/default_pull_message_result_handler.rs` | Typed result seam exists; production Pull leaf remains V1. | Keep Channel-free typed result handling and connect it only through the V2 Pull leaf. |
+| `rocketmq-broker/src/processor/pull_message_result_handler.rs` | Typed result contract exists; production Pull leaf remains V1. | Preserve the typed response-plan contract while the V2 Pull leaf is completed. |
+
+The V2-only processors under `long_polling/*_deferred/acceptance_tests`,
+`processor/fast_failure_dispatch/tests.rs`, the structured Send/Reply tests, and
+`processor/response_plan/tests` are already V2 infrastructure tests. Preserve
+them as regression coverage for `MIG-04` and the later production cutover.
+
+## Broker aggregate, router, and V1 drain
+
+| Production implementation or compatibility consumer | Current state | Owner and completion condition |
+|---|---|---|---|
+| `rocketmq-broker/src/processor.rs` — `BrokerProcessorType<MS, TS>` | `V1` generic wrapper enum. | `MIG-05`; route typed requests to completed V2 leaves. |
+| `rocketmq-broker/src/processor.rs` — `BrokerRequestProcessor<MS, TS>` | `V1` generic aggregate/router. | `MIG-05`; publish the V2 production route only after leaves and lifecycle ownership are ready. |
+| `rocketmq-broker/src/broker_runtime.rs` and `rocketmq-broker/src/broker_runtime/request_pipeline.rs` | Production composition still registers the Broker V1 aggregate. | `MIG-05`; perform the coordinated route cutover and keep old owners alive through bounded drain. |
+| `rocketmq-broker/src/processor/admin_broker_processor.rs` — `AdminBrokerProcessor<MS>` | `V1` aggregate with nested context consumers. | `MIG-05` removes its aggregate V1 adapter only after the `MIG-06` nested handlers are typed. |
+| `rocketmq-broker/src/long_polling/pull_request.rs` and `long_polling/long_polling_service/pull_request_hold_service.rs` | `Compatibility`; legacy Pull waiter/service stores or forwards `ConnectionHandlerContext`. | `MIG-05` seals acceptance and drains accepted work; `MIG-07` removes the empty legacy path. |
+| `rocketmq-broker/src/long_polling/pop_request.rs`, `pop_long_polling_service.rs`, and `pop_lite_long_polling_service.rs` | `Compatibility`; legacy Pop/Notification/PopLite waiter/services store or forward the context. | `MIG-05` seals acceptance and drains accepted work; `MIG-07` removes the empty legacy path. |
+
+The legacy long-poll test processors (`TestPullProcessor`, `FailingProcessor`,
+`ControlledProcessor`, `LegacyNotificationProcessor`, and Pop/PopLite
+`TestProcessor` fixtures) belong to these compatibility services. Update them
+with the owning service during cutover/drain; do not treat them as production
+processor inventory.
+
+## Admin nested handlers
+
+`MIG-06` owns every nested handler below. Most accept an unused `_ctx`; delete
+that parameter rather than replacing it with an unused whole request. Their
+inline context-wrapper tests migrate with the owning handler and
+`AdminBrokerProcessor` aggregate.
+
+| Directory | Nested handler files |
+|---|---|
+| `rocketmq-broker/src/processor/admin_broker_processor/` | `batch_mq_handler.rs`, `broker_config_request_handler.rs`, `broker_epoch_cache_handler.rs`, `broker_stats_handler.rs`, `consumer_request_handler.rs`, `create_acl_request_handler.rs`, `create_user_request_handler.rs`, `delete_acl_request_handler.rs`, `delete_user_request_handler.rs` |
+| Same directory | `get_acl_request_handler.rs`, `get_broker_ha_status_handler.rs`, `get_user_request_handler.rs`, `list_acl_request_handler.rs`, `list_users_request_handler.rs`, `message_related_handler.rs`, `notify_broker_role_change_handler.rs`, `notify_min_broker_id_handler.rs`, `offset_request_handler.rs` |
+| Same directory | `producer_request_handler.rs`, `reset_master_flusg_offset_handler.rs`, `subscription_group_handler.rs`, `topic_request_handler.rs`, `update_acl_request_handler.rs`, `update_broker_ha_handler.rs`, `update_cold_data_flow_ctr_group_config.rs`, `update_global_white_addrs_config_request_handler.rs`, `update_user_request_handler.rs` |
+
+## Auth and Proxy
+
+| Production implementation or consumer | Current state | Owner and completion condition |
+|---|---|---|
+| `rocketmq-auth/src/runtime.rs` | Accepts `Any` channel context and probes `ConnectionHandlerContext`, its wrapper, and `Channel` for source IP/channel identity. | `MIG-06`; consume a trusted typed request/session/auth view and fail closed when required provenance is absent. |
+| `rocketmq-auth/src/authorization/builder/default_authorization_context_builder.rs` | Repeats the three-way runtime downcast for source IP. | `MIG-06`; accept typed provenance directly and remove the legacy downcasts. |
+| `rocketmq-proxy/src/remoting.rs` — `ProxyRequestProcessor<P>` | `V1` generic production processor; derives proxy context from a raw `Channel`. | `MIG-06`; use `dispatch_embedded_v2` with `EmbeddedCaller::BrokerProxy` and consume the local V2 result. |
+| `rocketmq-proxy/src/auth.rs` | Probes context alias, wrapper, and `Channel` for source IP. | `MIG-06`; consume only trusted typed provenance and preserve fail-closed tests. |
+
+Proxy remoting inline tests that call the V1 `process_request` entry point belong
+to `ProxyRequestProcessor` and migrate in the same change.
+
+## Explicit exclusions
+
+The scan intentionally excludes these lookalikes from the production migration
+count while retaining them as review evidence:
+
+- Business methods named `process_request` that do not implement either
+  remoting processor trait, including `rocketmq-broker/src/proxy_facade.rs`.
+- The transport `SessionProcessor` contract used by local/network test servers;
+  it is typed and does not carry `ConnectionHandlerContext`.
+- V2-only fixture processors used to exercise response plans, provenance,
+  deferred registration, deadlines, lifecycle, and wire delivery.
+- Outbound client-side uses of `DefaultRequestProcessor`, such as Broker outer
+  API composition; they are consumers of the Transport migration, not Broker
+  server leaves.
+- Legacy long-poll business traits recorded in the compatibility section; they
+  are drain-owned consumers, not top-level `RequestProcessor` implementations.
+
+## Re-scan and update checklist
+
+Run a path-based search when beginning each migration batch, then classify every
+new match as production, compatibility, test fixture, or ordinary same-name
+code. Do not record file hashes and do not generate a fingerprint baseline.
+
+```powershell
+rg -n --glob '*.rs' `
+  'ConnectionHandlerContext|ConnectionHandlerContextWrapper|impl.*RequestProcessor|process_request\(' `
+  rocketmq-transport/src rocketmq-broker/src rocketmq-client/src `
+  rocketmq-namesrv/src rocketmq-controller/src rocketmq-proxy/src rocketmq-auth/src
+```
+
+- [x] All seven primary crates are represented.
+- [x] Generic production implementations and wrapper/aggregate implementations are recorded.
+- [x] All 27 Admin nested handler files are recorded.
+- [x] Test fixtures have an owning production processor, compatibility service, or explicit V2-infrastructure classification.
+- [x] Ordinary same-name business methods are excluded from mechanical migration.
+- [x] No source fingerprint, stored hash, or generated baseline is used.


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9841

### Brief Description

Add a live, path-based inventory for the remoting processor V2 migration. The ledger:

- classifies production V1, dual, V2 infrastructure, and bounded compatibility paths across the seven primary crates;
- assigns every concrete processor, generic owner, wrapper, aggregate, nested Admin handler, and typed context consumer to its migration batch;
- records the real Client, Namesrv, and Controller production wiring and the raw-Channel side contracts that require narrow session lifecycle ports;
- assigns test fixtures to their production or compatibility owners and excludes ordinary same-name business methods;
- explicitly avoids source hashes, fingerprints, and generated baseline gates.

### How Did You Test This Change?

- Ran a seven-crate path-based scan for V1/V2 processor implementations, context consumers, wrappers, and same-name methods.
- Verified all documented core paths exist and all 27 Admin nested handler files are present in the ledger.
- Verified the document contains no local filesystem paths.
- Ran `git diff --check HEAD^ HEAD` successfully.
- Completed an independent read-only audit of production wiring, generic owners, test ownership, and the no-fingerprint constraint; result: APPROVE.

This is a documentation-only change; no Cargo validation is required by the repository validation policy.
