### PR TITLE
[ISSUE #9845]♻️Migrate Broker leaf processors to the V2 request contract

### DIFF
--- a/rocketmq-broker/src/broker_runtime/composition.rs
+++ b/rocketmq-broker/src/broker_runtime/composition.rs
@@ -1171,12 +1171,18 @@ impl BrokerRuntime {
             broker_config.broker_identity.broker_id,
             broker_config.get_broker_addr().into(),
         );
-        let producer_manager = ProducerManager::new();
+        let client_session_transition_locks =
+            Arc::new(crate::client::session_transition_locks::ClientSessionTransitionLocks::default());
+        let producer_manager =
+            ProducerManager::new_with_session_transition_locks(Arc::clone(&client_session_transition_locks));
         let consumer_filter_manager = ConsumerFilterManager::new(broker_config.clone(), message_store_config.clone());
         let consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static> =
             Arc::new(DefaultConsumerIdsChangeListener::new(consumer_filter_manager.clone()));
-        let consumer_manager =
-            ConsumerManager::new_with_broker_stats(consumer_ids_change_listener.clone(), broker_config.clone());
+        let consumer_manager = ConsumerManager::new_with_broker_stats_and_session_transition_locks(
+            consumer_ids_change_listener.clone(),
+            broker_config.clone(),
+            client_session_transition_locks,
+        );
 
         let should_start_time = Arc::new(AtomicU64::new(0));
         let pop_inflight_message_counter = PopInflightMessageCounter::new(should_start_time);

--- a/rocketmq-broker/src/broker_runtime/request_pipeline.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline.rs
@@ -25,6 +25,8 @@ pub(super) struct BrokerRequestPipeline {
     pub(super) auth_admin_service: Option<Arc<AuthAdminService>>,
     pub(super) consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static>,
     pub(super) processor_wiring_complete: bool,
+    #[cfg(test)]
+    pub(super) pull_message_processor_for_test: Option<Arc<PullMessageProcessor<BrokerMessageStore>>>,
 }
 
 impl BrokerRequestPipeline {
@@ -39,6 +41,8 @@ impl BrokerRequestPipeline {
             auth_admin_service: None,
             consumer_ids_change_listener,
             processor_wiring_complete: false,
+            #[cfg(test)]
+            pull_message_processor_for_test: None,
         }
     }
 }
@@ -139,6 +143,19 @@ impl BrokerRuntime {
             pull_message_result_handler,
             Arc::clone(&pull_message_context),
         ));
+        let session_client_lookup: Arc<dyn crate::long_polling::pull_deferred::PullSessionClientLookup> =
+            Arc::new(self.composition.state.consumer_manager().session_registry());
+        pull_message_processor
+            .install_session_client_lookup(session_client_lookup)
+            .map_err(|_| BrokerStartupError::Initialization {
+                component: "pull_session_client_lookup",
+                detail: "Pull session client lookup was already installed".to_owned(),
+            })?;
+        #[cfg(test)]
+        {
+            self.composition.request_pipeline.pull_message_processor_for_test =
+                Some(Arc::clone(&pull_message_processor));
+        }
 
         let consumer_manage_processor = self.composition.state.build_consumer_manage_processor();
         let pull_request_hold_service = Arc::new(PullRequestHoldService::new(Arc::downgrade(&pull_message_processor)));

--- a/rocketmq-broker/src/client.rs
+++ b/rocketmq-broker/src/client.rs
@@ -23,3 +23,4 @@ pub(crate) mod net;
 pub(crate) mod producer_change_listener;
 pub(crate) mod producer_group_event;
 pub(crate) mod rebalance;
+pub(crate) mod session_transition_locks;

--- a/rocketmq-broker/src/client/client_channel_info.rs
+++ b/rocketmq-broker/src/client/client_channel_info.rs
@@ -16,6 +16,81 @@ use cheetah_string::CheetahString;
 use rocketmq_protocol::protocol::LanguageCode;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v2::SessionId;
