### PR TITLE
[ISSUE #9852]🚀Migrate Broker admin, auth, and proxy to V2

### DIFF
--- a/rocketmq-auth/src/authorization/builder.rs
+++ b/rocketmq-auth/src/authorization/builder.rs
@@ -14,17 +14,16 @@
 
 pub mod default_authorization_context_builder;
 
-use std::any::Any;
-
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
 use crate::authorization::context::default_authorization_context::DefaultAuthorizationContext;
 use crate::authorization::provider::AuthorizationResult;
+use crate::RemotingAuthContext;
 
 pub trait AuthorizationContextBuilder: Send + Sync {
     fn build_from_remoting(
         &self,
-        channel_context: &(dyn Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
     ) -> AuthorizationResult<Vec<DefaultAuthorizationContext>>;
 }

--- a/rocketmq-auth/src/authorization/builder/default_authorization_context_builder.rs
+++ b/rocketmq-auth/src/authorization/builder/default_authorization_context_builder.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -33,9 +32,6 @@ use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_security_api::Action;
 use rocketmq_security_api::ResourcePattern;
 use rocketmq_security_api::ResourceType;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
 
 use crate::authentication::enums::subject_type::SubjectType;
 use crate::authorization::builder::AuthorizationContextBuilder;
@@ -99,24 +95,11 @@ impl DefaultAuthorizationContextBuilder {
             .map(|username| format!("{}:{}", SubjectType::User.name(), username))
     }
 
-    fn source_ip(&self, channel_context: &dyn Any) -> String {
-        if let Some(context) = channel_context.downcast_ref::<RemotingAuthContext>() {
-            return context.source_ip().unwrap_or("unknown").to_owned();
-        }
-
-        if let Some(ctx) = channel_context.downcast_ref::<ConnectionHandlerContext>() {
-            return ctx.remote_address().ip().to_string();
-        }
-
-        if let Some(ctx) = channel_context.downcast_ref::<ConnectionHandlerContextWrapper>() {
-            return ctx.remote_address().ip().to_string();
-        }
-
-        if let Some(channel) = channel_context.downcast_ref::<Channel>() {
-            return channel.remote_address().ip().to_string();
-        }
-
-        String::from("unknown")
+    fn source_ip(auth_context: &RemotingAuthContext) -> AuthorizationResult<String> {
+        auth_context
+            .validate()
+            .map_err(|error| AuthorizationError::InvalidContext(error.to_string()))?;
+        Ok(auth_context.source_ip().unwrap_or("embedded").to_owned())
     }
 
     fn push_topic_sub_if_not_retry(
@@ -504,9 +487,12 @@ impl DefaultAuthorizationContextBuilder {
 impl AuthorizationContextBuilder for DefaultAuthorizationContextBuilder {
     fn build_from_remoting(
         &self,
-        channel_context: &(dyn Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
     ) -> AuthorizationResult<Vec<DefaultAuthorizationContext>> {
+        auth_context
+            .validate()
+            .map_err(|error| AuthorizationError::InvalidContext(error.to_string()))?;
         let mut contexts = Vec::new();
         let empty_fields = HashMap::new();
         let fields = match command.ext_fields() {
@@ -523,7 +509,7 @@ impl AuthorizationContextBuilder for DefaultAuthorizationContextBuilder {
 
         let subject_key = self.subject_key(command);
         let subject_key = subject_key.as_deref();
-        let source_ip = self.source_ip(channel_context);
+        let source_ip = Self::source_ip(auth_context)?;
         let rpc_code = command.code().to_string();
 
         match RequestCode::from(command.code()) {
@@ -875,7 +861,9 @@ mod tests {
             &[("AccessKey", "alice"), ("topic", "test-topic")],
         );
 
-        let contexts = builder.build_from_remoting(&(), &command).unwrap();
+        let contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &command)
+            .unwrap();
         assert_eq!(contexts.len(), 1);
         assert_eq!(contexts[0].subject_key(), Some("User:alice"));
         assert_eq!(contexts[0].resource_key(), Some("Topic:test-topic".to_string()));
@@ -894,7 +882,9 @@ mod tests {
             ],
         );
 
-        let contexts = builder.build_from_remoting(&(), &command).unwrap();
+        let contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &command)
+            .unwrap();
         assert_eq!(contexts.len(), 2);
         assert_eq!(contexts[0].subject_key(), Some("User:alice"));
         assert_eq!(contexts[1].resource_key(), Some("Group:group-a".to_string()));
@@ -922,7 +912,9 @@ mod tests {
             .set_ext_fields(ext_fields)
             .set_body(serde_json::to_vec(&heartbeat).unwrap());
 
-        let contexts = builder.build_from_remoting(&(), &command).unwrap();
+        let contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &command)
+            .unwrap();
         assert_eq!(contexts.len(), 2);
         assert_eq!(contexts[0].subject_key(), Some("User:alice"));
         assert_eq!(contexts[0].resource_key(), Some("Group:group-a".to_string()));
@@ -947,7 +939,9 @@ mod tests {
             .set_ext_fields(ext_fields)
             .set_body(serde_json::to_vec(&body).unwrap());
 
-        let contexts = builder.build_from_remoting(&(), &command).unwrap();
+        let contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &command)
+            .unwrap();
         assert_eq!(contexts.len(), 2);
         assert_eq!(contexts[0].resource_key(), Some("Group:group-a".to_string()));
         assert_eq!(contexts[1].resource_key(), Some("Topic:topic-a".to_string()));
@@ -964,7 +958,9 @@ mod tests {
             RequestCode::UpdateAndCreateTopic,
             &[("AccessKey", "rocketmq"), ("topic", "topic")],
         );
-        let topic_contexts = builder.build_from_remoting(&(), &topic_command).unwrap();
+        let topic_contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &topic_command)
+            .unwrap();
         assert_eq!(topic_contexts.len(), 1);
         assert_eq!(topic_contexts[0].subject_key(), Some("User:rocketmq"));
         assert_eq!(topic_contexts[0].resource_key(), Some("Topic:topic".to_string()));
@@ -978,7 +974,9 @@ mod tests {
             RequestCode::AuthCreateUser,
             &[("AccessKey", "rocketmq"), ("username", "alice")],
         );
-        let cluster_contexts = builder.build_from_remoting(&(), &cluster_command).unwrap();
+        let cluster_contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &cluster_command)
+            .unwrap();
         assert_eq!(cluster_contexts.len(), 1);
         assert_eq!(cluster_contexts[0].subject_key(), Some("User:rocketmq"));
         assert_eq!(
@@ -1005,14 +1003,18 @@ mod tests {
             RequestCode::CancelProxyDrain,
         ] {
             let command = command_with_fields(code, &[("AccessKey", "rocketmq")]);
-            let contexts = builder.build_from_remoting(&(), &command).unwrap();
+            let contexts = builder
+                .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &command)
+                .unwrap();
             assert_eq!(contexts.len(), 1);
             assert_eq!(contexts[0].resource_key(), Some("Cluster:DefaultCluster".to_string()));
             assert_eq!(contexts[0].actions(), &[Action::Update]);
         }
 
         let query = command_with_fields(RequestCode::GetProxyDrainState, &[("AccessKey", "rocketmq")]);
-        let contexts = builder.build_from_remoting(&(), &query).unwrap();
+        let contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &query)
+            .unwrap();
         assert_eq!(contexts.len(), 1);
         assert_eq!(contexts[0].resource_key(), Some("Cluster:DefaultCluster".to_string()));
         assert_eq!(contexts[0].actions(), &[Action::Get]);
@@ -1035,7 +1037,9 @@ mod tests {
             RequestCode::GetNamesrvConfig,
         ] {
             let command = command_with_fields(code, &[("AccessKey", "reader")]);
-            let contexts = builder.build_from_remoting(&(), &command).unwrap();
+            let contexts = builder
+                .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &command)
+                .unwrap();
             assert_eq!(contexts.len(), 1, "missing authorization context for {code:?}");
             assert_eq!(contexts[0].resource_key(), Some("Cluster:DefaultCluster".to_string()));
             assert_eq!(contexts[0].actions(), &[Action::Get]);
@@ -1045,7 +1049,9 @@ mod tests {
             RequestCode::GetBrokerMemberGroup,
             &[("AccessKey", "reader"), ("clusterName", "ClusterA")],
         );
-        let contexts = builder.build_from_remoting(&(), &member).unwrap();
+        let contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &member)
+            .unwrap();
         assert_eq!(contexts[0].resource_key(), Some("Cluster:ClusterA".to_string()));
         assert_eq!(contexts[0].actions(), &[Action::Get]);
 
@@ -1053,7 +1059,9 @@ mod tests {
             RequestCode::GetTopicsByCluster,
             &[("AccessKey", "reader"), ("cluster", "ClusterA")],
         );
-        let contexts = builder.build_from_remoting(&(), &topics).unwrap();
+        let contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &topics)
+            .unwrap();
         assert_eq!(contexts[0].resource_key(), Some("Cluster:ClusterA".to_string()));
         assert_eq!(contexts[0].actions(), &[Action::List]);
     }
@@ -1068,7 +1076,9 @@ mod tests {
         let topic_command = RemotingCommand::create_remoting_command(RequestCode::DeleteTopicInBrokerList.to_i32())
             .set_body(serde_json::to_vec(&topic_body).unwrap());
 
-        let topic_contexts = builder.build_from_remoting(&(), &topic_command).unwrap();
+        let topic_contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &topic_command)
+            .unwrap();
         assert_eq!(2, topic_contexts.len());
         assert_eq!(Some("Topic:TopicA".to_string()), topic_contexts[0].resource_key());
         assert_eq!(Some("Topic:TopicB".to_string()), topic_contexts[1].resource_key());
@@ -1083,7 +1093,9 @@ mod tests {
         let group_command = RemotingCommand::create_remoting_command(RequestCode::DeleteSubscriptionGroupList.to_i32())
             .set_body(serde_json::to_vec(&group_body).unwrap());
 
-        let group_contexts = builder.build_from_remoting(&(), &group_command).unwrap();
+        let group_contexts = builder
+            .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &group_command)
+            .unwrap();
         assert_eq!(2, group_contexts.len());
         assert_eq!(Some("Group:GroupA".to_string()), group_contexts[0].resource_key());
         assert_eq!(Some("Group:GroupB".to_string()), group_contexts[1].resource_key());
@@ -1100,7 +1112,29 @@ mod tests {
             RemotingCommand::create_remoting_command(RequestCode::DeleteSubscriptionGroupList.to_i32())
                 .set_body(b"not-json".to_vec()),
         ] {
-            assert!(builder.build_from_remoting(&(), &command).is_err());
+            assert!(builder
+                .build_from_remoting(&RemotingAuthContext::embedded("test-session"), &command)
+                .is_err());
         }
+    }
+
+    #[test]
+    fn missing_typed_ingress_metadata_is_rejected() {
+        let builder = DefaultAuthorizationContextBuilder::new(AuthConfig::default());
+        let command = command_with_fields(
+            RequestCode::SendMessage,
+            &[("AccessKey", "alice"), ("topic", "test-topic")],
+        );
+
+        let error = builder
+            .build_from_remoting(&RemotingAuthContext::default(), &command)
+            .expect_err("missing trusted session metadata must fail closed");
+        assert!(matches!(error, AuthorizationError::InvalidContext(_)));
+
+        let command_without_ext_fields = RemotingCommand::create_remoting_command(RequestCode::SendMessage.to_i32());
+        let error = builder
+            .build_from_remoting(&RemotingAuthContext::default(), &command_without_ext_fields)
+            .expect_err("missing trusted metadata must fail closed before the no-context fast path");
+        assert!(matches!(error, AuthorizationError::InvalidContext(_)));
     }
 }

