### PR TITLE
[ISSUE #9853]🚀Prepare Broker V2 aggregate and deferred handoff

### DIFF
--- a/rocketmq-broker/src/broker_runtime/deferred_producer.rs
+++ b/rocketmq-broker/src/broker_runtime/deferred_producer.rs
@@ -37,6 +37,10 @@ use tracing::warn;
 
 use crate::deferred_generation_handoff::DeferredGeneration;
 use crate::deferred_generation_handoff::DeferredGenerationHandoff;
+use crate::deferred_generation_handoff::DeferredGenerationTarget;
+use crate::deferred_generation_handoff::DeferredGenerationTargetTransitionError;
+use crate::deferred_generation_handoff::DeferredGenerationTransitionKind;
+use crate::deferred_generation_handoff::ReplayToken;
 use crate::deferred_generation_handoff::RoutePermit;
 use crate::lite::lite_event_dispatcher::DeferredEventObserver;
 use crate::lite::lite_event_dispatcher::LiteEventDispatcher;
@@ -66,6 +70,7 @@ use workers::submit_pop_lite_event;
 use workers::submit_pull;
 
 const PRODUCER_TICK: Duration = Duration::from_millis(20);
+const TRANSITION_BATCH_LIMIT: usize = 64;
 
 type PullMasterOnlineCallback = dyn Fn() + Send + Sync + 'static;
 type PopLagRefreshCallback =
@@ -284,8 +289,10 @@ where
                         {
                             break;
                         }
+                        producer.advance_generation_handoff();
                         producer.produce_pending_arrivals();
                         producer.produce_expired();
+                        producer.produce_pending_dispatcher_events();
                         producer.produce_pending_pop_lite_events();
                     }
                 })?,