+
+/// Client identity retained for a V2 transport session.
+///
+/// This value contains no transport writer, request, session view, or connection
+/// context. The stable session identifier is the only link back to transport
+/// lifecycle state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ClientSessionInfo {
+    session_id: SessionId,
+    client_id: CheetahString,
+    remote_address: Option<CheetahString>,
+    language: LanguageCode,
+    version: i32,
+    last_update_timestamp: u64,
+}
+
+impl ClientSessionInfo {
+    pub(crate) fn new(
+        session_id: SessionId,
+        client_id: CheetahString,
+        remote_address: Option<CheetahString>,
+        language: LanguageCode,
+        version: i32,
+    ) -> Self {
+        Self {
+            session_id,
+            client_id,
+            remote_address,
+            language,
+            version,
+            last_update_timestamp: current_millis(),
+        }
+    }
+
+    pub(crate) const fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+
+    pub(crate) const fn client_id(&self) -> &CheetahString {
+        &self.client_id
+    }
+
+    pub(crate) fn remote_address(&self) -> Option<&str> {
+        self.remote_address.as_deref()
+    }
+
+    pub(crate) const fn language(&self) -> LanguageCode {
+        self.language
+    }
+
+    pub(crate) const fn version(&self) -> i32 {
+        self.version
+    }
+
+    pub(crate) const fn last_update_timestamp(&self) -> u64 {
+        self.last_update_timestamp
+    }
+
+    pub(crate) fn refresh_from(&mut self, current: &Self) {
+        debug_assert_eq!(
+            self.client_id, current.client_id,
+            "a live SessionId cannot change client identity"
+        );
+        self.remote_address.clone_from(&current.remote_address);
+        self.language = current.language;
+        self.version = current.version;
+        self.last_update_timestamp = current_millis();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_last_update_timestamp_for_test(&mut self, timestamp: u64) {
+        self.last_update_timestamp = timestamp;
+    }
+}
 
 #[derive(Clone, Hash, PartialEq)]
 pub struct ClientChannelInfo {

--- a/rocketmq-broker/src/client/consumer_group_info.rs
+++ b/rocketmq-broker/src/client/consumer_group_info.rs
@@ -24,17 +24,21 @@ use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v2::SessionId;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
 
 use crate::client::client_channel_info::ClientChannelInfo;
+use crate::client::client_channel_info::ClientSessionInfo;
+use crate::client::consumer_ids_change_listener::ConsumerConnectionIdentity;
 
 #[derive(Clone)]
 pub struct ConsumerGroupInfo {
     group_name: CheetahString,
     subscription_table: Arc<DashMap<CheetahString, Arc<SubscriptionData>>>,
     channel_info_table: Arc<DashMap<Channel, ClientChannelInfo>>,
+    session_info_table: Arc<DashMap<SessionId, ClientSessionInfo>>,
     consume_type: ConsumeType,
     message_model: MessageModel,
     consume_from_where: ConsumeFromWhere,
@@ -52,6 +56,7 @@ impl ConsumerGroupInfo {
             group_name: group_name.into(),
             subscription_table: Arc::new(DashMap::new()),
             channel_info_table: Arc::new(DashMap::new()),
+            session_info_table: Arc::new(DashMap::new()),
             consume_type,
             message_model,
             consume_from_where,
@@ -64,6 +69,7 @@ impl ConsumerGroupInfo {
             group_name: group_name.into(),
             subscription_table: Arc::new(DashMap::new()),
             channel_info_table: Arc::new(DashMap::new()),
+            session_info_table: Arc::new(DashMap::new()),
             consume_type: ConsumeType::ConsumePassively,
             message_model: MessageModel::Clustering,
             consume_from_where: ConsumeFromWhere::ConsumeFromLastOffset,
@@ -142,9 +148,9 @@ impl ConsumerGroupInfo {
         self.channel_info_table.len()
     }
 
-    /// Returns whether the group has no registered channels.
+    /// Returns whether the group has neither legacy channels nor V2 sessions.
     pub fn channels_is_empty(&self) -> bool {
-        self.channel_info_table.is_empty()
+        self.channel_info_table.is_empty() && self.session_info_table.is_empty()
     }
 
     /// Inserts or replaces one channel registration using its channel identity as the key.
@@ -174,9 +180,113 @@ impl ConsumerGroupInfo {
     }
 
     pub fn get_all_client_ids(&self) -> Vec<CheetahString> {
-        self.channel_info_table
+        let mut client_ids = self
+            .channel_info_table
             .iter()
             .map(|info| info.value().client_id().clone())
+            .collect::<HashSet<_>>();
+        client_ids.extend(
+            self.session_info_table
+                .iter()
+                .map(|info| info.value().client_id().clone()),
+        );
+        client_ids.into_iter().collect()
+    }
+
+    pub(crate) fn session_client_id(&self, session_id: SessionId) -> Option<CheetahString> {
+        self.session_info_table
+            .get(&session_id)
+            .map(|info| info.client_id().clone())
+    }
+
+    pub(crate) fn session_info_snapshot(&self) -> Vec<ClientSessionInfo> {
+        self.session_info_table
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+
+    pub(crate) fn connection_identity_snapshot(&self) -> Vec<ConsumerConnectionIdentity> {
+        let mut identities = self
+            .channel_info_table
+            .iter()
+            .map(|entry| ConsumerConnectionIdentity::Legacy {
+                client_id: entry.client_id().clone(),
+            })
+            .collect::<Vec<_>>();
+        identities.extend(
+            self.session_info_table
+                .iter()
+                .map(|entry| ConsumerConnectionIdentity::Session {
+                    session_id: *entry.key(),
+                    client_id: entry.client_id().clone(),
+                }),
+        );
+        identities
+    }
+
+    pub(crate) fn update_session(
+        &mut self,
+        info_new: ClientSessionInfo,
+        consume_type: ConsumeType,
+        message_model: MessageModel,
+        consume_from_where: ConsumeFromWhere,
+    ) -> bool {
+        self.consume_type = consume_type;
+        self.message_model = message_model;
+        self.consume_from_where = consume_from_where;
+
+        let is_new = if let Some(mut info_old) = self.session_info_table.get_mut(&info_new.session_id()) {
+            info_old.refresh_from(&info_new);
+            false
+        } else {
+            self.session_info_table.insert(info_new.session_id(), info_new);
+            true
+        };
+        self.last_update_timestamp = current_millis();
+        is_new
+    }
+
+    pub(crate) fn unregister_session(&self, session_id: SessionId) -> Option<ClientSessionInfo> {
+        self.session_info_table.remove(&session_id).map(|(_, info)| info)
+    }
+
+    pub(crate) fn unregister_session_if_expired(
+        &self,
+        session_id: SessionId,
+        now: u64,
+        timeout: u64,
+    ) -> Option<ClientSessionInfo> {
+        self.session_info_table
+            .remove_if(&session_id, |_, info| {
+                now.saturating_sub(info.last_update_timestamp()) > timeout
+            })
+            .map(|(_, info)| info)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_session_last_update_timestamp_for_test(&self, session_id: SessionId, timestamp: u64) {
+        if let Some(mut info) = self.session_info_table.get_mut(&session_id) {
+            info.set_last_update_timestamp_for_test(timestamp);
+        }
+    }
+
+    pub(crate) fn remove_expired_sessions(&self, now: u64, timeout: u64) -> Vec<ClientSessionInfo> {
+        let expired = self
+            .session_info_table
+            .iter()
+            .filter(|entry| now.saturating_sub(entry.last_update_timestamp()) > timeout)
+            .map(|entry| entry.session_id())
+            .collect::<Vec<_>>();
+        expired
+            .into_iter()
+            .filter_map(|session_id| {
+                self.session_info_table
+                    .remove_if(&session_id, |_, info| {
+                        now.saturating_sub(info.last_update_timestamp()) > timeout
+                    })
+                    .map(|(_, info)| info)
+            })
             .collect()
     }
 

--- a/rocketmq-broker/src/client/consumer_ids_change_listener.rs
+++ b/rocketmq-broker/src/client/consumer_ids_change_listener.rs
@@ -14,7 +14,22 @@
 
 use std::any::Any;
 
+use cheetah_string::CheetahString;
+use rocketmq_transport::api::v2::SessionId;
+
 use crate::client::consumer_group_event::ConsumerGroupEvent;
+
+/// Stable identity of a consumer group member without transport write authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ConsumerConnectionIdentity {
+    Legacy {
+        client_id: CheetahString,
+    },
+    Session {
+        session_id: SessionId,
+        client_id: CheetahString,
+    },
+}
 
 /// Trait for listening to consumer ID changes.
 ///
@@ -33,6 +48,16 @@ pub trait ConsumerIdsChangeListener {
     /// * `group` - The name of the consumer group affected by the event.
     /// * `args` - Additional arguments or context provided with the event.
     fn handle(&self, event: ConsumerGroupEvent, group: &str, args: &[&dyn Any]);
+
+    /// Handles a V2 consumer membership change using stable identities instead of raw channels.
+    ///
+    /// The default implementation preserves compatibility for existing listeners. Implementors
+    /// that trigger rebalance or server push can opt in without receiving a `Channel` or request
+    /// context.
+    fn handle_connection_change(&self, group: &str, members: &[ConsumerConnectionIdentity]) {
+        let members = members.to_vec();
+        self.handle(ConsumerGroupEvent::Change, group, &[&members as &dyn Any]);
+    }
 
     /// Performs cleanup actions before shutdown.
     ///

--- a/rocketmq-broker/src/client/manager/consumer_manager.rs
+++ b/rocketmq-broker/src/client/manager/consumer_manager.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Weak;
@@ -23,6 +24,7 @@ use std::time::Instant;
 use crate::config::broker_config::BrokerConfig;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
+use parking_lot::Mutex;
 use parking_lot::RwLock;
 use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType;
@@ -31,13 +33,19 @@ use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store::BrokerStatsManager;
 use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v2::SessionId;
 use tracing::info;
 use tracing::warn;
 
 use crate::client::client_channel_info::ClientChannelInfo;
+use crate::client::client_channel_info::ClientSessionInfo;
 use crate::client::consumer_group_event::ConsumerGroupEvent;
 use crate::client::consumer_group_info::ConsumerGroupInfo;
+use crate::client::consumer_ids_change_listener::ConsumerConnectionIdentity;
 use crate::client::consumer_ids_change_listener::ConsumerIdsChangeListener;
+use crate::client::session_transition_locks::ClientSessionTransitionGuard;
+use crate::client::session_transition_locks::ClientSessionTransitionLocks;
+use crate::long_polling::pull_deferred::PullSessionClientLookup;
 
 /// Global mapping: Channel ID -> Set<Consumer Group>
 ///
@@ -56,6 +64,59 @@ static CHANNEL_CONSUMER_GROUPS: LazyLock<DashMap<CheetahString, HashSet<CheetahS
 /// Type alias for consumer change listener to reduce complexity
 type ConsumerListener = Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static>;
 
+#[cfg(test)]
+type EmptyGroupBarrierPair = (Arc<std::sync::Barrier>, Arc<std::sync::Barrier>);
+
+pub(crate) struct ConsumerSessionRegistration {
+    pub(crate) group: CheetahString,
+    pub(crate) consume_type: ConsumeType,
+    pub(crate) message_model: MessageModel,
+    pub(crate) consume_from_where: ConsumeFromWhere,
+    pub(crate) subscriptions: HashSet<SubscriptionData>,
+    pub(crate) notify_consumer_ids_changed: bool,
+    pub(crate) update_subscription: bool,
+}
+
+struct ConsumerSessionRemoval {
+    group: CheetahString,
+    callback_drain: Option<ConsumerSessionCallbackDrain>,
+}
+
+enum ConsumerSessionCallback {
+    GroupUnregister(CheetahString),
+    MembersChanged {
+        group: CheetahString,
+        members: Vec<ConsumerConnectionIdentity>,
+    },
+    RegisterSubscriptions {
+        group: CheetahString,
+        subscriptions: HashSet<SubscriptionData>,
+    },
+}
+
+#[derive(Default)]
+struct ConsumerSessionCallbackQueueState {
+    draining: bool,
+    pending: VecDeque<Vec<ConsumerSessionCallback>>,
+}
+
+#[derive(Default)]
+struct ConsumerSessionCallbackQueue {
+    state: Mutex<ConsumerSessionCallbackQueueState>,
+}
+
+struct ConsumerSessionCallbackDrain {
+    group: CheetahString,
+    queue: Arc<ConsumerSessionCallbackQueue>,
+}
+
+#[derive(Default)]
+pub(crate) struct ConsumerSessionBatch {
+    started_at: Option<Instant>,
+    changed_groups: HashSet<CheetahString>,
+    callback_drains: Vec<ConsumerSessionCallbackDrain>,
+}
+
 /// Manages consumer client connections and their lifecycle.
 ///
 /// This manager maintains:
@@ -73,6 +134,23 @@ pub struct ConsumerManager {
     consumer_compensation_table: Arc<DashMap<CheetahString, ConsumerGroupInfo>>,
     /// Topic -> Set<Group> reverse index for fast topic-to-group lookup
     topic_group_table: Arc<DashMap<CheetahString, HashSet<CheetahString>>>,
+    /// Canonical V2 session -> all consumer groups registered by that session.
+    session_to_groups: Arc<DashMap<SessionId, HashSet<CheetahString>>>,
+    /// Latest canonical V2 session for each consumer client identity.
+    client_session_table: Arc<DashMap<CheetahString, SessionId>>,
+    /// Immutable client identity claimed by each live V2 session.
+    session_client_table: Arc<DashMap<SessionId, CheetahString>>,
+    /// Consumer-id change notification policy captured for each V2 group registration.
+    session_notify_table: Arc<DashMap<(CheetahString, SessionId), bool>>,
+    /// Per-group ordered side-effect queues. Group state transitions enqueue before releasing
+    /// their group guard, and exactly one lock-free callback drainer preserves that order.
+    session_callback_queues: Arc<DashMap<CheetahString, Arc<ConsumerSessionCallbackQueue>>>,
+    #[cfg(test)]
+    empty_group_barriers: Arc<RwLock<Option<EmptyGroupBarrierPair>>>,
+    #[cfg(test)]
+    topic_empty_entry_barriers: Arc<RwLock<Option<EmptyGroupBarrierPair>>>,
+    /// Striped serialization for canonical client-session multi-index transitions.
+    session_transition_locks: Arc<ClientSessionTransitionLocks>,
     /// Listeners notified on consumer registration/unregistration events
     /// Uses Arc<RwLock<Vec>> to support dynamic listener registration at runtime
     consumer_ids_change_listener_list: Arc<RwLock<Vec<ConsumerListener>>>,
@@ -161,12 +239,121 @@ impl ConsumerClientRegistration {
         self.manager
             .unregister_consumer(group, client, notify_consumer_ids_changed);
     }
+
+    pub(crate) fn register_consumer_session(
+        &self,
+        group: &CheetahString,
+        client: ClientSessionInfo,
+        consume_type: ConsumeType,
+        message_model: MessageModel,
+        consume_from_where: ConsumeFromWhere,
+        subscriptions: HashSet<SubscriptionData>,
+        notify_consumer_ids_changed: bool,
+    ) -> bool {
+        self.manager
+            .register_consumer_sessions(
+                client,
+                vec![ConsumerSessionRegistration {
+                    group: group.clone(),
+                    consume_type,
+                    message_model,
+                    consume_from_where,
+                    subscriptions,
+                    notify_consumer_ids_changed,
+                    update_subscription: true,
+                }],
+            )
+            .contains(group)
+    }
+
+    pub(crate) fn register_consumer_session_without_sub(
+        &self,
+        group: &CheetahString,
+        client: ClientSessionInfo,
+        consume_type: ConsumeType,
+        message_model: MessageModel,
+        consume_from_where: ConsumeFromWhere,
+        notify_consumer_ids_changed: bool,
+    ) -> bool {
+        self.manager
+            .register_consumer_sessions(
+                client,
+                vec![ConsumerSessionRegistration {
+                    group: group.clone(),
+                    consume_type,
+                    message_model,
+                    consume_from_where,
+                    subscriptions: HashSet::new(),
+                    notify_consumer_ids_changed,
+                    update_subscription: false,
+                }],
+            )
+            .contains(group)
+    }
+
+    pub(crate) fn register_consumer_sessions(
+        &self,
+        client: ClientSessionInfo,
+        registrations: Vec<ConsumerSessionRegistration>,
+    ) -> HashSet<CheetahString> {
+        self.manager.register_consumer_sessions(client, registrations)
+    }
+
+    pub(crate) fn prepare_consumer_sessions(
+        &self,
+        transition: &ClientSessionTransitionGuard<'_>,
+        client: ClientSessionInfo,
+        registrations: Vec<ConsumerSessionRegistration>,
+    ) -> ConsumerSessionBatch {
+        self.manager
+            .register_consumer_sessions_locked(transition, client, registrations)
+    }
+
+    pub(crate) fn complete_consumer_sessions(&self, batch: ConsumerSessionBatch) -> HashSet<CheetahString> {
+        self.manager.complete_consumer_session_batch(batch)
+    }
+
+    pub(crate) fn session_transition_locks(&self) -> Arc<ClientSessionTransitionLocks> {
+        Arc::clone(&self.manager.session_transition_locks)
+    }
+
+    pub(crate) fn client_id_for_session(&self, session_id: SessionId) -> Option<CheetahString> {
+        self.manager
+            .session_client_table
+            .get(&session_id)
+            .map(|entry| entry.clone())
+    }
+
+    pub(crate) fn unregister_consumer_session(
+        &self,
+        group: &str,
+        session_id: SessionId,
+        notify_consumer_ids_changed: bool,
+    ) {
+        self.manager
+            .unregister_consumer_session(group, session_id, notify_consumer_ids_changed);
+    }
 }
 
 /// Read-only access to the live consumer table for assignment decisions.
 #[derive(Clone)]
 pub(crate) struct ConsumerAssignmentView {
     consumer_table: Arc<DashMap<CheetahString, ConsumerGroupInfo>>,
+}
+
+/// Live read-only mapping from a canonical V2 session and consumer group to
+/// the client identity most recently registered by heartbeat.
+#[derive(Clone)]
+pub(crate) struct ConsumerSessionRegistry {
+    consumer_table: Arc<DashMap<CheetahString, ConsumerGroupInfo>>,
+}
+
+impl PullSessionClientLookup for ConsumerSessionRegistry {
+    fn client_id(&self, session_id: SessionId, consumer_group: &CheetahString) -> Option<CheetahString> {
+        self.consumer_table
+            .get(consumer_group)
+            .and_then(|info| info.session_client_id(session_id))
+    }
 }
 
 impl ConsumerAssignmentView {
@@ -197,6 +384,10 @@ impl ConsumerConnectionHousekeeping {
     pub(crate) fn do_channel_close_event(&self, remote_addr: &str, channel: &Channel) -> bool {
         self.manager.do_channel_close_event(remote_addr, channel)
     }
+
+    pub(crate) fn do_session_close_event(&self, session_id: SessionId) -> bool {
+        self.manager.do_session_close_event(session_id)
+    }
 }
 
 impl ConsumerManager {
@@ -212,6 +403,12 @@ impl ConsumerManager {
         }
     }
 
+    pub(crate) fn session_registry(&self) -> ConsumerSessionRegistry {
+        ConsumerSessionRegistry {
+            consumer_table: Arc::clone(&self.consumer_table),
+        }
+    }
+
     pub(crate) fn connection_housekeeping(&self) -> ConsumerConnectionHousekeeping {
         ConsumerConnectionHousekeeping {
             manager: self.clone_shared_state(),
@@ -223,6 +420,16 @@ impl ConsumerManager {
             consumer_table: Arc::clone(&self.consumer_table),
             consumer_compensation_table: Arc::clone(&self.consumer_compensation_table),
             topic_group_table: Arc::clone(&self.topic_group_table),
+            session_to_groups: Arc::clone(&self.session_to_groups),
+            client_session_table: Arc::clone(&self.client_session_table),
+            session_client_table: Arc::clone(&self.session_client_table),
+            session_notify_table: Arc::clone(&self.session_notify_table),
+            session_callback_queues: Arc::clone(&self.session_callback_queues),
+            #[cfg(test)]
+            empty_group_barriers: Arc::clone(&self.empty_group_barriers),
+            #[cfg(test)]
+            topic_empty_entry_barriers: Arc::clone(&self.topic_empty_entry_barriers),
+            session_transition_locks: Arc::clone(&self.session_transition_locks),
             consumer_ids_change_listener_list: Arc::clone(&self.consumer_ids_change_listener_list),
             broker_stats_manager: self.broker_stats_manager.clone(),
             broker_config: self.broker_config.clone(),
@@ -237,6 +444,18 @@ impl ConsumerManager {
     /// * `consumer_ids_change_listener` - Listener for consumer change events
     /// * `expired_timeout` - Timeout for channel and subscription expiration (milliseconds)
     pub fn new(consumer_ids_change_listener: ConsumerListener, expired_timeout: u64) -> Self {
+        Self::new_with_session_transition_locks(
+            consumer_ids_change_listener,
+            expired_timeout,
+            Arc::new(ClientSessionTransitionLocks::default()),
+        )
+    }
+
+    pub(crate) fn new_with_session_transition_locks(
+        consumer_ids_change_listener: ConsumerListener,
+        expired_timeout: u64,
+        session_transition_locks: Arc<ClientSessionTransitionLocks>,
+    ) -> Self {
         let consumer_ids_change_listener_list = Arc::new(RwLock::new(vec![consumer_ids_change_listener]));
         ConsumerManager {
             // Uses 64 shards for improved concurrency under high load
@@ -244,6 +463,16 @@ impl ConsumerManager {
             consumer_compensation_table: Arc::new(DashMap::with_capacity_and_shard_amount(256, 16)),
             // Topic-Group reverse index for fast topic-to-group lookup
             topic_group_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            session_to_groups: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            client_session_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            session_client_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            session_notify_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            session_callback_queues: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            #[cfg(test)]
+            empty_group_barriers: Arc::new(RwLock::new(None)),
+            #[cfg(test)]
+            topic_empty_entry_barriers: Arc::new(RwLock::new(None)),
+            session_transition_locks,
             consumer_ids_change_listener_list,
             broker_stats_manager: None,
             broker_config: None,
@@ -261,6 +490,18 @@ impl ConsumerManager {
         consumer_ids_change_listener: ConsumerListener,
         broker_config: Arc<BrokerConfig>,
     ) -> Self {
+        Self::new_with_broker_stats_and_session_transition_locks(
+            consumer_ids_change_listener,
+            broker_config,
+            Arc::new(ClientSessionTransitionLocks::default()),
+        )
+    }
+
+    pub(crate) fn new_with_broker_stats_and_session_transition_locks(
+        consumer_ids_change_listener: ConsumerListener,
+        broker_config: Arc<BrokerConfig>,
+        session_transition_locks: Arc<ClientSessionTransitionLocks>,
+    ) -> Self {
         let consumer_ids_change_listener_list = Arc::new(RwLock::new(vec![consumer_ids_change_listener]));
         ConsumerManager {
             // Uses 64 shards for improved concurrency under high load
@@ -268,6 +509,16 @@ impl ConsumerManager {
             consumer_compensation_table: Arc::new(DashMap::with_capacity_and_shard_amount(256, 16)),
             // Topic-Group reverse index for fast topic-to-group lookup
             topic_group_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            session_to_groups: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            client_session_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            session_client_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            session_notify_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            session_callback_queues: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
+            #[cfg(test)]
+            empty_group_barriers: Arc::new(RwLock::new(None)),
+            #[cfg(test)]
+            topic_empty_entry_barriers: Arc::new(RwLock::new(None)),
+            session_transition_locks,
             consumer_ids_change_listener_list,
             broker_stats_manager: None,
             broker_config: Some(broker_config.clone()),
@@ -306,6 +557,11 @@ impl ConsumerManager {
             let group = group_info.get_group_name().clone();
             let consume_type = group_info.get_consume_type();
             for (_, client) in group_info.channel_info_snapshot() {
+                *counts
+                    .entry((group.clone(), client.language(), client.version(), consume_type))
+                    .or_default() += 1;
+            }
+            for client in group_info.session_info_snapshot() {
                 *counts
                     .entry((group.clone(), client.language(), client.version(), consume_type))
                     .or_default() += 1;
@@ -580,8 +836,9 @@ impl ConsumerManager {
                     if let Some(mut groups) = self.topic_group_table.get_mut(&old_topic) {
                         groups.remove(group);
                         if groups.is_empty() {
-                            drop(groups); // Release write lock before removing entry
-                            self.topic_group_table.remove(&old_topic);
+                            drop(groups);
+                            self.topic_group_table
+                                .remove_if(&old_topic, |_, current| current.is_empty());
                         }
                     }
                 }
@@ -692,6 +949,351 @@ impl ConsumerManager {
         r1
     }
 
+    fn register_consumer_sessions(
+        &self,
+        client: ClientSessionInfo,
+        registrations: Vec<ConsumerSessionRegistration>,
+    ) -> HashSet<CheetahString> {
+        let transition = self
+            .session_transition_locks
+            .lock(client.client_id(), client.session_id());
+        let batch = self.register_consumer_sessions_locked(&transition, client, registrations);
+        drop(transition);
+        self.complete_consumer_session_batch(batch)
+    }
+
+    fn register_consumer_sessions_locked(
+        &self,
+        transition: &ClientSessionTransitionGuard<'_>,
+        client: ClientSessionInfo,
+        registrations: Vec<ConsumerSessionRegistration>,
+    ) -> ConsumerSessionBatch {
+        assert!(
+            self.session_transition_locks
+                .covers(transition, client.client_id(), client.session_id()),
+            "consumer session mutation requires the matching transition guard"
+        );
+        let start = Instant::now();
+        if self
+            .session_client_table
+            .get(&client.session_id())
+            .is_some_and(|current| current.as_str() != client.client_id().as_str())
+        {
+            warn!(
+                "ignore consumer heartbeat that changes client identity for live session {:?}",
+                client.session_id()
+            );
+            return ConsumerSessionBatch::default();
+        }
+        let replaced_session = self
+            .client_session_table
+            .get(client.client_id())
+            .map(|entry| *entry.value())
+            .filter(|session_id| *session_id != client.session_id());
+        if registrations.is_empty() {
+            let removals = replaced_session
+                .map(|session_id| self.unregister_consumer_session_all_locked(session_id))
+                .unwrap_or_default();
+            let mut batch = ConsumerSessionBatch {
+                started_at: Some(start),
+                ..ConsumerSessionBatch::default()
+            };
+            for removal in removals {
+                batch.changed_groups.insert(removal.group);
+                if let Some(callback_drain) = removal.callback_drain {
+                    batch.callback_drains.push(callback_drain);
+                }
+            }
+            return batch;
+        }
+        self.client_session_table
+            .insert(client.client_id().clone(), client.session_id());
+        self.session_client_table
+            .insert(client.session_id(), client.client_id().clone());
+        let mut changed_groups = HashSet::new();
+        let mut callback_drains = Vec::with_capacity(registrations.len());
+        let mut unique_groups = HashSet::with_capacity(registrations.len());
+        for registration in registrations {
+            let ConsumerSessionRegistration {
+                group,
+                consume_type,
+                message_model,
+                consume_from_where,
+                subscriptions,
+                notify_consumer_ids_changed,
+                update_subscription,
+            } = registration;
+            if !unique_groups.insert(group.clone()) {
+                continue;
+            }
+            let mut group_info = self.consumer_table.entry(group.clone()).or_insert_with(|| {
+                ConsumerGroupInfo::new(group.clone(), consume_type, message_model, consume_from_where)
+            });
+
+            if update_subscription {
+                let old_topics = group_info.get_subscribe_topics();
+                let new_topics = subscriptions
+                    .iter()
+                    .map(|subscription| subscription.topic.clone())
+                    .collect::<HashSet<_>>();
+                for old_topic in old_topics.difference(&new_topics) {
+                    if let Some(mut groups) = self.topic_group_table.get_mut(old_topic) {
+                        groups.remove(&group);
+                        if groups.is_empty() {
+                            drop(groups);
+                            self.topic_group_table
+                                .remove_if(old_topic, |_, current| current.is_empty());
+                        }
+                    }
+                }
+                for subscription in &subscriptions {
+                    self.topic_group_table
+                        .entry(subscription.topic.clone())
+                        .or_default()
+                        .insert(group.clone());
+                }
+            }
+
+            let session_changed =
+                group_info.update_session(client.clone(), consume_type, message_model, consume_from_where);
+            let subscription_changed = update_subscription && group_info.update_subscription(&subscriptions);
+            let changed = session_changed || subscription_changed;
+            if changed {
+                changed_groups.insert(group.clone());
+            }
+            self.session_notify_table
+                .insert((group.clone(), client.session_id()), notify_consumer_ids_changed);
+            self.session_to_groups
+                .entry(client.session_id())
+                .or_default()
+                .insert(group.clone());
+            let mut callbacks = Vec::with_capacity(2);
+            if changed && notify_consumer_ids_changed && !is_broadcast_mode(message_model) {
+                callbacks.push(ConsumerSessionCallback::MembersChanged {
+                    group: group.clone(),
+                    members: group_info.connection_identity_snapshot(),
+                });
+            }
+            if update_subscription {
+                callbacks.push(ConsumerSessionCallback::RegisterSubscriptions {
+                    group: group.clone(),
+                    subscriptions,
+                });
+            }
+            if let Some(callback_drain) = self.enqueue_consumer_group_callbacks(&group, callbacks) {
+                callback_drains.push(callback_drain);
+            }
+            drop(group_info);
+        }
+        let removals = replaced_session
+            .map(|session_id| self.unregister_consumer_session_all_locked(session_id))
+            .unwrap_or_default();
+        for removal in removals {
+            changed_groups.insert(removal.group);
+            if let Some(callback_drain) = removal.callback_drain {
+                callback_drains.push(callback_drain);
+            }
+        }
+        ConsumerSessionBatch {
+            started_at: Some(start),
+            changed_groups,
+            callback_drains,
+        }
+    }
+
+    fn complete_consumer_session_batch(&self, batch: ConsumerSessionBatch) -> HashSet<CheetahString> {
+        let ConsumerSessionBatch {
+            started_at,
+            changed_groups,
+            callback_drains,
+        } = batch;
+        for callback_drain in callback_drains {
+            self.drain_consumer_session_callbacks(callback_drain);
+        }
+        if let (Some(started_at), Some(stats)) =
+            (started_at, self.broker_stats_manager.as_ref().and_then(Weak::upgrade))
+        {
+            stats.inc_consumer_register_time(started_at.elapsed().as_millis() as i32);
+        }
+        changed_groups
+    }
+
+    fn unregister_consumer_session(&self, group: &str, session_id: SessionId, notify_consumer_ids_changed: bool) {
+        let Some(client_id) = self.session_client_table.get(&session_id).map(|entry| entry.clone()) else {
+            return;
+        };
+        let transition = self.session_transition_locks.lock(&client_id, session_id);
+        let removal = self.unregister_consumer_session_locked(group, session_id, notify_consumer_ids_changed);
+        drop(transition);
+        if let Some(removal) = removal {
+            if let Some(callback_drain) = removal.callback_drain {
+                self.drain_consumer_session_callbacks(callback_drain);
+            }
+        }
+    }
+
+    fn unregister_consumer_session_locked(
+        &self,
+        group: &str,
+        session_id: SessionId,
+        notify_consumer_ids_changed: bool,
+    ) -> Option<ConsumerSessionRemoval> {
+        let group_info_guard = self.consumer_table.get_mut(group)?;
+        let client = group_info_guard.unregister_session(session_id)?;
+        let message_model = group_info_guard.get_message_model();
+        let group_is_empty = group_info_guard.channels_is_empty();
+        let notify_members_changed = self
+            .session_notify_table
+            .remove(&(group.into(), session_id))
+            .map(|(_, notify)| notify)
+            .unwrap_or(notify_consumer_ids_changed)
+            && !is_broadcast_mode(message_model);
+        let members = notify_members_changed.then(|| group_info_guard.connection_identity_snapshot());
+        let mut callbacks = Vec::with_capacity(2);
+        if let Some(members) = members {
+            callbacks.push(ConsumerSessionCallback::MembersChanged {
+                group: group.into(),
+                members,
+            });
+        }
+        if group_is_empty {
+            callbacks.push(ConsumerSessionCallback::GroupUnregister(group.into()));
+            // Clear the reverse index while this exact empty group entry is still guarded.
+            // A concurrent registration can then either repopulate this entry after the guard
+            // is released or create a replacement after the conditional outer removal.
+            self.clear_topic_group_table(&group_info_guard);
+            #[cfg(test)]
+            self.pause_empty_group_removal_for_test();
+        }
+        let callback_drain = self.enqueue_consumer_group_callbacks(group, callbacks);
+        drop(group_info_guard);
+        let session_has_groups = self.remove_consumer_session_group_index(session_id, group);
+        if !session_has_groups {
+            self.client_session_table
+                .remove_if(client.client_id(), |_, current| *current == session_id);
+            self.session_client_table
+                .remove_if(&session_id, |_, current| current == client.client_id());
+        }
+        if group_is_empty {
+            self.consumer_table
+                .remove_if(group, |_, current| current.channels_is_empty());
+        }
+        Some(ConsumerSessionRemoval {
+            group: group.into(),
+            callback_drain,
+        })
+    }
+
+    fn unregister_consumer_session_all_locked(&self, session_id: SessionId) -> Vec<ConsumerSessionRemoval> {
+        let groups = self
+            .session_to_groups
+            .get(&session_id)
+            .map(|entry| entry.value().clone())
+            .unwrap_or_default();
+        groups
+            .into_iter()
+            .filter_map(|group| self.unregister_consumer_session_locked(group.as_str(), session_id, false))
+            .collect()
+    }
+
+    fn do_session_close_event(&self, session_id: SessionId) -> bool {
+        let Some(client_id) = self.session_client_table.get(&session_id).map(|entry| entry.clone()) else {
+            return false;
+        };
+        let transition = self.session_transition_locks.lock(&client_id, session_id);
+        let removals = self.unregister_consumer_session_all_locked(session_id);
+        let removed = !removals.is_empty();
+        drop(transition);
+        for removal in removals {
+            if let Some(callback_drain) = removal.callback_drain {
+                self.drain_consumer_session_callbacks(callback_drain);
+            }
+        }
+        removed
+    }
+
+    fn enqueue_consumer_group_callbacks(
+        &self,
+        group: impl Into<CheetahString>,
+        callbacks: Vec<ConsumerSessionCallback>,
+    ) -> Option<ConsumerSessionCallbackDrain> {
+        if callbacks.is_empty() {
+            return None;
+        }
+        let group = group.into();
+        let queue_entry = self
+            .session_callback_queues
+            .entry(group.clone())
+            .or_insert_with(|| Arc::new(ConsumerSessionCallbackQueue::default()));
+        let queue = Arc::clone(queue_entry.value());
+        let mut state = queue.state.lock();
+        state.pending.push_back(callbacks);
+        if state.draining {
+            return None;
+        }
+        state.draining = true;
+        drop(state);
+        drop(queue_entry);
+        Some(ConsumerSessionCallbackDrain { group, queue })
+    }
+
+    fn drain_consumer_session_callbacks(&self, drain: ConsumerSessionCallbackDrain) {
+        loop {
+            let callbacks = {
+                let mut state = drain.queue.state.lock();
+                match state.pending.pop_front() {
+                    Some(callbacks) => callbacks,
+                    None => {
+                        state.draining = false;
+                        drop(state);
+                        self.session_callback_queues.remove_if(&drain.group, |_, current| {
+                            Arc::ptr_eq(current, &drain.queue) && {
+                                let state = current.state.lock();
+                                !state.draining && state.pending.is_empty()
+                            }
+                        });
+                        return;
+                    }
+                }
+            };
+            for callback in callbacks {
+                match callback {
+                    ConsumerSessionCallback::GroupUnregister(group) => {
+                        if self.consumer_table.get(&group).is_none() {
+                            self.call_consumer_ids_change_listener(ConsumerGroupEvent::Unregister, &group, &[]);
+                        }
+                    }
+                    ConsumerSessionCallback::MembersChanged { group, members } => {
+                        let listeners = self.consumer_ids_change_listener_list.read().clone();
+                        for listener in listeners {
+                            listener.handle_connection_change(&group, &members);
+                        }
+                    }
+                    ConsumerSessionCallback::RegisterSubscriptions { group, subscriptions } => self
+                        .call_consumer_ids_change_listener(
+                            ConsumerGroupEvent::Register,
+                            &group,
+                            &[&subscriptions as &dyn Any],
+                        ),
+                }
+            }
+        }
+    }
+
+    fn remove_consumer_session_group_index(&self, session_id: SessionId, group: &str) -> bool {
+        let Some(mut groups) = self.session_to_groups.get_mut(&session_id) else {
+            return false;
+        };
+        groups.remove(group);
+        let has_groups = !groups.is_empty();
+        drop(groups);
+        if !has_groups {
+            self.session_to_groups
+                .remove_if(&session_id, |_, current| current.is_empty());
+        }
+        has_groups
+    }
+
     /// Notifies all registered consumer IDs change listeners of an event.
     ///
     /// # Arguments
@@ -699,8 +1301,8 @@ impl ConsumerManager {
     /// * `group` - The affected consumer group
     /// * `args` - Additional event arguments
     pub fn call_consumer_ids_change_listener(&self, event: ConsumerGroupEvent, group: &str, args: &[&dyn Any]) {
-        let listeners = self.consumer_ids_change_listener_list.read();
-        for listener in listeners.iter() {
+        let listeners = self.consumer_ids_change_listener_list.read().clone();
+        for listener in listeners {
             listener.handle(event, group, args);
         }
     }
@@ -735,10 +1337,29 @@ impl ConsumerManager {
             if let Some(mut groups) = self.topic_group_table.get_mut(&topic) {
                 groups.remove(group_name);
                 if groups.is_empty() {
-                    drop(groups); // Release write lock before removing entry
-                    self.topic_group_table.remove(&topic);
+                    drop(groups);
+                    #[cfg(test)]
+                    self.pause_topic_empty_entry_removal_for_test();
+                    self.topic_group_table
+                        .remove_if(&topic, |_, current| current.is_empty());
                 }
             }
+        }
+    }
+
+    #[cfg(test)]
+    fn pause_empty_group_removal_for_test(&self) {
+        if let Some((entered, release)) = self.empty_group_barriers.write().take() {
+            entered.wait();
+            release.wait();
+        }
+    }
+
+    #[cfg(test)]
+    fn pause_topic_empty_entry_removal_for_test(&self) {
+        if let Some((entered, release)) = self.topic_empty_entry_barriers.write().take() {
+            entered.wait();
+            release.wait();
         }
     }
 
@@ -771,11 +1392,9 @@ impl ConsumerManager {
         client_channel_info: &ClientChannelInfo,
         is_notify_consumer_ids_changed_enable: bool,
     ) {
-        let consumer_group_info = self.consumer_table.get_mut(group);
-        if consumer_group_info.is_none() {
+        let Some(consumer_group_info) = self.consumer_table.get_mut(group) else {
             return;
-        }
-        let consumer_group_info = consumer_group_info.unwrap();
+        };
         let removed = consumer_group_info.unregister_channel(client_channel_info);
         if removed {
             self.call_consumer_ids_change_listener(
@@ -793,8 +1412,8 @@ impl ConsumerManager {
                 if let Some(mut groups) = CHANNEL_CONSUMER_GROUPS.get_mut(&channel_id) {
                     groups.remove(group);
                     if groups.is_empty() {
-                        drop(groups); // Release lock before removing entry
-                        CHANNEL_CONSUMER_GROUPS.remove(&channel_id);
+                        drop(groups);
+                        CHANNEL_CONSUMER_GROUPS.remove_if(&channel_id, |_, current| current.is_empty());
                     }
                 }
             }
@@ -802,18 +1421,19 @@ impl ConsumerManager {
         let message_model = consumer_group_info.get_message_model();
         let channels = consumer_group_info.get_all_channels();
         if consumer_group_info.channels_is_empty() {
-            // Clone consumer_group_info for cleanup before dropping the reference
-            let group_info_clone = consumer_group_info.clone();
-            drop(consumer_group_info); // Release the reference
-            if self.consumer_table.remove(group).is_some() {
+            self.clear_topic_group_table(&consumer_group_info);
+            #[cfg(test)]
+            self.pause_empty_group_removal_for_test();
+            drop(consumer_group_info);
+            if self
+                .consumer_table
+                .remove_if(group, |_, current| current.channels_is_empty())
+                .is_some()
+            {
                 info!(
                     "unregister consumer ok, no any connection, and remove consumer group, {}",
                     group
                 );
-
-                // Clear topic_group_table when removing consumer group
-                self.clear_topic_group_table(&group_info_clone);
-
                 self.call_consumer_ids_change_listener(ConsumerGroupEvent::Unregister, group, &[]);
             }
         }
@@ -877,6 +1497,7 @@ impl ConsumerManager {
         // Collect expired channels without holding write locks
         // Uses iter() instead of iter_mut() to allow concurrent reads
         let mut expired_channels: Vec<(CheetahString, Channel)> = Vec::new();
+        let mut expired_sessions: Vec<(CheetahString, ClientSessionInfo)> = Vec::new();
         let mut groups_to_check_empty = Vec::new();
 
         for entry in self.consumer_table.iter() {
@@ -885,6 +1506,7 @@ impl ConsumerManager {
             let channel_info_snapshot = consumer_group_info.channel_info_snapshot();
 
             let mut group_has_expired = false;
+            let mut legacy_channel_expired = false;
             // Collect expired channels for this group
             for (channel, client_channel_info) in channel_info_snapshot {
                 let diff = current_time as i64 - client_channel_info.last_update_timestamp() as i64;
@@ -898,12 +1520,80 @@ impl ConsumerManager {
 
                     expired_channels.push((group.clone(), channel));
                     group_has_expired = true;
+                    legacy_channel_expired = true;
                 }
             }
 
+            expired_sessions.extend(
+                consumer_group_info
+                    .session_info_snapshot()
+                    .into_iter()
+                    .filter(|client| {
+                        current_time.saturating_sub(client.last_update_timestamp()) > self.channel_expired_timeout
+                    })
+                    .map(|client| (group.clone(), client)),
+            );
+
             // Mark groups that might become empty after cleanup
             if group_has_expired {
-                groups_to_check_empty.push(group);
+                groups_to_check_empty.push((group, legacy_channel_expired));
+            }
+        }
+
+        for (group, candidate) in expired_sessions {
+            let transition = self
+                .session_transition_locks
+                .lock(candidate.client_id(), candidate.session_id());
+            let Some(consumer_group_info) = self.consumer_table.get(&group) else {
+                continue;
+            };
+            let Some(client) = consumer_group_info.unregister_session_if_expired(
+                candidate.session_id(),
+                current_time,
+                self.channel_expired_timeout,
+            ) else {
+                continue;
+            };
+            warn!(
+                "SCAN: remove expired V2 session from ConsumerManager consumerTable. session={:?}, \
+                 consumerGroup={}",
+                client.session_id(),
+                group
+            );
+            let notify_members_changed = self
+                .session_notify_table
+                .remove(&(group.clone(), client.session_id()))
+                .is_some_and(|(_, notify)| notify)
+                && !is_broadcast_mode(consumer_group_info.get_message_model());
+            let members = notify_members_changed.then(|| consumer_group_info.connection_identity_snapshot());
+            let group_is_empty = consumer_group_info.channels_is_empty();
+            let mut callbacks = Vec::with_capacity(2);
+            if let Some(members) = members {
+                callbacks.push(ConsumerSessionCallback::MembersChanged {
+                    group: group.clone(),
+                    members,
+                });
+            }
+            if group_is_empty {
+                callbacks.push(ConsumerSessionCallback::GroupUnregister(group.clone()));
+                self.clear_topic_group_table(&consumer_group_info);
+            }
+            let callback_drain = self.enqueue_consumer_group_callbacks(&group, callbacks);
+            drop(consumer_group_info);
+            let session_has_groups = self.remove_consumer_session_group_index(client.session_id(), &group);
+            if !session_has_groups {
+                self.client_session_table
+                    .remove_if(client.client_id(), |_, current| *current == client.session_id());
+                self.session_client_table
+                    .remove_if(&client.session_id(), |_, current| current == client.client_id());
+            }
+            if group_is_empty {
+                self.consumer_table
+                    .remove_if(&group, |_, current| current.channels_is_empty());
+            }
+            drop(transition);
+            if let Some(callback_drain) = callback_drain {
+                self.drain_consumer_session_callbacks(callback_drain);
             }
         }
 
@@ -921,7 +1611,7 @@ impl ConsumerManager {
                         groups.remove(&group);
                         if groups.is_empty() {
                             drop(groups);
-                            CHANNEL_CONSUMER_GROUPS.remove(&channel_id);
+                            CHANNEL_CONSUMER_GROUPS.remove_if(&channel_id, |_, current| current.is_empty());
                         }
                     }
                 }
@@ -940,35 +1630,32 @@ impl ConsumerManager {
             }
         }
 
-        // Handle empty groups and send change notifications
-        let mut groups_to_remove = Vec::new();
-
-        for group in groups_to_check_empty {
+        // Handle empty groups and send change notifications.
+        for (group, notify_legacy_change) in groups_to_check_empty {
             if let Some(consumer_group_info) = self.consumer_table.get(&group) {
                 if consumer_group_info.channels_is_empty() {
                     warn!(
                         "SCAN: remove expired channel from ConsumerManager consumerTable, all clear, consumerGroup={}",
                         group
                     );
-                    groups_to_remove.push(group);
-                } else if !is_broadcast_mode(consumer_group_info.get_message_model()) {
+                    self.clear_topic_group_table(&consumer_group_info);
+                    #[cfg(test)]
+                    self.pause_empty_group_removal_for_test();
+                    drop(consumer_group_info);
+                    if self
+                        .consumer_table
+                        .remove_if(&group, |_, current| current.channels_is_empty())
+                        .is_some()
+                    {
+                        self.call_consumer_ids_change_listener(ConsumerGroupEvent::Unregister, group.as_str(), &[]);
+                    }
+                } else if notify_legacy_change && !is_broadcast_mode(consumer_group_info.get_message_model()) {
                     // Notify remaining channels about the change
                     self.call_consumer_ids_change_listener(
                         ConsumerGroupEvent::Change,
                         &group,
                         &[&consumer_group_info.get_all_channels() as &dyn Any],
                     );
-                }
-            }
-        }
-
-        // Remove empty groups and clean up indexes
-        for group in groups_to_remove {
-            if let Some(group_info) = self.consumer_table.get(&group).map(|entry| entry.clone()) {
-                if self.consumer_table.remove(&group).is_some() {
-                    // Clear topic_group_table when removing consumer group
-                    self.clear_topic_group_table(&group_info);
-                    self.call_consumer_ids_change_listener(ConsumerGroupEvent::Unregister, group.as_str(), &[]);
                 }
             }
         }
@@ -1008,6 +1695,9 @@ impl ConsumerManager {
                             );
 
                             if info.channels_is_empty() {
+                                self.clear_topic_group_table(&info);
+                                #[cfg(test)]
+                                self.pause_empty_group_removal_for_test();
                                 remove_list.push(group.clone());
                             } else if !is_broadcast_mode(info.get_message_model()) {
                                 self.call_consumer_ids_change_listener(
@@ -1024,15 +1714,16 @@ impl ConsumerManager {
 
                 // Process removal list
                 for group in remove_list {
-                    if let Some(group_info) = self.consumer_table.get(&group).map(|entry| entry.clone()) {
-                        if self.consumer_table.remove(&group).is_some() {
-                            info!(
-                                "unregister consumer ok, no any connection, and remove consumer group, {}",
-                                group
-                            );
-                            self.clear_topic_group_table(&group_info);
-                            self.call_consumer_ids_change_listener(ConsumerGroupEvent::Unregister, group.as_str(), &[]);
-                        }
+                    if self
+                        .consumer_table
+                        .remove_if(&group, |_, current| current.channels_is_empty())
+                        .is_some()
+                    {
+                        info!(
+                            "unregister consumer ok, no any connection, and remove consumer group, {}",
+                            group
+                        );
+                        self.call_consumer_ids_change_listener(ConsumerGroupEvent::Unregister, group.as_str(), &[]);
                     }
                 }
 
@@ -1055,6 +1746,9 @@ impl ConsumerManager {
                 );
 
                 if info.channels_is_empty() {
+                    self.clear_topic_group_table(info);
+                    #[cfg(test)]
+                    self.pause_empty_group_removal_for_test();
                     remove_list.push(group.clone());
                 } else if !is_broadcast_mode(info.get_message_model()) {
                     // Send Change event only if group still has active channels
@@ -1070,16 +1764,16 @@ impl ConsumerManager {
         }
 
         for group in remove_list {
-            if let Some(group_info) = self.consumer_table.get(&group).map(|entry| entry.clone()) {
-                if self.consumer_table.remove(&group).is_some() {
-                    info!(
-                        "unregister consumer ok, no any connection, and remove consumer group, {}",
-                        group
-                    );
-                    // Clear topic_group_table when removing consumer group
-                    self.clear_topic_group_table(&group_info);
-                    self.call_consumer_ids_change_listener(ConsumerGroupEvent::Unregister, group.as_str(), &[]);
-                }
+            if self
+                .consumer_table
+                .remove_if(&group, |_, current| current.channels_is_empty())
+                .is_some()
+            {
+                info!(
+                    "unregister consumer ok, no any connection, and remove consumer group, {}",
+                    group
+                );
+                self.call_consumer_ids_change_listener(ConsumerGroupEvent::Unregister, group.as_str(), &[]);
             }
         }
 
@@ -1100,18 +1794,89 @@ fn is_broadcast_mode(message_model: MessageModel) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
+    use std::collections::HashSet;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use std::sync::Arc;
+    use std::sync::Barrier;
+    use std::sync::Mutex as StdMutex;
 
     use cheetah_string::CheetahString;
     use dashmap::DashMap;
+    use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
+    use rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType;
+    use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
+    use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
     use rocketmq_protocol::protocol::LanguageCode;
     use rocketmq_transport::api::v1::Channel;
+    use rocketmq_transport::test_support::session_id_for_test;
     use rocketmq_transport::test_support::Connection;
     use tokio::net::TcpStream;
 
     use super::ConsumerAssignmentView;
+    use super::ConsumerManager;
+    use super::ConsumerSessionRegistration;
+    use super::ConsumerSessionRegistry;
     use crate::client::client_channel_info::ClientChannelInfo;
+    use crate::client::client_channel_info::ClientSessionInfo;
+    use crate::client::consumer_group_event::ConsumerGroupEvent;
     use crate::client::consumer_group_info::ConsumerGroupInfo;
+    use crate::client::consumer_ids_change_listener::ConsumerConnectionIdentity;
+    use crate::client::consumer_ids_change_listener::ConsumerIdsChangeListener;
+    use crate::long_polling::pull_deferred::PullSessionClientLookup;
+
+    struct NoopConsumerListener;
+
+    impl ConsumerIdsChangeListener for NoopConsumerListener {
+        fn handle(&self, _event: ConsumerGroupEvent, _group: &str, _args: &[&dyn Any]) {}
+
+        fn shutdown(&self) {}
+    }
+
+    struct BlockingRecordingListener {
+        calls: AtomicUsize,
+        first_entered: Barrier,
+        release_first: Barrier,
+        snapshots: StdMutex<Vec<Vec<ConsumerConnectionIdentity>>>,
+    }
+
+    impl BlockingRecordingListener {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                first_entered: Barrier::new(2),
+                release_first: Barrier::new(2),
+                snapshots: StdMutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ConsumerIdsChangeListener for BlockingRecordingListener {
+        fn handle(&self, _event: ConsumerGroupEvent, _group: &str, _args: &[&dyn Any]) {}
+
+        fn handle_connection_change(&self, _group: &str, members: &[ConsumerConnectionIdentity]) {
+            if self.calls.fetch_add(1, Ordering::AcqRel) == 0 {
+                self.first_entered.wait();
+                self.release_first.wait();
+            }
+            self.snapshots.lock().expect("snapshot lock").push(members.to_vec());
+        }
+
+        fn shutdown(&self) {}
+    }
+
+    fn session_registration(group: CheetahString) -> ConsumerSessionRegistration {
+        ConsumerSessionRegistration {
+            group,
+            consume_type: ConsumeType::ConsumePassively,
+            message_model: MessageModel::Clustering,
+            consume_from_where: ConsumeFromWhere::ConsumeFromLastOffset,
+            subscriptions: HashSet::new(),
+            notify_consumer_ids_changed: false,
+            update_subscription: true,
+        }
+    }
 
     async fn create_test_channel() -> Channel {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
@@ -1159,5 +1924,666 @@ mod tests {
         assert!(group_info.unregister_channel(&client));
         assert!(view.client_ids(&group).is_empty());
         assert_eq!(view.client_ids_if_present(&group), Some(Vec::new()));
+    }
+
+    #[test]
+    fn consumer_session_registry_tracks_live_session_group_identity() {
+        let consumer_table = Arc::new(DashMap::new());
+        let registry = ConsumerSessionRegistry {
+            consumer_table: Arc::clone(&consumer_table),
+        };
+        let group = CheetahString::from_static_str("session-group");
+        let other_group = CheetahString::from_static_str("other-group");
+        let session_id = session_id_for_test(41);
+        let other_session_id = session_id_for_test(42);
+        let mut group_info = ConsumerGroupInfo::new(
+            group.clone(),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+        );
+        assert!(group_info.update_session(
+            ClientSessionInfo::new(session_id, "client-a".into(), None, LanguageCode::RUST, 1),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+        ));
+        consumer_table.insert(group.clone(), group_info.clone());
+
+        assert_eq!(
+            crate::long_polling::pull_deferred::PullSessionClientLookup::client_id(&registry, session_id, &group),
+            Some(CheetahString::from_static_str("client-a"))
+        );
+        assert_eq!(
+            crate::long_polling::pull_deferred::PullSessionClientLookup::client_id(&registry, session_id, &other_group),
+            None
+        );
+        assert_eq!(
+            crate::long_polling::pull_deferred::PullSessionClientLookup::client_id(&registry, other_session_id, &group),
+            None
+        );
+
+        assert!(!group_info.update_session(
+            ClientSessionInfo::new(session_id, "client-a".into(), None, LanguageCode::RUST, 2),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+        ));
+        assert_eq!(
+            crate::long_polling::pull_deferred::PullSessionClientLookup::client_id(&registry, session_id, &group),
+            Some(CheetahString::from_static_str("client-a"))
+        );
+        assert_eq!(group_info.session_info_snapshot()[0].version(), 2);
+
+        assert_eq!(
+            group_info
+                .unregister_session(session_id)
+                .map(|client| client.client_id().clone()),
+            Some(CheetahString::from_static_str("client-a"))
+        );
+        assert_eq!(
+            crate::long_polling::pull_deferred::PullSessionClientLookup::client_id(&registry, session_id, &group),
+            None
+        );
+    }
+
+    #[test]
+    fn consumer_session_reconnect_and_stale_disconnect_preserve_the_new_session() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 120_000);
+        let registration = manager.client_registration();
+        let registry = manager.session_registry();
+        let old_session = session_id_for_test(51);
+        let new_session = session_id_for_test(52);
+        let group_a = CheetahString::from_static_str("reconnect-group-a");
+        let group_b = CheetahString::from_static_str("reconnect-group-b");
+        for group in [&group_a, &group_b] {
+            assert!(registration.register_consumer_session(
+                group,
+                ClientSessionInfo::new(old_session, "reconnect-client".into(), None, LanguageCode::RUST, 1),
+                ConsumeType::ConsumePassively,
+                MessageModel::Clustering,
+                ConsumeFromWhere::ConsumeFromLastOffset,
+                HashSet::new(),
+                false,
+            ));
+        }
+        assert_eq!(
+            manager.session_to_groups.get(&old_session).map(|groups| groups.len()),
+            Some(2)
+        );
+
+        assert!(registration.register_consumer_session(
+            &group_a,
+            ClientSessionInfo::new(new_session, "reconnect-client".into(), None, LanguageCode::RUST, 2),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+            HashSet::new(),
+            false,
+        ));
+        assert_eq!(registry.client_id(old_session, &group_a), None);
+        assert_eq!(registry.client_id(old_session, &group_b), None);
+        assert_eq!(
+            registry.client_id(new_session, &group_a),
+            Some("reconnect-client".into())
+        );
+        assert!(!manager.session_to_groups.contains_key(&old_session));
+        assert_eq!(
+            manager.client_session_table.get("reconnect-client").map(|entry| *entry),
+            Some(new_session)
+        );
+
+        registration.unregister_consumer_session(group_a.as_str(), old_session, false);
+        assert_eq!(
+            registry.client_id(new_session, &group_a),
+            Some("reconnect-client".into())
+        );
+        registration.unregister_consumer_session(group_a.as_str(), new_session, false);
+        assert!(!manager.session_to_groups.contains_key(&new_session));
+        assert!(!manager.client_session_table.contains_key("reconnect-client"));
+    }
+
+    #[test]
+    fn concurrent_consumer_reconnect_has_one_canonical_session() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 120_000);
+        let first_registration = manager.client_registration();
+        let second_registration = first_registration.clone();
+        let group = CheetahString::from_static_str("concurrent-consumer-group");
+        let first_session = session_id_for_test(5_501);
+        let second_session = session_id_for_test(5_502);
+        let barrier = Arc::new(Barrier::new(2));
+
+        std::thread::scope(|scope| {
+            let first_group = group.clone();
+            let first_barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                first_barrier.wait();
+                first_registration.register_consumer_session(
+                    &first_group,
+                    ClientSessionInfo::new(first_session, "concurrent-client".into(), None, LanguageCode::RUST, 1),
+                    ConsumeType::ConsumePassively,
+                    MessageModel::Clustering,
+                    ConsumeFromWhere::ConsumeFromLastOffset,
+                    HashSet::new(),
+                    false,
+                );
+            });
+            let second_group = group.clone();
+            let second_barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                second_barrier.wait();
+                second_registration.register_consumer_session(
+                    &second_group,
+                    ClientSessionInfo::new(second_session, "concurrent-client".into(), None, LanguageCode::RUST, 2),
+                    ConsumeType::ConsumePassively,
+                    MessageModel::Clustering,
+                    ConsumeFromWhere::ConsumeFromLastOffset,
+                    HashSet::new(),
+                    false,
+                );
+            });
+        });
+
+        let canonical = *manager
+            .client_session_table
+            .get("concurrent-client")
+            .expect("one canonical consumer session");
+        let loser = if canonical == first_session {
+            second_session
+        } else {
+            first_session
+        };
+        let group_info = manager.consumer_table.get(&group).expect("consumer group remains live");
+        assert_eq!(group_info.session_info_snapshot().len(), 1);
+        assert_eq!(
+            group_info.session_client_id(canonical).as_deref(),
+            Some("concurrent-client")
+        );
+        assert_eq!(group_info.session_client_id(loser), None);
+        drop(group_info);
+        assert!(!manager.session_to_groups.contains_key(&loser));
+
+        manager
+            .client_registration()
+            .unregister_consumer_session(group.as_str(), loser, false);
+        assert_eq!(
+            manager.session_registry().client_id(canonical, &group).as_deref(),
+            Some("concurrent-client")
+        );
+    }
+
+    #[test]
+    fn consumer_membership_callbacks_are_ordered_per_group_across_clients() {
+        let listener = Arc::new(BlockingRecordingListener::new());
+        let manager = ConsumerManager::new(listener.clone(), 120_000);
+        let first_registration = manager.client_registration();
+        let second_registration = first_registration.clone();
+        let group = CheetahString::from_static_str("ordered-membership-group");
+        let first_group = group.clone();
+
+        std::thread::scope(|scope| {
+            scope.spawn(move || {
+                first_registration.register_consumer_session(
+                    &first_group,
+                    ClientSessionInfo::new(
+                        session_id_for_test(5_511),
+                        "ordered-client-a".into(),
+                        None,
+                        LanguageCode::RUST,
+                        1,
+                    ),
+                    ConsumeType::ConsumePassively,
+                    MessageModel::Clustering,
+                    ConsumeFromWhere::ConsumeFromLastOffset,
+                    HashSet::new(),
+                    true,
+                );
+            });
+
+            listener.first_entered.wait();
+            second_registration.register_consumer_session(
+                &group,
+                ClientSessionInfo::new(
+                    session_id_for_test(5_512),
+                    "ordered-client-b".into(),
+                    None,
+                    LanguageCode::RUST,
+                    1,
+                ),
+                ConsumeType::ConsumePassively,
+                MessageModel::Clustering,
+                ConsumeFromWhere::ConsumeFromLastOffset,
+                HashSet::new(),
+                true,
+            );
+            listener.release_first.wait();
+        });
+
+        let snapshots = listener.snapshots.lock().expect("snapshot lock");
+        assert_eq!(snapshots.len(), 2);
+        let client_ids = |members: &[ConsumerConnectionIdentity]| {
+            let mut ids = members
+                .iter()
+                .map(|member| match member {
+                    ConsumerConnectionIdentity::Legacy { client_id }
+                    | ConsumerConnectionIdentity::Session { client_id, .. } => client_id.clone(),
+                })
+                .collect::<Vec<_>>();
+            ids.sort();
+            ids
+        };
+        assert_eq!(
+            client_ids(&snapshots[0]),
+            vec![CheetahString::from_static_str("ordered-client-a")]
+        );
+        assert_eq!(
+            client_ids(&snapshots[1]),
+            vec![
+                CheetahString::from_static_str("ordered-client-a"),
+                CheetahString::from_static_str("ordered-client-b"),
+            ]
+        );
+    }
+
+    #[test]
+    fn replacing_an_empty_session_group_preserves_the_new_topic_reverse_index() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 120_000);
+        let old_registration = manager.client_registration();
+        let new_registration = old_registration.clone();
+        let group = CheetahString::from_static_str("topic-index-replacement-group");
+        let topic = CheetahString::from_static_str("topic-index-replacement-topic");
+        let old_session = session_id_for_test(5_521);
+        let new_session = session_id_for_test(5_522);
+        let registration_for = |group: CheetahString| ConsumerSessionRegistration {
+            group,
+            consume_type: ConsumeType::ConsumePassively,
+            message_model: MessageModel::Clustering,
+            consume_from_where: ConsumeFromWhere::ConsumeFromLastOffset,
+            subscriptions: HashSet::from([SubscriptionData {
+                topic: topic.clone(),
+                sub_string: "*".into(),
+                ..SubscriptionData::default()
+            }]),
+            notify_consumer_ids_changed: false,
+            update_subscription: true,
+        };
+        old_registration.register_consumer_sessions(
+            ClientSessionInfo::new(old_session, "topic-index-old".into(), None, LanguageCode::RUST, 1),
+            vec![registration_for(group.clone())],
+        );
+        assert!(manager
+            .topic_group_table
+            .get(&topic)
+            .is_some_and(|groups| groups.contains(&group)));
+
+        let empty_entered = Arc::new(Barrier::new(2));
+        let release_empty = Arc::new(Barrier::new(2));
+        *manager.empty_group_barriers.write() = Some((Arc::clone(&empty_entered), Arc::clone(&release_empty)));
+        let new_started = Arc::new(Barrier::new(2));
+        std::thread::scope(|scope| {
+            let old_group = group.clone();
+            scope.spawn(move || {
+                old_registration.unregister_consumer_session(old_group.as_str(), old_session, false);
+            });
+            empty_entered.wait();
+
+            let new_group = group.clone();
+            let new_started_worker = Arc::clone(&new_started);
+            scope.spawn(move || {
+                new_started_worker.wait();
+                new_registration.register_consumer_sessions(
+                    ClientSessionInfo::new(new_session, "topic-index-new".into(), None, LanguageCode::RUST, 2),
+                    vec![registration_for(new_group)],
+                );
+            });
+            new_started.wait();
+            release_empty.wait();
+        });
+
+        assert_eq!(
+            manager.session_registry().client_id(new_session, &group).as_deref(),
+            Some("topic-index-new")
+        );
+        assert!(manager
+            .topic_group_table
+            .get(&topic)
+            .is_some_and(|groups| groups.contains(&group)));
+    }
+
+    #[tokio::test]
+    async fn replacing_an_empty_legacy_group_with_a_session_preserves_the_new_topic_reverse_index() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 120_000);
+        let legacy_registration = manager.client_registration();
+        let session_registration = legacy_registration.clone();
+        let group = CheetahString::from_static_str("legacy-topic-index-replacement-group");
+        let topic = CheetahString::from_static_str("legacy-topic-index-replacement-topic");
+        let legacy = ClientChannelInfo::new(
+            create_test_channel().await,
+            "legacy-topic-index-old".into(),
+            LanguageCode::RUST,
+            1,
+        );
+        let subscriptions = || {
+            HashSet::from([SubscriptionData {
+                topic: topic.clone(),
+                sub_string: "*".into(),
+                ..SubscriptionData::default()
+            }])
+        };
+        legacy_registration.register_consumer(
+            &group,
+            legacy.clone(),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+            subscriptions(),
+            false,
+        );
+
+        let empty_entered = Arc::new(Barrier::new(2));
+        let release_empty = Arc::new(Barrier::new(2));
+        *manager.empty_group_barriers.write() = Some((Arc::clone(&empty_entered), Arc::clone(&release_empty)));
+        let new_started = Arc::new(Barrier::new(2));
+        let new_session = session_id_for_test(5_523);
+        std::thread::scope(|scope| {
+            let old_group = group.clone();
+            scope.spawn(move || {
+                legacy_registration.unregister_consumer(old_group.as_str(), &legacy, false);
+            });
+            empty_entered.wait();
+
+            let new_group = group.clone();
+            let new_started_worker = Arc::clone(&new_started);
+            scope.spawn(move || {
+                new_started_worker.wait();
+                session_registration.register_consumer_session(
+                    &new_group,
+                    ClientSessionInfo::new(
+                        new_session,
+                        "legacy-topic-index-new".into(),
+                        None,
+                        LanguageCode::RUST,
+                        2,
+                    ),
+                    ConsumeType::ConsumePassively,
+                    MessageModel::Clustering,
+                    ConsumeFromWhere::ConsumeFromLastOffset,
+                    subscriptions(),
+                    false,
+                );
+            });
+            new_started.wait();
+            release_empty.wait();
+        });
+
+        assert_eq!(
+            manager.session_registry().client_id(new_session, &group).as_deref(),
+            Some("legacy-topic-index-new")
+        );
+        assert!(manager
+            .topic_group_table
+            .get(&topic)
+            .is_some_and(|groups| groups.contains(&group)));
+    }
+
+    #[test]
+    fn removing_an_empty_topic_entry_does_not_delete_a_concurrent_group_registration() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 120_000);
+        let first_registration = manager.client_registration();
+        let second_registration = first_registration.clone();
+        let first_group = CheetahString::from_static_str("topic-entry-first-group");
+        let second_group = CheetahString::from_static_str("topic-entry-second-group");
+        let topic = CheetahString::from_static_str("topic-entry-shared-topic");
+        let registration_for = |group: CheetahString| ConsumerSessionRegistration {
+            group,
+            consume_type: ConsumeType::ConsumePassively,
+            message_model: MessageModel::Clustering,
+            consume_from_where: ConsumeFromWhere::ConsumeFromLastOffset,
+            subscriptions: HashSet::from([SubscriptionData {
+                topic: topic.clone(),
+                sub_string: "*".into(),
+                ..SubscriptionData::default()
+            }]),
+            notify_consumer_ids_changed: false,
+            update_subscription: true,
+        };
+        let first_session = session_id_for_test(5_524);
+        let second_session = session_id_for_test(5_525);
+        first_registration.register_consumer_sessions(
+            ClientSessionInfo::new(first_session, "topic-entry-first".into(), None, LanguageCode::RUST, 1),
+            vec![registration_for(first_group.clone())],
+        );
+
+        let empty_entered = Arc::new(Barrier::new(2));
+        let release_empty = Arc::new(Barrier::new(2));
+        *manager.topic_empty_entry_barriers.write() = Some((Arc::clone(&empty_entered), Arc::clone(&release_empty)));
+        std::thread::scope(|scope| {
+            let removed_group = first_group.clone();
+            scope.spawn(move || {
+                first_registration.unregister_consumer_session(removed_group.as_str(), first_session, false);
+            });
+            empty_entered.wait();
+            second_registration.register_consumer_sessions(
+                ClientSessionInfo::new(second_session, "topic-entry-second".into(), None, LanguageCode::RUST, 2),
+                vec![registration_for(second_group.clone())],
+            );
+            release_empty.wait();
+        });
+
+        let indexed_groups = manager.query_topic_consume_by_who(&topic);
+        assert!(!indexed_groups.contains(&first_group));
+        assert!(indexed_groups.contains(&second_group));
+        assert_eq!(
+            manager
+                .session_registry()
+                .client_id(second_session, &second_group)
+                .as_deref(),
+            Some("topic-entry-second")
+        );
+    }
+
+    #[tokio::test]
+    async fn consumer_group_lives_until_both_channel_and_session_tables_are_empty() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 120_000);
+        let registration = manager.client_registration();
+        let group = CheetahString::from_static_str("mixed-consumer-group");
+        let channel = create_test_channel().await;
+        let legacy = ClientChannelInfo::new(channel, "legacy-client".into(), LanguageCode::RUST, 1);
+        registration.register_consumer(
+            &group,
+            legacy.clone(),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+            HashSet::new(),
+            false,
+        );
+        let session_id = session_id_for_test(53);
+        registration.register_consumer_session(
+            &group,
+            ClientSessionInfo::new(session_id, "session-client".into(), None, LanguageCode::RUST, 2),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+            HashSet::new(),
+            false,
+        );
+
+        registration.unregister_consumer(group.as_str(), &legacy, false);
+        assert!(manager.get_consumer_group_info(&group).is_some());
+        registration.unregister_consumer_session(group.as_str(), session_id, false);
+        assert!(manager.get_consumer_group_info(&group).is_none());
+    }
+
+    #[test]
+    fn consumer_session_expiry_rechecks_timestamp_and_cleans_reverse_indexes() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 1);
+        let registration = manager.client_registration();
+        let group = CheetahString::from_static_str("expired-session-group");
+        let session_id = session_id_for_test(54);
+        registration.register_consumer_session(
+            &group,
+            ClientSessionInfo::new(session_id, "expired-client".into(), None, LanguageCode::RUST, 1),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+            HashSet::new(),
+            false,
+        );
+        manager
+            .get_consumer_group_info(&group)
+            .expect("registered group")
+            .set_session_last_update_timestamp_for_test(session_id, 0);
+        manager.scan_not_active_channel();
+
+        assert_eq!(manager.session_registry().client_id(session_id, &group), None);
+        assert!(!manager.session_to_groups.contains_key(&session_id));
+        assert!(!manager.client_session_table.contains_key("expired-client"));
+
+        let mut group_info = ConsumerGroupInfo::new(
+            group,
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+        );
+        let scan_timestamp = rocketmq_runtime::common::time_utils::current_millis();
+        let mut stale = ClientSessionInfo::new(session_id, "refreshed-client".into(), None, LanguageCode::RUST, 1);
+        stale.set_last_update_timestamp_for_test(scan_timestamp.saturating_sub(100));
+        group_info.update_session(
+            stale,
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+        );
+        group_info.update_session(
+            ClientSessionInfo::new(session_id, "refreshed-client".into(), None, LanguageCode::RUST, 2),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+        );
+        assert!(group_info.remove_expired_sessions(scan_timestamp, 1).is_empty());
+        assert_eq!(
+            group_info.session_client_id(session_id),
+            Some("refreshed-client".into())
+        );
+    }
+
+    #[test]
+    fn concurrent_consumer_heartbeat_batches_preserve_every_winning_group() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 120_000);
+        let first_registration = manager.client_registration();
+        let second_registration = first_registration.clone();
+        let groups = vec![
+            CheetahString::from_static_str("batch-consumer-a"),
+            CheetahString::from_static_str("batch-consumer-b"),
+        ];
+        let first_session = session_id_for_test(5_601);
+        let second_session = session_id_for_test(5_602);
+        let barrier = Arc::new(Barrier::new(2));
+
+        std::thread::scope(|scope| {
+            let first_groups = groups.clone();
+            let first_barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                first_barrier.wait();
+                first_registration.register_consumer_sessions(
+                    ClientSessionInfo::new(first_session, "batch-client".into(), None, LanguageCode::RUST, 1),
+                    first_groups.into_iter().map(session_registration).collect(),
+                );
+            });
+            let second_groups = groups.clone();
+            let second_barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                second_barrier.wait();
+                second_registration.register_consumer_sessions(
+                    ClientSessionInfo::new(second_session, "batch-client".into(), None, LanguageCode::RUST, 2),
+                    second_groups.into_iter().map(session_registration).collect(),
+                );
+            });
+        });
+
+        let canonical = *manager
+            .client_session_table
+            .get("batch-client")
+            .expect("canonical batch consumer session");
+        let loser = if canonical == first_session {
+            second_session
+        } else {
+            first_session
+        };
+        for group in &groups {
+            let group_info = manager.consumer_table.get(group).expect("winning group remains");
+            assert_eq!(group_info.session_info_snapshot().len(), 1);
+            assert_eq!(group_info.session_client_id(canonical).as_deref(), Some("batch-client"));
+            assert_eq!(group_info.session_client_id(loser), None);
+        }
+        assert_eq!(
+            manager.session_to_groups.get(&canonical).map(|entry| entry.len()),
+            Some(2)
+        );
+        assert!(!manager.session_to_groups.contains_key(&loser));
+        assert!(!manager.session_client_table.contains_key(&loser));
+    }
+
+    #[test]
+    fn consumer_session_close_cleans_all_groups_and_stale_close_preserves_replacement() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 120_000);
+        let registration = manager.client_registration();
+        let housekeeping = manager.connection_housekeeping();
+        let groups = [
+            CheetahString::from_static_str("close-consumer-a"),
+            CheetahString::from_static_str("close-consumer-b"),
+        ];
+        let old_session = session_id_for_test(5_701);
+        registration.register_consumer_sessions(
+            ClientSessionInfo::new(old_session, "close-client".into(), None, LanguageCode::RUST, 1),
+            groups.iter().cloned().map(session_registration).collect(),
+        );
+        assert!(housekeeping.do_session_close_event(old_session));
+        assert!(groups
+            .iter()
+            .all(|group| manager.get_consumer_group_info(group).is_none()));
+        assert!(!manager.session_to_groups.contains_key(&old_session));
+
+        let new_session = session_id_for_test(5_702);
+        registration.register_consumer_sessions(
+            ClientSessionInfo::new(new_session, "close-client".into(), None, LanguageCode::RUST, 2),
+            groups.iter().cloned().map(session_registration).collect(),
+        );
+        assert!(!housekeeping.do_session_close_event(old_session));
+        assert!(groups
+            .iter()
+            .all(|group| manager.get_consumer_group_info(group).is_some()));
+        assert_eq!(
+            manager.client_session_table.get("close-client").map(|entry| *entry),
+            Some(new_session)
+        );
+    }
+
+    #[test]
+    fn consumer_session_identity_is_immutable() {
+        let manager = ConsumerManager::new(Arc::new(NoopConsumerListener), 120_000);
+        let registration = manager.client_registration();
+        let session_id = session_id_for_test(5_801);
+        let group = CheetahString::from_static_str("identity-consumer-a");
+        registration.register_consumer_sessions(
+            ClientSessionInfo::new(session_id, "identity-a".into(), None, LanguageCode::RUST, 1),
+            vec![session_registration(group.clone())],
+        );
+        let changed = registration.register_consumer_sessions(
+            ClientSessionInfo::new(session_id, "identity-b".into(), None, LanguageCode::RUST, 2),
+            vec![session_registration(CheetahString::from_static_str(
+                "identity-consumer-b",
+            ))],
+        );
+        assert!(changed.is_empty());
+        assert_eq!(
+            manager.session_client_table.get(&session_id).map(|entry| entry.clone()),
+            Some("identity-a".into())
+        );
+        assert!(!manager.consumer_table.contains_key("identity-consumer-b"));
+
+        registration.unregister_consumer_session(group.as_str(), session_id, false);
+        assert!(!manager.session_client_table.contains_key(&session_id));
     }
 }

--- a/rocketmq-broker/src/client/manager/producer_manager.rs
+++ b/rocketmq-broker/src/client/manager/producer_manager.rs
@@ -27,20 +27,33 @@ use rocketmq_protocol::protocol::body::producer_table_info::ProducerTableInfo;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store::BrokerStatsManager;
 use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::ConnectionState;
+use rocketmq_transport::api::v2::SessionId;
 use tracing::info;
 use tracing::warn;
 
 use crate::client::client_channel_info::ClientChannelInfo;
+use crate::client::client_channel_info::ClientSessionInfo;
 use crate::client::producer_change_listener::ArcProducerChangeListener;
 use crate::client::producer_group_event::ProducerGroupEvent;
+use crate::client::session_transition_locks::ClientSessionTransitionGuard;
+use crate::client::session_transition_locks::ClientSessionTransitionLocks;
 use crate::types::ProducerGroupName;
 
 /// Timeout for considering a producer channel as expired (120 seconds in milliseconds)
 const CHANNEL_EXPIRED_TIMEOUT: u64 = 120_000;
 /// Number of retry attempts when getting an available channel
 const GET_AVAILABLE_CHANNEL_RETRY_COUNT: u32 = 3;
+
+struct ProducerSessionRemoval {
+    group: ProducerGroupName,
+    group_table_removed: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct ProducerSessionBatch {
+    removals: Vec<ProducerSessionRemoval>,
+}
 
 /// Manages producer client connections and their lifecycle.
 ///
@@ -52,6 +65,16 @@ const GET_AVAILABLE_CHANNEL_RETRY_COUNT: u32 = 3;
 pub struct ProducerManager {
     /// Group name -> (Channel -> ClientChannelInfo) mapping
     group_channel_table: Arc<DashMap<ProducerGroupName, DashMap<Channel, ClientChannelInfo>>>,
+    /// Group name -> (stable V2 session -> client identity) mapping.
+    group_session_table: Arc<DashMap<ProducerGroupName, DashMap<SessionId, ClientSessionInfo>>>,
+    /// Latest canonical V2 session for each producer client identity.
+    client_session_table: Arc<DashMap<CheetahString, SessionId>>,
+    /// Immutable client identity claimed by each live V2 session.
+    session_client_table: Arc<DashMap<SessionId, CheetahString>>,
+    /// Reverse lookup used to remove all producer groups owned by a V2 session.
+    session_to_groups: Arc<DashMap<SessionId, HashSet<ProducerGroupName>>>,
+    /// Striped serialization for canonical client-session multi-index transitions.
+    session_transition_locks: Arc<ClientSessionTransitionLocks>,
     /// Client ID -> Channel mapping for quick channel lookup by client ID
     client_channel_table: Arc<DashMap<CheetahString, Channel>>,
     /// Channel -> ProducerGroups mapping for fast channel close event processing
@@ -96,13 +119,45 @@ impl ProducerClientRegistration {
         self.manager.register_producer(group, client);
     }
 
-    pub(crate) fn unregister_producer(
+    pub(crate) fn unregister_producer(&self, group: &str, client: &ClientChannelInfo) {
+        self.manager.unregister_producer(group, client);
+    }
+
+    pub(crate) fn register_producer_session(&self, group: &ProducerGroupName, client: ClientSessionInfo) {
+        self.manager.register_producer_session(group, client);
+    }
+
+    pub(crate) fn register_producer_sessions(&self, groups: Vec<ProducerGroupName>, client: ClientSessionInfo) {
+        self.manager.register_producer_sessions(groups, client);
+    }
+
+    pub(crate) fn prepare_producer_sessions(
         &self,
-        group: &str,
-        client: &ClientChannelInfo,
-        context: &ConnectionHandlerContext,
-    ) {
-        self.manager.unregister_producer(group, client, context);
+        transition: &ClientSessionTransitionGuard<'_>,
+        groups: Vec<ProducerGroupName>,
+        client: ClientSessionInfo,
+    ) -> ProducerSessionBatch {
+        self.manager
+            .register_producer_sessions_locked(transition, groups, client)
+    }
+
+    pub(crate) fn complete_producer_sessions(&self, batch: ProducerSessionBatch) {
+        self.manager.dispatch_producer_session_removals(batch.removals);
+    }
+
+    pub(crate) fn session_transition_locks(&self) -> Arc<ClientSessionTransitionLocks> {
+        Arc::clone(&self.manager.session_transition_locks)
+    }
+
+    pub(crate) fn client_id_for_session(&self, session_id: SessionId) -> Option<CheetahString> {
+        self.manager
+            .session_client_table
+            .get(&session_id)
+            .map(|entry| entry.clone())
+    }
+
+    pub(crate) fn unregister_producer_session(&self, group: &str, session_id: SessionId) {
+        self.manager.unregister_producer_session(group, session_id);
     }
 }
 
@@ -122,6 +177,10 @@ impl ProducerConnectionHousekeeping {
     pub(crate) fn do_channel_close_event(&self, remote_addr: &str, channel: &Channel) -> bool {
         self.manager.do_channel_close_event(remote_addr, channel)
     }
+
+    pub(crate) fn do_session_close_event(&self, session_id: SessionId) -> bool {
+        self.manager.do_session_close_event(session_id)
+    }
 }
 
 /// Shared read capability for producer channel selection and connection snapshots.
@@ -131,6 +190,7 @@ impl ProducerConnectionHousekeeping {
 #[derive(Clone)]
 pub(crate) struct ProducerChannelRegistry {
     group_channel_table: Arc<DashMap<ProducerGroupName, DashMap<Channel, ClientChannelInfo>>>,
+    group_session_table: Arc<DashMap<ProducerGroupName, DashMap<SessionId, ClientSessionInfo>>>,
     positive_atomic_counter: Arc<AtomicI32>,
 }
 
@@ -140,7 +200,7 @@ impl ProducerChannelRegistry {
     }
 
     pub(crate) fn producer_table(&self) -> ProducerTableInfo {
-        producer_table_snapshot(&self.group_channel_table)
+        producer_table_snapshot(&self.group_channel_table, &self.group_session_table)
     }
 }
 
@@ -194,6 +254,7 @@ fn select_available_channel(
 
 fn producer_table_snapshot(
     group_channel_table: &DashMap<ProducerGroupName, DashMap<Channel, ClientChannelInfo>>,
+    group_session_table: &DashMap<ProducerGroupName, DashMap<SessionId, ClientSessionInfo>>,
 ) -> ProducerTableInfo {
     let mut producers: HashMap<String, Vec<ProducerInfo>> = HashMap::new();
     for group_entry in group_channel_table.iter() {
@@ -202,6 +263,26 @@ fn producer_table_snapshot(
             let producer = ProducerInfo::new(
                 client.client_id().to_string(),
                 client.channel().remote_address().to_string(),
+                client.language(),
+                client.version(),
+                client.last_update_timestamp() as i64,
+            );
+            producers
+                .entry(group_entry.key().to_string())
+                .or_default()
+                .push(producer);
+        }
+    }
+    for group_entry in group_session_table.iter() {
+        for session_entry in group_entry.value().iter() {
+            let client = session_entry.value();
+            let remote_address = client
+                .remote_address()
+                .map(str::to_owned)
+                .unwrap_or_else(|| format!("session:{:?}", client.session_id()));
+            let producer = ProducerInfo::new(
+                client.client_id().to_string(),
+                remote_address,
                 client.language(),
                 client.version(),
                 client.last_update_timestamp() as i64,
@@ -231,6 +312,11 @@ impl ProducerManager {
     pub(crate) fn clone_shared_state(&self) -> Self {
         Self {
             group_channel_table: Arc::clone(&self.group_channel_table),
+            group_session_table: Arc::clone(&self.group_session_table),
+            client_session_table: Arc::clone(&self.client_session_table),
+            session_client_table: Arc::clone(&self.session_client_table),
+            session_to_groups: Arc::clone(&self.session_to_groups),
+            session_transition_locks: Arc::clone(&self.session_transition_locks),
             client_channel_table: Arc::clone(&self.client_channel_table),
             channel_to_groups: Arc::clone(&self.channel_to_groups),
             positive_atomic_counter: Arc::clone(&self.positive_atomic_counter),
@@ -243,6 +329,7 @@ impl ProducerManager {
     pub(crate) fn channel_registry(&self) -> ProducerChannelRegistry {
         ProducerChannelRegistry {
             group_channel_table: Arc::clone(&self.group_channel_table),
+            group_session_table: Arc::clone(&self.group_session_table),
             positive_atomic_counter: Arc::clone(&self.positive_atomic_counter),
         }
     }
@@ -255,8 +342,19 @@ impl ProducerManager {
 
     /// Creates a new producer manager with empty state.
     pub fn new() -> Self {
+        Self::new_with_session_transition_locks(Arc::new(ClientSessionTransitionLocks::default()))
+    }
+
+    pub(crate) fn new_with_session_transition_locks(
+        session_transition_locks: Arc<ClientSessionTransitionLocks>,
+    ) -> Self {
         Self {
             group_channel_table: Arc::new(DashMap::new()),
+            group_session_table: Arc::new(DashMap::new()),
+            client_session_table: Arc::new(DashMap::new()),
+            session_client_table: Arc::new(DashMap::new()),
+            session_to_groups: Arc::new(DashMap::new()),
+            session_transition_locks,
             client_channel_table: Arc::new(DashMap::new()),
             channel_to_groups: Arc::new(DashMap::new()),
             positive_atomic_counter: Arc::new(AtomicI32::new(0)),
@@ -301,7 +399,12 @@ impl ProducerManager {
     /// # Returns
     /// The total count of producer groups
     pub fn group_size(&self) -> usize {
-        self.group_channel_table.len()
+        self.group_channel_table
+            .iter()
+            .map(|entry| entry.key().clone())
+            .chain(self.group_session_table.iter().map(|entry| entry.key().clone()))
+            .collect::<HashSet<_>>()
+            .len()
     }
 
     /// Returns connected producer counts grouped by client language and version.
@@ -310,6 +413,12 @@ impl ProducerManager {
         for group_entry in self.group_channel_table.iter() {
             for channel_entry in group_entry.value().iter() {
                 let client = channel_entry.value();
+                *counts.entry((client.language(), client.version())).or_default() += 1;
+            }
+        }
+        for group_entry in self.group_session_table.iter() {
+            for session_entry in group_entry.value().iter() {
+                let client = session_entry.value();
                 *counts.entry((client.language(), client.version())).or_default() += 1;
             }
         }
@@ -324,7 +433,7 @@ impl ProducerManager {
     /// The snapshot reflects the state at the time of the call and may become stale
     /// as producers connect or disconnect.
     pub fn get_producer_table(&self) -> ProducerTableInfo {
-        producer_table_snapshot(&self.group_channel_table)
+        producer_table_snapshot(&self.group_channel_table, &self.group_session_table)
     }
 
     /// Checks whether a producer group has at least one connected producer.
@@ -335,10 +444,16 @@ impl ProducerManager {
     /// # Returns
     /// `true` if the group exists and contains at least one producer, `false` otherwise
     pub fn group_online(&self, group: &str) -> bool {
-        self.group_channel_table
+        let has_channel = self
+            .group_channel_table
             .get(group)
             .map(|channels| !channels.is_empty())
-            .unwrap_or(false)
+            .unwrap_or(false);
+        has_channel
+            || self
+                .group_session_table
+                .get(group)
+                .is_some_and(|sessions| !sessions.is_empty())
     }
 
     /// Removes a producer from a group.
@@ -349,19 +464,13 @@ impl ProducerManager {
     /// # Arguments
     /// * `group` - The producer group name
     /// * `client_channel_info` - The client channel information
-    /// * `ctx` - Connection handler context containing the channel
-    pub fn unregister_producer(
-        &self,
-        group: &str,
-        _client_channel_info: &ClientChannelInfo,
-        ctx: &ConnectionHandlerContext,
-    ) {
+    pub fn unregister_producer(&self, group: &str, client_channel_info: &ClientChannelInfo) {
         let mut removed_info: Option<ClientChannelInfo> = None;
         let mut is_group_empty = false;
 
         // Atomically remove producer from group table
         if let Some(channel_table) = self.group_channel_table.get(group) {
-            if let Some((_channel, old)) = channel_table.remove(ctx.channel()) {
+            if let Some((_channel, old)) = channel_table.remove(client_channel_info.channel()) {
                 removed_info = Some(old);
                 is_group_empty = channel_table.is_empty();
             }
@@ -371,7 +480,7 @@ impl ProducerManager {
         if let Some(old) = removed_info {
             // Remove from clientChannelTable only if the channel matches
             if let Some(entry) = self.client_channel_table.get(old.client_id()) {
-                if entry.value() == ctx.channel() {
+                if entry.value() == client_channel_info.channel() {
                     drop(entry); // Release read lock before remove
                     self.client_channel_table.remove(old.client_id());
                 }
@@ -388,11 +497,11 @@ impl ProducerManager {
 
             // Update channel_to_groups mapping (if fast path is enabled)
             if self.is_fast_channel_event_enabled() {
-                if let Some(mut entry) = self.channel_to_groups.get_mut(ctx.channel()) {
+                if let Some(mut entry) = self.channel_to_groups.get_mut(client_channel_info.channel()) {
                     entry.remove(group);
                     if entry.is_empty() {
                         drop(entry);
-                        self.channel_to_groups.remove(ctx.channel());
+                        self.channel_to_groups.remove(client_channel_info.channel());
                     }
                 }
             }
@@ -405,7 +514,9 @@ impl ProducerManager {
                     .remove_if(group, |_, channel_map| channel_map.is_empty());
                 if removed.is_some() {
                     info!("unregister a producer group[{}] from groupChannelTable", group);
-                    self.call_producer_change_listener(ProducerGroupEvent::GroupUnregister, group, None);
+                    if !self.group_online(group) {
+                        self.call_producer_change_listener(ProducerGroupEvent::GroupUnregister, group, None);
+                    }
                 }
             }
         }
@@ -503,6 +614,172 @@ impl ProducerManager {
         );
     }
 
+    fn register_producer_session(&self, group: &ProducerGroupName, client: ClientSessionInfo) {
+        self.register_producer_sessions(vec![group.clone()], client);
+    }
+
+    fn register_producer_sessions(&self, groups: Vec<ProducerGroupName>, client: ClientSessionInfo) {
+        let transition = self
+            .session_transition_locks
+            .lock(client.client_id(), client.session_id());
+        let batch = self.register_producer_sessions_locked(&transition, groups, client);
+        drop(transition);
+        self.dispatch_producer_session_removals(batch.removals);
+    }
+
+    fn register_producer_sessions_locked(
+        &self,
+        transition: &ClientSessionTransitionGuard<'_>,
+        groups: Vec<ProducerGroupName>,
+        client: ClientSessionInfo,
+    ) -> ProducerSessionBatch {
+        assert!(
+            self.session_transition_locks
+                .covers(transition, client.client_id(), client.session_id()),
+            "producer session mutation requires the matching transition guard"
+        );
+        if self
+            .session_client_table
+            .get(&client.session_id())
+            .is_some_and(|current| current.as_str() != client.client_id().as_str())
+        {
+            warn!(
+                "ignore producer heartbeat that changes client identity for live session {:?}",
+                client.session_id()
+            );
+            return ProducerSessionBatch::default();
+        }
+        let replaced_session = self
+            .client_session_table
+            .get(client.client_id())
+            .map(|entry| *entry.value())
+            .filter(|session_id| *session_id != client.session_id());
+        if groups.is_empty() {
+            let removals = replaced_session
+                .map(|session_id| self.unregister_producer_session_all_locked(session_id))
+                .unwrap_or_default();
+            return ProducerSessionBatch { removals };
+        }
+        if self
+            .broker_config
+            .load_full()
+            .is_some_and(|config| !config.enable_register_producer && config.reject_transaction_message)
+        {
+            return ProducerSessionBatch::default();
+        }
+        let mut unique_groups = HashSet::with_capacity(groups.len());
+        for group in groups {
+            if !unique_groups.insert(group.clone()) {
+                continue;
+            }
+            let sessions = self.group_session_table.entry(group.clone()).or_default();
+            if let Some(mut existing) = sessions.get_mut(&client.session_id()) {
+                existing.refresh_from(&client);
+            } else {
+                sessions.insert(client.session_id(), client.clone());
+            }
+            drop(sessions);
+            self.session_to_groups
+                .entry(client.session_id())
+                .or_default()
+                .insert(group.clone());
+        }
+        self.client_session_table
+            .insert(client.client_id().clone(), client.session_id());
+        self.session_client_table
+            .insert(client.session_id(), client.client_id().clone());
+        let removals = replaced_session
+            .map(|session_id| self.unregister_producer_session_all_locked(session_id))
+            .unwrap_or_default();
+        info!(
+            "producer session heartbeat applied, session: {:?} clientId: {}",
+            client.session_id(),
+            client.client_id()
+        );
+        ProducerSessionBatch { removals }
+    }
+
+    fn unregister_producer_session(&self, group: &str, session_id: SessionId) {
+        let Some(client_id) = self.session_client_table.get(&session_id).map(|entry| entry.clone()) else {
+            return;
+        };
+        let transition = self.session_transition_locks.lock(&client_id, session_id);
+        let removal = self.unregister_producer_session_locked(group, session_id);
+        drop(transition);
+        self.dispatch_producer_session_removals(removal.into_iter().collect());
+    }
+
+    fn unregister_producer_session_locked(&self, group: &str, session_id: SessionId) -> Option<ProducerSessionRemoval> {
+        let sessions = self.group_session_table.get(group)?;
+        let (_, client) = sessions.remove(&session_id)?;
+        let sessions_empty = sessions.is_empty();
+        drop(sessions);
+        let group_table_removed = if sessions_empty {
+            self.group_session_table
+                .remove_if(group, |_, current| current.is_empty())
+                .is_some()
+        } else {
+            false
+        };
+        let session_has_groups = self.remove_producer_session_group_index(session_id, group);
+        if !session_has_groups {
+            self.client_session_table
+                .remove_if(client.client_id(), |_, current| *current == session_id);
+            self.session_client_table
+                .remove_if(&session_id, |_, current| current == client.client_id());
+        }
+        Some(ProducerSessionRemoval {
+            group: group.into(),
+            group_table_removed,
+        })
+    }
+
+    fn unregister_producer_session_all_locked(&self, session_id: SessionId) -> Vec<ProducerSessionRemoval> {
+        let groups = self
+            .session_to_groups
+            .get(&session_id)
+            .map(|entry| entry.value().clone())
+            .unwrap_or_default();
+        groups
+            .into_iter()
+            .filter_map(|group| self.unregister_producer_session_locked(group.as_str(), session_id))
+            .collect()
+    }
+
+    fn do_session_close_event(&self, session_id: SessionId) -> bool {
+        let Some(client_id) = self.session_client_table.get(&session_id).map(|entry| entry.clone()) else {
+            return false;
+        };
+        let transition = self.session_transition_locks.lock(&client_id, session_id);
+        let removals = self.unregister_producer_session_all_locked(session_id);
+        drop(transition);
+        let removed = !removals.is_empty();
+        self.dispatch_producer_session_removals(removals);
+        removed
+    }
+
+    fn dispatch_producer_session_removals(&self, removals: Vec<ProducerSessionRemoval>) {
+        for removal in removals {
+            if removal.group_table_removed && !self.group_online(&removal.group) {
+                self.call_producer_change_listener(ProducerGroupEvent::GroupUnregister, &removal.group, None);
+            }
+        }
+    }
+
+    fn remove_producer_session_group_index(&self, session_id: SessionId, group: &str) -> bool {
+        let Some(mut groups) = self.session_to_groups.get_mut(&session_id) else {
+            return false;
+        };
+        groups.remove(group);
+        let has_groups = !groups.is_empty();
+        drop(groups);
+        if !has_groups {
+            self.session_to_groups
+                .remove_if(&session_id, |_, current| current.is_empty());
+        }
+        has_groups
+    }
+
     /// Finds the channel associated with a client identifier.
     ///
     /// # Arguments
@@ -537,6 +814,58 @@ impl ProducerManager {
     /// notified of each removal.
     pub fn scan_not_active_channel(&self) {
         let current_time = current_millis();
+
+        let expired_sessions = self
+            .group_session_table
+            .iter()
+            .flat_map(|group_entry| {
+                group_entry
+                    .value()
+                    .iter()
+                    .filter(|session_entry| {
+                        current_time.saturating_sub(session_entry.last_update_timestamp()) > CHANNEL_EXPIRED_TIMEOUT
+                    })
+                    .map(|session_entry| {
+                        (
+                            group_entry.key().clone(),
+                            *session_entry.key(),
+                            session_entry.client_id().clone(),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        for (group, session_id, client_id) in expired_sessions {
+            let transition = self.session_transition_locks.lock(&client_id, session_id);
+            let removed = self.group_session_table.get(&group).and_then(|sessions| {
+                sessions
+                    .remove_if(&session_id, |_, info| {
+                        current_time.saturating_sub(info.last_update_timestamp()) > CHANNEL_EXPIRED_TIMEOUT
+                    })
+                    .map(|(_, info)| info)
+            });
+            let removal = removed.map(|client| {
+                let group_table_removed = self
+                    .group_session_table
+                    .remove_if(&group, |_, sessions| sessions.is_empty())
+                    .is_some();
+                let session_has_groups = self.remove_producer_session_group_index(session_id, &group);
+                if !session_has_groups {
+                    self.client_session_table
+                        .remove_if(client.client_id(), |_, current| *current == session_id);
+                    self.session_client_table
+                        .remove_if(&session_id, |_, current| current == client.client_id());
+                }
+                ProducerSessionRemoval {
+                    group,
+                    group_table_removed,
+                }
+            });
+            drop(transition);
+            if let Some(removal) = removal {
+                self.dispatch_producer_session_removals(vec![removal]);
+            }
+        }
 
         // Collect expired channels: (group_name, channel, client_info)
         let mut expired_channels: Vec<(ProducerGroupName, Channel, ClientChannelInfo)> = Vec::new();
@@ -612,7 +941,9 @@ impl ProducerManager {
                     "SCAN: remove expired channel from ProducerManager groupChannelTable, all clear, group={}",
                     group
                 );
-                self.call_producer_change_listener(ProducerGroupEvent::GroupUnregister, &group, None);
+                if !self.group_online(&group) {
+                    self.call_producer_change_listener(ProducerGroupEvent::GroupUnregister, &group, None);
+                }
             }
         }
     }
@@ -703,7 +1034,9 @@ impl ProducerManager {
                     "unregister a producer group[{}] from groupChannelTable (Fast Path)",
                     group
                 );
-                self.call_producer_change_listener(ProducerGroupEvent::GroupUnregister, &group, None);
+                if !self.group_online(&group) {
+                    self.call_producer_change_listener(ProducerGroupEvent::GroupUnregister, &group, None);
+                }
             }
         }
 
@@ -777,7 +1110,9 @@ impl ProducerManager {
                 .remove_if(&group, |_, channel_map| channel_map.is_empty());
             if removed.is_some() {
                 info!("unregister a producer group[{}] from groupChannelTable", group);
-                self.call_producer_change_listener(ProducerGroupEvent::GroupUnregister, &group, None);
+                if !self.group_online(&group) {
+                    self.call_producer_change_listener(ProducerGroupEvent::GroupUnregister, &group, None);
+                }
             }
         }
 
@@ -818,8 +1153,10 @@ impl ProducerManager {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::Barrier;
 
     use rocketmq_protocol::protocol::LanguageCode;
+    use rocketmq_transport::test_support::session_id_for_test;
     use rocketmq_transport::test_support::Connection;
     use tokio::net::TcpStream;
 
@@ -897,5 +1234,317 @@ mod tests {
         let registry_source = &source[registry_start..registry_end];
 
         assert!(!registry_source.contains("broker_config"));
+    }
+
+    #[test]
+    fn producer_session_metadata_is_live_in_indexes_metrics_and_snapshots() {
+        let manager = ProducerManager::new();
+        let group = CheetahString::from_static_str("session-producer");
+        let session_id = session_id_for_test(61);
+        manager.register_producer_session(
+            &group,
+            ClientSessionInfo::new(
+                session_id,
+                "session-client".into(),
+                Some("127.0.0.1:10611".into()),
+                LanguageCode::RUST,
+                7,
+            ),
+        );
+
+        assert_eq!(
+            manager.client_session_table.get("session-client").map(|entry| *entry),
+            Some(session_id)
+        );
+        assert_eq!(
+            manager.session_to_groups.get(&session_id).map(|groups| groups.len()),
+            Some(1)
+        );
+        assert_eq!(
+            manager.connection_count_by_client_attrs(),
+            vec![(LanguageCode::RUST, 7, 1)]
+        );
+        for snapshot in [
+            manager.get_producer_table(),
+            manager.channel_registry().producer_table(),
+        ] {
+            let producers = snapshot
+                .data()
+                .get(group.as_str())
+                .expect("V2 group in producer snapshot");
+            assert_eq!(producers.len(), 1);
+            assert_eq!(producers[0].client_id(), "session-client");
+            assert_eq!(producers[0].remote_ip(), "127.0.0.1:10611");
+            assert_eq!(producers[0].version(), 7);
+        }
+
+        manager.unregister_producer_session(group.as_str(), session_id);
+        assert!(!manager.client_session_table.contains_key("session-client"));
+        assert!(!manager.session_to_groups.contains_key(&session_id));
+    }
+
+    #[test]
+    fn producer_session_reconnect_and_stale_disconnect_preserve_the_new_session() {
+        let manager = ProducerManager::new();
+        let old_session = session_id_for_test(62);
+        let new_session = session_id_for_test(63);
+        let group_a = CheetahString::from_static_str("producer-reconnect-a");
+        let group_b = CheetahString::from_static_str("producer-reconnect-b");
+        for group in [&group_a, &group_b] {
+            manager.register_producer_session(
+                group,
+                ClientSessionInfo::new(old_session, "same-client".into(), None, LanguageCode::RUST, 1),
+            );
+        }
+        assert_eq!(
+            manager.session_to_groups.get(&old_session).map(|groups| groups.len()),
+            Some(2)
+        );
+
+        manager.register_producer_session(
+            &group_a,
+            ClientSessionInfo::new(new_session, "same-client".into(), None, LanguageCode::RUST, 2),
+        );
+        assert!(!manager.session_to_groups.contains_key(&old_session));
+        assert!(!manager.group_online(group_b.as_str()));
+        assert_eq!(
+            manager.client_session_table.get("same-client").map(|entry| *entry),
+            Some(new_session)
+        );
+
+        manager.unregister_producer_session(group_a.as_str(), old_session);
+        assert!(manager.group_online(group_a.as_str()));
+        let snapshot = manager.get_producer_table();
+        let producers = snapshot
+            .data()
+            .get(group_a.as_str())
+            .expect("replacement group snapshot");
+        assert_eq!(producers.len(), 1);
+        assert_eq!(producers[0].version(), 2);
+
+        manager.unregister_producer_session(group_a.as_str(), new_session);
+        assert!(!manager.group_online(group_a.as_str()));
+        assert!(!manager.client_session_table.contains_key("same-client"));
+    }
+
+    #[test]
+    fn concurrent_producer_reconnect_has_one_canonical_session() {
+        let manager = ProducerManager::new();
+        let first_registration = manager.client_registration();
+        let second_registration = first_registration.clone();
+        let group = CheetahString::from_static_str("concurrent-producer-group");
+        let first_session = session_id_for_test(6_501);
+        let second_session = session_id_for_test(6_502);
+        let barrier = Arc::new(Barrier::new(2));
+
+        std::thread::scope(|scope| {
+            let first_group = group.clone();
+            let first_barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                first_barrier.wait();
+                first_registration.register_producer_session(
+                    &first_group,
+                    ClientSessionInfo::new(first_session, "concurrent-client".into(), None, LanguageCode::RUST, 1),
+                );
+            });
+            let second_group = group.clone();
+            let second_barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                second_barrier.wait();
+                second_registration.register_producer_session(
+                    &second_group,
+                    ClientSessionInfo::new(second_session, "concurrent-client".into(), None, LanguageCode::RUST, 2),
+                );
+            });
+        });
+
+        let canonical = *manager
+            .client_session_table
+            .get("concurrent-client")
+            .expect("one canonical producer session");
+        let loser = if canonical == first_session {
+            second_session
+        } else {
+            first_session
+        };
+        let sessions = manager
+            .group_session_table
+            .get(&group)
+            .expect("producer group remains live");
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions.contains_key(&canonical));
+        assert!(!sessions.contains_key(&loser));
+        drop(sessions);
+        assert!(!manager.session_to_groups.contains_key(&loser));
+
+        manager
+            .client_registration()
+            .unregister_producer_session(group.as_str(), loser);
+        assert_eq!(
+            manager
+                .client_session_table
+                .get("concurrent-client")
+                .map(|entry| *entry),
+            Some(canonical)
+        );
+    }
+
+    #[tokio::test]
+    async fn producer_group_lives_until_both_channel_and_session_tables_are_empty() {
+        let manager = ProducerManager::new();
+        let group = CheetahString::from_static_str("mixed-producer-group");
+        let channel = create_test_channel().await;
+        let legacy = ClientChannelInfo::new(channel, "legacy-client".into(), LanguageCode::RUST, 1);
+        manager.register_producer(&group, &legacy);
+        let session_id = session_id_for_test(64);
+        manager.register_producer_session(
+            &group,
+            ClientSessionInfo::new(session_id, "session-client".into(), None, LanguageCode::RUST, 2),
+        );
+
+        manager.unregister_producer(group.as_str(), &legacy);
+        assert!(manager.group_online(group.as_str()));
+        assert_eq!(manager.get_producer_table().data()[group.as_str()].len(), 1);
+        manager.unregister_producer_session(group.as_str(), session_id);
+        assert!(!manager.group_online(group.as_str()));
+    }
+
+    #[test]
+    fn rejected_producer_session_registration_creates_no_empty_tables() {
+        let manager = ProducerManager::new();
+        manager.set_broker_config(Arc::new(BrokerConfig {
+            enable_register_producer: false,
+            reject_transaction_message: true,
+            ..BrokerConfig::default()
+        }));
+        manager.register_producer_session(
+            &CheetahString::from_static_str("rejected-session-group"),
+            ClientSessionInfo::new(
+                session_id_for_test(65),
+                "rejected-client".into(),
+                None,
+                LanguageCode::RUST,
+                1,
+            ),
+        );
+
+        assert!(manager.group_session_table.is_empty());
+        assert!(manager.client_session_table.is_empty());
+        assert!(manager.session_client_table.is_empty());
+        assert!(manager.session_to_groups.is_empty());
+        assert_eq!(manager.group_size(), 0);
+        assert!(manager.get_producer_table().data().is_empty());
+        assert!(manager.connection_count_by_client_attrs().is_empty());
+    }
+
+    #[test]
+    fn concurrent_producer_heartbeat_batches_preserve_every_winning_group() {
+        let manager = ProducerManager::new();
+        let first_registration = manager.client_registration();
+        let second_registration = first_registration.clone();
+        let groups = vec![
+            CheetahString::from_static_str("batch-producer-a"),
+            CheetahString::from_static_str("batch-producer-b"),
+        ];
+        let first_session = session_id_for_test(6_601);
+        let second_session = session_id_for_test(6_602);
+        let barrier = Arc::new(Barrier::new(2));
+
+        std::thread::scope(|scope| {
+            let first_groups = groups.clone();
+            let first_barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                first_barrier.wait();
+                first_registration.register_producer_sessions(
+                    first_groups,
+                    ClientSessionInfo::new(first_session, "batch-client".into(), None, LanguageCode::RUST, 1),
+                );
+            });
+            let second_groups = groups.clone();
+            let second_barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                second_barrier.wait();
+                second_registration.register_producer_sessions(
+                    second_groups,
+                    ClientSessionInfo::new(second_session, "batch-client".into(), None, LanguageCode::RUST, 2),
+                );
+            });
+        });
+
+        let canonical = *manager
+            .client_session_table
+            .get("batch-client")
+            .expect("canonical batch producer session");
+        let loser = if canonical == first_session {
+            second_session
+        } else {
+            first_session
+        };
+        for group in &groups {
+            let sessions = manager.group_session_table.get(group).expect("winning group remains");
+            assert_eq!(sessions.len(), 1);
+            assert!(sessions.contains_key(&canonical));
+            assert!(!sessions.contains_key(&loser));
+        }
+        assert_eq!(
+            manager.session_to_groups.get(&canonical).map(|entry| entry.len()),
+            Some(2)
+        );
+        assert!(!manager.session_to_groups.contains_key(&loser));
+        assert!(!manager.session_client_table.contains_key(&loser));
+    }
+
+    #[test]
+    fn producer_session_close_cleans_all_groups_and_stale_close_preserves_replacement() {
+        let manager = ProducerManager::new();
+        let registration = manager.client_registration();
+        let housekeeping = manager.connection_housekeeping();
+        let groups = vec![
+            CheetahString::from_static_str("close-producer-a"),
+            CheetahString::from_static_str("close-producer-b"),
+        ];
+        let old_session = session_id_for_test(6_701);
+        registration.register_producer_sessions(
+            groups.clone(),
+            ClientSessionInfo::new(old_session, "close-client".into(), None, LanguageCode::RUST, 1),
+        );
+        assert!(housekeeping.do_session_close_event(old_session));
+        assert!(groups.iter().all(|group| !manager.group_online(group)));
+        assert!(!manager.session_to_groups.contains_key(&old_session));
+
+        let new_session = session_id_for_test(6_702);
+        registration.register_producer_sessions(
+            groups.clone(),
+            ClientSessionInfo::new(new_session, "close-client".into(), None, LanguageCode::RUST, 2),
+        );
+        assert!(!housekeeping.do_session_close_event(old_session));
+        assert!(groups.iter().all(|group| manager.group_online(group)));
+        assert_eq!(
+            manager.client_session_table.get("close-client").map(|entry| *entry),
+            Some(new_session)
+        );
+    }
+
+    #[test]
+    fn producer_session_identity_is_immutable() {
+        let manager = ProducerManager::new();
+        let session_id = session_id_for_test(6_801);
+        let group = CheetahString::from_static_str("identity-producer-a");
+        manager.register_producer_session(
+            &group,
+            ClientSessionInfo::new(session_id, "identity-a".into(), None, LanguageCode::RUST, 1),
+        );
+        manager.register_producer_session(
+            &CheetahString::from_static_str("identity-producer-b"),
+            ClientSessionInfo::new(session_id, "identity-b".into(), None, LanguageCode::RUST, 2),
+        );
+        assert_eq!(
+            manager.session_client_table.get(&session_id).map(|entry| entry.clone()),
+            Some("identity-a".into())
+        );
+        assert!(!manager.group_session_table.contains_key("identity-producer-b"));
+
+        manager.unregister_producer_session(group.as_str(), session_id);
+        assert!(!manager.session_client_table.contains_key(&session_id));
     }
 }

--- a/rocketmq-broker/src/client/session_transition_locks.rs
+++ b/rocketmq-broker/src/client/session_transition_locks.rs
@@ -1,0 +1,89 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+use parking_lot::Mutex;
+use parking_lot::MutexGuard;
+use rocketmq_transport::api::v2::SessionId;
+
+const SESSION_TRANSITION_STRIPES: usize = 64;
+
+/// Serializes the multi-index transition for one client identity without placing a global lock
+/// on unrelated client heartbeats.
+pub(crate) struct ClientSessionTransitionLocks {
+    stripes: Box<[Mutex<()>]>,
+}
+
+pub(crate) struct ClientSessionTransitionGuard<'a> {
+    owner: &'a ClientSessionTransitionLocks,
+    client_stripe: usize,
+    session_stripe: usize,
+    _first: MutexGuard<'a, ()>,
+    _second: Option<MutexGuard<'a, ()>>,
+}
+
+impl Default for ClientSessionTransitionLocks {
+    fn default() -> Self {
+        let stripes = (0..SESSION_TRANSITION_STRIPES)
+            .map(|_| Mutex::new(()))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self { stripes }
+    }
+}
+
+impl ClientSessionTransitionLocks {
+    fn stripe_for(&self, key: &impl Hash) -> usize {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        (hasher.finish() as usize) % self.stripes.len()
+    }
+
+    pub(crate) fn lock(&self, client_id: &str, session_id: SessionId) -> ClientSessionTransitionGuard<'_> {
+        let client_stripe = self.stripe_for(&(0_u8, client_id));
+        let session_stripe = self.stripe_for(&(1_u8, session_id));
+        let (first_stripe, second_stripe) = if client_stripe <= session_stripe {
+            (client_stripe, session_stripe)
+        } else {
+            (session_stripe, client_stripe)
+        };
+        let first = self.stripes[first_stripe].lock();
+        let second = (first_stripe != second_stripe).then(|| self.stripes[second_stripe].lock());
+        ClientSessionTransitionGuard {
+            owner: self,
+            client_stripe,
+            session_stripe,
+            _first: first,
+            _second: second,
+        }
+    }
+
+    pub(crate) fn owns(&self, guard: &ClientSessionTransitionGuard<'_>) -> bool {
+        std::ptr::eq(self, guard.owner)
+    }
+
+    pub(crate) fn covers(
+        &self,
+        guard: &ClientSessionTransitionGuard<'_>,
+        client_id: &str,
+        session_id: SessionId,
+    ) -> bool {
+        self.owns(guard)
+            && guard.client_stripe == self.stripe_for(&(0_u8, client_id))
+            && guard.session_stripe == self.stripe_for(&(1_u8, session_id))
+    }
+}

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -401,6 +401,7 @@ pub mod bench_support {
     pub use crate::client::client_channel_info::ClientChannelInfo;
     pub use crate::client::consumer_group_event::ConsumerGroupEvent;
     pub use crate::client::consumer_group_info::ConsumerGroupInfo;
+    pub use crate::client::consumer_ids_change_listener::ConsumerConnectionIdentity;
     pub use crate::client::consumer_ids_change_listener::ConsumerIdsChangeListener;
     pub use crate::client::manager::consumer_manager::ConsumerManager;
     pub use crate::filter::manager::consumer_filter_manager::ConsumerFilterManagerStatsSnapshot;

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -185,44 +185,54 @@ where
         match self {
             BrokerProcessorType::Send(processor) => processor.process_request_shared(channel, ctx, request).await,
             BrokerProcessorType::Pull(processor) => processor.process_request_shared(channel, ctx, request).await,
-            BrokerProcessorType::Peek(processor) => processor.process_request_shared(channel, ctx, request).await,
+            BrokerProcessorType::Peek(processor) => {
+                processor
+                    .process_legacy(channel.remote_address().to_string(), request)
+                    .await
+            }
             BrokerProcessorType::Pop(processor) => processor.process_request_shared(channel, ctx, request).await,
             BrokerProcessorType::PopLite(processor) => processor.process_request_shared(channel, ctx, request).await,
-            BrokerProcessorType::Ack(processor) => processor.process_request_shared(channel, ctx, request).await,
+            BrokerProcessorType::Ack(processor) => {
+                processor
+                    .process_legacy(channel.remote_address().to_string(), request)
+                    .await
+            }
             BrokerProcessorType::ChangeInvisible(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
+                processor
+                    .process_legacy(channel.remote_address().to_string(), request)
+                    .await
             }
             BrokerProcessorType::Notification(processor) => {
                 processor.process_request_shared(channel, ctx, request).await
             }
             BrokerProcessorType::PollingInfo(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
+                processor
+                    .process_legacy(channel.remote_address().to_string(), request)
+                    .await
             }
             BrokerProcessorType::Reply(processor) => processor.process_request_shared(channel, ctx, request).await,
-            BrokerProcessorType::Recall(processor) => processor.process_request_shared(channel, ctx, request).await,
+            BrokerProcessorType::Recall(processor) => processor.process_legacy(ctx.remote_address(), request).await,
             BrokerProcessorType::QueryMessage(processor) => {
                 processor.process_request_shared(channel, ctx, request).await
             }
             BrokerProcessorType::ClientManage(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
+                processor.legacy_adapter().process_legacy(channel, request).await
             }
             BrokerProcessorType::ConsumerManage(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
+                processor
+                    .process_legacy(channel.remote_address().to_string().into(), request)
+                    .await
             }
             BrokerProcessorType::QueryAssignment(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
+                processor
+                    .process_legacy(channel.remote_address().to_string(), request)
+                    .await
             }
-            BrokerProcessorType::LiteManager(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
-            }
-            BrokerProcessorType::LiteSubscriptionCtl(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
-            }
-            BrokerProcessorType::EndTransaction(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
-            }
+            BrokerProcessorType::LiteManager(processor) => processor.process_legacy(request).await,
+            BrokerProcessorType::LiteSubscriptionCtl(processor) => processor.process_legacy(request).await,
+            BrokerProcessorType::EndTransaction(processor) => processor.process_legacy(request).await,
             BrokerProcessorType::Maintenance(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
+                processor.legacy_adapter().process_legacy(&channel, request).await
             }
             BrokerProcessorType::AdminBroker(processor) => {
                 processor.process_request_shared(channel, ctx, request).await
@@ -234,22 +244,22 @@ where
         match self {
             BrokerProcessorType::Send(processor) => processor.reject_request(code),
             BrokerProcessorType::Pull(processor) => processor.reject_request_shared(),
-            BrokerProcessorType::Peek(processor) => processor.reject_request(code),
+            BrokerProcessorType::Peek(_) => (false, None),
             BrokerProcessorType::Pop(processor) => processor.reject_request(code),
             BrokerProcessorType::PopLite(processor) => processor.reject_request(code),
-            BrokerProcessorType::Ack(processor) => processor.reject_request(code),
-            BrokerProcessorType::ChangeInvisible(processor) => processor.reject_request(code),
+            BrokerProcessorType::Ack(_) => (false, None),
+            BrokerProcessorType::ChangeInvisible(_) => (false, None),
             BrokerProcessorType::Notification(processor) => processor.reject_request(code),
-            BrokerProcessorType::PollingInfo(processor) => processor.reject_request(code),
+            BrokerProcessorType::PollingInfo(_) => (false, None),
             BrokerProcessorType::Reply(processor) => processor.reject_request(code),
-            BrokerProcessorType::Recall(processor) => processor.reject_request(code),
+            BrokerProcessorType::Recall(_) => (false, None),
             BrokerProcessorType::QueryMessage(processor) => processor.reject_request(code),
-            BrokerProcessorType::ClientManage(processor) => processor.reject_request(code),
-            BrokerProcessorType::ConsumerManage(processor) => processor.reject_request(code),
-            BrokerProcessorType::QueryAssignment(processor) => processor.reject_request(code),
-            BrokerProcessorType::LiteManager(processor) => processor.reject_request(code),
-            BrokerProcessorType::LiteSubscriptionCtl(processor) => processor.reject_request(code),
-            BrokerProcessorType::EndTransaction(processor) => processor.reject_request(code),
+            BrokerProcessorType::ClientManage(_) => (false, None),
+            BrokerProcessorType::ConsumerManage(_) => (false, None),
+            BrokerProcessorType::QueryAssignment(_) => (false, None),
+            BrokerProcessorType::LiteManager(_) => (false, None),
+            BrokerProcessorType::LiteSubscriptionCtl(_) => (false, None),
+            BrokerProcessorType::EndTransaction(_) => (false, None),
             BrokerProcessorType::Maintenance(_) => (false, None),
             BrokerProcessorType::AdminBroker(_) => (false, None),
         }

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -47,9 +47,10 @@ use rocketmq_store::BrokerReadWriteStore;
 use rocketmq_store::PutMessageResult;
 use rocketmq_store::PutMessageStatus;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_and_opaque;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -276,17 +277,29 @@ pub struct AckMessageProcessor<MS: BrokerReadWriteStore> {
     context: AckMessageProcessorContext<MS>,
 }
 
-impl<MS> RequestProcessor for AckMessageProcessor<MS>
+impl<MS> RequestProcessorV2 for AckMessageProcessor<MS>
 where
-    MS: BrokerReadWriteStore,
+    MS: BrokerReadWriteStore + 'static,
 {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_shared(channel, ctx, request).await
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let command_factory = self.context.command_factory;
+        let request_source = request_origin_label(request.origin());
+        let result = self.process_command(request.command_mut(), &request_source).await;
+        crate::processor::response_plan::immediate_outcome_from_command_result(
+            &command_factory,
+            result,
+            original_opaque,
+            "AckMessageProcessor V2 command dispatch completed without a response",
+        )
+    }
+}
+
+fn request_origin_label(origin: &RequestOrigin) -> CheetahString {
+    match origin {
+        RequestOrigin::Network { peer } => CheetahString::from_string(peer.address().to_string()),
+        RequestOrigin::Embedded { .. } => CheetahString::from_static_str("embedded"),
+        _ => CheetahString::from_static_str("unrecognized-origin"),
     }
 }
 
@@ -294,17 +307,26 @@ impl<MS> AckMessageProcessor<MS>
 where
     MS: BrokerReadWriteStore,
 {
-    pub async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        request_source: String,
         request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_source = CheetahString::from_string(request_source);
+        self.process_command(request, &request_source).await
+    }
+
+    /// V2 leaf business contract; the typed origin is reduced to a diagnostic/offset source label.
+    async fn process_command(
+        &self,
+        request: &mut RemotingCommand,
+        request_source: &CheetahString,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!("AckMessageProcessor received request code: {:?}", request_code);
         match request_code {
             RequestCode::AckMessage | RequestCode::BatchAckMessage => {
-                self.process_request_inner(channel, ctx, request_code, request).await
+                self.process_command_inner(request_code, request, request_source).await
             }
             _ => {
                 warn!("AckMessageProcessor received unknown request code: {:?}", request_code);
@@ -327,21 +349,20 @@ where
         AckMessageProcessor { context }
     }
 
-    pub async fn process_request_inner(
+    async fn process_command_inner(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
         request_code: RequestCode,
         request: &mut RemotingCommand,
+        request_source: &CheetahString,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match request_code {
-            RequestCode::AckMessage => self.process_ack(channel, ctx, request, true).await,
-            RequestCode::BatchAckMessage => self.process_batch_ack(channel, ctx, request, true).await,
+            RequestCode::AckMessage => self.process_ack(request, request_source).await,
+            RequestCode::BatchAckMessage => self.process_batch_ack(request, request_source).await,
             _ => {
                 error!(
                     "AckMessageProcessor failed to process RequestCode: {}, consumer: {} ",
                     request_code.to_i32(),
-                    channel.remote_address()
+                    request_source
                 );
                 Ok(Some(
                     self.context.command_factory.create_response_command_with_code_remark(
@@ -386,10 +407,8 @@ where
 {
     async fn process_ack(
         &self,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
-        _broker_allow_suspend: bool,
+        request_source: &CheetahString,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<AckMessageRequestHeader>()?;
         let topic_config = self
@@ -400,7 +419,7 @@ where
             error!(
                 "topic[{}] not exist, consumer: {},apply first please! {}",
                 request_header.topic,
-                channel.remote_address(),
+                request_source,
                 FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
             );
             return Ok(Some(
@@ -418,10 +437,7 @@ where
         if request_header.queue_id >= topic_config.read_queue_nums as i32 || request_header.queue_id < 0 {
             let error_msg = format!(
                 "queueId{}] is illegal, topic:[{}] topicConfig.readQueueNums:[{}] consumer:[{}]",
-                request_header.queue_id,
-                request_header.topic,
-                topic_config.read_queue_nums,
-                channel.remote_address()
+                request_header.queue_id, request_header.topic, topic_config.read_queue_nums, request_source
             );
             warn!("{}", error_msg);
 
@@ -457,17 +473,15 @@ where
             ));
         }
         let mut response = self.context.command_factory.create_success_response_command();
-        self.append_ack(Some(request_header), &mut response, None, &channel, None)
+        self.append_ack(Some(request_header), &mut response, None, request_source, None)
             .await?;
         Ok(Some(response))
     }
 
     async fn process_batch_ack(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
-        _broker_allow_suspend: bool,
+        request_source: &CheetahString,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         if request.get_body().is_none() {
             return Ok(Some(
@@ -487,7 +501,7 @@ where
         let mut response = self.context.command_factory.create_success_response_command();
         let broker_name = &req_body.broker_name;
         for ack in req_body.acks {
-            self.append_ack(None, &mut response, Some(ack), &_channel, Some(broker_name))
+            self.append_ack(None, &mut response, Some(ack), request_source, Some(broker_name))
                 .await?;
         }
         Ok(Some(response))
@@ -498,7 +512,7 @@ where
         request_header: Option<AckMessageRequestHeader>,
         response: &mut RemotingCommand,
         batch_ack: Option<BatchAck>,
-        channel: &Channel,
+        request_source: &CheetahString,
         broker_name: Option<&CheetahString>,
     ) -> RocketMQResult<()> {
         //handle single ack
@@ -533,7 +547,7 @@ where
                     ack_offset,
                     pop_time,
                     invisible_time,
-                    channel,
+                    request_source,
                     response,
                 )
                 .await;
@@ -598,7 +612,7 @@ where
                         offset,
                         pop_time,
                         invisible_time,
-                        channel,
+                        request_source,
                         response,
                     )
                     .await;
@@ -707,7 +721,7 @@ where
         ack_offset: i64,
         pop_time: i64,
         invisible_time: i64,
-        channel: &Channel,
+        request_source: &CheetahString,
         response: &mut RemotingCommand,
     ) {
         let lock_key = CheetahString::from_string(QueueLockManager::build_lock_key(&topic, &consume_group, q_id));
@@ -755,11 +769,7 @@ where
             Ordering::Equal => {
                 let error_info = format!(
                     "offset is illegal, key:{}, old:{}, commit:{}, next:{}, {}",
-                    lock_key,
-                    old_offset,
-                    ack_offset,
-                    next_offset,
-                    channel.remote_address()
+                    lock_key, old_offset, ack_offset, next_offset, request_source
                 );
                 response.set_code_ref(ResponseCode::MessageIllegal);
                 response.set_remark_mut(error_info);
@@ -779,7 +789,7 @@ where
                 };
                 if !has_offset_reset
                     && !self.context.consumer_offset.commit_offset(
-                        channel.remote_address().to_string().into(),
+                        request_source.clone(),
                         &consume_group,
                         &topic,
                         q_id,
@@ -831,8 +841,127 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicU64;
+
     use super::*;
+    use rocketmq_error::RocketMQResult;
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
+    use rocketmq_store::MessageStoreConfig;
     use rocketmq_store::StorePorts;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchError;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::ResponseBodyKind;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+    struct TestLeafProcessor<P> {
+        processor: Arc<tokio::sync::Mutex<P>>,
+    }
+
+    impl<P> Clone for TestLeafProcessor<P> {
+        fn clone(&self) -> Self {
+            Self {
+                processor: Arc::clone(&self.processor),
+            }
+        }
+    }
+
+    impl<P> TestLeafProcessor<P> {
+        fn new(processor: P) -> Self {
+            Self {
+                processor: Arc::new(tokio::sync::Mutex::new(processor)),
+            }
+        }
+    }
+
+    impl<P> RequestProcessorV2 for TestLeafProcessor<P>
+    where
+        P: RequestProcessorV2 + Send,
+    {
+        async fn process(&mut self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+            self.processor.lock().await.process(request).await
+        }
+    }
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    async fn dispatch_embedded_v2<P>(
+        processor: P,
+        command: RemotingCommand,
+    ) -> Result<EmbeddedDispatchOutcome, EmbeddedDispatchError>
+    where
+        P: RequestProcessorV2 + Send + 'static,
+    {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("ack-message-v2-test"))
+            .expect("AckMessage V2 test runtime");
+        let context = owner.root_context().component("ack-message-v2-test.request");
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            TestLeafProcessor::new(processor),
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            context.task_group().clone(),
+            Principal::new("ack-message-v2-test"),
+        );
+        let outcome = harness.dispatch(None, command).await;
+
+        drop(harness);
+        drop(context);
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
+        outcome
+    }
+
+    fn v2_test_processor() -> AckMessageProcessor<StorePorts> {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = MessageStoreConfig::default();
+        let topic_config_manager = Arc::new(TopicConfigManager::new(
+            broker_config.as_ref(),
+            &message_store_config,
+            true,
+            None,
+        ));
+        let store_host = "127.0.0.1:10911".parse().expect("valid store host");
+        let context = AckMessageProcessorContext::new(
+            AckMessagePolicy::from_config(broker_config.as_ref(), store_host),
+            topic_config_manager,
+            AckMessageOffsetCapability { manager: Weak::new() },
+            AckMessageOrderCapability { manager: Weak::new() },
+            AckMessageStoreCapability {
+                escape_bridge: Weak::new(),
+            },
+            PopInflightMessageCounter::new(Arc::new(AtomicU64::new(0))),
+            AckMessagePopCapability {
+                merge_service: Weak::new(),
+                notification_service: Weak::new(),
+                queue_lock_manager: QueueLockManager::new(),
+            },
+            Vec::new(),
+        );
+        AckMessageProcessor::new(context)
+    }
 
     #[test]
     fn ack_message_policy_captures_only_required_startup_values() {
@@ -873,5 +1002,21 @@ mod tests {
         assert!(!pop.notify_message_arriving(&topic, 0, &group));
         assert_eq!(order.commit_and_next(&group, &topic, 0, 0, 0), None);
         assert_eq!(order.check_block(&CheetahString::empty(), &group, &topic, 0, 1), None);
+    }
+
+    #[tokio::test]
+    async fn v2_embedded_unknown_request_returns_a_reply_plan() {
+        let outcome = dispatch_embedded_v2(
+            v2_test_processor(),
+            RemotingCommand::create_remoting_command(-98_451).set_opaque(317),
+        )
+        .await
+        .expect("embedded AckMessage V2 response");
+        let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+            panic!("AckMessage V2 unknown request must return a reply plan");
+        };
+
+        assert_eq!(plan.response_code(), ResponseCode::RequestCodeNotSupported as i32);
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Empty);
     }
 }

--- a/rocketmq-broker/src/processor/change_invisible_time_processor.rs
+++ b/rocketmq-broker/src/processor/change_invisible_time_processor.rs
@@ -43,9 +43,10 @@ use rocketmq_store::PopCheckPoint;
 use rocketmq_store::PutMessageResult;
 use rocketmq_store::PutMessageStatus;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_and_opaque;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -249,17 +250,29 @@ pub struct ChangeInvisibleTimeProcessor<MS: BrokerReadWriteStore> {
     context: ChangeInvisibleTimeProcessorContext<MS>,
 }
 
-impl<MS> RequestProcessor for ChangeInvisibleTimeProcessor<MS>
+impl<MS> RequestProcessorV2 for ChangeInvisibleTimeProcessor<MS>
 where
-    MS: BrokerReadWriteStore,
+    MS: BrokerReadWriteStore + 'static,
 {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_shared(channel, ctx, request).await
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let command_factory = self.context.command_factory;
+        let request_source = request_origin_label(request.origin());
+        let result = self.process_command(request.command_mut(), &request_source).await;
+        crate::processor::response_plan::immediate_outcome_from_command_result(
+            &command_factory,
+            result,
+            original_opaque,
+            "ChangeInvisibleTimeProcessor V2 command dispatch completed without a response",
+        )
+    }
+}
+
+fn request_origin_label(origin: &RequestOrigin) -> String {
+    match origin {
+        RequestOrigin::Network { peer } => peer.address().to_string(),
+        RequestOrigin::Embedded { .. } => "embedded".to_owned(),
+        _ => "unrecognized-origin".to_owned(),
     }
 }
 
@@ -267,16 +280,24 @@ impl<MS> ChangeInvisibleTimeProcessor<MS>
 where
     MS: BrokerReadWriteStore,
 {
-    pub async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        request_source: String,
         request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.process_command(request, &request_source).await
+    }
+
+    /// V2 leaf business contract; the typed origin is reduced to a diagnostic source label.
+    async fn process_command(
+        &self,
+        request: &mut RemotingCommand,
+        request_source: &str,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!("ChangeInvisibleTimeProcessor received request code: {:?}", request_code);
         match request_code {
-            RequestCode::ChangeMessageInvisibleTime => self.process_request_(channel, ctx, request_code, request).await,
+            RequestCode::ChangeMessageInvisibleTime => self.process_command_inner(request, request_source).await,
             _ => {
                 warn!(
                     "ChangeInvisibleTimeProcessor received unknown request code: {:?}",
@@ -307,22 +328,10 @@ impl<MS> ChangeInvisibleTimeProcessor<MS>
 where
     MS: BrokerReadWriteStore,
 {
-    async fn process_request_(
+    async fn process_command_inner(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        _request_code: RequestCode,
         request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_inner(channel, ctx, request, true).await
-    }
-
-    pub async fn process_request_inner(
-        &self,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-        _broker_allow_suspend: bool,
+        request_source: &str,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<ChangeInvisibleTimeRequestHeader>()?;
         if request_header
@@ -339,8 +348,7 @@ where
         if topic_config.is_none() {
             error!(
                 "The topic {} not exist, consumer: {} ",
-                request_header.topic,
-                channel.remote_address()
+                request_header.topic, request_source
             );
 
             return Ok(Some(
@@ -358,10 +366,7 @@ where
         if request_header.queue_id >= topic_config.read_queue_nums as i32 || request_header.queue_id < 0 {
             let error_info = format!(
                 "queueId[{}] is illegal, topic:[{}] topicConfig.readQueueNums:[{}] consumer:[{}]",
-                request_header.queue_id,
-                request_header.topic,
-                topic_config.read_queue_nums,
-                channel.remote_address()
+                request_header.queue_id, request_header.topic, topic_config.read_queue_nums, request_source
             );
 
             error!("{}", error_info);
@@ -387,11 +392,7 @@ where
         if request_header.offset < mix_offset || request_header.offset > max_offset {
             let info = format!(
                 "request offset[{}] not in queue offset range[{}-{}], topic:[{}] consumer:[{}]",
-                request_header.offset,
-                mix_offset,
-                max_offset,
-                request_header.topic,
-                channel.remote_address()
+                request_header.offset, mix_offset, max_offset, request_header.topic, request_source
             );
 
             info!("{}", info);
@@ -743,8 +744,138 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use rocketmq_error::RocketMQResult;
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
+    use rocketmq_store::MessageStoreConfig;
     use rocketmq_store::StorePorts;
+    use rocketmq_store::StoreRuntimeConfig;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchError;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::ResponseBodyKind;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+    use crate::offset::manager::consumer_offset_manager::ConsumerOffsetManager;
+
+    struct TestLeafProcessor<P> {
+        processor: Arc<tokio::sync::Mutex<P>>,
+    }
+
+    impl<P> Clone for TestLeafProcessor<P> {
+        fn clone(&self) -> Self {
+            Self {
+                processor: Arc::clone(&self.processor),
+            }
+        }
+    }
+
+    impl<P> TestLeafProcessor<P> {
+        fn new(processor: P) -> Self {
+            Self {
+                processor: Arc::new(tokio::sync::Mutex::new(processor)),
+            }
+        }
+    }
+
+    impl<P> RequestProcessorV2 for TestLeafProcessor<P>
+    where
+        P: RequestProcessorV2 + Send,
+    {
+        async fn process(&mut self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+            self.processor.lock().await.process(request).await
+        }
+    }
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    async fn dispatch_embedded_v2<P>(
+        processor: P,
+        command: RemotingCommand,
+    ) -> Result<EmbeddedDispatchOutcome, EmbeddedDispatchError>
+    where
+        P: RequestProcessorV2 + Send + 'static,
+    {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("change-invisible-v2-test"))
+            .expect("ChangeInvisibleTime V2 test runtime");
+        let context = owner.root_context().component("change-invisible-v2-test.request");
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            TestLeafProcessor::new(processor),
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            context.task_group().clone(),
+            Principal::new("change-invisible-v2-test"),
+        );
+        let outcome = harness.dispatch(None, command).await;
+
+        drop(harness);
+        drop(context);
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
+        outcome
+    }
+
+    fn v2_test_processor() -> ChangeInvisibleTimeProcessor<StorePorts> {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let topic_config_manager = Arc::new(TopicConfigManager::new(
+            broker_config.as_ref(),
+            message_store_config.as_ref(),
+            true,
+            None,
+        ));
+        let consumer_offset_manager = Arc::new(ConsumerOffsetManager::new(
+            Arc::clone(&broker_config),
+            Arc::clone(&message_store_config),
+        ));
+        let stats_context = crate::test_service_context("change-invisible-v2-stats");
+        let broker_stats_manager = Arc::new(BrokerStatsManager::new(
+            Arc::new(StoreRuntimeConfig::default()),
+            stats_context.task_group().clone(),
+        ));
+        let store_host = "127.0.0.1:10911".parse().expect("valid store host");
+        let context = ChangeInvisibleTimeProcessorContext::new(
+            ChangeInvisibleTimePolicy::from_config(broker_config.as_ref(), store_host),
+            topic_config_manager,
+            consumer_offset_manager.query_capability(),
+            ChangeInvisibleTimeOrderCapability { manager: Weak::new() },
+            ChangeInvisibleTimeLiteCapability { processor: Weak::new() },
+            broker_stats_manager,
+            ChangeInvisibleTimeStoreCapability {
+                escape_bridge: Weak::new(),
+            },
+            ChangeInvisibleTimePopCapability {
+                merge_service: Weak::new(),
+            },
+            QueueLockManager::new(),
+        );
+        ChangeInvisibleTimeProcessor::new(context)
+    }
 
     #[test]
     fn change_invisible_time_policy_captures_only_required_startup_values() {
@@ -793,5 +924,21 @@ mod tests {
         assert!(source.contains("Weak<PopBufferMergeService<MS>>"));
         assert!(source.contains("Weak<ConsumerOrderInfoManager>"));
         assert!(source.contains("queue_lock_manager: QueueLockManager"));
+    }
+
+    #[tokio::test]
+    async fn v2_embedded_unknown_request_returns_a_reply_plan() {
+        let outcome = dispatch_embedded_v2(
+            v2_test_processor(),
+            RemotingCommand::create_remoting_command(-98_452).set_opaque(318),
+        )
+        .await
+        .expect("embedded ChangeInvisibleTime V2 response");
+        let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+            panic!("ChangeInvisibleTime V2 unknown request must return a reply plan");
+        };
+
+        assert_eq!(plan.response_code(), ResponseCode::RequestCodeNotSupported as i32);
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Empty);
     }
 }

--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::config::broker_config::BrokerConfig;
@@ -35,14 +36,23 @@ use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFacto
 use rocketmq_store::BrokerStorePort;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_and_opaque;
 use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::SessionId;
+use rocketmq_transport::api::v2::SessionView;
 use tracing::info;
 use tracing::warn;
 
 use crate::client::client_channel_info::ClientChannelInfo;
+use crate::client::client_channel_info::ClientSessionInfo;
 use crate::client::manager::consumer_manager::ConsumerClientRegistration;
+use crate::client::manager::consumer_manager::ConsumerSessionRegistration;
 use crate::client::manager::producer_manager::ProducerClientRegistration;
+use crate::client::session_transition_locks::ClientSessionTransitionGuard;
+use crate::client::session_transition_locks::ClientSessionTransitionLocks;
+use crate::processor::response_plan::immediate_outcome_from_command_result;
 use crate::subscription::manager::subscription_group_manager::SubscriptionGroupConfigLookup;
 use crate::topic::manager::topic_config_manager::TopicConfigManager;
 use crate::transaction::queue::transaction_topic_registration::TransactionTopicRegistration;
@@ -56,6 +66,7 @@ pub struct ClientManageProcessor<MS: BrokerStorePort> {
     subscription_group_lookup: SubscriptionGroupConfigLookup,
     producer_registration: ProducerClientRegistration,
     consumer_registration: ConsumerClientRegistration,
+    session_transition_locks: Arc<ClientSessionTransitionLocks>,
     retry_topic_registration: Arc<TransactionTopicRegistration<MS>>,
 }
 
@@ -69,36 +80,35 @@ pub(crate) struct ClientManageProcessorContext<MS: BrokerStorePort> {
     pub(crate) retry_topic_registration: Arc<TransactionTopicRegistration<MS>>,
 }
 
-impl<MS> RequestProcessor for ClientManageProcessor<MS>
+/// Compatibility adapter that contains the only raw legacy Channel ingress for
+/// client heartbeat and unregister requests.
+pub(crate) struct LegacyClientManageProcessor<MS: BrokerStorePort> {
+    processor: ClientManageProcessor<MS>,
+}
+
+#[derive(Clone)]
+enum RegisteredClient {
+    Legacy(Box<ClientChannelInfo>),
+    Session(ClientSessionInfo),
+}
+
+impl<MS> RequestProcessorV2 for ClientManageProcessor<MS>
 where
-    MS: BrokerStorePort,
+    MS: BrokerStorePort + 'static,
 {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let request_code = RequestCode::from(request.code());
-        info!("ClientManageProcessor received request code: {:?}", request_code);
-        match request_code {
-            RequestCode::HeartBeat | RequestCode::UnregisterClient | RequestCode::CheckClientConfig => {
-                self.process_request_inner(channel, ctx, request_code, request).await
-            }
-            _ => {
-                warn!(
-                    "ClientManageProcessor received unknown request code: {:?}",
-                    request_code
-                );
-                let response = request_code_not_supported_with_factory_remark_and_opaque(
-                    &self.command_factory,
-                    request.code(),
-                    format!("ClientManageProcessor request code {} not supported", request.code()),
-                    request.opaque(),
-                );
-                Ok(Some(response))
-            }
-        }
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let session_id = request.session().id();
+        let remote_address = trusted_remote_address(request)?;
+        let result = self
+            .process_session_command(session_id, remote_address, request.command_mut())
+            .await;
+        immediate_outcome_from_command_result(
+            &self.command_factory,
+            result,
+            original_opaque,
+            "client manager returned no response",
+        )
     }
 }
 
@@ -107,6 +117,12 @@ where
     MS: BrokerStorePort,
 {
     pub(crate) fn new(context: ClientManageProcessorContext<MS>) -> Self {
+        let producer_session_transition_locks = context.producer_registration.session_transition_locks();
+        let session_transition_locks = context.consumer_registration.session_transition_locks();
+        assert!(
+            Arc::ptr_eq(&producer_session_transition_locks, &session_transition_locks),
+            "producer and consumer session registries must share one heartbeat transition lock"
+        );
         Self {
             command_factory: context.command_factory,
             consumer_group_heartbeat_table: Arc::new(parking_lot::RwLock::new(HashMap::new())),
@@ -115,7 +131,54 @@ where
             subscription_group_lookup: context.subscription_group_lookup,
             producer_registration: context.producer_registration,
             consumer_registration: context.consumer_registration,
+            session_transition_locks,
             retry_topic_registration: context.retry_topic_registration,
+        }
+    }
+
+    pub(crate) fn legacy_adapter(&self) -> LegacyClientManageProcessor<MS> {
+        LegacyClientManageProcessor {
+            processor: self.clone(),
+        }
+    }
+}
+
+impl<MS> LegacyClientManageProcessor<MS>
+where
+    MS: BrokerStorePort,
+{
+    pub(crate) async fn process_legacy(
+        &mut self,
+        channel: Channel,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_code = RequestCode::from(request.code());
+        info!("ClientManageProcessor received request code: {:?}", request_code);
+        match request_code {
+            RequestCode::HeartBeat => {
+                let heartbeat = decode_heartbeat(request)?;
+                let client = RegisteredClient::Legacy(Box::new(ClientChannelInfo::new(
+                    channel.clone(),
+                    heartbeat.client_id.clone(),
+                    request.language(),
+                    request.version(),
+                )));
+                self.processor
+                    .heart_beat(channel.remote_address().to_string(), heartbeat, client)
+                    .await
+            }
+            RequestCode::UnregisterClient => {
+                let header = request.decode_command_custom_header::<UnregisterClientRequestHeader>()?;
+                let client = RegisteredClient::Legacy(Box::new(ClientChannelInfo::new(
+                    channel,
+                    header.client_id.clone(),
+                    request.language(),
+                    request.version(),
+                )));
+                self.processor.unregister_client(header, client)
+            }
+            RequestCode::CheckClientConfig => self.processor.check_client_config(request),
+            _ => self.processor.unsupported(request, request_code),
         }
     }
 }
@@ -124,34 +187,57 @@ impl<MS> ClientManageProcessor<MS>
 where
     MS: BrokerStorePort,
 {
-    pub async fn process_request_shared(
-        &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+    async fn process_session_command(
+        &mut self,
+        session_id: SessionId,
+        remote_address: String,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut processor = self.clone();
-        processor.process_request(channel, ctx, request).await
+        let request_code = RequestCode::from(request.code());
+        info!("ClientManageProcessor received V2 request code: {:?}", request_code);
+        match request_code {
+            RequestCode::HeartBeat => {
+                let heartbeat = decode_heartbeat(request)?;
+                let client = RegisteredClient::Session(ClientSessionInfo::new(
+                    session_id,
+                    heartbeat.client_id.clone(),
+                    Some(remote_address.clone().into()),
+                    request.language(),
+                    request.version(),
+                ));
+                self.heart_beat(remote_address, heartbeat, client).await
+            }
+            RequestCode::UnregisterClient => {
+                let header = request.decode_command_custom_header::<UnregisterClientRequestHeader>()?;
+                let client = RegisteredClient::Session(ClientSessionInfo::new(
+                    session_id,
+                    header.client_id.clone(),
+                    Some(remote_address.into()),
+                    request.language(),
+                    request.version(),
+                ));
+                self.unregister_client(header, client)
+            }
+            RequestCode::CheckClientConfig => self.check_client_config(request),
+            _ => self.unsupported(request, request_code),
+        }
     }
 
-    async fn process_request_inner(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+    fn unsupported(
+        &self,
+        request: &RemotingCommand,
         request_code: RequestCode,
-        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        match request_code {
-            RequestCode::HeartBeat => self.heart_beat(channel, ctx, request).await,
-            RequestCode::UnregisterClient => self.unregister_client(channel, ctx, request),
-            RequestCode::CheckClientConfig => self.check_client_config(request),
-            _ => Ok(Some(request_code_not_supported_with_factory_remark_and_opaque(
-                &self.command_factory,
-                request.code(),
-                format!("ClientManageProcessor request code {} not supported", request.code()),
-                request.opaque(),
-            ))),
-        }
+        warn!(
+            "ClientManageProcessor received unknown request code: {:?}",
+            request_code
+        );
+        Ok(Some(request_code_not_supported_with_factory_remark_and_opaque(
+            &self.command_factory,
+            request.code(),
+            format!("ClientManageProcessor request code {} not supported", request.code()),
+            request.opaque(),
+        )))
     }
 
     fn check_client_config(
@@ -195,22 +281,16 @@ where
 
     fn unregister_client(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
+        request_header: UnregisterClientRequestHeader,
+        client: RegisteredClient,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let request_header = request.decode_command_custom_header::<UnregisterClientRequestHeader>()?;
-
-        let client_channel_info = ClientChannelInfo::new(
-            channel,
-            request_header.client_id.clone(),
-            request.language(),
-            request.version(),
-        );
-
         if let Some(ref group) = request_header.producer_group {
-            self.producer_registration
-                .unregister_producer(group, &client_channel_info, &ctx);
+            match &client {
+                RegisteredClient::Legacy(client) => self.producer_registration.unregister_producer(group, client),
+                RegisteredClient::Session(client) => self
+                    .producer_registration
+                    .unregister_producer_session(group, client.session_id()),
+            }
         }
 
         if let Some(ref group) = request_header.consumer_group {
@@ -221,11 +301,17 @@ where
                 } else {
                     true
                 };
-            self.consumer_registration.unregister_consumer(
-                group,
-                &client_channel_info,
-                is_notify_consumer_ids_changed_enable,
-            );
+            match &client {
+                RegisteredClient::Legacy(client) => {
+                    self.consumer_registration
+                        .unregister_consumer(group, client, is_notify_consumer_ids_changed_enable)
+                }
+                RegisteredClient::Session(client) => self.consumer_registration.unregister_consumer_session(
+                    group,
+                    client.session_id(),
+                    is_notify_consumer_ids_changed_enable,
+                ),
+            }
         }
 
         Ok(Some(self.command_factory.create_success_response_command()))
@@ -233,26 +319,19 @@ where
 
     async fn heart_beat(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
+        remote_address: String,
+        heartbeat_data: HeartbeatData,
+        client: RegisteredClient,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let heartbeat_data =
-            SerdeJsonUtils::from_json_bytes::<HeartbeatData>(request.body().as_ref().map(|v| v.as_ref()).unwrap())
-                .unwrap();
-        let client_channel_info = ClientChannelInfo::new(
-            channel.clone(),
-            heartbeat_data.client_id.clone(),
-            request.language(),
-            request.version(),
-        );
         if heartbeat_data.heartbeat_fingerprint != 0 {
-            return Ok(self
-                .heart_beat_v2(&channel, &ctx, heartbeat_data, client_channel_info)
-                .await);
+            return self.heart_beat_v2(&remote_address, heartbeat_data, client).await;
+        }
+        if let RegisteredClient::Session(session) = &client {
+            self.ensure_known_cross_role_session_identity(session)?;
         }
 
         //do consumer data handle
+        let mut consumer_session_registrations = Vec::new();
         for consumer_data in heartbeat_data.consumer_data_set.iter() {
             if self.broker_config.reject_pull_consumer_enable
                 && ConsumeType::ConsumeActively == consumer_data.consume_type
@@ -295,27 +374,72 @@ where
                     topic_sys_flag,
                 )
                 .await;
-            let changed = self.consumer_registration.register_consumer(
-                consumer_data.group_name.as_ref(),
-                client_channel_info.clone(),
-                consumer_data.consume_type,
-                consumer_data.message_model,
-                consumer_data.consume_from_where,
-                consumer_data.subscription_data_set.clone(),
-                is_notify_consumer_ids_changed_enable,
-            );
+            let changed = match client.clone() {
+                RegisteredClient::Legacy(client) => self.consumer_registration.register_consumer(
+                    consumer_data.group_name.as_ref(),
+                    *client,
+                    consumer_data.consume_type,
+                    consumer_data.message_model,
+                    consumer_data.consume_from_where,
+                    consumer_data.subscription_data_set.clone(),
+                    is_notify_consumer_ids_changed_enable,
+                ),
+                RegisteredClient::Session(_) => {
+                    consumer_session_registrations.push(ConsumerSessionRegistration {
+                        group: consumer_data.group_name.clone(),
+                        consume_type: consumer_data.consume_type,
+                        message_model: consumer_data.message_model,
+                        consume_from_where: consumer_data.consume_from_where,
+                        subscriptions: consumer_data.subscription_data_set.clone(),
+                        notify_consumer_ids_changed: is_notify_consumer_ids_changed_enable,
+                        update_subscription: true,
+                    });
+                    false
+                }
+            };
             if changed {
                 info!(
                     "ClientManageProcessor: registerConsumer info changed, SDK address={}, consumerData={:?}",
-                    channel.remote_address(),
-                    consumer_data
+                    remote_address, consumer_data
                 )
             }
         }
         //do producer data handle
-        for producer_data in heartbeat_data.producer_data_set.iter() {
-            self.producer_registration
-                .register_producer(&producer_data.group_name, &client_channel_info);
+        match client {
+            RegisteredClient::Legacy(client) => {
+                for producer_data in &heartbeat_data.producer_data_set {
+                    self.producer_registration
+                        .register_producer(&producer_data.group_name, &client);
+                }
+            }
+            RegisteredClient::Session(session) => {
+                let groups = heartbeat_data
+                    .producer_data_set
+                    .iter()
+                    .map(|producer| producer.group_name.clone())
+                    .collect();
+                let transition = self
+                    .session_transition_locks
+                    .lock(session.client_id(), session.session_id());
+                self.ensure_cross_role_session_identity(&transition, &session)?;
+                let consumer_batch = self.consumer_registration.prepare_consumer_sessions(
+                    &transition,
+                    session.clone(),
+                    consumer_session_registrations,
+                );
+                let producer_batch = self
+                    .producer_registration
+                    .prepare_producer_sessions(&transition, groups, session);
+                drop(transition);
+                let changed_groups = self.consumer_registration.complete_consumer_sessions(consumer_batch);
+                self.producer_registration.complete_producer_sessions(producer_batch);
+                if !changed_groups.is_empty() {
+                    info!(
+                        "ClientManageProcessor: consumer session registrations changed, SDK address={}, groups={:?}",
+                        remote_address, changed_groups
+                    );
+                }
+            }
         }
         let mut response_command = self.command_factory.create_success_response_command();
         response_command.ensure_ext_fields_initialized();
@@ -326,12 +450,15 @@ where
 
     async fn heart_beat_v2(
         &mut self,
-        channel: &Channel,
-        _ctx: &ConnectionHandlerContext,
+        remote_address: &str,
         heartbeat_data: HeartbeatData,
-        client_channel_info: ClientChannelInfo,
-    ) -> Option<RemotingCommand> {
+        client: RegisteredClient,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        if let RegisteredClient::Session(session) = &client {
+            self.ensure_known_cross_role_session_identity(session)?;
+        }
         let mut is_sub_change = false;
+        let mut consumer_session_registrations = Vec::new();
         for consumer_data in heartbeat_data.consumer_data_set.iter() {
             if self.broker_config.reject_pull_consumer_enable
                 && ConsumeType::ConsumeActively == consumer_data.consume_type
@@ -384,46 +511,140 @@ where
                 .await;
 
             let changed = if heartbeat_data.is_without_sub {
-                self.consumer_registration.register_consumer_without_sub(
-                    consumer_data.group_name.as_ref(),
-                    client_channel_info.clone(),
-                    consumer_data.consume_type,
-                    consumer_data.message_model,
-                    consumer_data.consume_from_where,
-                    is_notify_consumer_ids_changed_enable,
-                )
+                match client.clone() {
+                    RegisteredClient::Legacy(client) => self.consumer_registration.register_consumer_without_sub(
+                        consumer_data.group_name.as_ref(),
+                        *client,
+                        consumer_data.consume_type,
+                        consumer_data.message_model,
+                        consumer_data.consume_from_where,
+                        is_notify_consumer_ids_changed_enable,
+                    ),
+                    RegisteredClient::Session(_) => {
+                        consumer_session_registrations.push(ConsumerSessionRegistration {
+                            group: consumer_data.group_name.clone(),
+                            consume_type: consumer_data.consume_type,
+                            message_model: consumer_data.message_model,
+                            consume_from_where: consumer_data.consume_from_where,
+                            subscriptions: HashSet::new(),
+                            notify_consumer_ids_changed: is_notify_consumer_ids_changed_enable,
+                            update_subscription: false,
+                        });
+                        false
+                    }
+                }
             } else {
-                self.consumer_registration.register_consumer(
-                    consumer_data.group_name.as_ref(),
-                    client_channel_info.clone(),
-                    consumer_data.consume_type,
-                    consumer_data.message_model,
-                    consumer_data.consume_from_where,
-                    consumer_data.subscription_data_set.clone(),
-                    is_notify_consumer_ids_changed_enable,
-                )
+                match client.clone() {
+                    RegisteredClient::Legacy(client) => self.consumer_registration.register_consumer(
+                        consumer_data.group_name.as_ref(),
+                        *client,
+                        consumer_data.consume_type,
+                        consumer_data.message_model,
+                        consumer_data.consume_from_where,
+                        consumer_data.subscription_data_set.clone(),
+                        is_notify_consumer_ids_changed_enable,
+                    ),
+                    RegisteredClient::Session(_) => {
+                        consumer_session_registrations.push(ConsumerSessionRegistration {
+                            group: consumer_data.group_name.clone(),
+                            consume_type: consumer_data.consume_type,
+                            message_model: consumer_data.message_model,
+                            consume_from_where: consumer_data.consume_from_where,
+                            subscriptions: consumer_data.subscription_data_set.clone(),
+                            notify_consumer_ids_changed: is_notify_consumer_ids_changed_enable,
+                            update_subscription: true,
+                        });
+                        false
+                    }
+                }
             };
 
             if changed {
                 info!(
                     "heartBeatV2 ClientManageProcessor: registerConsumer info changed, SDK address={}, \
                      consumerData={:?}",
-                    channel.remote_address(),
-                    consumer_data
+                    remote_address, consumer_data
                 );
             }
         }
 
         //handle producer data
-        for producer_data in heartbeat_data.producer_data_set.iter() {
-            self.producer_registration
-                .register_producer(&producer_data.group_name, &client_channel_info);
+        match client {
+            RegisteredClient::Legacy(client) => {
+                for producer_data in &heartbeat_data.producer_data_set {
+                    self.producer_registration
+                        .register_producer(&producer_data.group_name, &client);
+                }
+            }
+            RegisteredClient::Session(session) => {
+                let groups = heartbeat_data
+                    .producer_data_set
+                    .iter()
+                    .map(|producer| producer.group_name.clone())
+                    .collect();
+                let transition = self
+                    .session_transition_locks
+                    .lock(session.client_id(), session.session_id());
+                self.ensure_cross_role_session_identity(&transition, &session)?;
+                let consumer_batch = self.consumer_registration.prepare_consumer_sessions(
+                    &transition,
+                    session.clone(),
+                    consumer_session_registrations,
+                );
+                let producer_batch = self
+                    .producer_registration
+                    .prepare_producer_sessions(&transition, groups, session);
+                drop(transition);
+                let changed_groups = self.consumer_registration.complete_consumer_sessions(consumer_batch);
+                self.producer_registration.complete_producer_sessions(producer_batch);
+                if !changed_groups.is_empty() {
+                    is_sub_change = true;
+                    info!(
+                        "heartBeatV2 ClientManageProcessor: consumer session registrations changed, SDK address={}, \
+                         groups={:?}",
+                        remote_address, changed_groups
+                    );
+                }
+            }
         }
         let mut response_command = self.command_factory.create_success_response_command();
         response_command.ensure_ext_fields_initialized();
         response_command.add_ext_field(IS_SUPPORT_HEART_BEAT_V2.to_string(), true.to_string());
         response_command.add_ext_field(IS_SUB_CHANGE.to_string(), is_sub_change.to_string());
-        Some(response_command)
+        Ok(Some(response_command))
+    }
+
+    fn ensure_cross_role_session_identity(
+        &self,
+        transition: &ClientSessionTransitionGuard<'_>,
+        session: &ClientSessionInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        assert!(
+            self.session_transition_locks
+                .covers(transition, session.client_id(), session.session_id()),
+            "session identity preflight requires the matching transition guard"
+        );
+        self.ensure_known_cross_role_session_identity(session)
+    }
+
+    fn ensure_known_cross_role_session_identity(
+        &self,
+        session: &ClientSessionInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let conflicts = [
+            self.consumer_registration.client_id_for_session(session.session_id()),
+            self.producer_registration.client_id_for_session(session.session_id()),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|client_id| client_id.as_str() != session.client_id().as_str());
+        if conflicts {
+            return Err(rocketmq_error::RocketMQError::request_body_invalid(
+                "HEART_BEAT",
+                "a live SessionId cannot change client identity",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -437,8 +658,59 @@ impl<MS: BrokerStorePort> Clone for ClientManageProcessor<MS> {
             subscription_group_lookup: self.subscription_group_lookup.clone(),
             producer_registration: self.producer_registration.clone(),
             consumer_registration: self.consumer_registration.clone(),
+            session_transition_locks: Arc::clone(&self.session_transition_locks),
             retry_topic_registration: Arc::clone(&self.retry_topic_registration),
         }
+    }
+}
+
+fn decode_heartbeat(request: &RemotingCommand) -> rocketmq_error::RocketMQResult<HeartbeatData> {
+    let body = request
+        .body()
+        .ok_or_else(|| rocketmq_error::RocketMQError::request_body_invalid("HEART_BEAT", "request body is empty"))?;
+    SerdeJsonUtils::from_json_bytes(body.as_ref())
+}
+
+fn trusted_remote_address(request: &RemotingRequest) -> rocketmq_error::RocketMQResult<String> {
+    let origin = match request.origin() {
+        RequestOrigin::Network { peer } => TrustedOriginFact::Network(peer.address()),
+        RequestOrigin::Embedded { .. } => TrustedOriginFact::Embedded,
+        _ => TrustedOriginFact::Unsupported,
+    };
+    let session = match request.session() {
+        SessionView::Network { remote_addr, .. } => TrustedSessionFact::Network(*remote_addr),
+        SessionView::Embedded { .. } => TrustedSessionFact::Embedded,
+        _ => TrustedSessionFact::Unsupported,
+    };
+    trusted_remote_address_from_facts(origin, session)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrustedOriginFact {
+    Network(std::net::SocketAddr),
+    Embedded,
+    Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrustedSessionFact {
+    Network(std::net::SocketAddr),
+    Embedded,
+    Unsupported,
+}
+
+fn trusted_remote_address_from_facts(
+    origin: TrustedOriginFact,
+    session: TrustedSessionFact,
+) -> rocketmq_error::RocketMQResult<String> {
+    match (origin, session) {
+        (TrustedOriginFact::Network(peer), TrustedSessionFact::Network(remote_addr)) if peer == remote_addr => {
+            Ok(remote_addr.to_string())
+        }
+        (TrustedOriginFact::Embedded, TrustedSessionFact::Embedded) => Ok("embedded".to_string()),
+        _ => Err(rocketmq_error::RocketMQError::invariant_violated(
+            "client manager request origin does not match its session view",
+        )),
     }
 }
 
@@ -455,15 +727,83 @@ mod tests {
     use rocketmq_protocol::protocol::heartbeat::consumer_data::ConsumerData;
     use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
     use rocketmq_protocol::protocol::heartbeat::producer_data::ProducerData;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
     use rocketmq_store::MessageStoreConfig;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
     use tokio::net::TcpStream;
 
     use super::*;
     use crate::broker_runtime::BrokerRuntime;
+    use crate::long_polling::pull_deferred::PullSessionClientLookup;
     use rocketmq_protocol::code::response_code::ResponseCode as RemotingResponseCode;
     use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::test_support::session_id_for_test;
     use rocketmq_transport::test_support::Connection;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    async fn dispatch_v2<P>(processor: P, command: RemotingCommand) -> EmbeddedDispatchOutcome
+    where
+        P: RequestProcessorV2 + Clone + Sync + 'static,
+    {
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            processor,
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            crate::test_task_group("client-manage-v2"),
+            Principal::new("client-manage-v2-test"),
+        );
+        harness
+            .dispatch(None, command)
+            .await
+            .expect("client manager V2 dispatch should complete")
+    }
+
+    struct ObservedClientManageProcessor<MS: BrokerStorePort> {
+        inner: ClientManageProcessor<MS>,
+        observed: Arc<std::sync::Mutex<Option<(bool, bool, i32)>>>,
+    }
+
+    impl<MS: BrokerStorePort> Clone for ObservedClientManageProcessor<MS> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+                observed: Arc::clone(&self.observed),
+            }
+        }
+    }
+
+    impl<MS: BrokerStorePort + 'static> RequestProcessorV2 for ObservedClientManageProcessor<MS> {
+        async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+            self.observed.lock().expect("observation lock").replace((
+                matches!(request.origin(), RequestOrigin::Embedded { .. }),
+                matches!(request.session(), SessionView::Embedded { .. }),
+                request.original_identity().original_opaque(),
+            ));
+            RequestProcessorV2::process(&mut self.inner, request).await
+        }
+    }
 
     #[test]
     fn production_processor_has_no_complete_runtime_owner() {
@@ -520,6 +860,88 @@ mod tests {
         let body = CheckClientRequestBody::new("client-id".to_string(), "group-a".to_string(), subscription_data);
         RemotingCommand::create_request_command(RequestCode::CheckClientConfig, EmptyHeader {})
             .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")))
+    }
+
+    fn session_heartbeat_request(
+        client_id: &str,
+        consumer_groups: &[CheetahString],
+        producer_groups: &[CheetahString],
+    ) -> RemotingCommand {
+        let heartbeat = HeartbeatData {
+            client_id: client_id.into(),
+            heartbeat_fingerprint: 0,
+            is_without_sub: false,
+            consumer_data_set: consumer_groups
+                .iter()
+                .cloned()
+                .map(|group_name| ConsumerData {
+                    group_name,
+                    consume_type: ConsumeType::ConsumePassively,
+                    message_model: MessageModel::Clustering,
+                    consume_from_where: ConsumeFromWhere::ConsumeFromLastOffset,
+                    subscription_data_set: HashSet::new(),
+                    unit_mode: false,
+                })
+                .collect(),
+            producer_data_set: producer_groups
+                .iter()
+                .cloned()
+                .map(|group_name| ProducerData { group_name })
+                .collect(),
+        };
+        RemotingCommand::create_request_command(RequestCode::HeartBeat, EmptyHeader {}).set_body(Bytes::from(
+            serde_json::to_vec(&heartbeat).expect("serialize session heartbeat"),
+        ))
+    }
+
+    #[tokio::test]
+    async fn client_manage_v2_uses_typed_embedded_origin_and_original_opaque() {
+        let mut runtime = new_test_runtime("client-manage-v2", false).await;
+        let observed = Arc::new(std::sync::Mutex::new(None));
+        let processor = ObservedClientManageProcessor {
+            inner: runtime.runtime_state_mut().build_client_manage_processor(),
+            observed: Arc::clone(&observed),
+        };
+        let request = check_request(SubscriptionData {
+            topic: "topic-a".into(),
+            sub_string: "*".into(),
+            expression_type: ExpressionType::TAG.into(),
+            ..Default::default()
+        })
+        .set_opaque(9_845);
+
+        let EmbeddedDispatchOutcome::Reply(plan) = dispatch_v2(processor, request).await else {
+            panic!("client manager V2 must return an inline response plan");
+        };
+
+        assert_eq!(
+            RemotingResponseCode::from(plan.response_code()),
+            RemotingResponseCode::Success
+        );
+        assert_eq!(*observed.lock().expect("observation lock"), Some((true, true, 9_845)));
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[test]
+    fn client_manage_rejects_origin_session_mismatch() {
+        let remote_addr = "127.0.0.1:10911".parse().expect("remote address");
+        let other_addr = "127.0.0.1:10912".parse().expect("other address");
+
+        assert!(trusted_remote_address_from_facts(
+            TrustedOriginFact::Network(remote_addr),
+            TrustedSessionFact::Embedded,
+        )
+        .is_err());
+        assert!(trusted_remote_address_from_facts(
+            TrustedOriginFact::Embedded,
+            TrustedSessionFact::Network(remote_addr),
+        )
+        .is_err());
+        assert!(trusted_remote_address_from_facts(
+            TrustedOriginFact::Network(remote_addr),
+            TrustedSessionFact::Network(other_addr),
+        )
+        .is_err());
     }
 
     #[tokio::test]
@@ -609,7 +1031,6 @@ mod tests {
             )
         };
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let client_channel_info = ClientChannelInfo::new(channel.clone(), "client-id".into(), Default::default(), 0);
         processor
             .consumer_group_heartbeat_table
@@ -632,8 +1053,13 @@ mod tests {
         };
 
         let response = processor
-            .heart_beat_v2(&channel, &ctx, heartbeat_data, client_channel_info)
+            .heart_beat_v2(
+                &channel.remote_address().to_string(),
+                heartbeat_data,
+                RegisteredClient::Legacy(Box::new(client_channel_info)),
+            )
             .await
+            .expect("heartbeat should succeed")
             .expect("processor should return response");
 
         assert_eq!(
@@ -664,7 +1090,7 @@ mod tests {
     #[tokio::test]
     async fn heart_beat_v1_and_unregister_share_live_client_registries() {
         let mut runtime = new_test_runtime("heartbeat-v1-unregister", false).await;
-        let (producer_manager, consumer_manager, mut processor) = {
+        let (producer_manager, consumer_manager, processor) = {
             let inner = runtime.runtime_state_mut();
             (
                 inner.producer_manager().clone_shared_state(),
@@ -673,7 +1099,6 @@ mod tests {
             )
         };
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let producer_group = CheetahString::from_static_str("producer-group");
         let consumer_group = CheetahString::from_static_str("group-a");
         let heartbeat_data = HeartbeatData {
@@ -696,8 +1121,9 @@ mod tests {
             .set_body(Bytes::from(
                 serde_json::to_vec(&heartbeat_data).expect("serialize heartbeat"),
             ));
-        let heartbeat_response = processor
-            .heart_beat(channel.clone(), ctx.clone(), &mut heartbeat_request)
+        let mut legacy_processor = processor.legacy_adapter();
+        let heartbeat_response = legacy_processor
+            .process_legacy(channel.clone(), &mut heartbeat_request)
             .await
             .expect("heartbeat should succeed")
             .expect("heartbeat should return response");
@@ -719,8 +1145,9 @@ mod tests {
             },
         );
         unregister_request.make_custom_header_to_net();
-        let unregister_response = processor
-            .unregister_client(channel, ctx, &mut unregister_request)
+        let unregister_response = legacy_processor
+            .process_legacy(channel, &mut unregister_request)
+            .await
             .expect("unregister should succeed")
             .expect("unregister should return response");
 
@@ -730,6 +1157,333 @@ mod tests {
         );
         assert!(!producer_manager.group_online(producer_group.as_str()));
         assert!(consumer_manager.get_consumer_group_info(&consumer_group).is_none());
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn session_command_core_uses_only_the_stable_session_identity_index() {
+        let mut runtime = new_test_runtime("session-identity-index", false).await;
+        let (producer_manager, consumer_manager, mut processor) = {
+            let inner = runtime.runtime_state_mut();
+            (
+                inner.producer_manager().clone_shared_state(),
+                inner.consumer_manager().clone_shared_state(),
+                inner.build_client_manage_processor(),
+            )
+        };
+        let session_id = session_id_for_test(9_846);
+        let producer_group = CheetahString::from_static_str("session-producer-group");
+        let consumer_group = CheetahString::from_static_str("session-consumer-group");
+        let heartbeat_data = HeartbeatData {
+            client_id: "session-client".into(),
+            heartbeat_fingerprint: 0,
+            is_without_sub: false,
+            consumer_data_set: HashSet::from([ConsumerData {
+                group_name: consumer_group.clone(),
+                consume_type: ConsumeType::ConsumePassively,
+                message_model: MessageModel::Clustering,
+                consume_from_where: ConsumeFromWhere::ConsumeFromLastOffset,
+                subscription_data_set: HashSet::new(),
+                unit_mode: false,
+            }]),
+            producer_data_set: HashSet::from([ProducerData {
+                group_name: producer_group.clone(),
+            }]),
+        };
+        let mut heartbeat_request = RemotingCommand::create_request_command(RequestCode::HeartBeat, EmptyHeader {})
+            .set_body(Bytes::from(
+                serde_json::to_vec(&heartbeat_data).expect("serialize heartbeat"),
+            ));
+
+        let heartbeat_response = processor
+            .process_session_command(session_id, "127.0.0.1:9846".to_owned(), &mut heartbeat_request)
+            .await
+            .expect("session heartbeat should succeed")
+            .expect("session heartbeat should return a response");
+        assert_eq!(
+            RemotingResponseCode::from(heartbeat_response.code()),
+            RemotingResponseCode::Success
+        );
+        let group_info = consumer_manager
+            .get_consumer_group_info(&consumer_group)
+            .expect("session consumer should be registered");
+        assert!(group_info.get_all_channels().is_empty());
+        assert_eq!(
+            crate::long_polling::pull_deferred::PullSessionClientLookup::client_id(
+                &consumer_manager.session_registry(),
+                session_id,
+                &consumer_group,
+            ),
+            Some(CheetahString::from_static_str("session-client"))
+        );
+        assert!(producer_manager.group_online(producer_group.as_str()));
+
+        let mut unregister_request = RemotingCommand::create_request_command(
+            RequestCode::UnregisterClient,
+            UnregisterClientRequestHeader {
+                client_id: "session-client".into(),
+                producer_group: Some(producer_group.clone()),
+                consumer_group: Some(consumer_group.clone()),
+                rpc_request_header: None,
+            },
+        );
+        unregister_request.make_custom_header_to_net();
+        processor
+            .process_session_command(session_id, "127.0.0.1:9846".to_owned(), &mut unregister_request)
+            .await
+            .expect("session unregister should succeed")
+            .expect("session unregister should return a response");
+
+        assert!(!producer_manager.group_online(producer_group.as_str()));
+        assert_eq!(
+            crate::long_polling::pull_deferred::PullSessionClientLookup::client_id(
+                &consumer_manager.session_registry(),
+                session_id,
+                &consumer_group,
+            ),
+            None
+        );
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn session_reconnect_cleans_the_role_omitted_by_the_new_heartbeat() {
+        let mut runtime = new_test_runtime("session-role-reconnect", false).await;
+        let (producer_manager, consumer_manager, mut processor) = {
+            let inner = runtime.runtime_state_mut();
+            (
+                inner.producer_manager().clone_shared_state(),
+                inner.consumer_manager().clone_shared_state(),
+                inner.build_client_manage_processor(),
+            )
+        };
+
+        let producer_group = CheetahString::from_static_str("role-reconnect-producer");
+        let consumer_group = CheetahString::from_static_str("role-reconnect-consumer");
+        let old_session = session_id_for_test(9_851);
+        let producer_only_session = session_id_for_test(9_852);
+        let mut old_request = session_heartbeat_request(
+            "role-reconnect-client",
+            std::slice::from_ref(&consumer_group),
+            std::slice::from_ref(&producer_group),
+        );
+        processor
+            .process_session_command(old_session, "127.0.0.1:9851".to_owned(), &mut old_request)
+            .await
+            .expect("initial mixed-role heartbeat")
+            .expect("initial heartbeat response");
+
+        let mut producer_only_request =
+            session_heartbeat_request("role-reconnect-client", &[], std::slice::from_ref(&producer_group));
+        processor
+            .process_session_command(
+                producer_only_session,
+                "127.0.0.1:9852".to_owned(),
+                &mut producer_only_request,
+            )
+            .await
+            .expect("producer-only reconnect")
+            .expect("producer-only response");
+
+        assert!(producer_manager.group_online(producer_group.as_str()));
+        assert!(consumer_manager.get_consumer_group_info(&consumer_group).is_none());
+        assert!(!producer_manager
+            .connection_housekeeping()
+            .do_session_close_event(old_session));
+        assert!(!consumer_manager
+            .connection_housekeeping()
+            .do_session_close_event(old_session));
+        assert!(producer_manager
+            .connection_housekeeping()
+            .do_session_close_event(producer_only_session));
+        assert!(!producer_manager.group_online(producer_group.as_str()));
+
+        let second_producer_group = CheetahString::from_static_str("role-reconnect-producer-2");
+        let second_consumer_group = CheetahString::from_static_str("role-reconnect-consumer-2");
+        let second_old_session = session_id_for_test(9_853);
+        let consumer_only_session = session_id_for_test(9_854);
+        let mut second_old_request = session_heartbeat_request(
+            "role-reconnect-client-2",
+            std::slice::from_ref(&second_consumer_group),
+            std::slice::from_ref(&second_producer_group),
+        );
+        processor
+            .process_session_command(second_old_session, "127.0.0.1:9853".to_owned(), &mut second_old_request)
+            .await
+            .expect("second initial mixed-role heartbeat")
+            .expect("second initial heartbeat response");
+
+        let mut consumer_only_request = session_heartbeat_request(
+            "role-reconnect-client-2",
+            std::slice::from_ref(&second_consumer_group),
+            &[],
+        );
+        processor
+            .process_session_command(
+                consumer_only_session,
+                "127.0.0.1:9854".to_owned(),
+                &mut consumer_only_request,
+            )
+            .await
+            .expect("consumer-only reconnect")
+            .expect("consumer-only response");
+
+        assert!(!producer_manager.group_online(second_producer_group.as_str()));
+        assert_eq!(
+            consumer_manager
+                .session_registry()
+                .client_id(consumer_only_session, &second_consumer_group)
+                .as_deref(),
+            Some("role-reconnect-client-2")
+        );
+        assert!(!producer_manager
+            .connection_housekeeping()
+            .do_session_close_event(second_old_session));
+        assert!(!consumer_manager
+            .connection_housekeeping()
+            .do_session_close_event(second_old_session));
+        assert!(consumer_manager
+            .connection_housekeeping()
+            .do_session_close_event(consumer_only_session));
+        assert!(consumer_manager
+            .get_consumer_group_info(&second_consumer_group)
+            .is_none());
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn session_identity_conflict_is_rejected_before_either_role_commits() {
+        let mut runtime = new_test_runtime("session-cross-role-identity", false).await;
+        let (producer_manager, consumer_manager, mut processor) = {
+            let inner = runtime.runtime_state_mut();
+            (
+                inner.producer_manager().clone_shared_state(),
+                inner.consumer_manager().clone_shared_state(),
+                inner.build_client_manage_processor(),
+            )
+        };
+        let consumer_first_session = session_id_for_test(9_861);
+        let consumer_group = CheetahString::from_static_str("identity-consumer-first");
+        let rejected_producer_group = CheetahString::from_static_str("identity-producer-rejected");
+        let mut consumer_first =
+            session_heartbeat_request("identity-client-a", std::slice::from_ref(&consumer_group), &[]);
+        processor
+            .process_session_command(consumer_first_session, "127.0.0.1:9861".to_owned(), &mut consumer_first)
+            .await
+            .expect("consumer-first heartbeat")
+            .expect("consumer-first response");
+        let mut conflicting_producer =
+            session_heartbeat_request("identity-client-b", &[], std::slice::from_ref(&rejected_producer_group));
+        assert!(processor
+            .process_session_command(
+                consumer_first_session,
+                "127.0.0.1:9862".to_owned(),
+                &mut conflicting_producer,
+            )
+            .await
+            .is_err());
+        assert!(!producer_manager.group_online(rejected_producer_group.as_str()));
+        assert_eq!(
+            consumer_manager
+                .session_registry()
+                .client_id(consumer_first_session, &consumer_group)
+                .as_deref(),
+            Some("identity-client-a")
+        );
+
+        let producer_first_session = session_id_for_test(9_862);
+        let producer_group = CheetahString::from_static_str("identity-producer-first");
+        let rejected_consumer_group = CheetahString::from_static_str("identity-consumer-rejected");
+        let mut producer_first =
+            session_heartbeat_request("identity-client-c", &[], std::slice::from_ref(&producer_group));
+        processor
+            .process_session_command(producer_first_session, "127.0.0.1:9863".to_owned(), &mut producer_first)
+            .await
+            .expect("producer-first heartbeat")
+            .expect("producer-first response");
+        let mut conflicting_consumer =
+            session_heartbeat_request("identity-client-d", std::slice::from_ref(&rejected_consumer_group), &[]);
+        assert!(processor
+            .process_session_command(
+                producer_first_session,
+                "127.0.0.1:9864".to_owned(),
+                &mut conflicting_consumer,
+            )
+            .await
+            .is_err());
+        assert!(consumer_manager
+            .get_consumer_group_info(&rejected_consumer_group)
+            .is_none());
+        assert!(producer_manager.group_online(producer_group.as_str()));
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn concurrent_mixed_role_heartbeats_choose_one_cross_role_session() {
+        let mut runtime = new_test_runtime("session-cross-role-race", false).await;
+        let (consumer_manager, processor) = {
+            let inner = runtime.runtime_state_mut();
+            (
+                inner.consumer_manager().clone_shared_state(),
+                inner.build_client_manage_processor(),
+            )
+        };
+        let producer_registration = processor.producer_registration.clone();
+        let consumer_registration = processor.consumer_registration.clone();
+        let first_session = session_id_for_test(9_871);
+        let second_session = session_id_for_test(9_872);
+        let producer_group = CheetahString::from_static_str("cross-role-race-producer");
+        let consumer_group = CheetahString::from_static_str("cross-role-race-consumer");
+        let mut first_processor = processor.clone();
+        let mut second_processor = processor;
+        let mut first_request = session_heartbeat_request(
+            "cross-role-race-client",
+            std::slice::from_ref(&consumer_group),
+            std::slice::from_ref(&producer_group),
+        );
+        let mut second_request = session_heartbeat_request(
+            "cross-role-race-client",
+            std::slice::from_ref(&consumer_group),
+            std::slice::from_ref(&producer_group),
+        );
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let first_barrier = Arc::clone(&barrier);
+        let second_barrier = Arc::clone(&barrier);
+        let (first_result, second_result) = tokio::join!(
+            async move {
+                first_barrier.wait().await;
+                first_processor
+                    .process_session_command(first_session, "127.0.0.1:9871".to_owned(), &mut first_request)
+                    .await
+            },
+            async move {
+                second_barrier.wait().await;
+                second_processor
+                    .process_session_command(second_session, "127.0.0.1:9872".to_owned(), &mut second_request)
+                    .await
+            }
+        );
+        assert!(first_result.is_ok());
+        assert!(second_result.is_ok());
+
+        let first_is_producer = producer_registration.client_id_for_session(first_session).is_some();
+        let first_is_consumer = consumer_registration.client_id_for_session(first_session).is_some();
+        let second_is_producer = producer_registration.client_id_for_session(second_session).is_some();
+        let second_is_consumer = consumer_registration.client_id_for_session(second_session).is_some();
+        assert_eq!(first_is_producer, first_is_consumer);
+        assert_eq!(second_is_producer, second_is_consumer);
+        assert_ne!(first_is_producer, second_is_producer);
+        assert_eq!(
+            consumer_manager
+                .get_consumer_group_info(&consumer_group)
+                .expect("winning consumer group")
+                .session_info_snapshot()
+                .len(),
+            1
+        );
+
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 

--- a/rocketmq-broker/src/processor/consumer_manage_processor.rs
+++ b/rocketmq-broker/src/processor/consumer_manage_processor.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
@@ -29,17 +30,20 @@ use rocketmq_protocol::protocol::static_topic::topic_queue_mapping_utils::TopicQ
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_store::BrokerStorePort;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_and_opaque;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
 use rocketmq_transport::api::v1::RpcClient;
 use rocketmq_transport::api::v1::RpcClientImpl;
 use rocketmq_transport::api::v1::RpcRequest;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::SessionView;
 use tracing::info;
 use tracing::warn;
 
 use crate::client::manager::consumer_manager::ConsumerAssignmentView;
 use crate::offset::manager::consumer_offset_manager::ConsumerOffsetRequestCapability;
+use crate::processor::response_plan::immediate_outcome_from_command_result;
 use crate::subscription::manager::subscription_group_manager::SubscriptionGroupConfigLookup;
 use crate::topic::manager::topic_config_manager::TopicConfigManager;
 use crate::topic::manager::topic_queue_mapping_manager::TopicQueueMappingManager;
@@ -68,36 +72,20 @@ pub(crate) struct ConsumerManageProcessorContext<MS: BrokerStorePort> {
     pub(crate) forward_timeout: u64,
 }
 
-impl<MS> RequestProcessor for ConsumerManageProcessor<MS>
+impl<MS> RequestProcessorV2 for ConsumerManageProcessor<MS>
 where
-    MS: BrokerStorePort,
+    MS: BrokerStorePort + 'static,
 {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let request_code = RequestCode::from(request.code());
-        info!("ConsumerManageProcessor received request code: {:?}", request_code);
-        match request_code {
-            RequestCode::GetConsumerListByGroup
-            | RequestCode::UpdateConsumerOffset
-            | RequestCode::QueryConsumerOffset => self.process_request_inner(channel, ctx, request_code, request).await,
-            _ => {
-                warn!(
-                    "ConsumerManageProcessor received unknown request code: {:?}",
-                    request_code
-                );
-                let response = request_code_not_supported_with_factory_remark_and_opaque(
-                    &self.command_factory,
-                    request.code(),
-                    format!("ConsumerManageProcessor request code {} not supported", request.code()),
-                    request.opaque(),
-                );
-                Ok(Some(response))
-            }
-        }
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let request_source = trusted_request_source(request)?;
+        let result = self.process_command(request_source, request.command_mut()).await;
+        immediate_outcome_from_command_result(
+            &self.command_factory,
+            result,
+            original_opaque,
+            "consumer manager returned no response",
+        )
     }
 }
 
@@ -119,14 +107,13 @@ where
         }
     }
 
-    pub async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        request_source: CheetahString,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut processor = self.clone();
-        processor.process_request(channel, ctx, request).await
+        processor.process_command(request_source, request).await
     }
 }
 
@@ -151,25 +138,35 @@ impl<MS> ConsumerManageProcessor<MS>
 where
     MS: BrokerStorePort,
 {
-    async fn process_request_inner(
+    async fn process_command(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request_code: RequestCode,
+        request_source: CheetahString,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_code = RequestCode::from(request.code());
+        info!("ConsumerManageProcessor received request code: {:?}", request_code);
         match request_code {
-            RequestCode::GetConsumerListByGroup => self.get_consumer_list_by_group(channel, ctx, request).await,
-            RequestCode::UpdateConsumerOffset => self.update_consumer_offset(channel, ctx, request).await,
-            RequestCode::QueryConsumerOffset => self.query_consumer_offset(channel, ctx, request).await,
-            _ => Ok(None),
+            RequestCode::GetConsumerListByGroup => self.get_consumer_list_by_group(&request_source, request).await,
+            RequestCode::UpdateConsumerOffset => self.update_consumer_offset(request_source, request).await,
+            RequestCode::QueryConsumerOffset => self.query_consumer_offset(request).await,
+            _ => {
+                warn!(
+                    "ConsumerManageProcessor received unknown request code: {:?}",
+                    request_code
+                );
+                Ok(Some(request_code_not_supported_with_factory_remark_and_opaque(
+                    &self.command_factory,
+                    request.code(),
+                    format!("ConsumerManageProcessor request code {} not supported", request.code()),
+                    request.opaque(),
+                )))
+            }
         }
     }
 
     pub async fn get_consumer_list_by_group(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        request_source: &str,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let response = self.command_factory.create_success_response_command();
@@ -180,8 +177,7 @@ where
             None => {
                 warn!(
                     "getConsumerGroupInfo failed, {} {}",
-                    request_header.consumer_group,
-                    channel.remote_address()
+                    request_header.consumer_group, request_source
                 );
             }
             Some(client_ids) => {
@@ -197,8 +193,7 @@ where
                 } else {
                     warn!(
                         "getAllClientId failed, {} {}",
-                        request_header.consumer_group,
-                        channel.remote_address()
+                        request_header.consumer_group, request_source
                     )
                 }
             }
@@ -212,8 +207,7 @@ where
 
     async fn update_consumer_offset(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        request_source: CheetahString,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut request_header = request.decode_command_custom_header::<UpdateConsumerOffsetRequestHeader>()?;
@@ -274,20 +268,13 @@ where
                     .set_remark("Offset has been previously reset"),
             ));
         }
-        self.consumer_offset.commit_offset(
-            channel.remote_address().to_string().into(),
-            group,
-            topic,
-            queue_id,
-            offset,
-        );
+        self.consumer_offset
+            .commit_offset(request_source, group, topic, queue_id, offset);
         Ok(Some(response.set_code(ResponseCode::Success)))
     }
 
     async fn query_consumer_offset(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut request_header = request.decode_command_custom_header::<QueryConsumerOffsetRequestHeader>()?;
@@ -566,8 +553,187 @@ where
     }
 }
 
+fn trusted_request_source(request: &RemotingRequest) -> rocketmq_error::RocketMQResult<CheetahString> {
+    let origin = match request.origin() {
+        RequestOrigin::Network { peer } => TrustedOriginFact::Network(peer.address()),
+        RequestOrigin::Embedded { .. } => TrustedOriginFact::Embedded,
+        _ => TrustedOriginFact::Unsupported,
+    };
+    let session = match request.session() {
+        SessionView::Network { remote_addr, .. } => TrustedSessionFact::Network(*remote_addr),
+        SessionView::Embedded { .. } => TrustedSessionFact::Embedded,
+        _ => TrustedSessionFact::Unsupported,
+    };
+    trusted_request_source_from_facts(origin, session)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrustedOriginFact {
+    Network(std::net::SocketAddr),
+    Embedded,
+    Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrustedSessionFact {
+    Network(std::net::SocketAddr),
+    Embedded,
+    Unsupported,
+}
+
+fn trusted_request_source_from_facts(
+    origin: TrustedOriginFact,
+    session: TrustedSessionFact,
+) -> rocketmq_error::RocketMQResult<CheetahString> {
+    match (origin, session) {
+        (TrustedOriginFact::Network(peer), TrustedSessionFact::Network(remote_addr)) if peer == remote_addr => {
+            Ok(remote_addr.to_string().into())
+        }
+        (TrustedOriginFact::Embedded, TrustedSessionFact::Embedded) => Ok(CheetahString::from_static_str("embedded")),
+        _ => Err(rocketmq_error::RocketMQError::invariant_violated(
+            "consumer manager request origin does not match its session view",
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use rocketmq_protocol::code::request_code::RequestCode;
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::header::empty_header::EmptyHeader;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
+    use rocketmq_store::MessageStoreConfig;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+    use super::*;
+    use crate::broker_runtime::BrokerMessageStore;
+    use crate::broker_runtime::BrokerRuntime;
+    use crate::config::broker_config::BrokerConfig;
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    fn temp_test_root(label: &str) -> PathBuf {
+        let unique = format!(
+            "rocketmq-broker-consumer-manage-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time before unix epoch")
+                .as_nanos()
+        );
+        std::env::temp_dir().join(unique)
+    }
+
+    async fn new_test_runtime(label: &str) -> BrokerRuntime {
+        let temp_root = temp_test_root(label);
+        let broker_config = Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        });
+        let message_store_config = Arc::new(MessageStoreConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        });
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        assert!(runtime.initialize().await.is_ok());
+        runtime
+    }
+
+    fn consumer_processor_for_test(runtime: &mut BrokerRuntime) -> ConsumerManageProcessor<BrokerMessageStore> {
+        let inner = runtime.runtime_state_mut();
+        ConsumerManageProcessor::new(ConsumerManageProcessorContext {
+            command_factory: application_remoting_command_factory(),
+            consumer_view: inner.consumer_manager().assignment_view(),
+            consumer_offset: inner.consumer_offset_manager_handle().request_capability(),
+            topic_queue_mapping_manager: inner.topic_queue_mapping_manager_handle(),
+            subscription_group_lookup: inner.subscription_group_manager().config_lookup(),
+            topic_config_manager: inner.topic_config_manager_handle(),
+            rpc_client: inner.broker_outer_api().rpc_client().clone(),
+            use_server_side_reset_offset: inner.broker_config().use_server_side_reset_offset,
+            forward_timeout: inner.broker_config().forward_timeout,
+        })
+    }
+
+    async fn dispatch_v2(
+        processor: ConsumerManageProcessor<BrokerMessageStore>,
+        command: RemotingCommand,
+    ) -> EmbeddedDispatchOutcome {
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            processor,
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            crate::test_task_group("consumer-manage-v2"),
+            Principal::new("consumer-manage-v2-test"),
+        )
+        .dispatch(None, command)
+        .await
+        .expect("consumer manager V2 dispatch should complete")
+    }
+
+    #[tokio::test]
+    async fn consumer_manage_v2_maps_header_errors_into_a_response_plan() {
+        let mut runtime = new_test_runtime("consumer-manage-v2").await;
+        let processor = consumer_processor_for_test(&mut runtime);
+        let request = RemotingCommand::create_request_command(RequestCode::GetConsumerListByGroup, EmptyHeader {})
+            .set_opaque(4_204);
+
+        let EmbeddedDispatchOutcome::Reply(plan) = dispatch_v2(processor, request).await else {
+            panic!("consumer manager V2 must return an inline response plan");
+        };
+
+        assert_eq!(ResponseCode::from(plan.response_code()), ResponseCode::InvalidParameter);
+        assert_eq!(plan.body_len(), 0);
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[test]
+    fn consumer_manage_rejects_origin_session_mismatch() {
+        let remote_addr = "127.0.0.1:10911".parse().expect("remote address");
+        let other_addr = "127.0.0.1:10912".parse().expect("other address");
+
+        assert!(trusted_request_source_from_facts(
+            TrustedOriginFact::Network(remote_addr),
+            TrustedSessionFact::Embedded,
+        )
+        .is_err());
+        assert!(trusted_request_source_from_facts(
+            TrustedOriginFact::Embedded,
+            TrustedSessionFact::Network(remote_addr),
+        )
+        .is_err());
+        assert!(trusted_request_source_from_facts(
+            TrustedOriginFact::Network(remote_addr),
+            TrustedSessionFact::Network(other_addr),
+        )
+        .is_err());
+    }
+
     #[test]
     fn production_processor_has_no_complete_runtime_owner() {
         let source = include_str!("consumer_manage_processor.rs");

--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -38,9 +38,9 @@ use rocketmq_store::MessageStoreConfig;
 use rocketmq_store::PutMessageResult;
 use rocketmq_store::PutMessageStatus;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_and_opaque;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -165,18 +165,36 @@ impl<TM, MS: BrokerWriteStore> Clone for EndTransactionProcessor<TM, MS> {
     }
 }
 
-impl<TM, MS> RequestProcessor for EndTransactionProcessor<TM, MS>
+impl<TM, MS> RequestProcessorV2 for EndTransactionProcessor<TM, MS>
 where
-    TM: TransactionalMessageService,
-    MS: BrokerWriteStore,
+    TM: TransactionalMessageService + 'static,
+    MS: BrokerWriteStore + 'static,
 {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_mut(channel, ctx, request).await
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let opaque = request.original_identity().original_opaque();
+        let command_factory = self.context.command_factory;
+        let result = match self.process_command(request.command_mut()).await {
+            Ok(Some(response)) => Ok(Some(response)),
+            Ok(None) => Ok(Some(
+                // Legacy callers use None for pending or unknown transaction states. V2 must make
+                // that branch explicit: one-way ingress still suppresses this plan in the dispatcher,
+                // while a malformed two-way caller receives a deterministic protocol error instead
+                // of a false success or an indefinite timeout.
+                command_factory
+                    .create_response_command_with_code_remark(
+                        ResponseCode::IllegalOperation,
+                        "transaction state is pending or unsupported",
+                    )
+                    .set_opaque(opaque),
+            )),
+            Err(error) => Err(error),
+        };
+        crate::processor::response_plan::immediate_outcome_from_command_result(
+            &command_factory,
+            result,
+            opaque,
+            "EndTransactionProcessor V2 command dispatch completed without a response",
+        )
     }
 }
 
@@ -185,26 +203,23 @@ where
     TM: TransactionalMessageService,
     MS: BrokerWriteStore,
 {
-    pub async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut processor = self.clone();
-        processor.process_request_mut(channel, ctx, request).await
+        processor.process_command(request).await
     }
 
-    async fn process_request_mut(
+    /// V2 leaf business contract; transaction completion does not need a transport handle.
+    async fn process_command(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!("EndTransactionProcessor received request code: {:?}", request_code);
         match request_code {
-            RequestCode::EndTransaction => self.process_request_inner(channel, ctx, request_code, request).await,
+            RequestCode::EndTransaction => self.process_command_inner(request).await,
             _ => {
                 warn!(
                     "EndTransactionProcessor received unknown request code: {:?}",
@@ -236,11 +251,8 @@ where
     TM: TransactionalMessageService,
     MS: BrokerWriteStore,
 {
-    async fn process_request_inner(
+    async fn process_command_inner(
         &mut self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
-        _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<EndTransactionRequestHeader>()?;
@@ -678,10 +690,121 @@ fn end_message_transaction(msg_ext: &mut MessageExt) -> MessageExtBrokerInner {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
+    use crate::broker_runtime::BrokerRuntime;
     use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
     use rocketmq_protocol::protocol::SerializeType;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
     use rocketmq_store::StorePorts;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    fn temp_test_root(label: &str) -> PathBuf {
+        let unique = format!(
+            "rocketmq-broker-end-transaction-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time before unix epoch")
+                .as_nanos()
+        );
+        std::env::temp_dir().join(unique)
+    }
+
+    async fn new_test_runtime(label: &str) -> BrokerRuntime {
+        let temp_root = temp_test_root(label);
+        let broker_config = Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        });
+        let message_store_config = Arc::new(MessageStoreConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        });
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        assert!(runtime.initialize().await.is_ok());
+        runtime
+    }
+
+    async fn dispatch_v2<P>(processor: P, command: RemotingCommand) -> EmbeddedDispatchOutcome
+    where
+        P: RequestProcessorV2 + Clone + Sync + 'static,
+    {
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            processor,
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            crate::test_task_group("end-transaction-v2"),
+            Principal::new("end-transaction-v2-test"),
+        )
+        .dispatch(None, command)
+        .await
+        .expect("end transaction V2 dispatch should complete")
+    }
+
+    #[tokio::test]
+    async fn end_transaction_v2_maps_legacy_pending_none_to_illegal_operation() {
+        let mut runtime = new_test_runtime("v2-pending").await;
+        let processor = {
+            let inner = runtime.runtime_state_mut();
+            let transactional_message_service = inner
+                .transactional_message_service()
+                .cloned()
+                .expect("transactional message service should be initialized");
+            let escape_bridge = inner.escape_bridge();
+            EndTransactionProcessor::new(
+                transactional_message_service,
+                EndTransactionProcessorContext::new(
+                    EndTransactionPolicy::from_configs(&inner.broker_config(), &inner.message_store_config()),
+                    EndTransactionStoreCapability::new(&escape_bridge),
+                    inner.broker_stats_manager_handle(),
+                    None,
+                ),
+            )
+        };
+        let request = RemotingCommand::create_request_command(
+            RequestCode::EndTransaction,
+            EndTransactionRequestHeader {
+                producer_group: "producer-group".into(),
+                commit_or_rollback: MessageSysFlag::TRANSACTION_NOT_TYPE,
+                msg_id: "message-id".into(),
+                ..Default::default()
+            },
+        )
+        .set_opaque(6_606);
+
+        let EmbeddedDispatchOutcome::Reply(plan) = dispatch_v2(processor, request).await else {
+            panic!("end transaction V2 must return an inline response plan");
+        };
+
+        assert_eq!(ResponseCode::from(plan.response_code()), ResponseCode::IllegalOperation);
+        assert_eq!(plan.body_len(), 0);
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
 
     #[test]
     fn final_end_transaction_reply_preserves_error_semantics_on_both_wire_formats() {

--- a/rocketmq-broker/src/processor/lite_manager_processor.rs
+++ b/rocketmq-broker/src/processor/lite_manager_processor.rs
@@ -49,9 +49,9 @@ use rocketmq_store::ConsumeQueueStore;
 use rocketmq_store::ConsumeQueueStoreTrait;
 use rocketmq_store::MessageStoreConfig;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_and_opaque;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use tracing::warn;
 
 use crate::failover::escape_bridge::EscapeBridge;
@@ -290,10 +290,16 @@ impl<MS: BrokerReadWriteStore> LiteManagerProcessor<MS> {
 }
 
 impl<MS: BrokerReadWriteStore> LiteManagerProcessor<MS> {
-    pub(crate) async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.process_command(request).await
+    }
+
+    /// V2 leaf business contract: it only builds a response command and never uses a transport handle.
+    async fn process_command(
+        &self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match RequestCode::from(request.code()) {
@@ -316,14 +322,17 @@ impl<MS: BrokerReadWriteStore> LiteManagerProcessor<MS> {
     }
 }
 
-impl<MS: BrokerReadWriteStore> RequestProcessor for LiteManagerProcessor<MS> {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_shared(channel, ctx, request).await
+impl<MS: BrokerReadWriteStore + 'static> RequestProcessorV2 for LiteManagerProcessor<MS> {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let command_factory = self.context.command_factory;
+        let result = self.process_command(request.command_mut()).await;
+        crate::processor::response_plan::immediate_outcome_from_command_result(
+            &command_factory,
+            result,
+            original_opaque,
+            "LiteManagerProcessor V2 command dispatch completed without a response",
+        )
     }
 }
 
@@ -952,17 +961,135 @@ impl<MS: BrokerReadWriteStore> LiteManagerProcessor<MS> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::sync::Arc;
 
     use crate::config::broker_config::BrokerConfig;
     use cheetah_string::CheetahString;
+    use rocketmq_protocol::code::request_code::RequestCode;
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::header::empty_header::EmptyHeader;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
     use rocketmq_store::MessageStoreConfig;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::HandlerOutcome;
+    use rocketmq_transport::api::v2::RemotingRequest;
+    use rocketmq_transport::api::v2::RequestProcessorV2;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
 
+    use super::LiteManagerContext;
     use super::LiteManagerOffsetCapability;
     use super::LiteManagerPolicy;
+    use super::LiteManagerProcessor;
     use super::LiteManagerStoreCapability;
+    use crate::broker_runtime::BrokerMessageStore;
     use crate::broker_runtime::BrokerRuntime;
     use crate::lite::lite_lifecycle_manager::LiteLifecycleManager;
+    use crate::lite::lite_sharding::LiteShardingView;
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    #[derive(Clone)]
+    struct SharedLiteManagerProcessor {
+        inner: Arc<tokio::sync::Mutex<LiteManagerProcessor<BrokerMessageStore>>>,
+    }
+
+    impl RequestProcessorV2 for SharedLiteManagerProcessor {
+        async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+            self.inner.lock().await.process(request).await
+        }
+    }
+
+    fn temp_test_root(label: &str) -> PathBuf {
+        let unique = format!(
+            "rocketmq-broker-lite-manager-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time before unix epoch")
+                .as_nanos()
+        );
+        std::env::temp_dir().join(unique)
+    }
+
+    async fn new_test_runtime(label: &str) -> BrokerRuntime {
+        let temp_root = temp_test_root(label);
+        let broker_config = Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        });
+        let message_store_config = Arc::new(MessageStoreConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        });
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        assert!(runtime.initialize().await.is_ok());
+        runtime
+    }
+
+    fn lite_manager_processor_for_test(runtime: &mut BrokerRuntime) -> LiteManagerProcessor<BrokerMessageStore> {
+        let inner = runtime.runtime_state_mut();
+        let consumer_offset_manager = inner.consumer_offset_manager_handle();
+        let escape_bridge = inner.escape_bridge();
+        let pop_lite_message_processor = inner
+            .pop_lite_message_processor()
+            .map(Arc::downgrade)
+            .unwrap_or_default();
+        LiteManagerProcessor::new(LiteManagerContext::new(
+            LiteManagerPolicy::from_configs(&inner.broker_config(), &inner.message_store_config()),
+            inner.topic_config_manager_handle(),
+            inner.subscription_group_manager().clone(),
+            inner.lite_subscription_registry().clone(),
+            inner.lite_event_dispatcher().clone(),
+            inner.lite_lifecycle_manager().clone(),
+            LiteShardingView::new(
+                inner.broker_config().broker_name().clone(),
+                inner.topic_route_info_manager(),
+            ),
+            LiteManagerOffsetCapability::new(&consumer_offset_manager),
+            LiteManagerStoreCapability::new(&escape_bridge),
+            pop_lite_message_processor,
+        ))
+    }
+
+    async fn dispatch_v2(
+        processor: LiteManagerProcessor<BrokerMessageStore>,
+        command: RemotingCommand,
+    ) -> EmbeddedDispatchOutcome {
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            SharedLiteManagerProcessor {
+                inner: Arc::new(tokio::sync::Mutex::new(processor)),
+            },
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            crate::test_task_group("lite-manager-v2"),
+            Principal::new("lite-manager-v2-test"),
+        )
+        .dispatch(None, command)
+        .await
+        .expect("Lite manager V2 dispatch should complete")
+    }
 
     #[test]
     fn lite_manager_policy_captures_only_required_startup_values() {
@@ -983,6 +1110,23 @@ mod tests {
         assert_eq!(policy.broker_name, *broker_config.broker_name());
         assert_eq!(policy.max_client_event_count, 17);
         assert_eq!(policy.dispatch_delay_millis, 29);
+    }
+
+    #[tokio::test]
+    async fn lite_manager_v2_returns_broker_info_as_an_owned_body_plan() {
+        let mut runtime = new_test_runtime("v2-broker-info").await;
+        let processor = lite_manager_processor_for_test(&mut runtime);
+        let request =
+            RemotingCommand::create_request_command(RequestCode::GetBrokerLiteInfo, EmptyHeader {}).set_opaque(8_808);
+
+        let EmbeddedDispatchOutcome::Reply(plan) = dispatch_v2(processor, request).await else {
+            panic!("Lite manager V2 must return an inline response plan");
+        };
+
+        assert_eq!(ResponseCode::from(plan.response_code()), ResponseCode::Success);
+        assert!(plan.body_len() > 0);
+        assert_eq!(plan.body_part_count(), 1);
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
+++ b/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
@@ -29,9 +29,9 @@ use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use rocketmq_store::BrokerStorePort;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use tracing::warn;
 
 use crate::lite::lite_event_dispatcher::LiteEventDispatcher;
@@ -108,10 +108,16 @@ impl<MS: BrokerStorePort> LiteSubscriptionCtlProcessor<MS> {
 }
 
 impl<MS: BrokerStorePort> LiteSubscriptionCtlProcessor<MS> {
-    pub(crate) async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.process_command(request).await
+    }
+
+    /// V2 leaf business contract; the subscription registry retains no raw session handle.
+    async fn process_command(
+        &self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let body = match request.body() {
@@ -181,7 +187,6 @@ impl<MS: BrokerStorePort> LiteSubscriptionCtlProcessor<MS> {
                     {
                         return Ok(Some(self.response_with_code(request, code, remark)));
                     }
-                    registry.update_client_channel(entry.client_id(), channel.clone());
                     self.context.event_dispatcher.touch_client(entry.client_id());
                     let removed_lmq_names = if group_config.lite_sub_exclusive() {
                         self.exclude_conflicting_subscriptions(
@@ -249,7 +254,6 @@ impl<MS: BrokerStorePort> LiteSubscriptionCtlProcessor<MS> {
                         Ok(group_config) => group_config,
                         Err((code, remark)) => return Ok(Some(self.response_with_code(request, code, remark))),
                     };
-                    registry.update_client_channel(entry.client_id(), channel.clone());
                     self.context.event_dispatcher.touch_client(entry.client_id());
                     registry.add_complete_subscription(
                         entry.client_id(),
@@ -275,14 +279,17 @@ impl<MS: BrokerStorePort> LiteSubscriptionCtlProcessor<MS> {
     }
 }
 
-impl<MS: BrokerStorePort> RequestProcessor for LiteSubscriptionCtlProcessor<MS> {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_shared(channel, ctx, request).await
+impl<MS: BrokerStorePort + 'static> RequestProcessorV2 for LiteSubscriptionCtlProcessor<MS> {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let command_factory = self.context.command_factory;
+        let result = self.process_command(request.command_mut()).await;
+        crate::processor::response_plan::immediate_outcome_from_command_result(
+            &command_factory,
+            result,
+            original_opaque,
+            "LiteSubscriptionCtlProcessor V2 command dispatch completed without a response",
+        )
     }
 }
 
@@ -483,11 +490,19 @@ mod tests {
     use rocketmq_protocol::protocol::body::lite_subscription_ctl_request_body::LiteSubscriptionCtlRequestBody;
     use rocketmq_protocol::protocol::header::empty_header::EmptyHeader;
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
     use rocketmq_store::MessageStoreConfig;
-    use rocketmq_transport::api::v1::Channel;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
-    use rocketmq_transport::api::v1::RequestProcessor;
-    use rocketmq_transport::test_support::Connection;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::HandlerOutcome;
+    use rocketmq_transport::api::v2::RemotingRequest;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
 
     use super::LiteSubscriptionCtlContext;
     use super::LiteSubscriptionCtlPolicy;
@@ -496,6 +511,26 @@ mod tests {
     use crate::broker_runtime::BrokerRuntime;
     use crate::processor::pop_lite_message_processor::PopLiteMessageStoreCapability;
     use crate::processor::pop_lite_message_processor::PopLiteOffsetCapability;
+    use rocketmq_transport::api::v2::RequestProcessorV2;
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    #[derive(Clone)]
+    struct SharedLiteSubscriptionProcessor {
+        inner: Arc<tokio::sync::Mutex<LiteSubscriptionCtlProcessor<BrokerMessageStore>>>,
+    }
+
+    impl RequestProcessorV2 for SharedLiteSubscriptionProcessor {
+        async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+            self.inner.lock().await.process(request).await
+        }
+    }
 
     fn temp_test_root(label: &str) -> std::path::PathBuf {
         let millis = SystemTime::now()
@@ -550,18 +585,29 @@ mod tests {
         ))
     }
 
-    async fn create_test_channel() -> Channel {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
-        let local_addr = listener.local_addr().expect("local listener addr");
-        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
-        std_stream.set_nonblocking(true).expect("set nonblocking");
-        drop(listener);
-        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
-        let connection = Connection::new(tcp_stream);
-        rocketmq_transport::test_support::TestChannelBuilder::new(connection, crate::test_task_group("channel"))
-            .addresses(local_addr, local_addr)
-            .build()
-            .expect("build test channel")
+    async fn dispatch_v2(
+        processor: LiteSubscriptionCtlProcessor<BrokerMessageStore>,
+        command: RemotingCommand,
+    ) -> EmbeddedDispatchOutcome {
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            SharedLiteSubscriptionProcessor {
+                inner: Arc::new(tokio::sync::Mutex::new(processor)),
+            },
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            crate::test_task_group("lite-subscription-v2"),
+            Principal::new("lite-subscription-v2-test"),
+        )
+        .dispatch(None, command)
+        .await
+        .expect("Lite subscription V2 dispatch should complete")
     }
 
     fn seed_group_config(runtime: &mut BrokerRuntime, group: &str, attributes: HashMap<CheetahString, CheetahString>) {
@@ -586,6 +632,22 @@ mod tests {
         let policy = LiteSubscriptionCtlPolicy::from_config(&broker_config);
 
         assert_eq!(policy.max_lite_subscription_count, 37);
+    }
+
+    #[tokio::test]
+    async fn lite_subscription_v2_returns_illegal_operation_for_a_missing_body() {
+        let mut runtime = new_test_runtime("v2-missing-body").await;
+        let processor = lite_subscription_processor_for_test(&mut runtime);
+        let request =
+            RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {}).set_opaque(7_707);
+
+        let EmbeddedDispatchOutcome::Reply(plan) = dispatch_v2(processor, request).await else {
+            panic!("Lite subscription V2 must return an inline response plan");
+        };
+
+        assert_eq!(ResponseCode::from(plan.response_code()), ResponseCode::IllegalOperation);
+        assert_eq!(plan.body_len(), 0);
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 
     #[test]
@@ -644,11 +706,9 @@ mod tests {
         let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
             .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
-        let mut processor = lite_subscription_processor_for_test(&mut runtime);
+        let processor = lite_subscription_processor_for_test(&mut runtime);
         let response = processor
-            .process_request(channel, ctx, &mut request)
+            .process_command(&mut request)
             .await
             .expect("processor request should succeed")
             .expect("processor should return a response");
@@ -695,12 +755,10 @@ mod tests {
             .with_lite_topic_set(HashSet::from([CheetahString::from_static_str("child-a")]))]);
         let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
             .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
-        let channel = create_test_channel().await;
-        let ctx = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
-        let mut processor = lite_subscription_processor_for_test(&mut runtime);
+        let processor = lite_subscription_processor_for_test(&mut runtime);
 
         let response = processor
-            .process_request(channel, ctx, &mut request)
+            .process_command(&mut request)
             .await
             .expect("processor request")
             .expect("response");
@@ -737,11 +795,9 @@ mod tests {
         let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
             .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
-        let mut processor = lite_subscription_processor_for_test(&mut runtime);
+        let processor = lite_subscription_processor_for_test(&mut runtime);
         let response = processor
-            .process_request(channel.clone(), ctx.clone(), &mut request)
+            .process_command(&mut request)
             .await
             .expect("processor request should succeed")
             .expect("processor should return a response");
@@ -762,7 +818,7 @@ mod tests {
             );
 
         let stale_response = processor
-            .process_request(channel, ctx, &mut stale_request)
+            .process_command(&mut stale_request)
             .await
             .expect("processor stale request should succeed")
             .expect("processor should return a response");
@@ -819,11 +875,9 @@ mod tests {
         let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
             .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
-        let mut processor = lite_subscription_processor_for_test(&mut runtime);
+        let processor = lite_subscription_processor_for_test(&mut runtime);
         let response = processor
-            .process_request(channel, ctx, &mut request)
+            .process_command(&mut request)
             .await
             .expect("processor request should succeed")
             .expect("processor should return a response");
@@ -861,11 +915,9 @@ mod tests {
         let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
             .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
-        let mut processor = lite_subscription_processor_for_test(&mut runtime);
+        let processor = lite_subscription_processor_for_test(&mut runtime);
         let response = processor
-            .process_request(channel, ctx, &mut request)
+            .process_command(&mut request)
             .await
             .expect("processor request should succeed")
             .expect("processor should return a response");
@@ -920,11 +972,9 @@ mod tests {
         let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
             .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
-        let mut processor = lite_subscription_processor_for_test(&mut runtime);
+        let processor = lite_subscription_processor_for_test(&mut runtime);
         let response = processor
-            .process_request(channel, ctx, &mut request)
+            .process_command(&mut request)
             .await
             .expect("processor request should succeed")
             .expect("processor should return a response");
@@ -983,11 +1033,9 @@ mod tests {
         let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
             .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
-        let mut processor = lite_subscription_processor_for_test(&mut runtime);
+        let processor = lite_subscription_processor_for_test(&mut runtime);
         let response = processor
-            .process_request(channel, ctx, &mut request)
+            .process_command(&mut request)
             .await
             .expect("processor request should succeed")
             .expect("processor should return a response");

--- a/rocketmq-broker/src/processor/maintenance_request_processor.rs
+++ b/rocketmq-broker/src/processor/maintenance_request_processor.rs
@@ -50,12 +50,15 @@ use rocketmq_store_api::checkpoint::CheckpointStorageIdentity;
 use rocketmq_store_api::ReleaseCheckpointStore;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_and_remark;
 use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 
 use crate::config::broker_config::BrokerConfig;
+use crate::processor::response_plan::immediate_outcome_from_command_result;
 
 /// Broker endpoint for release-checkpoint operations.
+#[derive(Clone)]
 pub struct MaintenanceRequestProcessor {
     command_factory: RemotingCommandFactory,
     broker_config: Arc<BrokerConfig>,
@@ -96,43 +99,51 @@ impl MaintenanceRequestProcessor {
         }
     }
 
-    pub(crate) async fn process_request_shared(
+    pub(crate) fn legacy_adapter(&self) -> LegacyMaintenanceRequestProcessor {
+        LegacyMaintenanceRequestProcessor {
+            processor: self.clone(),
+        }
+    }
+
+    async fn process_authorized(
         &self,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        grant: &MaintenanceAuthorizationGrant,
         request: &mut RemotingCommand,
-    ) -> RocketMQResult<Option<RemotingCommand>> {
-        let grant = self.authorize(&channel, request).await?;
+    ) -> RocketMQResult<RemotingCommand> {
         let response = match RequestCode::from(request.code()) {
-            RequestCode::MaintenanceGetCapabilities => self.capabilities(&grant).await?,
-            RequestCode::MaintenanceCreateStoreCheckpoint => self.create_store_checkpoint(&grant, request).await?,
+            RequestCode::MaintenanceGetCapabilities => self.capabilities(grant).await?,
+            RequestCode::MaintenanceCreateStoreCheckpoint => self.create_store_checkpoint(grant, request).await?,
             RequestCode::MaintenanceVerifyCheckpoint => self.verify_store_checkpoint(request)?,
-            RequestCode::MaintenanceRestoreVerify => self.restore_verify(&grant, request).await?,
+            RequestCode::MaintenanceRestoreVerify => self.restore_verify(grant, request).await?,
             _ => {
-                return Ok(Some(request_code_not_supported_with_factory_and_remark(
+                return Ok(request_code_not_supported_with_factory_and_remark(
                     &self.command_factory,
                     request.code(),
                     format!("request type {} is not a Broker maintenance operation", request.code()),
-                )));
+                ));
             }
         };
-        Ok(Some(response.set_opaque(request.opaque())))
+        Ok(response.set_opaque(request.opaque()))
     }
 
-    async fn authorize(
-        &self,
-        channel: &Channel,
-        request: &RemotingCommand,
-    ) -> RocketMQResult<MaintenanceAuthorizationGrant> {
+    fn authorize_v2(&self, request: &RemotingRequest) -> RocketMQResult<MaintenanceAuthorizationGrant> {
         if !self.broker_config.maintenance_enabled {
             return Err(RocketMQError::authentication_failed(
                 "Broker maintenance API is disabled",
             ));
         }
-        let principal = self
-            .auth_runtime
-            .authenticate_maintenance_principal(request, Some(channel.channel_id()))
-            .await?;
+        let principal = request
+            .authentication()
+            .principal()
+            .ok_or_else(|| RocketMQError::authentication_failed("maintenance request is anonymous"))?;
+        self.authorize_principal(principal.id(), request.command())
+    }
+
+    fn authorize_principal(
+        &self,
+        principal: &str,
+        request: &RemotingCommand,
+    ) -> RocketMQResult<MaintenanceAuthorizationGrant> {
         let header = request
             .decode_command_custom_header::<MaintenanceRequestHeader>()
             .map_err(|source| RocketMQError::request_header_source("decode privileged maintenance header", source))?;
@@ -248,14 +259,44 @@ impl MaintenanceRequestProcessor {
     }
 }
 
-impl RequestProcessor for MaintenanceRequestProcessor {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+pub(crate) struct LegacyMaintenanceRequestProcessor {
+    processor: MaintenanceRequestProcessor,
+}
+
+impl LegacyMaintenanceRequestProcessor {
+    pub(crate) async fn process_legacy(
+        &self,
+        channel: &Channel,
         request: &mut RemotingCommand,
     ) -> RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_shared(channel, ctx, request).await
+        if !self.processor.broker_config.maintenance_enabled {
+            return Err(RocketMQError::authentication_failed(
+                "Broker maintenance API is disabled",
+            ));
+        }
+        let principal = self
+            .processor
+            .auth_runtime
+            .authenticate_maintenance_principal(request, Some(channel.channel_id()))
+            .await?;
+        let grant = self.processor.authorize_principal(principal.as_str(), request)?;
+        self.processor.process_authorized(&grant, request).await.map(Some)
+    }
+}
+
+impl RequestProcessorV2 for MaintenanceRequestProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let result = match self.authorize_v2(request) {
+            Ok(grant) => self.process_authorized(&grant, request.command_mut()).await.map(Some),
+            Err(error) => Err(error),
+        };
+        immediate_outcome_from_command_result(
+            &self.command_factory,
+            result,
+            original_opaque,
+            "maintenance processor returned no response",
+        )
     }
 }
 
@@ -406,7 +447,117 @@ fn checkpoint_verification_to_wire(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+    use std::sync::Weak;
+
+    use rocketmq_auth::AuthConfig;
+    use rocketmq_auth::AuthRuntimeBuilder;
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::MaintenancePolicy;
+    use rocketmq_security_api::MaintenancePrincipalBinding;
+    use rocketmq_security_api::MaintenanceResourceBudget;
+    use rocketmq_security_api::MaintenanceRole;
+    use rocketmq_security_api::MaintenanceRoleGrant;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
+    use rocketmq_security_api::MAINTENANCE_POLICY_SCHEMA_VERSION;
+    use rocketmq_store::StorePorts;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
     use super::*;
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    fn maintenance_policy() -> MaintenancePolicy {
+        MaintenancePolicy {
+            schema_version: MAINTENANCE_POLICY_SCHEMA_VERSION,
+            policy_id: "broker-maintenance-v2-test".to_string(),
+            policy_version: 7,
+            require_authentication: true,
+            require_authorization: true,
+            require_fencing_token: true,
+            max_request_lifetime_millis: 30_000,
+            resource_budget: MaintenanceResourceBudget {
+                max_checkpoint_bytes: 4_096,
+                max_store_members: 1,
+                max_concurrent_operations: 1,
+            },
+            principal_bindings: vec![MaintenancePrincipalBinding {
+                principal: "release-operator".to_string(),
+                roles: BTreeSet::from([MaintenanceRole::ReleaseOperator]),
+            }],
+            role_grants: vec![MaintenanceRoleGrant {
+                role: MaintenanceRole::ReleaseOperator,
+                capabilities: BTreeSet::from([MaintenanceCapability::ReleaseCheckpoint]),
+            }],
+        }
+    }
+
+    async fn maintenance_processor_for_test() -> MaintenanceRequestProcessor {
+        let service_context = crate::test_service_context("maintenance-v2");
+        let auth_runtime = Arc::new(
+            AuthRuntimeBuilder::new(AuthConfig::default(), service_context.component("auth"))
+                .build()
+                .await
+                .expect("build maintenance auth runtime"),
+        );
+        let authorizer = Arc::new(MaintenanceAuthorizer::new(
+            maintenance_policy().into_validated().expect("valid maintenance policy"),
+        ));
+        let checkpoint_service = Arc::new(StoreReleaseCheckpointService::new(
+            Weak::<StorePorts>::new(),
+            PathBuf::from("maintenance-v2-unused"),
+            service_context.component("checkpoint"),
+        ));
+        MaintenanceRequestProcessor::new(
+            Arc::new(BrokerConfig {
+                maintenance_enabled: true,
+                authentication_enabled: true,
+                authorization_enabled: true,
+                ..BrokerConfig::default()
+            }),
+            auth_runtime,
+            authorizer,
+            checkpoint_service,
+        )
+    }
+
+    async fn dispatch_v2(
+        processor: MaintenanceRequestProcessor,
+        principal: &'static str,
+        command: RemotingCommand,
+    ) -> Result<EmbeddedDispatchOutcome, rocketmq_transport::api::v2::EmbeddedDispatchError> {
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            processor,
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            crate::test_task_group("maintenance-request-v2"),
+            Principal::new(principal),
+        )
+        .dispatch(None, command)
+        .await
+    }
 
     fn wire_manifest(backend: ReleaseCheckpointBackend) -> StoreReleaseCheckpointManifest {
         StoreReleaseCheckpointManifest {
@@ -436,6 +587,48 @@ mod tests {
             wal_retained: true,
             persistent_volume_retained: true,
         }
+    }
+
+    fn verify_request(opaque: i32) -> RemotingCommand {
+        let deadline_unix_millis = rocketmq_runtime::common::time_utils::current_millis() + 20_000;
+        RemotingCommand::create_request_command(
+            RequestCode::MaintenanceVerifyCheckpoint,
+            MaintenanceRequestHeader {
+                operation_id: "verify-checkpoint-7".into(),
+                policy_version: 7,
+                deadline_unix_millis,
+                fencing_token: 42,
+            },
+        )
+        .set_body(
+            serde_json::to_vec(&wire_manifest(ReleaseCheckpointBackend::Local))
+                .expect("serialize maintenance manifest"),
+        )
+        .set_opaque(opaque)
+    }
+
+    #[tokio::test]
+    async fn maintenance_v2_uses_authenticated_principal_for_authorization() {
+        let processor = maintenance_processor_for_test().await;
+
+        let EmbeddedDispatchOutcome::Reply(plan) =
+            dispatch_v2(processor.clone(), "release-operator", verify_request(5_505))
+                .await
+                .expect("bound maintenance principal should be authorized")
+        else {
+            panic!("authorized maintenance V2 must return an inline response plan");
+        };
+        assert_eq!(ResponseCode::from(plan.response_code()), ResponseCode::Success);
+        assert!(plan.body_len() > 0);
+
+        let EmbeddedDispatchOutcome::Reply(denied) = dispatch_v2(processor, "ordinary-admin", verify_request(5_506))
+            .await
+            .expect("authorization failures should become typed response plans")
+        else {
+            panic!("denied maintenance V2 must return an inline response plan");
+        };
+        assert_eq!(ResponseCode::from(denied.response_code()), ResponseCode::NoPermission);
+        assert_eq!(denied.body_len(), 0);
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/peek_message_processor.rs
+++ b/rocketmq-broker/src/processor/peek_message_processor.rs
@@ -36,9 +36,10 @@ use rocketmq_store::BrokerStatsManager;
 use rocketmq_store::GetMessageResult;
 use rocketmq_store::GetMessageStatus;
 use rocketmq_transport::api::v1::command_from_error_with_factory_remark_and_opaque;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use tracing::error;
 use tracing::warn;
 
@@ -198,33 +199,43 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
     }
 }
 
-impl<MS: BrokerReadWriteStore> RequestProcessor for PeekMessageProcessor<MS> {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_internal(channel, ctx, request, true).await
+impl<MS: BrokerReadWriteStore + 'static> RequestProcessorV2 for PeekMessageProcessor<MS> {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let command_factory = self.context.command_factory;
+        let request_source = request_origin_label(request.origin());
+        let result = self.process_command(request.command_mut(), &request_source).await;
+        crate::processor::response_plan::immediate_outcome_from_command_result(
+            &command_factory,
+            result,
+            original_opaque,
+            "PeekMessageProcessor V2 command dispatch completed without a response",
+        )
+    }
+}
+
+fn request_origin_label(origin: &RequestOrigin) -> String {
+    match origin {
+        RequestOrigin::Network { peer } => peer.address().to_string(),
+        RequestOrigin::Embedded { .. } => "embedded".to_owned(),
+        _ => "unrecognized-origin".to_owned(),
     }
 }
 
 impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
-    pub async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        request_source: String,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_internal(channel, ctx, request, true).await
+        self.process_command(request, &request_source).await
     }
 
-    async fn process_request_internal(
+    /// V2 leaf business contract; the typed origin is reduced to a diagnostic source label.
+    async fn process_command(
         &self,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
-        _broker_allow_suspend: bool,
+        request_source: &str,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let begin_time_mills = self.context.message_store.now();
 
@@ -240,8 +251,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
             Err(e) => {
                 error!(
                     "Failed to decode PeekMessageRequestHeader: {:?}, channel: {}",
-                    e,
-                    channel.remote_address()
+                    e, request_source
                 );
                 let remark = format!("decode request header failed: {:?}", e);
                 let error = RocketMQError::request_header_error(remark.clone());
@@ -270,8 +280,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
         if topic_config.is_none() {
             error!(
                 "The topic {} not exist, consumer: {}",
-                request_header.topic,
-                channel.remote_address()
+                request_header.topic, request_source
             );
             let response = response.set_code(ResponseCode::TopicNotExist).set_remark(format!(
                 "topic[{}] not exist, apply first please! {}",
@@ -294,10 +303,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
         if request_header.queue_id >= topic_config.read_queue_nums as i32 {
             let error_info = format!(
                 "queueId[{}] is illegal, topic:[{}] topicConfig.readQueueNums:[{}] consumer:[{}]",
-                request_header.queue_id,
-                request_header.topic,
-                topic_config.read_queue_nums,
-                channel.remote_address()
+                request_header.queue_id, request_header.topic, topic_config.read_queue_nums, request_source
             );
             warn!("{}", error_info);
             let response = response.set_code(ResponseCode::SystemError).set_remark(error_info);
@@ -342,14 +348,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
 
         if need_retry {
             rest_num = self
-                .peek_retry_topic(
-                    &request_header,
-                    &mut get_message_result,
-                    random_q,
-                    revive_qid,
-                    &channel,
-                    pop_time,
-                )
+                .peek_retry_topic(&request_header, &mut get_message_result, random_q, revive_qid, pop_time)
                 .await;
         }
 
@@ -364,7 +363,6 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
                         queue_id,
                         rest_num,
                         revive_qid,
-                        &channel,
                         pop_time,
                     )
                     .await;
@@ -378,7 +376,6 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
                     request_header.queue_id,
                     rest_num,
                     revive_qid,
-                    &channel,
                     pop_time,
                 )
                 .await;
@@ -386,14 +383,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
 
         if !need_retry && get_message_result.message_mapped_list().len() < request_header.max_msg_nums as usize {
             rest_num = self
-                .peek_retry_topic(
-                    &request_header,
-                    &mut get_message_result,
-                    random_q,
-                    revive_qid,
-                    &channel,
-                    pop_time,
-                )
+                .peek_retry_topic(&request_header, &mut get_message_result, random_q, revive_qid, pop_time)
                 .await;
         }
 
@@ -478,7 +468,6 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
         get_message_result: &mut GetMessageResult,
         random_q: u32,
         revive_qid: i32,
-        channel: &Channel,
         pop_time: i64,
     ) -> i64 {
         let mut rest_num = 0i64;
@@ -499,7 +488,6 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
                             queue_id,
                             rest_num,
                             revive_qid,
-                            channel,
                             pop_time,
                         )
                         .await;
@@ -521,7 +509,6 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
         queue_id: i32,
         mut rest_num: i64,
         _revive_qid: i32,
-        _channel: &Channel,
         _pop_time: i64,
     ) -> i64 {
         // Determine topic (retry or normal)
@@ -647,8 +634,149 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use rocketmq_error::RocketMQResult;
+    use rocketmq_protocol::code::request_code::RequestCode;
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
+    use rocketmq_store::MessageStoreConfig;
+    use rocketmq_store::StateMachineVersionView;
     use rocketmq_store::StorePorts;
+    use rocketmq_store::StoreRuntimeConfig;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchError;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::ResponseBodyKind;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+    use crate::offset::manager::consumer_offset_manager::ConsumerOffsetManager;
+    use crate::subscription::manager::subscription_group_manager::SubscriptionGroupManager;
+    use crate::subscription::manager::subscription_group_manager::SubscriptionGroupManagerConfig;
+
+    struct TestLeafProcessor<P> {
+        processor: Arc<tokio::sync::Mutex<P>>,
+    }
+
+    impl<P> Clone for TestLeafProcessor<P> {
+        fn clone(&self) -> Self {
+            Self {
+                processor: Arc::clone(&self.processor),
+            }
+        }
+    }
+
+    impl<P> TestLeafProcessor<P> {
+        fn new(processor: P) -> Self {
+            Self {
+                processor: Arc::new(tokio::sync::Mutex::new(processor)),
+            }
+        }
+    }
+
+    impl<P> RequestProcessorV2 for TestLeafProcessor<P>
+    where
+        P: RequestProcessorV2 + Send,
+    {
+        async fn process(&mut self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+            self.processor.lock().await.process(request).await
+        }
+    }
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    async fn dispatch_embedded_v2<P>(
+        processor: P,
+        command: RemotingCommand,
+    ) -> Result<EmbeddedDispatchOutcome, EmbeddedDispatchError>
+    where
+        P: RequestProcessorV2 + Send + 'static,
+    {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("peek-message-v2-test"))
+            .expect("PeekMessage V2 test runtime");
+        let context = owner.root_context().component("peek-message-v2-test.request");
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            TestLeafProcessor::new(processor),
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            context.task_group().clone(),
+            Principal::new("peek-message-v2-test"),
+        );
+        let outcome = harness.dispatch(None, command).await;
+
+        drop(harness);
+        drop(context);
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
+        outcome
+    }
+
+    fn v2_test_processor() -> PeekMessageProcessor<StorePorts> {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let topic_config_manager = Arc::new(TopicConfigManager::new(
+            broker_config.as_ref(),
+            message_store_config.as_ref(),
+            true,
+            None,
+        ));
+        let subscription_group_manager = SubscriptionGroupManager::new(
+            SubscriptionGroupManagerConfig::from_configs(broker_config.as_ref(), message_store_config.as_ref()),
+            StateMachineVersionView::default(),
+            None,
+        );
+        let consumer_offset_manager = Arc::new(ConsumerOffsetManager::new(
+            Arc::clone(&broker_config),
+            Arc::clone(&message_store_config),
+        ));
+        let stats_context = crate::test_service_context("peek-message-v2-stats");
+        let broker_stats_manager = Arc::new(BrokerStatsManager::new(
+            Arc::new(StoreRuntimeConfig::default()),
+            stats_context.task_group().clone(),
+        ));
+        let context = PeekMessageProcessorContext::new(
+            PeekMessagePolicy::from_config(broker_config.as_ref()),
+            PopPolicyState::from_configs(
+                broker_config.as_ref(),
+                message_store_config.as_ref(),
+                "127.0.0.1:10911".parse().expect("valid store host"),
+            ),
+            topic_config_manager,
+            subscription_group_manager.config_lookup(),
+            consumer_offset_manager.query_capability(),
+            broker_stats_manager,
+            PeekMessageStoreCapability {
+                escape_bridge: Weak::new(),
+            },
+            PeekPopOffsetCapability {
+                merge_service: Weak::new(),
+            },
+        );
+        PeekMessageProcessor::new(context)
+    }
 
     #[test]
     fn peek_policy_captures_only_required_startup_values() {
@@ -710,5 +838,21 @@ mod tests {
         assert!(source.contains("Weak<EscapeBridge<MS>>"));
         assert!(source.contains("Weak<PopBufferMergeService<MS>>"));
         assert!(source.contains("ConsumerOffsetQueryCapability<MS>"));
+    }
+
+    #[tokio::test]
+    async fn v2_embedded_header_error_returns_a_reply_plan() {
+        let outcome = dispatch_embedded_v2(
+            v2_test_processor(),
+            RemotingCommand::create_remoting_command(RequestCode::PeekMessage).set_opaque(319),
+        )
+        .await
+        .expect("embedded PeekMessage V2 response");
+        let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+            panic!("PeekMessage V2 header error must return a reply plan");
+        };
+
+        assert_eq!(plan.response_code(), ResponseCode::InvalidParameter as i32);
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Empty);
     }
 }

--- a/rocketmq-broker/src/processor/polling_info_processor.rs
+++ b/rocketmq-broker/src/processor/polling_info_processor.rs
@@ -24,9 +24,10 @@ use rocketmq_protocol::protocol::header::polling_info_response_header::PollingIn
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use tracing::error;
 use tracing::warn;
 
@@ -98,31 +99,35 @@ impl Clone for PollingInfoProcessor {
     }
 }
 
-impl RequestProcessor for PollingInfoProcessor {
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_internal(channel, request).await
+impl RequestProcessorV2 for PollingInfoProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let command_factory = self.command_factory;
+        let peer_label = request_peer_label(request.origin());
+        let result = self.process_command(&peer_label, request.command_mut()).await;
+        crate::processor::response_plan::immediate_outcome_from_command_result(
+            &command_factory,
+            result,
+            original_opaque,
+            "PollingInfoProcessor V2 command dispatch completed without a response",
+        )
     }
 }
 
 impl PollingInfoProcessor {
-    pub async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        peer_label: String,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut processor = self.clone();
-        processor.process_request(channel, ctx, request).await
+        processor.process_command(&peer_label, request).await
     }
 
-    async fn process_request_internal(
+    /// V2 leaf business contract; the trusted peer label is diagnostic metadata only.
+    async fn process_command(
         &mut self,
-        channel: Channel,
+        peer_label: &str,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut response = self.command_factory.create_java_default_error_response_command();
@@ -133,8 +138,7 @@ impl PollingInfoProcessor {
             .map_err(|e| {
                 error!(
                     "Failed to decode PollingInfoRequestHeader: {:?}, channel: {}",
-                    e,
-                    channel.remote_address()
+                    e, peer_label
                 );
                 e
             })?;
@@ -154,11 +158,7 @@ impl PollingInfoProcessor {
         let topic_config = self.topic_config_manager.select_topic_config(&request_header.topic);
 
         if topic_config.is_none() {
-            error!(
-                "The topic {} not exist, consumer: {}",
-                request_header.topic,
-                channel.remote_address()
-            );
+            error!("The topic {} not exist, consumer: {}", request_header.topic, peer_label);
             let response = response.set_code(ResponseCode::TopicNotExist).set_remark(format!(
                 "topic[{}] not exist, apply first please! {}",
                 request_header.topic, "https://rocketmq.apache.org/docs/bestPractice/06FAQ"
@@ -179,10 +179,7 @@ impl PollingInfoProcessor {
         if request_header.queue_id >= topic_config.read_queue_nums as i32 {
             let error_info = format!(
                 "queueId[{}] is illegal, topic:[{}] topicConfig.readQueueNums:[{}] consumer:[{}]",
-                request_header.queue_id,
-                request_header.topic,
-                topic_config.read_queue_nums,
-                channel.remote_address()
+                request_header.queue_id, request_header.topic, topic_config.read_queue_nums, peer_label
             );
             warn!("{}", error_info);
             let response = response.set_code(ResponseCode::SystemError).set_remark(error_info);
@@ -247,15 +244,48 @@ impl PollingInfoProcessor {
     }
 }
 
+fn request_peer_label(origin: &RequestOrigin) -> String {
+    match origin {
+        RequestOrigin::Network { peer } => peer.address().to_string(),
+        RequestOrigin::Embedded { .. } => "embedded".to_owned(),
+        _ => "unrecognized-origin".to_owned(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use crate::config::broker_config::BrokerConfig;
     use cheetah_string::CheetahString;
     use rocketmq_model::common::key_builder::KeyBuilder;
+    use rocketmq_protocol::code::request_code::RequestCode;
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+    use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+    use rocketmq_protocol::protocol::SerializeType;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
     use rocketmq_store::MessageStoreConfig;
     use rocketmq_store::StateMachineVersionView;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::ServerConfig;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::ResponseBodyKind;
+    use rocketmq_transport::api::v2::TransportServerV2;
+    use rocketmq_transport::test_support::Connection;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+    use tokio::net::TcpStream;
+    use tokio::sync::oneshot;
 
     use super::PollingCountProvider;
     use super::PollingInfoProcessor;
@@ -268,6 +298,54 @@ mod tests {
     impl PollingCountProvider for FixedPollingCount {
         fn polling_count(&self, _key: &str) -> i32 {
             self.0
+        }
+    }
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    struct EmbeddedV2Fixture {
+        owner: RuntimeOwner,
+        context: rocketmq_runtime::ChildServiceContext,
+        harness: EmbeddedRequestHarnessV2<PollingInfoProcessor>,
+    }
+
+    impl EmbeddedV2Fixture {
+        fn new(processor: PollingInfoProcessor) -> Self {
+            let owner = RuntimeOwner::new(RuntimeConfig::server_default("polling-info-v2-test"))
+                .expect("PollingInfo V2 test runtime");
+            let context = owner.root_context().component("polling-info-v2-test.request");
+            let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+                processor,
+                Vec::new(),
+                Arc::new(TransportSecurity::secure_enforced(
+                    Some(Arc::new(AllowEmbeddedPolicy)),
+                    None,
+                )),
+                Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            ));
+            let harness = EmbeddedRequestHarnessV2::new(
+                dispatcher,
+                context.task_group().clone(),
+                Principal::new("polling-info-v2-test"),
+            );
+            Self {
+                owner,
+                context,
+                harness,
+            }
+        }
+
+        async fn finish(self) {
+            drop(self.harness);
+            drop(self.context);
+            assert!(self.owner.shutdown_tasks().await.is_healthy());
+            assert!(self.owner.shutdown_background().is_healthy());
         }
     }
 
@@ -314,6 +392,101 @@ mod tests {
         assert_eq!(processor.get_polling_num("topic@group@0"), 7);
         drop(provider);
         assert_eq!(processor.get_polling_num("topic@group@0"), 0);
+    }
+
+    #[tokio::test]
+    async fn v2_embedded_header_error_is_an_empty_reply_plan() {
+        let provider: Arc<dyn PollingCountProvider> = Arc::new(FixedPollingCount(0));
+        let fixture = EmbeddedV2Fixture::new(test_processor(Arc::downgrade(&provider)));
+        let request = RemotingCommand::create_remoting_command(RequestCode::PollingInfo).set_opaque(711);
+
+        let outcome = fixture
+            .harness
+            .dispatch(None, request)
+            .await
+            .expect("embedded PollingInfo V2 header-error response");
+        let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+            panic!("PollingInfo V2 header error must return a reply plan");
+        };
+
+        assert_eq!(plan.response_code(), ResponseCode::SystemError as i32);
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Empty);
+        assert_eq!(plan.body_len(), 0);
+        fixture.finish().await;
+    }
+
+    #[tokio::test]
+    async fn v2_network_header_error_preserves_request_identity_and_wire_metadata() {
+        const ORIGINAL_OPAQUE: i32 = 9_013;
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("polling-info-v2-network-test"))
+            .expect("PollingInfo V2 network test runtime");
+        let server_context = owner.root_context().component("polling-info-v2-network-test.server");
+        let runner_context = owner.root_context().component("polling-info-v2-network-test.runner");
+        let factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(4_201, SerializeType::ROCKETMQ));
+        let provider: Arc<dyn PollingCountProvider> = Arc::new(FixedPollingCount(0));
+        let mut processor = test_processor(Arc::downgrade(&provider));
+        processor.command_factory = factory;
+        let server = TransportServerV2::new(
+            Arc::new(ServerConfig {
+                bind_address: "127.0.0.1".to_owned(),
+                listen_port: 0,
+                ..ServerConfig::default()
+            }),
+            server_context,
+            processor,
+        );
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let (startup_sender, startup_receiver) = oneshot::channel();
+        let (result_sender, result_receiver) = oneshot::channel();
+        runner_context
+            .spawn_service("polling-info-v2-server", async move {
+                let result = server
+                    .try_run_with_shutdown_report_and_startup(
+                        async move {
+                            let _ = shutdown_receiver.await;
+                        },
+                        startup_sender,
+                    )
+                    .await;
+                let _ = result_sender.send(result);
+            })
+            .expect("spawn PollingInfo V2 server");
+
+        let address = startup_receiver
+            .await
+            .expect("PollingInfo V2 startup channel")
+            .expect("PollingInfo V2 server startup");
+        let mut client = Connection::new(
+            TcpStream::connect(address)
+                .await
+                .expect("connect PollingInfo V2 client"),
+        );
+        let request = RemotingCommand::create_remoting_command(RequestCode::PollingInfo).set_opaque(ORIGINAL_OPAQUE);
+        let request_version = request.version();
+        let request_serialize_type = request.serialize_type();
+        assert_ne!(request_version, factory.defaults().version());
+        client.send_command(request).await.expect("send PollingInfo V2 request");
+
+        let response = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+            .await
+            .expect("PollingInfo V2 response deadline")
+            .expect("PollingInfo V2 connection remains open")
+            .expect("PollingInfo V2 response frame");
+        assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+        assert_eq!(response.code(), ResponseCode::SystemError as i32);
+        assert_eq!(response.version(), request_version);
+        assert_eq!(response.serialize_type(), request_serialize_type);
+
+        client.shutdown().await.expect("shutdown PollingInfo V2 client");
+        let _ = shutdown_sender.send(());
+        let report = tokio::time::timeout(Duration::from_secs(2), result_receiver)
+            .await
+            .expect("PollingInfo V2 shutdown deadline")
+            .expect("PollingInfo V2 shutdown result channel")
+            .expect("PollingInfo V2 shutdown report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -316,12 +316,22 @@ where
         }
     }
 
-    #[allow(dead_code, reason = "installed by the forthcoming V2 Pull composition root")]
     pub(crate) fn install_session_client_lookup(
         &self,
         lookup: Arc<dyn PullSessionClientLookup>,
     ) -> Result<(), Arc<dyn PullSessionClientLookup>> {
         self.session_client_lookup.set(lookup)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn session_client_id_for_test(
+        &self,
+        session_id: SessionId,
+        consumer_group: &CheetahString,
+    ) -> Option<CheetahString> {
+        self.session_client_lookup
+            .get()
+            .and_then(|lookup| lookup.client_id(session_id, consumer_group))
     }
 
     pub(crate) fn set_wakeup_task_group(&self, task_group: TaskGroup) {

--- a/rocketmq-broker/src/processor/query_assignment_processor.rs
+++ b/rocketmq-broker/src/processor/query_assignment_processor.rs
@@ -44,9 +44,10 @@ use rocketmq_runtime::MetadataDeadline;
 use rocketmq_runtime::MetadataIoActor;
 use rocketmq_store::MessageStoreConfig;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_and_opaque;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -75,18 +76,33 @@ pub struct QueryAssignmentProcessor {
     metadata_io: Option<MetadataIoActor>,
 }
 
-impl RequestProcessor for QueryAssignmentProcessor {
-    async fn process_request(
+impl RequestProcessorV2 for QueryAssignmentProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let command_factory = self.command_factory;
+        let peer_label = request_peer_label(request.origin());
+        let result = self.process_command(request.command_mut(), &peer_label).await;
+        crate::processor::response_plan::immediate_outcome_from_command_result(
+            &command_factory,
+            result,
+            original_opaque,
+            "QueryAssignmentProcessor V2 command dispatch completed without a response",
+        )
+    }
+}
+
+impl QueryAssignmentProcessor {
+    /// V2 leaf business contract; the peer label is retained only for diagnostics.
+    async fn process_command(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
+        peer_label: &str,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!("QueryAssignmentProcessor received request code: {:?}", request_code);
         match request_code {
             RequestCode::QueryAssignment | RequestCode::SetMessageRequestMode => {
-                self.process_request_inner(channel, ctx, request_code, request).await
+                self.process_command_inner(request_code, request, peer_label).await
             }
             _ => {
                 warn!(
@@ -103,9 +119,7 @@ impl RequestProcessor for QueryAssignmentProcessor {
             }
         }
     }
-}
 
-impl QueryAssignmentProcessor {
     pub(crate) fn new(
         broker_config: Arc<BrokerConfig>,
         message_store_config: Arc<MessageStoreConfig>,
@@ -176,14 +190,13 @@ impl QueryAssignmentProcessor {
         &self.message_request_mode_manager
     }
 
-    pub async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        peer_label: String,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut processor = self.clone();
-        processor.process_request(channel, ctx, request).await
+        processor.process_command(request, &peer_label).await
     }
 }
 
@@ -202,16 +215,15 @@ impl Clone for QueryAssignmentProcessor {
 }
 
 impl QueryAssignmentProcessor {
-    pub async fn process_request_inner(
+    async fn process_command_inner(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
         request_code: RequestCode,
         request: &mut RemotingCommand,
+        peer_label: &str,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match request_code {
-            RequestCode::QueryAssignment => self.query_assignment(channel, ctx, request).await,
-            RequestCode::SetMessageRequestMode => self.set_message_request_mode(channel, ctx, request).await,
+            RequestCode::QueryAssignment => self.query_assignment(request, peer_label).await,
+            RequestCode::SetMessageRequestMode => self.set_message_request_mode(request).await,
             _ => Ok(None),
         }
     }
@@ -223,8 +235,6 @@ impl QueryAssignmentProcessor {
     ///
     /// # Arguments
     ///
-    /// * `channel` - The network channel
-    /// * `_ctx` - Connection handler context (unused)
     /// * `request` - The remoting command containing QueryAssignmentRequestBody
     ///
     /// # Returns
@@ -232,9 +242,8 @@ impl QueryAssignmentProcessor {
     /// A RemotingCommand response containing QueryAssignmentResponseBody with assigned queues
     async fn query_assignment(
         &mut self,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
+        peer_label: &str,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         if request.get_body().is_none() {
             return Ok(Some(self.command_factory.create_response_command_with_code_remark(
@@ -309,7 +318,7 @@ impl QueryAssignmentProcessor {
                 request_body.message_model,
                 &request_body.strategy_name,
                 set_message_request_mode_request_body,
-                channel,
+                peer_label,
             )
             .await;
         let assignments = if let Some(message_queues) = message_queues {
@@ -362,7 +371,7 @@ impl QueryAssignmentProcessor {
     ///   balancing strategy.
     /// * `set_message_request_mode_request_body` - A `SetMessageRequestModeRequestBody` containing
     ///   the message request mode settings.
-    /// * `channel` - A `Channel` representing the network channel.
+    /// * `peer_label` - Trusted ingress metadata used only in diagnostics.
     ///
     /// # Returns
     ///
@@ -376,7 +385,7 @@ impl QueryAssignmentProcessor {
         message_model: MessageModel,
         strategy_name: &CheetahString,
         set_message_request_mode_request_body: SetMessageRequestModeRequestBody,
-        channel: Channel,
+        peer_label: &str,
     ) -> Option<HashSet<MessageQueue>> {
         match message_model {
             // handle broadcasting consumer, this mode returns all message queues
@@ -436,11 +445,7 @@ impl QueryAssignmentProcessor {
 
                 let strategy = self.load_strategy.get(strategy_name);
                 if strategy.is_none() {
-                    warn!(
-                        "QueryLoad: unsupported strategy [{}],  {}",
-                        strategy_name,
-                        channel.remote_address()
-                    );
+                    warn!("QueryLoad: unsupported strategy [{}],  {}", strategy_name, peer_label);
                     return None;
                 }
                 // Safe to unwrap here: already checked strategy.is_none() above
@@ -506,8 +511,6 @@ impl QueryAssignmentProcessor {
 
     async fn set_message_request_mode(
         &mut self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         if request.get_body().is_none() {
@@ -551,6 +554,14 @@ impl QueryAssignmentProcessor {
     }
 }
 
+fn request_peer_label(origin: &RequestOrigin) -> String {
+    match origin {
+        RequestOrigin::Network { peer } => peer.address().to_string(),
+        RequestOrigin::Embedded { .. } => "embedded".to_owned(),
+        _ => "unrecognized-origin".to_owned(),
+    }
+}
+
 fn allocate(
     consumer_group: &CheetahString,
     current_cid: &CheetahString,
@@ -589,15 +600,91 @@ fn allocate(
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use cheetah_string::CheetahString;
     use rocketmq_model::allocation::AllocateMessageQueueAveragely;
     use rocketmq_model::allocation::AllocateMessageQueueAveragelyByCircle;
     use rocketmq_model::allocation::AllocateMessageQueueStrategy;
     use rocketmq_model::common::message::message_queue::MessageQueue;
+    use rocketmq_protocol::code::request_code::RequestCode;
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
+    use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_protocol::protocol::RemotingSerializable;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
+    use rocketmq_store::MessageStoreConfig;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::ServerConfig;
+    use rocketmq_transport::api::v1::TransportClientConfig;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v1::TransportTelemetry;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::ResponseBodyKind;
+    use rocketmq_transport::api::v2::TransportServerV2;
+    use rocketmq_transport::test_support::Connection;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+    use tokio::net::TcpStream;
+    use tokio::sync::oneshot;
 
     use super::allocate;
+    use super::QueryAssignmentProcessor;
+    use crate::client::consumer_group_event::ConsumerGroupEvent;
+    use crate::client::consumer_ids_change_listener::ConsumerIdsChangeListener;
+    use crate::client::manager::consumer_manager::ConsumerManager;
+    use crate::config::broker_config::BrokerConfig;
+    use crate::out_api::broker_outer_api::BrokerOuterAPI;
+    use crate::topic::manager::topic_route_info_manager::TopicRouteInfoManager;
+
+    struct NoopConsumerListener;
+
+    impl ConsumerIdsChangeListener for NoopConsumerListener {
+        fn handle(&self, _event: ConsumerGroupEvent, _group: &str, _args: &[&dyn Any]) {}
+
+        fn shutdown(&self) {}
+    }
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    fn v2_test_processor(owner: &RuntimeOwner) -> QueryAssignmentProcessor {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let broker_outer_api = BrokerOuterAPI::new(
+            Arc::new(TransportClientConfig::default()),
+            owner.root_context().component("query-assignment-v2-test.outer-api"),
+            TransportTelemetry::noop(),
+        );
+        let topic_route_info_manager = TopicRouteInfoManager::new(broker_outer_api, 60_000, None);
+        topic_route_info_manager.topic_subscribe_info_table.insert(
+            CheetahString::from_static_str("v2-assignment-topic"),
+            [MessageQueue::from_parts("v2-assignment-topic", "broker-a", 0)]
+                .into_iter()
+                .collect(),
+        );
+        let consumer_assignment_view = ConsumerManager::new(Arc::new(NoopConsumerListener), 60_000).assignment_view();
+        QueryAssignmentProcessor::new(
+            broker_config,
+            message_store_config,
+            topic_route_info_manager,
+            consumer_assignment_view,
+        )
+    }
 
     #[test]
     fn allocate_returns_error_when_current_cid_is_empty() {
@@ -731,5 +818,178 @@ mod tests {
             .unwrap();
         // With round-robin, consumer1 should get queue 0 and 2
         assert_eq!(result.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn v2_embedded_unknown_request_returns_a_reply_plan() {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("query-assignment-v2-test"))
+            .expect("QueryAssignment V2 test runtime");
+        let context = owner.root_context().component("query-assignment-v2-test.request");
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            v2_test_processor(&owner),
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            context.task_group().clone(),
+            Principal::new("query-assignment-v2-test"),
+        );
+
+        let outcome = harness
+            .dispatch(None, RemotingCommand::create_remoting_command(-98_453).set_opaque(320))
+            .await
+            .expect("embedded QueryAssignment V2 response");
+        let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+            panic!("QueryAssignment V2 unknown request must return a reply plan");
+        };
+
+        assert_eq!(plan.response_code(), ResponseCode::RequestCodeNotSupported as i32);
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Empty);
+
+        drop(harness);
+        drop(context);
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
+    }
+
+    #[tokio::test]
+    async fn v2_embedded_query_success_returns_an_owned_body_plan() {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("query-assignment-v2-body-test"))
+            .expect("QueryAssignment V2 body test runtime");
+        let context = owner.root_context().component("query-assignment-v2-body-test.request");
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            v2_test_processor(&owner),
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            context.task_group().clone(),
+            Principal::new("query-assignment-v2-body-test"),
+        );
+        let body = QueryAssignmentRequestBody {
+            topic: CheetahString::from_static_str("v2-assignment-topic"),
+            consumer_group: CheetahString::from_static_str("v2-assignment-group"),
+            client_id: CheetahString::from_static_str("v2-assignment-client"),
+            strategy_name: CheetahString::from_static_str("AVG"),
+            message_model: MessageModel::Broadcasting,
+        }
+        .encode()
+        .expect("encode QueryAssignment request body");
+        let request = RemotingCommand::create_remoting_command(RequestCode::QueryAssignment)
+            .set_body(body)
+            .set_opaque(322);
+
+        let outcome = harness
+            .dispatch(None, request)
+            .await
+            .expect("embedded QueryAssignment V2 success response");
+        let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+            panic!("QueryAssignment V2 success must return a reply plan");
+        };
+
+        assert_eq!(plan.response_code(), ResponseCode::Success as i32);
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Bytes);
+        assert!(plan.body_len() > 0);
+        assert_eq!(plan.body_part_count(), 1);
+
+        drop(harness);
+        drop(context);
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
+    }
+
+    #[tokio::test]
+    async fn v2_network_query_success_preserves_opaque_and_body() {
+        const ORIGINAL_OPAQUE: i32 = 9_014;
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("query-assignment-v2-network-test"))
+            .expect("QueryAssignment V2 network test runtime");
+        let server_context = owner
+            .root_context()
+            .component("query-assignment-v2-network-test.server");
+        let runner_context = owner
+            .root_context()
+            .component("query-assignment-v2-network-test.runner");
+        let server = TransportServerV2::new(
+            Arc::new(ServerConfig {
+                bind_address: "127.0.0.1".to_owned(),
+                listen_port: 0,
+                ..ServerConfig::default()
+            }),
+            server_context,
+            v2_test_processor(&owner),
+        );
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let (startup_sender, startup_receiver) = oneshot::channel();
+        let (result_sender, result_receiver) = oneshot::channel();
+        runner_context
+            .spawn_service("query-assignment-v2-server", async move {
+                let result = server
+                    .try_run_with_shutdown_report_and_startup(
+                        async move {
+                            let _ = shutdown_receiver.await;
+                        },
+                        startup_sender,
+                    )
+                    .await;
+                let _ = result_sender.send(result);
+            })
+            .expect("spawn QueryAssignment V2 server");
+
+        let address = startup_receiver
+            .await
+            .expect("QueryAssignment V2 startup channel")
+            .expect("QueryAssignment V2 server startup");
+        let body = QueryAssignmentRequestBody {
+            topic: CheetahString::from_static_str("v2-assignment-topic"),
+            consumer_group: CheetahString::from_static_str("v2-assignment-group"),
+            client_id: CheetahString::from_static_str("v2-assignment-client"),
+            strategy_name: CheetahString::from_static_str("AVG"),
+            message_model: MessageModel::Broadcasting,
+        }
+        .encode()
+        .expect("encode QueryAssignment network request body");
+        let mut client = Connection::new(
+            TcpStream::connect(address)
+                .await
+                .expect("connect QueryAssignment V2 client"),
+        );
+        client
+            .send_command(
+                RemotingCommand::create_remoting_command(RequestCode::QueryAssignment)
+                    .set_body(body)
+                    .set_opaque(ORIGINAL_OPAQUE),
+            )
+            .await
+            .expect("send QueryAssignment V2 request");
+
+        let response = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+            .await
+            .expect("QueryAssignment V2 response deadline")
+            .expect("QueryAssignment V2 connection remains open")
+            .expect("QueryAssignment V2 response frame");
+        assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+        assert_eq!(response.code(), ResponseCode::Success as i32);
+        assert!(response.body().is_some_and(|body| !body.is_empty()));
+
+        client.shutdown().await.expect("shutdown QueryAssignment V2 client");
+        let _ = shutdown_sender.send(());
+        let report = tokio::time::timeout(Duration::from_secs(2), result_receiver)
+            .await
+            .expect("QueryAssignment V2 shutdown deadline")
+            .expect("QueryAssignment V2 shutdown result channel")
+            .expect("QueryAssignment V2 shutdown report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
     }
 }

--- a/rocketmq-broker/src/processor/recall_message_processor.rs
+++ b/rocketmq-broker/src/processor/recall_message_processor.rs
@@ -46,9 +46,10 @@ use rocketmq_store_api::TimerRecallRequest;
 use rocketmq_store_api::TimerRecallStatus;
 use rocketmq_store_api::TimerStoreMode;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_and_opaque;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use tracing::info;
 use tracing::warn;
 
@@ -207,22 +208,52 @@ impl<MS: BrokerWriteStore> Clone for RecallMessageProcessor<MS> {
     }
 }
 
-impl<MS> RequestProcessor for RecallMessageProcessor<MS>
+impl<MS> RequestProcessorV2 for RecallMessageProcessor<MS>
+where
+    MS: BrokerWriteStore + 'static,
+{
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_opaque = request.original_identity().original_opaque();
+        let command_factory = self.context.command_factory;
+        let remote_address = recall_remote_address(request.origin())?;
+        let result = self.process_command(request.command_mut(), remote_address).await;
+        crate::processor::response_plan::immediate_outcome_from_command_result(
+            &command_factory,
+            result,
+            original_opaque,
+            "RecallMessageProcessor V2 command dispatch completed without a response",
+        )
+    }
+}
+
+fn recall_remote_address(origin: &RequestOrigin) -> rocketmq_error::RocketMQResult<std::net::SocketAddr> {
+    match origin {
+        RequestOrigin::Network { peer } => Ok(peer.address()),
+        RequestOrigin::Embedded { .. } => Err(rocketmq_error::RocketMQError::illegal_argument(
+            "RecallMessage requires a trusted network origin for the persisted born host",
+        )),
+        _ => Err(rocketmq_error::RocketMQError::invariant_violated(
+            "RecallMessage received an unrecognized request origin",
+        )),
+    }
+}
+
+impl<MS> RecallMessageProcessor<MS>
 where
     MS: BrokerWriteStore,
 {
-    async fn process_request(
+    /// V2 leaf business contract; it uses only trusted origin metadata to construct the message birth address.
+    async fn process_command(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
+        remote_address: std::net::SocketAddr,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!("RecallMessageProcessor received request code: {:?}", request_code);
 
         match request_code {
             RequestCode::RecallMessage => {
-                let response = self.process_recall_message(&channel, &ctx, request).await?;
+                let response = self.process_recall_message(remote_address, request).await?;
                 Ok(Some(response))
             }
             _ => {
@@ -243,26 +274,19 @@ where
             }
         }
     }
-}
 
-impl<MS> RecallMessageProcessor<MS>
-where
-    MS: BrokerWriteStore,
-{
-    pub async fn process_request_shared(
+    pub(crate) async fn process_legacy(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        remote_address: std::net::SocketAddr,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut processor = self.clone();
-        processor.process_request(channel, ctx, request).await
+        processor.process_command(request, remote_address).await
     }
 
     async fn process_recall_message(
         &mut self,
-        _channel: &Channel,
-        ctx: &ConnectionHandlerContext,
+        remote_address: std::net::SocketAddr,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let mut response = self
@@ -405,7 +429,7 @@ where
         }
 
         let msg_inner = self.build_message(
-            ctx,
+            remote_address,
             &request_header,
             handle_topic,
             handle_timestamp_str,
@@ -435,7 +459,7 @@ where
 
     fn build_message(
         &self,
-        ctx: &ConnectionHandlerContext,
+        born_host: std::net::SocketAddr,
         request_header: &RecallMessageRequestHeader,
         handle_topic: &str,
         handle_timestamp_str: &str,
@@ -504,7 +528,6 @@ where
 
         let properties_string = MessageDecoder::message_properties_to_string(&properties);
 
-        let born_host = ctx.remote_address();
         let store_host = self.context.policy.store_host;
 
         let mut message = Message::builder()
@@ -620,8 +643,72 @@ fn recall_response_header_missing() -> RocketMQError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
     use rocketmq_protocol::protocol::SerializeType;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
+    use rocketmq_store::MessageStoreConfig;
     use rocketmq_store::StorePorts;
+    use rocketmq_store::StoreRuntimeConfig;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedCaller;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::ResponseBodyKind;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+    struct AllowEmbeddedPolicy;
+
+    impl RequestPolicy for AllowEmbeddedPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    fn v2_test_processor() -> RecallMessageProcessor<StorePorts> {
+        let broker_config = BrokerConfig::default();
+        let message_store_config = MessageStoreConfig::default();
+        let topic_config_manager = Arc::new(TopicConfigManager::new(
+            &broker_config,
+            &message_store_config,
+            true,
+            None,
+        ));
+        let stats_context = crate::test_service_context("recall-message-v2-stats");
+        let broker_stats_manager = Arc::new(BrokerStatsManager::new(
+            Arc::new(StoreRuntimeConfig::default()),
+            stats_context.task_group().clone(),
+        ));
+        let context = RecallMessageProcessorContext::new(
+            RecallMessagePolicy::from_configs(
+                &broker_config,
+                &message_store_config,
+                "127.0.0.1:10911".parse().expect("valid store host"),
+            ),
+            topic_config_manager,
+            RecallMessageStoreCapability {
+                escape_bridge: Weak::new(),
+            },
+            broker_stats_manager,
+        );
+        RecallMessageProcessor::new(context)
+    }
+
+    #[test]
+    fn embedded_recall_cannot_forge_a_persisted_network_born_host() {
+        let origin = RequestOrigin::Embedded {
+            caller: EmbeddedCaller::BrokerProxy,
+        };
+
+        assert!(recall_remote_address(&origin).is_err());
+    }
 
     #[test]
     fn recall_response_keeps_region_field() {
@@ -701,6 +788,42 @@ mod tests {
             capability.put_message(MessageExtBrokerInner::default()).await,
             Err(MessageStoreUnavailable)
         ));
+    }
+
+    #[tokio::test]
+    async fn v2_embedded_recall_fails_closed_before_business_processing() {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("recall-message-v2-test"))
+            .expect("RecallMessage V2 test runtime");
+        let context = owner.root_context().component("recall-message-v2-test.request");
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            v2_test_processor(),
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            context.task_group().clone(),
+            Principal::new("recall-message-v2-test"),
+        );
+
+        let outcome = harness
+            .dispatch(None, RemotingCommand::create_remoting_command(-98_454).set_opaque(321))
+            .await
+            .expect("embedded RecallMessage rejection must produce a typed response plan");
+        let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+            panic!("embedded RecallMessage request must fail closed with a reply plan");
+        };
+        assert_eq!(plan.response_code(), ResponseCode::InvalidParameter as i32);
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Empty);
+
+        drop(harness);
+        drop(context);
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/response_plan.rs
+++ b/rocketmq-broker/src/processor/response_plan.rs
@@ -20,12 +20,15 @@ use std::fs::File;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use rocketmq_error::ErrorKind;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_error::SerializationError;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_store::FileRangeTransferHandle;
 use rocketmq_store::SelectMappedBufferResult;
+use rocketmq_transport::api::v1::command_from_error_with_factory_and_opaque;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::FileRegionLease;
 use rocketmq_transport::api::v2::FileRegion;
@@ -90,6 +93,19 @@ impl FileRegionLease for StoreFileRegionLease {
 }
 
 impl BrokerResponseParts {
+    /// Splits a legacy response command into the body-free head and affine byte owner required by
+    /// the V2 response contract.
+    ///
+    /// Ordinary processor migrations use this boundary while their V1 compatibility shell still
+    /// returns a command. It prevents each leaf from open-coding body extraction or accidentally
+    /// placing a body-bearing head in a [`ResponsePlan`].
+    pub(crate) fn from_command(mut command: RemotingCommand) -> Result<Self, BrokerResponseBuildError> {
+        match command.take_body() {
+            Some(body) => Self::bytes(command, body),
+            None => Self::command(command),
+        }
+    }
+
     pub(crate) fn command(head: RemotingCommand) -> Result<Self, BrokerResponseBuildError> {
         Self::new(head, BrokerResponseBodyOwner::Empty)
     }
@@ -164,6 +180,25 @@ impl BrokerResponseParts {
     fn body(&self) -> &BrokerResponseBodyOwner {
         &self.body
     }
+}
+
+/// Converts an ordinary Broker leaf result into its immediate V2 outcome while preserving the
+/// Broker-owned wire factory for typed request-header failures.
+pub(crate) fn immediate_outcome_from_command_result(
+    command_factory: &RemotingCommandFactory,
+    result: RocketMQResult<Option<RemotingCommand>>,
+    original_opaque: i32,
+    missing_response: &'static str,
+) -> RocketMQResult<HandlerOutcome> {
+    let command = match result {
+        Ok(Some(command)) => command,
+        Ok(None) => return Err(RocketMQError::invariant_violated(missing_response)),
+        Err(error) if error.kind() == ErrorKind::RequestHeaderError => {
+            command_from_error_with_factory_and_opaque(command_factory, &error, original_opaque)
+        }
+        Err(error) => return Err(error),
+    };
+    BrokerResponseParts::from_command(command)?.into_handler_outcome()
 }
 
 fn validate_head(head: &RemotingCommand) -> Result<(), BrokerResponseBuildError> {

--- a/rocketmq-broker/src/processor/response_plan/tests.rs
+++ b/rocketmq-broker/src/processor/response_plan/tests.rs
@@ -98,6 +98,60 @@ fn response_parts_reject_every_invalid_head_before_storing_an_owner() {
 }
 
 #[test]
+fn legacy_command_conversion_extracts_the_body_before_plan_validation() {
+    let parts = BrokerResponseParts::from_command(response_head().set_body(Bytes::from_static(b"body")))
+        .expect("legacy response body should become the affine bytes owner");
+    let BrokerResponseBodyOwner::Bytes(body) = parts.body() else {
+        panic!("legacy response bytes must be extracted from the head");
+    };
+    assert_eq!(body.as_ref(), b"body");
+
+    let plan = parts
+        .into_response_plan()
+        .expect("converted command should build a response plan");
+    assert_eq!(plan.body_kind(), ResponseBodyKind::Bytes);
+    assert_eq!(plan.body_len(), 4);
+}
+
+#[test]
+fn immediate_leaf_mapper_turns_only_typed_header_failures_into_replies() {
+    let header_error = RocketMQError::request_header_error("malformed leaf header");
+    let expected_response_code = header_error.boundary_view().remoting().code.as_i32();
+    let outcome = immediate_outcome_from_command_result(
+        &rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory(),
+        Err(header_error),
+        9845,
+        "ordinary leaf returned no response",
+    )
+    .expect("typed request-header failures should become a Broker reply");
+    let HandlerOutcome::Reply(plan) = outcome else {
+        panic!("ordinary leaf error mapping must produce one reply")
+    };
+    assert_eq!(plan.response_code(), expected_response_code);
+
+    let non_header = RocketMQError::illegal_argument("business failure");
+    let result = immediate_outcome_from_command_result(
+        &rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory(),
+        Err(non_header),
+        9845,
+        "ordinary leaf returned no response",
+    );
+    assert!(result.is_err(), "non-header errors remain visible to the dispatcher");
+}
+
+#[test]
+fn immediate_leaf_mapper_rejects_legacy_none_semantics() {
+    let result = immediate_outcome_from_command_result(
+        &rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory(),
+        Ok(None),
+        9845,
+        "ordinary leaf returned no response",
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
 fn bytes_owner_moves_into_the_plan_without_a_builder_copy() {
     let drops = Arc::new(AtomicUsize::new(0));
     let body = Bytes::from_owner(DropBytes {

--- a/rocketmq-broker/src/subscription/lite_subscription_registry.rs
+++ b/rocketmq-broker/src/subscription/lite_subscription_registry.rs
@@ -20,7 +20,6 @@ use dashmap::DashMap;
 use rocketmq_model::common::lite::get_parent_topic;
 use rocketmq_model::common::lite::LiteSubscription;
 use rocketmq_runtime::common::time_utils::current_millis;
-use rocketmq_transport::api::v1::Channel;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct LiteSubscriptionKey {
@@ -42,7 +41,6 @@ impl LiteSubscriptionKey {
 #[derive(Clone, Default)]
 pub(crate) struct LiteSubscriptionRegistry {
     subscriptions: Arc<DashMap<LiteSubscriptionKey, LiteSubscription>>,
-    client_channels: Arc<DashMap<CheetahString, Channel>>,
     wildcard_groups: Arc<DashMap<CheetahString, HashSet<CheetahString>>>,
     wildcard_clients: Arc<DashMap<WildcardGroupKey, HashSet<CheetahString>>>,
 }
@@ -73,10 +71,6 @@ pub(crate) struct LiteSubscriptionRecord {
 }
 
 impl LiteSubscriptionRegistry {
-    pub(crate) fn update_client_channel(&self, client_id: &CheetahString, channel: Channel) {
-        self.client_channels.insert(client_id.clone(), channel);
-    }
-
     pub(crate) fn add_partial_subscription(
         &self,
         client_id: &CheetahString,
@@ -117,7 +111,6 @@ impl LiteSubscriptionRegistry {
 
         if empty {
             self.subscriptions.remove(&key);
-            self.cleanup_client_channel_if_unused(client_id);
             None
         } else {
             Some(snapshot)
@@ -153,7 +146,6 @@ impl LiteSubscriptionRegistry {
         self.set_wildcard_client(client_id, group, topic, wildcard);
         if effective_topics.is_empty() {
             self.subscriptions.remove(&key);
-            self.cleanup_client_channel_if_unused(client_id);
         } else {
             self.subscriptions.insert(key, subscription.clone());
         }
@@ -173,7 +165,6 @@ impl LiteSubscriptionRegistry {
             self.set_wildcard_client(&key.client_id, &key.group, &key.topic, false);
             self.subscriptions.remove(&key);
         }
-        self.cleanup_client_channel_if_unused(client_id);
         removed
     }
 
@@ -290,16 +281,6 @@ impl LiteSubscriptionRegistry {
             if remove_topic_entry {
                 self.wildcard_groups.remove(topic);
             }
-        }
-    }
-
-    fn cleanup_client_channel_if_unused(&self, client_id: &CheetahString) {
-        if self
-            .subscriptions
-            .iter()
-            .all(|entry| entry.key().client_id != *client_id)
-        {
-            self.client_channels.remove(client_id);
         }
     }
 }

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -3162,6 +3162,97 @@ async fn phase3_broker_production_request_codes_dispatch_to_expected_processors(
 }
 
 #[tokio::test]
+async fn pull_processor_uses_the_live_consumer_session_registry_installed_by_pipeline() {
+    let mut runtime = new_phase3_test_runtime("pull-session-client-lookup").await;
+    let _ = runtime.init_processor();
+    let pull_processor = runtime
+        .composition
+        .request_pipeline
+        .pull_message_processor_for_test
+        .as_ref()
+        .cloned()
+        .expect("request pipeline should retain the test Pull processor handle");
+    let registration = runtime.composition.state.consumer_manager().client_registration();
+    let session_id = rocketmq_transport::test_support::session_id_for_test(9_845);
+    let replacement_session_id = rocketmq_transport::test_support::session_id_for_test(9_846);
+    let group = CheetahString::from_static_str("pull-session-group");
+
+    assert!(registration.register_consumer_session(
+        &group,
+        crate::client::client_channel_info::ClientSessionInfo::new(
+            session_id,
+            "pull-session-client".into(),
+            None,
+            rocketmq_protocol::protocol::LanguageCode::RUST,
+            1,
+        ),
+        rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType::ConsumePassively,
+        rocketmq_protocol::protocol::heartbeat::message_model::MessageModel::Clustering,
+        rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere::ConsumeFromLastOffset,
+        HashSet::new(),
+        false,
+    ));
+    assert_eq!(
+        pull_processor.session_client_id_for_test(session_id, &group),
+        Some(CheetahString::from_static_str("pull-session-client"))
+    );
+
+    assert!(!registration.register_consumer_session(
+        &group,
+        crate::client::client_channel_info::ClientSessionInfo::new(
+            session_id,
+            "pull-session-client".into(),
+            None,
+            rocketmq_protocol::protocol::LanguageCode::RUST,
+            2,
+        ),
+        rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType::ConsumePassively,
+        rocketmq_protocol::protocol::heartbeat::message_model::MessageModel::Clustering,
+        rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere::ConsumeFromLastOffset,
+        HashSet::new(),
+        false,
+    ));
+    assert_eq!(
+        pull_processor.session_client_id_for_test(session_id, &group),
+        Some(CheetahString::from_static_str("pull-session-client"))
+    );
+
+    assert!(registration.register_consumer_session(
+        &group,
+        crate::client::client_channel_info::ClientSessionInfo::new(
+            replacement_session_id,
+            "pull-session-client".into(),
+            None,
+            rocketmq_protocol::protocol::LanguageCode::RUST,
+            3,
+        ),
+        rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType::ConsumePassively,
+        rocketmq_protocol::protocol::heartbeat::message_model::MessageModel::Clustering,
+        rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere::ConsumeFromLastOffset,
+        HashSet::new(),
+        false,
+    ));
+    assert_eq!(pull_processor.session_client_id_for_test(session_id, &group), None);
+    assert_eq!(
+        pull_processor.session_client_id_for_test(replacement_session_id, &group),
+        Some(CheetahString::from_static_str("pull-session-client"))
+    );
+
+    // A delayed close for the replaced transport session must not remove the live replacement.
+    registration.unregister_consumer_session(group.as_str(), session_id, false);
+    assert_eq!(
+        pull_processor.session_client_id_for_test(replacement_session_id, &group),
+        Some(CheetahString::from_static_str("pull-session-client"))
+    );
+    registration.unregister_consumer_session(group.as_str(), replacement_session_id, false);
+    assert_eq!(
+        pull_processor.session_client_id_for_test(replacement_session_id, &group),
+        None
+    );
+    let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+}
+
+#[tokio::test]
 async fn phase3_send_message_processor_writes_to_local_store() {
     let mut runtime = new_phase3_test_runtime("phase3-send").await;
     let topic = CheetahString::from_static_str("phase3-send-topic");

--- a/rocketmq-doc/en/remoting-processor-v2-migration-ledger.md
+++ b/rocketmq-doc/en/remoting-processor-v2-migration-ledger.md
@@ -88,19 +88,19 @@ outcome and no longer receives a raw context solely for dispatch compatibility.
 
 | Production implementation | Current state | Notable migration responsibility |
 |---|---|---|
-| `rocketmq-broker/src/processor/ack_message_processor.rs` — `AckMessageProcessor<MS>` | `V1` generic leaf | Use typed origin/session facts only where required. |
-| `rocketmq-broker/src/processor/change_invisible_time_processor.rs` — `ChangeInvisibleTimeProcessor<MS>` | `V1` generic leaf | Preserve response mapping without direct response writes. |
-| `rocketmq-broker/src/processor/client_manage_processor.rs` — `ClientManageProcessor<MS>` | `V1` generic leaf | Move client identity and registry operations to stable session identities/narrow push handles. |
-| `rocketmq-broker/src/processor/consumer_manage_processor.rs` — `ConsumerManageProcessor<MS>` | `V1` generic leaf | Move consumer registry operations to stable session identities/narrow push handles. |
-| `rocketmq-broker/src/processor/end_transaction_processor.rs` — `EndTransactionProcessor<TM, MS>` | `V1` generic leaf | Return a typed reply/error plan. |
-| `rocketmq-broker/src/processor/lite_manager_processor.rs` — `LiteManagerProcessor<MS>` | `V1` generic leaf | Remove unused transport context and retain protocol behavior. |
-| `rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs` — `LiteSubscriptionCtlProcessor<MS>` | `V1` generic leaf | Remove unused transport context and retain protocol behavior. |
-| `rocketmq-broker/src/processor/maintenance_request_processor.rs` — `MaintenanceRequestProcessor` | `V1` leaf | Replace raw session access with the narrow typed view actually required. |
-| `rocketmq-broker/src/processor/peek_message_processor.rs` — `PeekMessageProcessor<MS>` | `V1` generic leaf | Return a typed response plan. |
-| `rocketmq-broker/src/processor/polling_info_processor.rs` — `PollingInfoProcessor` | `V1` leaf | Remove unused context and return a typed reply. |
-| `rocketmq-broker/src/processor/query_assignment_processor.rs` — `QueryAssignmentProcessor` | `V1` leaf | Remove unused context and return a typed reply. |
-| `rocketmq-broker/src/processor/recall_message_processor.rs` — `RecallMessageProcessor<MS>` | `V1` generic leaf | Preserve typed error mapping and response semantics. |
-| `rocketmq-broker/src/client/manager/producer_manager.rs` | Registry/context consumer | Stores/indexes raw `Channel` values and accepts `ConnectionHandlerContext`. | Establish the canonical `SessionId` to client identity read seam needed by Pull, and retain only an explicit server-push capability where writes are required. |
+| `rocketmq-broker/src/processor/ack_message_processor.rs` — `AckMessageProcessor<MS>` | `Dual`: V2 leaf + V1 aggregate projection | Uses a typed network/embedded source label; the core receives no transport handle. |
+| `rocketmq-broker/src/processor/change_invisible_time_processor.rs` — `ChangeInvisibleTimeProcessor<MS>` | `Dual`: V2 leaf + V1 aggregate projection | Returns a typed response plan without direct response writes. |
+| `rocketmq-broker/src/processor/client_manage_processor.rs` — `ClientManageProcessor<MS>` | `Dual`: V2 leaf + isolated V1 wrapper | V2 registration uses canonical `SessionId`; raw `Channel` remains confined to `LegacyClientManageProcessor`. |
+| `rocketmq-broker/src/processor/consumer_manage_processor.rs` — `ConsumerManageProcessor<MS>` | `Dual`: V2 leaf + V1 aggregate projection | Uses typed request-source metadata and the live SessionId registry. |
+| `rocketmq-broker/src/processor/end_transaction_processor.rs` — `EndTransactionProcessor<TM, MS>` | `Dual`: V2 leaf + V1 aggregate projection | Returns a typed reply/error plan and makes the legacy no-response branch explicit. |
+| `rocketmq-broker/src/processor/lite_manager_processor.rs` — `LiteManagerProcessor<MS>` | `Dual`: V2 leaf + V1 aggregate projection | Has no transport-context dependency and preserves protocol behavior. |
+| `rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs` — `LiteSubscriptionCtlProcessor<MS>` | `Dual`: V2 leaf + V1 aggregate projection | Removed the unused Channel cache from `LiteSubscriptionRegistry`. |
+| `rocketmq-broker/src/processor/maintenance_request_processor.rs` — `MaintenanceRequestProcessor` | `Dual`: V2 leaf + isolated V1 wrapper | V2 authorization uses the authenticated principal; legacy channel authentication stays in the wrapper. |
+| `rocketmq-broker/src/processor/peek_message_processor.rs` — `PeekMessageProcessor<MS>` | `Dual`: V2 leaf + V1 aggregate projection | Uses typed source metadata and returns a typed response plan. |
+| `rocketmq-broker/src/processor/polling_info_processor.rs` — `PollingInfoProcessor` | `Dual`: V2 leaf + V1 aggregate projection | Embedded callers are labeled explicitly rather than assigned a synthetic address. |
+| `rocketmq-broker/src/processor/query_assignment_processor.rs` — `QueryAssignmentProcessor` | `Dual`: V2 leaf + V1 aggregate projection | The core receives only a diagnostic source label and returns a typed reply. |
+| `rocketmq-broker/src/processor/recall_message_processor.rs` — `RecallMessageProcessor<MS>` | `Dual`: V2 leaf + V1 aggregate projection | Requires a trusted network origin for the persisted born host and fails closed for embedded calls. |
+| `rocketmq-broker/src/client/manager/producer_manager.rs` and `consumer_manager.rs` | Dual registries: V1 `Channel` + V2 `SessionId` | Stable SessionId tables, reverse indexes, ordered typed consumer-member notifications, merged snapshots, and the live Pull client-identity seam coexist with V1 drain tables until Broker cutover. |
 
 The manager migration must not retain `RemotingRequest` or `SessionView` as an
 arbitrary send handle. Existing source-text assertions are not completion

--- a/rocketmq-transport/src/test_support.rs
+++ b/rocketmq-transport/src/test_support.rs
@@ -25,6 +25,7 @@ use rocketmq_runtime::TaskGroup;
 use crate::base::pending_request_table::PendingRequestTable;
 use crate::net::channel::Channel;
 use crate::net::channel::ChannelInner;
+use crate::session_view::SessionId;
 
 mod embedded_v2;
 pub use embedded_v2::EmbeddedRequestHarnessV2;
@@ -52,6 +53,20 @@ pub use crate::write_strategy::FrameWriteMode;
 pub use crate::write_strategy::FrameWriter;
 pub use crate::writer_runtime::MicroBatchConfig;
 pub use crate::writer_runtime::WriterQueueConfig;
+
+/// Creates a stable session identity for downstream behavior tests.
+///
+/// Production code cannot construct [`SessionId`] values; it receives them from the trusted
+/// transport boundary. This fixture is available only when the explicit `test-support` feature is
+/// enabled and rejects the sentinels excluded by the production allocator.
+#[must_use]
+pub fn session_id_for_test(owner_id: u64) -> SessionId {
+    assert!(
+        !matches!(owner_id, 0 | u64::MAX),
+        "test session owner must use a production-valid identity"
+    );
+    SessionId::from_session_owner(owner_id)
+}
 
 /// Builds a real transport-backed channel for downstream tests without
 /// exposing response-table or channel ownership internals.


### PR DESCRIPTION
## Summary

- migrate the 12 MIG-03 Broker leaf processors to the canonical `RequestProcessorV2` request contract and typed `ResponsePlan` outcomes
- replace retained raw connection/channel identity in client registries with stable `SessionId` indexes while preserving the isolated V1 compatibility boundary required before MIG-05
- make producer/consumer heartbeat transitions atomic across roles, keep consumer membership callbacks FIFO per group, and close reverse-index replacement races
- wire Pull assignment to the live consumer session registry and remove the Lite subscription raw `Channel` cache
- add focused V2 wire, identity, reconnect, close, callback-ordering, and deterministic concurrency regressions

## Validation

- `cargo fmt -p rocketmq-broker -- --check`
- `cargo fmt -p rocketmq-transport -- --check`
- `cargo check -p rocketmq-broker --lib`
- `cargo test -p rocketmq-broker --lib v2_ -- --test-threads=1` (41 passed)
- `cargo test -p rocketmq-transport --lib` (659 passed)
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- Sol/xhigh architecture audit: APPROVE, no P0/P1 findings

## Baseline notes

- the full Broker lib suite reaches the existing `trigger_lite_dispatch_respects_broker_max_client_event_count_fallback` failure (`left: 1`, `right: 2`); the same focused command reproduces on a clean `origin/main` worktree
- the error hygiene guard retains only pre-existing main-branch findings in notification/reply/send response codes, source stringification, and endpoint-state redaction; MIG-03 adds no new finding
- XCT-02 `ServerPushSender` and production V2 disconnect subscription remain intentionally deferred to the later cutover stage

Fixes #9845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-based registration and tracking for producers and consumers.
  * Improved handling of client reconnects, session replacement, expiration, and cleanup.
  * Consumer and producer membership views now include both legacy and session-based clients.
  * Pull requests can resolve client identities through the active consumer session.
  * Added V2 request handling with clearer response outcomes and fail-closed validation.

* **Bug Fixes**
  * Prevented inconsistent concurrent session transitions and identity changes.
  * Improved error responses for invalid or incomplete requests.

* **Documentation**
  * Updated the processor migration documentation to reflect completed V2 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->