--- a/rocketmq-auth/src/authorization/factory.rs
+++ b/rocketmq-auth/src/authorization/factory.rs
@@ -147,13 +147,13 @@ impl AuthorizationFactory {
 
     pub fn new_contexts_from_command(
         config: &AuthConfig,
-        channel_context: &(dyn Any + Send + Sync),
+        auth_context: &crate::RemotingAuthContext,
         command: &RemotingCommand,
     ) -> RocketMQResult<Option<Vec<DefaultAuthorizationContext>>> {
         let _provider = Self::get_provider(config)?;
         let builder = DefaultAuthorizationContextBuilder::new(config.clone());
         builder
-            .build_from_remoting(channel_context, command)
+            .build_from_remoting(auth_context, command)
             .map(Some)
             .map_err(RocketMQError::from)
     }
@@ -261,9 +261,13 @@ mod tests {
         let command =
             RemotingCommand::create_remoting_command(RequestCode::SendMessage.to_i32()).set_ext_fields(fields);
 
-        let contexts = AuthorizationFactory::new_contexts_from_command(&config, &(), &command)
-            .unwrap()
-            .unwrap();
+        let contexts = AuthorizationFactory::new_contexts_from_command(
+            &config,
+            &crate::RemotingAuthContext::embedded("test-session"),
+            &command,
+        )
+        .unwrap()
+        .unwrap();
 
         assert_eq!(contexts.len(), 1);
         assert_eq!(contexts[0].subject_key(), Some("User:alice"));

--- a/rocketmq-auth/src/authorization/provider.rs
+++ b/rocketmq-auth/src/authorization/provider.rs
@@ -38,6 +38,7 @@ use crate::authorization::metadata_provider::LocalAuthorizationMetadataProvider;
 use crate::config::AuthConfig;
 use crate::runtime::ProviderRegistry;
 use crate::AuthMetrics;
+use crate::RemotingAuthContext;
 
 /// Result type for authorization operations.
 pub type AuthorizationResult<T> = Result<T, AuthorizationError>;
@@ -276,13 +277,13 @@ pub trait AuthorizationProvider: Send + Sync {
         Ok(Vec::new())
     }
 
-    /// Create authorization contexts from channel context and remoting command.
+    /// Create authorization contexts from trusted remoting ingress facts and command.
     ///
-    /// Parses channel context (connection info) and RocketMQ remoting command
+    /// Parses typed ingress facts and RocketMQ remoting command
     /// to construct authorization contexts for TCP-based protocols.
     ///
     /// # Arguments
-    /// * `channel_context` - Channel context (connection, remote address, etc.)
+    /// * `auth_context` - Trusted, read-only source and session facts
     /// * `command` - RocketMQ remoting command containing request code and data
     ///
     /// # Returns
@@ -293,7 +294,7 @@ pub trait AuthorizationProvider: Send + Sync {
     #[allow(unused_variables)]
     fn new_contexts_from_remoting_command(
         &self,
-        channel_context: &(dyn std::any::Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
     ) -> AuthorizationResult<Vec<DefaultAuthorizationContext>> {
         // Default implementation returns empty list (no-op)
@@ -341,7 +342,7 @@ impl AuthorizationProvider for NoopAuthorizationProvider {
 
     fn new_contexts_from_remoting_command(
         &self,
-        _channel_context: &(dyn std::any::Any + Send + Sync),
+        _auth_context: &RemotingAuthContext,
         _command: &RemotingCommand,
     ) -> AuthorizationResult<Vec<DefaultAuthorizationContext>> {
         // Return empty contexts (no authorization needed)
@@ -592,13 +593,13 @@ impl AuthorizationProvider for DefaultAuthorizationProvider {
 
     fn new_contexts_from_remoting_command(
         &self,
-        channel_context: &(dyn std::any::Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
     ) -> AuthorizationResult<Vec<DefaultAuthorizationContext>> {
         let builder = self.context_builder.as_ref().ok_or_else(|| {
             AuthorizationError::NotInitialized("Authorization context builder is not configured".to_string())
         })?;
-        builder.build_from_remoting(channel_context, command)
+        builder.build_from_remoting(auth_context, command)
     }
 }
 

--- a/rocketmq-auth/src/remoting_auth_context.rs
+++ b/rocketmq-auth/src/remoting_auth_context.rs
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::net::SocketAddr;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_transport::api::v2::EmbeddedCaller;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::SessionView;
+
 /// Typed, read-only transport facts used by remoting authentication and authorization.
 ///
 /// This value carries no connection, writer, cancellation, or lifecycle authority.
@@ -19,13 +28,73 @@
 pub struct RemotingAuthContext {
     source_ip: Option<String>,
     channel_id: Option<String>,
+    embedded: bool,
 }
 
 impl RemotingAuthContext {
-    /// Creates an authentication context from trusted ingress facts.
+    /// Creates a compatibility authentication context from ingress facts.
+    ///
+    /// New network adapters should use [`Self::network`]. Embedded trust can
+    /// only be projected by [`Self::from_request`] from a transport-owned
+    /// request; missing network metadata never implies embedded trust.
     #[must_use]
     pub fn new(source_ip: Option<String>, channel_id: Option<String>) -> Self {
-        Self { source_ip, channel_id }
+        Self {
+            source_ip,
+            channel_id,
+            embedded: false,
+        }
+    }
+
+    /// Creates a context for a network request from trusted ingress metadata.
+    #[must_use]
+    pub fn network(source_ip: impl Into<String>, channel_id: impl Into<String>) -> Self {
+        Self {
+            source_ip: Some(source_ip.into()),
+            channel_id: Some(channel_id.into()),
+            embedded: false,
+        }
+    }
+
+    /// Creates a context for a trusted in-process request.
+    #[must_use]
+    pub(crate) fn embedded(channel_id: impl Into<String>) -> Self {
+        Self {
+            source_ip: None,
+            channel_id: Some(channel_id.into()),
+            embedded: true,
+        }
+    }
+
+    /// Projects authentication facts from a request assembled by the trusted
+    /// V2 transport boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an authentication error if origin and session kinds disagree or
+    /// required network/session metadata is missing.
+    pub fn from_request(request: &RemotingRequest) -> RocketMQResult<Self> {
+        let channel_id = format!(
+            "transport-session-{}",
+            request.original_identity().request_id().owner_id()
+        );
+        let context = match (request.origin(), request.session()) {
+            (RequestOrigin::Network { peer }, SessionView::Network { remote_addr, .. }) => {
+                validate_network_origin(peer.address(), *remote_addr)?;
+                Self::network(remote_addr.ip().to_string(), channel_id)
+            }
+            (RequestOrigin::Embedded { caller }, SessionView::Embedded { .. }) => {
+                validate_embedded_caller(*caller)?;
+                Self::embedded(channel_id)
+            }
+            _ => {
+                return Err(RocketMQError::authentication_failed(
+                    "remoting request origin does not match its session",
+                ));
+            }
+        };
+        context.validate()?;
+        Ok(context)
     }
 
     /// Returns the trusted source IP, when the ingress has a network peer.
@@ -39,15 +108,75 @@ impl RemotingAuthContext {
     pub fn channel_id(&self) -> Option<&str> {
         self.channel_id.as_deref()
     }
+
+    /// Returns whether the request came from a trusted in-process adapter.
+    #[must_use]
+    pub const fn is_embedded(&self) -> bool {
+        self.embedded
+    }
+
+    /// Verifies that the context carries a complete, internally consistent
+    /// trusted-ingress projection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an authentication error for missing session identity, missing
+    /// network source, or mixed embedded/network facts.
+    pub fn validate(&self) -> RocketMQResult<()> {
+        let channel_id = self.channel_id().filter(|value| !value.trim().is_empty());
+        if channel_id.is_none() {
+            return Err(RocketMQError::authentication_failed(
+                "remoting authentication context is missing a session identity",
+            ));
+        }
+        if self.embedded {
+            if self.source_ip.is_some() {
+                return Err(RocketMQError::authentication_failed(
+                    "embedded remoting authentication context cannot carry a network source",
+                ));
+            }
+            return Ok(());
+        }
+        if self.source_ip().filter(|value| !value.trim().is_empty()).is_none() {
+            return Err(RocketMQError::authentication_failed(
+                "network remoting authentication context is missing a source address",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_network_origin(peer: SocketAddr, remote_addr: SocketAddr) -> RocketMQResult<()> {
+    if peer != remote_addr {
+        return Err(RocketMQError::authentication_failed(
+            "remoting request peer does not match its session source",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_embedded_caller(caller: EmbeddedCaller) -> RocketMQResult<()> {
+    match caller {
+        EmbeddedCaller::BrokerProxy => Ok(()),
+        _ => Err(RocketMQError::authentication_failed(
+            "embedded remoting caller is not trusted by Broker authentication",
+        )),
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+
+    use rocketmq_transport::api::v2::EmbeddedCaller;
+
+    use super::validate_embedded_caller;
+    use super::validate_network_origin;
     use super::RemotingAuthContext;
 
     #[test]
     fn exposes_only_owned_authentication_facts() {
-        let context = RemotingAuthContext::new(Some("192.0.2.10".to_owned()), Some("transport-session-17".to_owned()));
+        let context = RemotingAuthContext::network("192.0.2.10", "transport-session-17");
 
         assert_eq!(context.source_ip(), Some("192.0.2.10"));
         assert_eq!(context.channel_id(), Some("transport-session-17"));
@@ -55,9 +184,33 @@ mod tests {
 
     #[test]
     fn embedded_context_can_omit_network_facts() {
-        let context = RemotingAuthContext::new(None, None);
+        let context = RemotingAuthContext::embedded("embedded-session-1");
 
         assert_eq!(context.source_ip(), None);
-        assert_eq!(context.channel_id(), None);
+        assert_eq!(context.channel_id(), Some("embedded-session-1"));
+        assert!(context.is_embedded());
+        assert!(context.validate().is_ok());
+    }
+
+    #[test]
+    fn missing_network_facts_fail_closed() {
+        assert!(RemotingAuthContext::default().validate().is_err());
+        assert!(RemotingAuthContext::new(Some("192.0.2.10".to_owned()), None)
+            .validate()
+            .is_err());
+    }
+
+    #[test]
+    fn mismatched_network_peer_and_session_source_fail_closed() {
+        let peer: SocketAddr = "192.0.2.10:10911".parse().unwrap();
+        let session_source: SocketAddr = "192.0.2.11:10911".parse().unwrap();
+
+        assert!(validate_network_origin(peer, session_source).is_err());
+        assert!(validate_network_origin(peer, peer).is_ok());
+    }
+
+    #[test]
+    fn broker_proxy_is_an_explicitly_trusted_embedded_caller() {
+        assert!(validate_embedded_caller(EmbeddedCaller::BrokerProxy).is_ok());
     }
 }

--- a/rocketmq-auth/src/runtime.rs
+++ b/rocketmq-auth/src/runtime.rs
@@ -23,9 +23,6 @@ use rocketmq_security_api::LayerFailureKind;
 use rocketmq_security_api::LayerRequirement;
 use rocketmq_security_api::ResourcePattern;
 use rocketmq_security_api::ResourceType;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -494,22 +491,45 @@ impl AuthRuntime {
 
     pub async fn check_remoting(
         &self,
-        channel_context: &(dyn std::any::Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
     ) -> RocketMQResult<()> {
-        let source_ip = source_ip_from_channel_context(channel_context);
-        let channel_id = channel_id_from_channel_context(channel_context);
-        self.check_remoting_with_source_ip(channel_context, command, source_ip.as_deref(), channel_id.as_deref())
+        self.check_remoting_for_code(auth_context, command, command.code())
             .await
+    }
+
+    /// Checks a remoting command using the immutable operation captured at
+    /// ingress rather than the processor-mutable command code.
+    pub async fn check_remoting_for_code(
+        &self,
+        auth_context: &RemotingAuthContext,
+        command: &RemotingCommand,
+        original_code: i32,
+    ) -> RocketMQResult<()> {
+        let mut authoritative_command = command.clone();
+        authoritative_command.set_code_mut(original_code);
+        self.check_remoting_with_source_ip(
+            auth_context,
+            &authoritative_command,
+            auth_context.source_ip(),
+            auth_context.channel_id(),
+        )
+        .await
     }
 
     pub async fn check_remoting_with_source_ip(
         &self,
-        channel_context: &(dyn std::any::Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
         source_ip: Option<&str>,
         channel_id: Option<&str>,
     ) -> RocketMQResult<()> {
+        auth_context.validate()?;
+        if source_ip != auth_context.source_ip() || channel_id != auth_context.channel_id() {
+            return Err(RocketMQError::authentication_failed(
+                "remoting authentication metadata does not match its typed ingress context",
+            ));
+        }
         if self.is_acl_white_remote_address(access_key_from_command(command), source_ip)? {
             return Ok(());
         }
@@ -518,7 +538,7 @@ impl AuthRuntime {
             .authenticate_remoting(command, channel_id)
             .await?;
         self.authorization_service
-            .authorize_remoting(channel_context, command)
+            .authorize_remoting(auth_context, command)
             .await
     }
 
@@ -530,24 +550,38 @@ impl AuthRuntime {
     /// become an abstention and deliberately carry no request or credential data.
     pub async fn evaluate_remoting_detailed(
         &self,
-        channel_context: &(dyn std::any::Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
     ) -> LayerEvaluation<DetailedDecision> {
-        let source_ip = source_ip_from_channel_context(channel_context);
-        let channel_id = channel_id_from_channel_context(channel_context);
+        self.evaluate_remoting_detailed_for_code(auth_context, command, command.code())
+            .await
+    }
+
+    /// Evaluates remoting authentication and authorization against the
+    /// immutable operation code captured by trusted ingress.
+    pub async fn evaluate_remoting_detailed_for_code(
+        &self,
+        auth_context: &RemotingAuthContext,
+        command: &RemotingCommand,
+        original_code: i32,
+    ) -> LayerEvaluation<DetailedDecision> {
+        let mut authoritative_command = command.clone();
+        authoritative_command.set_code_mut(original_code);
+        let command = &authoritative_command;
+        auth_context.validate().map_err(|_| LayerFailureKind::Error)?;
         let is_whitelisted = self
-            .is_acl_white_remote_address(access_key_from_command(command), source_ip.as_deref())
+            .is_acl_white_remote_address(access_key_from_command(command), auth_context.source_ip())
             .map_err(|_| LayerFailureKind::Error)?;
         if is_whitelisted {
             return Ok(DetailedDecision::Allow);
         }
 
         self.authentication_service
-            .authenticate_remoting(command, channel_id.as_deref())
+            .authenticate_remoting(command, auth_context.channel_id())
             .await
             .map_err(|_| LayerFailureKind::Error)?;
         self.authorization_service
-            .authorize_remoting_detailed(channel_context, command)
+            .authorize_remoting_detailed(auth_context, command)
             .await
     }
 
@@ -669,9 +703,10 @@ impl AuthorizationService {
 
     pub async fn authorize_remoting(
         &self,
-        channel_context: &(dyn std::any::Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
     ) -> RocketMQResult<()> {
+        auth_context.validate()?;
         if !self.config.authorization_enabled {
             return Ok(());
         }
@@ -682,7 +717,7 @@ impl AuthorizationService {
 
         let contexts = self
             .provider
-            .new_contexts_from_remoting_command(channel_context, command)
+            .new_contexts_from_remoting_command(auth_context, command)
             .map_err(|error| {
                 self.metrics.record_authorization_result(false);
                 map_authorization_error(error)
@@ -705,9 +740,10 @@ impl AuthorizationService {
     /// denials, while provider and context errors retain a fail-closed failure kind.
     pub async fn authorize_remoting_detailed(
         &self,
-        channel_context: &(dyn std::any::Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
     ) -> LayerEvaluation<DetailedDecision> {
+        auth_context.validate().map_err(|_| LayerFailureKind::Error)?;
         if !self.config.authorization_enabled {
             return Ok(DetailedDecision::Abstain);
         }
@@ -718,7 +754,7 @@ impl AuthorizationService {
 
         let contexts = self
             .provider
-            .new_contexts_from_remoting_command(channel_context, command)
+            .new_contexts_from_remoting_command(auth_context, command)
             .map_err(|error| {
                 self.metrics.record_authorization_result(false);
                 project_authorization_error(&error)
@@ -1162,38 +1198,6 @@ fn access_key_from_command(command: &RemotingCommand) -> Option<&str> {
     })
 }
 
-fn source_ip_from_channel_context(channel_context: &(dyn std::any::Any + Send + Sync)) -> Option<String> {
-    if let Some(context) = channel_context.downcast_ref::<RemotingAuthContext>() {
-        return context.source_ip().map(str::to_owned);
-    }
-    if let Some(ctx) = channel_context.downcast_ref::<ConnectionHandlerContext>() {
-        return Some(ctx.remote_address().ip().to_string());
-    }
-    if let Some(ctx) = channel_context.downcast_ref::<ConnectionHandlerContextWrapper>() {
-        return Some(ctx.remote_address().ip().to_string());
-    }
-    if let Some(channel) = channel_context.downcast_ref::<Channel>() {
-        return Some(channel.remote_address().ip().to_string());
-    }
-    None
-}
-
-fn channel_id_from_channel_context(channel_context: &(dyn std::any::Any + Send + Sync)) -> Option<String> {
-    if let Some(context) = channel_context.downcast_ref::<RemotingAuthContext>() {
-        return context.channel_id().map(str::to_owned);
-    }
-    if let Some(ctx) = channel_context.downcast_ref::<ConnectionHandlerContext>() {
-        return Some(ctx.channel().channel_id().to_owned());
-    }
-    if let Some(ctx) = channel_context.downcast_ref::<ConnectionHandlerContextWrapper>() {
-        return Some(ctx.channel().channel_id().to_owned());
-    }
-    if let Some(channel) = channel_context.downcast_ref::<Channel>() {
-        return Some(channel.channel_id().to_owned());
-    }
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -1374,7 +1378,10 @@ accounts:
         .unwrap();
 
         let broker_get = signed_command(RequestCode::GetBrokerRuntimeInfo, "sre-reader", "reader-secret", &[]);
-        runtime.check_remoting(&(), &broker_get).await.unwrap();
+        runtime
+            .check_remoting(&RemotingAuthContext::embedded("test-session"), &broker_get)
+            .await
+            .unwrap();
 
         let topic_mutation = signed_command(
             RequestCode::UpdateAndCreateTopic,
@@ -1382,7 +1389,10 @@ accounts:
             "reader-secret",
             &[("topic", "Orders")],
         );
-        let error = runtime.check_remoting(&(), &topic_mutation).await.unwrap_err();
+        let error = runtime
+            .check_remoting(&RemotingAuthContext::embedded("test-session"), &topic_mutation)
+            .await
+            .unwrap_err();
         assert!(
             matches!(error, RocketMQError::BrokerPermissionDenied { .. }),
             "unexpected mutation denial error: {error:?}"
@@ -1443,7 +1453,50 @@ accounts:
         let signature = acl_signer::cal_signature("alicetopic-a".as_bytes(), "secret").unwrap();
         let command = send_message_command("topic-a", "alice", &signature);
 
-        runtime.check_remoting(&(), &command).await.unwrap();
+        runtime
+            .check_remoting(&RemotingAuthContext::embedded("test-session"), &command)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn remoting_runtime_rejects_missing_or_mismatched_ingress_metadata() {
+        let runtime = AuthRuntimeBuilder::new(AuthConfig::default()).build().await.unwrap();
+        let command = RemotingCommand::create_remoting_command(RequestCode::SendMessage.to_i32());
+
+        runtime
+            .check_remoting(&RemotingAuthContext::default(), &command)
+            .await
+            .expect_err("missing session and source metadata must fail closed");
+
+        let context = RemotingAuthContext::network("192.0.2.10", "session-a");
+        runtime
+            .check_remoting_with_source_ip(&context, &command, Some("192.0.2.11"), Some("session-a"))
+            .await
+            .expect_err("metadata overrides must match the typed ingress context");
+    }
+
+    #[tokio::test]
+    async fn authoritative_operation_code_cannot_be_replaced_by_a_mutated_command_code() {
+        let runtime = AuthRuntimeBuilder::new(AuthConfig {
+            authentication_enabled: true,
+            authentication_whitelist: CheetahString::from(RequestCode::HeartBeat.to_i32().to_string()),
+            ..AuthConfig::default()
+        })
+        .build()
+        .await
+        .unwrap();
+        let context = RemotingAuthContext::embedded("test-session");
+        let mutated = RemotingCommand::create_remoting_command(RequestCode::HeartBeat.to_i32());
+
+        runtime
+            .check_remoting(&context, &mutated)
+            .await
+            .expect("the test command code is explicitly whitelisted");
+        runtime
+            .check_remoting_for_code(&context, &mutated, RequestCode::SendMessage.to_i32())
+            .await
+            .expect_err("the immutable SendMessage operation must still require authentication");
     }
 
     #[tokio::test]
@@ -1487,7 +1540,9 @@ accounts:
                 .expect("test signature should be generated"),
         );
         assert_eq!(
-            runtime.evaluate_remoting_detailed(&(), &command).await,
+            runtime
+                .evaluate_remoting_detailed(&RemotingAuthContext::embedded("test-session"), &command)
+                .await,
             Ok(DetailedDecision::Allow)
         );
 
@@ -1651,18 +1706,27 @@ accounts:
 
         let global_command = send_message_command_without_credentials("TopicA");
         runtime
-            .check_remoting_with_source_ip(&(), &global_command, Some("10.10.1.2"), None)
+            .check_remoting(
+                &RemotingAuthContext::network("10.10.1.2", "test-session"),
+                &global_command,
+            )
             .await
             .unwrap();
 
         let account_command = send_message_command("TopicA", "alice", "");
         runtime
-            .check_remoting_with_source_ip(&(), &account_command, Some("192.168.0.7"), None)
+            .check_remoting(
+                &RemotingAuthContext::network("192.168.0.7", "test-session"),
+                &account_command,
+            )
             .await
             .unwrap();
 
         runtime
-            .check_remoting_with_source_ip(&(), &account_command, Some("192.168.1.7"), None)
+            .check_remoting(
+                &RemotingAuthContext::network("192.168.1.7", "test-session"),
+                &account_command,
+            )
             .await
             .expect_err("non-whitelisted source should still require a valid signature");
     }
@@ -1766,7 +1830,10 @@ accounts:
         let signature = acl_signer::cal_signature("alicetopic-a".as_bytes(), "secret").unwrap();
         let command = send_message_command("topic-a", "alice", &signature);
 
-        restarted.check_remoting(&(), &command).await.unwrap();
+        restarted
+            .check_remoting(&RemotingAuthContext::embedded("test-session"), &command)
+            .await
+            .unwrap();
         restarted.shutdown().await.unwrap();
     }
 
@@ -2210,13 +2277,16 @@ accounts:
         let signature = acl_signer::cal_signature("aliceTopicA".as_bytes(), "secret").unwrap();
         let valid_command = send_message_command("TopicA", "alice", &signature);
         runtime
-            .check_remoting_with_source_ip(&(), &valid_command, Some("127.0.0.1"), Some("channel-a"))
+            .check_remoting(&RemotingAuthContext::network("127.0.0.1", "channel-a"), &valid_command)
             .await
             .unwrap();
 
         let invalid_command = send_message_command("TopicA", "alice", "bad-signature");
         runtime
-            .check_remoting_with_source_ip(&(), &invalid_command, Some("127.0.0.1"), Some("channel-b"))
+            .check_remoting(
+                &RemotingAuthContext::network("127.0.0.1", "channel-b"),
+                &invalid_command,
+            )
             .await
             .expect_err("invalid signature should fail authentication");
 

--- a/rocketmq-auth/tests/java_alignment.rs
+++ b/rocketmq-auth/tests/java_alignment.rs
@@ -13,6 +13,7 @@ use rocketmq_auth::AuthorizationMetadataProvider;
 use rocketmq_auth::AuthorizationRequest;
 use rocketmq_auth::Policy;
 use rocketmq_auth::PolicyResource;
+use rocketmq_auth::RemotingAuthContext;
 use rocketmq_auth::Subject;
 use rocketmq_auth::SubjectType;
 use rocketmq_auth::User;
@@ -42,6 +43,10 @@ fn temp_auth_config(temp: &TempDir) -> AuthConfig {
         auth_config_path: CheetahString::from(temp.path().join("auth-store").to_string_lossy().as_ref()),
         ..AuthConfig::default()
     }
+}
+
+fn network_auth_context(source_ip: &str, channel_id: &str) -> RemotingAuthContext {
+    RemotingAuthContext::network(source_ip, channel_id)
 }
 
 fn send_message_command(
@@ -129,7 +134,7 @@ async fn remoting_signature_matches_java_sorted_value_only_content() {
         Some(b"body"),
     );
     runtime
-        .check_remoting(&(), &command)
+        .check_remoting(&network_auth_context("127.0.0.1", "test-session"), &command)
         .await
         .expect("Java value-only signed content should authenticate");
 
@@ -143,7 +148,7 @@ async fn remoting_signature_matches_java_sorted_value_only_content() {
         Some(b"body"),
     );
     runtime
-        .check_remoting(&(), &command)
+        .check_remoting(&network_auth_context("127.0.0.1", "test-session"), &command)
         .await
         .expect_err("key+value signed content must not match Java remoting signature semantics");
 }
@@ -194,33 +199,33 @@ accounts:
     let signature = cal_signature(b"aliceTopicA", "secret").expect("signature should calculate");
     let command = send_message_command("TopicA", Some("alice"), Some(signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &command, Some("172.16.0.1"), None)
+        .check_remoting(&network_auth_context("172.16.0.1", "test-session"), &command)
         .await
         .expect("custom TopicA=PUB should override default topic DENY");
 
     let signature = cal_signature(b"aliceTopicB", "secret").expect("signature should calculate");
     let command = send_message_command("TopicB", Some("alice"), Some(signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &command, Some("172.16.0.1"), None)
+        .check_remoting(&network_auth_context("172.16.0.1", "test-session"), &command)
         .await
         .expect_err("defaultTopicPerm=DENY should reject non-custom topic");
 
     let command = send_message_command("TopicB", Some("alice"), Some(""), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &command, Some("192.168.0.7"), None)
+        .check_remoting(&network_auth_context("192.168.0.7", "test-session"), &command)
         .await
         .expect("account whiteRemoteAddress should bypass signature and ACL checks");
 
     let command = send_message_command("TopicB", None, None, &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &command, Some("10.10.1.2"), None)
+        .check_remoting(&network_auth_context("10.10.1.2", "test-session"), &command)
         .await
         .expect("globalWhiteRemoteAddresses should bypass missing credentials");
 
     let signature = cal_signature(b"adminTopicB", "admin-secret").expect("signature should calculate");
     let command = send_message_command("TopicB", Some("admin"), Some(signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &command, Some("172.16.0.1"), None)
+        .check_remoting(&network_auth_context("172.16.0.1", "test-session"), &command)
         .await
         .expect("admin=true should map to SUPER user and bypass ACL DENY");
 }
@@ -261,7 +266,7 @@ async fn custom_deny_takes_precedence_over_custom_allow_for_same_resource() {
     let signature = cal_signature(b"aliceTopicA", "secret").expect("signature should calculate");
     let command = send_message_command("TopicA", Some("alice"), Some(signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &command, Some("172.16.0.1"), None)
+        .check_remoting(&network_auth_context("172.16.0.1", "test-session"), &command)
         .await
         .expect_err("DENY should have higher priority than ALLOW for the same custom resource");
 }
@@ -284,7 +289,7 @@ async fn super_user_short_circuits_acl_lookup() {
     let signature = cal_signature(b"rootTopicWithoutAcl", "secret").expect("signature should calculate");
     let command = send_message_command("TopicWithoutAcl", Some("root"), Some(signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &command, Some("172.16.0.1"), None)
+        .check_remoting(&network_auth_context("172.16.0.1", "test-session"), &command)
         .await
         .expect("SUPER user should pass without a matching ACL");
 }
@@ -321,7 +326,7 @@ accounts:
     let old_signature = cal_signature(b"aliceTopicA", "first").expect("signature should calculate");
     let old_command = send_message_command("TopicA", Some("alice"), Some(old_signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &old_command, Some("172.16.0.1"), Some("channel-a"))
+        .check_remoting(&network_auth_context("172.16.0.1", "channel-a"), &old_command)
         .await
         .expect("initial ACL should authorize TopicA with the first secret");
     let generation_before_reload = runtime.acl_generation();
@@ -333,10 +338,8 @@ accounts:
         workers.push(tokio::spawn(async move {
             for _ in 0..25 {
                 let command = send_message_command("TopicA", Some("alice"), Some(old_signature.as_str()), &[], None);
-                let channel_context = ();
-                let _ = runtime
-                    .check_remoting_with_source_ip(&channel_context, &command, Some("172.16.0.1"), Some("channel-a"))
-                    .await;
+                let auth_context = network_auth_context("172.16.0.1", "channel-a");
+                let _ = runtime.check_remoting(&auth_context, &command).await;
                 tokio::task::yield_now().await;
             }
         }));
@@ -369,14 +372,14 @@ accounts:
 
     let old_command = send_message_command("TopicA", Some("alice"), Some(old_signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &old_command, Some("172.16.0.1"), Some("channel-a"))
+        .check_remoting(&network_auth_context("172.16.0.1", "channel-a"), &old_command)
         .await
         .expect_err("reloaded ACL should reject the old secret and old topic");
 
     let new_signature = cal_signature(b"aliceTopicB", "second").expect("signature should calculate");
     let new_command = send_message_command("TopicB", Some("alice"), Some(new_signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &new_command, Some("172.16.0.1"), Some("channel-a"))
+        .check_remoting(&network_auth_context("172.16.0.1", "channel-a"), &new_command)
         .await
         .expect("reloaded ACL should authorize TopicB with the second secret");
 
@@ -435,14 +438,14 @@ accounts:
     let old_signature = cal_signature(b"aliceTopicA", "first").expect("signature should calculate");
     let old_command = send_message_command("TopicA", Some("alice"), Some(old_signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &old_command, Some("172.16.0.1"), Some("channel-a"))
+        .check_remoting(&network_auth_context("172.16.0.1", "channel-a"), &old_command)
         .await
         .expect("failed reload must keep the previous working ACL snapshot");
 
     let new_signature = cal_signature(b"aliceTopicB", "first").expect("signature should calculate");
     let new_command = send_message_command("TopicB", Some("alice"), Some(new_signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &new_command, Some("172.16.0.1"), Some("channel-a"))
+        .check_remoting(&network_auth_context("172.16.0.1", "channel-a"), &new_command)
         .await
         .expect_err("failed reload must not partially apply the invalid ACL file");
 }
@@ -482,7 +485,7 @@ accounts:
     let bob_signature = cal_signature(b"bobTopicB", "second").expect("signature should calculate");
     let bob_command = send_message_command("TopicB", Some("bob"), Some(bob_signature.as_str()), &[], None);
     runtime
-        .check_remoting_with_source_ip(&(), &bob_command, Some("172.16.0.1"), Some("channel-b"))
+        .check_remoting(&network_auth_context("172.16.0.1", "channel-b"), &bob_command)
         .await
         .expect("initial ACL should authorize bob and populate provider caches");
     let generation_before_reload = runtime.acl_generation();
@@ -509,7 +512,7 @@ accounts:
     );
 
     runtime
-        .check_remoting_with_source_ip(&(), &bob_command, Some("172.16.0.1"), Some("channel-b"))
+        .check_remoting(&network_auth_context("172.16.0.1", "channel-b"), &bob_command)
         .await
         .expect_err("successful reload must remove deleted ACL-file accounts and invalidate cached ACLs");
 }
@@ -527,9 +530,13 @@ fn authorization_factory_caches_provider_by_config_name_and_builds_contexts() {
     assert!(Arc::ptr_eq(&provider1, &provider2));
 
     let command = send_message_command("TopicA", Some("alice"), Some("signature"), &[], None);
-    let contexts = AuthorizationFactory::new_contexts_from_command(&config, &(), &command)
-        .expect("contexts should be built through the factory")
-        .expect("default provider should create contexts");
+    let contexts = AuthorizationFactory::new_contexts_from_command(
+        &config,
+        &network_auth_context("127.0.0.1", "test-session"),
+        &command,
+    )
+    .expect("contexts should be built through the factory")
+    .expect("default provider should create contexts");
 
     assert_eq!(contexts.len(), 1);
     assert_eq!(contexts[0].subject_key(), Some("User:alice"));

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -227,6 +227,8 @@ use crate::processor::send_message_processor::capability::SendMessageProcessorCo
 use crate::processor::send_message_processor::capability::SendMessageStoreCapability;
 use crate::processor::send_message_processor::capability::SendMessageTopicCapability;
 use crate::processor::send_message_processor::SendMessageProcessor;
+use crate::processor::v2::BrokerProcessorTypeV2;
+use crate::processor::v2::BrokerRequestProcessorV2;
 use crate::processor::BrokerProcessorType;
 use crate::processor::BrokerRequestProcessor;
 use crate::schedule::schedule_message_service::ScheduleMessageService;
@@ -287,6 +289,10 @@ type DefaultServerProcessor =
 
 type FasterServerProcessor =
     BrokerRequestProcessor<BrokerMessageStore, DefaultTransactionalMessageService<BrokerMessageStore>>;
+
+type DefaultServerProcessorV2 = BrokerRequestProcessorV2<
+    BrokerProcessorTypeV2<BrokerMessageStore, DefaultTransactionalMessageService<BrokerMessageStore>>,
+>;
 
 type BrokerScheduledTasks = ScheduledTaskManager;
 

--- a/rocketmq-broker/src/broker_runtime/request_pipeline.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline.rs
@@ -22,6 +22,8 @@ pub(super) struct BrokerRequestPipeline {
     pub(super) proxy_request_processor: Option<DefaultServerProcessor>,
     pub(super) authorized_dispatcher:
         Option<Arc<rocketmq_transport::api::v1::AuthorizedCommandDispatcher<DefaultServerProcessor>>>,
+    pub(super) prepared_v2_dispatcher:
+        Option<Arc<rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2<DefaultServerProcessorV2>>>,
     pub(super) auth_runtime: Option<Arc<AuthRuntime>>,
     pub(super) maintenance_authorizer: Option<Arc<MaintenanceAuthorizer>>,
     pub(super) auth_admin_service: Option<Arc<AuthAdminService>>,
@@ -39,6 +41,7 @@ impl BrokerRequestPipeline {
             admission_controller: None,
             proxy_request_processor: None,
             authorized_dispatcher: None,
+            prepared_v2_dispatcher: None,
             auth_runtime: None,
             maintenance_authorizer: None,
             auth_admin_service: None,
@@ -870,5 +873,11 @@ impl BrokerRuntime {
         &self,
     ) -> Option<Arc<rocketmq_transport::api::v1::AuthorizedCommandDispatcher<DefaultServerProcessor>>> {
         self.composition.request_pipeline.authorized_dispatcher.clone()
+    }
+
+    pub(crate) fn prepared_v2_dispatcher(
+        &self,
+    ) -> Option<Arc<rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2<DefaultServerProcessorV2>>> {
+        self.composition.request_pipeline.prepared_v2_dispatcher.clone()
     }
 }

--- a/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
@@ -16,6 +16,28 @@
 
 use super::super::*;
 
+/// Coarse transport gate for the prepared Broker V2 graph.
+///
+/// This decision only continues to the Broker-owned AuthRuntime check. It is
+/// deliberately not a substitute for Broker authentication or ACL policy.
+struct BrokerV2IngressPolicy;
+
+impl rocketmq_security_api::IngressPolicy for BrokerV2IngressPolicy {
+    fn evaluate_ingress(
+        &self,
+        _request: rocketmq_security_api::SecurityRequestView<'_>,
+    ) -> rocketmq_security_api::LayerEvaluation<rocketmq_security_api::IngressDecision> {
+        Ok(rocketmq_security_api::IngressDecision::AllowToContinue)
+    }
+}
+
+fn prepared_v2_transport_security() -> Arc<rocketmq_transport::api::v1::TransportSecurity> {
+    Arc::new(
+        rocketmq_transport::api::v1::TransportSecurity::development_insecure_loopback(None, None)
+            .with_ingress_policy(Arc::new(BrokerV2IngressPolicy)),
+    )
+}
+
 impl BrokerRuntime {
     pub(in crate::broker_runtime) async fn start_basic_service(
         &mut self,
@@ -55,13 +77,37 @@ impl BrokerRuntime {
                 component: "authorized_dispatcher",
                 detail: "shared Broker admission boundary was not initialized".to_owned(),
             })?;
+        let transport_security =
+            Arc::new(rocketmq_transport::api::v1::TransportSecurity::development_insecure_loopback(None, None));
+        let prepared_v2_transport_security = prepared_v2_transport_security();
+        let mut prepared_v2_processor = DefaultServerProcessorV2::from_legacy_graph(&request_processor);
+        let broker_config = self.composition.state.broker_config();
+        if !broker_config.authentication_enabled && !broker_config.authorization_enabled {
+            prepared_v2_processor.set_auth_disabled_by_validated_config();
+        }
+        if !prepared_v2_processor.is_auth_configured() {
+            return Err(BrokerStartupError::Initialization {
+                component: "broker_v2_auth",
+                detail: "prepared Broker V2 dispatcher requires an explicit AuthRuntime or validated disabled state"
+                    .to_owned(),
+            });
+        }
+        let prepared_v2_dispatcher = Arc::new(
+            rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2::new_with_telemetry(
+                prepared_v2_processor,
+                Vec::new(),
+                prepared_v2_transport_security,
+                Arc::clone(&admission),
+                self.composition.state.transport_telemetry.clone(),
+            ),
+        );
         let authorized_dispatcher = Arc::new(
             rocketmq_transport::api::v1::AuthorizedCommandDispatcher::try_new(
                 request_processor.clone(),
                 Vec::new(),
                 &service_context.process_budget(),
                 self.composition.state.transport_telemetry.clone(),
-                Arc::new(rocketmq_transport::api::v1::TransportSecurity::development_insecure_loopback(None, None)),
+                transport_security,
                 admission,
             )
             .map_err(|error| BrokerStartupError::Initialization {
@@ -71,6 +117,7 @@ impl BrokerRuntime {
         );
         self.composition.request_pipeline.proxy_request_processor = Some(request_processor.clone());
         self.composition.request_pipeline.authorized_dispatcher = Some(authorized_dispatcher.clone());
+        self.composition.request_pipeline.prepared_v2_dispatcher = Some(prepared_v2_dispatcher);
         self.lifecycle
             .startup_journal
             .complete(BrokerComponent::RequestProcessors);
@@ -260,5 +307,112 @@ impl BrokerRuntime {
             .startup_journal
             .complete(BrokerComponent::BackgroundServices);
         Ok((normal_listener, fast_listener))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+    use rocketmq_security_api::Principal;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::HandlerOutcome;
+    use rocketmq_transport::api::v2::RemotingRequest;
+    use rocketmq_transport::api::v2::RequestProcessorV2;
+    use rocketmq_transport::api::v2::ResponsePlan;
+
+    use super::prepared_v2_transport_security;
+    use crate::processor::v2::BrokerRequestProcessorV2;
+
+    const STARTUP_PROBE_CODE: i32 = 98_520;
+
+    #[derive(Clone)]
+    struct StartupProbe {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl RequestProcessorV2 for StartupProbe {
+        async fn process(&mut self, _request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(HandlerOutcome::Reply(ResponsePlan::empty_response(
+                ResponseCode::Success as i32,
+            )))
+        }
+    }
+
+    #[tokio::test]
+    async fn prepared_v2_security_continues_to_broker_acl_and_acl_remains_fail_closed() {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("broker-prepared-v2-security-test"))
+            .expect("prepared V2 security test runtime");
+        let service = owner.root_context().component("broker-prepared-v2-security");
+
+        let allowed_calls = Arc::new(AtomicUsize::new(0));
+        let mut explicitly_disabled = BrokerRequestProcessorV2::new();
+        explicitly_disabled.set_auth_disabled_by_validated_config();
+        explicitly_disabled.register_processor(
+            STARTUP_PROBE_CODE,
+            StartupProbe {
+                calls: Arc::clone(&allowed_calls),
+            },
+        );
+        let allowed = AuthorizedCommandDispatcherV2::new(
+            explicitly_disabled,
+            Vec::new(),
+            prepared_v2_transport_security(),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        )
+        .dispatch_embedded_v2(
+            service.task_group(),
+            Principal::new("broker-proxy"),
+            None,
+            RemotingCommand::create_remoting_command(STARTUP_PROBE_CODE),
+        )
+        .await
+        .expect("coarse ingress should continue to Broker ACL");
+        let EmbeddedDispatchOutcome::Reply(plan) = allowed else {
+            panic!("explicitly disabled Broker ACL should reach the leaf")
+        };
+        assert_eq!(plan.response_code(), ResponseCode::Success as i32);
+        assert_eq!(allowed_calls.load(Ordering::SeqCst), 1);
+
+        let denied_calls = Arc::new(AtomicUsize::new(0));
+        let mut unconfigured = BrokerRequestProcessorV2::new();
+        unconfigured.register_processor(
+            STARTUP_PROBE_CODE,
+            StartupProbe {
+                calls: Arc::clone(&denied_calls),
+            },
+        );
+        let denied = AuthorizedCommandDispatcherV2::new(
+            unconfigured,
+            Vec::new(),
+            prepared_v2_transport_security(),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        )
+        .dispatch_embedded_v2(
+            service.task_group(),
+            Principal::new("broker-proxy"),
+            None,
+            RemotingCommand::create_remoting_command(STARTUP_PROBE_CODE),
+        )
+        .await
+        .expect("Broker ACL denial should be a response plan");
+        let EmbeddedDispatchOutcome::Reply(plan) = denied else {
+            panic!("unconfigured Broker ACL should fail closed with one reply")
+        };
+        assert_eq!(plan.response_code(), ResponseCode::NoPermission as i32);
+        assert_eq!(denied_calls.load(Ordering::SeqCst), 0);
+
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
     }
 }

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use rocketmq_auth::AuthRuntime;
+use rocketmq_auth::RemotingAuthContext;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
@@ -237,9 +238,7 @@ where
             BrokerProcessorType::Maintenance(processor) => {
                 processor.legacy_adapter().process_legacy(&channel, request).await
             }
-            BrokerProcessorType::AdminBroker(processor) => {
-                processor.process_request_shared(channel, ctx, request).await
-            }
+            BrokerProcessorType::AdminBroker(processor) => processor.process_request_shared(channel, request).await,
         }
     }
 
@@ -392,7 +391,11 @@ where
         }
         if !privileged_maintenance {
             if let Some(auth_runtime) = &self.auth_runtime {
-                if let Err(error) = auth_runtime.check_remoting(&ctx, request).await {
+                let auth_context = RemotingAuthContext::network(
+                    ctx.remote_address().ip().to_string(),
+                    ctx.channel().channel_id().to_owned(),
+                );
+                if let Err(error) = auth_runtime.check_remoting(&auth_context, request).await {
                     let response = command_from_error_with_factory_remark_and_opaque(
                         &self.command_factory,
                         &error,

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -54,8 +54,18 @@ use rocketmq_transport::api::v1::request_code_not_supported_with_remark;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::EmbeddedCaller;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::SessionView;
+use std::fmt;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::warn;
+
+use crate::processor::response_plan::immediate_outcome_from_command_result;
 
 mod batch_mq_handler;
 mod broker_config_request_handler;
@@ -84,8 +94,11 @@ mod update_broker_ha_handler;
 mod update_cold_data_flow_ctr_group_config;
 mod update_global_white_addrs_config_request_handler;
 mod update_user_request_handler;
+#[cfg(test)]
+mod v2_concurrency_tests;
 
 pub struct AdminBrokerProcessor<MS: BrokerAdminStore> {
+    command_factory: RemotingCommandFactory,
     topic_request_handler: TopicRequestHandler,
     broker_config_request_handler: BrokerConfigRequestHandler<MS>,
     consumer_request_handler: ConsumerRequestHandler,
@@ -123,10 +136,10 @@ where
     async fn process_request(
         &mut self,
         channel: Channel,
-        ctx: ConnectionHandlerContext,
+        _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.process_request_shared(channel, ctx, request).await
+        self.process_request_shared(channel, request).await
     }
 }
 
@@ -134,11 +147,132 @@ impl<MS: BrokerAdminStore> AdminBrokerProcessor<MS> {
     pub(crate) async fn process_request_shared(
         &self,
         channel: Channel,
-        ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
-        self.process_request_inner(channel, ctx, request_code, request).await
+        let metadata = AdminRequestMetadata::legacy_network(channel.remote_address());
+        self.process_request_inner(&metadata, request_code, request).await
+    }
+
+    pub(crate) async fn process_v2_shared(
+        &self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome>
+    where
+        MS: 'static,
+    {
+        let original_opaque = request.original_identity().original_opaque();
+        let metadata = AdminRequestMetadata::try_from_request(request)?;
+        let request_code = RequestCode::from(request.original_identity().original_code());
+        let result = self
+            .process_request_inner(&metadata, request_code, request.command_mut())
+            .await;
+        immediate_outcome_from_command_result(
+            &self.command_factory,
+            result,
+            original_opaque,
+            "Admin Broker processor returned no response",
+        )
+    }
+}
+
+impl<MS> RequestProcessorV2 for AdminBrokerProcessor<MS>
+where
+    MS: BrokerAdminStore + 'static,
+{
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_shared(request).await
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AdminRequestCaller {
+    Network(SocketAddr),
+    BrokerProxy,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct AdminRequestMetadata {
+    caller: AdminRequestCaller,
+}
+
+impl AdminRequestMetadata {
+    fn legacy_network(remote_addr: SocketAddr) -> Self {
+        Self {
+            caller: AdminRequestCaller::Network(remote_addr),
+        }
+    }
+
+    fn try_from_request(request: &RemotingRequest) -> rocketmq_error::RocketMQResult<Self> {
+        let origin = match request.origin() {
+            RequestOrigin::Network { peer } => AdminOriginFact::Network(peer.address()),
+            RequestOrigin::Embedded {
+                caller: EmbeddedCaller::BrokerProxy,
+            } => AdminOriginFact::BrokerProxy,
+            _ => AdminOriginFact::Unsupported,
+        };
+        let session = match request.session() {
+            SessionView::Network { remote_addr, .. } => AdminSessionFact::Network(*remote_addr),
+            SessionView::Embedded { .. } => AdminSessionFact::Embedded,
+            _ => AdminSessionFact::Unsupported,
+        };
+        trusted_admin_metadata(origin, session)
+    }
+
+    pub(super) fn source_ip(self) -> String {
+        match self.caller {
+            AdminRequestCaller::Network(remote_addr) => remote_addr.ip().to_string(),
+            AdminRequestCaller::BrokerProxy => "embedded:broker-proxy".to_owned(),
+        }
+    }
+
+    pub(super) fn network_remote_addr(self) -> Option<SocketAddr> {
+        match self.caller {
+            AdminRequestCaller::Network(remote_addr) => Some(remote_addr),
+            AdminRequestCaller::BrokerProxy => None,
+        }
+    }
+}
+
+impl fmt::Display for AdminRequestMetadata {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.caller {
+            AdminRequestCaller::Network(remote_addr) => remote_addr.fmt(formatter),
+            AdminRequestCaller::BrokerProxy => formatter.write_str("embedded:broker-proxy"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AdminOriginFact {
+    Network(SocketAddr),
+    BrokerProxy,
+    Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AdminSessionFact {
+    Network(SocketAddr),
+    Embedded,
+    Unsupported,
+}
+
+fn trusted_admin_metadata(
+    origin: AdminOriginFact,
+    session: AdminSessionFact,
+) -> rocketmq_error::RocketMQResult<AdminRequestMetadata> {
+    match (origin, session) {
+        (AdminOriginFact::Network(peer), AdminSessionFact::Network(remote_addr)) if peer == remote_addr => {
+            Ok(AdminRequestMetadata {
+                caller: AdminRequestCaller::Network(remote_addr),
+            })
+        }
+        (AdminOriginFact::BrokerProxy, AdminSessionFact::Embedded) => Ok(AdminRequestMetadata {
+            caller: AdminRequestCaller::BrokerProxy,
+        }),
+        _ => Err(RocketMQError::invariant_violated(
+            "Admin Broker request origin does not match its trusted session view",
+        )),
     }
 }
 
@@ -195,6 +329,7 @@ impl<MS: BrokerAdminStore> AdminBrokerProcessor<MS> {
         let broker_stats_handler = BrokerStatsHandler::new(broker_runtime_inner.broker_stats_manager_handle());
 
         AdminBrokerProcessor {
+            command_factory,
             topic_request_handler,
             broker_config_request_handler,
             consumer_request_handler,
@@ -229,336 +364,323 @@ impl<MS: BrokerAdminStore> AdminBrokerProcessor<MS> {
 impl<MS: BrokerAdminStore> AdminBrokerProcessor<MS> {
     async fn process_request_inner(
         &self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match request_code {
             RequestCode::UpdateAndCreateTopic => {
                 self.topic_request_handler
-                    .update_and_create_topic(&self.broker_config_request_handler, channel, ctx, request_code, request)
+                    .update_and_create_topic(&self.broker_config_request_handler, metadata, request_code, request)
                     .await
             }
             RequestCode::UpdateTopicConfigCas => {
                 self.topic_request_handler
-                    .update_topic_config_cas(&self.broker_config_request_handler, channel, ctx, request_code, request)
+                    .update_topic_config_cas(&self.broker_config_request_handler, metadata, request_code, request)
                     .await
             }
             RequestCode::UpdateAndCreateTopicList => {
                 self.topic_request_handler
-                    .update_and_create_topic_list(
-                        &self.broker_config_request_handler,
-                        channel,
-                        ctx,
-                        request_code,
-                        request,
-                    )
+                    .update_and_create_topic_list(&self.broker_config_request_handler, metadata, request_code, request)
                     .await
             }
             RequestCode::DeleteTopicInBroker => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .delete_topic(broker_runtime_inner, channel, ctx, request_code, request)
+                    .delete_topic(broker_runtime_inner, metadata, request_code, request)
                     .await
             }
             RequestCode::DeleteTopicInBrokerList => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .delete_topic_list(broker_runtime_inner, channel, ctx, request_code, request)
+                    .delete_topic_list(broker_runtime_inner, metadata, request_code, request)
                     .await
             }
             RequestCode::GetAllTopicConfig => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .get_all_topic_config(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_all_topic_config(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetTimerCheckPoint => {
                 self.broker_config_request_handler
-                    .get_timer_check_point(channel, ctx, request_code, request)
+                    .get_timer_check_point(request_code, request)
                     .await
             }
             RequestCode::GetTimerMetrics => {
                 self.broker_config_request_handler
-                    .get_timer_metrics(channel, ctx, request_code, request)
+                    .get_timer_metrics(request_code, request)
                     .await
             }
             RequestCode::UpdateBrokerConfig | RequestCode::UpdateBrokerConfigCas => {
                 self.broker_config_request_handler
-                    .update_broker_config(channel, ctx, request_code, request)
+                    .update_broker_config(metadata, request_code, request)
                     .await
             }
             RequestCode::GetBrokerConfig => {
                 self.broker_config_request_handler
-                    .get_broker_config(channel, ctx, request_code, request)
+                    .get_broker_config(request_code, request)
                     .await
             }
             RequestCode::UpdateColdDataFlowCtrConfig => {
                 self.update_cold_data_flow_ctr_group_config_request_handler
-                    .update_cold_data_flow_ctr_group_config(channel, ctx, request_code, request)
+                    .update_cold_data_flow_ctr_group_config(request_code, request)
                     .await
             }
             RequestCode::RemoveColdDataFlowCtrConfig => {
                 self.update_cold_data_flow_ctr_group_config_request_handler
-                    .remove_cold_data_flow_ctr_group_config(channel, ctx, request_code, request)
+                    .remove_cold_data_flow_ctr_group_config(request_code, request)
                     .await
             }
             RequestCode::GetColdDataFlowCtrInfo => {
                 self.update_cold_data_flow_ctr_group_config_request_handler
-                    .get_cold_data_flow_ctr_info(channel, ctx, request_code, request)
+                    .get_cold_data_flow_ctr_info(request_code, request)
                     .await
             }
             RequestCode::SetCommitlogReadMode => {
                 self.broker_config_request_handler
-                    .set_commitlog_read_mode(channel, ctx, request_code, request)
+                    .set_commitlog_read_mode(request_code, request)
                     .await
             }
             RequestCode::SearchOffsetByTimestamp => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.message_related_handler
-                    .search_offset_by_timestamp(broker_runtime_inner, channel, ctx, request_code, request)
+                    .search_offset_by_timestamp(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetMaxOffset => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_max_offset(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_max_offset(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetMinOffset => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_min_offset(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_min_offset(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetEarliestMsgStoreTime => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_earliest_msg_store_time(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_earliest_msg_store_time(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetBrokerRuntimeInfo => {
                 self.broker_config_request_handler
-                    .get_broker_runtime_info(channel, ctx, request_code, request)
+                    .get_broker_runtime_info(request_code, request)
                     .await
             }
             RequestCode::LockBatchMq => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.batch_mq_handler
-                    .lock_natch_mq(broker_runtime_inner, channel, ctx, request_code, request)
+                    .lock_natch_mq(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::UnlockBatchMq => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.batch_mq_handler
-                    .unlock_batch_mq(broker_runtime_inner, channel, ctx, request_code, request)
+                    .unlock_batch_mq(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::UpdateAndCreateSubscriptionGroup => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
-                    .update_and_create_subscription_group(broker_runtime_inner, channel, ctx, request_code, request)
+                    .update_and_create_subscription_group(broker_runtime_inner, metadata, request_code, request)
                     .await
             }
             RequestCode::UpdateSubscriptionGroupConfigCas => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
-                    .update_subscription_group_config_cas(broker_runtime_inner, channel, ctx, request_code, request)
+                    .update_subscription_group_config_cas(broker_runtime_inner, metadata, request_code, request)
                     .await
             }
             RequestCode::UpdateAndCreateSubscriptionGroupList => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
-                    .update_and_create_subscription_group_list(
-                        broker_runtime_inner,
-                        channel,
-                        ctx,
-                        request_code,
-                        request,
-                    )
+                    .update_and_create_subscription_group_list(broker_runtime_inner, metadata, request_code, request)
                     .await
             }
             RequestCode::GetAllSubscriptionGroupConfig => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_all_subscription_group_config(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_all_subscription_group_config(broker_runtime_inner, metadata, request_code, request)
                     .await
             }
             RequestCode::DeleteSubscriptionGroup => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
-                    .delete_subscription_group(broker_runtime_inner, channel, ctx, request_code, request)
+                    .delete_subscription_group(broker_runtime_inner, metadata, request_code, request)
                     .await
             }
             RequestCode::DeleteSubscriptionGroupList => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
-                    .delete_subscription_group_list(broker_runtime_inner, channel, ctx, request_code, request)
+                    .delete_subscription_group_list(broker_runtime_inner, metadata, request_code, request)
                     .await
             }
             RequestCode::GetTopicStatsInfo => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .get_topic_stats_info(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_topic_stats_info(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetConsumerConnectionList => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .get_consumer_connection_list(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_consumer_connection_list(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetProducerConnectionList => {
                 self.producer_request_handler
-                    .get_producer_connection_list(ctx, request)
+                    .get_producer_connection_list(request)
                     .await
             }
-            RequestCode::GetAllProducerInfo => self.producer_request_handler.get_all_producer_info(ctx, request).await,
+            RequestCode::GetAllProducerInfo => self.producer_request_handler.get_all_producer_info(request).await,
             RequestCode::GetConsumeStats => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .get_consume_stats(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_consume_stats(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetAllConsumerOffset => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .get_all_consumer_offset(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_all_consumer_offset(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetAllDelayOffset => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .get_all_delay_offset(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_all_delay_offset(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetAllMessageRequestMode => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .get_all_message_request_mode(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_all_message_request_mode(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::InvokeBrokerToResetOffset => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .invoke_broker_to_reset_offset(broker_runtime_inner, channel, ctx, request_code, request)
+                    .invoke_broker_to_reset_offset(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::InvokeBrokerToGetConsumerStatus => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .invoke_broker_to_get_consumer_status(broker_runtime_inner, channel, ctx, request_code, request)
+                    .invoke_broker_to_get_consumer_status(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::QueryTopicConsumeByWho => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .query_topic_consume_by_who(broker_runtime_inner, channel, ctx, request_code, request)
+                    .query_topic_consume_by_who(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::QueryTopicsByConsumer => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .query_topics_by_consumer(broker_runtime_inner, channel, ctx, request_code, request)
+                    .query_topics_by_consumer(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::QuerySubscriptionByConsumer => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .query_subscription_by_consumer(broker_runtime_inner, channel, ctx, request_code, request)
+                    .query_subscription_by_consumer(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::QueryConsumeTimeSpan => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .query_consume_time_span(broker_runtime_inner, channel, ctx, request_code, request)
+                    .query_consume_time_span(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetSystemTopicListFromBroker => {
                 self.topic_request_handler
-                    .get_system_topic_list_from_broker(channel, ctx, request_code, request)
+                    .get_system_topic_list_from_broker(request_code, request)
                     .await
             }
             RequestCode::CleanExpiredConsumequeue => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .clean_expired_consumequeue(broker_runtime_inner, channel, ctx, request_code, request)
+                    .clean_expired_consumequeue(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::DeleteExpiredCommitlog => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.offset_request_handler
-                    .delete_expired_commitlog(broker_runtime_inner, channel, ctx, request_code, request)
+                    .delete_expired_commitlog(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::CleanUnusedTopic => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .clean_unused_topic(broker_runtime_inner, channel, ctx, request_code, request)
+                    .clean_unused_topic(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetConsumerRunningInfo => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .get_consumer_running_info(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_consumer_running_info(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::QueryCorrectionOffset => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .query_correction_offset(broker_runtime_inner, channel, ctx, request_code, request)
+                    .query_correction_offset(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::ConsumeMessageDirectly => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .consume_message_directly(broker_runtime_inner, channel, ctx, request_code, request)
+                    .consume_message_directly(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::CloneGroupOffset => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .clone_group_offset(broker_runtime_inner, channel, ctx, request_code, request)
+                    .clone_group_offset(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::ViewBrokerStatsData => {
                 self.broker_stats_handler
-                    .view_broker_stats_data(channel, ctx, request_code, request)
+                    .view_broker_stats_data(request_code, request)
                     .await
             }
             RequestCode::GetBrokerConsumeStats => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.consumer_request_handler
-                    .get_broker_consume_stats(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_broker_consume_stats(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::QueryConsumeQueue => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.message_related_handler
-                    .query_consume_queue(broker_runtime_inner, channel, ctx, request_code, request)
+                    .query_consume_queue(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::CheckRocksdbCqWriteProgress => {
                 self.offset_request_handler
-                    .check_rocksdb_cq_write_progress(channel, ctx, request_code, request)
+                    .check_rocksdb_cq_write_progress(request_code, request)
                     .await
             }
             RequestCode::ExportRocksdbConfigToJson => {
                 self.broker_config_request_handler
-                    .export_rocksdb_config_to_json(channel, ctx, request_code, request)
+                    .export_rocksdb_config_to_json(request_code, request)
                     .await
             }
             RequestCode::UpdateAndGetGroupForbidden => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
-                    .update_and_get_group_forbidden(broker_runtime_inner, channel, ctx, request_code, request)
+                    .update_and_get_group_forbidden(broker_runtime_inner, metadata, request_code, request)
                     .await
             }
             RequestCode::GetSubscriptionGroupConfig => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.subscription_group_handler
-                    .get_subscription_group_config(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_subscription_group_config(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::UpdateAndCreateAclConfig => Ok(get_legacy_acl_cmd_response(
@@ -575,33 +697,32 @@ impl<MS: BrokerAdminStore> AdminBrokerProcessor<MS> {
             )),
             RequestCode::UpdateGlobalWhiteAddrsConfig => {
                 self.update_global_white_addrs_config_request_handler
-                    .update_global_white_addrs_config(channel, ctx, request_code, request)
+                    .update_global_white_addrs_config(request_code, request)
                     .await
             }
             RequestCode::ResumeCheckHalfMessage => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.message_related_handler
-                    .resume_check_half_message(broker_runtime_inner, channel, ctx, request_code, request)
+                    .resume_check_half_message(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::PopRollback => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.message_related_handler
-                    .pop_rollback(broker_runtime_inner, channel, ctx, request_code, request)
+                    .pop_rollback(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetTopicConfig => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.topic_request_handler
-                    .get_topic_config(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_topic_config(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::UpdateAndCreateStaticTopic => {
                 self.topic_request_handler
                     .update_and_create_static_topic(
                         &self.broker_config_request_handler,
-                        channel,
-                        ctx,
+                        metadata,
                         request_code,
                         request,
                     )
@@ -610,97 +731,63 @@ impl<MS: BrokerAdminStore> AdminBrokerProcessor<MS> {
             RequestCode::NotifyMinBrokerIdChange => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.notify_min_broker_handler
-                    .notify_min_broker_id_change(broker_runtime_inner, channel, ctx, request_code, request)
+                    .notify_min_broker_id_change(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::ExchangeBrokerHaInfo => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.update_broker_ha_handler
-                    .update_broker_ha_info(broker_runtime_inner, channel, ctx, request_code, request)
+                    .update_broker_ha_info(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetBrokerHaStatus => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.get_broker_ha_status_handler
-                    .get_broker_ha_status(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_broker_ha_status(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::ResetMasterFlushOffset => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.reset_master_flusg_offset_handler
-                    .reset_master_flush_offset(broker_runtime_inner, channel, ctx, request_code, request)
+                    .reset_master_flush_offset(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::GetBrokerEpochCache => {
                 let broker_runtime_inner = self.broker_config_request_handler.broker_runtime_inner();
                 self.broker_epoch_cache_handler
-                    .get_broker_epoch_cache(broker_runtime_inner, channel, ctx, request_code, request)
+                    .get_broker_epoch_cache(broker_runtime_inner, request_code, request)
                     .await
             }
             RequestCode::NotifyBrokerRoleChanged => {
                 self.notify_broker_role_change_handler
-                    .notify_broker_role_changed(
-                        &self.broker_config_request_handler,
-                        channel,
-                        ctx,
-                        request_code,
-                        request,
-                    )
+                    .notify_broker_role_changed(&self.broker_config_request_handler, metadata, request_code, request)
                     .await
             }
             RequestCode::AuthCreateUser => {
                 self.create_user_request_handler
-                    .create_user(channel, ctx, request_code, request)
+                    .create_user(request_code, request)
                     .await
             }
             RequestCode::AuthUpdateUser => {
                 self.update_user_request_handler
-                    .update_user(channel, ctx, request_code, request)
+                    .update_user(request_code, request)
                     .await
             }
             RequestCode::AuthDeleteUser => {
                 self.delete_user_request_handler
-                    .delete_user(channel, ctx, request_code, request)
+                    .delete_user(request_code, request)
                     .await
             }
-            RequestCode::AuthGetUser => {
-                self.get_user_request_handler
-                    .get_user(channel, ctx, request_code, request)
-                    .await
-            }
-            RequestCode::AuthListUsers => {
-                self.list_users_request_handler
-                    .list_users(channel, ctx, request_code, request)
-                    .await
-            }
-            RequestCode::AuthCreateAcl => {
-                self.create_acl_request_handler
-                    .create_acl(channel, ctx, request_code, request)
-                    .await
-            }
-            RequestCode::AuthUpdateAcl => {
-                self.update_acl_request_handler
-                    .update_acl(channel, ctx, request_code, request)
-                    .await
-            }
-            RequestCode::AuthDeleteAcl => {
-                self.delete_acl_request_handler
-                    .delete_acl(channel, ctx, request_code, request)
-                    .await
-            }
-            RequestCode::AuthGetAcl => {
-                self.get_acl_request_handler
-                    .get_acl(channel, ctx, request_code, request)
-                    .await
-            }
-            RequestCode::AuthListAcl => {
-                self.list_acl_request_handler
-                    .list_acl(channel, ctx, request_code, request)
-                    .await
-            }
+            RequestCode::AuthGetUser => self.get_user_request_handler.get_user(request_code, request).await,
+            RequestCode::AuthListUsers => self.list_users_request_handler.list_users(request_code, request).await,
+            RequestCode::AuthCreateAcl => self.create_acl_request_handler.create_acl(request_code, request).await,
+            RequestCode::AuthUpdateAcl => self.update_acl_request_handler.update_acl(request_code, request).await,
+            RequestCode::AuthDeleteAcl => self.delete_acl_request_handler.delete_acl(request_code, request).await,
+            RequestCode::AuthGetAcl => self.get_acl_request_handler.get_acl(request_code, request).await,
+            RequestCode::AuthListAcl => self.list_acl_request_handler.list_acl(request_code, request).await,
             RequestCode::SwitchTimerEngine => {
                 self.broker_config_request_handler
-                    .switch_timer_engine(channel, ctx, request_code, request)
+                    .switch_timer_engine(request_code, request)
                     .await
             }
             _ => Ok(get_unknown_cmd_response(request_code)),
@@ -758,13 +845,66 @@ fn auth_admin_body_decode_error(operation: &'static str, error: RocketMQError) -
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+
     use rocketmq_error::RocketMQError;
     use rocketmq_protocol::code::request_code::RequestCode;
     use rocketmq_protocol::code::response_code::ResponseCode;
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_store::LocalFileMessageStore;
+    use rocketmq_transport::api::v2::RequestProcessorV2;
 
     use super::get_legacy_acl_cmd_response;
     use super::map_auth_admin_error_response;
+    use super::trusted_admin_metadata;
+    use super::AdminBrokerProcessor;
+    use super::AdminOriginFact;
+    use super::AdminRequestCaller;
+    use super::AdminSessionFact;
+
+    #[test]
+    fn admin_broker_processor_formally_implements_v2() {
+        fn assert_v2<T: RequestProcessorV2>() {}
+
+        assert_v2::<AdminBrokerProcessor<LocalFileMessageStore>>();
+    }
+
+    #[test]
+    fn admin_request_metadata_accepts_only_matching_trusted_facts() {
+        let remote_addr: SocketAddr = "192.0.2.10:10911".parse().expect("valid remote address");
+        let metadata = trusted_admin_metadata(
+            AdminOriginFact::Network(remote_addr),
+            AdminSessionFact::Network(remote_addr),
+        )
+        .expect("matching network facts should be trusted");
+        assert_eq!(metadata.caller, AdminRequestCaller::Network(remote_addr));
+        assert_eq!(metadata.source_ip(), "192.0.2.10");
+        assert_eq!(metadata.to_string(), "192.0.2.10:10911");
+
+        let metadata = trusted_admin_metadata(AdminOriginFact::BrokerProxy, AdminSessionFact::Embedded)
+            .expect("broker proxy embedded facts should be trusted");
+        assert_eq!(metadata.caller, AdminRequestCaller::BrokerProxy);
+        assert_eq!(metadata.source_ip(), "embedded:broker-proxy");
+        assert_eq!(metadata.to_string(), "embedded:broker-proxy");
+        assert_eq!(metadata.network_remote_addr(), None);
+    }
+
+    #[test]
+    fn admin_request_metadata_fails_closed_on_origin_session_mismatch() {
+        let first: SocketAddr = "192.0.2.10:10911".parse().expect("valid first address");
+        let second: SocketAddr = "192.0.2.11:10911".parse().expect("valid second address");
+
+        for (origin, session) in [
+            (AdminOriginFact::Network(first), AdminSessionFact::Network(second)),
+            (AdminOriginFact::Network(first), AdminSessionFact::Embedded),
+            (AdminOriginFact::BrokerProxy, AdminSessionFact::Network(first)),
+            (AdminOriginFact::Unsupported, AdminSessionFact::Embedded),
+            (AdminOriginFact::BrokerProxy, AdminSessionFact::Unsupported),
+        ] {
+            let error = trusted_admin_metadata(origin, session).expect_err("untrusted fact pair must fail closed");
+            assert!(error.to_string().contains("trusted session view"));
+        }
+    }
 
     #[test]
     fn auth_admin_handlers_do_not_retain_broker_runtime() {

--- a/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
@@ -25,8 +25,6 @@ use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingDeserializable;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use tokio::time::timeout;
 use tracing::warn;
 
@@ -42,8 +40,6 @@ impl BatchMqHandler {
     pub async fn lock_natch_mq<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -120,8 +116,6 @@ impl BatchMqHandler {
     pub async fn unlock_batch_mq<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -39,8 +39,6 @@ use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store::BrokerAdminStore;
 use rocketmq_store::CommitLogReadMode;
 use rocketmq_transport::api::v1::request_code_not_supported_with_remark;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use sysinfo::Disks;
 
 use crate::auth::auth_admin_service::AuthAdminService;
@@ -48,6 +46,8 @@ use crate::broker::broker_admin_runtime::BrokerAdminRuntime;
 use crate::broker::log_filter_control::BrokerLogFilterRequest;
 use crate::broker::log_filter_control::LOG_FILTER_KEYS;
 use crate::topic::manager::topic_config_coordinator::TopicRegistrationAction;
+
+use super::AdminRequestMetadata;
 
 #[derive(Clone)]
 pub(super) struct BrokerConfigRequestHandler<MS: BrokerAdminStore> {
@@ -129,8 +129,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
     pub async fn update_broker_config(
         &self,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -187,7 +186,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
                     "generation-checked broker config updates do not accept log filter properties",
                 )));
             }
-            return self.update_log_filter(channel, request, response, &properties).await;
+            return self.update_log_filter(metadata, request, response, &properties).await;
         }
 
         let commit_result = match expected_generation {
@@ -241,7 +240,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 
     async fn update_log_filter(
         &self,
-        channel: Channel,
+        metadata: &AdminRequestMetadata,
         request: &RemotingCommand,
         response: RemotingCommand,
         properties: &HashMap<CheetahString, CheetahString>,
@@ -259,7 +258,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
                     .set_remark("remote log filter reload is disabled or unavailable"),
             ));
         };
-        let source_ip = channel.remote_address().ip().to_string();
+        let source_ip = metadata.source_ip();
         let operator = request
             .get_ext_fields()
             .and_then(|fields| fields.get(&CheetahString::from_static_str("AccessKey")))
@@ -331,8 +330,6 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 
     pub async fn get_broker_config(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -372,8 +369,6 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 
     pub async fn get_broker_runtime_info(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -386,8 +381,6 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 
     pub async fn set_commitlog_read_mode(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -439,9 +432,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 
     pub async fn export_rocksdb_config_to_json(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
-        _request_code: RequestCode,
+        request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let response = RemotingCommand::create_java_default_error_response_command();
@@ -512,7 +503,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 
         Ok(Some(
             request_code_not_supported_with_remark(
-                request.code(),
+                request_code.to_i32(),
                 "EXPORT_ROCKSDB_CONFIG_TO_JSON requires a real RocksDB config backend; current Rust broker uses \
                  file-backed config managers",
             )
@@ -522,8 +513,6 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 
     pub async fn get_timer_metrics(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -532,8 +521,6 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 
     pub async fn get_timer_check_point(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -542,8 +529,6 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
 
     pub async fn switch_timer_engine(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -1093,11 +1078,11 @@ mod tests {
     use rocketmq_store::TimerMessageStore;
     use rocketmq_store::TimerMetricsSerializeWrapper;
     use rocketmq_transport::api::v1::Channel;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
     use rocketmq_transport::test_support::Connection;
 
     use crate::broker_runtime::BrokerRuntime;
 
+    use super::AdminRequestMetadata;
     use super::BrokerConfigRequestHandler;
 
     fn temp_test_root(label: &str) -> std::path::PathBuf {
@@ -1213,8 +1198,6 @@ mod tests {
         let admin = runtime.admin_runtime_for_test();
         let handler = BrokerConfigRequestHandler::new(admin.clone());
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request =
             RemotingCommand::create_remoting_command(RequestCode::SetCommitlogReadMode).set_ext_fields(HashMap::new());
         request.add_ext_field(
@@ -1223,7 +1206,7 @@ mod tests {
         );
 
         let response = handler
-            .set_commitlog_read_mode(channel, ctx, RequestCode::SetCommitlogReadMode, &mut request)
+            .set_commitlog_read_mode(RequestCode::SetCommitlogReadMode, &mut request)
             .await
             .expect("set commitlog read mode should succeed")
             .expect("set commitlog read mode should return response");
@@ -1235,8 +1218,6 @@ mod tests {
             .expect("message store should exist")
             .data_read_ahead_enabled());
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request =
             RemotingCommand::create_remoting_command(RequestCode::SetCommitlogReadMode).set_ext_fields(HashMap::new());
         request.add_ext_field(
@@ -1245,7 +1226,7 @@ mod tests {
         );
 
         let response = handler
-            .set_commitlog_read_mode(channel, ctx, RequestCode::SetCommitlogReadMode, &mut request)
+            .set_commitlog_read_mode(RequestCode::SetCommitlogReadMode, &mut request)
             .await
             .expect("set commitlog read mode should succeed")
             .expect("set commitlog read mode should return response");
@@ -1338,17 +1319,10 @@ mod tests {
         let runtime = new_test_runtime("get-broker-config-generation", false).await;
         let admin = runtime.admin_runtime_for_test();
         let handler = BrokerConfigRequestHandler::new(admin);
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerConfig);
 
         let response = handler
-            .get_broker_config(
-                channel.clone(),
-                Arc::clone(&ctx),
-                RequestCode::GetBrokerConfig,
-                &mut request,
-            )
+            .get_broker_config(RequestCode::GetBrokerConfig, &mut request)
             .await
             .expect("get broker config should return broker response")
             .expect("get broker config should return a response");
@@ -1377,7 +1351,7 @@ mod tests {
             .is_some_and(|body| String::from_utf8_lossy(body).contains("flushDelayOffsetInterval")));
 
         let second_response = handler
-            .get_broker_config(channel, ctx, RequestCode::GetBrokerConfig, &mut request)
+            .get_broker_config(RequestCode::GetBrokerConfig, &mut request)
             .await
             .expect("repeated get broker config should return broker response")
             .expect("repeated get broker config should return a response");
@@ -1397,9 +1371,8 @@ mod tests {
         let runtime = new_test_runtime("update-broker-config", false).await;
         let admin = runtime.admin_runtime_for_test();
         let handler = BrokerConfigRequestHandler::new(admin.clone());
-
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+
         let mut request = RemotingCommand::create_remoting_command(RequestCode::UpdateBrokerConfig).set_body(concat!(
             "enableLiteEventMode=false\n",
             "maxLiteSubscriptionCount=5\n",
@@ -1408,7 +1381,11 @@ mod tests {
         ));
 
         let response = handler
-            .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfig, &mut request)
+            .update_broker_config(
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::UpdateBrokerConfig,
+                &mut request,
+            )
             .await
             .expect("update broker config should return broker response")
             .expect("update broker config should return a response");
@@ -1427,9 +1404,8 @@ mod tests {
         let runtime = new_test_runtime("update-broker-config-cas", false).await;
         let admin = runtime.admin_runtime_for_test();
         let handler = BrokerConfigRequestHandler::new(admin.clone());
-
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+
         let mut request = RemotingCommand::create_request_command(
             RequestCode::UpdateBrokerConfigCas,
             UpdateBrokerConfigRequestHeader { expected_generation: 1 },
@@ -1439,7 +1415,11 @@ mod tests {
         let request_opaque = request.opaque();
 
         let response = handler
-            .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfigCas, &mut request)
+            .update_broker_config(
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::UpdateBrokerConfigCas,
+                &mut request,
+            )
             .await
             .expect("CAS update should return broker response")
             .expect("CAS update should return a response");
@@ -1458,8 +1438,6 @@ mod tests {
         );
         assert_eq!(admin.broker_config().max_client_event_count, 7);
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut stale_request = RemotingCommand::create_request_command(
             RequestCode::UpdateBrokerConfigCas,
             UpdateBrokerConfigRequestHeader { expected_generation: 1 },
@@ -1468,7 +1446,11 @@ mod tests {
         stale_request.make_custom_header_to_net();
 
         let stale_response = handler
-            .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfigCas, &mut stale_request)
+            .update_broker_config(
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::UpdateBrokerConfigCas,
+                &mut stale_request,
+            )
             .await
             .expect("stale CAS update should return broker response")
             .expect("stale CAS update should return a response");
@@ -1497,7 +1479,6 @@ mod tests {
         let admin = runtime.admin_runtime_for_test();
         let handler = BrokerConfigRequestHandler::new(admin);
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_remoting_command(RequestCode::UpdateBrokerConfig).set_body(concat!(
             "logFilter=info,rocketmq_broker=debug\n",
             "logFilterReason=incident investigation\n",
@@ -1505,7 +1486,11 @@ mod tests {
         ));
 
         let response = handler
-            .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfig, &mut request)
+            .update_broker_config(
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::UpdateBrokerConfig,
+                &mut request,
+            )
             .await
             .expect("log filter update should return broker response")
             .expect("log filter update should return a response");
@@ -1524,12 +1509,15 @@ mod tests {
         let handler = BrokerConfigRequestHandler::new(admin.clone());
 
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_remoting_command(RequestCode::UpdateBrokerConfig)
             .set_body("unknownKey=true\nmaxClientEventCount=0");
 
         let response = handler
-            .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfig, &mut request)
+            .update_broker_config(
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::UpdateBrokerConfig,
+                &mut request,
+            )
             .await
             .expect("update broker config should return broker response")
             .expect("update broker config should return a response");
@@ -1541,12 +1529,15 @@ mod tests {
         assert_eq!(admin.broker_config().max_client_event_count, 100);
 
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request =
             RemotingCommand::create_remoting_command(RequestCode::UpdateBrokerConfig).set_body("unknownKey=true");
 
         let response = handler
-            .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfig, &mut request)
+            .update_broker_config(
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::UpdateBrokerConfig,
+                &mut request,
+            )
             .await
             .expect("update broker config should return broker response")
             .expect("update broker config should return a response");
@@ -1625,8 +1616,6 @@ mod tests {
     async fn export_rocksdb_config_without_rocksdb_returns_not_supported() {
         let runtime = new_test_runtime("export-config", false).await;
         let handler = BrokerConfigRequestHandler::new(runtime.admin_runtime_for_test());
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::ExportRocksdbConfigToJson,
             ExportRocksdbConfigToJsonRequestHeader {
@@ -1636,7 +1625,7 @@ mod tests {
         request.make_custom_header_to_net();
 
         let response = handler
-            .export_rocksdb_config_to_json(channel, ctx, RequestCode::ExportRocksdbConfigToJson, &mut request)
+            .export_rocksdb_config_to_json(RequestCode::ExportRocksdbConfigToJson, &mut request)
             .await
             .expect("export config should succeed")
             .expect("export config should return response");
@@ -1685,8 +1674,6 @@ mod tests {
         }
 
         let handler = BrokerConfigRequestHandler::new(runtime.admin_runtime_for_test());
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::ExportRocksdbConfigToJson,
             ExportRocksdbConfigToJsonRequestHeader {
@@ -1696,7 +1683,7 @@ mod tests {
         request.make_custom_header_to_net();
 
         let response = handler
-            .export_rocksdb_config_to_json(channel, ctx, RequestCode::ExportRocksdbConfigToJson, &mut request)
+            .export_rocksdb_config_to_json(RequestCode::ExportRocksdbConfigToJson, &mut request)
             .await
             .expect("export config should succeed")
             .expect("export config should return response");
@@ -1727,8 +1714,6 @@ mod tests {
         let admin = runtime.admin_runtime_for_test();
         let handler = BrokerConfigRequestHandler::new(admin.clone());
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut file_request =
             RemotingCommand::create_remoting_command(RequestCode::SwitchTimerEngine).set_ext_fields(HashMap::new());
         file_request.add_ext_field(
@@ -1737,7 +1722,7 @@ mod tests {
         );
 
         let response = handler
-            .switch_timer_engine(channel, ctx, RequestCode::SwitchTimerEngine, &mut file_request)
+            .switch_timer_engine(RequestCode::SwitchTimerEngine, &mut file_request)
             .await
             .expect("switch timer engine should succeed")
             .expect("switch timer engine should return response");
@@ -1748,8 +1733,6 @@ mod tests {
             .expect("timer message store should exist")
             .is_should_running_dequeue());
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut rocksdb_request =
             RemotingCommand::create_remoting_command(RequestCode::SwitchTimerEngine).set_ext_fields(HashMap::new());
         rocksdb_request.add_ext_field(
@@ -1758,7 +1741,7 @@ mod tests {
         );
 
         let response = handler
-            .switch_timer_engine(channel, ctx, RequestCode::SwitchTimerEngine, &mut rocksdb_request)
+            .switch_timer_engine(RequestCode::SwitchTimerEngine, &mut rocksdb_request)
             .await
             .expect("switch timer engine should succeed")
             .expect("switch timer engine should return response");

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_epoch_cache_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_epoch_cache_handler.rs
@@ -18,8 +18,6 @@ use rocketmq_protocol::protocol::body::epoch_entry_cache::EpochEntryCache;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
 use crate::broker::broker_admin_runtime::BrokerAdminRuntime;
 
@@ -33,8 +31,6 @@ impl BrokerEpochCacheHandler {
     pub async fn get_broker_epoch_cache<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_stats_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_stats_handler.rs
@@ -20,8 +20,6 @@ use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::subscription::broker_stats_data::BrokerStatsData;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_store::BrokerStatsManager;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -36,8 +34,6 @@ impl BrokerStatsHandler {
 
     pub async fn view_broker_stats_data(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -51,8 +51,6 @@ use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFacto
 use rocketmq_protocol::protocol::LanguageCode;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use tracing::warn;
 
 use crate::broker::broker_admin_runtime::BrokerAdminRuntime;
@@ -79,8 +77,6 @@ impl ConsumerRequestHandler {
     pub async fn get_consumer_connection_list<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -120,8 +116,6 @@ impl ConsumerRequestHandler {
     pub async fn get_consume_stats<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -236,8 +230,6 @@ impl ConsumerRequestHandler {
     pub async fn get_broker_consume_stats<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -292,8 +284,6 @@ impl ConsumerRequestHandler {
     pub async fn query_correction_offset<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -328,8 +318,6 @@ impl ConsumerRequestHandler {
     pub async fn consume_message_directly<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -492,8 +480,6 @@ impl ConsumerRequestHandler {
     pub async fn get_all_consumer_offset<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -515,8 +501,6 @@ impl ConsumerRequestHandler {
     pub async fn get_all_message_request_mode<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -551,8 +535,6 @@ impl ConsumerRequestHandler {
     pub async fn invoke_broker_to_reset_offset<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -598,8 +580,6 @@ impl ConsumerRequestHandler {
     pub async fn invoke_broker_to_get_consumer_status<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -619,8 +599,6 @@ impl ConsumerRequestHandler {
     pub async fn query_subscription_by_consumer<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -641,8 +619,6 @@ impl ConsumerRequestHandler {
     pub async fn query_consume_time_span<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -718,8 +694,6 @@ impl ConsumerRequestHandler {
     pub async fn clone_group_offset<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -774,8 +748,6 @@ impl ConsumerRequestHandler {
     pub async fn get_consumer_running_info<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -1048,7 +1020,6 @@ mod tests {
     use rocketmq_store::BrokerAdminStore;
     use rocketmq_store::MessageStoreConfig;
     use rocketmq_transport::api::v1::Channel;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
     use rocketmq_transport::test_support::Connection;
 
     use super::ConsumerRequestHandler;
@@ -1146,18 +1117,10 @@ mod tests {
             );
 
         let handler = ConsumerRequestHandler::new();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request =
             RemotingCommand::create_request_command(RequestCode::GetAllMessageRequestMode, EmptyHeader {});
         let mut response = handler
-            .get_all_message_request_mode(
-                &admin,
-                channel,
-                ctx,
-                RequestCode::GetAllMessageRequestMode,
-                &mut request,
-            )
+            .get_all_message_request_mode(&admin, RequestCode::GetAllMessageRequestMode, &mut request)
             .await
             .expect("get all message request mode should succeed")
             .expect("get all message request mode should return response");
@@ -1207,11 +1170,9 @@ mod tests {
             GetConsumeStatsInBrokerHeader { is_order: false },
         );
         request.make_custom_header_to_net();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let mut response = handler
-            .get_broker_consume_stats(&admin, channel, ctx, RequestCode::GetBrokerConsumeStats, &mut request)
+            .get_broker_consume_stats(&admin, RequestCode::GetBrokerConsumeStats, &mut request)
             .await
             .expect("get broker consume stats should succeed")
             .expect("get broker consume stats should return response");
@@ -1268,11 +1229,9 @@ mod tests {
             },
         );
         request.make_custom_header_to_net();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let mut response = handler
-            .query_correction_offset(&admin, channel, ctx, RequestCode::QueryCorrectionOffset, &mut request)
+            .query_correction_offset(&admin, RequestCode::QueryCorrectionOffset, &mut request)
             .await
             .expect("query correction offset should succeed")
             .expect("query correction offset should return response");
@@ -1321,11 +1280,9 @@ mod tests {
             },
         );
         request.make_custom_header_to_net();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let response = handler
-            .consume_message_directly(&admin, channel, ctx, RequestCode::ConsumeMessageDirectly, &mut request)
+            .consume_message_directly(&admin, RequestCode::ConsumeMessageDirectly, &mut request)
             .await
             .expect("consume message directly should succeed")
             .expect("consume message directly should return response");
@@ -1361,8 +1318,6 @@ mod tests {
             .commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 9);
 
         let handler = ConsumerRequestHandler::new();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::InvokeBrokerToResetOffset,
             ResetOffsetRequestHeader {
@@ -1378,13 +1333,7 @@ mod tests {
         request.make_custom_header_to_net();
 
         let mut response = handler
-            .invoke_broker_to_reset_offset(
-                &admin,
-                channel,
-                ctx,
-                RequestCode::InvokeBrokerToResetOffset,
-                &mut request,
-            )
+            .invoke_broker_to_reset_offset(&admin, RequestCode::InvokeBrokerToResetOffset, &mut request)
             .await
             .expect("invoke broker to reset offset should succeed")
             .expect("invoke broker to reset offset should return response");
@@ -1428,8 +1377,6 @@ mod tests {
     async fn invoke_broker_to_get_consumer_status_returns_offline_group_error() {
         let runtime = new_test_runtime("consumer-status").await;
         let handler = ConsumerRequestHandler::new_with_factory(test_command_factory(9344, SerializeType::JSON));
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::InvokeBrokerToGetConsumerStatus,
             GetConsumerStatusRequestHeader::new(
@@ -1442,8 +1389,6 @@ mod tests {
         let response = handler
             .invoke_broker_to_get_consumer_status(
                 &runtime.admin_runtime_for_test(),
-                channel,
-                ctx,
                 RequestCode::InvokeBrokerToGetConsumerStatus,
                 &mut request,
             )
@@ -1465,8 +1410,6 @@ mod tests {
     async fn invoke_broker_to_reset_offset_preserves_factory_for_client_side_error() {
         let runtime = new_test_runtime_with_server_side_reset("client-reset-error", false).await;
         let handler = ConsumerRequestHandler::new_with_factory(test_command_factory(9345, SerializeType::JSON));
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::InvokeBrokerToResetOffset,
             ResetOffsetRequestHeader {
@@ -1484,8 +1427,6 @@ mod tests {
         let response = handler
             .invoke_broker_to_reset_offset(
                 &runtime.admin_runtime_for_test(),
-                channel,
-                ctx,
                 RequestCode::InvokeBrokerToResetOffset,
                 &mut request,
             )
@@ -1503,8 +1444,6 @@ mod tests {
     async fn invoke_broker_to_reset_offset_preserves_factory_for_server_side_error() {
         let runtime = new_test_runtime("server-reset-error").await;
         let handler = ConsumerRequestHandler::new_with_factory(test_command_factory(9346, SerializeType::ROCKETMQ));
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::InvokeBrokerToResetOffset,
             ResetOffsetRequestHeader {
@@ -1522,8 +1461,6 @@ mod tests {
         let response = handler
             .invoke_broker_to_reset_offset(
                 &runtime.admin_runtime_for_test(),
-                channel,
-                ctx,
                 RequestCode::InvokeBrokerToResetOffset,
                 &mut request,
             )
@@ -1563,8 +1500,6 @@ mod tests {
         );
 
         let handler = ConsumerRequestHandler::new();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::QuerySubscriptionByConsumer,
             QuerySubscriptionByConsumerRequestHeader {
@@ -1576,13 +1511,7 @@ mod tests {
         request.make_custom_header_to_net();
 
         let mut response = handler
-            .query_subscription_by_consumer(
-                &admin,
-                channel,
-                ctx,
-                RequestCode::QuerySubscriptionByConsumer,
-                &mut request,
-            )
+            .query_subscription_by_consumer(&admin, RequestCode::QuerySubscriptionByConsumer, &mut request)
             .await
             .expect("query subscription by consumer should succeed")
             .expect("query subscription by consumer should return response");
@@ -1625,11 +1554,9 @@ mod tests {
             },
         );
         request.make_custom_header_to_net();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let mut response = handler
-            .query_consume_time_span(&admin, channel, ctx, RequestCode::QueryConsumeTimeSpan, &mut request)
+            .query_consume_time_span(&admin, RequestCode::QueryConsumeTimeSpan, &mut request)
             .await
             .expect("query consume time span should succeed")
             .expect("query consume time span should return response");
@@ -1682,11 +1609,9 @@ mod tests {
             },
         );
         request.make_custom_header_to_net();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let response = handler
-            .clone_group_offset(&admin, channel, ctx, RequestCode::CloneGroupOffset, &mut request)
+            .clone_group_offset(&admin, RequestCode::CloneGroupOffset, &mut request)
             .await
             .expect("clone group offset should succeed")
             .expect("clone group offset should return response");

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
@@ -21,7 +21,6 @@ use rocketmq_protocol::protocol::body::acl_info::AclInfo;
 use rocketmq_protocol::protocol::header::create_acl_request_header::CreateAclRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingDeserializable;
-use rocketmq_transport::api::v1::Channel;
 
 use crate::auth::acl_converter::AclConverter;
 use crate::auth::auth_admin_service::AuthAdminService;
@@ -38,8 +37,6 @@ impl CreateAclRequestHandler {
 
     pub async fn create_acl(
         &self,
-        _channel: Channel,
-        _ctx: rocketmq_transport::api::v1::ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
@@ -8,8 +8,6 @@ use rocketmq_protocol::protocol::body::user_info::UserInfo;
 use rocketmq_protocol::protocol::header::create_user_request_header::CreateUserRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingDeserializable;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
 use crate::auth::auth_admin_service::AuthAdminService;
 use crate::auth::user_converter::UserConverter;
@@ -26,8 +24,6 @@ impl CreateUserRequestHandler {
 
     pub async fn create_user(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
@@ -5,8 +5,6 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::delete_acl_request_header::DeleteAclRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
 use crate::auth::auth_admin_service::AuthAdminService;
 
@@ -22,8 +20,6 @@ impl DeleteAclRequestHandler {
 
     pub async fn delete_acl(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
@@ -6,8 +6,6 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::delete_user_request_header::DeleteUserRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
 use crate::auth::auth_admin_service::AuthAdminService;
 
@@ -23,8 +21,6 @@ impl DeleteUserRequestHandler {
 
     pub async fn delete_user(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
@@ -20,7 +20,6 @@ use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::get_acl_request_header::GetAclRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingSerializable;
-use rocketmq_transport::api::v1::Channel;
 
 use crate::auth::auth_admin_service::AuthAdminService;
 
@@ -36,8 +35,6 @@ impl GetAclRequestHandler {
 
     pub async fn get_acl(
         &self,
-        _channel: Channel,
-        _ctx: rocketmq_transport::api::v1::ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -96,9 +93,6 @@ mod tests {
     use rocketmq_protocol::protocol::RemotingSerializable;
     use rocketmq_security_api::Action;
     use rocketmq_store::MessageStoreConfig;
-    use rocketmq_transport::api::v1::Channel;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
-    use rocketmq_transport::test_support::Connection;
 
     use super::*;
     use crate::auth::auth_admin_service::AuthAdminService;
@@ -133,20 +127,6 @@ mod tests {
         let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
         assert!(runtime.initialize().await.is_ok());
         runtime
-    }
-
-    async fn create_test_channel() -> Channel {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
-        let local_addr = listener.local_addr().expect("local listener addr");
-        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
-        std_stream.set_nonblocking(true).expect("set nonblocking");
-        drop(listener);
-        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
-        let connection = Connection::new(tcp_stream);
-        rocketmq_transport::test_support::TestChannelBuilder::new(connection, crate::test_task_group("channel"))
-            .addresses(local_addr, local_addr)
-            .build()
-            .expect("build test channel")
     }
 
     fn build_acl_info(resource: &str, actions: &str) -> AclInfo {
@@ -197,8 +177,6 @@ mod tests {
         let create_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
         let update_handler = UpdateAclRequestHandler::new(auth_admin_service.clone());
         let get_handler = GetAclRequestHandler::new(auth_admin_service.clone());
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let mut create_request = RemotingCommand::create_request_command(
             RequestCode::AuthCreateAcl,
@@ -215,12 +193,7 @@ mod tests {
         create_request.add_ext_field("AccessKey", "admin");
         create_request.make_custom_header_to_net();
         let create_response = create_handler
-            .create_acl(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthCreateAcl,
-                &mut create_request,
-            )
+            .create_acl(RequestCode::AuthCreateAcl, &mut create_request)
             .await
             .expect("create acl should succeed")
             .expect("create acl should return response");
@@ -242,12 +215,7 @@ mod tests {
         update_request.add_ext_field("AccessKey", "admin");
         update_request.make_custom_header_to_net();
         let update_response = update_handler
-            .update_acl(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthUpdateAcl,
-                &mut update_request,
-            )
+            .update_acl(RequestCode::AuthUpdateAcl, &mut update_request)
             .await
             .expect("update acl should succeed")
             .expect("update acl should return response");
@@ -262,7 +230,7 @@ mod tests {
         );
         get_request.make_custom_header_to_net();
         let mut get_response = get_handler
-            .get_acl(channel, ctx, RequestCode::AuthGetAcl, &mut get_request)
+            .get_acl(RequestCode::AuthGetAcl, &mut get_request)
             .await
             .expect("get acl should succeed")
             .expect("get acl should return response");
@@ -305,8 +273,6 @@ mod tests {
         let update_user_handler = UpdateUserRequestHandler::new(auth_admin_service.clone());
         let create_acl_handler = CreateAclRequestHandler::new(auth_admin_service.clone());
         let update_acl_handler = UpdateAclRequestHandler::new(auth_admin_service);
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let mut create_user_request = RemotingCommand::create_request_command(
             RequestCode::AuthCreateUser,
@@ -317,12 +283,7 @@ mod tests {
         .set_body(b"{not-json".to_vec());
         create_user_request.make_custom_header_to_net();
         let create_user_response = create_user_handler
-            .create_user(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthCreateUser,
-                &mut create_user_request,
-            )
+            .create_user(RequestCode::AuthCreateUser, &mut create_user_request)
             .await
             .expect("malformed user body should return a response")
             .expect("malformed user body should return a response");
@@ -340,12 +301,7 @@ mod tests {
         .set_body(b"{not-json".to_vec());
         update_user_request.make_custom_header_to_net();
         let update_user_response = update_user_handler
-            .update_user(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthUpdateUser,
-                &mut update_user_request,
-            )
+            .update_user(RequestCode::AuthUpdateUser, &mut update_user_request)
             .await
             .expect("malformed update user body should return a response")
             .expect("malformed update user body should return a response");
@@ -363,12 +319,7 @@ mod tests {
         .set_body(b"{not-json".to_vec());
         create_acl_request.make_custom_header_to_net();
         let create_acl_response = create_acl_handler
-            .create_acl(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthCreateAcl,
-                &mut create_acl_request,
-            )
+            .create_acl(RequestCode::AuthCreateAcl, &mut create_acl_request)
             .await
             .expect("malformed acl body should return a response")
             .expect("malformed acl body should return a response");
@@ -386,12 +337,7 @@ mod tests {
         .set_body(b"{not-json".to_vec());
         update_acl_request.make_custom_header_to_net();
         let update_acl_response = update_acl_handler
-            .update_acl(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthUpdateAcl,
-                &mut update_acl_request,
-            )
+            .update_acl(RequestCode::AuthUpdateAcl, &mut update_acl_request)
             .await
             .expect("malformed update acl body should return a response")
             .expect("malformed update acl body should return a response");
@@ -420,8 +366,6 @@ mod tests {
         );
         let list_users_handler = ListUsersRequestHandler::new(auth_admin_service.clone());
         let list_acl_handler = ListAclRequestHandler::new(auth_admin_service);
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let mut list_users_request = RemotingCommand::create_request_command(
             RequestCode::AuthListUsers,
@@ -431,12 +375,7 @@ mod tests {
         );
         list_users_request.make_custom_header_to_net();
         let list_users_response = list_users_handler
-            .list_users(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthListUsers,
-                &mut list_users_request,
-            )
+            .list_users(RequestCode::AuthListUsers, &mut list_users_request)
             .await
             .expect("empty user list should return a response")
             .expect("empty user list should return a response");
@@ -453,12 +392,7 @@ mod tests {
         );
         list_acl_request.make_custom_header_to_net();
         let list_acl_response = list_acl_handler
-            .list_acl(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthListAcl,
-                &mut list_acl_request,
-            )
+            .list_acl(RequestCode::AuthListAcl, &mut list_acl_request)
             .await
             .expect("empty acl list should return a response")
             .expect("empty acl list should return a response");
@@ -492,8 +426,6 @@ mod tests {
         auth_admin_service.create_user(alice).await.expect("create alice user");
 
         let handler = UpdateUserRequestHandler::new(auth_admin_service.clone());
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::AuthUpdateUser,
             UpdateUserRequestHeader {
@@ -515,7 +447,7 @@ mod tests {
         request.make_custom_header_to_net();
 
         let response = handler
-            .update_user(channel, ctx, RequestCode::AuthUpdateUser, &mut request)
+            .update_user(RequestCode::AuthUpdateUser, &mut request)
             .await
             .expect("update should return response")
             .expect("update should return response");
@@ -551,9 +483,6 @@ mod tests {
         alice.set_user_status(UserStatus::Enable);
         auth_admin_service.create_user(alice).await.expect("create alice user");
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
-
         let create_handler = CreateUserRequestHandler::new(auth_admin_service.clone());
         let mut create_request = RemotingCommand::create_request_command(
             RequestCode::AuthCreateUser,
@@ -575,12 +504,7 @@ mod tests {
         create_request.add_ext_field("AccessKey", "alice");
         create_request.make_custom_header_to_net();
         let create_response = create_handler
-            .create_user(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthCreateUser,
-                &mut create_request,
-            )
+            .create_user(RequestCode::AuthCreateUser, &mut create_request)
             .await
             .expect("create super response")
             .expect("create super response");
@@ -611,7 +535,7 @@ mod tests {
         update_request.add_ext_field("AccessKey", "alice");
         update_request.make_custom_header_to_net();
         let update_response = update_handler
-            .update_user(channel, ctx, RequestCode::AuthUpdateUser, &mut update_request)
+            .update_user(RequestCode::AuthUpdateUser, &mut update_request)
             .await
             .expect("update super response")
             .expect("update super response");
@@ -667,8 +591,6 @@ mod tests {
 
         let delete_handler = DeleteAclRequestHandler::new(auth_admin_service.clone());
         let get_handler = GetAclRequestHandler::new(auth_admin_service);
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut delete_request = RemotingCommand::create_request_command(
             RequestCode::AuthDeleteAcl,
             DeleteAclRequestHeader::with_policy_type(
@@ -679,12 +601,7 @@ mod tests {
         );
         delete_request.make_custom_header_to_net();
         let delete_response = delete_handler
-            .delete_acl(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::AuthDeleteAcl,
-                &mut delete_request,
-            )
+            .delete_acl(RequestCode::AuthDeleteAcl, &mut delete_request)
             .await
             .expect("delete acl response")
             .expect("delete acl response");
@@ -698,7 +615,7 @@ mod tests {
         );
         get_request.make_custom_header_to_net();
         let mut get_response = get_handler
-            .get_acl(channel, ctx, RequestCode::AuthGetAcl, &mut get_request)
+            .get_acl(RequestCode::AuthGetAcl, &mut get_request)
             .await
             .expect("get acl response")
             .expect("get acl response");

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
@@ -16,8 +16,6 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
 use crate::broker::broker_admin_runtime::BrokerAdminRuntime;
 
@@ -31,8 +29,6 @@ impl GetBrokerHaStatusHandler {
     pub async fn get_broker_ha_status<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -82,8 +78,6 @@ mod tests {
     use rocketmq_protocol::protocol::body::ha_runtime_info::HARuntimeInfo;
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
     use rocketmq_store::MessageStoreConfig;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
-    use rocketmq_transport::test_support::Connection;
 
     use crate::broker_runtime::BrokerRuntime;
 
@@ -95,20 +89,6 @@ mod tests {
             .expect("time should move forward")
             .as_millis();
         std::env::temp_dir().join(format!("rocketmq-rust-ha-status-{label}-{millis}"))
-    }
-
-    async fn create_test_channel() -> Channel {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
-        let local_addr = listener.local_addr().expect("local listener addr");
-        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
-        std_stream.set_nonblocking(true).expect("set nonblocking");
-        drop(listener);
-        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
-        let connection = Connection::new(tcp_stream);
-        rocketmq_transport::test_support::TestChannelBuilder::new(connection, crate::test_task_group("channel"))
-            .addresses(local_addr, local_addr)
-            .build()
-            .expect("build test channel")
     }
 
     #[tokio::test]
@@ -127,15 +107,11 @@ mod tests {
         assert!(runtime.initialize().await.is_ok());
 
         let handler = GetBrokerHaStatusHandler::new();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerHaStatus);
 
         let response = handler
             .get_broker_ha_status(
                 &runtime.admin_runtime_for_test(),
-                channel,
-                ctx,
                 RequestCode::GetBrokerHaStatus,
                 &mut request,
             )
@@ -157,15 +133,11 @@ mod tests {
         let message_store_config = Arc::new(MessageStoreConfig::default());
         let runtime = BrokerRuntime::new(broker_config, message_store_config);
         let handler = GetBrokerHaStatusHandler::new();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerHaStatus);
 
         let response = handler
             .get_broker_ha_status(
                 &runtime.admin_runtime_for_test(),
-                channel,
-                ctx,
                 RequestCode::GetBrokerHaStatus,
                 &mut request,
             )

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
@@ -19,8 +19,6 @@ use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::get_user_request_headers::GetUserRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingSerializable;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -35,8 +33,6 @@ impl GetUserRequestHandler {
 
     pub async fn get_user(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
@@ -5,8 +5,6 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::header::list_acl_request_header::ListAclRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingSerializable;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
 use crate::auth::auth_admin_service::AuthAdminService;
 
@@ -22,8 +20,6 @@ impl ListAclRequestHandler {
 
     pub async fn list_acl(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
@@ -18,8 +18,6 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::header::list_users_request_header::ListUsersRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingSerializable;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -34,8 +32,6 @@ impl ListUsersRequestHandler {
 
     pub async fn list_users(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
@@ -35,8 +35,6 @@ use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_store::BrokerAdminStore;
 use rocketmq_store::MessageFilter;
 use rocketmq_store::PutMessageStatus;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RpcClient;
 use rocketmq_transport::api::v1::RpcRequest;
 use serde::Serialize;
@@ -56,8 +54,6 @@ impl MessageRelatedHandler {
     pub async fn search_offset_by_timestamp<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -110,8 +106,6 @@ impl MessageRelatedHandler {
     pub async fn resume_check_half_message<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -183,8 +177,6 @@ impl MessageRelatedHandler {
     pub async fn query_consume_queue<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -298,8 +290,6 @@ impl MessageRelatedHandler {
     pub async fn pop_rollback<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -525,7 +515,6 @@ mod tests {
     use rocketmq_store::DispatchRequest;
     use rocketmq_store::MessageStoreConfig;
     use rocketmq_transport::api::v1::Channel;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
     use rocketmq_transport::test_support::Connection;
 
     use super::cq_ext_unit_response_serialize_error;
@@ -620,8 +609,6 @@ mod tests {
             .expect("put message should return msg id");
 
         let handler = MessageRelatedHandler::new();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::ResumeCheckHalfMessage,
             ResumeCheckHalfMessageRequestHeader {
@@ -632,7 +619,7 @@ mod tests {
         request.make_custom_header_to_net();
 
         let response = handler
-            .resume_check_half_message(&admin, channel, ctx, RequestCode::ResumeCheckHalfMessage, &mut request)
+            .resume_check_half_message(&admin, RequestCode::ResumeCheckHalfMessage, &mut request)
             .await
             .expect("resume check half message should succeed")
             .expect("resume check half message should return response");
@@ -694,8 +681,6 @@ mod tests {
             });
 
         let handler = MessageRelatedHandler::new();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
             RequestCode::QueryConsumeQueue,
             QueryConsumeQueueRequestHeader {
@@ -710,7 +695,7 @@ mod tests {
         request.make_custom_header_to_net();
 
         let mut response = handler
-            .query_consume_queue(&admin, channel, ctx, RequestCode::QueryConsumeQueue, &mut request)
+            .query_consume_queue(&admin, RequestCode::QueryConsumeQueue, &mut request)
             .await
             .expect("query consume queue should succeed")
             .expect("query consume queue should return response");
@@ -760,13 +745,11 @@ mod tests {
         pop_message_processor.start().await;
 
         let handler = MessageRelatedHandler::new();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(RequestCode::PopRollback, EmptyHeader::default());
         request.make_custom_header_to_net();
 
         let response = handler
-            .pop_rollback(&admin, channel, ctx, RequestCode::PopRollback, &mut request)
+            .pop_rollback(&admin, RequestCode::PopRollback, &mut request)
             .await
             .expect("pop rollback should succeed")
             .expect("pop rollback should return response");

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_broker_role_change_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_broker_role_change_handler.rs
@@ -19,12 +19,11 @@ use rocketmq_protocol::protocol::header::notify_broker_role_change_request_heade
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingDeserializable;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use tracing::info;
 use tracing::warn;
 
 use super::broker_config_request_handler::BrokerConfigRequestHandler;
+use super::AdminRequestMetadata;
 
 #[derive(Clone)]
 pub struct NotifyBrokerRoleChangeHandler;
@@ -37,8 +36,7 @@ impl NotifyBrokerRoleChangeHandler {
     pub async fn notify_broker_role_changed<MS: BrokerAdminStore>(
         &self,
         broker_config_request_handler: &BrokerConfigRequestHandler<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -75,6 +73,13 @@ impl NotifyBrokerRoleChangeHandler {
             request_header
         );
 
+        let Some(controller_leader_address) = metadata.network_remote_addr() else {
+            warn!("Reject embedded notifyBrokerRoleChanged because the controller network peer is unavailable");
+            return Ok(Some(response.set_code(ResponseCode::NoPermission).set_remark(
+                "notify broker role change requires a trusted network controller peer",
+            )));
+        };
+
         if broker_config_request_handler
             .broker_runtime_inner()
             .replicas_manager()
@@ -85,7 +90,7 @@ impl NotifyBrokerRoleChangeHandler {
         }
 
         let sync_state_set = sync_state_set_info.get_sync_state_set().cloned().unwrap_or_default();
-        let controller_leader_address = channel.remote_address().to_string().into();
+        let controller_leader_address = controller_leader_address.to_string().into();
 
         if let Err(error) = broker_config_request_handler
             .apply_controller_role_change(
@@ -123,11 +128,14 @@ mod tests {
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
     use rocketmq_store::MessageStoreConfig;
     use rocketmq_transport::api::v1::Channel;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
     use rocketmq_transport::test_support::Connection;
 
     use crate::broker_runtime::BrokerRuntime;
+    use crate::processor::admin_broker_processor::trusted_admin_metadata;
+    use crate::processor::admin_broker_processor::AdminOriginFact;
+    use crate::processor::admin_broker_processor::AdminSessionFact;
 
+    use super::AdminRequestMetadata;
     use super::BrokerConfigRequestHandler;
     use super::NotifyBrokerRoleChangeHandler;
 
@@ -156,7 +164,6 @@ mod tests {
         let handler = NotifyBrokerRoleChangeHandler::new();
 
         let channel = create_test_channel().await;
-        let ctx = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let header = NotifyBrokerRoleChangedRequestHeader {
             master_address: Some(CheetahString::from_static_str("127.0.0.1:10911")),
             master_epoch: Some(1),
@@ -172,8 +179,7 @@ mod tests {
         let response = handler
             .notify_broker_role_changed(
                 &broker_config_request_handler,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::NotifyBrokerRoleChanged,
                 &mut request,
             )
@@ -182,5 +188,46 @@ mod tests {
             .expect("notification should return a response");
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+    }
+
+    #[tokio::test]
+    async fn embedded_proxy_cannot_supply_a_controller_network_endpoint() {
+        let runtime = BrokerRuntime::new(
+            Arc::new(BrokerConfig::default()),
+            Arc::new(MessageStoreConfig::default()),
+        );
+        let admin = runtime.admin_runtime_for_test();
+        let broker_config_request_handler = BrokerConfigRequestHandler::new(admin);
+        let handler = NotifyBrokerRoleChangeHandler::new();
+        let header = NotifyBrokerRoleChangedRequestHeader {
+            master_address: Some(CheetahString::from_static_str("127.0.0.1:10911")),
+            master_epoch: Some(1),
+            sync_state_set_epoch: Some(1),
+            master_broker_id: Some(0),
+        };
+        let body = SyncStateSet::with_values(HashSet::from([0]), 1);
+        let mut request = RemotingCommand::create_request_command(RequestCode::NotifyBrokerRoleChanged, header)
+            .set_body(Bytes::from(
+                serde_json::to_vec(&body).expect("serialize sync-state set"),
+            ));
+        let metadata = trusted_admin_metadata(AdminOriginFact::BrokerProxy, AdminSessionFact::Embedded)
+            .expect("trusted embedded Broker Proxy metadata");
+
+        let response = handler
+            .notify_broker_role_changed(
+                &broker_config_request_handler,
+                &metadata,
+                RequestCode::NotifyBrokerRoleChanged,
+                &mut request,
+            )
+            .await
+            .expect("embedded notification should return a response")
+            .expect("embedded notification should fail closed with a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
+        assert_eq!(
+            response.remark().map(CheetahString::as_str),
+            Some("notify broker role change requires a trusted network controller peer")
+        );
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -24,8 +24,6 @@ use rocketmq_protocol::protocol::header::namesrv::brokerid_change_request_header
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::tokio_lock::RocketMQTokioRwLock;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -62,8 +60,6 @@ impl NotifyMinBrokerChangeIdHandler {
     pub async fn notify_min_broker_id_change<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -28,13 +28,13 @@ use rocketmq_protocol::protocol::static_topic::topic_queue_mapping_context::Topi
 use rocketmq_protocol::protocol::static_topic::topic_queue_mapping_utils::TopicQueueMappingUtils;
 use rocketmq_store::BrokerAdminStore;
 use rocketmq_transport::api::v1::request_code_not_supported_with_remark;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RpcClient;
 use rocketmq_transport::api::v1::RpcRequest;
 use tracing::error;
 
 use crate::broker::broker_admin_runtime::BrokerAdminRuntime;
+
+use super::AdminRequestMetadata;
 
 pub(super) struct OffsetRequestHandler;
 
@@ -46,8 +46,6 @@ impl OffsetRequestHandler {
     pub async fn get_max_offset<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -78,8 +76,6 @@ impl OffsetRequestHandler {
     pub async fn get_min_offset<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -245,8 +241,6 @@ impl OffsetRequestHandler {
     pub async fn get_all_delay_offset<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -267,8 +261,6 @@ impl OffsetRequestHandler {
     pub async fn get_earliest_msg_store_time<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -297,8 +289,6 @@ impl OffsetRequestHandler {
     pub async fn clean_expired_consumequeue<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -312,8 +302,6 @@ impl OffsetRequestHandler {
     pub async fn delete_expired_commitlog<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -326,15 +314,13 @@ impl OffsetRequestHandler {
 
     pub async fn check_rocksdb_cq_write_progress(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
-        _request_code: RequestCode,
+        request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let _request_header = request.decode_command_custom_header::<CheckRocksdbCqWriteProgressRequestHeader>()?;
         Ok(Some(
             request_code_not_supported_with_remark(
-                request.code(),
+                request_code.to_i32(),
                 "CHECK_ROCKSDB_CQ_WRITE_PROGRESS requires a real RocksDB consume queue backend; current Rust broker \
                  uses file-backed consume queues",
             )
@@ -345,18 +331,14 @@ impl OffsetRequestHandler {
     pub async fn get_all_subscription_group_config<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let response_command = RemotingCommand::create_java_default_error_response_command();
         let content = broker_runtime_inner.subscription_group_manager().encode_pretty(false);
         if content.is_empty() {
-            error!(
-                "No subscription group config in this broker,client:{}",
-                channel.remote_address()
-            );
+            error!("No subscription group config in this broker,client:{}", metadata);
             return Ok(Some(
                 response_command
                     .set_code(ResponseCode::SystemError)
@@ -474,9 +456,6 @@ mod tests {
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
     use rocketmq_store::BrokerReadStore;
     use rocketmq_store::MessageStoreConfig;
-    use rocketmq_transport::api::v1::Channel;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
-    use rocketmq_transport::test_support::Connection;
 
     use super::static_topic_offset_broker_name_missing;
     use super::static_topic_offset_mapping_missing;
@@ -505,20 +484,6 @@ mod tests {
         let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
         assert!(runtime.initialize().await.is_ok());
         runtime
-    }
-
-    async fn create_test_channel() -> Channel {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
-        let local_addr = listener.local_addr().expect("local listener addr");
-        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
-        std_stream.set_nonblocking(true).expect("set nonblocking");
-        drop(listener);
-        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
-        let connection = Connection::new(tcp_stream);
-        rocketmq_transport::test_support::TestChannelBuilder::new(connection, crate::test_task_group("channel"))
-            .addresses(local_addr, local_addr)
-            .build()
-            .expect("build test channel")
     }
 
     #[test]
@@ -558,11 +523,9 @@ mod tests {
             },
         );
         request.make_custom_header_to_net();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let response = handler
-            .get_earliest_msg_store_time(&admin, channel, ctx, RequestCode::GetEarliestMsgStoreTime, &mut request)
+            .get_earliest_msg_store_time(&admin, RequestCode::GetEarliestMsgStoreTime, &mut request)
             .await
             .expect("get earliest msg store time should succeed")
             .expect("get earliest msg store time should return response");
@@ -585,14 +548,10 @@ mod tests {
         let handler = OffsetRequestHandler::new();
         let mut request =
             RemotingCommand::create_request_command(RequestCode::CleanExpiredConsumequeue, EmptyHeader {});
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let response = handler
             .clean_expired_consumequeue(
                 &runtime.admin_runtime_for_test(),
-                channel,
-                ctx,
                 RequestCode::CleanExpiredConsumequeue,
                 &mut request,
             )
@@ -618,11 +577,9 @@ mod tests {
             },
         );
         request.make_custom_header_to_net();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let response = handler
-            .check_rocksdb_cq_write_progress(channel, ctx, RequestCode::CheckRocksdbCqWriteProgress, &mut request)
+            .check_rocksdb_cq_write_progress(RequestCode::CheckRocksdbCqWriteProgress, &mut request)
             .await
             .expect("check rocksdb cq write progress should succeed")
             .expect("check rocksdb cq write progress should return response");

--- a/rocketmq-broker/src/processor/admin_broker_processor/producer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/producer_request_handler.rs
@@ -4,7 +4,6 @@ use rocketmq_protocol::protocol::body::producer_connection::ProducerConnection;
 use rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingSerializable;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
 use crate::client::manager::producer_manager::ProducerChannelRegistry;
 
@@ -18,7 +17,6 @@ impl ProducerRequestHandler {
     }
     pub async fn get_producer_connection_list(
         &self,
-        _ctx: ConnectionHandlerContext,
         request: &RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let response = RemotingCommand::create_java_default_error_response_command();
@@ -48,7 +46,6 @@ impl ProducerRequestHandler {
 
     pub async fn get_all_producer_info(
         &self,
-        _ctx: ConnectionHandlerContext,
         _request: &RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let producer_table_info = self.producer_registry.producer_table();

--- a/rocketmq-broker/src/processor/admin_broker_processor/reset_master_flusg_offset_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/reset_master_flusg_offset_handler.rs
@@ -17,8 +17,6 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::header::reset_master_flush_offset_header::ResetMasterFlushOffsetHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
 use crate::broker::broker_admin_runtime::BrokerAdminRuntime;
 
@@ -32,8 +30,6 @@ impl ResetMasterFlushOffsetHandler {
     pub async fn reset_master_flush_offset<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
@@ -32,12 +32,12 @@ use rocketmq_protocol::protocol::RemotingDeserializable;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use std::collections::HashSet;
 use tracing::info;
 
 use crate::broker::broker_admin_runtime::BrokerAdminRuntime;
+
+use super::AdminRequestMetadata;
 use crate::subscription::manager::subscription_group_manager::SubscriptionGroupConfigCasError;
 
 pub(super) struct SubscriptionGroupHandler;
@@ -50,8 +50,7 @@ impl SubscriptionGroupHandler {
     pub async fn update_and_create_subscription_group<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -61,7 +60,7 @@ impl SubscriptionGroupHandler {
 
         info!(
             "AdminBrokerProcessor#updateAndCreateSubscriptionGroup called by {}",
-            _channel.remote_address()
+            metadata
         );
         let Some(body) = request.get_body() else {
             return Ok(Some(
@@ -117,8 +116,7 @@ impl SubscriptionGroupHandler {
     pub async fn update_subscription_group_config_cas<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -134,8 +132,7 @@ impl SubscriptionGroupHandler {
             };
         info!(
             "Broker receive version-checked Subscription Group patch for group={}, caller address={}",
-            request_header.group,
-            channel.remote_address()
+            request_header.group, metadata
         );
 
         if let Err(error) = validate_subscription_group_name(request_header.group.as_str()) {
@@ -287,8 +284,6 @@ impl SubscriptionGroupHandler {
     pub async fn get_subscription_group_config<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -340,14 +335,13 @@ impl SubscriptionGroupHandler {
     pub async fn update_and_create_subscription_group_list<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         info!(
             "AdminBrokerProcessor#updateAndCreateSubscriptionGroupList called by {}",
-            channel.remote_address()
+            metadata
         );
 
         let response = RemotingCommand::create_java_default_error_response_command();
@@ -392,16 +386,12 @@ impl SubscriptionGroupHandler {
     pub async fn delete_subscription_group<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<DeleteSubscriptionGroupRequestHeader>()?;
-        info!(
-            "AdminBrokerProcessor#deleteSubscriptionGroup called by {}",
-            channel.remote_address()
-        );
+        info!("AdminBrokerProcessor#deleteSubscriptionGroup called by {}", metadata);
 
         let should_clean_offset = request_header.clean_offset
             || broker_runtime_inner
@@ -441,8 +431,7 @@ impl SubscriptionGroupHandler {
     pub async fn delete_subscription_group_list<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -488,8 +477,7 @@ impl SubscriptionGroupHandler {
         }
         info!(
             "AdminBrokerProcessor#deleteSubscriptionGroupList: groupNames={:?}, caller={}",
-            groups,
-            channel.remote_address()
+            groups, metadata
         );
 
         let clean_offsets = groups
@@ -531,18 +519,14 @@ impl SubscriptionGroupHandler {
     pub async fn update_and_get_group_forbidden<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<UpdateGroupForbiddenRequestHeader>()?;
         info!(
             "AdminBrokerProcessor#updateAndGetGroupForbidden called by {} for object {}@{} readable={:?}",
-            channel.remote_address(),
-            request_header.group,
-            request_header.topic,
-            request_header.readable
+            metadata, request_header.group, request_header.topic, request_header.readable
         );
 
         if let Some(readable) = request_header.readable {
@@ -591,7 +575,6 @@ mod tests {
     use rocketmq_protocol::protocol::RemotingSerializable;
     use rocketmq_store::MessageStoreConfig;
     use rocketmq_transport::api::v1::Channel;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
     use rocketmq_transport::test_support::Connection;
 
     use super::*;
@@ -640,6 +623,7 @@ mod tests {
         let runtime = new_test_runtime("update-list").await;
         let admin = runtime.admin_runtime_for_test();
         let handler = SubscriptionGroupHandler::new();
+        let channel = create_test_channel().await;
 
         let body = SubscriptionGroupList {
             group_config_list: vec![
@@ -651,13 +635,10 @@ mod tests {
             RemotingCommand::create_request_command(RequestCode::UpdateAndCreateSubscriptionGroupList, EmptyHeader {})
                 .set_body(body.encode().expect("encode subscription group list"));
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .update_and_create_subscription_group_list(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateAndCreateSubscriptionGroupList,
                 &mut request,
             )
@@ -687,12 +668,10 @@ mod tests {
 
         let mut missing = RemotingCommand::create_remoting_command(RequestCode::UpdateAndCreateSubscriptionGroup);
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .update_and_create_subscription_group(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateAndCreateSubscriptionGroup,
                 &mut missing,
             )
@@ -704,12 +683,10 @@ mod tests {
         let mut malformed = RemotingCommand::create_remoting_command(RequestCode::UpdateAndCreateSubscriptionGroup)
             .set_body(Bytes::from_static(b"{not-json"));
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .update_and_create_subscription_group(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateAndCreateSubscriptionGroup,
                 &mut malformed,
             )
@@ -723,12 +700,10 @@ mod tests {
         let mut single = RemotingCommand::create_remoting_command(RequestCode::UpdateAndCreateSubscriptionGroup)
             .set_body(invalid.encode().expect("invalid config should still encode"));
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .update_and_create_subscription_group(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateAndCreateSubscriptionGroup,
                 &mut single,
             )
@@ -751,12 +726,10 @@ mod tests {
             RemotingCommand::create_request_command(RequestCode::UpdateAndCreateSubscriptionGroupList, EmptyHeader {})
                 .set_body(body.encode().expect("subscription group list should encode"));
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .update_and_create_subscription_group_list(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateAndCreateSubscriptionGroupList,
                 &mut list,
             )
@@ -811,9 +784,13 @@ mod tests {
         request.make_custom_header_to_net();
 
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
-            .delete_subscription_group(&admin, channel, ctx, RequestCode::DeleteSubscriptionGroup, &mut request)
+            .delete_subscription_group(
+                &admin,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::DeleteSubscriptionGroup,
+                &mut request,
+            )
             .await
             .expect("delete group request should succeed")
             .expect("delete group request should return response");
@@ -854,12 +831,10 @@ mod tests {
         request.make_custom_header_to_net();
 
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut response = handler
             .update_and_get_group_forbidden(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateAndGetGroupForbidden,
                 &mut request,
             )
@@ -918,12 +893,10 @@ mod tests {
         request.make_custom_header_to_net();
         let request_opaque = request.opaque();
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .update_subscription_group_config_cas(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateSubscriptionGroupConfigCas,
                 &mut request,
             )
@@ -967,12 +940,10 @@ mod tests {
         );
         stale_request.make_custom_header_to_net();
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let stale_response = handler
             .update_subscription_group_config_cas(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateSubscriptionGroupConfigCas,
                 &mut stale_request,
             )
@@ -999,16 +970,8 @@ mod tests {
             },
         );
         get_request.make_custom_header_to_net();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let get_response = handler
-            .get_subscription_group_config(
-                &admin,
-                channel,
-                ctx,
-                RequestCode::GetSubscriptionGroupConfig,
-                &mut get_request,
-            )
+            .get_subscription_group_config(&admin, RequestCode::GetSubscriptionGroupConfig, &mut get_request)
             .await
             .expect("get Subscription Group config should run")
             .expect("get Subscription Group config should return a response");
@@ -1041,12 +1004,10 @@ mod tests {
         let mut empty = RemotingCommand::create_remoting_command(RequestCode::DeleteSubscriptionGroupList.to_i32())
             .set_body(empty_body.encode().unwrap());
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .delete_subscription_group_list(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::DeleteSubscriptionGroupList,
                 &mut empty,
             )
@@ -1064,12 +1025,10 @@ mod tests {
         let mut invalid = RemotingCommand::create_remoting_command(RequestCode::DeleteSubscriptionGroupList.to_i32())
             .set_body(invalid_body.encode().unwrap());
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .delete_subscription_group_list(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::DeleteSubscriptionGroupList,
                 &mut invalid,
             )
@@ -1087,12 +1046,10 @@ mod tests {
         let mut request = RemotingCommand::create_remoting_command(RequestCode::DeleteSubscriptionGroupList.to_i32())
             .set_body(body.encode().unwrap());
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .delete_subscription_group_list(
                 &admin,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::DeleteSubscriptionGroupList,
                 &mut request,
             )

--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -44,13 +44,13 @@ use rocketmq_protocol::protocol::static_topic::topic_queue_mapping_detail::Topic
 use rocketmq_protocol::protocol::RemotingDeserializable;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use tracing::info;
 
 use crate::broker::broker_admin_runtime::BrokerAdminRuntime;
+
+use super::AdminRequestMetadata;
 use crate::failover::escape_bridge::MessageStoreUnavailable;
 use crate::processor::admin_broker_processor::broker_config_request_handler::BrokerConfigRequestHandler;
 use crate::topic::manager::topic_config_manager::TopicConfigCasError;
@@ -130,8 +130,7 @@ impl TopicRequestHandler {
     pub async fn update_and_create_topic<MS: BrokerAdminStore>(
         &self,
         broker_config_request_handler: &BrokerConfigRequestHandler<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -141,8 +140,7 @@ impl TopicRequestHandler {
             request.decode_required_header::<CreateTopicRequestHeader>("decode create-topic request header")?;
         info!(
             "Broker receive request to update or create topic={}, caller address={}",
-            request_header.topic,
-            channel.remote_address()
+            request_header.topic, metadata
         );
         let topic = request_header.topic.clone();
         let result = TopicValidator::validate_topic(topic.as_str());
@@ -209,7 +207,7 @@ impl TopicRequestHandler {
                 "Broker receive request to update or create topic={}, but topicConfig has  no changes , so \
                  idempotent, caller address={}",
                 topic.as_str(),
-                channel.remote_address(),
+                metadata,
             );
             return Ok(Some(RemotingCommand::create_success_response_command()));
         }
@@ -227,8 +225,7 @@ impl TopicRequestHandler {
     pub async fn update_topic_config_cas<MS: BrokerAdminStore>(
         &self,
         broker_config_request_handler: &BrokerConfigRequestHandler<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -244,8 +241,7 @@ impl TopicRequestHandler {
         };
         info!(
             "Broker receive version-checked Topic patch for topic={}, caller address={}",
-            request_header.topic,
-            channel.remote_address()
+            request_header.topic, metadata
         );
 
         let topic = request_header.topic;
@@ -392,8 +388,7 @@ impl TopicRequestHandler {
     pub async fn update_and_create_static_topic<MS: BrokerAdminStore>(
         &self,
         broker_config_request_handler: &BrokerConfigRequestHandler<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -402,8 +397,7 @@ impl TopicRequestHandler {
         let request_header = request.decode_command_custom_header::<CreateTopicRequestHeader>()?;
         info!(
             "Broker receive request to update or create static topic={}, caller address={}",
-            request_header.topic,
-            channel.remote_address()
+            request_header.topic, metadata
         );
 
         let Some(body) = request.body() else {
@@ -492,8 +486,7 @@ impl TopicRequestHandler {
     pub async fn update_and_create_topic_list<MS: BrokerAdminStore>(
         &self,
         broker_config_request_handler: &BrokerConfigRequestHandler<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -506,8 +499,7 @@ impl TopicRequestHandler {
         }
         info!(
             "AdminBrokerProcessor#updateAndCreateTopicList: topicNames: {}, called by {}",
-            topic_names,
-            channel.remote_address()
+            topic_names, metadata
         );
         let response = RemotingCommand::create_java_default_error_response_command();
         for topic_config in request_body.topic_config_list.iter() {
@@ -545,8 +537,7 @@ impl TopicRequestHandler {
                 info!(
                     "Broker receive request to update or create topic={}, but topicConfig has  no changes , so \
                      idempotent, caller address={}",
-                    topic,
-                    channel.remote_address(),
+                    topic, metadata,
                 );
                 return Ok(Some(RemotingCommand::create_success_response_command()));
             }
@@ -566,8 +557,7 @@ impl TopicRequestHandler {
     pub async fn delete_topic<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -577,8 +567,7 @@ impl TopicRequestHandler {
         let topic = &request_header.topic;
         info!(
             "AdminBrokerProcessor#deleteTopic: broker receive request to delete topic={}, caller={}",
-            topic,
-            channel.remote_address()
+            topic, metadata
         );
         if topic.is_empty() {
             return Ok(Some(
@@ -652,8 +641,7 @@ impl TopicRequestHandler {
     pub async fn delete_topic_list<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        metadata: &AdminRequestMetadata,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -712,8 +700,7 @@ impl TopicRequestHandler {
 
         info!(
             "AdminBrokerProcessor#deleteTopicList: broker receive request to delete topics={:?}, caller={}",
-            topics,
-            channel.remote_address()
+            topics, metadata
         );
         let original_topics = topics.clone();
         for topic in &original_topics {
@@ -780,8 +767,6 @@ impl TopicRequestHandler {
     pub async fn get_all_topic_config<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -817,8 +802,6 @@ impl TopicRequestHandler {
 
     pub async fn get_system_topic_list_from_broker(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -835,8 +818,6 @@ impl TopicRequestHandler {
     pub async fn get_topic_stats_info<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -897,8 +878,6 @@ impl TopicRequestHandler {
     pub async fn get_topic_config<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -957,8 +936,6 @@ impl TopicRequestHandler {
     pub async fn query_topic_consume_by_who<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -980,8 +957,6 @@ impl TopicRequestHandler {
     pub async fn query_topics_by_consumer<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -1008,8 +983,6 @@ impl TopicRequestHandler {
     pub async fn clean_unused_topic<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -1067,10 +1040,10 @@ mod tests {
     use rocketmq_protocol::protocol::RemotingSerializable;
     use rocketmq_store::MessageStoreConfig;
     use rocketmq_transport::api::v1::Channel;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
     use rocketmq_transport::test_support::Connection;
 
     use super::decode_topic_queue_mapping_detail;
+    use super::AdminRequestMetadata;
     use super::TopicRequestHandler;
     use crate::broker_runtime::BrokerRuntime;
     use crate::processor::admin_broker_processor::broker_config_request_handler::BrokerConfigRequestHandler;
@@ -1150,6 +1123,7 @@ mod tests {
         let admin = runtime.admin_runtime_for_test();
         let handler = TopicRequestHandler::new();
         let broker_config_request_handler = BrokerConfigRequestHandler::new(admin.clone());
+        let channel = create_test_channel().await;
 
         let detail = TopicQueueMappingDetail {
             topic_queue_mapping_info:
@@ -1183,14 +1157,11 @@ mod tests {
         );
         request.make_custom_header_to_net();
         request.set_body_mut_ref(detail.encode().expect("encode topic queue mapping detail"));
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let response = handler
             .update_and_create_static_topic(
                 &broker_config_request_handler,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateAndCreateStaticTopic,
                 &mut request,
             )
@@ -1243,12 +1214,10 @@ mod tests {
         request.make_custom_header_to_net();
         let request_opaque = request.opaque();
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
             .update_topic_config_cas(
                 &broker_config_request_handler,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateTopicConfigCas,
                 &mut request,
             )
@@ -1288,12 +1257,10 @@ mod tests {
         );
         stale_request.make_custom_header_to_net();
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let stale_response = handler
             .update_topic_config_cas(
                 &broker_config_request_handler,
-                channel,
-                ctx,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
                 RequestCode::UpdateTopicConfigCas,
                 &mut stale_request,
             )
@@ -1328,10 +1295,8 @@ mod tests {
             },
         );
         get_request.make_custom_header_to_net();
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let get_response = handler
-            .get_topic_config(&admin, channel, ctx, RequestCode::GetTopicConfig, &mut get_request)
+            .get_topic_config(&admin, RequestCode::GetTopicConfig, &mut get_request)
             .await
             .expect("get Topic config should run")
             .expect("get Topic config should return a response");
@@ -1365,9 +1330,13 @@ mod tests {
         let mut empty = RemotingCommand::create_remoting_command(RequestCode::DeleteTopicInBrokerList.to_i32())
             .set_body(empty_body.encode().unwrap());
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
-            .delete_topic_list(&admin, channel, ctx, RequestCode::DeleteTopicInBrokerList, &mut empty)
+            .delete_topic_list(
+                &admin,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::DeleteTopicInBrokerList,
+                &mut empty,
+            )
             .await
             .unwrap()
             .unwrap();
@@ -1382,9 +1351,13 @@ mod tests {
         let mut invalid = RemotingCommand::create_remoting_command(RequestCode::DeleteTopicInBrokerList.to_i32())
             .set_body(invalid_body.encode().unwrap());
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
-            .delete_topic_list(&admin, channel, ctx, RequestCode::DeleteTopicInBrokerList, &mut invalid)
+            .delete_topic_list(
+                &admin,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::DeleteTopicInBrokerList,
+                &mut invalid,
+            )
             .await
             .unwrap()
             .unwrap();
@@ -1398,9 +1371,13 @@ mod tests {
         let mut request = RemotingCommand::create_remoting_command(RequestCode::DeleteTopicInBrokerList.to_i32())
             .set_body(body.encode().unwrap());
         let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
-            .delete_topic_list(&admin, channel, ctx, RequestCode::DeleteTopicInBrokerList, &mut request)
+            .delete_topic_list(
+                &admin,
+                &AdminRequestMetadata::legacy_network(channel.remote_address()),
+                RequestCode::DeleteTopicInBrokerList,
+                &mut request,
+            )
             .await
             .unwrap()
             .unwrap();

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
@@ -21,7 +21,6 @@ use rocketmq_protocol::protocol::body::acl_info::AclInfo;
 use rocketmq_protocol::protocol::header::update_acl_request_header::UpdateAclRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingDeserializable;
-use rocketmq_transport::api::v1::Channel;
 
 use crate::auth::acl_converter::AclConverter;
 use crate::auth::auth_admin_service::AuthAdminService;
@@ -38,8 +37,6 @@ impl UpdateAclRequestHandler {
 
     pub async fn update_acl(
         &self,
-        _channel: Channel,
-        _ctx: rocketmq_transport::api::v1::ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
@@ -19,8 +19,6 @@ use rocketmq_protocol::protocol::header::exchange_ha_info_request_header::Exchan
 use rocketmq_protocol::protocol::header::exchange_ha_info_response_header::ExchangeHaInfoResponseHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_store::BrokerAdminStore;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use tracing::info;
 
 use crate::broker::broker_admin_runtime::BrokerAdminRuntime;
@@ -35,8 +33,6 @@ impl UpdateBrokerHaHandler {
     pub async fn update_broker_ha_info<MS: BrokerAdminStore>(
         &self,
         broker_runtime_inner: &BrokerAdminRuntime<MS>,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_cold_data_flow_ctr_group_config.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_cold_data_flow_ctr_group_config.rs
@@ -19,8 +19,6 @@ use rocketmq_model::common::mix_all;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
 #[derive(Clone)]
 pub struct UpdateColdDataFlowCtrGroupConfigRequestHandler {
@@ -36,8 +34,6 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
 
     pub async fn update_cold_data_flow_ctr_group_config(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -76,8 +72,6 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
 
     pub async fn remove_cold_data_flow_ctr_group_config(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -102,8 +96,6 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
 
     pub async fn get_cold_data_flow_ctr_info(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -131,8 +123,6 @@ mod tests {
     use rocketmq_protocol::code::response_code::ResponseCode;
     use rocketmq_protocol::protocol::header::empty_header::EmptyHeader;
     use rocketmq_store::MessageStoreConfig;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
-    use rocketmq_transport::test_support::Connection;
 
     use super::*;
     use crate::broker_runtime::BrokerRuntime;
@@ -162,20 +152,6 @@ mod tests {
         runtime
     }
 
-    async fn create_test_channel() -> Channel {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
-        let local_addr = listener.local_addr().expect("local listener addr");
-        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
-        std_stream.set_nonblocking(true).expect("set nonblocking");
-        drop(listener);
-        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
-        let connection = Connection::new(tcp_stream);
-        rocketmq_transport::test_support::TestChannelBuilder::new(connection, crate::test_task_group("channel"))
-            .addresses(local_addr, local_addr)
-            .build()
-            .expect("build test channel")
-    }
-
     #[tokio::test]
     async fn update_and_get_cold_data_flow_ctr_info_round_trips_config() {
         let runtime = new_test_runtime("update-get", true).await;
@@ -185,15 +161,8 @@ mod tests {
             RemotingCommand::create_request_command(RequestCode::UpdateColdDataFlowCtrConfig, EmptyHeader {})
                 .set_body("group-a=128\ngroup-b=256");
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
-            .update_cold_data_flow_ctr_group_config(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::UpdateColdDataFlowCtrConfig,
-                &mut request,
-            )
+            .update_cold_data_flow_ctr_group_config(RequestCode::UpdateColdDataFlowCtrConfig, &mut request)
             .await
             .expect("update cold data flow ctr should succeed")
             .expect("update cold data flow ctr should return response");
@@ -215,7 +184,7 @@ mod tests {
         let mut info_request =
             RemotingCommand::create_request_command(RequestCode::GetColdDataFlowCtrInfo, EmptyHeader {});
         let mut info_response = handler
-            .get_cold_data_flow_ctr_info(channel, ctx, RequestCode::GetColdDataFlowCtrInfo, &mut info_request)
+            .get_cold_data_flow_ctr_info(RequestCode::GetColdDataFlowCtrInfo, &mut info_request)
             .await
             .expect("get cold data flow ctr info should succeed")
             .expect("get cold data flow ctr info should return response");
@@ -258,18 +227,10 @@ mod tests {
         let admin = runtime.admin_runtime_for_test();
         let handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(admin.cold_data_cg_ctr_service_handle());
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
-
         let mut update_request =
             RemotingCommand::create_request_command(RequestCode::UpdateColdDataFlowCtrConfig, EmptyHeader {});
         let update_response = handler
-            .update_cold_data_flow_ctr_group_config(
-                channel.clone(),
-                ctx.clone(),
-                RequestCode::UpdateColdDataFlowCtrConfig,
-                &mut update_request,
-            )
+            .update_cold_data_flow_ctr_group_config(RequestCode::UpdateColdDataFlowCtrConfig, &mut update_request)
             .await
             .expect("empty update should succeed")
             .expect("empty update should return response");
@@ -279,12 +240,7 @@ mod tests {
         let mut remove_request =
             RemotingCommand::create_request_command(RequestCode::RemoveColdDataFlowCtrConfig, EmptyHeader {});
         let remove_response = handler
-            .remove_cold_data_flow_ctr_group_config(
-                channel,
-                ctx,
-                RequestCode::RemoveColdDataFlowCtrConfig,
-                &mut remove_request,
-            )
+            .remove_cold_data_flow_ctr_group_config(RequestCode::RemoveColdDataFlowCtrConfig, &mut remove_request)
             .await
             .expect("empty remove should succeed")
             .expect("empty remove should return response");
@@ -307,15 +263,8 @@ mod tests {
             RemotingCommand::create_request_command(RequestCode::RemoveColdDataFlowCtrConfig, EmptyHeader {})
                 .set_body("group-a");
 
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
-            .remove_cold_data_flow_ctr_group_config(
-                channel,
-                ctx,
-                RequestCode::RemoveColdDataFlowCtrConfig,
-                &mut request,
-            )
+            .remove_cold_data_flow_ctr_group_config(RequestCode::RemoveColdDataFlowCtrConfig, &mut request)
             .await
             .expect("remove cold data flow ctr should succeed")
             .expect("remove cold data flow ctr should return response");
@@ -333,19 +282,12 @@ mod tests {
     #[tokio::test]
     async fn missing_cold_data_service_returns_system_error() {
         let handler = UpdateColdDataFlowCtrGroupConfigRequestHandler::new(None);
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request =
             RemotingCommand::create_request_command(RequestCode::UpdateColdDataFlowCtrConfig, EmptyHeader {})
                 .set_body("group-a=128");
 
         let response = handler
-            .update_cold_data_flow_ctr_group_config(
-                channel,
-                ctx,
-                RequestCode::UpdateColdDataFlowCtrConfig,
-                &mut request,
-            )
+            .update_cold_data_flow_ctr_group_config(RequestCode::UpdateColdDataFlowCtrConfig, &mut request)
             .await
             .expect("missing service should return broker response")
             .expect("missing service response");

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
@@ -19,7 +19,6 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::update_global_white_addrs_config_request_header::UpdateGlobalWhiteAddrsConfigRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
-use rocketmq_transport::api::v1::Channel;
 
 use crate::auth::auth_admin_service::AuthAdminService;
 
@@ -35,8 +34,6 @@ impl UpdateGlobalWhiteAddrsConfigRequestHandler {
 
     pub async fn update_global_white_addrs_config(
         &self,
-        _channel: Channel,
-        _ctx: rocketmq_transport::api::v1::ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -102,8 +99,6 @@ mod tests {
     use rocketmq_auth::AuthConfig;
     use rocketmq_auth::ProviderRegistry;
     use rocketmq_store::MessageStoreConfig;
-    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
-    use rocketmq_transport::test_support::Connection;
 
     use super::*;
     use crate::broker_runtime::BrokerRuntime;
@@ -132,20 +127,6 @@ mod tests {
         runtime
     }
 
-    async fn create_test_channel() -> Channel {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
-        let local_addr = listener.local_addr().expect("local listener addr");
-        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
-        std_stream.set_nonblocking(true).expect("set nonblocking");
-        drop(listener);
-        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
-        let connection = Connection::new(tcp_stream);
-        rocketmq_transport::test_support::TestChannelBuilder::new(connection, crate::test_task_group("channel"))
-            .addresses(local_addr, local_addr)
-            .build()
-            .expect("build test channel")
-    }
-
     #[test]
     fn parse_global_white_addrs_splits_comma_values() {
         assert_eq!(
@@ -165,8 +146,6 @@ mod tests {
         .expect("create provider registry");
         let auth_admin_service = Arc::new(AuthAdminService::with_provider_registry(provider_registry.clone()));
         let handler = UpdateGlobalWhiteAddrsConfigRequestHandler::new(auth_admin_service);
-        let channel = create_test_channel().await;
-        let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
         let mut request = RemotingCommand::create_request_command(
             RequestCode::UpdateGlobalWhiteAddrsConfig,
@@ -177,7 +156,7 @@ mod tests {
         request.make_custom_header_to_net();
 
         let response = handler
-            .update_global_white_addrs_config(channel, ctx, RequestCode::UpdateGlobalWhiteAddrsConfig, &mut request)
+            .update_global_white_addrs_config(RequestCode::UpdateGlobalWhiteAddrsConfig, &mut request)
             .await
             .expect("request should be handled")
             .expect("response should exist");

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
@@ -8,8 +8,6 @@ use rocketmq_protocol::protocol::body::user_info::UserInfo;
 use rocketmq_protocol::protocol::header::update_user_request_header::UpdateUserRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingDeserializable;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -24,8 +22,6 @@ impl UpdateUserRequestHandler {
 
     pub async fn update_user(
         &self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/v2_concurrency_tests.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/v2_concurrency_tests.rs
@@ -1,0 +1,417 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::thread;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_auth::AuthConfig;
+use rocketmq_auth::ProviderRegistry;
+use rocketmq_auth::User;
+use rocketmq_auth::UserStatus;
+use rocketmq_auth::UserType;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::body::user_info::UserInfo;
+use rocketmq_protocol::protocol::header::create_user_request_header::CreateUserRequestHeader;
+use rocketmq_protocol::protocol::header::get_user_request_headers::GetUserRequestHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::RemotingSerializable;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_security_api::AuthenticatedRequestContext;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::RequestPolicy;
+use rocketmq_store::MessageStoreConfig;
+use rocketmq_store::StorePorts;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::IngressRequestView;
+use rocketmq_transport::api::v2::RejectRequestDecision;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrdering;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponseWriteObservationV2;
+use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+use super::AdminBrokerProcessor;
+use crate::auth::auth_admin_service::AuthAdminService;
+use crate::broker_runtime::BrokerRuntime;
+use crate::config::broker_config::BrokerConfig;
+use crate::processor::v2::BrokerProcessorTypeV2;
+use crate::transaction::queue::default_transactional_message_service::DefaultTransactionalMessageService;
+
+type TestAdminLeaf = BrokerProcessorTypeV2<StorePorts, DefaultTransactionalMessageService<StorePorts>>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ObservedAdminOperation {
+    original_code: i32,
+    command_code: i32,
+    original_opaque: i32,
+    username: Option<String>,
+    response_code: Option<i32>,
+}
+
+#[derive(Clone)]
+struct ObservedAdminProcessor {
+    inner: TestAdminLeaf,
+    operations: Arc<Mutex<Vec<ObservedAdminOperation>>>,
+    mutate_command_code: Option<i32>,
+}
+
+impl RequestProcessorV2 for ObservedAdminProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        if let Some(code) = self.mutate_command_code {
+            request.command_mut().set_code_mut(code);
+        }
+        let original = request.original_identity();
+        let command_code = request.command().code();
+        let username = request
+            .command()
+            .ext_fields()
+            .and_then(|fields| fields.get("username"))
+            .map(ToString::to_string);
+        let outcome = RequestProcessorV2::process(&mut self.inner, request).await?;
+        let response_code = match &outcome {
+            HandlerOutcome::Reply(plan) => Some(plan.response_code()),
+            HandlerOutcome::Deferred(_) | HandlerOutcome::NoReply(_) => None,
+        };
+        self.operations.lock().push(ObservedAdminOperation {
+            original_code: original.original_code(),
+            command_code,
+            original_opaque: original.original_opaque(),
+            username,
+            response_code,
+        });
+        Ok(outcome)
+    }
+
+    fn reject_request(&self, code: i32) -> RejectRequestDecision {
+        RequestProcessorV2::reject_request(&self.inner, code)
+    }
+
+    fn request_ordering(&self, request: IngressRequestView<'_>) -> RequestOrdering {
+        RequestProcessorV2::request_ordering(&self.inner, request)
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        RequestProcessorV2::observe_response_write(&self.inner, observation);
+    }
+}
+
+struct AllowEmbeddedAdminPolicy;
+
+impl RequestPolicy for AllowEmbeddedAdminPolicy {
+    fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+        Decision::Allow
+    }
+}
+
+struct AdminV2Fixture {
+    owner: Option<RuntimeOwner>,
+    harness: Option<EmbeddedRequestHarnessV2<ObservedAdminProcessor>>,
+    operations: Arc<Mutex<Vec<ObservedAdminOperation>>>,
+    auth_admin_service: Arc<AuthAdminService>,
+    temp_root: PathBuf,
+}
+
+impl AdminV2Fixture {
+    fn new(mutate_command_code: Option<i32>) -> Box<Self> {
+        static NEXT_TEMP_ROOT: AtomicU64 = AtomicU64::new(1);
+
+        let temp_root = std::env::temp_dir().join(format!(
+            "rocketmq-admin-v2-concurrency-{}-{}",
+            std::process::id(),
+            NEXT_TEMP_ROOT.fetch_add(1, Ordering::Relaxed)
+        ));
+        let broker_config = Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        });
+        let message_store_config = Arc::new(MessageStoreConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        });
+        let runtime = BrokerRuntime::new(broker_config, message_store_config);
+        let provider_registry =
+            ProviderRegistry::local(&AuthConfig::default()).expect("create in-memory auth registry");
+        let auth_admin_service = Arc::new(AuthAdminService::with_provider_registry(provider_registry));
+        let processor: TestAdminLeaf = BrokerProcessorTypeV2::AdminBroker(Arc::new(AdminBrokerProcessor::new(
+            runtime.admin_runtime_for_test(),
+            Arc::clone(&auth_admin_service),
+        )));
+        let operations = Arc::new(Mutex::new(Vec::new()));
+        let processor = ObservedAdminProcessor {
+            inner: processor,
+            operations: Arc::clone(&operations),
+            mutate_command_code,
+        };
+        let mut runtime_config = RuntimeConfig::server_default("admin-v2-concurrency-test");
+        runtime_config.thread_stack_size = Some(16 * 1024 * 1024);
+        let owner = RuntimeOwner::new(runtime_config).expect("Admin V2 concurrency test runtime");
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            processor,
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedAdminPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let harness = EmbeddedRequestHarnessV2::new(
+            dispatcher,
+            owner
+                .root_context()
+                .component("admin-v2-concurrency-request")
+                .task_group()
+                .clone(),
+            Principal::new("broker-proxy"),
+        );
+        drop(runtime);
+        Box::new(Self {
+            owner: Some(owner),
+            harness: Some(harness),
+            operations,
+            auth_admin_service,
+            temp_root,
+        })
+    }
+
+    fn harness(&self) -> &EmbeddedRequestHarnessV2<ObservedAdminProcessor> {
+        self.harness.as_ref().expect("Admin V2 harness must remain installed")
+    }
+
+    async fn seed_user(&self, username: &'static str) {
+        let mut user = User::of_with_type(username, format!("{username}-password"), UserType::Normal);
+        user.set_user_status(UserStatus::Enable);
+        self.auth_admin_service
+            .create_user(user)
+            .await
+            .expect("seed Admin V2 read fixture user");
+    }
+
+    async fn finish(mut self: Box<Self>) {
+        drop(self.harness.take());
+        let owner = self.owner.take().expect("Admin V2 runtime owner must remain installed");
+        assert!(owner.shutdown_tasks().await.is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
+        let temp_root = self.temp_root.clone();
+        drop(self);
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+}
+
+fn get_user_request(username: &'static str, opaque: i32) -> RemotingCommand {
+    let mut request = RemotingCommand::create_request_command(
+        RequestCode::AuthGetUser,
+        GetUserRequestHeader {
+            username: CheetahString::from_static_str(username),
+        },
+    )
+    .set_opaque(opaque);
+    request.make_custom_header_to_net();
+    request
+}
+
+fn create_user_request(username: &'static str, opaque: i32) -> RemotingCommand {
+    let mut request = RemotingCommand::create_request_command(
+        RequestCode::AuthCreateUser,
+        CreateUserRequestHeader {
+            username: CheetahString::from_static_str(username),
+        },
+    )
+    .set_body(
+        UserInfo {
+            username: None,
+            password: Some(CheetahString::from_static_str("mutation-password")),
+            user_type: Some(CheetahString::from_static_str("Normal")),
+            user_status: Some(CheetahString::from_static_str("enable")),
+        }
+        .encode()
+        .expect("encode Admin V2 create-user body"),
+    )
+    .set_opaque(opaque);
+    request.make_custom_header_to_net();
+    request
+}
+
+fn expect_success_reply(outcome: EmbeddedDispatchOutcome, expected_body: bool) {
+    let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+        panic!("Admin V2 operation must produce one immediate response")
+    };
+    assert_eq!(ResponseCode::from(plan.response_code()), ResponseCode::Success);
+    assert_eq!(plan.body_len() > 0, expected_body);
+}
+
+fn run_admin_v2_test(name: &'static str, body: fn(&RuntimeOwner)) {
+    thread::Builder::new()
+        .name(name.to_owned())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            let owner = RuntimeOwner::new(RuntimeConfig::server_default(format!("{name}-driver")))
+                .expect("Admin V2 test driver runtime");
+            body(&owner);
+            assert!(owner.block_on(owner.shutdown_tasks()).is_healthy());
+            assert!(owner.shutdown_background().is_healthy());
+        })
+        .expect("start Admin V2 test thread")
+        .join()
+        .expect("Admin V2 test thread must not panic");
+}
+
+#[test]
+fn shared_dispatcher_preserves_concurrent_read_and_mutation_identity() {
+    run_admin_v2_test("admin-v2-concurrency", |owner| {
+        owner.block_on(shared_dispatcher_concurrency_body());
+    });
+}
+
+async fn shared_dispatcher_concurrency_body() {
+    const FIRST_READ_OPAQUE: i32 = 72_001;
+    const SECOND_READ_OPAQUE: i32 = 72_002;
+    const FIRST_MUTATION_OPAQUE: i32 = 72_101;
+    const SECOND_MUTATION_OPAQUE: i32 = 72_102;
+
+    let fixture = AdminV2Fixture::new(None);
+    fixture.seed_user("read-alpha").await;
+    fixture.seed_user("read-beta").await;
+
+    let first_read = Box::pin(
+        fixture
+            .harness()
+            .dispatch(None, get_user_request("read-alpha", FIRST_READ_OPAQUE)),
+    );
+    let second_read = Box::pin(
+        fixture
+            .harness()
+            .dispatch(None, get_user_request("read-beta", SECOND_READ_OPAQUE)),
+    );
+    let (first_read, second_read) = tokio::join!(first_read, second_read);
+    expect_success_reply(first_read.expect("first concurrent Admin V2 read"), true);
+    expect_success_reply(second_read.expect("second concurrent Admin V2 read"), true);
+
+    let first_mutation = Box::pin(
+        fixture
+            .harness()
+            .dispatch(None, create_user_request("write-alpha", FIRST_MUTATION_OPAQUE)),
+    );
+    let second_mutation = Box::pin(
+        fixture
+            .harness()
+            .dispatch(None, create_user_request("write-beta", SECOND_MUTATION_OPAQUE)),
+    );
+    let (first_mutation, second_mutation) = tokio::join!(first_mutation, second_mutation);
+    expect_success_reply(first_mutation.expect("first concurrent Admin V2 mutation"), false);
+    expect_success_reply(second_mutation.expect("second concurrent Admin V2 mutation"), false);
+
+    for username in ["write-alpha", "write-beta"] {
+        let user = fixture
+            .auth_admin_service
+            .get_user(username)
+            .await
+            .expect("read concurrent Admin V2 mutation state")
+            .expect("concurrent Admin V2 mutation must not be lost");
+        assert_eq!(user.username.as_deref(), Some(username));
+        assert_eq!(user.password.as_deref(), Some("mutation-password"));
+    }
+
+    let mut operations = fixture.operations.lock().clone();
+    operations.sort_by_key(|operation| operation.original_opaque);
+    assert_eq!(
+        operations,
+        vec![
+            ObservedAdminOperation {
+                original_code: RequestCode::AuthGetUser as i32,
+                command_code: RequestCode::AuthGetUser as i32,
+                original_opaque: FIRST_READ_OPAQUE,
+                username: Some("read-alpha".to_owned()),
+                response_code: Some(ResponseCode::Success as i32),
+            },
+            ObservedAdminOperation {
+                original_code: RequestCode::AuthGetUser as i32,
+                command_code: RequestCode::AuthGetUser as i32,
+                original_opaque: SECOND_READ_OPAQUE,
+                username: Some("read-beta".to_owned()),
+                response_code: Some(ResponseCode::Success as i32),
+            },
+            ObservedAdminOperation {
+                original_code: RequestCode::AuthCreateUser as i32,
+                command_code: RequestCode::AuthCreateUser as i32,
+                original_opaque: FIRST_MUTATION_OPAQUE,
+                username: Some("write-alpha".to_owned()),
+                response_code: Some(ResponseCode::Success as i32),
+            },
+            ObservedAdminOperation {
+                original_code: RequestCode::AuthCreateUser as i32,
+                command_code: RequestCode::AuthCreateUser as i32,
+                original_opaque: SECOND_MUTATION_OPAQUE,
+                username: Some("write-beta".to_owned()),
+                response_code: Some(ResponseCode::Success as i32),
+            },
+        ]
+    );
+
+    fixture.finish().await;
+}
+
+#[test]
+fn dispatch_uses_original_code_after_mutable_command_code_changes() {
+    run_admin_v2_test("admin-v2-original-code", |owner| {
+        owner.block_on(original_code_mutation_body());
+    });
+}
+
+async fn original_code_mutation_body() {
+    const OPAQUE: i32 = 72_201;
+
+    let fixture = AdminV2Fixture::new(Some(RequestCode::AuthDeleteUser as i32));
+    fixture.seed_user("original-code-user").await;
+
+    let outcome = Box::pin(
+        fixture
+            .harness()
+            .dispatch(None, get_user_request("original-code-user", OPAQUE)),
+    )
+    .await
+    .expect("Admin V2 dispatch after command-code mutation");
+    expect_success_reply(outcome, true);
+    assert!(fixture
+        .auth_admin_service
+        .get_user("original-code-user")
+        .await
+        .expect("read original-code behavior state")
+        .is_some());
+    assert_eq!(
+        fixture.operations.lock().as_slice(),
+        &[ObservedAdminOperation {
+            original_code: RequestCode::AuthGetUser as i32,
+            command_code: RequestCode::AuthDeleteUser as i32,
+            original_opaque: OPAQUE,
+            username: Some("original-code-user".to_owned()),
+            response_code: Some(ResponseCode::Success as i32),
+        }]
+    );
+
+    fixture.finish().await;
+}

--- a/rocketmq-broker/src/processor/maintenance_request_processor.rs
+++ b/rocketmq-broker/src/processor/maintenance_request_processor.rs
@@ -108,9 +108,10 @@ impl MaintenanceRequestProcessor {
     async fn process_authorized(
         &self,
         grant: &MaintenanceAuthorizationGrant,
+        request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> RocketMQResult<RemotingCommand> {
-        let response = match RequestCode::from(request.code()) {
+        let response = match request_code {
             RequestCode::MaintenanceGetCapabilities => self.capabilities(grant).await?,
             RequestCode::MaintenanceCreateStoreCheckpoint => self.create_store_checkpoint(grant, request).await?,
             RequestCode::MaintenanceVerifyCheckpoint => self.verify_store_checkpoint(request)?,
@@ -118,15 +119,22 @@ impl MaintenanceRequestProcessor {
             _ => {
                 return Ok(request_code_not_supported_with_factory_and_remark(
                     &self.command_factory,
-                    request.code(),
-                    format!("request type {} is not a Broker maintenance operation", request.code()),
+                    request_code.to_i32(),
+                    format!(
+                        "request type {} is not a Broker maintenance operation",
+                        request_code.to_i32()
+                    ),
                 ));
             }
         };
         Ok(response.set_opaque(request.opaque()))
     }
 
-    fn authorize_v2(&self, request: &RemotingRequest) -> RocketMQResult<MaintenanceAuthorizationGrant> {
+    fn authorize_v2(
+        &self,
+        request: &RemotingRequest,
+        original_code: i32,
+    ) -> RocketMQResult<MaintenanceAuthorizationGrant> {
         if !self.broker_config.maintenance_enabled {
             return Err(RocketMQError::authentication_failed(
                 "Broker maintenance API is disabled",
@@ -136,7 +144,9 @@ impl MaintenanceRequestProcessor {
             .authentication()
             .principal()
             .ok_or_else(|| RocketMQError::authentication_failed("maintenance request is anonymous"))?;
-        self.authorize_principal(principal.id(), request.command())
+        let mut authoritative_command = request.command().clone();
+        authoritative_command.set_code_mut(original_code);
+        self.authorize_principal(principal.id(), &authoritative_command)
     }
 
     fn authorize_principal(
@@ -269,6 +279,7 @@ impl LegacyMaintenanceRequestProcessor {
         channel: &Channel,
         request: &mut RemotingCommand,
     ) -> RocketMQResult<Option<RemotingCommand>> {
+        let request_code = RequestCode::from(request.code());
         if !self.processor.broker_config.maintenance_enabled {
             return Err(RocketMQError::authentication_failed(
                 "Broker maintenance API is disabled",
@@ -280,7 +291,10 @@ impl LegacyMaintenanceRequestProcessor {
             .authenticate_maintenance_principal(request, Some(channel.channel_id()))
             .await?;
         let grant = self.processor.authorize_principal(principal.as_str(), request)?;
-        self.processor.process_authorized(&grant, request).await.map(Some)
+        self.processor
+            .process_authorized(&grant, request_code, request)
+            .await
+            .map(Some)
     }
 }
 
@@ -293,8 +307,12 @@ impl RequestProcessorV2 for MaintenanceRequestProcessor {
 impl MaintenanceRequestProcessor {
     pub(crate) async fn process_v2_shared(&self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
-        let result = match self.authorize_v2(request) {
-            Ok(grant) => self.process_authorized(&grant, request.command_mut()).await.map(Some),
+        let original_code = request.original_identity().original_code();
+        let result = match self.authorize_v2(request, original_code) {
+            Ok(grant) => self
+                .process_authorized(&grant, RequestCode::from(original_code), request.command_mut())
+                .await
+                .map(Some),
             Err(error) => Err(error),
         };
         immediate_outcome_from_command_result(
@@ -454,11 +472,15 @@ fn checkpoint_verification_to_wire(
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::net::SocketAddr;
     use std::path::PathBuf;
     use std::sync::Weak;
 
+    use cheetah_string::CheetahString;
+    use dashmap::DashMap;
     use rocketmq_auth::AuthConfig;
     use rocketmq_auth::AuthRuntimeBuilder;
+    use rocketmq_model::common::config::TopicConfig;
     use rocketmq_protocol::code::response_code::ResponseCode;
     use rocketmq_security_api::AuthenticatedRequestContext;
     use rocketmq_security_api::Decision;
@@ -470,9 +492,13 @@ mod tests {
     use rocketmq_security_api::Principal;
     use rocketmq_security_api::RequestPolicy;
     use rocketmq_security_api::MAINTENANCE_POLICY_SCHEMA_VERSION;
+    use rocketmq_store::LocalFileMessageStore;
+    use rocketmq_store::MessageStoreConfig;
     use rocketmq_store::StorePorts;
+    use rocketmq_store::StoreRuntimeConfig;
     use rocketmq_transport::api::v1::AdmissionController;
     use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::RPCHook;
     use rocketmq_transport::api::v1::TransportSecurity;
     use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
     use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
@@ -485,6 +511,24 @@ mod tests {
     impl RequestPolicy for AllowEmbeddedPolicy {
         fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
             Decision::Allow
+        }
+    }
+
+    struct MutateMaintenanceCodeHook;
+
+    impl RPCHook for MutateMaintenanceCodeHook {
+        fn do_before_request(&self, _remote_addr: SocketAddr, request: &mut RemotingCommand) -> RocketMQResult<()> {
+            request.set_code_mut(RequestCode::MaintenanceCreateStoreCheckpoint.to_i32());
+            Ok(())
+        }
+
+        fn do_after_response(
+            &self,
+            _remote_addr: SocketAddr,
+            _request: &RemotingCommand,
+            _response: &mut RemotingCommand,
+        ) -> RocketMQResult<()> {
+            Ok(())
         }
     }
 
@@ -542,14 +586,68 @@ mod tests {
         )
     }
 
+    async fn maintenance_processor_with_store_for_test(
+    ) -> (MaintenanceRequestProcessor, Arc<StorePorts>, tempfile::TempDir) {
+        let service_context = crate::test_service_context("maintenance-v2-original-code");
+        let auth_runtime = Arc::new(
+            AuthRuntimeBuilder::new(AuthConfig::default(), service_context.component("auth"))
+                .build()
+                .await
+                .expect("build maintenance auth runtime"),
+        );
+        let authorizer = Arc::new(MaintenanceAuthorizer::new(
+            maintenance_policy().into_validated().expect("valid maintenance policy"),
+        ));
+        let root = tempfile::tempdir().expect("maintenance checkpoint root");
+        let topic_table: Arc<DashMap<CheetahString, Arc<TopicConfig>>> = Arc::new(DashMap::new());
+        let store = Arc::new(StorePorts::local_file(LocalFileMessageStore::new(
+            Arc::new(MessageStoreConfig {
+                store_path_root_dir: root.path().to_string_lossy().into_owned().into(),
+                timer_wheel_enable: false,
+                ..MessageStoreConfig::default()
+            }),
+            Arc::new(StoreRuntimeConfig::default()),
+            topic_table,
+            None,
+            false,
+            service_context.component("store"),
+        )));
+        let checkpoint_service = Arc::new(StoreReleaseCheckpointService::new(
+            Arc::downgrade(&store),
+            root.path().join("checkpoints"),
+            service_context.component("checkpoint"),
+        ));
+        let processor = MaintenanceRequestProcessor::new(
+            Arc::new(BrokerConfig {
+                maintenance_enabled: true,
+                authentication_enabled: true,
+                authorization_enabled: true,
+                ..BrokerConfig::default()
+            }),
+            auth_runtime,
+            authorizer,
+            checkpoint_service,
+        );
+        (processor, store, root)
+    }
+
     async fn dispatch_v2(
         processor: MaintenanceRequestProcessor,
         principal: &'static str,
         command: RemotingCommand,
     ) -> Result<EmbeddedDispatchOutcome, rocketmq_transport::api::v2::EmbeddedDispatchError> {
+        dispatch_v2_with_hooks(processor, principal, command, Vec::new()).await
+    }
+
+    async fn dispatch_v2_with_hooks(
+        processor: MaintenanceRequestProcessor,
+        principal: &'static str,
+        command: RemotingCommand,
+        hooks: Vec<Arc<dyn RPCHook>>,
+    ) -> Result<EmbeddedDispatchOutcome, rocketmq_transport::api::v2::EmbeddedDispatchError> {
         let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
             processor,
-            Vec::new(),
+            hooks,
             Arc::new(TransportSecurity::secure_enforced(
                 Some(Arc::new(AllowEmbeddedPolicy)),
                 None,
@@ -563,6 +661,19 @@ mod tests {
         )
         .dispatch(None, command)
         .await
+    }
+
+    fn capabilities_request(opaque: i32) -> RemotingCommand {
+        RemotingCommand::create_request_command(
+            RequestCode::MaintenanceGetCapabilities,
+            MaintenanceRequestHeader {
+                operation_id: "get-capabilities".into(),
+                policy_version: 7,
+                deadline_unix_millis: rocketmq_runtime::common::time_utils::current_millis() + 20_000,
+                fencing_token: 42,
+            },
+        )
+        .set_opaque(opaque)
     }
 
     fn wire_manifest(backend: ReleaseCheckpointBackend) -> StoreReleaseCheckpointManifest {
@@ -635,6 +746,25 @@ mod tests {
         };
         assert_eq!(ResponseCode::from(denied.response_code()), ResponseCode::NoPermission);
         assert_eq!(denied.body_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn maintenance_v2_before_hook_cannot_replace_the_original_operation() {
+        let (processor, _store, _root) = maintenance_processor_with_store_for_test().await;
+
+        let EmbeddedDispatchOutcome::Reply(plan) = dispatch_v2_with_hooks(
+            processor,
+            "release-operator",
+            capabilities_request(5_507),
+            vec![Arc::new(MutateMaintenanceCodeHook)],
+        )
+        .await
+        .expect("original maintenance capability request should remain authoritative") else {
+            panic!("maintenance capability request must return an inline response plan");
+        };
+
+        assert_eq!(ResponseCode::from(plan.response_code()), ResponseCode::Success);
+        assert!(plan.body_len() > 0);
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -301,12 +301,12 @@ where
         request: &mut RemotingRequest,
     ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
         let original = request.original_identity();
-        let inbound_peer = send_request_peer(request.origin())?;
+        let origin = request.origin().clone();
         let control = request.control().clone();
         let (receive_span, parsed_request) = self.receive_span_and_request(request.command());
         let result = self
             .process_v2_request(
-                inbound_peer,
+                origin,
                 control,
                 original.request_id(),
                 original.original_code(),
@@ -333,7 +333,7 @@ where
 
     async fn process_v2_request(
         &self,
-        inbound_peer: SocketAddr,
+        origin: RequestOrigin,
         control: rocketmq_transport::api::v2::RequestControlView,
         request_id: RequestId,
         original_code: i32,
@@ -346,6 +346,7 @@ where
         debug!("SendMessageProcessor V2 received request code: {:?}", request_code);
         match request_code {
             RequestCode::SendMessage | RequestCode::SendMessageV2 | RequestCode::SendBatchMessage => {
+                let inbound_peer = send_request_peer(&origin)?;
                 self.process_v2_send_message(
                     inbound_peer,
                     control,

--- a/rocketmq-broker/src/processor/v2.rs
+++ b/rocketmq-broker/src/processor/v2.rs
@@ -14,15 +14,16 @@
 
 //! Broker-owned aggregate for the formal V2 processor contract.
 //!
-//! This aggregate deliberately has no legacy default/Admin variant. Admin is
-//! retained by the V1 compatibility aggregate until its child handlers expose
-//! formal V2 leaves; production server composition must not publish this route
-//! before that dependency is complete.
+//! The prepared embedded graph shallow-clones the frozen V1 registration table
+//! and reuses every leaf through its formal V2 seam. It remains independent of
+//! production listener publication, which is owned by the later cutover stage.
 
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use rocketmq_auth::AuthRuntime;
+use rocketmq_auth::RemotingAuthContext;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
@@ -49,7 +50,10 @@ use super::fast_failure_queue_kind;
 use super::is_privileged_maintenance_request;
 use super::request_ordering;
 use super::AckMessageProcessor;
+use super::AdminBrokerProcessor;
 use super::BrokerFastFailure;
+use super::BrokerProcessorType;
+use super::BrokerRequestProcessor;
 use super::ChangeInvisibleTimeProcessor;
 use super::ClientManageProcessor;
 use super::ConsumerManageProcessor;
@@ -72,11 +76,7 @@ use super::SendMessageProcessor;
 use crate::processor::response_plan::BrokerResponseParts;
 use crate::transaction::transactional_message_service::TransactionalMessageService;
 
-/// Every Broker leaf that already implements the formal V2 processor contract.
-///
-/// Admin is intentionally absent. Adding it requires the MIG-06 child-handler
-/// migration and is the prerequisite for publishing this aggregate as the
-/// production server route.
+/// Every Broker leaf that implements the formal V2 processor contract.
 pub enum BrokerProcessorTypeV2<MS: BrokerStorePort, TS> {
     Send(Arc<SendMessageProcessor<MS, TS>>),
     Pull(Arc<PullMessageProcessor<MS>>),
@@ -97,6 +97,7 @@ pub enum BrokerProcessorTypeV2<MS: BrokerStorePort, TS> {
     LiteSubscriptionCtl(Arc<LiteSubscriptionCtlProcessor<MS>>),
     EndTransaction(Arc<EndTransactionProcessor<TS, MS>>),
     Maintenance(Arc<MaintenanceRequestProcessor>),
+    AdminBroker(Arc<AdminBrokerProcessor<MS>>),
 }
 
 impl<MS, TS> Clone for BrokerProcessorTypeV2<MS, TS>
@@ -124,6 +125,7 @@ where
             Self::LiteSubscriptionCtl(processor) => Self::LiteSubscriptionCtl(Arc::clone(processor)),
             Self::EndTransaction(processor) => Self::EndTransaction(Arc::clone(processor)),
             Self::Maintenance(processor) => Self::Maintenance(Arc::clone(processor)),
+            Self::AdminBroker(processor) => Self::AdminBroker(Arc::clone(processor)),
         }
     }
 }
@@ -154,6 +156,7 @@ where
             Self::LiteSubscriptionCtl(processor) => processor.process_v2_shared(request).await,
             Self::EndTransaction(processor) => processor.process_v2_shared(request).await,
             Self::Maintenance(processor) => processor.process_v2_shared(request).await,
+            Self::AdminBroker(processor) => processor.process_v2_shared(request).await,
         }
     }
 
@@ -178,6 +181,7 @@ where
             | Self::LiteSubscriptionCtl(_)
             | Self::EndTransaction(_)
             | Self::Maintenance(_) => (false, None),
+            Self::AdminBroker(_) => (false, None),
         };
         legacy_rejection(legacy)
     }
@@ -225,7 +229,42 @@ where
             Self::Maintenance(processor) => {
                 RequestProcessorV2::observe_response_write(processor.as_ref(), observation);
             }
+            Self::AdminBroker(_) => {}
         }
+    }
+}
+
+impl<MS, TS> BrokerProcessorTypeV2<MS, TS>
+where
+    MS: BrokerStorePort,
+{
+    fn from_legacy(processor: &BrokerProcessorType<MS, TS>) -> Self {
+        match processor {
+            BrokerProcessorType::Send(processor) => Self::Send(Arc::clone(processor)),
+            BrokerProcessorType::Pull(processor) => Self::Pull(Arc::clone(processor)),
+            BrokerProcessorType::Peek(processor) => Self::Peek(Arc::clone(processor)),
+            BrokerProcessorType::Pop(processor) => Self::Pop(Arc::clone(processor)),
+            BrokerProcessorType::PopLite(processor) => Self::PopLite(Arc::clone(processor)),
+            BrokerProcessorType::Ack(processor) => Self::Ack(Arc::clone(processor)),
+            BrokerProcessorType::ChangeInvisible(processor) => Self::ChangeInvisible(Arc::clone(processor)),
+            BrokerProcessorType::Notification(processor) => Self::Notification(Arc::clone(processor)),
+            BrokerProcessorType::PollingInfo(processor) => Self::PollingInfo(Arc::clone(processor)),
+            BrokerProcessorType::Reply(processor) => Self::Reply(Arc::clone(processor)),
+            BrokerProcessorType::Recall(processor) => Self::Recall(Arc::clone(processor)),
+            BrokerProcessorType::QueryMessage(processor) => Self::QueryMessage(Arc::clone(processor)),
+            BrokerProcessorType::ClientManage(processor) => Self::ClientManage(Arc::clone(processor)),
+            BrokerProcessorType::ConsumerManage(processor) => Self::ConsumerManage(Arc::clone(processor)),
+            BrokerProcessorType::QueryAssignment(processor) => Self::QueryAssignment(Arc::clone(processor)),
+            BrokerProcessorType::LiteManager(processor) => Self::LiteManager(Arc::clone(processor)),
+            BrokerProcessorType::LiteSubscriptionCtl(processor) => Self::LiteSubscriptionCtl(Arc::clone(processor)),
+            BrokerProcessorType::EndTransaction(processor) => Self::EndTransaction(Arc::clone(processor)),
+            BrokerProcessorType::Maintenance(processor) => Self::Maintenance(Arc::clone(processor)),
+            BrokerProcessorType::AdminBroker(processor) => Self::AdminBroker(Arc::clone(processor)),
+        }
+    }
+
+    fn is_maintenance(&self) -> bool {
+        matches!(self, Self::Maintenance(_))
     }
 }
 
@@ -265,6 +304,15 @@ pub struct BrokerRequestProcessorV2<P> {
     default_request_processor: Option<Arc<P>>,
     maintenance_routes: Arc<HashSet<i32>>,
     broker_fast_failure: Option<BrokerFastFailure>,
+    auth: BrokerAuthState,
+}
+
+#[derive(Clone, Default)]
+enum BrokerAuthState {
+    #[default]
+    Unconfigured,
+    DisabledByValidatedConfig,
+    Runtime(Arc<AuthRuntime>),
 }
 
 impl<P> BrokerRequestProcessorV2<P>
@@ -282,6 +330,7 @@ where
             default_request_processor: None,
             maintenance_routes: Arc::new(HashSet::new()),
             broker_fast_failure: None,
+            auth: BrokerAuthState::Unconfigured,
         }
     }
 
@@ -304,6 +353,23 @@ where
         }
         self.broker_fast_failure = Some(broker_fast_failure);
     }
+
+    /// Installs the Broker ACL runtime used before any ordinary leaf dispatch.
+    pub(crate) fn set_auth_runtime(&mut self, auth_runtime: Arc<AuthRuntime>) {
+        self.auth = BrokerAuthState::Runtime(auth_runtime);
+    }
+
+    /// Explicitly records that both Broker authentication and authorization
+    /// were disabled by validated composition configuration.
+    pub(crate) fn set_auth_disabled_by_validated_config(&mut self) {
+        self.auth = BrokerAuthState::DisabledByValidatedConfig;
+    }
+
+    /// Returns whether composition made an explicit fail-closed ACL decision.
+    #[must_use]
+    pub(crate) const fn is_auth_configured(&self) -> bool {
+        !matches!(self.auth, BrokerAuthState::Unconfigured)
+    }
 }
 
 impl<P> Default for BrokerRequestProcessorV2<P>
@@ -315,6 +381,49 @@ where
     }
 }
 
+impl<MS, TS> BrokerRequestProcessorV2<BrokerProcessorTypeV2<MS, TS>>
+where
+    MS: BrokerStorePort,
+    TS: TransactionalMessageService,
+{
+    /// Builds a prepared V2 router over the exact leaf instances registered in
+    /// the frozen compatibility graph.
+    ///
+    /// This only shallow-clones leaf `Arc`s and immutable routing metadata. It
+    /// does not publish a listener, create a second service owner, or duplicate
+    /// processor state.
+    pub(crate) fn from_legacy_graph(legacy: &BrokerRequestProcessor<MS, TS>) -> Self {
+        let process_table = legacy
+            .process_table
+            .iter()
+            .map(|(code, processor)| (*code, BrokerProcessorTypeV2::from_legacy(processor)))
+            .collect::<HashMap<_, _>>();
+        let maintenance_routes = process_table
+            .iter()
+            .filter_map(|(code, processor)| processor.is_maintenance().then_some(*code))
+            .collect::<HashSet<_>>();
+        let default_request_processor = legacy
+            .default_request_processor
+            .as_ref()
+            .map(|processor| Arc::new(BrokerProcessorTypeV2::from_legacy(processor.as_ref())));
+        let auth = legacy
+            .auth_runtime
+            .as_ref()
+            .map_or(BrokerAuthState::Unconfigured, |runtime| {
+                BrokerAuthState::Runtime(Arc::clone(runtime))
+            });
+
+        Self {
+            command_factory: legacy.command_factory,
+            process_table: Arc::new(process_table),
+            default_request_processor,
+            maintenance_routes: Arc::new(maintenance_routes),
+            broker_fast_failure: legacy.broker_fast_failure.clone(),
+            auth,
+        }
+    }
+}
+
 impl<P> Clone for BrokerRequestProcessorV2<P> {
     fn clone(&self) -> Self {
         Self {
@@ -323,6 +432,7 @@ impl<P> Clone for BrokerRequestProcessorV2<P> {
             default_request_processor: self.default_request_processor.clone(),
             maintenance_routes: Arc::clone(&self.maintenance_routes),
             broker_fast_failure: self.broker_fast_failure.clone(),
+            auth: self.auth.clone(),
         }
     }
 }
@@ -348,6 +458,50 @@ where
                 opaque,
             );
             return BrokerResponseParts::from_command(response)?.into_handler_outcome();
+        }
+
+        if !is_privileged_maintenance_request(RequestCode::from(request_code)) {
+            match &self.auth {
+                BrokerAuthState::Unconfigured => {
+                    let error = rocketmq_error::RocketMQError::authentication_failed(
+                        "Broker V2 authentication is not configured",
+                    );
+                    let response = command_from_error_with_factory_remark_and_opaque(
+                        &self.command_factory,
+                        &error,
+                        error.to_string(),
+                        opaque,
+                    );
+                    return BrokerResponseParts::from_command(response)?.into_handler_outcome();
+                }
+                BrokerAuthState::DisabledByValidatedConfig => {}
+                BrokerAuthState::Runtime(auth_runtime) => {
+                    let auth_context = match RemotingAuthContext::from_request(request) {
+                        Ok(auth_context) => auth_context,
+                        Err(error) => {
+                            let response = command_from_error_with_factory_remark_and_opaque(
+                                &self.command_factory,
+                                &error,
+                                error.to_string(),
+                                opaque,
+                            );
+                            return BrokerResponseParts::from_command(response)?.into_handler_outcome();
+                        }
+                    };
+                    if let Err(error) = auth_runtime
+                        .check_remoting_for_code(&auth_context, request.command(), request_code)
+                        .await
+                    {
+                        let response = command_from_error_with_factory_remark_and_opaque(
+                            &self.command_factory,
+                            &error,
+                            error.to_string(),
+                            opaque,
+                        );
+                        return BrokerResponseParts::from_command(response)?.into_handler_outcome();
+                    }
+                }
+            }
         }
 
         let (processor, default_processor) = match self.process_table.get(&request_code).cloned() {

--- a/rocketmq-broker/src/processor/v2/tests.rs
+++ b/rocketmq-broker/src/processor/v2/tests.rs
@@ -16,14 +16,19 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use parking_lot::Mutex;
+use rocketmq_auth::AuthConfig;
+use rocketmq_auth::AuthRuntimeBuilder;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeContext;
 use rocketmq_runtime::RuntimeOwner;
 use rocketmq_security_api::AuthenticatedRequestContext;
 use rocketmq_security_api::Decision;
 use rocketmq_security_api::Principal;
 use rocketmq_security_api::RequestPolicy;
+use rocketmq_transport::api::v1::no_permission_with_remark;
 use rocketmq_transport::api::v1::AdmissionController;
 use rocketmq_transport::api::v1::AdmissionLimits;
 use rocketmq_transport::api::v1::RPCHook;
@@ -199,6 +204,7 @@ async fn router_selects_by_immutable_original_code_and_forwards_mutable_command(
     let seen = Arc::clone(&probe.seen);
     let observations = Arc::clone(&probe.observations);
     let mut router = BrokerRequestProcessorV2::new();
+    router.set_auth_disabled_by_validated_config();
     router.register_processor(ROUTED_CODE, probe);
     let fixture = RouterFixture::new(PreMutatingRouter { inner: router }, Vec::new());
 
@@ -228,6 +234,7 @@ async fn router_v2_ordering_matches_v1_before_command_mutation() {
     let probe = ProbeProcessor::new(false);
     let seen = Arc::clone(&probe.seen);
     let mut router = BrokerRequestProcessorV2::new();
+    router.set_auth_disabled_by_validated_config();
     router.register_processor(RequestCode::SendMessage as i32, probe.clone());
     router.register_processor(RequestCode::QueryMessage as i32, probe.clone());
     router.register_maintenance_processor(RequestCode::MaintenanceGetCapabilities as i32, probe);
@@ -307,6 +314,75 @@ fn malformed_chosen_rejection_fails_closed_with_an_owned_fallback() {
     assert_eq!(plan.body_kind(), rocketmq_transport::api::v2::ResponseBodyKind::Empty);
 }
 
+#[tokio::test]
+async fn unconfigured_auth_fails_closed_before_leaf_dispatch() {
+    let probe = ProbeProcessor::new(false);
+    let calls = Arc::clone(&probe.calls);
+    let mut router = BrokerRequestProcessorV2::new();
+    router.register_processor(ROUTED_CODE, probe);
+    assert!(!router.is_auth_configured());
+    let fixture = RouterFixture::new(router, Vec::new());
+
+    let outcome = fixture
+        .harness
+        .dispatch(None, RemotingCommand::create_remoting_command(ROUTED_CODE))
+        .await
+        .expect("unconfigured auth must produce an owned denial");
+    let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+        panic!("unconfigured auth must return one denial reply");
+    };
+    assert_eq!(
+        plan.response_code(),
+        no_permission_with_remark("expected denial").code()
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    fixture.finish().await;
+}
+
+#[tokio::test]
+async fn broker_auth_uses_original_code_after_a_before_hook_mutates_the_command() {
+    let runtime_context = RuntimeContext::from_current("broker-v2-original-auth-code-test");
+    let auth_runtime = Arc::new(
+        AuthRuntimeBuilder::new(
+            AuthConfig {
+                authentication_enabled: true,
+                authentication_whitelist: CheetahString::from(MUTATED_CODE.to_string()),
+                ..AuthConfig::default()
+            },
+            runtime_context.service_context("broker-v2.original-auth-code"),
+        )
+        .build()
+        .await
+        .expect("test auth runtime should initialize"),
+    );
+    let probe = ProbeProcessor::new(false);
+    let calls = Arc::clone(&probe.calls);
+    let mut router = BrokerRequestProcessorV2::new();
+    router.register_processor(ROUTED_CODE, probe);
+    router.set_auth_runtime(Arc::clone(&auth_runtime));
+    let fixture = RouterFixture::new(PreMutatingRouter { inner: router }, Vec::new());
+
+    let outcome = fixture
+        .harness
+        .dispatch(None, RemotingCommand::create_remoting_command(ROUTED_CODE))
+        .await
+        .expect("Broker auth denial should remain an owned response");
+    let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+        panic!("Broker auth denial must return one reply");
+    };
+    assert_eq!(
+        plan.response_code(),
+        no_permission_with_remark("expected denial").code()
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+    fixture.finish().await;
+    auth_runtime
+        .shutdown()
+        .await
+        .expect("test auth runtime should shut down");
+}
+
 fn fast_failure(max_count: usize) -> BrokerFastFailure {
     BrokerFastFailure::new(Arc::new(BrokerConfig {
         broker_fast_failure_enable: true,
@@ -323,6 +399,7 @@ async fn router_fast_failure_keeps_response_affine_and_releases_run_resources() 
     let probe = ProbeProcessor::new(false);
     let calls = Arc::clone(&probe.calls);
     let mut router = BrokerRequestProcessorV2::new();
+    router.set_auth_disabled_by_validated_config();
     router.register_processor(RequestCode::SendMessage as i32, probe);
     router.set_broker_fast_failure(service.clone());
     let fixture = RouterFixture::new(router, Vec::new());

--- a/rocketmq-broker/src/proxy_facade.rs
+++ b/rocketmq-broker/src/proxy_facade.rs
@@ -30,12 +30,15 @@ use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
 use rocketmq_protocol::protocol::route::route_data_view::QueueData;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use rocketmq_runtime::BlockingExecutor;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_security_api::Principal;
 use rocketmq_store::MessageStoreConfig;
 use rocketmq_transport::api::v1::RequestContext;
 use rocketmq_transport::api::v1::RequestDeadline;
+use rocketmq_transport::api::v2::EmbeddedDispatchErrorKind;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
 
 use crate::broker_runtime::BrokerRuntime;
 use crate::lifecycle::BrokerReadiness;
@@ -46,6 +49,7 @@ const LOCAL_PROXY_RESPONSE_TIMEOUT: Duration = Duration::from_secs(3);
 pub struct ProxyBrokerFacade {
     runtime: BrokerRuntime,
     local_request_tasks: TaskGroup,
+    compatibility_materialization_blocking: BlockingExecutor,
 }
 
 impl ProxyBrokerFacade {
@@ -150,6 +154,7 @@ impl ProxyBrokerFacade {
     ) -> Self {
         let runtime_context = service_context.component("embedded-broker");
         let local_request_tasks = service_context.component("local-request").task_group().clone();
+        let compatibility_materialization_blocking = service_context.storage_io().clone();
         Self {
             runtime: BrokerRuntime::new_with_validated_config_telemetry_and_factory(
                 Arc::new(validated_config),
@@ -158,6 +163,7 @@ impl ProxyBrokerFacade {
                 command_factory,
             ),
             local_request_tasks,
+            compatibility_materialization_blocking,
         }
     }
 
@@ -243,10 +249,137 @@ impl ProxyBrokerFacade {
             .mark_response_type();
         Ok(response)
     }
+
+    /// Dispatches one local Proxy command through the prepared Broker V2 graph.
+    ///
+    /// The transport boundary fixes the origin to `EmbeddedCaller::BrokerProxy`;
+    /// the principal below is a composition-owned service identity and is never
+    /// read from command headers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the prepared V2 dispatcher is unavailable, the
+    /// embedded request cannot be admitted or completed, or the response
+    /// deadline elapses.
+    pub async fn process_request_v2(
+        &self,
+        request: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+        timeout: Duration,
+    ) -> rocketmq_error::RocketMQResult<EmbeddedDispatchOutcome> {
+        self.process_request_v2_with_deadline(request, RequestDeadline::after(timeout))
+            .await
+    }
+
+    /// Dispatches through Broker V2 and materializes the terminal plan for the
+    /// frozen outer V1 Proxy remoting listener.
+    ///
+    /// This bridge is intentionally limited to the V1 compatibility boundary.
+    /// New V2 callers must consume [`EmbeddedDispatchOutcome`] directly through
+    /// [`Self::process_request_v2`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when V2 dispatch fails, the response violates the
+    /// terminal contract, or bounded response materialization cannot complete
+    /// before `timeout`.
+    pub async fn process_request_v2_compatibility(
+        &self,
+        request: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+        timeout: Duration,
+    ) -> rocketmq_error::RocketMQResult<rocketmq_protocol::protocol::remoting_command::RemotingCommand> {
+        let opaque = request.opaque();
+        let deadline = RequestDeadline::after(timeout);
+        match self.process_request_v2_with_deadline(request, deadline).await? {
+            EmbeddedDispatchOutcome::Reply(plan) => {
+                let response = rocketmq_transport::api::v1::materialize_embedded_v2_compatibility_response(
+                    plan,
+                    Some(deadline),
+                    &self.local_request_tasks,
+                    &self.compatibility_materialization_blocking,
+                )
+                .await
+                .map_err(|error| embedded_v2_compatibility_materialization_error(error, timeout))?;
+                Ok(response.set_opaque(opaque).mark_response_type())
+            }
+            EmbeddedDispatchOutcome::OneWay { .. } => Ok(
+                rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_response_command_with_code(
+                    rocketmq_protocol::code::response_code::ResponseCode::Success,
+                )
+                .set_opaque(opaque)
+                .mark_response_type(),
+            ),
+            EmbeddedDispatchOutcome::Deferred { .. } => Err(rocketmq_error::RocketMQError::invariant_violated(
+                "terminal embedded Broker V2 dispatch returned deferred",
+            )),
+            EmbeddedDispatchOutcome::NoReply { .. } => Err(rocketmq_error::RocketMQError::invariant_violated(
+                "outer V1 Proxy compatibility request completed without a response",
+            )),
+            _ => Err(rocketmq_error::RocketMQError::invariant_violated(
+                "embedded Broker V2 dispatch returned an unsupported compatibility outcome",
+            )),
+        }
+    }
+
+    async fn process_request_v2_with_deadline(
+        &self,
+        mut request: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+        deadline: RequestDeadline,
+    ) -> rocketmq_error::RocketMQResult<EmbeddedDispatchOutcome> {
+        request.make_custom_header_to_net();
+        let dispatcher = self
+            .runtime
+            .prepared_v2_dispatcher()
+            .ok_or_else(embedded_broker_v2_request_processor_not_ready)?;
+        dispatcher
+            .dispatch_embedded_v2_wait_response(
+                &self.local_request_tasks,
+                Principal::new("broker-proxy"),
+                Some(deadline),
+                request,
+            )
+            .await
+            .map_err(|error| embedded_dispatch_v2_error(error, deadline.budget()))
+    }
 }
 
 fn embedded_broker_request_processor_not_ready() -> rocketmq_error::RocketMQError {
     rocketmq_error::RocketMQError::not_initialized("embedded_broker_request_processor")
+}
+
+fn embedded_broker_v2_request_processor_not_ready() -> rocketmq_error::RocketMQError {
+    rocketmq_error::RocketMQError::not_initialized("embedded_broker_v2_request_processor")
+}
+
+fn embedded_dispatch_v2_error(
+    error: rocketmq_transport::api::v2::EmbeddedDispatchError,
+    timeout: Duration,
+) -> rocketmq_error::RocketMQError {
+    if matches!(error.kind(), EmbeddedDispatchErrorKind::DeadlineExceeded) {
+        return rocketmq_error::RocketMQError::Timeout {
+            operation: "embedded_broker_v2_response",
+            timeout_ms: timeout.as_millis().min(u128::from(u64::MAX)) as u64,
+        };
+    }
+    rocketmq_error::RocketMQError::response_process_failed("embedded_broker_v2_dispatch", error.to_string())
+}
+
+fn embedded_v2_compatibility_materialization_error(
+    error: rocketmq_transport::api::v1::EmbeddedV2CompatibilityMaterializationError,
+    timeout: Duration,
+) -> rocketmq_error::RocketMQError {
+    if matches!(
+        error.kind(),
+        rocketmq_transport::api::v1::EmbeddedV2CompatibilityMaterializationErrorKind::DeadlineExceeded
+    ) {
+        return rocketmq_error::RocketMQError::Timeout {
+            operation: "embedded_broker_v2_compatibility_materialization",
+            timeout_ms: timeout.as_millis().min(u128::from(u64::MAX)) as u64,
+        };
+    }
+    rocketmq_error::RocketMQError::response_process_failed(
+        "embedded_broker_v2_compatibility_materialization",
+        error.to_string(),
+    )
 }
 
 fn embedded_dispatch_error(

--- a/rocketmq-broker/tests/admin_processor_concurrency_tests.rs
+++ b/rocketmq-broker/tests/admin_processor_concurrency_tests.rs
@@ -19,7 +19,7 @@ fn admin_dispatch_is_shared_without_a_request_wide_mutex() {
     let admin = include_str!("../src/processor/admin_broker_processor.rs").replace("\r\n", "\n");
 
     assert!(processor.contains("AdminBroker(Arc<AdminBrokerProcessor<MS>>)"));
-    assert!(processor.contains("processor.process_request_shared(channel, ctx, request).await"));
+    assert!(processor.contains("processor.process_request_shared(channel, request).await"));
     assert!(!processor.contains("Mutex<AdminBrokerProcessor"));
     assert!(!processor.contains("processor.lock().await.process_request"));
     assert!(!request_pipeline.contains("Mutex::new(AdminBrokerProcessor::new"));

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -2789,12 +2789,13 @@ mod tests {
         let mut processor = bootstrap.name_server_runtime.init_processors();
         let broker_session = (request.code() == RequestCode::RegisterBroker as i32)
             .then(|| BrokerSession::detached(harness.channel().channel_id_owned(), harness.channel().remote_address()));
-        let auth_context = rocketmq_auth::RemotingAuthContext::new(
-            Some(harness.channel().remote_address().ip().to_string()),
-            Some(harness.channel().channel_id().to_owned()),
+        let auth_context = rocketmq_auth::RemotingAuthContext::network(
+            harness.channel().remote_address().ip().to_string(),
+            harness.channel().channel_id().to_owned(),
         );
+        let original_code = request.code();
         processor
-            .process_command(&auth_context, request, broker_session)
+            .process_command(&auth_context, original_code, request, broker_session)
             .await
             .expect("request processing should succeed")
             .expect("processor should always return a response")

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -38,7 +38,6 @@ use rocketmq_transport::api::v2::RequestProcessorV2;
 use rocketmq_transport::api::v2::ResponsePlan;
 use rocketmq_transport::api::v2::ResponseWriteObservationV2;
 use rocketmq_transport::api::v2::ResponseWriteOutcomeV2;
-use rocketmq_transport::api::v2::SessionView;
 
 pub use self::client_request_processor::ClientRequestProcessor;
 pub use self::cluster_test_request_processor::ClusterTestRequestProcessor;
@@ -172,6 +171,7 @@ impl NameServerRequestProcessor {
     pub(crate) async fn process_command(
         &mut self,
         auth_context: &RemotingAuthContext,
+        original_code: i32,
         request: &mut RemotingCommand,
         broker_session: Option<crate::route::types::BrokerSession>,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
@@ -180,8 +180,8 @@ impl NameServerRequestProcessor {
             .in_flight_requests
             .as_ref()
             .map(|in_flight_requests| in_flight_requests.enter());
-        let route_request_started = (request.code() == RequestCode::GetRouteinfoByTopic as i32).then(Instant::now);
-        let request_class = match classify_namesrv_request(RequestCode::from(request.code())) {
+        let route_request_started = (original_code == RequestCode::GetRouteinfoByTopic as i32).then(Instant::now);
+        let request_class = match classify_namesrv_request(RequestCode::from(original_code)) {
             Some(request_class) => request_class,
             None => {
                 let error = RocketMQError::authentication_failed("request code is not authorized by NameServer");
@@ -201,7 +201,11 @@ impl NameServerRequestProcessor {
                 .unwrap_or(LayerRequirement::Optional)
         });
         let detailed = match &self.auth_runtime {
-            Some(auth_runtime) => auth_runtime.evaluate_remoting_detailed(auth_context, request).await,
+            Some(auth_runtime) => {
+                auth_runtime
+                    .evaluate_remoting_detailed_for_code(auth_context, request, original_code)
+                    .await
+            }
             None => Ok(DetailedDecision::Abstain),
         };
         if matches!(
@@ -295,12 +299,12 @@ impl NameServerRequestProcessor {
             None
         };
         let had_admission_lease = _admission_lease.is_some();
-        let response = match self.processor_table.get(request.code_ref()).cloned() {
+        let response = match self.processor_table.get(&original_code).cloned() {
             None => match self.default_request_processor.clone() {
                 None => {
                     let response = self
                         .command_factory
-                        .request_code_not_supported_with_opaque(request.code(), request.opaque());
+                        .request_code_not_supported_with_opaque(original_code, request.opaque());
                     Ok(Some(response))
                 }
                 Some(mut processor) => processor_response(&mut processor, request, broker_session).await,
@@ -367,14 +371,15 @@ impl NameServerRequestProcessor {
 
 impl RequestProcessorV2 for NameServerRequestProcessor {
     async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
-        let auth_context = remoting_auth_context(request);
-        let broker_session = if request.command().code() == RequestCode::RegisterBroker as i32 {
+        let auth_context = RemotingAuthContext::from_request(request)?;
+        let original_code = request.original_identity().original_code();
+        let broker_session = if original_code == RequestCode::RegisterBroker as i32 {
             Some(crate::processor::default_request_processor::broker_session_from_request(request)?)
         } else {
             None
         };
         let response = self
-            .process_command(&auth_context, request.command_mut(), broker_session)
+            .process_command(&auth_context, original_code, request.command_mut(), broker_session)
             .await?;
         response_outcome(response)
     }
@@ -415,19 +420,6 @@ pub(crate) fn response_outcome(response: Option<RemotingCommand>) -> rocketmq_er
     let plan = ResponsePlan::from_command(response)
         .map_err(|error| RocketMQError::response_process_failed("namesrv.response_plan", error.to_string()))?;
     Ok(HandlerOutcome::Reply(plan))
-}
-
-fn remoting_auth_context(request: &RemotingRequest) -> RemotingAuthContext {
-    let source_ip = match request.session() {
-        SessionView::Network { remote_addr, .. } => Some(remote_addr.ip().to_string()),
-        SessionView::Embedded { .. } => None,
-        _ => None,
-    };
-    let channel_id = Some(format!(
-        "transport-session-{}",
-        request.original_identity().request_id().owner_id()
-    ));
-    RemotingAuthContext::new(source_ip, channel_id)
 }
 
 fn record_admission_metric(
@@ -503,7 +495,7 @@ mod tests {
     }
 
     fn auth_context() -> RemotingAuthContext {
-        RemotingAuthContext::new(Some("127.0.0.1".to_owned()), Some("namesrv-v2-test-session".to_owned()))
+        RemotingAuthContext::network("127.0.0.1", "namesrv-v2-test-session")
     }
 
     #[test]
@@ -562,13 +554,50 @@ mod tests {
             RemotingCommand::create_remoting_command(RequestCode::RegisterBroker.to_i32()).set_opaque(0x5a5a);
 
         let response = processor
-            .process_command(&auth_context(), &mut request, None)
+            .process_command(&auth_context(), request.code(), &mut request, None)
             .await
             .expect("authorization denial should be encoded as a response")
             .expect("authorization denial should return a command");
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
         assert_eq!(response.opaque(), 0x5a5a);
+        auth_runtime.shutdown().await.expect("auth runtime should shut down");
+    }
+
+    #[tokio::test]
+    async fn mutated_command_code_cannot_replace_the_original_authorization_operation() {
+        let runtime = RuntimeContext::from_current("namesrv-original-auth-code-test");
+        let mutated_code = RequestCode::GetRouteinfoByTopic.to_i32().to_string();
+        let auth_runtime = Arc::new(
+            AuthRuntimeBuilder::new(
+                AuthConfig {
+                    authentication_enabled: true,
+                    authorization_enabled: true,
+                    authentication_whitelist: CheetahString::from_string(mutated_code.clone()),
+                    authorization_whitelist: CheetahString::from_string(mutated_code),
+                    ..AuthConfig::default()
+                },
+                runtime.service_context("namesrv.original-auth-code"),
+            )
+            .build()
+            .await
+            .expect("test auth runtime should initialize"),
+        );
+        let mut processor = NameServerRequestProcessor::new().with_auth_runtime(Some(Arc::clone(&auth_runtime)));
+        let mut request = route_request(0x5a5f);
+
+        let response = processor
+            .process_command(
+                &auth_context(),
+                RequestCode::RegisterBroker.to_i32(),
+                &mut request,
+                None,
+            )
+            .await
+            .expect("authorization denial should be encoded as a response")
+            .expect("authorization denial should return a command");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
         auth_runtime.shutdown().await.expect("auth runtime should shut down");
     }
 
@@ -584,7 +613,7 @@ mod tests {
         let mut request = route_request(0x5a5b);
 
         let response = processor
-            .process_command(&auth_context(), &mut request, None)
+            .process_command(&auth_context(), request.code(), &mut request, None)
             .await
             .expect("required abstention should produce a response")
             .expect("required abstention should return a command");
@@ -605,7 +634,7 @@ mod tests {
         let mut request = route_request(0x5a5c);
 
         let response = processor
-            .process_command(&auth_context(), &mut request, None)
+            .process_command(&auth_context(), request.code(), &mut request, None)
             .await
             .expect("optional abstention should reach the route handler")
             .expect("route handler should return a command");
@@ -615,6 +644,32 @@ mod tests {
             ResponseCode::from(response.code()),
             ResponseCode::RequestCodeNotSupported
         );
+    }
+
+    #[tokio::test]
+    async fn leaf_lookup_uses_the_original_code_after_command_mutation() {
+        let runtime = RuntimeContext::from_current("namesrv-original-route-code-test");
+        let bootstrap = crate::bootstrap::Builder::new(
+            runtime.service_context("namesrv-bootstrap"),
+            rocketmq_observability::TelemetryHandle::noop(),
+        )
+        .build();
+        let mut processor = route_processor(&bootstrap, None, LayerRequirement::Optional);
+        let mut request = route_request(0x5a60);
+        request.set_code_ref(RequestCode::GetBrokerClusterInfo.to_i32());
+
+        let response = processor
+            .process_command(
+                &auth_context(),
+                RequestCode::GetRouteinfoByTopic.to_i32(),
+                &mut request,
+                None,
+            )
+            .await
+            .expect("original route must reach the registered leaf")
+            .expect("route handler must return a command");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::TopicNotExist);
     }
 
     #[tokio::test]
@@ -648,7 +703,7 @@ mod tests {
         );
         let mut allowed_request = route_request(0x5a5d);
         let allowed = allowed_processor
-            .process_command(&auth_context(), &mut allowed_request, None)
+            .process_command(&auth_context(), allowed_request.code(), &mut allowed_request, None)
             .await
             .expect("whitelisted authorization should reach the route handler")
             .expect("route handler should return a command");
@@ -674,7 +729,7 @@ mod tests {
         );
         let mut denied_request = route_request(0x5a5e);
         let denied = denied_processor
-            .process_command(&auth_context(), &mut denied_request, None)
+            .process_command(&auth_context(), denied_request.code(), &mut denied_request, None)
             .await
             .expect("detailed denial should produce a response")
             .expect("detailed denial should return a command");

--- a/rocketmq-proxy-core/src/context.rs
+++ b/rocketmq-proxy-core/src/context.rs
@@ -20,6 +20,8 @@ use std::time::Instant;
 
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_transport::api::v1::ConnectionContext;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::SessionView;
 use tonic::metadata::MetadataMap;
 use tonic::Request;
 use uuid::Uuid;
@@ -185,6 +187,43 @@ impl<P> ProxyContextWithPrincipal<P> {
             connection_id: Some(channel.connection_id().to_owned()),
             deadline_at: None,
             received_at: Instant::now(),
+            authenticated_principal: None,
+        }
+    }
+
+    /// Builds Proxy metadata from the immutable V2 request and session views.
+    ///
+    /// Network addresses are read only from the transport-owned session. An
+    /// embedded session deliberately produces no socket metadata.
+    pub fn from_remoting_request_v2(rpc_name: &'static str, request: &RemotingRequest) -> Self {
+        let command = request.command();
+        let received_at = Instant::now();
+        let deadline_at = request
+            .control()
+            .deadline()
+            .map(|deadline| received_at.checked_add(deadline.remaining()).unwrap_or(received_at));
+        let (remote_addr, local_addr) = match request.session() {
+            SessionView::Network {
+                local_addr,
+                remote_addr,
+                ..
+            } => (Some(remote_addr.to_string()), Some(local_addr.to_string())),
+            SessionView::Embedded { .. } => (None, None),
+            _ => (None, None),
+        };
+
+        Self {
+            request_id: request.original_identity().original_opaque().to_string(),
+            rpc_name,
+            remote_addr,
+            local_addr,
+            client_id: remoting_ext_field(command, "clientID"),
+            language: Some(format!("{:?}", command.language())),
+            client_version: Some(command.version().to_string()),
+            namespace: remoting_ext_field(command, "namespace"),
+            connection_id: Some(format!("{:?}", request.session().id())),
+            deadline_at,
+            received_at,
             authenticated_principal: None,
         }
     }

--- a/rocketmq-proxy-core/src/ingress/remoting.rs
+++ b/rocketmq-proxy-core/src/ingress/remoting.rs
@@ -23,6 +23,7 @@ use rocketmq_model::result::SendStatus;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
 
 use crate::proto::v2;
 use crate::status::ProxyPayloadStatus;
@@ -42,6 +43,24 @@ pub trait ProxyRemotingBackend: Send + Sync {
     /// request. The facade is responsible for mapping that error to a wire
     /// response.
     fn process(&self, request: RemotingCommand) -> ProxyServiceFuture<'_, RemotingCommand>;
+
+    /// Processes a canonical command through the channel-free Broker V2 boundary.
+    ///
+    /// Implementations that own an embedded Broker override this method and
+    /// return its affine local dispatch result. Remote cluster backends keep
+    /// using [`Self::process`] because they do not own an in-process Broker
+    /// dispatcher.
+    fn process_v2(&self, request: RemotingCommand) -> ProxyServiceFuture<'_, EmbeddedDispatchOutcome> {
+        Box::pin(async move {
+            let response = self.process(request).await?;
+            let plan = rocketmq_transport::api::v2::ResponsePlan::from_command(response).map_err(|error| {
+                crate::ProxyError::Transport {
+                    message: format!("backend response could not become a V2 response plan: {error}"),
+                }
+            })?;
+            Ok(EmbeddedDispatchOutcome::Reply(plan))
+        })
+    }
 }
 
 /// Stable operations recognized by the Remoting ingress.

--- a/rocketmq-proxy-local/src/execution.rs
+++ b/rocketmq-proxy-local/src/execution.rs
@@ -472,7 +472,9 @@ impl LocalBrokerCommand {
             | Self::QueryTopicMessageType { .. }
             | Self::QuerySubscriptionGroup { .. }
             | Self::QueryAssignment { .. } => LocalExecutionClass::Control,
-            Self::ProcessRemoting { request, .. } => match RequestCode::from(request.code()) {
+            Self::ProcessRemoting { request, .. }
+            | Self::ProcessRemotingV2Compatibility { request, .. }
+            | Self::ProcessRemotingV2 { request, .. } => match RequestCode::from(request.code()) {
                 RequestCode::PopMessage | RequestCode::PullMessage => LocalExecutionClass::LongPoll,
                 RequestCode::AckMessage
                 | RequestCode::BatchAckMessage
@@ -504,7 +506,9 @@ impl LocalBrokerCommand {
             | Self::EndTransaction {
                 client_id, request_id, ..
             } => LocalOrderingKey::new("producer", [client_id.clone().unwrap_or_else(|| request_id.clone())]),
-            Self::ProcessRemoting { request, .. } => remoting_ordering_key(request),
+            Self::ProcessRemoting { request, .. }
+            | Self::ProcessRemotingV2Compatibility { request, .. }
+            | Self::ProcessRemotingV2 { request, .. } => remoting_ordering_key(request),
         }
     }
 }

--- a/rocketmq-proxy-local/src/local.rs
+++ b/rocketmq-proxy-local/src/local.rs
@@ -129,6 +129,7 @@ use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_transport::api::v1::RemotingDeserializable;
 use rocketmq_transport::api::v1::RpcRequestHeader;
 use rocketmq_transport::api::v1::TopicRequestHeader;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::oneshot;
@@ -208,6 +209,16 @@ pub(crate) enum LocalBrokerCommand {
         timeout: Duration,
         reply: oneshot::Sender<ProxyResult<RemotingCommand>>,
     },
+    ProcessRemotingV2Compatibility {
+        request: RemotingCommand,
+        timeout: Duration,
+        reply: oneshot::Sender<ProxyResult<RemotingCommand>>,
+    },
+    ProcessRemotingV2 {
+        request: RemotingCommand,
+        timeout: Duration,
+        reply: oneshot::Sender<ProxyResult<EmbeddedDispatchOutcome>>,
+    },
 }
 
 impl QueuedLocalBrokerCommand {
@@ -223,8 +234,13 @@ impl QueuedLocalBrokerCommand {
         let Some(deadline_at) = self.deadline_at else {
             return;
         };
-        if let LocalBrokerCommand::ProcessRemoting { timeout, .. } = &mut self.command {
-            *timeout = deadline_at.saturating_duration_since(now);
+        match &mut self.command {
+            LocalBrokerCommand::ProcessRemoting { timeout, .. }
+            | LocalBrokerCommand::ProcessRemotingV2Compatibility { timeout, .. }
+            | LocalBrokerCommand::ProcessRemotingV2 { timeout, .. } => {
+                *timeout = deadline_at.saturating_duration_since(now);
+            }
+            _ => {}
         }
     }
 }
@@ -232,7 +248,9 @@ impl QueuedLocalBrokerCommand {
 impl LocalBrokerCommand {
     fn timeout(&self) -> Option<Duration> {
         match self {
-            Self::ProcessRemoting { timeout, .. } => Some(*timeout),
+            Self::ProcessRemoting { timeout, .. }
+            | Self::ProcessRemotingV2Compatibility { timeout, .. }
+            | Self::ProcessRemotingV2 { timeout, .. } => Some(*timeout),
             _ => None,
         }
     }
@@ -310,7 +328,11 @@ impl LocalBrokerCommand {
                 .saturating_add(request.commit_log_message_id.as_ref().map_or(0, String::len))
                 .saturating_add(client_id.as_ref().map_or(0, String::len))
                 .saturating_add(request_id.len()),
-            Self::ProcessRemoting { request, .. } => base.saturating_add(request.body().map_or(0, bytes::Bytes::len)),
+            Self::ProcessRemoting { request, .. }
+            | Self::ProcessRemotingV2Compatibility { request, .. }
+            | Self::ProcessRemotingV2 { request, .. } => {
+                base.saturating_add(request.body().map_or(0, bytes::Bytes::len))
+            }
         }
         .max(1)
     }
@@ -361,6 +383,12 @@ impl LocalBrokerCommand {
                 let _ = reply.send(Err(error));
             }
             Self::ProcessRemoting { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::ProcessRemotingV2Compatibility { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::ProcessRemotingV2 { reply, .. } => {
                 let _ = reply.send(Err(error));
             }
         }
@@ -540,6 +568,73 @@ impl LocalBrokerFacadeClient {
         .await
     }
 
+    /// Processes one command through Broker V2 and materializes the terminal
+    /// response for the outer V1 Proxy remoting listener.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the local Broker worker is unavailable, V2
+    /// dispatch fails, or bounded compatibility materialization fails.
+    pub async fn process_remoting_v2_compatibility(&self, request: RemotingCommand) -> ProxyResult<RemotingCommand> {
+        self.process_remoting_v2_compatibility_with_timeout(request, Duration::from_secs(3))
+            .await
+    }
+
+    /// Processes one command through Broker V2 and materializes the terminal
+    /// response for the outer V1 Proxy remoting listener with an explicit
+    /// timeout.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the local Broker worker is unavailable, V2
+    /// dispatch fails, or bounded compatibility materialization cannot finish
+    /// within `timeout`.
+    pub async fn process_remoting_v2_compatibility_with_timeout(
+        &self,
+        mut request: RemotingCommand,
+        timeout: Duration,
+    ) -> ProxyResult<RemotingCommand> {
+        request.make_custom_header_to_net();
+        self.execute(|reply| LocalBrokerCommand::ProcessRemotingV2Compatibility {
+            request,
+            timeout,
+            reply,
+        })
+        .await
+    }
+
+    /// Processes one local remoting command through the Broker V2 dispatcher.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the local Broker worker is unavailable, rejects
+    /// the command, or does not complete within the default timeout.
+    pub async fn process_remoting_v2(&self, request: RemotingCommand) -> ProxyResult<EmbeddedDispatchOutcome> {
+        self.process_remoting_v2_with_timeout(request, Duration::from_secs(3))
+            .await
+    }
+
+    /// Processes one local remoting command through the Broker V2 dispatcher
+    /// with an explicit terminal-response timeout.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the local Broker worker is unavailable, rejects
+    /// the command, or does not complete within `timeout`.
+    pub async fn process_remoting_v2_with_timeout(
+        &self,
+        mut request: RemotingCommand,
+        timeout: Duration,
+    ) -> ProxyResult<EmbeddedDispatchOutcome> {
+        request.make_custom_header_to_net();
+        self.execute(|reply| LocalBrokerCommand::ProcessRemotingV2 {
+            request,
+            timeout,
+            reply,
+        })
+        .await
+    }
+
     pub async fn send_message(
         &self,
         request: SendMessageRequest,
@@ -651,7 +746,11 @@ impl LocalRemotingBackend {
 
 impl ProxyRemotingBackend for LocalRemotingBackend {
     fn process(&self, request: RemotingCommand) -> ProxyServiceFuture<'_, RemotingCommand> {
-        Box::pin(async move { self.client.process_remoting(request).await })
+        Box::pin(async move { self.client.process_remoting_v2_compatibility(request).await })
+    }
+
+    fn process_v2(&self, request: RemotingCommand) -> ProxyServiceFuture<'_, EmbeddedDispatchOutcome> {
+        Box::pin(async move { self.client.process_remoting_v2(request).await })
     }
 }
 
@@ -1202,6 +1301,37 @@ async fn handle_local_broker_command(
                     .process_request_with_timeout(request, timeout)
                     .await
                     .map_err(Into::into)
+            };
+            let _ = reply.send(result);
+        }
+        LocalBrokerCommand::ProcessRemotingV2Compatibility {
+            request,
+            timeout,
+            reply,
+        } => {
+            let result = if let Some(message) = startup_error {
+                Err(ProxyError::Transport {
+                    message: message.to_owned(),
+                })
+            } else {
+                facade
+                    .process_request_v2_compatibility(request, timeout)
+                    .await
+                    .map_err(Into::into)
+            };
+            let _ = reply.send(result);
+        }
+        LocalBrokerCommand::ProcessRemotingV2 {
+            request,
+            timeout,
+            reply,
+        } => {
+            let result = if let Some(message) = startup_error {
+                Err(ProxyError::Transport {
+                    message: message.to_owned(),
+                })
+            } else {
+                facade.process_request_v2(request, timeout).await.map_err(Into::into)
             };
             let _ = reply.send(result);
         }
@@ -2560,6 +2690,7 @@ mod tests {
     use rocketmq_proxy_core::MessageQueueTarget;
     use rocketmq_proxy_core::ProxyError;
     use rocketmq_proxy_core::ProxyMessage;
+    use rocketmq_proxy_core::ProxyRemotingBackend;
     use rocketmq_proxy_core::ProxyTopicMessageType;
     use rocketmq_proxy_core::PullMessageRequest;
     use rocketmq_proxy_core::ReceiveMessageRequest;
@@ -2583,6 +2714,7 @@ mod tests {
     use super::transaction_resolution_flag;
     use super::validate_local_queue_config;
     use super::LocalBrokerFacadeClient;
+    use super::LocalRemotingBackend;
     use crate::LocalConfig;
 
     fn batch_entry(id: &str) -> SendMessageEntry {
@@ -2884,6 +3016,49 @@ mod tests {
                 resource: "local broker command queue"
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn outer_v1_local_backend_enqueues_only_v2_compatibility_dispatch() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let client = LocalBrokerFacadeClient {
+            sender,
+            count_budget: Arc::new(tokio::sync::Semaphore::new(1)),
+            byte_budget: Arc::new(tokio::sync::Semaphore::new(4_096)),
+            rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            broker_name: "broker-a".to_owned(),
+        };
+        let backend = LocalRemotingBackend::new(client);
+        let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerConfig).set_opaque(9_852);
+
+        let call = tokio::spawn(async move { backend.process(request).await });
+        let queued = receiver.recv().await.expect("V1 backend must enqueue local work");
+        match queued.command {
+            super::LocalBrokerCommand::ProcessRemotingV2Compatibility {
+                request,
+                timeout,
+                reply,
+            } => {
+                assert_eq!(RequestCode::from(request.code()), RequestCode::GetBrokerConfig);
+                assert_eq!(request.opaque(), 9_852);
+                assert_eq!(timeout, Duration::from_secs(3));
+                let response = RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                    .set_opaque(request.opaque())
+                    .mark_response_type();
+                assert!(
+                    reply.send(Ok(response)).is_ok(),
+                    "backend call must own the reply receiver"
+                );
+            }
+            super::LocalBrokerCommand::ProcessRemoting { .. } => {
+                panic!("outer V1 backend must not enqueue the legacy embedded dispatcher")
+            }
+            _ => panic!("outer V1 backend enqueued an unrelated command"),
+        }
+
+        let response = call.await.expect("backend task joins").expect("backend succeeds");
+        assert_eq!(response.opaque(), 9_852);
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
     }
 
     #[test]

--- a/rocketmq-proxy/src/auth.rs
+++ b/rocketmq-proxy/src/auth.rs
@@ -38,6 +38,7 @@ use rocketmq_auth::DefaultAuthorizationContext;
 use rocketmq_auth::DefaultAuthorizationProvider;
 use rocketmq_auth::PolicyResource;
 use rocketmq_auth::ProviderRegistry;
+use rocketmq_auth::RemotingAuthContext;
 use rocketmq_auth::Subject;
 use rocketmq_auth::SubjectType;
 use rocketmq_auth::User;
@@ -60,9 +61,6 @@ use rocketmq_protocol::protocol::namespace_util::NamespaceUtil;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_security_api::Action;
-use rocketmq_transport::api::v1::Channel;
-use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
 use tonic::Request;
 #[cfg(feature = "cluster-mode")]
 use tracing::warn;
@@ -393,9 +391,9 @@ impl ProxyAuthRuntime {
     pub async fn authenticate_remoting(
         &self,
         command: &RemotingCommand,
-        channel_id: Option<&str>,
-        source_ip: Option<&str>,
+        auth_context: &RemotingAuthContext,
     ) -> ProxyResult<Option<AuthenticatedPrincipal>> {
+        auth_context.validate().map_err(ProxyError::from)?;
         let code = command.code().to_string();
         let requires_authentication = self.authentication_required(code.as_str());
         let requires_authorization = self.authorization_required(code.as_str());
@@ -405,15 +403,15 @@ impl ProxyAuthRuntime {
 
         let authentication_context = self
             .authentication_builder
-            .build_from_remoting(command, channel_id)
+            .build_from_remoting(command, auth_context.channel_id())
             .map_err(|error| ProxyError::from(RocketMQError::authentication_failed(error.to_string())))?;
         let username = authentication_context.username().map(ToString::to_string);
-        let source_ip = source_ip.unwrap_or("unknown").to_owned();
+        let source_ip = auth_context.source_ip().unwrap_or("embedded").to_owned();
         let channel_id = authentication_context
             .base
             .channel_id()
             .map(ToString::to_string)
-            .or_else(|| channel_id.map(ToOwned::to_owned));
+            .or_else(|| auth_context.channel_id().map(ToOwned::to_owned));
 
         if self
             .auth_runtime
@@ -448,18 +446,18 @@ impl ProxyAuthRuntime {
 
     pub async fn authorize_remoting(
         &self,
-        channel_context: &(dyn std::any::Any + Send + Sync),
+        auth_context: &RemotingAuthContext,
         command: &RemotingCommand,
     ) -> ProxyResult<()> {
+        auth_context.validate().map_err(ProxyError::from)?;
         let code = command.code().to_string();
         if !self.authorization_required(code.as_str()) {
             return Ok(());
         }
 
-        let source_ip = source_ip_from_channel_context(channel_context);
         if self
             .auth_runtime
-            .is_acl_white_remote_address(access_key_from_command(command), source_ip.as_deref())
+            .is_acl_white_remote_address(access_key_from_command(command), auth_context.source_ip())
             .map_err(ProxyError::from)?
         {
             return Ok(());
@@ -467,7 +465,7 @@ impl ProxyAuthRuntime {
 
         let contexts = self
             .authorization_provider
-            .new_contexts_from_remoting_command(channel_context, command)
+            .new_contexts_from_remoting_command(auth_context, command)
             .map_err(map_authorization_error)?;
         let sync_metadata = should_sync_remoting_auth_metadata(command.code());
         if sync_metadata {
@@ -882,19 +880,6 @@ impl Subject for MetadataSubject {
     }
 }
 
-fn source_ip_from_channel_context(channel_context: &(dyn std::any::Any + Send + Sync)) -> Option<String> {
-    if let Some(ctx) = channel_context.downcast_ref::<ConnectionHandlerContext>() {
-        return Some(ctx.remote_address().ip().to_string());
-    }
-    if let Some(ctx) = channel_context.downcast_ref::<ConnectionHandlerContextWrapper>() {
-        return Some(ctx.remote_address().ip().to_string());
-    }
-    if let Some(channel) = channel_context.downcast_ref::<Channel>() {
-        return Some(channel.remote_address().ip().to_string());
-    }
-    None
-}
-
 fn should_sync_remoting_auth_metadata(code: i32) -> bool {
     !matches!(
         RequestCode::from(code),
@@ -948,6 +933,10 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("{prefix}-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&dir).expect("test temp directory should be created");
         dir
+    }
+
+    fn remoting_auth_context(source_ip: &str, channel_id: &str) -> RemotingAuthContext {
+        RemotingAuthContext::new(Some(source_ip.to_owned()), Some(channel_id.to_owned()))
     }
 
     #[tokio::test]
@@ -1242,13 +1231,13 @@ mod tests {
                 "read-secret",
             );
             let principal = runtime
-                .authenticate_remoting(&command, Some("proxy-management"), Some("127.0.0.1"))
+                .authenticate_remoting(&command, &remoting_auth_context("127.0.0.1", "proxy-management"))
                 .await
                 .expect("local Proxy credential should authenticate")
                 .expect("principal should exist");
             assert_eq!(principal.username(), "sre-reader");
             runtime
-                .authorize_remoting(&(), &command)
+                .authorize_remoting(&remoting_auth_context("127.0.0.1", "proxy-management"), &command)
                 .await
                 .expect("local Proxy ACL should authorize the operation");
         }
@@ -1327,7 +1316,7 @@ accounts:
         command.add_ext_field("AccessKey", "alice");
 
         let principal = runtime
-            .authenticate_remoting(&command, Some("channel-a"), Some("192.168.0.7"))
+            .authenticate_remoting(&command, &remoting_auth_context("192.168.0.7", "channel-a"))
             .await
             .expect("white remote address should bypass signature")
             .expect("principal should be returned");
@@ -1402,14 +1391,14 @@ accounts:
             .expect("runtime should be enabled");
         let command = send_message_command("TopicA", "alice", "secret");
         let principal = restarted
-            .authenticate_remoting(&command, Some("channel-a"), Some("127.0.0.1"))
+            .authenticate_remoting(&command, &remoting_auth_context("127.0.0.1", "channel-a"))
             .await
             .expect("authentication should use persisted user")
             .expect("principal should exist");
         assert_eq!(principal.username(), "alice");
 
         restarted
-            .authorize_remoting(&(), &command)
+            .authorize_remoting(&remoting_auth_context("127.0.0.1", "channel-a"), &command)
             .await
             .expect("authorization should use persisted ACL");
 
@@ -1446,11 +1435,11 @@ accounts:
 
         let command = send_message_command("TopicA", "alice", "secret");
         runtime
-            .authenticate_remoting(&command, Some("channel-a"), Some("127.0.0.1"))
+            .authenticate_remoting(&command, &remoting_auth_context("127.0.0.1", "channel-a"))
             .await
             .expect("authentication should pass");
         let error = runtime
-            .authorize_remoting(&(), &command)
+            .authorize_remoting(&remoting_auth_context("127.0.0.1", "channel-a"), &command)
             .await
             .expect_err("authorization should deny");
         assert!(matches!(

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
+use rocketmq_auth::RemotingAuthContext;
 use rocketmq_error::RocketMQError;
 use rocketmq_model::common::entity::ClientGroup;
 use rocketmq_model::common::filter::expression_type::ExpressionType;
@@ -99,6 +100,12 @@ use rocketmq_transport::api::v1::RequestProcessor;
 use rocketmq_transport::api::v1::ServerConfig;
 use rocketmq_transport::api::v1::TransportServer;
 use rocketmq_transport::api::v1::TransportTelemetry;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RejectRequestDecision;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponsePlan;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
@@ -247,10 +254,8 @@ where
         }
         if let Some(auth_runtime) = &self.auth_runtime {
             let source_ip = channel.remote_address().ip().to_string();
-            match auth_runtime
-                .authenticate_remoting(request, Some(channel.channel_id()), Some(source_ip.as_str()))
-                .await
-            {
+            let auth_context = RemotingAuthContext::new(Some(source_ip), Some(channel.channel_id().to_owned()));
+            match auth_runtime.authenticate_remoting(request, &auth_context).await {
                 Ok(Some(principal)) => context.set_authenticated_principal(principal),
                 Ok(None) => {}
                 Err(error) => {
@@ -267,7 +272,7 @@ where
                     request.opaque(),
                 )));
             }
-            if let Err(error) = auth_runtime.authorize_remoting(&channel, request).await {
+            if let Err(error) = auth_runtime.authorize_remoting(&auth_context, request).await {
                 return Ok(Some(auth_error_response(
                     &self.dispatcher.command_factory,
                     request.opaque(),
@@ -298,6 +303,92 @@ where
     fn reject_request(&self, _code: i32) -> RejectRequestResponse {
         (false, None)
     }
+}
+
+impl<P> RequestProcessorV2 for ProxyRequestProcessor<P>
+where
+    P: MessagingProcessor + 'static,
+{
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let original_code = request.original_identity().original_code();
+        let mut auth_command = request.command().clone();
+        auth_command.set_code_ref(original_code);
+        let mut context =
+            ProxyContext::from_remoting_request_v2(RemotingIngressRoute::rpc_name(original_code), request);
+        let drain_management = is_drain_management_request(original_code);
+        if drain_management && self.auth_runtime.is_none() {
+            return response_plan(authentication_required_response(
+                &self.dispatcher.command_factory,
+                request.original_identity().original_opaque(),
+            ));
+        }
+
+        if let Some(auth_runtime) = &self.auth_runtime {
+            let auth_context = match RemotingAuthContext::from_request(request) {
+                Ok(auth_context) => auth_context,
+                Err(error) => {
+                    return response_plan(auth_error_response(
+                        &self.dispatcher.command_factory,
+                        request.original_identity().original_opaque(),
+                        ProxyError::from(error),
+                    ));
+                }
+            };
+            match auth_runtime.authenticate_remoting(&auth_command, &auth_context).await {
+                Ok(Some(principal)) => context.set_authenticated_principal(principal),
+                Ok(None) => {}
+                Err(error) => {
+                    return response_plan(auth_error_response(
+                        &self.dispatcher.command_factory,
+                        request.original_identity().original_opaque(),
+                        error,
+                    ));
+                }
+            }
+            if drain_management && context.authenticated_principal().is_none() {
+                return response_plan(authentication_required_response(
+                    &self.dispatcher.command_factory,
+                    request.original_identity().original_opaque(),
+                ));
+            }
+            if let Err(error) = auth_runtime.authorize_remoting(&auth_context, &auth_command).await {
+                return response_plan(auth_error_response(
+                    &self.dispatcher.command_factory,
+                    request.original_identity().original_opaque(),
+                    error,
+                ));
+            }
+        }
+
+        let _drain_admission = if drain_management {
+            None
+        } else {
+            match self.drain.try_admit() {
+                Ok(admission) => Some(admission),
+                Err(_) => {
+                    return response_plan(
+                        self.dispatcher
+                            .command_factory
+                            .create_response_command_with_code(ResponseCode::ServiceNotAvailable)
+                            .set_remark("Proxy is draining and does not accept new requests")
+                            .set_opaque(request.original_identity().original_opaque()),
+                    );
+                }
+            }
+        };
+
+        self.dispatcher.dispatch_v2(&context, request).await
+    }
+
+    fn reject_request(&self, _code: i32) -> RejectRequestDecision {
+        RejectRequestDecision::Proceed
+    }
+}
+
+fn response_plan(response: RemotingCommand) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+    ResponsePlan::from_command(response)
+        .map(HandlerOutcome::Reply)
+        .map_err(|error| RocketMQError::response_process_failed("proxy_v2_response_plan", error.to_string()))
 }
 
 #[doc(hidden)]
@@ -752,6 +843,61 @@ where
                 ),
             ),
         }
+    }
+
+    async fn dispatch_v2(
+        &self,
+        context: &ProxyContext,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let route =
+            rocketmq_proxy_core::remoting::classify_remoting_request(request.original_identity().original_code());
+        if matches!(
+            route,
+            RemotingIngressRoute::ForwardBackend
+                | RemotingIngressRoute::LockBatchMessageQueue
+                | RemotingIngressRoute::UnlockBatchMessageQueue
+        ) {
+            let Some(backend) = self.remoting_backend.as_ref() else {
+                return response_plan(unsupported_response(
+                    &self.command_factory,
+                    request.original_identity().original_opaque(),
+                    format!(
+                        "proxy remoting backend is unavailable for request code {}",
+                        request.original_identity().original_code()
+                    ),
+                ));
+            };
+            let mut backend_command = request.command().clone();
+            backend_command.set_code_ref(request.original_identity().original_code());
+            backend_command.set_opaque_mut(request.original_identity().original_opaque());
+            return match backend.process_v2(backend_command).await {
+                Ok(EmbeddedDispatchOutcome::Reply(plan)) => Ok(HandlerOutcome::Reply(plan)),
+                Ok(EmbeddedDispatchOutcome::OneWay { .. }) => Ok(HandlerOutcome::Reply(ResponsePlan::empty_response(
+                    ResponseCode::Success as i32,
+                ))),
+                Ok(EmbeddedDispatchOutcome::NoReply { reason, .. }) => request
+                    .protocol_no_response(reason)
+                    .map(HandlerOutcome::NoReply)
+                    .map_err(Into::into),
+                Ok(EmbeddedDispatchOutcome::Deferred { .. }) => Err(RocketMQError::invariant_violated(
+                    "terminal Proxy backend route returned an unresolved deferred outcome",
+                )),
+                Err(error) => response_plan(proxy_error_response(
+                    &self.command_factory,
+                    request.original_identity().original_opaque(),
+                    error,
+                )),
+                Ok(_) => Err(RocketMQError::invariant_violated(
+                    "Proxy backend returned an unsupported embedded dispatch outcome",
+                )),
+            };
+        }
+
+        let mut dispatch_command = request.command().clone();
+        dispatch_command.set_code_ref(request.original_identity().original_code());
+        dispatch_command.set_opaque_mut(request.original_identity().original_opaque());
+        response_plan(self.dispatch(context, &dispatch_command).await)
     }
 
     async fn dispatch_forward_backend(&self, request: &RemotingCommand) -> RemotingCommand {
@@ -2253,6 +2399,8 @@ fn auth_error_response(command_factory: &RemotingCommandFactory, opaque: i32, er
 mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
+    #[cfg(feature = "local-mode")]
+    use std::net::TcpListener;
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::time::Duration;
@@ -2264,6 +2412,7 @@ mod tests {
     use rocketmq_auth::Policy;
     use rocketmq_auth::PolicyDecision;
     use rocketmq_auth::PolicyResource;
+    use rocketmq_auth::RemotingAuthContext;
     use rocketmq_auth::SubjectType;
     use rocketmq_auth::User;
     use rocketmq_auth::UserStatus;
@@ -2280,6 +2429,8 @@ mod tests {
     use rocketmq_model::common::mix_all::IS_SUPPORT_HEART_BEAT_V2;
     use rocketmq_model::result::SendResult;
     use rocketmq_model::result::SendStatus;
+    #[cfg(feature = "local-mode")]
+    use rocketmq_observability::TelemetryHandle;
     use rocketmq_protocol::code::request_code::RequestCode;
     use rocketmq_protocol::code::response_code::ResponseCode;
     use rocketmq_protocol::common::message::message_decoder as MessageDecoder;
@@ -2292,6 +2443,7 @@ mod tests {
     use rocketmq_protocol::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
     use rocketmq_protocol::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
     use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+    use rocketmq_protocol::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
     use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
     use rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
     use rocketmq_protocol::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
@@ -2324,17 +2476,42 @@ mod tests {
     use rocketmq_protocol::protocol::route::route_data_view::QueueData;
     use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
     use rocketmq_protocol::protocol::SerializeType;
+    #[cfg(feature = "local-mode")]
+    use rocketmq_proxy_local::LocalBrokerFacadeClient;
+    #[cfg(feature = "local-mode")]
+    use rocketmq_proxy_local::LocalConfig;
+    #[cfg(feature = "local-mode")]
+    use rocketmq_proxy_local::LocalRemotingBackend;
+    #[cfg(feature = "local-mode")]
+    use rocketmq_runtime::RuntimeConfig;
     use rocketmq_runtime::RuntimeContext;
+    #[cfg(feature = "local-mode")]
+    use rocketmq_runtime::RuntimeOwner;
     use rocketmq_runtime::ServiceLifecycle;
     use rocketmq_runtime::ServiceLifecycleConfig;
     use rocketmq_security_api::Action;
+    use rocketmq_security_api::AuthenticatedRequestContext;
+    use rocketmq_security_api::Decision;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::RequestPolicy;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
     use rocketmq_transport::api::v1::RemotingDeserializable;
     use rocketmq_transport::api::v1::RemotingSerializable;
     use rocketmq_transport::api::v1::RequestProcessor;
+    use rocketmq_transport::api::v1::TransportSecurity;
+    use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+    use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::HandlerOutcome;
+    use rocketmq_transport::api::v2::RejectRequestDecision;
+    use rocketmq_transport::api::v2::RemotingRequest;
+    use rocketmq_transport::api::v2::RequestProcessorV2;
+    use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
     use rocketmq_transport::test_support::LocalRequestHarness;
     use tokio::time::timeout;
 
     use super::response_with_header;
+    use super::ProxyDrainPhase;
     use super::ProxyRemotingBackend;
     use super::ProxyRemotingDispatcher;
     use super::ProxyRequestProcessor;
@@ -2427,6 +2604,131 @@ mod tests {
             },
             ..ProxyConfig::default()
         })
+    }
+
+    #[cfg(feature = "local-mode")]
+    fn available_embedded_broker_port() -> u16 {
+        loop {
+            let broker = TcpListener::bind(("0.0.0.0", 0)).expect("reserve an ephemeral embedded Broker port");
+            let port = broker.local_addr().expect("read ephemeral Broker port").port();
+            let Some(fast_port) = port.checked_sub(2) else {
+                continue;
+            };
+            let Some(ha_port) = port.checked_add(1) else {
+                continue;
+            };
+            if port == 10_912 || fast_port == 10_912 {
+                continue;
+            }
+            let Ok(fast) = TcpListener::bind(("0.0.0.0", fast_port)) else {
+                continue;
+            };
+            let Ok(ha) = TcpListener::bind(("0.0.0.0", ha_port)) else {
+                continue;
+            };
+            drop((broker, fast, ha));
+            return port;
+        }
+    }
+
+    #[cfg(feature = "local-mode")]
+    #[test]
+    fn outer_v1_proxy_request_reaches_local_broker_v2_compatibility_path() {
+        let mut runtime_config = RuntimeConfig::server_default("proxy-v1-local-backend-v2-compatibility-test");
+        runtime_config.thread_stack_size = Some(16 * 1024 * 1024);
+        let owner = RuntimeOwner::new(runtime_config).expect("construct V2 compatibility test runtime");
+        owner.block_on(outer_v1_proxy_request_reaches_local_broker_v2_compatibility_path_body(
+            &owner,
+        ));
+        let report = owner
+            .shutdown_runtime_blocking()
+            .expect("V2 compatibility test runtime shuts down");
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[cfg(feature = "local-mode")]
+    async fn outer_v1_proxy_request_reaches_local_broker_v2_compatibility_path_body(owner: &RuntimeOwner) {
+        let service = owner
+            .root_context()
+            .component("proxy-v1-local-backend-v2-compatibility");
+        let store = tempfile::tempdir().expect("create embedded Broker store directory");
+        let local_client = LocalBrokerFacadeClient::new(
+            LocalConfig {
+                broker_listen_port: available_embedded_broker_port(),
+                store_root_dir: store.path().to_string_lossy().into_owned(),
+                command_queue_max_age_millis: 10_000,
+                ..LocalConfig::default()
+            },
+            &service,
+            TelemetryHandle::noop(),
+        )
+        .expect("construct production local Broker facade client");
+        let backend = Arc::new(LocalRemotingBackend::new(local_client));
+        let processor = Arc::new(DefaultMessagingProcessor::new(Arc::new(
+            LocalServiceManager::with_services(
+                Arc::new(StaticRouteService::default()),
+                Arc::new(StaticMetadataService::default()),
+                Arc::new(DefaultAssignmentService),
+                Arc::new(TestMessageService),
+                Arc::new(TestConsumerService),
+                Arc::new(DefaultTransactionService),
+            ),
+        )));
+        let mut request_processor = ProxyRequestProcessor::new(
+            Arc::new(ProxyConfig {
+                mode: ProxyMode::Local,
+                ..ProxyConfig::default()
+            }),
+            processor,
+            ClientSessionRegistry::default(),
+            None,
+            Some(backend),
+        );
+        let harness = LocalRequestHarness::new(service.component("outer-v1").task_group().clone())
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::ConsumerSendMsgBack,
+            ConsumerSendMsgBackRequestHeader {
+                offset: 0,
+                group: CheetahString::from("missing-v2-compatibility-group"),
+                delay_level: 0,
+                ..ConsumerSendMsgBackRequestHeader::default()
+            },
+        )
+        .set_opaque(9_852);
+        request.make_custom_header_to_net();
+        assert_eq!(
+            request
+                .decode_command_custom_header::<ConsumerSendMsgBackRequestHeader>()
+                .expect("outer V1 fixture must carry wire header fields")
+                .group
+                .as_str(),
+            "missing-v2-compatibility-group"
+        );
+
+        let response = request_processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("outer V1 Proxy dispatch succeeds")
+            .expect("ordinary request returns one compatibility response");
+
+        assert_eq!(response.opaque(), 9_852);
+        let remark = response.remark().map(CheetahString::as_str).unwrap_or_default();
+        assert_eq!(
+            ResponseCode::from(response.code()),
+            ResponseCode::SystemError,
+            "{remark}"
+        );
+        assert!(
+            remark.contains("look message by offset failed, the offset is 0"),
+            "{remark}"
+        );
+
+        drop(request_processor);
+        drop(harness);
+        let report = service.task_group().shutdown(Duration::from_secs(10)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
     }
 
     #[tokio::test]
@@ -2534,6 +2836,128 @@ mod tests {
                 ))
             })
         }
+    }
+
+    struct AllowEmbeddedProxyPolicy;
+
+    impl RequestPolicy for AllowEmbeddedProxyPolicy {
+        fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    #[derive(Clone)]
+    struct MutatingV2Fixture<P> {
+        inner: P,
+    }
+
+    impl<P> RequestProcessorV2 for MutatingV2Fixture<P>
+    where
+        P: RequestProcessorV2 + Clone + Sync,
+    {
+        async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+            request.command_mut().set_code_ref(RequestCode::BeginProxyDrain);
+            request.command_mut().set_opaque_mut(-9_852);
+            self.inner.process(request).await
+        }
+
+        fn reject_request(&self, code: i32) -> RejectRequestDecision {
+            self.inner.reject_request(code)
+        }
+    }
+
+    #[tokio::test]
+    async fn embedded_v2_routes_and_binds_from_original_identity_without_a_channel() {
+        let backend = Arc::new(TestRemotingBackend::default());
+        let processor = Arc::new(DefaultMessagingProcessor::new(Arc::new(
+            LocalServiceManager::with_services(
+                Arc::new(StaticRouteService::default()),
+                Arc::new(StaticMetadataService::default()),
+                Arc::new(DefaultAssignmentService),
+                Arc::new(TestMessageService),
+                Arc::new(TestConsumerService),
+                Arc::new(DefaultTransactionService),
+            ),
+        )));
+        let drain = ProxyDrainController::default();
+        let proxy = ProxyRequestProcessor::new_with_drain_controller(
+            Arc::new(ProxyConfig {
+                mode: ProxyMode::Local,
+                ..ProxyConfig::default()
+            }),
+            processor,
+            ClientSessionRegistry::default(),
+            None,
+            Some(backend.clone()),
+            drain.clone(),
+        );
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            MutatingV2Fixture { inner: proxy },
+            Vec::new(),
+            Arc::new(TransportSecurity::secure_enforced(
+                Some(Arc::new(AllowEmbeddedProxyPolicy)),
+                None,
+            )),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let runtime = RuntimeContext::from_current("proxy-embedded-v2-original-identity-test");
+        let service = runtime.service_context("proxy-embedded-v2-original-identity");
+        let harness =
+            EmbeddedRequestHarnessV2::new(dispatcher, service.task_group().clone(), Principal::new("broker-proxy"));
+
+        let response = harness
+            .dispatch(
+                None,
+                RemotingCommand::create_remoting_command(RequestCode::ConsumerSendMsgBack).set_opaque(9_701),
+            )
+            .await
+            .expect("embedded V2 Proxy reply");
+        let EmbeddedDispatchOutcome::Reply(plan) = response else {
+            panic!("forward backend must produce a reply")
+        };
+        assert_eq!(plan.response_code(), ResponseCode::Success.to_i32());
+
+        let local_response = harness
+            .dispatch(
+                None,
+                RemotingCommand::new_request(
+                    RequestCode::CheckClientConfig,
+                    ProxyDrainOperationRequestBody {
+                        schema_version: PROXY_DRAIN_SCHEMA_VERSION.to_owned(),
+                        operation_id: "must-not-start".to_owned(),
+                    }
+                    .encode()
+                    .expect("decoy drain body should encode"),
+                )
+                .set_opaque(9_703),
+            )
+            .await
+            .expect("embedded V2 non-backend reply");
+        let EmbeddedDispatchOutcome::Reply(plan) = local_response else {
+            panic!("original CheckClientConfig route must produce a reply")
+        };
+        assert_eq!(plan.response_code(), ResponseCode::Success.to_i32());
+        assert_eq!(drain.phase(), ProxyDrainPhase::Accepting);
+
+        let mut one_way = RemotingCommand::create_remoting_command(RequestCode::ConsumerSendMsgBack).set_opaque(9_702);
+        one_way.mark_oneway_rpc_ref();
+        let one_way_outcome = harness
+            .dispatch(None, one_way)
+            .await
+            .expect("embedded V2 one-way compatibility mapping");
+        assert!(matches!(one_way_outcome, EmbeddedDispatchOutcome::OneWay { .. }));
+
+        {
+            let seen = backend.seen_requests.lock().expect("backend mutex poisoned");
+            assert_eq!(seen.len(), 2);
+            assert_eq!(seen[0].code(), RequestCode::ConsumerSendMsgBack.to_i32());
+            assert_eq!(seen[0].opaque(), 9_701);
+            assert_eq!(seen[1].code(), RequestCode::ConsumerSendMsgBack.to_i32());
+            assert_eq!(seen[1].opaque(), 9_702);
+        }
+
+        let shutdown = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(shutdown.is_healthy(), "{}", shutdown.to_json());
     }
 
     async fn test_auth_runtime(authentication_enabled: bool, authorization_enabled: bool) -> ProxyAuthRuntime {
@@ -3737,9 +4161,10 @@ mod tests {
         );
         command.make_custom_header_to_net();
         let command = sign_remoting_command(command, "alice", "secret");
+        let auth_context = RemotingAuthContext::network("127.0.0.1", "channel-a");
 
         let principal = auth_runtime
-            .authenticate_remoting(&command, Some("channel-a"), Some("127.0.0.1"))
+            .authenticate_remoting(&command, &auth_context)
             .await
             .expect("authentication should succeed");
         assert_eq!(
@@ -3747,19 +4172,20 @@ mod tests {
             "alice"
         );
         auth_runtime
-            .authorize_remoting(&(), &command)
+            .authorize_remoting(&auth_context, &command)
             .await
             .expect("authorization should succeed");
 
         let denied_runtime = test_auth_runtime(true, true).await;
         seed_normal_user(&denied_runtime, "bob", "secret").await;
         let denied_command = sign_remoting_command(command.clone(), "bob", "secret");
+        let denied_auth_context = RemotingAuthContext::network("127.0.0.1", "channel-b");
         denied_runtime
-            .authenticate_remoting(&denied_command, Some("channel-b"), Some("127.0.0.1"))
+            .authenticate_remoting(&denied_command, &denied_auth_context)
             .await
             .expect("authentication should still succeed");
         let error = denied_runtime
-            .authorize_remoting(&(), &denied_command)
+            .authorize_remoting(&denied_auth_context, &denied_command)
             .await
             .expect_err("authorization should fail without matching acl");
         assert!(matches!(

--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -173,11 +173,14 @@ pub use response::ResponseErrorKind;
 pub use response::ResponseReceipt;
 pub use response::ResponseTerminalState;
 pub use response::WriteProgress;
+pub(crate) use response_plan::materialize_embedded_v2_compatibility_response;
 #[allow(
     unused_imports,
     reason = "later private response stages name the RSP-03 binding capability through dispatch"
 )]
 pub(crate) use response_plan::BoundResponsePlan;
+pub use response_plan::EmbeddedV2CompatibilityMaterializationError;
+pub use response_plan::EmbeddedV2CompatibilityMaterializationErrorKind;
 #[allow(
     unused_imports,
     reason = "RSP-06 exposes the private legacy materialization failure to later embedded wiring"

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -165,6 +165,7 @@ impl AuthorizedDispatchBoundary {
 pub struct AuthorizedCommandDispatcherV2<P> {
     boundary: Arc<AuthorizedDispatchBoundary>,
     core: Arc<AuthorizedDispatcherCore<crate::dispatch::ExplicitV2Processor<P>>>,
+    telemetry: TransportTelemetry,
 }
 
 impl<P> AuthorizedCommandDispatcherV2<P>
@@ -179,9 +180,28 @@ where
         security: Arc<TransportSecurity>,
         admission: Arc<AdmissionController>,
     ) -> Self {
+        Self::new_with_telemetry(
+            request_processor,
+            rpc_hooks,
+            security,
+            admission,
+            TransportTelemetry::noop(),
+        )
+    }
+
+    /// Creates a V2 dispatcher with the composition-owned transport telemetry.
+    #[must_use]
+    pub fn new_with_telemetry(
+        request_processor: P,
+        rpc_hooks: Vec<Arc<dyn RPCHook>>,
+        security: Arc<TransportSecurity>,
+        admission: Arc<AdmissionController>,
+        telemetry: TransportTelemetry,
+    ) -> Self {
         Self {
             boundary: Arc::new(AuthorizedDispatchBoundary::new(security, admission)),
             core: Arc::new(AuthorizedDispatcherCore::new(request_processor, rpc_hooks)),
+            telemetry,
         }
     }
 

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded_v2.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded_v2.rs
@@ -29,6 +29,7 @@ use crate::base::pending_request_table::materialize_and_estimate_remoting_comman
 use crate::deadline::RequestDeadline;
 use crate::dispatch::remoting_request::RemotingRequestBuilder;
 use crate::dispatch::remoting_request::RequestLifecycleProvenance;
+use crate::dispatch::DeferredSessionCleanupOwner;
 use crate::dispatch::EmbeddedCaller;
 use crate::dispatch::EmbeddedDispatchError;
 use crate::dispatch::EmbeddedDispatchOutcome;
@@ -81,7 +82,43 @@ where
         task_group: &TaskGroup,
         principal: Principal,
         deadline: Option<RequestDeadline>,
+        command: RemotingCommand,
+    ) -> TerminalResult {
+        self.dispatch_embedded_v2_inner(task_group, principal, deadline, command, false)
+            .await
+    }
+
+    /// Dispatches one embedded command and resolves an accepted deferred
+    /// response into its final in-process response plan.
+    ///
+    /// This terminal form is intended for the Broker-owned local Proxy. It
+    /// retains the embedded session and its deferred cleanup owner while the
+    /// processor's registration is live, but waits only after the admitted
+    /// processor future has returned and released its processor permit.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed, redacted error for the same boundary failures as
+    /// [`Self::dispatch_embedded_v2`], plus deferred response cancellation,
+    /// deadline, session-close, or local handoff failure.
+    pub async fn dispatch_embedded_v2_wait_response(
+        &self,
+        task_group: &TaskGroup,
+        principal: Principal,
+        deadline: Option<RequestDeadline>,
+        command: RemotingCommand,
+    ) -> TerminalResult {
+        self.dispatch_embedded_v2_inner(task_group, principal, deadline, command, true)
+            .await
+    }
+
+    async fn dispatch_embedded_v2_inner(
+        &self,
+        task_group: &TaskGroup,
+        principal: Principal,
+        deadline: Option<RequestDeadline>,
         mut command: RemotingCommand,
+        wait_for_deferred_response: bool,
     ) -> TerminalResult {
         let (terminal_sender, mut terminal_receiver) = terminal();
         let request_started = Instant::now();
@@ -93,6 +130,9 @@ where
             }
         };
         let session_record = EmbeddedSessionRecord::new(session_id);
+        let embedded_session_view = session_record.view();
+        let deferred_cleanup =
+            wait_for_deferred_response.then(|| DeferredSessionCleanupOwner::new(embedded_session_view.id()));
         let principal_for_security = principal.clone();
         let context =
             match RequestContext::try_embedded_with_caller(EmbeddedCaller::BrokerProxy, Some(principal), deadline) {
@@ -107,6 +147,8 @@ where
             };
         let retained_bytes = materialize_and_estimate_remoting_command_retained_bytes(&mut command);
         let lifecycle = RequestLifecycleProvenance::from_embedded_session(&session_record, task_group);
+        let mut session_record = Some(session_record);
+        let mut deferred_cleanup = deferred_cleanup;
         let builder = RemotingRequestBuilder::new(original, request_started, context, lifecycle, command);
         let ordering = self
             .core
@@ -115,6 +157,8 @@ where
         let control = builder.control().clone();
         terminal_receiver.attach_control(control, original.is_one_way());
         let mut admitted_session = None;
+        let mut deferred_lifecycle = None;
+        let mut deferred_receiver = None;
 
         if builder.deadline().is_some_and(RequestDeadline::is_expired) {
             match ResponsePlan::command(deadline_response(original.original_opaque())) {
@@ -169,17 +213,79 @@ where
             {
                 Ok(scope) => match self.boundary.session(task_group, scope) {
                     Ok(session) => {
-                        self.admit_embedded(
-                            &session,
-                            builder,
-                            ordering,
-                            retained_bytes,
-                            original,
-                            request_started,
-                            terminal_sender,
-                        )
-                        .await;
-                        admitted_session = Some(session);
+                        let class = AdmissionClass::for_request_code(original.original_code());
+                        let builder = if wait_for_deferred_response && !original.is_one_way() {
+                            let (response, receiver) = ResponseSink::local_plan(builder.control().clone());
+                            deferred_receiver = Some(receiver);
+                            response
+                                .local_deferred_seed_with_resume(
+                                    self.telemetry.clone(),
+                                    &embedded_session_view,
+                                    task_group,
+                                    ordering,
+                                    class,
+                                    session.executor.deferred_resume_executor(),
+                                )
+                                .map(|seed| {
+                                    let seed = match deferred_cleanup.as_ref() {
+                                        Some(cleanup) => seed.with_session_cleanup(cleanup.registration()),
+                                        None => seed,
+                                    };
+                                    builder.with_deferred_response_seed(seed)
+                                })
+                                .ok_or(crate::dispatch::remoting_request::RemotingRequestBuildError::DeferredResponseOwnerMismatch)
+                        } else {
+                            Ok(builder)
+                        };
+                        match builder {
+                            Ok(builder) => {
+                                if wait_for_deferred_response {
+                                    match (session_record.take(), deferred_cleanup.take()) {
+                                        (Some(record), Some(cleanup)) => {
+                                            deferred_lifecycle =
+                                                Some(EmbeddedDeferredLifecycle::new(session, record, cleanup));
+                                            if let Some(lifecycle) = deferred_lifecycle.as_ref() {
+                                                self.admit_embedded(
+                                                    lifecycle.session(),
+                                                    builder,
+                                                    ordering,
+                                                    retained_bytes,
+                                                    original,
+                                                    request_started,
+                                                    terminal_sender,
+                                                    true,
+                                                )
+                                                .await;
+                                            } else {
+                                                let _ = terminal_sender
+                                                    .complete(Err(EmbeddedDispatchError::completion_closed()));
+                                            }
+                                        }
+                                        _ => {
+                                            let _ = terminal_sender
+                                                .complete(Err(EmbeddedDispatchError::completion_closed()));
+                                        }
+                                    }
+                                } else {
+                                    self.admit_embedded(
+                                        &session,
+                                        builder,
+                                        ordering,
+                                        retained_bytes,
+                                        original,
+                                        request_started,
+                                        terminal_sender,
+                                        false,
+                                    )
+                                    .await;
+                                    admitted_session = Some(session);
+                                }
+                            }
+                            Err(error) => {
+                                let _ =
+                                    terminal_sender.complete(Err(EmbeddedDispatchError::request_construction(error)));
+                            }
+                        }
                     }
                     Err(error) => {
                         let _ = terminal_sender.complete(Err(EmbeddedDispatchError::runtime(error)));
@@ -191,14 +297,36 @@ where
             }
         }
 
-        let result = terminal_receiver.receive().await;
-        if let Some(session) = admitted_session {
+        let initial_result = terminal_receiver.receive().await;
+        let result = match initial_result {
+            Ok(EmbeddedDispatchOutcome::Deferred { .. }) if wait_for_deferred_response => {
+                match deferred_receiver.take() {
+                    Some(receiver) => receiver
+                        .receive()
+                        .await
+                        .map(EmbeddedDispatchOutcome::Reply)
+                        .map_err(EmbeddedDispatchError::response),
+                    None => Err(EmbeddedDispatchError::completion_closed()),
+                }
+            }
+            result => result,
+        };
+        if let Some(lifecycle) = deferred_lifecycle.as_mut() {
+            lifecycle.close();
+        }
+        let session = deferred_lifecycle
+            .as_ref()
+            .map(EmbeddedDeferredLifecycle::session)
+            .or(admitted_session.as_ref());
+        if let Some(session) = session {
+            session.begin_close();
             let drain_budget = deadline.map_or(Duration::from_secs(3), RequestDeadline::remaining);
             session
                 .drain_until(ShutdownDeadline::after(drain_budget))
                 .await
                 .log_if_unhealthy();
         }
+        drop(deferred_lifecycle);
         drop(session_record);
         result
     }
@@ -212,6 +340,7 @@ where
         original: OriginalRequestIdentity,
         request_started: Instant,
         terminal_sender: EmbeddedTerminalSender,
+        commit_deferred: bool,
     ) {
         let admitted_core = Arc::clone(&self.core);
         let rejected_core = Arc::clone(&self.core);
@@ -227,7 +356,15 @@ where
             ordering,
             move |_operation| async move {
                 let mut processor = admitted_core.clone_explicit_processor();
-                let result = execute_admitted(&admitted_core, &mut processor, builder, original, request_started).await;
+                let result = execute_admitted(
+                    &admitted_core,
+                    &mut processor,
+                    builder,
+                    original,
+                    request_started,
+                    commit_deferred,
+                )
+                .await;
                 if admitted_terminal.complete(result).is_err() {
                     admitted_core.report_failure_category("completion_closed");
                 }
@@ -291,6 +428,48 @@ where
     }
 }
 
+struct EmbeddedDeferredLifecycle {
+    session: AuthorizedDispatchSession,
+    session_record: EmbeddedSessionRecord,
+    cleanup: DeferredSessionCleanupOwner,
+    active: bool,
+}
+
+impl EmbeddedDeferredLifecycle {
+    fn new(
+        session: AuthorizedDispatchSession,
+        session_record: EmbeddedSessionRecord,
+        cleanup: DeferredSessionCleanupOwner,
+    ) -> Self {
+        Self {
+            session,
+            session_record,
+            cleanup,
+            active: true,
+        }
+    }
+
+    const fn session(&self) -> &AuthorizedDispatchSession {
+        &self.session
+    }
+
+    fn close(&mut self) {
+        if !self.active {
+            return;
+        }
+        let _ = self.cleanup.close();
+        self.session_record.close();
+        self.session.begin_close();
+        self.active = false;
+    }
+}
+
+impl Drop for EmbeddedDeferredLifecycle {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
 fn capture_identity(command: &RemotingCommand) -> Result<(u64, OriginalRequestIdentity), EmbeddedDispatchError> {
     let session_id = crate::dispatch::reserve_session_owner().ok_or_else(EmbeddedDispatchError::identity_exhausted)?;
     let sequence = AtomicU64::new(1);
@@ -305,6 +484,7 @@ async fn execute_admitted<P>(
     builder: RemotingRequestBuilder,
     original: OriginalRequestIdentity,
     request_started: Instant,
+    commit_deferred: bool,
 ) -> TerminalResult
 where
     P: RequestProcessorV2 + Clone + Sync + 'static,
@@ -356,6 +536,7 @@ where
         request_started,
         outcome,
         observe_write,
+        commit_deferred,
     )
     .await
 }
@@ -396,6 +577,7 @@ where
         request_started,
         outcome,
         candidate.observe_write,
+        false,
     )
     .await
 }
@@ -426,6 +608,7 @@ where
         request_started,
         outcome,
         candidate.observe_write,
+        false,
     )
     .await
 }
@@ -437,6 +620,7 @@ async fn finish_resolved<P>(
     request_started: Instant,
     outcome: EmbeddedResolvedOutcome,
     observe_write: bool,
+    commit_deferred: bool,
 ) -> TerminalResult
 where
     P: RequestProcessorV2 + Clone + Sync + 'static,
@@ -445,9 +629,13 @@ where
         EmbeddedResolvedOutcome::OneWay => Ok(EmbeddedDispatchOutcome::OneWay {
             request_id: original.request_id(),
         }),
-        EmbeddedResolvedOutcome::Deferred(registration) => Ok(EmbeddedDispatchOutcome::Deferred {
-            request_id: registration.request_id(),
-        }),
+        EmbeddedResolvedOutcome::Deferred(registration) => {
+            let request_id = registration.request_id();
+            if commit_deferred {
+                registration.commit().map_err(EmbeddedDispatchError::deferred_commit)?;
+            }
+            Ok(EmbeddedDispatchOutcome::Deferred { request_id })
+        }
         EmbeddedResolvedOutcome::NoReply(marker) => Ok(EmbeddedDispatchOutcome::NoReply {
             request_id: marker.request_id(),
             reason: marker.reason(),

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded_v2/tests.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded_v2/tests.rs
@@ -57,6 +57,8 @@ mod lifecycle;
 mod ownership;
 #[path = "tests/policy.rs"]
 mod policy;
+#[path = "tests/terminal_wait.rs"]
+mod terminal_wait;
 use policy::DenyPolicy;
 
 #[derive(Clone, Copy)]

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded_v2/tests/lifecycle.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded_v2/tests/lifecycle.rs
@@ -80,6 +80,7 @@ async fn admitted_non_oneway_deadline_response_is_observed_without_terminal_fail
         builder,
         original,
         request_started,
+        false,
     )
     .await
     .expect_err("expired local handoff must preserve the deadline stop");

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded_v2/tests/terminal_wait.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded_v2/tests/terminal_wait.rs
@@ -1,0 +1,322 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use crate::dispatch::DeferredAdmission;
+use crate::dispatch::DeferredId;
+use crate::dispatch::DeferredParts;
+use crate::dispatch::DeferredRegistry;
+use crate::dispatch::DeferredRequest;
+use crate::dispatch::DeferredResumeRetainedSize;
+use crate::dispatch::DeferredRetainedSizeParts;
+use crate::dispatch::DeferredWaitLimits;
+use crate::dispatch::DeferredWakeReason;
+use crate::telemetry::TransportTelemetry;
+
+#[derive(Clone)]
+struct TerminalDeferredProcessor {
+    registry: DeferredRegistry<()>,
+    admission: DeferredAdmission,
+    registered: Arc<Mutex<Option<DeferredId>>>,
+    registered_notify: Arc<tokio::sync::Notify>,
+    commit_checkpoint: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
+}
+
+impl TerminalDeferredProcessor {
+    fn new(registry: DeferredRegistry<()>, admission: DeferredAdmission) -> Self {
+        Self {
+            registry,
+            admission,
+            registered: Arc::new(Mutex::new(None)),
+            registered_notify: Arc::new(tokio::sync::Notify::new()),
+            commit_checkpoint: None,
+        }
+    }
+
+    fn with_commit_checkpoint(mut self, checkpoint: impl Fn() + Send + Sync + 'static) -> Self {
+        self.commit_checkpoint = Some(Arc::new(checkpoint));
+        self
+    }
+
+    async fn registered_id(&self) -> DeferredId {
+        loop {
+            let notified = self.registered_notify.notified();
+            if let Some(id) = *self.registered.lock().expect("registered id lock") {
+                return id;
+            }
+            notified.await;
+        }
+    }
+}
+
+impl RequestProcessorV2 for TerminalDeferredProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let responder = request
+            .take_deferred_responder()
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let retained = DeferredRegistry::<()>::try_retained_size(DeferredRetainedSizeParts::new(0))
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let permit = self
+            .admission
+            .try_reserve(retained)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let mut registration = self
+            .registry
+            .register(DeferredRequest::new((), DeferredParts::new(responder, permit)))
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        if let Some(checkpoint) = self.commit_checkpoint.clone() {
+            registration.set_commit_checkpoint(move || checkpoint());
+        }
+        *self.registered.lock().expect("registered id lock") = Some(registration.deferred_id());
+        self.registered_notify.notify_waiters();
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+}
+
+fn deferred_fixture(
+    name: &'static str,
+) -> (
+    EmbeddedFixture,
+    Arc<AdmissionController>,
+    DeferredAdmission,
+    DeferredRegistry<()>,
+) {
+    let fixture = EmbeddedFixture::new(name);
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let admission = DeferredAdmission::try_configure(controller.as_ref(), DeferredWaitLimits::new(8, 1024 * 1024))
+        .expect("embedded deferred admission");
+    (fixture, controller, admission, DeferredRegistry::new())
+}
+
+fn dispatcher(
+    processor: TerminalDeferredProcessor,
+    controller: Arc<AdmissionController>,
+    telemetry: TransportTelemetry,
+) -> AuthorizedCommandDispatcherV2<TerminalDeferredProcessor> {
+    AuthorizedCommandDispatcherV2::new_with_telemetry(
+        processor,
+        Vec::new(),
+        Arc::new(TransportSecurity::secure_enforced(Some(Arc::new(AllowPolicy)), None)),
+        controller,
+        telemetry,
+    )
+}
+
+fn assert_released(
+    fixture: &EmbeddedFixture,
+    controller: &AdmissionController,
+    admission: &DeferredAdmission,
+    registry: &DeferredRegistry<()>,
+) {
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
+    let deferred = admission.snapshot();
+    assert_eq!(deferred.waiting_count(), 0);
+    assert_eq!(deferred.retained_bytes(), 0);
+    let resources = controller.snapshot();
+    assert_eq!(resources.queued.current_count, 0);
+    assert_eq!(resources.inflight.current_count, 0);
+    assert_eq!(resources.processors.current_count, 0);
+    assert_eq!(fixture.task_group.task_count(), 0);
+}
+
+async fn wait_until_active(registry: &DeferredRegistry<()>, id: DeferredId) {
+    for _ in 0..128 {
+        if registry.test_is_active(id) {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("deferred registration did not become active");
+}
+
+async fn wait_until_execution_released(controller: &AdmissionController) {
+    for _ in 0..128 {
+        let resources = controller.snapshot();
+        if resources.queued.current_count == 0
+            && resources.inflight.current_count == 0
+            && resources.processors.current_count == 0
+        {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("embedded processor execution permits did not release");
+}
+
+async fn wait_until_released(registry: &DeferredRegistry<()>, fixture: &EmbeddedFixture) {
+    for _ in 0..128 {
+        if registry.test_index_counts() == (0, 0, 0) && fixture.task_group.task_count() == 0 {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("embedded deferred resources did not drain");
+}
+
+#[tokio::test]
+async fn terminal_wait_commits_resumes_and_returns_the_final_plan_with_composition_telemetry() {
+    let (fixture, controller, admission, registry) = deferred_fixture("embedded-v2-terminal-arrival");
+    let processor = TerminalDeferredProcessor::new(registry.clone(), admission.clone());
+    let observer = processor.clone();
+    let (telemetry, deferred_state_constructions) = TransportTelemetry::with_deferred_state_construction_capture();
+    let dispatcher = Arc::new(dispatcher(processor, Arc::clone(&controller), telemetry));
+    let task_group = fixture.task_group.clone();
+    let dispatch = tokio::spawn({
+        let dispatcher = Arc::clone(&dispatcher);
+        async move {
+            dispatcher
+                .dispatch_embedded_v2_wait_response(&task_group, Principal::new("broker-proxy"), None, request(false).0)
+                .await
+        }
+    });
+
+    let id = observer.registered_id().await;
+    wait_until_active(&registry, id).await;
+    wait_until_execution_released(controller.as_ref()).await;
+    let resources = controller.snapshot();
+    assert_eq!(resources.queued.current_count, 0);
+    assert_eq!(resources.inflight.current_count, 0);
+    assert_eq!(resources.processors.current_count, 0);
+    let claim = registry
+        .claim(id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("claim committed embedded wait");
+    claim
+        .resume(DeferredResumeRetainedSize::new(0), |(), reason| async move {
+            assert_eq!(reason, DeferredWakeReason::MessageArrived);
+            ResponsePlan::bytes(
+                RemotingCommand::create_response_command_with_code(0),
+                Bytes::from_static(b"embedded-terminal-response"),
+            )
+            .map_err(|error| RocketMQError::response_process_failed("terminal_wait_test", error.to_string()))
+        })
+        .await
+        .expect("resume final embedded response");
+    let outcome = dispatch
+        .await
+        .expect("terminal dispatch join")
+        .expect("terminal embedded response");
+    let EmbeddedDispatchOutcome::Reply(plan) = outcome else {
+        panic!("terminal wait must return the final response plan")
+    };
+    assert_eq!(plan.test_head().opaque(), 811);
+    let ResponseBody::Bytes(body) = plan.test_body() else {
+        panic!("terminal response must retain its contiguous body")
+    };
+    assert_eq!(body.as_ref(), b"embedded-terminal-response");
+    assert_eq!(deferred_state_constructions.load(Ordering::SeqCst), 1);
+    assert_released(&fixture, controller.as_ref(), &admission, &registry);
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn terminal_wait_deadline_closes_the_committed_registry_entry_and_releases_all_resources() {
+    let (fixture, controller, admission, registry) = deferred_fixture("embedded-v2-terminal-deadline");
+    let processor = TerminalDeferredProcessor::new(registry.clone(), admission.clone());
+    let observer = processor.clone();
+    let dispatcher = Arc::new(dispatcher(
+        processor,
+        Arc::clone(&controller),
+        TransportTelemetry::noop(),
+    ));
+    let task_group = fixture.task_group.clone();
+    let dispatch = tokio::spawn({
+        let dispatcher = Arc::clone(&dispatcher);
+        async move {
+            dispatcher
+                .dispatch_embedded_v2_wait_response(
+                    &task_group,
+                    Principal::new("broker-proxy"),
+                    Some(RequestDeadline::after(Duration::from_millis(25))),
+                    request(false).0,
+                )
+                .await
+        }
+    });
+
+    let id = observer.registered_id().await;
+    wait_until_active(&registry, id).await;
+    let error = dispatch
+        .await
+        .expect("terminal deadline join")
+        .expect_err("terminal deadline must stop the embedded wait");
+    assert_eq!(error.kind(), EmbeddedDispatchErrorKind::DeadlineExceeded);
+    assert_released(&fixture, controller.as_ref(), &admission, &registry);
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn dropping_terminal_wait_closes_the_embedded_session_and_registry_without_leaks() {
+    let (fixture, controller, admission, registry) = deferred_fixture("embedded-v2-terminal-drop");
+    let processor = TerminalDeferredProcessor::new(registry.clone(), admission.clone());
+    let observer = processor.clone();
+    let dispatcher = Arc::new(dispatcher(
+        processor,
+        Arc::clone(&controller),
+        TransportTelemetry::noop(),
+    ));
+    let task_group = fixture.task_group.clone();
+    let dispatch = tokio::spawn({
+        let dispatcher = Arc::clone(&dispatcher);
+        async move {
+            dispatcher
+                .dispatch_embedded_v2_wait_response(&task_group, Principal::new("broker-proxy"), None, request(false).0)
+                .await
+        }
+    });
+
+    let id = observer.registered_id().await;
+    wait_until_active(&registry, id).await;
+    tokio::task::yield_now().await;
+    dispatch.abort();
+    assert!(dispatch
+        .await
+        .expect_err("terminal wait must be aborted")
+        .is_cancelled());
+    wait_until_released(&registry, &fixture).await;
+    assert_released(&fixture, controller.as_ref(), &admission, &registry);
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn parent_cancel_during_commit_fails_closed_and_rolls_back_every_owner() {
+    let (fixture, controller, admission, registry) = deferred_fixture("embedded-v2-terminal-commit-cancel");
+    let cancel_group = fixture.task_group.clone();
+    let processor = TerminalDeferredProcessor::new(registry.clone(), admission.clone())
+        .with_commit_checkpoint(move || cancel_group.cancel());
+    let observer = processor.clone();
+    let dispatcher = Arc::new(dispatcher(
+        processor,
+        Arc::clone(&controller),
+        TransportTelemetry::noop(),
+    ));
+
+    let error = dispatcher
+        .dispatch_embedded_v2_wait_response(
+            &fixture.task_group,
+            Principal::new("broker-proxy"),
+            None,
+            request(false).0,
+        )
+        .await
+        .expect_err("cancellation at commit must fail closed");
+    assert!(matches!(
+        error.kind(),
+        EmbeddedDispatchErrorKind::Cancelled | EmbeddedDispatchErrorKind::DeferredCommit
+    ));
+    let _ = observer.registered_id().await;
+    assert_released(&fixture, controller.as_ref(), &admission, &registry);
+    fixture.shutdown().await;
+}

--- a/rocketmq-transport/src/dispatch/deferred_registry.rs
+++ b/rocketmq-transport/src/dispatch/deferred_registry.rs
@@ -838,6 +838,11 @@ where
     }
 
     #[cfg(test)]
+    pub(crate) fn test_is_active(&self, id: DeferredId) -> bool {
+        self.inner.is_active(id)
+    }
+
+    #[cfg(test)]
     pub(crate) fn test_session_member_count(&self, session_id: SessionId) -> usize {
         self.inner.session_member_count(session_id)
     }
@@ -932,7 +937,7 @@ impl DeferredRegistration {
     }
 
     #[cfg(test)]
-    fn set_commit_checkpoint(&mut self, checkpoint: impl FnOnce() + Send + 'static) {
+    pub(crate) fn set_commit_checkpoint(&mut self, checkpoint: impl FnOnce() + Send + 'static) {
         self.owner
             .as_mut()
             .expect("active registration owns its transaction")

--- a/rocketmq-transport/src/dispatch/deferred_registry/internal.rs
+++ b/rocketmq-transport/src/dispatch/deferred_registry/internal.rs
@@ -824,6 +824,15 @@ where
     }
 
     #[cfg(test)]
+    pub(super) fn is_active(&self, id: DeferredId) -> bool {
+        self.state
+            .lock()
+            .primary
+            .get(&id)
+            .is_some_and(|entry| matches!(entry.phase, EntryPhase::Active(_)))
+    }
+
+    #[cfg(test)]
     pub(super) fn claim_marker_count(&self) -> usize {
         self.state.lock().claims.len()
     }

--- a/rocketmq-transport/src/dispatch/embedded_dispatch.rs
+++ b/rocketmq-transport/src/dispatch/embedded_dispatch.rs
@@ -17,6 +17,7 @@ use std::fmt;
 
 use rocketmq_runtime::RuntimeError;
 
+use super::DeferredCommitError;
 use super::HandlerOutcomeContractError;
 use super::ProtocolNoResponseReason;
 use super::RequestId;
@@ -91,6 +92,8 @@ pub enum EmbeddedDispatchErrorKind {
     ResponseBinding,
     /// The processor violated the affine handler-outcome contract.
     HandlerContract,
+    /// Trusted deferred storage could not commit the provisional waiter.
+    DeferredCommit,
     /// A one-way request produced a deferred or no-reply contract.
     OneWayContract,
     /// The caller dropped the sole terminal result receiver.
@@ -190,6 +193,13 @@ impl EmbeddedDispatchError {
         )
     }
 
+    pub(crate) fn deferred_commit(error: DeferredCommitError) -> Self {
+        Self::new(
+            EmbeddedDispatchErrorKind::DeferredCommit,
+            EmbeddedDispatchErrorSource::DeferredCommit(error),
+        )
+    }
+
     pub(crate) fn one_way_contract(outcome: &'static str) -> Self {
         Self::new(
             EmbeddedDispatchErrorKind::OneWayContract,
@@ -252,6 +262,7 @@ enum EmbeddedDispatchErrorSource {
     ResponseConstruction(ResponsePlanError),
     ResponseBinding(ResponseBindingError),
     HandlerContract(HandlerOutcomeContractError),
+    DeferredCommit(DeferredCommitError),
     OneWayContract(OneWayContract),
     CompletionClosed(CompletionClosed),
     Response(ResponseError),
@@ -268,6 +279,7 @@ impl EmbeddedDispatchErrorSource {
             Self::ResponseConstruction(error) => error,
             Self::ResponseBinding(error) => error,
             Self::HandlerContract(error) => error,
+            Self::DeferredCommit(error) => error,
             Self::OneWayContract(error) => error,
             Self::CompletionClosed(error) => error,
             Self::Response(error) => error,

--- a/rocketmq-transport/src/dispatch/response_plan.rs
+++ b/rocketmq-transport/src/dispatch/response_plan.rs
@@ -30,6 +30,9 @@ use crate::file_region::FileRegionSequence;
 
 pub(crate) use binding::BoundResponsePlan;
 pub(crate) use binding::ResponseBindingError;
+pub(crate) use materializer::materialize_embedded_v2_compatibility_response;
+pub use materializer::EmbeddedV2CompatibilityMaterializationError;
+pub use materializer::EmbeddedV2CompatibilityMaterializationErrorKind;
 pub(crate) use materializer::LegacyLocalMaterializationError;
 pub(crate) use materializer::LegacyMaterializationLimits;
 

--- a/rocketmq-transport/src/dispatch/response_plan/materializer.rs
+++ b/rocketmq-transport/src/dispatch/response_plan/materializer.rs
@@ -18,6 +18,9 @@ use std::collections::TryReserveError;
 use std::error::Error;
 use std::fmt;
 use std::io;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 use bytes::Bytes;
 use rocketmq_error::RocketMQError;
@@ -25,16 +28,23 @@ use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::BlockingExecutor;
 use rocketmq_runtime::RuntimeError;
 use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_runtime::TaskGroup;
 
 use super::ResponseBody;
 use crate::codec::remoting_command_codec::FrameLimits;
 use crate::dispatch::LocalResponsePlanReceiver;
 use crate::dispatch::RequestControlView;
+use crate::dispatch::RequestMeta;
 use crate::dispatch::ResponseError;
+use crate::dispatch::ResponsePlan;
 use crate::dispatch::WriteProgress;
 use crate::file_region::FileRegionSequence;
 use crate::file_region_io::read_file_region_chunk;
 use crate::file_region_io::FILE_REGION_READ_CHUNK_BYTES;
+use crate::session_view::EmbeddedSessionRecord;
+
+const EMBEDDED_V2_COMPATIBILITY_MAX_BODY_PARTS: usize = 1_024;
+static EMBEDDED_V2_COMPATIBILITY_SESSION_OWNER: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct LegacyMaterializationLimits {
@@ -99,6 +109,94 @@ enum LegacyLocalMaterializationErrorKind {
     Allocation,
     Runtime,
     FileIo,
+}
+
+/// Stable failure category for the V1-only embedded V2 compatibility bridge.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum EmbeddedV2CompatibilityMaterializationErrorKind {
+    /// The parent request lifecycle was cancelled.
+    Cancelled,
+    /// The compatibility materialization session closed.
+    SessionClosed,
+    /// The original request deadline elapsed.
+    DeadlineExceeded,
+    /// Local response delivery failed.
+    Response,
+    /// The response exceeded the fixed compatibility bounds.
+    Limits,
+    /// The response head and body do not fit the compatibility frame profile.
+    Frame,
+    /// A bounded destination allocation failed.
+    Allocation,
+    /// The injected blocking executor rejected or failed the operation.
+    Runtime,
+    /// Reading a leased file region failed.
+    FileIo,
+}
+
+/// Typed, redacted failure from V1-only materialization of a V2 response plan.
+pub struct EmbeddedV2CompatibilityMaterializationError {
+    kind: EmbeddedV2CompatibilityMaterializationErrorKind,
+    source: LegacyLocalMaterializationError,
+}
+
+impl EmbeddedV2CompatibilityMaterializationError {
+    /// Returns the stable failure category.
+    #[must_use]
+    pub const fn kind(&self) -> EmbeddedV2CompatibilityMaterializationErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for EmbeddedV2CompatibilityMaterializationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EmbeddedV2CompatibilityMaterializationError")
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for EmbeddedV2CompatibilityMaterializationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "embedded V2 compatibility response materialization failed: {:?}",
+            self.kind
+        )
+    }
+}
+
+impl Error for EmbeddedV2CompatibilityMaterializationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl From<LegacyLocalMaterializationError> for EmbeddedV2CompatibilityMaterializationError {
+    fn from(source: LegacyLocalMaterializationError) -> Self {
+        let kind = match source.kind() {
+            LegacyLocalMaterializationErrorKind::Cancelled => {
+                EmbeddedV2CompatibilityMaterializationErrorKind::Cancelled
+            }
+            LegacyLocalMaterializationErrorKind::SessionClosed => {
+                EmbeddedV2CompatibilityMaterializationErrorKind::SessionClosed
+            }
+            LegacyLocalMaterializationErrorKind::DeadlineExceeded => {
+                EmbeddedV2CompatibilityMaterializationErrorKind::DeadlineExceeded
+            }
+            LegacyLocalMaterializationErrorKind::Response => EmbeddedV2CompatibilityMaterializationErrorKind::Response,
+            LegacyLocalMaterializationErrorKind::Limits => EmbeddedV2CompatibilityMaterializationErrorKind::Limits,
+            LegacyLocalMaterializationErrorKind::Frame => EmbeddedV2CompatibilityMaterializationErrorKind::Frame,
+            LegacyLocalMaterializationErrorKind::Allocation => {
+                EmbeddedV2CompatibilityMaterializationErrorKind::Allocation
+            }
+            LegacyLocalMaterializationErrorKind::Runtime => EmbeddedV2CompatibilityMaterializationErrorKind::Runtime,
+            LegacyLocalMaterializationErrorKind::FileIo => EmbeddedV2CompatibilityMaterializationErrorKind::FileIo,
+        };
+        Self { kind, source }
+    }
 }
 
 impl LegacyLocalMaterializationErrorKind {
@@ -235,26 +333,62 @@ impl LocalResponsePlanReceiver {
             .receive()
             .await
             .map_err(LegacyLocalMaterializationError::response)?;
-        ensure_running(&control)?;
+        materialize_plan(plan, control, limits, blocking).await
+    }
+}
 
-        let body_len = plan.body_len();
-        let body_part_count = plan.body_part_count();
-        limits.validate_plan(body_len, body_part_count)?;
+pub(crate) async fn materialize_embedded_v2_compatibility_response(
+    plan: ResponsePlan,
+    deadline: Option<crate::deadline::RequestDeadline>,
+    task_group: &TaskGroup,
+    blocking: &BlockingExecutor,
+) -> Result<RemotingCommand, EmbeddedV2CompatibilityMaterializationError> {
+    let session_owner = EMBEDDED_V2_COMPATIBILITY_SESSION_OWNER
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |owner| owner.checked_add(1))
+        .map_err(|_| {
+            EmbeddedV2CompatibilityMaterializationError::from(LegacyLocalMaterializationError::limits(
+                RocketMQError::invariant_violated("embedded V2 compatibility session identity exhausted"),
+            ))
+        })?;
+    let session = EmbeddedSessionRecord::new(session_owner);
+    let meta = RequestMeta::new(Instant::now(), deadline);
+    let control = RequestControlView::from_meta(&meta, session.view().state().clone(), task_group);
+    let frame_limits = FrameLimits::java_compatibility();
+    let limits = LegacyMaterializationLimits::try_new(
+        frame_limits,
+        frame_limits.max_body_bytes,
+        EMBEDDED_V2_COMPATIBILITY_MAX_BODY_PARTS,
+    )
+    .map_err(EmbeddedV2CompatibilityMaterializationError::from)?;
+    materialize_plan(plan, control, limits, blocking)
+        .await
+        .map_err(EmbeddedV2CompatibilityMaterializationError::from)
+}
 
-        let (head, body, body_len, _) = plan.into_materialization_parts();
-        limits
-            .frame_limits
-            .encode_frame_head(head.clone(), body_len)
-            .map_err(LegacyLocalMaterializationError::frame)?;
-        ensure_running(&control)?;
+async fn materialize_plan(
+    plan: ResponsePlan,
+    control: RequestControlView,
+    limits: LegacyMaterializationLimits,
+    blocking: &BlockingExecutor,
+) -> Result<RemotingCommand, LegacyLocalMaterializationError> {
+    ensure_running(&control)?;
+    let body_len = plan.body_len();
+    let body_part_count = plan.body_part_count();
+    limits.validate_plan(body_len, body_part_count)?;
 
-        match body {
-            ResponseBody::Empty => Ok(head),
-            ResponseBody::Bytes(body) => Ok(head.set_body(body)),
-            ResponseBody::Segments(segments) => materialize_segments(head, segments, body_len),
-            ResponseBody::FileRegions(regions) => {
-                materialize_file_regions(head, regions, body_len, control, blocking).await
-            }
+    let (head, body, body_len, _) = plan.into_materialization_parts();
+    limits
+        .frame_limits
+        .encode_frame_head(head.clone(), body_len)
+        .map_err(LegacyLocalMaterializationError::frame)?;
+    ensure_running(&control)?;
+
+    match body {
+        ResponseBody::Empty => Ok(head),
+        ResponseBody::Bytes(body) => Ok(head.set_body(body)),
+        ResponseBody::Segments(segments) => materialize_segments(head, segments, body_len),
+        ResponseBody::FileRegions(regions) => {
+            materialize_file_regions(head, regions, body_len, control, blocking).await
         }
     }
 }

--- a/rocketmq-transport/src/dispatch/response_plan/materializer/materializer_tests.rs
+++ b/rocketmq-transport/src/dispatch/response_plan/materializer/materializer_tests.rs
@@ -272,6 +272,60 @@ async fn empty_bytes_single_segment_and_multi_segment_follow_their_copy_contract
 }
 
 #[tokio::test]
+async fn embedded_v2_v1_compatibility_seam_reuses_bounded_segments_and_file_region_materialization() {
+    let (harness, _) = ControlHarness::new("embedded-v2-compatibility-materializer", None);
+    let segments = ResponsePlan::segments(
+        response_head(74, 9_852),
+        vec![Bytes::from_static(b"v2-"), Bytes::from_static(b"compatibility")],
+    )
+    .expect("segments plan");
+    let segments = materialize_embedded_v2_compatibility_response(segments, None, &harness.parent, harness.blocking())
+        .await
+        .expect("segments materialize through V1-only seam");
+    assert_eq!(segments.opaque(), 9_852);
+    assert_eq!(segments.body().expect("segments body").as_ref(), b"v2-compatibility");
+
+    let (regions, lease, accesses, drops) = counting_region(b"leased-file-region");
+    let file = ResponsePlan::file_regions(response_head(75, 9_853), regions).expect("file plan");
+    let file = materialize_embedded_v2_compatibility_response(file, None, &harness.parent, harness.blocking())
+        .await
+        .expect("file regions materialize on the injected blocking lane");
+    assert_eq!(file.opaque(), 9_853);
+    assert_eq!(file.body().expect("file body").as_ref(), b"leased-file-region");
+    assert!(accesses.load(Ordering::SeqCst) > 1);
+    drop(file);
+    drop(lease);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn embedded_v2_v1_compatibility_seam_preserves_the_absolute_deadline_and_typed_error() {
+    let (harness, _) = ControlHarness::new("embedded-v2-compatibility-deadline", None);
+    let deadline = RequestDeadline::after(Duration::from_secs(1));
+    tokio::time::advance(Duration::from_secs(1)).await;
+
+    let result = materialize_embedded_v2_compatibility_response(
+        ResponsePlan::command(response_head(76, 9_854)).expect("empty plan"),
+        Some(deadline),
+        &harness.parent,
+        harness.blocking(),
+    )
+    .await;
+    let error = match result {
+        Ok(_) => panic!("expired absolute deadline must reject materialization"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error.kind(),
+        EmbeddedV2CompatibilityMaterializationErrorKind::DeadlineExceeded
+    );
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
 async fn cached_body_and_part_limits_are_exact_and_reject_one_over_before_encoding_or_file_access() {
     let (harness, control) = ControlHarness::new("legacy-materializer-cached-limits", None);
 

--- a/rocketmq-transport/src/dispatch/response_sink.rs
+++ b/rocketmq-transport/src/dispatch/response_sink.rs
@@ -268,6 +268,46 @@ impl ResponseSink {
         )
     }
 
+    /// Builds the deferred responder seed for a canonical embedded local-plan
+    /// owner. The lifecycle proof prevents a sink, session view, and task group
+    /// from unrelated dispatches being combined.
+    pub(crate) fn local_deferred_seed_with_resume(
+        &self,
+        telemetry: crate::telemetry::TransportTelemetry,
+        session: &crate::session_view::SessionView,
+        task_group: &TaskGroup,
+        ordering: crate::request_ordering::RequestOrdering,
+        class: crate::admission::AdmissionClass,
+        executor: crate::session_executor::DeferredResumeExecutor,
+    ) -> Option<DeferredResponseSeed> {
+        if !matches!(session, crate::session_view::SessionView::Embedded { .. })
+            || !self.is_local_plan_owner(session.state(), task_group)
+        {
+            return None;
+        }
+        Some(
+            DeferredResponseSeed::new(
+                self.clone(),
+                telemetry,
+                session.id(),
+                self.local_plan_control()?.clone(),
+            )
+            .with_resume_context(ordering, class, executor),
+        )
+    }
+
+    fn local_plan_control(&self) -> Option<&crate::dispatch::RequestControlView> {
+        match self {
+            Self::Local(LocalResponseSink {
+                mode: LocalResponseMode::Plan(state),
+            }) => Some(state.control()),
+            Self::Network(_)
+            | Self::Local(LocalResponseSink {
+                mode: LocalResponseMode::Legacy(_),
+            }) => None,
+        }
+    }
+
     #[allow(
         dead_code,
         reason = "DSP-05 bridge provenance remains dormant until DSP-06 coexistence routing"

--- a/rocketmq-transport/src/public_api.rs
+++ b/rocketmq-transport/src/public_api.rs
@@ -69,6 +69,8 @@ pub use crate::dispatch::AuthorizedCommandDispatcher;
 pub use crate::dispatch::AuthorizedDispatchBoundary;
 pub use crate::dispatch::DispatchError;
 pub use crate::dispatch::DispatchOutcome;
+pub use crate::dispatch::EmbeddedV2CompatibilityMaterializationError;
+pub use crate::dispatch::EmbeddedV2CompatibilityMaterializationErrorKind;
 pub use crate::dispatch::LocalResponseReceiver;
 pub use crate::dispatch::RequestContext;
 pub use crate::dispatch::RequestContextError;
@@ -141,6 +143,28 @@ pub use crate::tls::PrivateKeyLoader;
 pub use crate::tls::TlsServerRuntime;
 pub use rocketmq_protocol::protocol::RemotingDeserializable;
 pub use rocketmq_protocol::protocol::RemotingSerializable;
+
+/// Materializes one V2 response plan for a frozen V1 embedded compatibility
+/// consumer without exposing V2 response storage.
+///
+/// The conversion uses the Java-compatible 16 MiB body envelope, at most 1024
+/// body parts, the supplied absolute deadline and parent task lifecycle, and
+/// the injected blocking lane for leased file regions. This function is
+/// intentionally exported only from [`crate::api::v1`].
+///
+/// # Errors
+///
+/// Returns a typed, redacted error when the lifecycle stops, the fixed limits
+/// are exceeded, a destination allocation fails, or file-region I/O fails.
+pub async fn materialize_embedded_v2_compatibility_response(
+    plan: crate::api::v2::ResponsePlan,
+    deadline: Option<RequestDeadline>,
+    task_group: &rocketmq_runtime::TaskGroup,
+    blocking: &rocketmq_runtime::BlockingExecutor,
+) -> Result<rocketmq_protocol::protocol::remoting_command::RemotingCommand, EmbeddedV2CompatibilityMaterializationError>
+{
+    crate::dispatch::materialize_embedded_v2_compatibility_response(plan, deadline, task_group, blocking).await
+}
 
 pub use crate::error_response::apply_error_to_response;
 pub use crate::error_response::command_from_error;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9852

### Brief Description

- Migrates the Broker admin aggregate and all 27 nested handlers to the V2 request contract while preserving the frozen V1 compatibility entry point.
- Replaces remoting context downcasts in Broker and NameServer authorization with trusted typed request, session, origin, and principal views; unconfigured Broker ACL remains fail-closed and uses the immutable original request code.
- Routes the raw local Proxy backend through the embedded Broker V2 terminal dispatcher without synthetic network channels, while keeping the real outer Proxy channel for heartbeat and server push compatibility.
- Adds the V1-only bounded response-plan materializer, terminal deferred lifecycle ownership, production telemetry wiring, and regression coverage for concurrency, cancellation, deadline, original identity, and resource cleanup.

### How Did You Test This Change?

- Package-scoped `cargo fmt -- --check` for all affected root-workspace packages: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- Focused Auth, NameServer, Broker admin/ACL/maintenance/send, Proxy, Proxy Local, Transport terminal-wait, materializer, and production-chain tests: passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `.\scripts\check-error-hygiene.ps1`: no new findings; the same 85 pre-existing findings reproduce on `main`.
- `fuzz`: `cargo +nightly-2026-07-05 check --locked --all-targets --all-features`: passed.
- `rocketmq-example`: Clippy passed; the aggregate cargo-fmt command hit Windows error 206, and all 22 Cargo targets passed equivalent per-target `rustfmt --check` validation.
- `rocketmq-tools/rocketmq-mcp`: check, read-only boundary, default tests (117 passed), all-feature tests (141 passed), Clippy, and docs passed; all 4 Cargo targets passed equivalent per-target formatting after the aggregate command hit Windows error 206.
- Sol xhigh final review: APPROVE with P0/P1/P2/P3 all zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Broker V2 request processing across broker, proxy, and embedded execution paths.
  - Added support for deferred responses, including waiting for final results and V1-compatible response conversion.
  - Added trusted network and embedded request context validation.
  - Added administrative request handling through the V2 pipeline.

- **Bug Fixes**
  - Authorization now fails closed when request identity or origin metadata is missing or inconsistent.
  - Preserved the original operation code, preventing request mutations from bypassing authorization or routing.
  - Improved timeout, cancellation, and deferred-resource cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->