@@ -325,11 +332,17 @@ where
     ) where
         F: FnOnce(),
     {
+        let default_generation = self.handoff.default_generation();
         let Ok(route) = self.handoff.acquire_pull_candidate(topic.clone(), queue_id) else {
             return;
         };
         if route.generation() == DeferredGeneration::Legacy {
             legacy();
+            if default_generation == DeferredGeneration::New {
+                if let Err(error) = self.pull.latch_offset(topic, queue_id, logic_offset) {
+                    warn!(?error, "failed to retain deferred Pull handoff replay");
+                }
+            }
             return;
         }
         match self.pull.latch_offset(topic, queue_id, logic_offset) {
@@ -542,6 +555,138 @@ where
     fn produce_pending_pop_lite_events(&self) {
         for client_id in self.pop_lite.take_pending_replays(NonZeroUsize::MIN) {
             let _ = self.notify_pop_lite_event(&client_id);
+        }
+    }
+
+    fn produce_pending_dispatcher_events(&self) {
+        for client_id in self.lite_dispatcher.pending_client_ids() {
+            let target = DeferredGenerationTarget::pop_lite(client_id.clone());
+            if self.handoff.generation_for(&target) == DeferredGeneration::New {
+                self.lite_dispatcher.replay_pending_event(&client_id);
+            }
+        }
+    }
+
+    fn advance_generation_handoff(self: &Arc<Self>) {
+        for candidate in self.handoff.take_transition_candidates(TRANSITION_BATCH_LIMIT) {
+            let target = candidate.target;
+            match candidate.kind {
+                DeferredGenerationTransitionKind::LegacyTarget => {
+                    match self.handoff.try_transition_target_to_new(target.clone(), |candidate| {
+                        self.legacy_target_occupied(candidate)
+                    }) {
+                        Ok(replay) => self.replay_transition(replay),
+                        Err(
+                            DeferredGenerationTargetTransitionError::Draining(_)
+                            | DeferredGenerationTargetTransitionError::LegacyTableOccupied,
+                        ) => self.handoff.requeue_transition_candidate(&target),
+                        Err(
+                            DeferredGenerationTargetTransitionError::ShutdownSealed
+                            | DeferredGenerationTargetTransitionError::CutoverNotPublished
+                            | DeferredGenerationTargetTransitionError::TargetAbsent
+                            | DeferredGenerationTargetTransitionError::TargetAlreadyNew,
+                        ) => {}
+                    }
+                }
+                DeferredGenerationTransitionKind::AbandonedReplay => {
+                    if let Ok(replay) = self.handoff.retry_abandoned_replay(target) {
+                        self.replay_transition(replay);
+                    }
+                }
+            }
+        }
+    }
+
+    fn legacy_target_occupied(&self, target: &DeferredGenerationTarget) -> bool {
+        match target {
+            DeferredGenerationTarget::Pull { .. } => self
+                .pull_request_hold_service
+                .upgrade()
+                .is_none_or(|service| service.legacy_target_occupied(target)),
+            DeferredGenerationTarget::Pop { .. } => self.pop_processor.upgrade().is_none_or(|processor| {
+                processor
+                    .pop_long_polling_service()
+                    .is_none_or(|service| service.legacy_target_occupied(target))
+            }),
+            DeferredGenerationTarget::Notification { .. } => self
+                .notification_processor
+                .upgrade()
+                .is_none_or(|processor| processor.pop_long_polling_service().legacy_target_occupied(target)),
+            DeferredGenerationTarget::PopLite { .. } => self
+                .pop_lite_processor
+                .upgrade()
+                .is_none_or(|processor| processor.pop_lite_long_polling_service().legacy_target_occupied(target)),
+        }
+    }
+
+    fn replay_transition(self: &Arc<Self>, replay: ReplayToken) {
+        let target = replay.target().clone();
+        let accepted = match &target {
+            DeferredGenerationTarget::Pull { topic, queue_id } => self.replay_pull_target(topic, *queue_id),
+            DeferredGenerationTarget::Pop { topic, queue_id, .. } => self.replay_pop_target(topic, *queue_id),
+            DeferredGenerationTarget::Notification { topic, queue_id, .. } => {
+                self.replay_notification_target(topic, *queue_id)
+            }
+            DeferredGenerationTarget::PopLite { client_id } => {
+                self.lite_dispatcher.replay_pending_event(client_id);
+                true
+            }
+        };
+        if accepted {
+            replay.complete_after_replay_accepted();
+        } else {
+            warn!(?target, "deferred handoff replay was retained for retry");
+        }
+    }
+
+    fn replay_pull_target(self: &Arc<Self>, topic: &CheetahString, queue_id: i32) -> bool {
+        let Some(store) = self.replay_message_store() else {
+            return false;
+        };
+        let max_offset = store.get_max_offset_in_queue(topic, queue_id);
+        match self.pull.latch_offset(topic, queue_id, max_offset) {
+            Ok(()) => {
+                self.produce_pending_pull_offsets();
+                true
+            }
+            Err(error) => {
+                warn!(?error, "failed to retain deferred Pull transition replay");
+                false
+            }
+        }
+    }
+
+    fn replay_pop_target(self: &Arc<Self>, topic: &CheetahString, queue_id: i32) -> bool {
+        let Some(store) = self.replay_message_store() else {
+            return false;
+        };
+        let max_offset = store.get_max_offset_in_queue(topic, queue_id);
+        match self.pop.latch_offset(topic, queue_id, max_offset) {
+            Ok(()) => {
+                self.produce_pending_pop_offsets();
+                true
+            }
+            Err(error) => {
+                warn!(?error, "failed to retain deferred POP transition replay");
+                false
+            }
+        }
+    }
+
+    fn replay_notification_target(self: &Arc<Self>, topic: &CheetahString, queue_id: i32) -> bool {
+        let Some(store) = self.replay_message_store() else {
+            return false;
+        };
+        let max_offset = store.get_max_offset_in_queue(topic, queue_id);
+        match self.notification.latch_offset(topic, queue_id, max_offset) {
+            Ok(()) => {
+                self.produce_pending_notification_offsets();
+                true
+            }
+            Err(error) => {
+                warn!(?error, "failed to retain deferred Notification transition replay");
+                false
+            }
         }
     }
 

--- a/rocketmq-broker/src/broker_runtime/deferred_producer/e2e_tests.rs
+++ b/rocketmq-broker/src/broker_runtime/deferred_producer/e2e_tests.rs
@@ -219,7 +219,7 @@ fn notification_request() -> RemotingCommand {
     request
 }
 
-fn publish_test_targets(runtime: &BrokerRuntime) {
+fn publish_test_targets(runtime: &BrokerRuntime, producer: &Arc<super::BrokerDeferredProducer<BrokerMessageStore>>) {
     let deferred = runtime
         .composition
         .data_plane
@@ -253,13 +253,11 @@ fn publish_test_targets(runtime: &BrokerRuntime) {
     transaction.publish_default_new().expect("publish New default");
     drop(transaction);
     drop(permits);
+    producer.advance_generation_handoff();
     for target in [pull_target, pop_target, notification_target] {
-        handoff
-            .try_transition_target_to_new(target.clone(), |_| false)
-            .expect("transition drained test target")
-            .complete_after_replay_accepted();
         assert_eq!(handoff.generation_for(&target), DeferredGeneration::New);
     }
+    assert!(handoff.zero_report().is_zero());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -349,7 +347,7 @@ async fn store_replay_workers_resume_three_canonical_sessions_exactly_once_and_r
         controller,
     )
     .await;
-    publish_test_targets(&runtime);
+    publish_test_targets(&runtime, &producer);
 
     pull_client.send_command(pull_request()).await.expect("send Pull wait");
     pop_client.send_command(pop_request()).await.expect("send POP wait");

--- a/rocketmq-broker/src/broker_runtime/deferred_producer/workers.rs
+++ b/rocketmq-broker/src/broker_runtime/deferred_producer/workers.rs
@@ -63,7 +63,11 @@ where
                         let reason = pending.value_mut().reason();
                         let batch = producer.pull.reserve_pending_arrival_batch(pending.value_mut());
                         let exhausted = batch.exhausted();
-                        producer.resume_pull_candidates(batch.into_candidates(), reason).await;
+                        let retain_for_legacy = producer.resume_pull_candidates(batch.into_candidates(), reason).await;
+                        if retain_for_legacy {
+                            pending.rearm_from_start();
+                            return;
+                        }
                         if exhausted && pending.finish_if_clean() {
                             break;
                         }
@@ -79,13 +83,15 @@ where
         &self,
         candidates: Vec<crate::long_polling::pull_deferred::PullCandidateReservation>,
         reason: DeferredWakeReason,
-    ) {
+    ) -> bool {
+        let mut retain_for_legacy = false;
         for candidate in candidates {
             let key = candidate.key();
             let Ok(route) = self.handoff.acquire_pull_candidate(key.topic().clone(), key.queue_id()) else {
                 continue;
             };
             if route.generation() != DeferredGeneration::New {
+                retain_for_legacy = true;
                 continue;
             }
             let Ok(claimed) = self.pull.claim_candidate(candidate, reason).await else {
@@ -94,6 +100,7 @@ where
             let _route = route;
             submit_pull(Arc::clone(&self.pull), self.pull_processor.clone(), claimed);
         }
+        retain_for_legacy
     }
 
     pub(super) fn spawn_pull_pending_offset(self: &Arc<Self>, reservation: PullPendingOffsetReservation) {
@@ -130,7 +137,7 @@ where
                             continue;
                         };
                         if route.generation() != DeferredGeneration::New {
-                            continue;
+                            return;
                         }
                         let criteria = Arc::clone(candidate.criteria());
                         match store_range_matches(
@@ -186,6 +193,7 @@ where
                     return;
                 };
                 loop {
+                    let mut retain_for_legacy = false;
                     let batch = producer.pop.pending_consumer_group_batch(pending.value_mut());
                     let exhausted = batch.exhausted();
                     for consumer_group in batch.into_consumer_groups() {
@@ -205,6 +213,7 @@ where
                             continue;
                         };
                         if route.generation() != DeferredGeneration::New {
+                            retain_for_legacy = true;
                             continue;
                         }
                         let Ok(claimed) = producer
@@ -216,6 +225,10 @@ where
                         };
                         let _route = route;
                         submit_pop(Arc::clone(&producer.pop), producer.pop_processor.clone(), claimed);
+                    }
+                    if retain_for_legacy {
+                        pending.rearm_from_start();
+                        return;
                     }
                     if exhausted && pending.finish_if_clean() {
                         break;
@@ -244,6 +257,7 @@ where
         let mut covered = reservation.range();
         let mut ranges = VecDeque::from([covered]);
         loop {
+            let mut retain_for_legacy = false;
             while let Some(range) = ranges.pop_front() {
                 let Some(store) = self.replay_message_store() else {
                     return;
@@ -274,6 +288,7 @@ where
                                     continue;
                                 };
                                 if route.generation() != DeferredGeneration::New {
+                                    retain_for_legacy = true;
                                     skipped.push(candidate);
                                     continue;
                                 }
@@ -315,6 +330,9 @@ where
                     tokio::task::yield_now().await;
                 }
             }
+            if retain_for_legacy {
+                return;
+            }
             let Some(updated) = reservation.finish_or_updated() else {
                 break;
             };
@@ -338,7 +356,11 @@ where
                 loop {
                     let batch = producer.notification.reserve_pending_arrival_batch(pending.value_mut());
                     let exhausted = batch.exhausted();
-                    producer.resume_notification_candidates(batch.into_candidates()).await;
+                    let retain_for_legacy = producer.resume_notification_candidates(batch.into_candidates()).await;
+                    if retain_for_legacy {
+                        pending.rearm_from_start();
+                        return;
+                    }
                     if exhausted && pending.finish_if_clean() {
                         break;
                     }
@@ -370,6 +392,7 @@ where
         let mut covered = reservation.range();
         let mut ranges = VecDeque::from([covered]);
         loop {
+            let mut retain_for_legacy = false;
             while let Some(range) = ranges.pop_front() {
                 let Some(store) = self.replay_message_store() else {
                     return;
@@ -390,6 +413,7 @@ where
                             continue;
                         };
                         if route.generation() != DeferredGeneration::New {
+                            retain_for_legacy = true;
                             continue;
                         }
                         let filter = candidate.criteria().filter().cloned();
@@ -426,6 +450,9 @@ where
                     tokio::task::yield_now().await;
                 }
             }
+            if retain_for_legacy {
+                return;
+            }
             let Some(updated) = reservation.finish_or_updated() else {
                 break;
             };
@@ -438,7 +465,8 @@ where
     pub(super) async fn resume_notification_candidates(
         &self,
         candidates: Vec<crate::long_polling::notification_deferred::index::NotificationCandidateReservation>,
-    ) {
+    ) -> bool {
+        let mut retain_for_legacy = false;
         for candidate in candidates {
             let key = candidate.key();
             let Ok(route) = self.handoff.acquire_notification_candidate(
@@ -449,6 +477,7 @@ where
                 continue;
             };
             if route.generation() != DeferredGeneration::New {
+                retain_for_legacy = true;
                 continue;
             }
             let Ok(claimed) = self.notification.claim_arrival_candidate(candidate).await else {
@@ -461,6 +490,7 @@ where
                 claimed,
             );
         }
+        retain_for_legacy
     }
 }
 

--- a/rocketmq-broker/src/deferred_generation_handoff.rs
+++ b/rocketmq-broker/src/deferred_generation_handoff.rs
@@ -14,6 +14,10 @@
 
 //! Broker-private accounting and cutover control for deferred generations.
 
+use std::sync::atomic::AtomicBool;
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
@@ -38,6 +42,11 @@ pub(crate) use target::*;
 #[derive(Debug)]
 pub(crate) struct DeferredGenerationHandoff {
     write_gate: Arc<Mutex<DeferredGenerationHandoffState>>,
+    transition_scan_ready: AtomicBool,
+    #[cfg(test)]
+    transition_candidate_scans: AtomicUsize,
+    #[cfg(test)]
+    seal_gate_attempts: AtomicUsize,
 }
 
 impl Default for DeferredGenerationHandoff {
@@ -51,6 +60,11 @@ impl DeferredGenerationHandoff {
     pub(crate) fn new() -> Self {
         Self {
             write_gate: Arc::new(Mutex::new(DeferredGenerationHandoffState::default())),
+            transition_scan_ready: AtomicBool::new(false),
+            #[cfg(test)]
+            transition_candidate_scans: AtomicUsize::new(0),
+            #[cfg(test)]
+            seal_gate_attempts: AtomicUsize::new(0),
         }
     }
 
@@ -65,15 +79,21 @@ impl DeferredGenerationHandoff {
     }
 
     pub(crate) fn seal(&self) -> DeferredGenerationSeal {
+        #[cfg(test)]
+        self.seal_gate_attempts.fetch_add(1, Ordering::Release);
         let mut state = self.write_gate.lock();
-        if state.shutdown_sealed {
+        let result = if state.shutdown_sealed {
             DeferredGenerationSeal::AlreadySealed
         } else {
             state.shutdown_sealed = true;
             state.legacy_acceptance_sealed = true;
+            state.clear_transition_candidates();
+            state.discard_abandoned_replays();
             state.prune_quiescent_targets();
             DeferredGenerationSeal::Sealed
-        }
+        };
+        self.transition_scan_ready.store(false, Ordering::Release);
+        result
     }
 
     #[must_use]
@@ -154,7 +174,11 @@ impl DeferredGenerationHandoff {
             DeferredGenerationCutoverStage::Open
         };
         state.cutover_transaction_active = true;
-        Ok(DeferredGenerationCutover { state, stage })
+        Ok(DeferredGenerationCutover {
+            state,
+            stage,
+            transition_scan_ready: &self.transition_scan_ready,
+        })
     }
 
     /// Runs one legacy-table operation with the coordinator write gate held.
@@ -172,8 +196,12 @@ impl DeferredGenerationHandoff {
     }
 
     /// Changes one drained target from Legacy to New and authorizes its replay.
-    /// The injected legacy-table probe runs under the write gate and must not
-    /// call back into this coordinator.
+    ///
+    /// The injected exact legacy-table probe runs outside the write gate after
+    /// acceptance has been sealed, so legacy occupancy can only decrease. The
+    /// coordinator counters are checked under the gate both before and after
+    /// that probe. This preserves the global admission -> coordinator -> table
+    /// lock order and prevents a Pop/PopLite admission lock inversion.
     pub(crate) fn try_transition_target_to_new<F>(
         &self,
         target: DeferredGenerationTarget,
@@ -265,6 +293,40 @@ impl DeferredGenerationHandoff {
             target,
             armed: true,
         })
+    }
+
+    /// Returns one fair, bounded transition batch after the cutover becomes
+    /// externally routable. The readiness load is the complete default-Legacy
+    /// tick path and does not acquire the coordinator gate.
+    pub(crate) fn take_transition_candidates(&self, limit: usize) -> Vec<DeferredGenerationTransitionCandidate> {
+        if limit == 0 || !self.transition_scan_ready.load(Ordering::Acquire) {
+            return Vec::new();
+        }
+        #[cfg(test)]
+        self.transition_candidate_scans.fetch_add(1, Ordering::Relaxed);
+        self.write_gate.lock().take_transition_candidates(limit)
+    }
+
+    pub(crate) fn requeue_transition_candidate(&self, target: &DeferredGenerationTarget) {
+        if !self.transition_scan_ready.load(Ordering::Acquire) {
+            return;
+        }
+        self.write_gate.lock().enqueue_transition_candidate(target);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn transition_scan_ready_for_test(&self) -> bool {
+        self.transition_scan_ready.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn transition_candidate_scans_for_test(&self) -> usize {
+        self.transition_candidate_scans.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn seal_gate_attempts_for_test(&self) -> usize {
+        self.seal_gate_attempts.load(Ordering::Acquire)
     }
 
     #[must_use]

--- a/rocketmq-broker/src/deferred_generation_handoff/cutover_replay.rs
+++ b/rocketmq-broker/src/deferred_generation_handoff/cutover_replay.rs
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 use std::panic::AssertUnwindSafe;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use parking_lot::{Mutex, MutexGuard};
 
 use super::state::DeferredGenerationHandoffState;
-use super::{DeferredGeneration, DeferredGenerationTarget, DeferredGenerationTargetSnapshot};
+use super::{DeferredGenerationTarget, DeferredGenerationTargetSnapshot};
 
 /// Issued after an explicit Legacy → New transition.
 #[derive(Debug)]
@@ -103,6 +105,7 @@ impl<F> DeferredGenerationV2Publisher<F> {
 pub(crate) struct DeferredGenerationCutover<'a> {
     pub(super) state: MutexGuard<'a, DeferredGenerationHandoffState>,
     pub(super) stage: DeferredGenerationCutoverStage,
+    pub(super) transition_scan_ready: &'a AtomicBool,
 }
 
 impl DeferredGenerationCutover<'_> {
@@ -158,8 +161,9 @@ impl DeferredGenerationCutover<'_> {
         if self.stage != DeferredGenerationCutoverStage::V2AggregatePublished {
             return Err(DeferredGenerationCutoverError::InvalidStage);
         }
-        self.state.default_generation = DeferredGeneration::New;
+        self.state.publish_default_new();
         self.stage = DeferredGenerationCutoverStage::DefaultNewPublished;
+        self.transition_scan_ready.store(true, Ordering::Release);
         Ok(())
     }
 }

--- a/rocketmq-broker/src/deferred_generation_handoff/state.rs
+++ b/rocketmq-broker/src/deferred_generation_handoff/state.rs
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::VecDeque;
 
 use super::DeferredGeneration;
 use super::DeferredGenerationHandoffSnapshot;
 use super::DeferredGenerationRouteError;
 use super::DeferredGenerationTarget;
 use super::DeferredGenerationTargetSnapshot;
+use super::DeferredGenerationTransitionCandidate;
+use super::DeferredGenerationTransitionKind;
 
 #[derive(Debug)]
 pub(super) struct DeferredGenerationHandoffState {
@@ -28,6 +31,7 @@ pub(super) struct DeferredGenerationHandoffState {
     pub(super) v2_aggregate_published: bool,
     pub(super) cutover_transaction_active: bool,
     pub(super) targets: HashMap<DeferredGenerationTarget, DeferredGenerationTargetState>,
+    transition_queue: VecDeque<DeferredGenerationTarget>,
 }
 
 impl Default for DeferredGenerationHandoffState {
@@ -39,6 +43,7 @@ impl Default for DeferredGenerationHandoffState {
             v2_aggregate_published: false,
             cutover_transaction_active: false,
             targets: HashMap::new(),
+            transition_queue: VecDeque::new(),
         }
     }
 }
@@ -178,11 +183,88 @@ impl DeferredGenerationHandoffState {
     }
 
     pub(super) fn abandon_replay_token(&mut self, target: &DeferredGenerationTarget) {
+        let mut enqueue = false;
         if let Some(target_state) = self.targets.get_mut(target) {
             if target_state.replay_tokens > 0 {
                 target_state.replay_tokens -= 1;
-                target_state.abandoned_replays += 1;
+                if !self.shutdown_sealed {
+                    target_state.abandoned_replays += 1;
+                    enqueue = true;
+                }
             }
+        }
+        if enqueue {
+            self.enqueue_transition_candidate(target);
+        }
+        self.remove_if_quiescent_and_default(target);
+    }
+
+    pub(super) fn publish_default_new(&mut self) {
+        self.default_generation = DeferredGeneration::New;
+        let queued = self
+            .targets
+            .iter_mut()
+            .filter_map(|(target, state)| {
+                if state.generation == DeferredGeneration::Legacy && !state.transition_queued {
+                    state.transition_queued = true;
+                    Some(target.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        self.transition_queue.extend(queued);
+    }
+
+    pub(super) fn take_transition_candidates(&mut self, limit: usize) -> Vec<DeferredGenerationTransitionCandidate> {
+        let mut candidates = Vec::with_capacity(limit.min(self.transition_queue.len()));
+        while candidates.len() < limit {
+            let Some(target) = self.transition_queue.pop_front() else {
+                break;
+            };
+            let Some(state) = self.targets.get_mut(&target) else {
+                continue;
+            };
+            state.transition_queued = false;
+            let kind = if state.generation == DeferredGeneration::Legacy {
+                Some(DeferredGenerationTransitionKind::LegacyTarget)
+            } else if state.abandoned_replays > 0 {
+                Some(DeferredGenerationTransitionKind::AbandonedReplay)
+            } else {
+                None
+            };
+            if let Some(kind) = kind {
+                candidates.push(DeferredGenerationTransitionCandidate { target, kind });
+            }
+        }
+        candidates
+    }
+
+    pub(super) fn enqueue_transition_candidate(&mut self, target: &DeferredGenerationTarget) {
+        if self.shutdown_sealed {
+            return;
+        }
+        let Some(state) = self.targets.get_mut(target) else {
+            return;
+        };
+        let eligible = state.generation == DeferredGeneration::Legacy || state.abandoned_replays > 0;
+        if !eligible || state.transition_queued {
+            return;
+        }
+        state.transition_queued = true;
+        self.transition_queue.push_back(target.clone());
+    }
+
+    pub(super) fn clear_transition_candidates(&mut self) {
+        self.transition_queue.clear();
+        for state in self.targets.values_mut() {
+            state.transition_queued = false;
+        }
+    }
+
+    pub(super) fn discard_abandoned_replays(&mut self) {
+        for state in self.targets.values_mut() {
+            state.abandoned_replays = 0;
         }
     }
 
@@ -247,6 +329,7 @@ pub(super) struct DeferredGenerationTargetState {
     pub(super) replay_tokens: usize,
     pub(super) abandoned_replays: usize,
     pop_lite_wake_active: bool,
+    transition_queued: bool,
 }
 
 impl DeferredGenerationTargetState {
@@ -261,6 +344,7 @@ impl DeferredGenerationTargetState {
             replay_tokens: 0,
             abandoned_replays: 0,
             pop_lite_wake_active: false,
+            transition_queued: false,
         }
     }
 

--- a/rocketmq-broker/src/deferred_generation_handoff/target.rs
+++ b/rocketmq-broker/src/deferred_generation_handoff/target.rs
@@ -42,6 +42,18 @@ pub(crate) enum DeferredGenerationTarget {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DeferredGenerationTransitionKind {
+    LegacyTarget,
+    AbandonedReplay,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DeferredGenerationTransitionCandidate {
+    pub(crate) target: DeferredGenerationTarget,
+    pub(crate) kind: DeferredGenerationTransitionKind,
+}
+
 impl DeferredGenerationTarget {
     #[must_use]
     pub(crate) const fn pop(topic: CheetahString, consumer_group: CheetahString, queue_id: i32) -> Self {

--- a/rocketmq-broker/src/deferred_generation_handoff/tests.rs
+++ b/rocketmq-broker/src/deferred_generation_handoff/tests.rs
@@ -298,6 +298,65 @@ fn cutover_seals_then_explicitly_transitions_drained_legacy_target() {
 }
 
 #[test]
+fn transition_scan_is_o1_closed_before_publish_and_bounded_after_publish() {
+    let handoff = DeferredGenerationHandoff::new();
+    let target = pop_target();
+    let wait = enroll(&handoff, target.clone());
+    let probes = AtomicUsize::new(0);
+
+    assert!(!handoff.transition_scan_ready_for_test());
+    assert!(handoff.take_transition_candidates(1).is_empty());
+    assert_eq!(handoff.transition_candidate_scans_for_test(), 0);
+    assert_eq!(probes.load(Ordering::Relaxed), 0);
+
+    publish_new(&handoff);
+    drop(wait);
+    assert!(handoff.transition_scan_ready_for_test());
+    let candidates = handoff.take_transition_candidates(1);
+    assert_eq!(handoff.transition_candidate_scans_for_test(), 1);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].target, target);
+    assert_eq!(candidates[0].kind, DeferredGenerationTransitionKind::LegacyTarget);
+    let replay = handoff
+        .try_transition_target_to_new(target, |_| {
+            probes.fetch_add(1, Ordering::Relaxed);
+            false
+        })
+        .expect("published candidate probes then transitions");
+    assert_eq!(probes.load(Ordering::Relaxed), 1);
+    replay.complete_after_replay_accepted();
+    assert!(handoff.zero_report().is_zero());
+}
+
+#[test]
+fn transition_candidates_requeue_at_the_tail_without_fixed_prefix_starvation() {
+    let handoff = DeferredGenerationHandoff::new();
+    let targets = [
+        DeferredGenerationTarget::pull(string("pull-a"), 0),
+        DeferredGenerationTarget::pull(string("pull-b"), 0),
+        DeferredGenerationTarget::pull(string("pull-c"), 0),
+    ];
+    let waits = targets
+        .iter()
+        .cloned()
+        .map(|target| enroll(&handoff, target))
+        .collect::<Vec<_>>();
+    publish_new(&handoff);
+    drop(waits);
+
+    let first = handoff
+        .take_transition_candidates(1)
+        .pop()
+        .expect("first bounded candidate");
+    handoff.requeue_transition_candidate(&first.target);
+    let second = handoff
+        .take_transition_candidates(1)
+        .pop()
+        .expect("next bounded candidate");
+    assert_ne!(second.target, first.target, "requeued work moves behind its peers");
+}
+
+#[test]
 fn transition_rejects_absent_and_explicitly_new_targets() {
     let handoff = DeferredGenerationHandoff::new();
     publish_new(&handoff);
@@ -351,17 +410,34 @@ fn dropped_replay_token_stays_abandoned_until_explicit_retry_completion() {
     assert_eq!(snapshot.tracked_targets, 1);
     assert!(!handoff.zero_report().is_zero());
 
+    let abandoned = handoff
+        .take_transition_candidates(1)
+        .pop()
+        .expect("abandoned replay is returned to the transition queue");
+    assert_eq!(abandoned.target, target);
+    assert_eq!(abandoned.kind, DeferredGenerationTransitionKind::AbandonedReplay);
     let retry = handoff
-        .retry_abandoned_replay(target)
+        .retry_abandoned_replay(abandoned.target)
         .expect("abandoned replay remains explicitly retryable");
     assert_eq!(handoff.snapshot().replay_tokens, 1);
     assert_eq!(handoff.snapshot().abandoned_replays, 0);
+
+    drop(retry);
+    let retried = handoff
+        .take_transition_candidates(1)
+        .pop()
+        .expect("a failed replay is requeued at the tail");
+    assert_eq!(retried.target, target);
+    assert_eq!(retried.kind, DeferredGenerationTransitionKind::AbandonedReplay);
+    let retry = handoff
+        .retry_abandoned_replay(retried.target)
+        .expect("requeued replay remains retryable");
     retry.complete_after_replay_accepted();
     assert!(handoff.zero_report().is_zero());
 }
 
 #[test]
-fn shutdown_prunes_quiescent_legacy_marker_but_not_abandoned_replay() {
+fn shutdown_prunes_quiescent_legacy_marker_and_abandoned_replay() {
     let handoff = DeferredGenerationHandoff::new();
     let legacy = pop_target();
     let wait = enroll(&handoff, legacy.clone());
@@ -388,9 +464,28 @@ fn shutdown_prunes_quiescent_legacy_marker_but_not_abandoned_replay() {
     );
     assert_eq!(handoff.seal(), DeferredGenerationSeal::Sealed);
     let snapshot = handoff.snapshot();
-    assert_eq!(snapshot.abandoned_replays, 1);
-    assert_eq!(snapshot.tracked_targets, 1);
-    assert!(!handoff.zero_report().is_zero());
+    assert_eq!(snapshot.abandoned_replays, 0);
+    assert_eq!(snapshot.tracked_targets, 0);
+    assert!(handoff.zero_report().is_zero());
+}
+
+#[test]
+fn replay_token_dropped_after_shutdown_does_not_create_abandoned_work() {
+    let handoff = DeferredGenerationHandoff::new();
+    let target = pop_target();
+    let wait = enroll(&handoff, target.clone());
+    publish_new(&handoff);
+    drop(wait);
+    let replay = handoff
+        .try_transition_target_to_new(target, |_| false)
+        .expect("drained target transition");
+
+    assert_eq!(handoff.seal(), DeferredGenerationSeal::Sealed);
+    assert_eq!(handoff.snapshot().replay_tokens, 1);
+    drop(replay);
+
+    assert!(handoff.take_transition_candidates(1).is_empty());
+    assert!(handoff.zero_report().is_zero());
 }
 
 #[test]
@@ -421,6 +516,9 @@ fn interrupted_cutover_resumes_from_the_last_published_stage() {
         let mut transaction = handoff.cutover_transaction().expect("cutover transaction");
         transaction.seal_legacy_acceptance().expect("seal legacy acceptance");
     }
+    assert!(!handoff.transition_scan_ready_for_test());
+    assert!(handoff.take_transition_candidates(1).is_empty());
+    assert_eq!(handoff.transition_candidate_scans_for_test(), 0);
     {
         let mut transaction = handoff.cutover_transaction().expect("resumed transaction");
         transaction
@@ -430,6 +528,9 @@ fn interrupted_cutover_resumes_from_the_last_published_stage() {
             .publish_v2_aggregate(DeferredGenerationV2Publisher::nonblocking_atomic(|| Ok::<_, ()>(())))
             .expect("publish V2 aggregate");
     }
+    assert!(!handoff.transition_scan_ready_for_test());
+    assert!(handoff.take_transition_candidates(1).is_empty());
+    assert_eq!(handoff.transition_candidate_scans_for_test(), 0);
     let mut transaction = handoff.cutover_transaction().expect("second resumed transaction");
     transaction
         .publish_v2_aggregate(DeferredGenerationV2Publisher::nonblocking_atomic(|| Ok::<_, ()>(())))
@@ -538,6 +639,9 @@ fn shutdown_and_producer_routing_serialize_after_controlled_publish_commit() {
 
     shutdown_started_rx.recv().expect("shutdown started");
     route_started_rx.recv().expect("producer route started");
+    while handoff.seal_gate_attempts_for_test() == 0 {
+        std::thread::yield_now();
+    }
     assert!(
         shutdown_done_rx.try_recv().is_err(),
         "shutdown must wait for publish commit"
@@ -563,6 +667,10 @@ fn shutdown_and_producer_routing_serialize_after_controlled_publish_commit() {
     assert!(snapshot.sealed);
     assert!(snapshot.v2_aggregate_published);
     assert_eq!(snapshot.default_generation, DeferredGeneration::New);
+    assert!(!handoff.transition_scan_ready_for_test());
+    let scans = handoff.transition_candidate_scans_for_test();
+    assert!(handoff.take_transition_candidates(1).is_empty());
+    assert_eq!(handoff.transition_candidate_scans_for_test(), scans);
 }
 
 #[test]

--- a/rocketmq-broker/src/lite/lite_event_dispatcher.rs
+++ b/rocketmq-broker/src/lite/lite_event_dispatcher.rs
@@ -498,6 +498,15 @@ impl LiteEventDispatcher {
             .collect()
     }
 
+    pub(crate) fn replay_pending_event(&self, client_id: &CheetahString) -> bool {
+        self.scan(current_millis());
+        let pending = self.client_events.get(client_id).is_some_and(|entry| !entry.is_empty());
+        if pending {
+            self.notify_client(client_id);
+        }
+        pending
+    }
+
     pub(crate) fn take_pending_events(&self, client_id: &CheetahString) -> Vec<CheetahString> {
         let Some(reservation) = self.reserve_pending_events(client_id) else {
             return Vec::new();
@@ -788,6 +797,16 @@ mod tests {
         tokio::time::timeout(Duration::from_millis(10), legacy_notify.notified())
             .await
             .expect("legacy generation receives the dispatcher signal");
+
+        let replayed = Arc::new(AtomicU64::new(0));
+        let replayed_observer = Arc::clone(&replayed);
+        dispatcher.set_deferred_event_observer(Arc::new(move |_| {
+            replayed_observer.fetch_add(1, Ordering::AcqRel);
+            true
+        }));
+        assert!(dispatcher.replay_pending_event(&legacy_client));
+        assert_eq!(replayed.load(Ordering::Acquire), 1);
+        assert_eq!(dispatcher.pending_events(&legacy_client).len(), 1);
     }
 
     #[test]

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
@@ -873,6 +873,15 @@ impl<RP: PopLiteLongPollingRequestProcessor + Sync + 'static> PopLiteLongPolling
         self.polling_map.get(key).map(|queue| queue.len() as i32).unwrap_or(0)
     }
 
+    pub(crate) fn legacy_target_occupied(&self, target: &DeferredGenerationTarget) -> bool {
+        let DeferredGenerationTarget::PopLite { client_id } = target else {
+            return false;
+        };
+        let _admission = self.polling_admission.lock();
+        self.polling_map.get(client_id).is_some_and(|queue| !queue.is_empty())
+            || self.waking_clients.contains_key(client_id)
+    }
+
     pub(crate) fn resource_snapshot(&self) -> PopLiteLongPollingResourceSnapshot {
         let oldest_request_age = self.polling_map.iter().fold(None::<Duration>, |oldest, queue| {
             queue.value().iter().fold(oldest, |oldest, request| {
@@ -1297,6 +1306,12 @@ mod tests {
         cutover.join().expect("cutover thread");
 
         let target = DeferredGenerationTarget::pop_lite(client_id.clone());
+        assert!(service.legacy_target_occupied(&target));
+        assert!(
+            !service.legacy_target_occupied(&DeferredGenerationTarget::pop_lite(CheetahString::from_static_str(
+                "unrelated-pop-lite-client"
+            ),))
+        );
         assert!(matches!(
             handoff.try_transition_target_to_new(target.clone(), |_| {
                 service
@@ -1308,6 +1323,7 @@ mod tests {
                 | Err(crate::deferred_generation_handoff::DeferredGenerationTargetTransitionError::LegacyTableOccupied)
         ));
         session.close();
+        assert!(!service.legacy_target_occupied(&target));
         let replay = handoff
             .try_transition_target_to_new(target, |_| {
                 service
@@ -1553,11 +1569,11 @@ mod tests {
             started: Notify::new(),
             release: Notify::new(),
         });
-        let tree = ResourceBudgetTree::new(
-            "pop-lite-handoff-single-flight",
-            BudgetLimit::new(4, 256 * 1024, FullPolicy::Reject),
-        )
-        .expect("root budget");
+        let mut runtime = BrokerRuntime::new(
+            Arc::new(BrokerConfig::default()),
+            Arc::new(MessageStoreConfig::default()),
+        );
+        let state = runtime.runtime_state_mut();
         let context = PopLiteLongPollingServiceContext::try_with_resource_budget(
             PopLiteLongPollingPolicy {
                 pop_polling_map_size: 2,
@@ -1565,8 +1581,8 @@ mod tests {
                 pop_polling_size: 4,
             },
             LiteEventDispatcher::default(),
-            None,
-            &tree.root(),
+            state.broker_service_context(),
+            state.resource_budget(),
         )
         .expect("PopLite request budget");
         let service = Arc::new(PopLiteLongPollingService::new(context, Arc::downgrade(&processor)));
@@ -1575,12 +1591,17 @@ mod tests {
             .install_handoff(Arc::clone(&handoff))
             .expect("install the Broker coordinator");
         PopLiteLongPollingService::start(&service).await;
+        assert!(service.is_running(), "Broker-owned PopLite service must start");
         let client_id = CheetahString::from_static_str("single-flight-client");
-        for _ in 0..2 {
+        let (first_session, first_session_group, first_context, _first_peer) =
+            session_execution_test_context(8_404, None).await;
+        let (second_session, second_session_group, second_context, _second_peer) =
+            session_execution_test_context(8_405, None).await;
+        for context in [first_context, second_context] {
             let mut command = RemotingCommand::create_remoting_command(0);
             assert_eq!(
                 service.polling(
-                    test_context().await,
+                    context,
                     &mut command,
                     &client_id,
                     i64::try_from(current_millis()).expect("test clock fits i64"),
@@ -1602,7 +1623,10 @@ mod tests {
 
         processor.release.notify_one();
         tokio::time::timeout(Duration::from_secs(1), async {
-            while handoff.snapshot().continuations != 0 {
+            while handoff.snapshot().continuations != 0
+                || service.legacy_resource_snapshot().waking_clients != 0
+                || service.legacy_resource_snapshot().active_executions != 0
+            {
                 tokio::task::yield_now().await;
             }
         })
@@ -1612,14 +1636,27 @@ mod tests {
         processor.release.notify_one();
         assert!(service.wake_up_client(&client_id));
         tokio::time::timeout(Duration::from_secs(1), async {
-            while !handoff.zero_report().is_zero() {
+            while !handoff.zero_report().is_zero()
+                || service.legacy_resource_snapshot().waking_clients != 0
+                || service.legacy_resource_snapshot().active_executions != 0
+            {
                 tokio::task::yield_now().await;
             }
         })
         .await
         .expect("second PopLite terminal releases final ownership");
         assert_eq!(processor.calls.load(Ordering::Acquire), 2);
+        first_session.close();
+        second_session.close();
         service.shutdown().await;
+        for session_group in [first_session_group, second_session_group] {
+            let report = session_group
+                .shutdown_until(ShutdownDeadline::after(Duration::from_secs(1)))
+                .await;
+            assert!(report.is_healthy(), "{}", report.to_json());
+        }
+        assert!(service.legacy_resource_snapshot().is_zero());
+        assert!(handoff.zero_report().is_zero());
     }
 
     fn assert_budget_released_and_readmits(

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -1181,6 +1181,27 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
         self.polling_map.get(key).map(|queue| queue.len() as i32).unwrap_or(0)
     }
 
+    pub(crate) fn legacy_target_occupied(&self, target: &DeferredGenerationTarget) -> bool {
+        let (topic, consumer_group, queue_id) = match target {
+            DeferredGenerationTarget::Pop {
+                topic,
+                consumer_group,
+                queue_id,
+            }
+            | DeferredGenerationTarget::Notification {
+                topic,
+                consumer_group,
+                queue_id,
+            } => (topic, consumer_group, *queue_id),
+            _ => return false,
+        };
+        let key = KeyBuilder::build_polling_key(topic, consumer_group, queue_id);
+        let _admission = self.polling_admission.lock();
+        self.polling_map
+            .get(key.as_str())
+            .is_some_and(|queue| !queue.is_empty())
+    }
+
     #[cfg(test)]
     pub(crate) fn is_running(&self) -> bool {
         self.running.load(Ordering::Acquire)
@@ -1701,6 +1722,12 @@ mod tests {
             _ => DeferredGenerationTarget::pop(topic.clone(), group.clone(), 0),
         };
         let key = CheetahString::from_string(KeyBuilder::build_polling_key(&topic, &group, 0));
+        assert!(service.legacy_target_occupied(&target));
+        assert!(!service.legacy_target_occupied(&DeferredGenerationTarget::pop(
+            CheetahString::from_static_str("unrelated-pop-topic"),
+            group.clone(),
+            0,
+        )));
         assert!(matches!(
             handoff.try_transition_target_to_new(target.clone(), |_| {
                 service.polling_map.get(&key).is_some_and(|queue| !queue.is_empty())
@@ -1709,6 +1736,7 @@ mod tests {
                 | Err(crate::deferred_generation_handoff::DeferredGenerationTargetTransitionError::LegacyTableOccupied)
         ));
         session.close();
+        assert!(!service.legacy_target_occupied(&target));
         let replay = handoff
             .try_transition_target_to_new(target, |_| {
                 service.polling_map.get(&key).is_some_and(|queue| !queue.is_empty())

--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -289,6 +289,17 @@ where
         }
     }
 
+    pub(crate) fn legacy_target_occupied(&self, target: &DeferredGenerationTarget) -> bool {
+        let DeferredGenerationTarget::Pull { topic, queue_id } = target else {
+            return false;
+        };
+        let key = build_key(topic.as_str(), *queue_id);
+        self.pull_request_table
+            .read()
+            .get(&key)
+            .is_some_and(|requests| !requests.is_empty())
+    }
+
     pub(crate) fn install_handoff(
         &self,
         handoff: Arc<DeferredGenerationHandoff>,
@@ -1100,12 +1111,18 @@ mod tests {
             assert!(service.suspend_pull_request(topic.as_str(), 0, request));
         }
         let key = build_key(topic.as_str(), 0);
+        let target = DeferredGenerationTarget::pull(topic.clone(), 0);
         assert_eq!(service.pull_request_table.read()[&key].len(), 2);
         assert_eq!(handoff.snapshot().occupancy, 2);
 
         first_session.close();
         assert_eq!(service.pull_request_table.read()[&key].len(), 1);
         assert_eq!(handoff.snapshot().occupancy, 1);
+        assert!(service.legacy_target_occupied(&target));
+        assert!(!service.legacy_target_occupied(&DeferredGenerationTarget::pull(
+            CheetahString::from_static_str("unrelated-pull-topic"),
+            0,
+        )));
 
         second_session.close();
         assert!(service.pull_request_table.read()[&key].is_empty());
@@ -1199,6 +1216,7 @@ mod tests {
 
         session.close();
         assert!(service.pull_request_table.read()[&key].is_empty());
+        assert!(!service.legacy_target_occupied(&target));
         let replay = handoff
             .try_transition_target_to_new(target, |_| false)
             .expect("empty Pull table may transition exactly once");

--- a/rocketmq-broker/src/long_polling/notification_deferred/service/continuation.rs
+++ b/rocketmq-broker/src/long_polling/notification_deferred/service/continuation.rs
@@ -177,9 +177,13 @@ impl PendingArrivalValue for NotificationPendingArrival {
         self.retained_bytes
     }
 
-    fn coalesce_refresh(&mut self) {
+    fn rewind_from_start(&mut self) {
         self.cursor.restart_for_refresh();
         self.remaining_conflicts = self.max_conflicts;
+    }
+
+    fn coalesce_refresh(&mut self) {
+        self.rewind_from_start();
     }
 }
 

--- a/rocketmq-broker/src/long_polling/pending_arrival_latch.rs
+++ b/rocketmq-broker/src/long_polling/pending_arrival_latch.rs
@@ -23,6 +23,10 @@ use parking_lot::Mutex;
 pub(crate) trait PendingArrivalValue {
     fn retained_bytes(&self) -> usize;
 
+    /// Rewinds a partially consumed replay so the next producer tick starts
+    /// from the first candidate without requiring another Store arrival.
+    fn rewind_from_start(&mut self);
+
     /// Coalesces another arrival for the same target into a conservative
     /// refresh. The refresh may inspect more waiters, but registry claim
     /// ownership still prevents duplicate canonical resumes.
@@ -302,6 +306,15 @@ where
 {
     pub(crate) fn value_mut(&mut self) -> &mut V {
         self.value.as_mut().expect("active pending claim retains its value")
+    }
+
+    /// Rearms this exact pending value after routing observes a Legacy target.
+    ///
+    /// Drop returns the value and its original admission ownership to the
+    /// latch; rewinding here prevents a cursor that already passed the Legacy
+    /// waiter from deleting the event on the next producer tick.
+    pub(crate) fn rearm_from_start(&mut self) {
+        self.value_mut().rewind_from_start();
     }
 
     /// Returns true only after atomically proving that no arrival was merged

--- a/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests/network.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests/network.rs
@@ -442,6 +442,85 @@ async fn prepared_wake_replays_then_observed_resume_writes_one_bound_frame() {
 }
 
 #[tokio::test]
+async fn legacy_route_rearms_a_real_waiter_for_the_next_tick_without_a_new_arrival() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 2, 2, 2);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier,
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, controller).await;
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 98_290))
+        .await
+        .expect("send real deferred POP waiter");
+    let registered = registrations.recv().await.expect("observe real POP waiter");
+
+    let topic = CheetahString::from_static_str("TopicA");
+    service
+        .latch_arrival(&topic, 0, None, 0, None, None, service.fanout_cursor())
+        .expect("retain one arrival before the Legacy route is observed");
+    let mut first_tick = service
+        .pending_arrival_reservations()
+        .pop()
+        .expect("first producer tick reserves the arrival")
+        .claim()
+        .expect("first producer tick claims the arrival");
+    let first_batch = service.pending_consumer_group_batch(first_tick.value_mut());
+    assert!(first_batch.exhausted());
+    let first_group = first_batch
+        .into_consumer_groups()
+        .into_iter()
+        .next()
+        .expect("first tick scans the waiter's consumer group");
+    let first_candidate = service
+        .reserve_arrival_candidate(first_tick.value_mut().view(&first_group), PopSelectionOrder::Oldest)
+        .expect("first tick reaches the real waiter");
+    assert_eq!(first_candidate.id(), registered.id);
+    drop(first_candidate);
+
+    // This is the worker's Legacy branch: no new Store callback marks the
+    // latch dirty, so an explicit rewind is the only way to retain the event.
+    first_tick.rearm_from_start();
+    drop(first_tick);
+    assert_eq!(service.resource_snapshot().pending_arrivals, 1);
+
+    let mut next_tick = service
+        .pending_arrival_reservations()
+        .pop()
+        .expect("next producer tick retries without another arrival")
+        .claim()
+        .expect("next producer tick claims the same arrival");
+    let next_batch = service.pending_consumer_group_batch(next_tick.value_mut());
+    assert!(next_batch.exhausted());
+    let next_group = next_batch
+        .into_consumer_groups()
+        .into_iter()
+        .next()
+        .expect("rewound tick scans the same consumer group");
+    let next_candidate = service
+        .reserve_arrival_candidate(next_tick.value_mut().view(&next_group), PopSelectionOrder::Oldest)
+        .expect("rewound tick reaches the same real waiter");
+    assert_eq!(next_candidate.id(), registered.id);
+    assert!(next_tick.finish_if_clean());
+    let claimed = service
+        .claim_candidate(next_candidate, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("transitioned New route can claim the retained waiter");
+    drop(claimed);
+
+    drop(client);
+    let _ = service.shutdown();
+    running.finish().await;
+    assert_released(&service);
+}
+
+#[tokio::test]
 async fn provisional_oldest_claim_does_not_hide_active_second_waiter() {
     let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
     let service = service(controller.as_ref(), 4, 4, 4);

--- a/rocketmq-broker/src/long_polling/pop_deferred/service/continuation.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/service/continuation.rs
@@ -136,8 +136,12 @@ impl PendingArrivalValue for PopPendingArrival {
         self.retained_bytes
     }
 
-    fn coalesce_refresh(&mut self) {
+    fn rewind_from_start(&mut self) {
         self.cursor = PopFanoutCursor::new();
+    }
+
+    fn coalesce_refresh(&mut self) {
+        self.rewind_from_start();
     }
 }
 

--- a/rocketmq-broker/src/long_polling/pull_deferred/service/continuation.rs
+++ b/rocketmq-broker/src/long_polling/pull_deferred/service/continuation.rs
@@ -143,8 +143,12 @@ impl PendingArrivalValue for PullPendingArrival {
         self.retained_bytes
     }
 
-    fn coalesce_refresh(&mut self) {
+    fn rewind_from_start(&mut self) {
         self.cursor = PullScanCursor::new();
+    }
+
+    fn coalesce_refresh(&mut self) {
+        self.rewind_from_start();
     }
 }
 

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -86,6 +86,7 @@ pub(crate) mod reply_message_processor;
 mod request_ordering;
 pub(crate) mod response_plan;
 pub(crate) mod send_message_processor;
+pub(crate) mod v2;
 #[cfg(test)]
 pub(crate) mod v2_leaf_test_support;
 

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -282,6 +282,15 @@ where
     MS: BrokerReadWriteStore + 'static,
 {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl<MS: BrokerReadWriteStore> AckMessageProcessor<MS> {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let command_factory = self.context.command_factory;
         let request_source = request_origin_label(request.origin());

--- a/rocketmq-broker/src/processor/change_invisible_time_processor.rs
+++ b/rocketmq-broker/src/processor/change_invisible_time_processor.rs
@@ -255,6 +255,15 @@ where
     MS: BrokerReadWriteStore + 'static,
 {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl<MS: BrokerReadWriteStore> ChangeInvisibleTimeProcessor<MS> {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let command_factory = self.context.command_factory;
         let request_source = request_origin_label(request.origin());

--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -97,6 +97,15 @@ where
     MS: BrokerStorePort + 'static,
 {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl<MS: BrokerStorePort> ClientManageProcessor<MS> {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let session_id = request.session().id();
         let remote_address = trusted_remote_address(request)?;
@@ -188,7 +197,7 @@ where
     MS: BrokerStorePort,
 {
     async fn process_session_command(
-        &mut self,
+        &self,
         session_id: SessionId,
         remote_address: String,
         request: &mut RemotingCommand,
@@ -318,7 +327,7 @@ where
     }
 
     async fn heart_beat(
-        &mut self,
+        &self,
         remote_address: String,
         heartbeat_data: HeartbeatData,
         client: RegisteredClient,
@@ -449,7 +458,7 @@ where
     }
 
     async fn heart_beat_v2(
-        &mut self,
+        &self,
         remote_address: &str,
         heartbeat_data: HeartbeatData,
         client: RegisteredClient,
@@ -1023,7 +1032,7 @@ mod tests {
     #[tokio::test]
     async fn heart_beat_v2_without_sub_registers_consumer_and_marks_sub_change() {
         let mut runtime = new_test_runtime("heartbeat-v2-without-sub", false).await;
-        let (consumer_manager, mut processor) = {
+        let (consumer_manager, processor) = {
             let inner = runtime.runtime_state_mut();
             (
                 inner.consumer_manager().clone_shared_state(),
@@ -1163,7 +1172,7 @@ mod tests {
     #[tokio::test]
     async fn session_command_core_uses_only_the_stable_session_identity_index() {
         let mut runtime = new_test_runtime("session-identity-index", false).await;
-        let (producer_manager, consumer_manager, mut processor) = {
+        let (producer_manager, consumer_manager, processor) = {
             let inner = runtime.runtime_state_mut();
             (
                 inner.producer_manager().clone_shared_state(),
@@ -1249,7 +1258,7 @@ mod tests {
     #[tokio::test]
     async fn session_reconnect_cleans_the_role_omitted_by_the_new_heartbeat() {
         let mut runtime = new_test_runtime("session-role-reconnect", false).await;
-        let (producer_manager, consumer_manager, mut processor) = {
+        let (producer_manager, consumer_manager, processor) = {
             let inner = runtime.runtime_state_mut();
             (
                 inner.producer_manager().clone_shared_state(),
@@ -1355,7 +1364,7 @@ mod tests {
     #[tokio::test]
     async fn session_identity_conflict_is_rejected_before_either_role_commits() {
         let mut runtime = new_test_runtime("session-cross-role-identity", false).await;
-        let (producer_manager, consumer_manager, mut processor) = {
+        let (producer_manager, consumer_manager, processor) = {
             let inner = runtime.runtime_state_mut();
             (
                 inner.producer_manager().clone_shared_state(),
@@ -1436,8 +1445,8 @@ mod tests {
         let second_session = session_id_for_test(9_872);
         let producer_group = CheetahString::from_static_str("cross-role-race-producer");
         let consumer_group = CheetahString::from_static_str("cross-role-race-consumer");
-        let mut first_processor = processor.clone();
-        let mut second_processor = processor;
+        let first_processor = processor.clone();
+        let second_processor = processor;
         let mut first_request = session_heartbeat_request(
             "cross-role-race-client",
             std::slice::from_ref(&consumer_group),

--- a/rocketmq-broker/src/processor/consumer_manage_processor.rs
+++ b/rocketmq-broker/src/processor/consumer_manage_processor.rs
@@ -77,6 +77,15 @@ where
     MS: BrokerStorePort + 'static,
 {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl<MS: BrokerStorePort> ConsumerManageProcessor<MS> {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let request_source = trusted_request_source(request)?;
         let result = self.process_command(request_source, request.command_mut()).await;
@@ -112,7 +121,7 @@ where
         request_source: CheetahString,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut processor = self.clone();
+        let processor = self.clone();
         processor.process_command(request_source, request).await
     }
 }
@@ -139,7 +148,7 @@ where
     MS: BrokerStorePort,
 {
     async fn process_command(
-        &mut self,
+        &self,
         request_source: CheetahString,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -165,7 +174,7 @@ where
     }
 
     pub async fn get_consumer_list_by_group(
-        &mut self,
+        &self,
         request_source: &str,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -206,7 +215,7 @@ where
     }
 
     async fn update_consumer_offset(
-        &mut self,
+        &self,
         request_source: CheetahString,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -274,7 +283,7 @@ where
     }
 
     async fn query_consumer_offset(
-        &mut self,
+        &self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut request_header = request.decode_command_custom_header::<QueryConsumerOffsetRequestHeader>()?;
@@ -335,7 +344,7 @@ where
     /// This handles the case where the consumer offset needs to be committed to a different broker
     /// based on the static topic queue mapping.
     async fn rewrite_request_for_static_topic_for_consume_offset(
-        &mut self,
+        &self,
         request_header: &mut UpdateConsumerOffsetRequestHeader,
         mapping_context: &mut TopicQueueMappingContext,
     ) -> Option<RemotingCommand> {
@@ -411,7 +420,7 @@ where
     }
 
     async fn rewrite_request_for_static_topic(
-        &mut self,
+        &self,
         request_header: &mut QueryConsumerOffsetRequestHeader,
         mapping_context: &mut TopicQueueMappingContext,
     ) -> Option<RemotingCommand> {
@@ -535,7 +544,7 @@ where
     }
 
     fn rewrite_response_for_static_topic(
-        &mut self,
+        &self,
         request_header: &QueryConsumerOffsetRequestHeader,
         response_header: &mut QueryConsumerOffsetResponseHeader,
         mapping_context: &TopicQueueMappingContext,

--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -171,6 +171,19 @@ where
     MS: BrokerWriteStore + 'static,
 {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl<TM, MS> EndTransactionProcessor<TM, MS>
+where
+    TM: TransactionalMessageService,
+    MS: BrokerWriteStore,
+{
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let opaque = request.original_identity().original_opaque();
         let command_factory = self.context.command_factory;
         let result = match self.process_command(request.command_mut()).await {
@@ -207,13 +220,13 @@ where
         &self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut processor = self.clone();
+        let processor = self.clone();
         processor.process_command(request).await
     }
 
     /// V2 leaf business contract; transaction completion does not need a transport handle.
     async fn process_command(
-        &mut self,
+        &self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
@@ -252,7 +265,7 @@ where
     MS: BrokerWriteStore,
 {
     async fn process_command_inner(
-        &mut self,
+        &self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<EndTransactionRequestHeader>()?;
@@ -520,7 +533,7 @@ where
         command
     }
 
-    async fn send_final_message(&mut self, msg_inner: MessageExtBrokerInner) -> RemotingCommand {
+    async fn send_final_message(&self, msg_inner: MessageExtBrokerInner) -> RemotingCommand {
         // Save topic before moving msg_inner
         let topic = msg_inner.get_topic().clone();
 

--- a/rocketmq-broker/src/processor/fast_failure_dispatch.rs
+++ b/rocketmq-broker/src/processor/fast_failure_dispatch.rs
@@ -249,6 +249,18 @@ impl FastFailureRunGuard {
             )
         })
     }
+
+    /// Completes a V2 run without transferring response ownership through the
+    /// legacy fast-failure response channel.
+    ///
+    /// The V2 handler outcome remains affine and is delivered only by the
+    /// canonical dispatcher. Fast failure owns scheduling/accounting here,
+    /// not the response plan.
+    pub(super) fn complete_v2(mut self) {
+        self.service.complete(self.queue_kind, &self.task, None);
+        self.response_rx.take();
+        self.settled = true;
+    }
 }
 
 impl Drop for FastFailureRunGuard {

--- a/rocketmq-broker/src/processor/lite_manager_processor.rs
+++ b/rocketmq-broker/src/processor/lite_manager_processor.rs
@@ -324,6 +324,15 @@ impl<MS: BrokerReadWriteStore> LiteManagerProcessor<MS> {
 
 impl<MS: BrokerReadWriteStore + 'static> RequestProcessorV2 for LiteManagerProcessor<MS> {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl<MS: BrokerReadWriteStore> LiteManagerProcessor<MS> {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let command_factory = self.context.command_factory;
         let result = self.process_command(request.command_mut()).await;

--- a/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
+++ b/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
@@ -281,6 +281,15 @@ impl<MS: BrokerStorePort> LiteSubscriptionCtlProcessor<MS> {
 
 impl<MS: BrokerStorePort + 'static> RequestProcessorV2 for LiteSubscriptionCtlProcessor<MS> {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl<MS: BrokerStorePort> LiteSubscriptionCtlProcessor<MS> {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let command_factory = self.context.command_factory;
         let result = self.process_command(request.command_mut()).await;

--- a/rocketmq-broker/src/processor/maintenance_request_processor.rs
+++ b/rocketmq-broker/src/processor/maintenance_request_processor.rs
@@ -286,6 +286,12 @@ impl LegacyMaintenanceRequestProcessor {
 
 impl RequestProcessorV2 for MaintenanceRequestProcessor {
     async fn process(&mut self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl MaintenanceRequestProcessor {
+    pub(crate) async fn process_v2_shared(&self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let result = match self.authorize_v2(request) {
             Ok(grant) => self.process_authorized(&grant, request.command_mut()).await.map(Some),

--- a/rocketmq-broker/src/processor/notification_processor.rs
+++ b/rocketmq-broker/src/processor/notification_processor.rs
@@ -560,6 +560,10 @@ impl<MS> NotificationProcessor<MS>
 where
     MS: BrokerReadWriteStore,
 {
+    pub(crate) fn pop_long_polling_service(&self) -> &Arc<PopLongPollingService<NotificationProcessor<MS>>> {
+        &self.pop_long_polling_service
+    }
+
     pub(crate) fn install_deferred_generation_handoff(
         &self,
         handoff: Arc<DeferredGenerationHandoff>,

--- a/rocketmq-broker/src/processor/peek_message_processor.rs
+++ b/rocketmq-broker/src/processor/peek_message_processor.rs
@@ -201,6 +201,15 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
 
 impl<MS: BrokerReadWriteStore + 'static> RequestProcessorV2 for PeekMessageProcessor<MS> {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let command_factory = self.context.command_factory;
         let request_source = request_origin_label(request.origin());

--- a/rocketmq-broker/src/processor/polling_info_processor.rs
+++ b/rocketmq-broker/src/processor/polling_info_processor.rs
@@ -101,6 +101,15 @@ impl Clone for PollingInfoProcessor {
 
 impl RequestProcessorV2 for PollingInfoProcessor {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl PollingInfoProcessor {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let command_factory = self.command_factory;
         let peer_label = request_peer_label(request.origin());
@@ -120,13 +129,13 @@ impl PollingInfoProcessor {
         peer_label: String,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut processor = self.clone();
+        let processor = self.clone();
         processor.process_command(&peer_label, request).await
     }
 
     /// V2 leaf business contract; the trusted peer label is diagnostic metadata only.
     async fn process_command(
-        &mut self,
+        &self,
         peer_label: &str,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/query_assignment_processor.rs
+++ b/rocketmq-broker/src/processor/query_assignment_processor.rs
@@ -78,6 +78,15 @@ pub struct QueryAssignmentProcessor {
 
 impl RequestProcessorV2 for QueryAssignmentProcessor {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl QueryAssignmentProcessor {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let command_factory = self.command_factory;
         let peer_label = request_peer_label(request.origin());
@@ -94,7 +103,7 @@ impl RequestProcessorV2 for QueryAssignmentProcessor {
 impl QueryAssignmentProcessor {
     /// V2 leaf business contract; the peer label is retained only for diagnostics.
     async fn process_command(
-        &mut self,
+        &self,
         request: &mut RemotingCommand,
         peer_label: &str,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -195,7 +204,7 @@ impl QueryAssignmentProcessor {
         peer_label: String,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut processor = self.clone();
+        let processor = self.clone();
         processor.process_command(request, &peer_label).await
     }
 }
@@ -216,7 +225,7 @@ impl Clone for QueryAssignmentProcessor {
 
 impl QueryAssignmentProcessor {
     async fn process_command_inner(
-        &mut self,
+        &self,
         request_code: RequestCode,
         request: &mut RemotingCommand,
         peer_label: &str,
@@ -241,7 +250,7 @@ impl QueryAssignmentProcessor {
     ///
     /// A RemotingCommand response containing QueryAssignmentResponseBody with assigned queues
     async fn query_assignment(
-        &mut self,
+        &self,
         request: &mut RemotingCommand,
         peer_label: &str,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -378,7 +387,7 @@ impl QueryAssignmentProcessor {
     /// An `Option<HashSet<MessageQueue>>` containing the allocated message queues, or `None` if no
     /// queues are allocated.
     async fn do_load_balance(
-        &mut self,
+        &self,
         topic: &CheetahString,
         consumer_group: &CheetahString,
         client_id: &CheetahString,
@@ -510,7 +519,7 @@ impl QueryAssignmentProcessor {
     }
 
     async fn set_message_request_mode(
-        &mut self,
+        &self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         if request.get_body().is_none() {

--- a/rocketmq-broker/src/processor/recall_message_processor.rs
+++ b/rocketmq-broker/src/processor/recall_message_processor.rs
@@ -213,6 +213,15 @@ where
     MS: BrokerWriteStore + 'static,
 {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+impl<MS: BrokerWriteStore> RecallMessageProcessor<MS> {
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let command_factory = self.context.command_factory;
         let remote_address = recall_remote_address(request.origin())?;
@@ -244,7 +253,7 @@ where
 {
     /// V2 leaf business contract; it uses only trusted origin metadata to construct the message birth address.
     async fn process_command(
-        &mut self,
+        &self,
         request: &mut RemotingCommand,
         remote_address: std::net::SocketAddr,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -280,12 +289,12 @@ where
         remote_address: std::net::SocketAddr,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut processor = self.clone();
+        let processor = self.clone();
         processor.process_command(request, remote_address).await
     }
 
     async fn process_recall_message(
-        &mut self,
+        &self,
         remote_address: std::net::SocketAddr,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {

--- a/rocketmq-broker/src/processor/request_ordering.rs
+++ b/rocketmq-broker/src/processor/request_ordering.rs
@@ -16,6 +16,7 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_transport::api::v1::RequestOrdering;
 use rocketmq_transport::api::v1::RequestOrderingKey;
+use rocketmq_transport::api::v2::IngressRequestView;
 
 const CLIENT_LIFECYCLE_KEY: u64 = 0x434c_4945_4e54;
 const SEND_NAMESPACE: u64 = 0x5345_4e44;
@@ -25,7 +26,18 @@ const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
 pub(super) fn broker_request_ordering(request: &RemotingCommand) -> RequestOrdering {
-    match RequestCode::from(request.code()) {
+    broker_request_ordering_parts(request.code(), request.ext_fields())
+}
+
+pub(super) fn broker_request_ordering_v2(ingress: IngressRequestView<'_>) -> RequestOrdering {
+    broker_request_ordering_parts(ingress.original_identity().original_code(), ingress.ext_fields())
+}
+
+fn broker_request_ordering_parts(
+    request_code: i32,
+    ext_fields: Option<&std::collections::HashMap<cheetah_string::CheetahString, cheetah_string::CheetahString>>,
+) -> RequestOrdering {
+    match RequestCode::from(request_code) {
         RequestCode::HeartBeat | RequestCode::UnregisterClient | RequestCode::CheckClientConfig => {
             RequestOrdering::Ordered(RequestOrderingKey::new(CLIENT_LIFECYCLE_KEY))
         }
@@ -34,17 +46,17 @@ pub(super) fn broker_request_ordering(request: &RemotingCommand) -> RequestOrder
         | RequestCode::SendBatchMessage
         | RequestCode::SendReplyMessage
         | RequestCode::SendReplyMessageV2 => ordered_by_fields(
-            request,
+            ext_fields,
             SEND_NAMESPACE,
             &[&["producerGroup", "a"], &["topic", "b"], &["queueId", "e"]],
         ),
         RequestCode::UpdateConsumerOffset | RequestCode::QueryConsumerOffset => ordered_by_fields(
-            request,
+            ext_fields,
             OFFSET_NAMESPACE,
             &[&["consumerGroup"], &["topic"], &["queueId"]],
         ),
         RequestCode::EndTransaction => ordered_by_fields(
-            request,
+            ext_fields,
             TRANSACTION_NAMESPACE,
             &[
                 &["producerGroup"],
@@ -59,10 +71,13 @@ pub(super) fn broker_request_ordering(request: &RemotingCommand) -> RequestOrder
     }
 }
 
-fn ordered_by_fields(request: &RemotingCommand, namespace: u64, fields: &[&[&str]]) -> RequestOrdering {
+fn ordered_by_fields(
+    ext_fields: Option<&std::collections::HashMap<cheetah_string::CheetahString, cheetah_string::CheetahString>>,
+    namespace: u64,
+    fields: &[&[&str]],
+) -> RequestOrdering {
     let mut hash = FNV_OFFSET_BASIS;
     hash_u64(&mut hash, namespace);
-    let ext_fields = request.ext_fields();
     for aliases in fields {
         let value = aliases
             .iter()

--- a/rocketmq-broker/src/processor/v2.rs
+++ b/rocketmq-broker/src/processor/v2.rs
@@ -1,0 +1,477 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Broker-owned aggregate for the formal V2 processor contract.
+//!
+//! This aggregate deliberately has no legacy default/Admin variant. Admin is
+//! retained by the V1 compatibility aggregate until its child handlers expose
+//! formal V2 leaves; production server composition must not publish this route
+//! before that dependency is complete.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+use rocketmq_store::BrokerStorePort;
+use rocketmq_transport::api::v1::command_from_error_with_factory_and_opaque;
+use rocketmq_transport::api::v1::command_from_error_with_factory_remark_and_opaque;
+use rocketmq_transport::api::v1::request_code_not_supported_with_factory;
+use rocketmq_transport::api::v1::request_code_not_supported_with_factory_and_opaque;
+use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::IngressRequestView;
+use rocketmq_transport::api::v2::RejectRequestDecision;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrdering;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponseWriteObservationV2;
+use tracing::warn;
+
+use super::fast_failure_dispatch;
+use super::fast_failure_queue_kind;
+use super::is_privileged_maintenance_request;
+use super::request_ordering;
+use super::AckMessageProcessor;
+use super::BrokerFastFailure;
+use super::ChangeInvisibleTimeProcessor;
+use super::ClientManageProcessor;
+use super::ConsumerManageProcessor;
+use super::EndTransactionProcessor;
+use super::LiteManagerProcessor;
+use super::LiteSubscriptionCtlProcessor;
+use super::MaintenanceRequestProcessor;
+use super::NotificationProcessor;
+use super::PeekMessageProcessor;
+use super::PollingInfoProcessor;
+use super::PopLiteMessageProcessor;
+use super::PopMessageProcessor;
+use super::PullMessageProcessor;
+use super::QueryAssignmentProcessor;
+use super::QueryMessageProcessor;
+use super::QueryMessageStoreCapability;
+use super::RecallMessageProcessor;
+use super::ReplyMessageProcessor;
+use super::SendMessageProcessor;
+use crate::processor::response_plan::BrokerResponseParts;
+use crate::transaction::transactional_message_service::TransactionalMessageService;
+
+/// Every Broker leaf that already implements the formal V2 processor contract.
+///
+/// Admin is intentionally absent. Adding it requires the MIG-06 child-handler
+/// migration and is the prerequisite for publishing this aggregate as the
+/// production server route.
+pub enum BrokerProcessorTypeV2<MS: BrokerStorePort, TS> {
+    Send(Arc<SendMessageProcessor<MS, TS>>),
+    Pull(Arc<PullMessageProcessor<MS>>),
+    Peek(Arc<PeekMessageProcessor<MS>>),
+    Pop(Arc<PopMessageProcessor<MS>>),
+    PopLite(Arc<PopLiteMessageProcessor<MS>>),
+    Ack(Arc<AckMessageProcessor<MS>>),
+    ChangeInvisible(Arc<ChangeInvisibleTimeProcessor<MS>>),
+    Notification(Arc<NotificationProcessor<MS>>),
+    PollingInfo(Arc<PollingInfoProcessor>),
+    Reply(Arc<ReplyMessageProcessor<MS, TS>>),
+    Recall(Arc<RecallMessageProcessor<MS>>),
+    QueryMessage(Arc<QueryMessageProcessor<QueryMessageStoreCapability<MS>>>),
+    ClientManage(Arc<ClientManageProcessor<MS>>),
+    ConsumerManage(Arc<ConsumerManageProcessor<MS>>),
+    QueryAssignment(Arc<QueryAssignmentProcessor>),
+    LiteManager(Arc<LiteManagerProcessor<MS>>),
+    LiteSubscriptionCtl(Arc<LiteSubscriptionCtlProcessor<MS>>),
+    EndTransaction(Arc<EndTransactionProcessor<TS, MS>>),
+    Maintenance(Arc<MaintenanceRequestProcessor>),
+}
+
+impl<MS, TS> Clone for BrokerProcessorTypeV2<MS, TS>
+where
+    MS: BrokerStorePort,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Send(processor) => Self::Send(Arc::clone(processor)),
+            Self::Pull(processor) => Self::Pull(Arc::clone(processor)),
+            Self::Peek(processor) => Self::Peek(Arc::clone(processor)),
+            Self::Pop(processor) => Self::Pop(Arc::clone(processor)),
+            Self::PopLite(processor) => Self::PopLite(Arc::clone(processor)),
+            Self::Ack(processor) => Self::Ack(Arc::clone(processor)),
+            Self::ChangeInvisible(processor) => Self::ChangeInvisible(Arc::clone(processor)),
+            Self::Notification(processor) => Self::Notification(Arc::clone(processor)),
+            Self::PollingInfo(processor) => Self::PollingInfo(Arc::clone(processor)),
+            Self::Reply(processor) => Self::Reply(Arc::clone(processor)),
+            Self::Recall(processor) => Self::Recall(Arc::clone(processor)),
+            Self::QueryMessage(processor) => Self::QueryMessage(Arc::clone(processor)),
+            Self::ClientManage(processor) => Self::ClientManage(Arc::clone(processor)),
+            Self::ConsumerManage(processor) => Self::ConsumerManage(Arc::clone(processor)),
+            Self::QueryAssignment(processor) => Self::QueryAssignment(Arc::clone(processor)),
+            Self::LiteManager(processor) => Self::LiteManager(Arc::clone(processor)),
+            Self::LiteSubscriptionCtl(processor) => Self::LiteSubscriptionCtl(Arc::clone(processor)),
+            Self::EndTransaction(processor) => Self::EndTransaction(Arc::clone(processor)),
+            Self::Maintenance(processor) => Self::Maintenance(Arc::clone(processor)),
+        }
+    }
+}
+
+impl<MS, TS> RequestProcessorV2 for BrokerProcessorTypeV2<MS, TS>
+where
+    MS: BrokerStorePort + Send + Sync + 'static,
+    TS: TransactionalMessageService + Send + Sync + 'static,
+{
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        match self {
+            Self::Send(processor) => processor.process_v2_shared(request).await,
+            Self::Pull(processor) => processor.process_v2_shared(request).await,
+            Self::Peek(processor) => processor.process_v2_shared(request).await,
+            Self::Pop(processor) => processor.process_v2_shared(request).await,
+            Self::PopLite(processor) => processor.process_v2_shared(request).await,
+            Self::Ack(processor) => processor.process_v2_shared(request).await,
+            Self::ChangeInvisible(processor) => processor.process_v2_shared(request).await,
+            Self::Notification(processor) => processor.process_v2_shared(request).await,
+            Self::PollingInfo(processor) => processor.process_v2_shared(request).await,
+            Self::Reply(processor) => processor.process_v2_shared(request).await,
+            Self::Recall(processor) => processor.process_v2_shared(request).await,
+            Self::QueryMessage(processor) => processor.process_v2_shared(request).await,
+            Self::ClientManage(processor) => processor.process_v2_shared(request).await,
+            Self::ConsumerManage(processor) => processor.process_v2_shared(request).await,
+            Self::QueryAssignment(processor) => processor.process_v2_shared(request).await,
+            Self::LiteManager(processor) => processor.process_v2_shared(request).await,
+            Self::LiteSubscriptionCtl(processor) => processor.process_v2_shared(request).await,
+            Self::EndTransaction(processor) => processor.process_v2_shared(request).await,
+            Self::Maintenance(processor) => processor.process_v2_shared(request).await,
+        }
+    }
+
+    fn reject_request(&self, code: i32) -> RejectRequestDecision {
+        let legacy = match self {
+            Self::Send(processor) => RequestProcessor::reject_request(processor.as_ref(), code),
+            Self::Pull(processor) => processor.reject_request_shared(),
+            Self::Pop(processor) => RequestProcessor::reject_request(processor.as_ref(), code),
+            Self::Notification(processor) => RequestProcessor::reject_request(processor.as_ref(), code),
+            Self::Reply(processor) => RequestProcessor::reject_request(processor.as_ref(), code),
+            Self::QueryMessage(processor) => RequestProcessor::reject_request(processor.as_ref(), code),
+            Self::Peek(_)
+            | Self::PopLite(_)
+            | Self::Ack(_)
+            | Self::ChangeInvisible(_)
+            | Self::PollingInfo(_)
+            | Self::Recall(_)
+            | Self::ClientManage(_)
+            | Self::ConsumerManage(_)
+            | Self::QueryAssignment(_)
+            | Self::LiteManager(_)
+            | Self::LiteSubscriptionCtl(_)
+            | Self::EndTransaction(_)
+            | Self::Maintenance(_) => (false, None),
+        };
+        legacy_rejection(legacy)
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        match self {
+            Self::Send(processor) => RequestProcessorV2::observe_response_write(processor.as_ref(), observation),
+            Self::Pull(processor) => RequestProcessorV2::observe_response_write(processor.as_ref(), observation),
+            Self::Peek(processor) => RequestProcessorV2::observe_response_write(processor.as_ref(), observation),
+            Self::Pop(processor) => RequestProcessorV2::observe_response_write(processor.as_ref(), observation),
+            Self::PopLite(processor) => RequestProcessorV2::observe_response_write(processor.as_ref(), observation),
+            Self::Ack(processor) => RequestProcessorV2::observe_response_write(processor.as_ref(), observation),
+            Self::ChangeInvisible(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::Notification(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::PollingInfo(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::Reply(processor) => RequestProcessorV2::observe_response_write(processor.as_ref(), observation),
+            Self::Recall(processor) => RequestProcessorV2::observe_response_write(processor.as_ref(), observation),
+            Self::QueryMessage(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::ClientManage(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::ConsumerManage(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::QueryAssignment(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::LiteManager(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::LiteSubscriptionCtl(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::EndTransaction(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+            Self::Maintenance(processor) => {
+                RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
+            }
+        }
+    }
+}
+
+fn legacy_rejection(legacy: (bool, Option<RemotingCommand>)) -> RejectRequestDecision {
+    match legacy {
+        (true, Some(response)) => response_rejection(response, "legacy leaf rejection"),
+        (true, None) => {
+            warn!("Broker leaf rejected a V2 request without an owned response; using canonical fallback rejection");
+            fallback_rejection("legacy leaf rejection without response")
+        }
+        (false, _) => RejectRequestDecision::Proceed,
+    }
+}
+
+fn response_rejection(response: RemotingCommand, source: &'static str) -> RejectRequestDecision {
+    match ResponsePlan::from_command(response) {
+        Ok(plan) => RejectRequestDecision::Reject(plan),
+        Err(error) => {
+            warn!(%error, source, "Broker V2 rejection response could not become an owned plan");
+            fallback_rejection(source)
+        }
+    }
+}
+
+fn fallback_rejection(source: &'static str) -> RejectRequestDecision {
+    warn!(source, "Broker V2 rejection is using the canonical fallback response");
+    RejectRequestDecision::Reject(ResponsePlan::empty_response(ResponseCode::SystemBusy as i32))
+}
+
+/// Code-indexed Broker V2 router over a statically selected formal leaf type.
+///
+/// The generic form keeps tests and later composition code independent of the
+/// concrete enum while production will use [`BrokerProcessorTypeV2`].
+pub struct BrokerRequestProcessorV2<P> {
+    command_factory: RemotingCommandFactory,
+    process_table: Arc<HashMap<i32, P>>,
+    default_request_processor: Option<Arc<P>>,
+    maintenance_routes: Arc<HashSet<i32>>,
+    broker_fast_failure: Option<BrokerFastFailure>,
+}
+
+impl<P> BrokerRequestProcessorV2<P>
+where
+    P: Clone,
+{
+    pub fn new() -> Self {
+        Self::new_with_factory(application_remoting_command_factory())
+    }
+
+    pub fn new_with_factory(command_factory: RemotingCommandFactory) -> Self {
+        Self {
+            command_factory,
+            process_table: Arc::new(HashMap::new()),
+            default_request_processor: None,
+            maintenance_routes: Arc::new(HashSet::new()),
+            broker_fast_failure: None,
+        }
+    }
+
+    pub fn register_processor(&mut self, request_code: i32, processor: P) {
+        Arc::make_mut(&mut self.process_table).insert(request_code, processor);
+    }
+
+    pub fn register_maintenance_processor(&mut self, request_code: i32, processor: P) {
+        self.register_processor(request_code, processor);
+        Arc::make_mut(&mut self.maintenance_routes).insert(request_code);
+    }
+
+    pub fn register_default_processor(&mut self, processor: P) {
+        self.default_request_processor = Some(Arc::new(processor));
+    }
+
+    pub fn set_broker_fast_failure(&mut self, broker_fast_failure: BrokerFastFailure) {
+        if broker_fast_failure.legacy_send_detach_requested() {
+            warn!("sendRequestExecutorDetachedEnable is deprecated and ignored by structured V2 fast-failure dispatch");
+        }
+        self.broker_fast_failure = Some(broker_fast_failure);
+    }
+}
+
+impl<P> Default for BrokerRequestProcessorV2<P>
+where
+    P: Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<P> Clone for BrokerRequestProcessorV2<P> {
+    fn clone(&self) -> Self {
+        Self {
+            command_factory: self.command_factory,
+            process_table: Arc::clone(&self.process_table),
+            default_request_processor: self.default_request_processor.clone(),
+            maintenance_routes: Arc::clone(&self.maintenance_routes),
+            broker_fast_failure: self.broker_fast_failure.clone(),
+        }
+    }
+}
+
+impl<P> RequestProcessorV2 for BrokerRequestProcessorV2<P>
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original = request.original_identity();
+        let request_code = original.original_code();
+        let opaque = original.original_opaque();
+        if is_privileged_maintenance_request(RequestCode::from(request_code))
+            && !self.maintenance_routes.contains(&request_code)
+        {
+            let error = rocketmq_error::RocketMQError::authentication_failed(
+                "Broker maintenance API is disabled or unavailable",
+            );
+            let response = command_from_error_with_factory_remark_and_opaque(
+                &self.command_factory,
+                &error,
+                error.to_string(),
+                opaque,
+            );
+            return BrokerResponseParts::from_command(response)?.into_handler_outcome();
+        }
+
+        let (processor, default_processor) = match self.process_table.get(&request_code).cloned() {
+            Some(processor) => (processor, false),
+            None => match self.default_request_processor.as_ref() {
+                Some(processor) => (processor.as_ref().clone(), true),
+                None => {
+                    let response =
+                        request_code_not_supported_with_factory_and_opaque(&self.command_factory, request_code, opaque);
+                    return BrokerResponseParts::from_command(response)?.into_handler_outcome();
+                }
+            },
+        };
+
+        let result = self
+            .process_with_optional_fast_failure(
+                fast_failure_queue_kind(request_code, default_processor),
+                processor,
+                request,
+            )
+            .await;
+        map_request_header_error(&self.command_factory, result, opaque)
+    }
+
+    fn reject_request(&self, code: i32) -> RejectRequestDecision {
+        match self.process_table.get(&code) {
+            Some(processor) => processor.reject_request(code),
+            None => match self.default_request_processor.as_ref() {
+                Some(processor) => processor.reject_request(code),
+                None => {
+                    let response = request_code_not_supported_with_factory(&self.command_factory, code);
+                    response_rejection(response, "unsupported request code")
+                }
+            },
+        }
+    }
+
+    fn request_ordering(&self, ingress: IngressRequestView<'_>) -> RequestOrdering {
+        request_ordering::broker_request_ordering_v2(ingress)
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        let original_code = observation.original_code();
+        if let Some(processor) = self.process_table.get(&original_code) {
+            processor.observe_response_write(observation);
+        } else if let Some(processor) = self.default_request_processor.as_ref() {
+            processor.observe_response_write(observation);
+        }
+    }
+}
+
+impl<P> BrokerRequestProcessorV2<P>
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    async fn process_with_optional_fast_failure(
+        &self,
+        queue_kind: Option<crate::latency::broker_fast_failure::FastFailureQueueKind>,
+        mut processor: P,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let Some(queue_kind) = queue_kind else {
+            return processor.process(request).await;
+        };
+        let Some(broker_fast_failure) = &self.broker_fast_failure else {
+            return processor.process(request).await;
+        };
+        if !broker_fast_failure.is_enabled() {
+            return processor.process(request).await;
+        }
+
+        let opaque = request.original_identity().original_opaque();
+        let metadata = fast_failure_dispatch::FastFailureRequestMetadata::from_command(request.command());
+        let admission = match fast_failure_dispatch::try_admit(broker_fast_failure, queue_kind, metadata) {
+            Ok(admission) => admission,
+            Err(rejection) => {
+                return rejection
+                    .into_response_plan()
+                    .map(HandlerOutcome::Reply)
+                    .map_err(|error| rocketmq_error::RocketMQError::internal("broker-v2-fast-failure", error));
+            }
+        };
+        let run = match admission
+            .await_run(fast_failure_dispatch::FastFailureControl::from(request.control()))
+            .await
+        {
+            Ok(run) => run,
+            Err(fast_failure_dispatch::FastFailureAwaitError::Rejected(rejection)) => {
+                return rejection
+                    .into_response_plan()
+                    .map(HandlerOutcome::Reply)
+                    .map_err(|error| rocketmq_error::RocketMQError::internal("broker-v2-fast-failure", error));
+            }
+            Err(fast_failure_dispatch::FastFailureAwaitError::LifecycleStopped) => {
+                return Err(rocketmq_error::RocketMQError::invariant_violated(
+                    "V2 fast-failure request lifecycle stopped before Broker dispatch",
+                ));
+            }
+        };
+        let result = processor.process(request).await;
+        run.complete_v2();
+        match result {
+            Ok(outcome) => Ok(outcome),
+            Err(error) => {
+                let response = command_from_error_with_factory_and_opaque(&self.command_factory, &error, opaque);
+                BrokerResponseParts::from_command(response)?.into_handler_outcome()
+            }
+        }
+    }
+}
+
+fn map_request_header_error(
+    command_factory: &RemotingCommandFactory,
+    result: rocketmq_error::RocketMQResult<HandlerOutcome>,
+    opaque: i32,
+) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+    match result {
+        Err(error) if error.kind() == rocketmq_error::ErrorKind::RequestHeaderError => {
+            let response = command_from_error_with_factory_and_opaque(command_factory, &error, opaque);
+            BrokerResponseParts::from_command(response)?.into_handler_outcome()
+        }
+        result => result,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-broker/src/processor/v2/tests.rs
+++ b/rocketmq-broker/src/processor/v2/tests.rs
@@ -1,0 +1,372 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_security_api::AuthenticatedRequestContext;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::RequestPolicy;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::RPCHook;
+use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+use rocketmq_transport::api::v2::RejectRequestDecision;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponseWriteObservationV2;
+use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+use super::*;
+use crate::config::broker_config::BrokerConfig;
+use crate::latency::broker_fast_failure::FastFailureQueueKind;
+
+const ROUTED_CODE: i32 = 91_501;
+const MUTATED_CODE: i32 = 91_502;
+type ObservedRequest = (i32, i32, i32, i32);
+
+#[derive(Clone)]
+struct ProbeProcessor {
+    calls: Arc<AtomicUsize>,
+    seen: Arc<Mutex<Vec<ObservedRequest>>>,
+    observations: Arc<Mutex<Vec<i32>>>,
+    reject: bool,
+}
+
+impl ProbeProcessor {
+    fn new(reject: bool) -> Self {
+        Self {
+            calls: Arc::new(AtomicUsize::new(0)),
+            seen: Arc::new(Mutex::new(Vec::new())),
+            observations: Arc::new(Mutex::new(Vec::new())),
+            reject,
+        }
+    }
+}
+
+impl RequestProcessorV2 for ProbeProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.seen.lock().push((
+            request.original_identity().original_code(),
+            request.command().code(),
+            request.original_identity().original_opaque(),
+            request.command().opaque(),
+        ));
+        request.command_mut().add_ext_field("broker-v2-probe", "mutated");
+        let response = RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+            .set_opaque(request.original_identity().original_opaque());
+        Ok(HandlerOutcome::Reply(
+            ResponsePlan::command(response).expect("probe response plan"),
+        ))
+    }
+
+    fn reject_request(&self, _code: i32) -> RejectRequestDecision {
+        if !self.reject {
+            return RejectRequestDecision::Proceed;
+        }
+        RejectRequestDecision::Reject(
+            ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                ResponseCode::SystemBusy,
+            ))
+            .expect("probe rejection plan"),
+        )
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        self.observations.lock().push(observation.original_code());
+    }
+}
+
+#[derive(Clone)]
+struct PreMutatingRouter {
+    inner: BrokerRequestProcessorV2<ProbeProcessor>,
+}
+
+impl RequestProcessorV2 for PreMutatingRouter {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        request.command_mut().set_code_mut(MUTATED_CODE);
+        request.command_mut().set_opaque_mut(77_777);
+        RequestProcessorV2::process(&mut self.inner, request).await
+    }
+
+    fn reject_request(&self, code: i32) -> RejectRequestDecision {
+        RequestProcessorV2::reject_request(&self.inner, code)
+    }
+
+    fn request_ordering(&self, request: IngressRequestView<'_>) -> RequestOrdering {
+        RequestProcessorV2::request_ordering(&self.inner, request)
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        RequestProcessorV2::observe_response_write(&self.inner, observation);
+    }
+}
+
+#[derive(Clone)]
+struct OrderingProbeRouter {
+    inner: PreMutatingRouter,
+    observed: Arc<Mutex<Vec<RequestOrdering>>>,
+}
+
+impl RequestProcessorV2 for OrderingProbeRouter {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        RequestProcessorV2::process(&mut self.inner, request).await
+    }
+
+    fn reject_request(&self, code: i32) -> RejectRequestDecision {
+        RequestProcessorV2::reject_request(&self.inner, code)
+    }
+
+    fn request_ordering(&self, ingress: IngressRequestView<'_>) -> RequestOrdering {
+        let ordering = RequestProcessorV2::request_ordering(&self.inner, ingress);
+        self.observed.lock().push(ordering);
+        ordering
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        RequestProcessorV2::observe_response_write(&self.inner, observation);
+    }
+}
+
+struct AllowEmbeddedPolicy;
+
+impl RequestPolicy for AllowEmbeddedPolicy {
+    fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+        Decision::Allow
+    }
+}
+
+struct RouterFixture<P> {
+    owner: RuntimeOwner,
+    harness: EmbeddedRequestHarnessV2<P>,
+}
+
+impl<P> RouterFixture<P>
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    fn new(router: P, hooks: Vec<Arc<dyn RPCHook>>) -> Self {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("broker-v2-router-test"))
+            .expect("Broker V2 router test runtime");
+        let request_context = owner.root_context().component("broker-v2-router-request");
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            router,
+            hooks,
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            request_context.task_group().clone(),
+            Principal::new("broker-v2-router-test"),
+        );
+        Self { owner, harness }
+    }
+
+    async fn finish(self) {
+        drop(self.harness);
+        assert!(self.owner.shutdown_tasks().await.is_healthy());
+        assert!(self.owner.shutdown_background().is_healthy());
+    }
+}
+
+#[tokio::test]
+async fn router_selects_by_immutable_original_code_and_forwards_mutable_command() {
+    const ORIGINAL_OPAQUE: i32 = 43;
+    let probe = ProbeProcessor::new(false);
+    let seen = Arc::clone(&probe.seen);
+    let observations = Arc::clone(&probe.observations);
+    let mut router = BrokerRequestProcessorV2::new();
+    router.register_processor(ROUTED_CODE, probe);
+    let fixture = RouterFixture::new(PreMutatingRouter { inner: router }, Vec::new());
+
+    let outcome = fixture
+        .harness
+        .dispatch(
+            None,
+            RemotingCommand::create_remoting_command(ROUTED_CODE).set_opaque(ORIGINAL_OPAQUE),
+        )
+        .await
+        .expect("formal V2 aggregate dispatch");
+    let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+        panic!("formal V2 aggregate must produce one reply");
+    };
+
+    assert_eq!(plan.response_code(), ResponseCode::Success as i32);
+    assert_eq!(
+        seen.lock().as_slice(),
+        &[(ROUTED_CODE, MUTATED_CODE, ORIGINAL_OPAQUE, 77_777)]
+    );
+    assert_eq!(observations.lock().as_slice(), &[ROUTED_CODE]);
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn router_v2_ordering_matches_v1_before_command_mutation() {
+    let probe = ProbeProcessor::new(false);
+    let seen = Arc::clone(&probe.seen);
+    let mut router = BrokerRequestProcessorV2::new();
+    router.register_processor(RequestCode::SendMessage as i32, probe.clone());
+    router.register_processor(RequestCode::QueryMessage as i32, probe.clone());
+    router.register_maintenance_processor(RequestCode::MaintenanceGetCapabilities as i32, probe);
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let fixture = RouterFixture::new(
+        OrderingProbeRouter {
+            inner: PreMutatingRouter { inner: router },
+            observed: Arc::clone(&observed),
+        },
+        Vec::new(),
+    );
+
+    let mut ordered = RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(61);
+    ordered.add_ext_field("producerGroup", "producer-a");
+    ordered.add_ext_field("topic", "topic-a");
+    ordered.add_ext_field("queueId", "3");
+    let concurrent = RemotingCommand::create_remoting_command(RequestCode::QueryMessage).set_opaque(62);
+    let maintenance = RemotingCommand::create_remoting_command(RequestCode::MaintenanceGetCapabilities).set_opaque(63);
+    let commands = [ordered, concurrent, maintenance];
+    let expected = commands
+        .iter()
+        .map(request_ordering::broker_request_ordering)
+        .collect::<Vec<_>>();
+
+    for command in commands {
+        let outcome = fixture
+            .harness
+            .dispatch(None, command)
+            .await
+            .expect("formal V2 ordering dispatch");
+        assert!(matches!(outcome, EmbeddedDispatchOutcome::Reply(_)));
+    }
+
+    assert_eq!(observed.lock().as_slice(), expected.as_slice());
+    assert!(matches!(expected[0], RequestOrdering::Ordered(_)));
+    assert_eq!(expected[1], RequestOrdering::Concurrent);
+    assert_eq!(expected[2], RequestOrdering::Concurrent);
+    assert_eq!(
+        seen.lock()
+            .iter()
+            .map(|(original_code, mutable_code, _, _)| (*original_code, *mutable_code))
+            .collect::<Vec<_>>(),
+        vec![
+            (RequestCode::SendMessage as i32, MUTATED_CODE),
+            (RequestCode::QueryMessage as i32, MUTATED_CODE),
+            (RequestCode::MaintenanceGetCapabilities as i32, MUTATED_CODE),
+        ]
+    );
+    fixture.finish().await;
+}
+
+#[test]
+fn router_delegates_typed_rejection_and_rejects_unknown_codes() {
+    let mut router = BrokerRequestProcessorV2::new();
+    router.register_processor(ROUTED_CODE, ProbeProcessor::new(true));
+
+    let RejectRequestDecision::Reject(route_plan) = router.reject_request(ROUTED_CODE) else {
+        panic!("registered leaf rejection must remain affine");
+    };
+    assert_eq!(route_plan.response_code(), ResponseCode::SystemBusy as i32);
+
+    let RejectRequestDecision::Reject(unknown_plan) = router.reject_request(ROUTED_CODE + 1) else {
+        panic!("unknown Broker V2 code must fail before execution");
+    };
+    let expected = request_code_not_supported_with_factory(&application_remoting_command_factory(), ROUTED_CODE + 1);
+    assert_eq!(unknown_plan.response_code(), expected.code());
+}
+
+#[test]
+fn malformed_chosen_rejection_fails_closed_with_an_owned_fallback() {
+    let malformed = RemotingCommand::create_remoting_command(ROUTED_CODE).mark_oneway_rpc();
+
+    let RejectRequestDecision::Reject(plan) = response_rejection(malformed, "malformed test rejection") else {
+        panic!("malformed rejection must not proceed into processor execution");
+    };
+    assert_eq!(plan.response_code(), ResponseCode::SystemBusy as i32);
+    assert_eq!(plan.body_kind(), rocketmq_transport::api::v2::ResponseBodyKind::Empty);
+}
+
+fn fast_failure(max_count: usize) -> BrokerFastFailure {
+    BrokerFastFailure::new(Arc::new(BrokerConfig {
+        broker_fast_failure_enable: true,
+        broker_fast_failure_pending_max_count: max_count,
+        broker_fast_failure_pending_max_bytes: 64 * 1024,
+        wait_time_mills_in_send_queue: 60_000,
+        ..BrokerConfig::default()
+    }))
+}
+
+#[tokio::test]
+async fn router_fast_failure_keeps_response_affine_and_releases_run_resources() {
+    let service = fast_failure(1);
+    let probe = ProbeProcessor::new(false);
+    let calls = Arc::clone(&probe.calls);
+    let mut router = BrokerRequestProcessorV2::new();
+    router.register_processor(RequestCode::SendMessage as i32, probe);
+    router.set_broker_fast_failure(service.clone());
+    let fixture = RouterFixture::new(router, Vec::new());
+
+    let first = fixture
+        .harness
+        .dispatch(
+            None,
+            RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(51),
+        )
+        .await
+        .expect("admitted fast-failure V2 dispatch");
+    let EmbeddedDispatchOutcome::Reply(first) = first else {
+        panic!("admitted V2 route must reply");
+    };
+    assert_eq!(first.response_code(), ResponseCode::Success as i32);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(service.pending_count_snapshot().iter().all(|(_, count)| *count == 0));
+
+    let held = fast_failure_dispatch::try_admit(
+        &service,
+        FastFailureQueueKind::Send,
+        fast_failure_dispatch::FastFailureRequestMetadata::from_command(
+            &RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(52),
+        ),
+    )
+    .expect("fill the single pending fast-failure budget");
+    let rejected = fixture
+        .harness
+        .dispatch(
+            None,
+            RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(53),
+        )
+        .await
+        .expect("budget rejection remains a typed reply");
+    let EmbeddedDispatchOutcome::Reply(rejected) = rejected else {
+        panic!("budget rejection must own one response plan");
+    };
+    assert_eq!(rejected.response_code(), ResponseCode::SystemBusy as i32);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    drop(held);
+    let budget = service.pending_budget_snapshot();
+    assert_eq!(budget.current_count, 0);
+    assert_eq!(budget.current_bytes, 0);
+
+    fixture.finish().await;
+}

--- a/rocketmq-transport/src/dispatch/response_plan.rs
+++ b/rocketmq-transport/src/dispatch/response_plan.rs
@@ -167,6 +167,21 @@ pub struct ResponsePlan {
 }
 
 impl ResponsePlan {
+    /// Creates an empty response plan from a response code.
+    ///
+    /// Unlike [`Self::command`], this constructor is infallible because it
+    /// creates the response head itself: the head is response-typed, is not
+    /// one-way, and has no attached body.
+    #[must_use]
+    pub fn empty_response(code: i32) -> Self {
+        Self::new(
+            RemotingCommand::create_response_command_with_code(code),
+            ResponseBody::Empty,
+            0,
+            0,
+        )
+    }
+
     /// Creates a response with an empty body.
     ///
     /// # Errors
@@ -498,6 +513,9 @@ mod tests {
 
     #[test]
     fn constructors_keep_exactly_one_normalized_body_owner() {
+        let infallible_empty = ResponsePlan::empty_response(7);
+        assert_metadata(&infallible_empty, ResponseBodyKind::Empty, 0, 0);
+
         let empty = ResponsePlan::command(response_head()).expect("valid empty response");
         assert_metadata(&empty, ResponseBodyKind::Empty, 0, 0);
 

--- a/rocketmq-transport/tests/public_api_v2.rs
+++ b/rocketmq-transport/tests/public_api_v2.rs
@@ -197,6 +197,7 @@ fn assert_response_plan_contract(plan: Option<ResponsePlan>) {
     }
 
     let _: fn(RemotingCommand) -> Result<ResponsePlan, ResponsePlanError> = ResponsePlan::command;
+    let _: fn(i32) -> ResponsePlan = ResponsePlan::empty_response;
     let _: fn(RemotingCommand, Bytes) -> Result<ResponsePlan, ResponsePlanError> = ResponsePlan::bytes;
     let _: fn(RemotingCommand, Vec<Bytes>) -> Result<ResponsePlan, ResponsePlanError> = ResponsePlan::segments;
     let _: fn(RemotingCommand, FileRegionSequence) -> Result<ResponsePlan, ResponsePlanError> =
@@ -581,6 +582,11 @@ fn v2_processor_contract_preserves_local_and_send_future_boundaries() {
 
 #[test]
 fn v2_processor_side_contracts_are_typed_and_body_free() {
+    let empty = ResponsePlan::empty_response(6);
+    assert_eq!(empty.response_code(), 6);
+    assert_eq!(empty.body_kind(), ResponseBodyKind::Empty);
+    assert_eq!(empty.body_len(), 0);
+
     let plan = ResponsePlan::bytes(
         RemotingCommand::create_response_command_with_code(7),
         Bytes::from_static(b"owned rejection"),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9853

### Brief Description

- Add a parallel Broker V2 aggregate/router while preserving the frozen V1 compatibility aggregate and leaving production listeners unchanged.
- Route by immutable original request identity, forward one mutable typed request to 19 shallow-`Arc` V2 leaves, and preserve ordering, typed rejection, fast-failure, and response-write observation semantics.
- Keep malformed rejection fail-closed with an infallible empty-response plan instead of falling through to request processing.
- Advance the existing Broker-owned deferred generation handoff with exact Pull, Pop, Notification, and PopLite legacy occupancy probes, explicit pending-arrival rearm, bounded fair transition scheduling, canonical replay, and shutdown-safe abandoned replay handling.
- Keep Admin/Auth/Proxy and the production normal/fast listener cutover as explicit follow-up work in #9852 and #9851.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker processor::v2::tests:: --lib` (10 passed)
- `cargo test -p rocketmq-broker deferred_generation_handoff::tests:: --lib` (20 passed)
- `cargo test -p rocketmq-broker legacy_route_rearms_a_real_waiter_for_the_next_tick_without_a_new_arrival --lib` (1 passed)
- `cargo test -p rocketmq-broker installed_handoff --lib` (3 passed)
- `cargo test -p rocketmq-broker store_replay_workers_resume_three_canonical_sessions_exactly_once_and_rearm_retry --lib` (1 passed)
- `cargo test -p rocketmq-broker broker_runtime::deferred_producer::workers::replay_tests:: --lib` (4 passed)
- Focused Broker fast-failure, four-route exact-probe, replay worker, Lite dispatcher replay, and real Store replay E2E tests passed.
- `cargo test -p rocketmq-transport --lib` (666 passed)
- Focused `rocketmq-transport` `public_api_v2` test passed.
- `cargo check -p rocketmq-broker --tests`
- `cargo fmt -p rocketmq-broker -- --check`
- `cargo fmt -p rocketmq-transport -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-error-hygiene.ps1` completed with only the repository's pre-existing generic-response, source-stringification, and redaction baseline findings; the processor-boundary mapping check is clean.
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added V2 request processing with routing, ordering, authorization, and fast-failure handling.
  * Added support for empty responses in transport workflows.
  * Added replay support for pending deferred events.

* **Bug Fixes**
  * Improved deferred-generation transitions with bounded retries and safer cutover handling.
  * Preserved legacy-routed pull, POP, and notification requests for subsequent processing.
  * Improved cleanup of abandoned replay work during shutdown.

* **Tests**
  * Expanded coverage for request routing, generation handoff, replay behavior, shutdown, and long-polling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->