### PR TITLE
[ISSUE #9851]🚀Cut over Broker aggregate and deferred routes to V2

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::sync::OnceLock;
 use std::sync::Weak;
 use std::time::Duration;
 use std::time::Instant;
@@ -78,10 +79,10 @@ use rocketmq_store::StorePorts;
 #[cfg(all(test, feature = "rocksdb_store"))]
 use rocketmq_store::StoreType;
 use rocketmq_store::TimerMessageStore;
-use rocketmq_transport::api::v1::ChannelEventListener;
 use rocketmq_transport::api::v1::ServerConfig;
 use rocketmq_transport::api::v1::TransportClientConfig;
-use rocketmq_transport::api::v1::TransportServer;
+use rocketmq_transport::api::v2::TransportServerV2;
+use rocketmq_transport::api::v2::V2SessionRegistry;
 use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 use tracing::error;
@@ -290,9 +291,12 @@ type DefaultServerProcessor =
 type FasterServerProcessor =
     BrokerRequestProcessor<BrokerMessageStore, DefaultTransactionalMessageService<BrokerMessageStore>>;
 
-type DefaultServerProcessorV2 = BrokerRequestProcessorV2<
+pub(crate) type DefaultServerProcessorV2 = BrokerRequestProcessorV2<
     BrokerProcessorTypeV2<BrokerMessageStore, DefaultTransactionalMessageService<BrokerMessageStore>>,
 >;
+
+pub(crate) type DefaultBrokerDispatcherV2 =
+    rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2<DefaultServerProcessorV2>;
 
 type BrokerScheduledTasks = ScheduledTaskManager;
 

--- a/rocketmq-broker/src/broker_runtime/composition.rs
+++ b/rocketmq-broker/src/broker_runtime/composition.rs
@@ -41,12 +41,13 @@ impl BrokerComposition {
         state: Box<BrokerRuntimeState<BrokerMessageStore>>,
         escape_bridge_owner: Arc<EscapeBridge<BrokerMessageStore>>,
         consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static>,
+        v2_session_registry: Arc<V2SessionRegistry>,
         configuration_error: Option<String>,
         #[cfg(feature = "rocksdb_store")] rocksdb_config_managers: Option<BrokerRocksDbConfigManagers>,
     ) -> Self {
         Self {
             state,
-            request_pipeline: BrokerRequestPipeline::new(consumer_ids_change_listener),
+            request_pipeline: BrokerRequestPipeline::new(consumer_ids_change_listener, v2_session_registry),
             data_plane: BrokerDataPlane::new(escape_bridge_owner),
             control_plane: BrokerControlPlane::new(),
             metadata: BrokerMetadata::new(
@@ -1464,12 +1465,18 @@ impl BrokerRuntime {
                 .clone()
                 .expect("BrokerRuntime always owns an injected service context"),
         )));
-        state.client_housekeeping_service = Some(Arc::new(ClientHousekeepingService::new(
+        let client_housekeeping_service = Arc::new(ClientHousekeepingService::new(
             state.producer_manager.connection_housekeeping(),
             state.consumer_manager.connection_housekeeping(),
             stats_manager,
             state.broker_service_context(),
-        )));
+        ));
+        let v2_session_lifecycle_listener: Arc<dyn rocketmq_transport::api::v2::V2SessionLifecycleListener> =
+            client_housekeeping_service.clone();
+        let v2_session_registry = Arc::new(V2SessionRegistry::with_lifecycle_listener(
+            v2_session_lifecycle_listener,
+        ));
+        state.client_housekeeping_service = Some(client_housekeeping_service);
         state.slave_synchronize = Some(Arc::new(SlaveSynchronize::new_with_master_addr(
             SlaveSynchronizeContext::new(
                 SlaveSynchronizePolicy::from_config(state.get_broker_addr().clone(), &state.message_store_config()),
@@ -1498,6 +1505,7 @@ impl BrokerRuntime {
                 state,
                 escape_bridge,
                 consumer_ids_change_listener,
+                v2_session_registry,
                 None,
                 #[cfg(feature = "rocksdb_store")]
                 rocksdb_config_managers,

--- a/rocketmq-broker/src/broker_runtime/request_pipeline.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline.rs
@@ -22,8 +22,8 @@ pub(super) struct BrokerRequestPipeline {
     pub(super) proxy_request_processor: Option<DefaultServerProcessor>,
     pub(super) authorized_dispatcher:
         Option<Arc<rocketmq_transport::api::v1::AuthorizedCommandDispatcher<DefaultServerProcessor>>>,
-    pub(super) prepared_v2_dispatcher:
-        Option<Arc<rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2<DefaultServerProcessorV2>>>,
+    canonical_v2_dispatcher: CanonicalV2DispatcherSlot<DefaultBrokerDispatcherV2>,
+    v2_session_registry: Arc<V2SessionRegistry>,
     pub(super) auth_runtime: Option<Arc<AuthRuntime>>,
     pub(super) maintenance_authorizer: Option<Arc<MaintenanceAuthorizer>>,
     pub(super) auth_admin_service: Option<Arc<AuthAdminService>>,
@@ -31,17 +31,89 @@ pub(super) struct BrokerRequestPipeline {
     pub(super) processor_wiring_complete: bool,
     #[cfg(test)]
     pub(super) pull_message_processor_for_test: Option<Arc<PullMessageProcessor<BrokerMessageStore>>>,
+    #[cfg(test)]
+    v2_pre_publish_checkpoint: Option<BrokerV2PrePublishCheckpoint>,
+    #[cfg(test)]
+    v2_dispatcher_identity_snapshot: Option<BrokerV2DispatcherIdentitySnapshot>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum CanonicalV2DispatcherPublishError {
+    AlreadyPublished,
+}
+
+struct CanonicalV2DispatcherSlot<T> {
+    value: OnceLock<Arc<T>>,
+}
+
+impl<T> CanonicalV2DispatcherSlot<T> {
+    const fn new() -> Self {
+        Self { value: OnceLock::new() }
+    }
+
+    fn publish(&self, value: Arc<T>) -> Result<(), CanonicalV2DispatcherPublishError> {
+        self.value
+            .set(value)
+            .map_err(|_| CanonicalV2DispatcherPublishError::AlreadyPublished)
+    }
+
+    fn get(&self) -> Option<Arc<T>> {
+        self.value.get().cloned()
+    }
+}
+
+#[cfg(test)]
+mod canonical_v2_dispatcher_slot_tests {
+    use super::*;
+
+    #[test]
+    fn publish_is_single_assignment_and_rejects_replacement() {
+        let slot = CanonicalV2DispatcherSlot::new();
+        let first = Arc::new(1_u8);
+        let replacement = Arc::new(2_u8);
+
+        assert_eq!(slot.publish(Arc::clone(&first)), Ok(()));
+        assert!(Arc::ptr_eq(&slot.get().expect("published dispatcher"), &first));
+        assert_eq!(
+            slot.publish(replacement),
+            Err(CanonicalV2DispatcherPublishError::AlreadyPublished)
+        );
+        assert!(Arc::ptr_eq(&slot.get().expect("original dispatcher remains"), &first));
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct BrokerV2DispatcherIdentitySnapshot {
+    pub(crate) normal_is_canonical: bool,
+    pub(crate) fast_is_canonical: bool,
+    pub(crate) embedded_proxy_is_canonical: bool,
+}
+
+#[cfg(test)]
+pub(crate) struct BrokerV2PrePublishSnapshot {
+    pub(crate) dispatcher: Arc<DefaultBrokerDispatcherV2>,
+    pub(crate) pop_lite_processor: Arc<PopLiteMessageProcessor<BrokerMessageStore>>,
+    pub(crate) handoff: Arc<crate::deferred_generation_handoff::DeferredGenerationHandoff>,
+}
+
+#[cfg(test)]
+struct BrokerV2PrePublishCheckpoint {
+    reached: oneshot::Sender<BrokerV2PrePublishSnapshot>,
+    release: oneshot::Receiver<()>,
 }
 
 impl BrokerRequestPipeline {
     pub(super) fn new(
         consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static>,
+        v2_session_registry: Arc<V2SessionRegistry>,
     ) -> Self {
         Self {
             admission_controller: None,
             proxy_request_processor: None,
             authorized_dispatcher: None,
-            prepared_v2_dispatcher: None,
+            canonical_v2_dispatcher: CanonicalV2DispatcherSlot::new(),
+            v2_session_registry,
             auth_runtime: None,
             maintenance_authorizer: None,
             auth_admin_service: None,
@@ -49,7 +121,58 @@ impl BrokerRequestPipeline {
             processor_wiring_complete: false,
             #[cfg(test)]
             pull_message_processor_for_test: None,
+            #[cfg(test)]
+            v2_pre_publish_checkpoint: None,
+            #[cfg(test)]
+            v2_dispatcher_identity_snapshot: None,
         }
+    }
+
+    pub(super) fn publish_canonical_v2_dispatcher(
+        &self,
+        dispatcher: Arc<DefaultBrokerDispatcherV2>,
+    ) -> Result<(), CanonicalV2DispatcherPublishError> {
+        self.canonical_v2_dispatcher.publish(dispatcher)
+    }
+
+    pub(super) fn canonical_v2_dispatcher(&self) -> Option<Arc<DefaultBrokerDispatcherV2>> {
+        self.canonical_v2_dispatcher.get()
+    }
+
+    pub(super) fn v2_session_registry(&self) -> Arc<V2SessionRegistry> {
+        Arc::clone(&self.v2_session_registry)
+    }
+
+    #[cfg(test)]
+    pub(super) async fn reach_v2_pre_publish_checkpoint(
+        &mut self,
+        dispatcher: Arc<DefaultBrokerDispatcherV2>,
+        pop_lite_processor: Arc<PopLiteMessageProcessor<BrokerMessageStore>>,
+        handoff: Arc<crate::deferred_generation_handoff::DeferredGenerationHandoff>,
+    ) {
+        if let Some(checkpoint) = self.v2_pre_publish_checkpoint.take() {
+            let _ = checkpoint.reached.send(BrokerV2PrePublishSnapshot {
+                dispatcher,
+                pop_lite_processor,
+                handoff,
+            });
+            let _ = checkpoint.release.await;
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn record_v2_dispatcher_identity(
+        &mut self,
+        canonical: &Arc<DefaultBrokerDispatcherV2>,
+        normal: &Arc<DefaultBrokerDispatcherV2>,
+        fast: &Arc<DefaultBrokerDispatcherV2>,
+        embedded_proxy: &Arc<DefaultBrokerDispatcherV2>,
+    ) {
+        self.v2_dispatcher_identity_snapshot = Some(BrokerV2DispatcherIdentitySnapshot {
+            normal_is_canonical: Arc::ptr_eq(canonical, normal),
+            fast_is_canonical: Arc::ptr_eq(canonical, fast),
+            embedded_proxy_is_canonical: Arc::ptr_eq(canonical, embedded_proxy),
+        });
     }
 
     pub(super) fn install_admission_controller(
@@ -875,9 +998,29 @@ impl BrokerRuntime {
         self.composition.request_pipeline.authorized_dispatcher.clone()
     }
 
-    pub(crate) fn prepared_v2_dispatcher(
-        &self,
-    ) -> Option<Arc<rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2<DefaultServerProcessorV2>>> {
-        self.composition.request_pipeline.prepared_v2_dispatcher.clone()
+    pub(crate) fn canonical_v2_dispatcher(&self) -> Option<Arc<DefaultBrokerDispatcherV2>> {
+        self.composition.request_pipeline.canonical_v2_dispatcher()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_v2_pre_publish_checkpoint_for_test(
+        &mut self,
+    ) -> (oneshot::Receiver<BrokerV2PrePublishSnapshot>, oneshot::Sender<()>) {
+        assert!(
+            self.composition.request_pipeline.v2_pre_publish_checkpoint.is_none(),
+            "Broker V2 pre-publication checkpoint may only be installed once"
+        );
+        let (reached, reached_rx) = oneshot::channel();
+        let (release, release_rx) = oneshot::channel();
+        self.composition.request_pipeline.v2_pre_publish_checkpoint = Some(BrokerV2PrePublishCheckpoint {
+            reached,
+            release: release_rx,
+        });
+        (reached_rx, release)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn v2_dispatcher_identity_snapshot_for_test(&self) -> Option<BrokerV2DispatcherIdentitySnapshot> {
+        self.composition.request_pipeline.v2_dispatcher_identity_snapshot
     }
 }

--- a/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
@@ -15,6 +15,8 @@
 //! Listener and background-service startup owned by the Broker request pipeline.
 
 use super::super::*;
+use crate::deferred_generation_handoff::DeferredGenerationV2PublishError;
+use crate::deferred_generation_handoff::DeferredGenerationV2Publisher;
 
 /// Coarse transport gate for the prepared Broker V2 graph.
 ///
@@ -58,7 +60,7 @@ impl BrokerRuntime {
             });
         }
         self.initialize_deferred_lifecycle()?;
-        let (request_processor, fast_request_processor) = self.init_processor_checked()?;
+        let (request_processor, _fast_request_processor) = self.init_processor_checked()?;
         self.initialize_consumer_lag_observability();
         let service_context =
             self.composition
@@ -117,7 +119,79 @@ impl BrokerRuntime {
         );
         self.composition.request_pipeline.proxy_request_processor = Some(request_processor.clone());
         self.composition.request_pipeline.authorized_dispatcher = Some(authorized_dispatcher.clone());
-        self.composition.request_pipeline.prepared_v2_dispatcher = Some(prepared_v2_dispatcher);
+        let deferred_handoff =
+            self.composition
+                .deferred_generation_handoff()
+                .ok_or_else(|| BrokerStartupError::Initialization {
+                    component: "deferred_generation_handoff",
+                    detail: "Broker deferred handoff must exist before canonical V2 publication".to_owned(),
+                })?;
+        #[cfg(test)]
+        {
+            let pop_lite_processor = self
+                .composition
+                .state
+                .pop_lite_message_processor
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| BrokerStartupError::Initialization {
+                    component: "broker_v2_pre_publish_checkpoint",
+                    detail: "PopLite processor must exist before the test checkpoint".to_owned(),
+                })?;
+            self.composition
+                .request_pipeline
+                .reach_v2_pre_publish_checkpoint(
+                    Arc::clone(&prepared_v2_dispatcher),
+                    pop_lite_processor,
+                    Arc::clone(&deferred_handoff),
+                )
+                .await;
+        }
+        {
+            let pipeline = &self.composition.request_pipeline;
+            let mut cutover =
+                deferred_handoff
+                    .cutover_transaction()
+                    .map_err(|error| BrokerStartupError::Initialization {
+                        component: "broker_v2_cutover",
+                        detail: format!("failed to begin canonical V2 publication transaction: {error:?}"),
+                    })?;
+            cutover
+                .seal_legacy_acceptance()
+                .map_err(|error| BrokerStartupError::Initialization {
+                    component: "broker_v2_cutover",
+                    detail: format!("failed to seal legacy deferred acceptance: {error:?}"),
+                })?;
+            cutover
+                .publish_v2_aggregate(DeferredGenerationV2Publisher::nonblocking_atomic(|| {
+                    pipeline.publish_canonical_v2_dispatcher(prepared_v2_dispatcher)
+                }))
+                .map_err(|error| BrokerStartupError::Initialization {
+                    component: "broker_v2_dispatcher",
+                    detail: match error {
+                        DeferredGenerationV2PublishError::Cutover(error) => {
+                            format!("canonical V2 dispatcher publication violated cutover ordering: {error:?}")
+                        }
+                        DeferredGenerationV2PublishError::Publish(error) => {
+                            format!("canonical V2 dispatcher publication failed: {error:?}")
+                        }
+                    },
+                })?;
+            cutover
+                .publish_default_new()
+                .map_err(|error| BrokerStartupError::Initialization {
+                    component: "broker_v2_cutover",
+                    detail: format!("failed to publish New as the default deferred generation: {error:?}"),
+                })?;
+        }
+        let canonical_v2_dispatcher = self
+            .composition
+            .request_pipeline
+            .canonical_v2_dispatcher()
+            .ok_or_else(|| BrokerStartupError::Initialization {
+                component: "broker_v2_dispatcher",
+                detail: "canonical V2 dispatcher was not visible after successful publication".to_owned(),
+            })?;
         self.lifecycle
             .startup_journal
             .complete(BrokerComponent::RequestProcessors);
@@ -134,28 +208,37 @@ impl BrokerRuntime {
         self.lifecycle.remoting_server_task_group = Some(remoting_server_task_group.clone());
 
         let broker_config = self.composition.state.broker_config();
-        let mut server = TransportServer::new_with_telemetry(
+        let normal_dispatcher = Arc::clone(&canonical_v2_dispatcher);
+        let fast_dispatcher = Arc::clone(&canonical_v2_dispatcher);
+        #[cfg(test)]
+        {
+            let embedded_proxy_dispatcher = self
+                .composition
+                .request_pipeline
+                .canonical_v2_dispatcher()
+                .expect("canonical V2 dispatcher was published above");
+            self.composition.request_pipeline.record_v2_dispatcher_identity(
+                &canonical_v2_dispatcher,
+                &normal_dispatcher,
+                &fast_dispatcher,
+                &embedded_proxy_dispatcher,
+            );
+        }
+        let v2_session_registry = self.composition.request_pipeline.v2_session_registry();
+        let server = TransportServerV2::new_with_authorized_dispatcher(
             Arc::new(broker_config.broker_server_config.clone()),
             service_context.component("broker.remoting-server.normal"),
-            self.composition.state.transport_telemetry.clone(),
+            normal_dispatcher,
         )
-        .with_authorized_dispatcher(authorized_dispatcher.clone());
+        .with_telemetry(self.composition.state.transport_telemetry.clone())
+        .with_session_registry(Arc::clone(&v2_session_registry));
         // Start the normal Broker remoting server.
-        let client_housekeeping_service_main = self
-            .composition
-            .state
-            .client_housekeeping_service
-            .clone()
-            .map(|item| item as Arc<dyn ChannelEventListener>);
-        let client_housekeeping_service_fast = client_housekeeping_service_main.clone();
         let shutdown_token = remoting_server_task_group.cancellation_token();
         let (normal_report_tx, normal_report_rx) = oneshot::channel();
         let (normal_startup_tx, normal_startup_rx) = oneshot::channel();
         if let Err(error) = remoting_server_task_group.spawn_service("broker.remoting-server.normal", async move {
             let report = server
                 .try_run_with_shutdown_report_and_startup(
-                    request_processor,
-                    client_housekeeping_service_main,
                     async move {
                         shutdown_token.cancelled().await;
                     },
@@ -172,20 +255,19 @@ impl BrokerRuntime {
         // Start the fast Broker remoting server.
         let mut fast_server_config = broker_config.broker_server_config.clone();
         fast_server_config.listen_port = broker_config.broker_server_config.listen_port - 2;
-        let mut fast_server = TransportServer::new_with_telemetry(
+        let fast_server = TransportServerV2::new_with_authorized_dispatcher(
             Arc::new(fast_server_config),
             service_context.component("broker.remoting-server.fast"),
-            self.composition.state.transport_telemetry.clone(),
+            fast_dispatcher,
         )
-        .with_authorized_dispatcher(authorized_dispatcher);
+        .with_telemetry(self.composition.state.transport_telemetry.clone())
+        .with_session_registry(v2_session_registry);
         let shutdown_token = remoting_server_task_group.cancellation_token();
         let (fast_report_tx, fast_report_rx) = oneshot::channel();
         let (fast_startup_tx, fast_startup_rx) = oneshot::channel();
         if let Err(error) = remoting_server_task_group.spawn_service("broker.remoting-server.fast", async move {
             let report = fast_server
                 .try_run_with_shutdown_report_and_startup(
-                    fast_request_processor,
-                    client_housekeeping_service_fast,
                     async move {
                         shutdown_token.cancelled().await;
                     },
@@ -416,3 +498,7 @@ mod tests {
         assert!(owner.shutdown_background().is_healthy());
     }
 }
+
+#[cfg(test)]
+#[path = "startup/cutover_network_tests.rs"]
+mod cutover_network_tests;

--- a/rocketmq-broker/src/broker_runtime/request_pipeline/startup/cutover_network_tests.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline/startup/cutover_network_tests.rs
@@ -1,0 +1,532 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use futures::FutureExt;
+use rocketmq_model::common::attribute::subscription_group_attributes::LITE_BIND_TOPIC_ATTRIBUTE_NAME;
+use rocketmq_model::common::attribute::topic_attributes;
+use rocketmq_model::common::attribute::Attribute;
+use rocketmq_model::common::config::TopicConfig;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_store::MessageStoreConfig;
+use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v1::ConnectionHandlerContext;
+use rocketmq_transport::test_support::Connection;
+use rocketmq_transport::test_support::LegacySessionExecutionHarness;
+use rocketmq_transport::test_support::TestChannelBuilder;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+
+use crate::broker_runtime::BrokerRuntime;
+use crate::config::broker_config::BrokerConfig;
+use crate::deferred_generation_handoff::DeferredGeneration;
+use crate::deferred_generation_handoff::DeferredGenerationTarget;
+use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingService;
+use crate::long_polling::polling_result::PollingResult;
+
+const CLIENT_ID: &str = "broker-cutover-client";
+const GROUP: &str = "broker-cutover-group";
+const TOPIC: &str = "broker-cutover-topic";
+const LEGACY_OPAQUE: i32 = 98_510_001;
+const NORMAL_OPAQUE: i32 = 98_510_002;
+const FAST_OPAQUE: i32 = 98_510_003;
+const TIMEOUT_OPAQUE: i32 = 98_510_004;
+const SHORT_POLL_TIME: i64 = 500;
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+struct LegacyWaiter {
+    channel: Channel,
+    session: LegacySessionExecutionHarness,
+    task_group: TaskGroup,
+    peer: Connection,
+}
+
+fn reserve_listener_ports() -> (u32, usize) {
+    for _ in 0..128 {
+        let normal =
+            std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve Broker normal listener port");
+        let normal_port = normal.local_addr().expect("normal listener address").port();
+        let Some(fast_port) = normal_port.checked_sub(2) else {
+            continue;
+        };
+        let Ok(fast) = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, fast_port)) else {
+            continue;
+        };
+        let ha = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve Broker HA listener port");
+        let ha_port = ha.local_addr().expect("HA listener address").port();
+        if ha_port != normal_port && ha_port != fast_port {
+            drop((normal, fast, ha));
+            return (u32::from(normal_port), usize::from(ha_port));
+        }
+    }
+    panic!("could not reserve a normal/fast/HA listener port set");
+}
+
+fn runtime_config(
+    root: &TempDir,
+    listen_port: u32,
+    ha_listen_port: usize,
+) -> (Arc<BrokerConfig>, Arc<MessageStoreConfig>) {
+    let root_path = root.path().to_string_lossy().into_owned();
+    let mut broker = BrokerConfig {
+        broker_ip1: CheetahString::from_static_str("127.0.0.1"),
+        broker_ip2: Some(CheetahString::from_static_str("127.0.0.1")),
+        listen_port,
+        store_path_root_dir: root_path.clone().into(),
+        auth_config_path: root.path().join("auth.json").to_string_lossy().into_owned().into(),
+        ..BrokerConfig::default()
+    };
+    broker.broker_server_config.bind_address = "127.0.0.1".to_owned();
+    broker.broker_server_config.listen_port = listen_port;
+    let store = MessageStoreConfig {
+        store_path_root_dir: root_path.into(),
+        ha_listen_port,
+        ..MessageStoreConfig::default()
+    };
+    (Arc::new(broker), Arc::new(store))
+}
+
+fn pop_lite_request(opaque: i32, poll_time: i64) -> RemotingCommand {
+    let header = PopLiteMessageRequestHeader {
+        client_id: CheetahString::from_static_str(CLIENT_ID),
+        consumer_group: CheetahString::from_static_str(GROUP),
+        topic: CheetahString::from_static_str(TOPIC),
+        max_msg_num: 1,
+        invisible_time: 30_000,
+        poll_time,
+        born_time: i64::try_from(current_millis()).expect("test clock fits the protocol field"),
+        attempt_id: None,
+        rpc: None,
+    };
+    let mut command = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, header).set_opaque(opaque);
+    command.make_custom_header_to_net();
+    command
+}
+
+fn seed_lite_topic_and_group(runtime: &mut BrokerRuntime) {
+    let state = runtime.runtime_state_mut();
+    let mut topic = TopicConfig::with_queues(TOPIC, 1, 1);
+    topic.attributes.insert(
+        CheetahString::from_string(format!(
+            "+{}",
+            topic_attributes::TopicAttributes::topic_message_type_attribute().name()
+        )),
+        CheetahString::from_static_str("LITE"),
+    );
+    state.topic_config_manager().update_topic_config(topic, 0);
+
+    let mut group = SubscriptionGroupConfig::new(CheetahString::from_static_str(GROUP));
+    group.set_attributes(HashMap::from([(
+        CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
+        CheetahString::from_static_str(TOPIC),
+    )]));
+    state
+        .subscription_group_manager_mut()
+        .update_subscription_group_config(&mut group);
+}
+
+async fn legacy_session(context: ChildServiceContext, owner_id: u64) -> (ConnectionHandlerContext, LegacyWaiter) {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind legacy session listener");
+    let address = listener.local_addr().expect("legacy session listener address");
+    let (peer, accepted) = tokio::join!(TcpStream::connect(address), listener.accept());
+    let peer = peer.expect("connect legacy session peer");
+    let (transport, remote_address) = accepted.expect("accept legacy session transport");
+    let local_address = transport.local_addr().expect("legacy transport local address");
+    let task_group = context.task_group().clone();
+    let channel = TestChannelBuilder::new(Connection::new(transport), task_group.clone())
+        .addresses(local_address, remote_address)
+        .build()
+        .expect("build real transport-backed legacy channel");
+    let session = LegacySessionExecutionHarness::new(owner_id, &task_group);
+    let handler_context = session.context(channel.clone(), 4 * 1024, RequestCode::PopLiteMessage.to_i32());
+    (
+        handler_context,
+        LegacyWaiter {
+            channel,
+            session,
+            task_group,
+            peer: Connection::new(peer),
+        },
+    )
+}
+
+async fn wait_until(mut condition: impl FnMut() -> bool, label: &'static str) {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        while !condition() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {label}"));
+}
+
+async fn receive_one(connection: &mut Connection, label: &'static str) -> RemotingCommand {
+    tokio::time::timeout(TEST_TIMEOUT, connection.receive_command())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {label}"))
+        .unwrap_or_else(|| panic!("connection closed before {label}"))
+        .unwrap_or_else(|error| panic!("failed to receive {label}: {error}"))
+}
+
+async fn wait_until_deferred(connection: &mut Connection, condition: impl FnMut() -> bool, label: &'static str) {
+    let registered = wait_until(condition, label);
+    tokio::pin!(registered);
+    tokio::select! {
+        () = &mut registered => {}
+        response = connection.receive_command() => {
+            let response = response
+                .unwrap_or_else(|| panic!("connection closed before {label}"))
+                .unwrap_or_else(|error| panic!("failed while waiting for {label}: {error}"));
+            panic!(
+                "{label} returned an immediate response: code={}, opaque={}, remark={:?}",
+                response.code(),
+                response.opaque(),
+                response.remark(),
+            );
+        }
+    }
+}
+
+async fn collect_until_close(mut connection: Connection, label: &'static str) -> Vec<RemotingCommand> {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let mut frames = Vec::new();
+        while let Some(frame) = connection.receive_command().await {
+            frames.push(frame.expect("receive terminal Broker frame"));
+        }
+        frames
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {label} connection close"))
+}
+
+async fn assert_no_buffered_frame_and_close(connection: &mut Connection, label: &'static str) {
+    match connection.receive_command().now_or_never() {
+        Some(Some(Ok(frame))) => panic!(
+            "{label} emitted a duplicate frame: code={}, opaque={}, remark={:?}",
+            frame.code(),
+            frame.opaque(),
+            frame.remark()
+        ),
+        Some(Some(Err(error))) => panic!("{label} failed while checking for a duplicate frame: {error}"),
+        Some(None) | None => {}
+    }
+    connection
+        .shutdown()
+        .await
+        .unwrap_or_else(|error| panic!("failed to close {label}: {error}"));
+}
+
+#[test]
+fn broker_cutover_routes_legacy_then_normal_v2_once_and_keeps_fast_waiter_quiescent() {
+    let mut owner_config = RuntimeConfig::server_default("broker-cutover-network-arrival");
+    owner_config.thread_stack_size = Some(16 * 1024 * 1024);
+    let owner = RuntimeOwner::new(owner_config).expect("Broker cutover runtime owner");
+    let broker_context = owner.root_context().component("broker-cutover-runtime");
+    let legacy_context = owner.root_context().component("broker-cutover-legacy-session");
+    let temp = tempfile::tempdir().expect("create Broker cutover test root");
+    let (listen_port, ha_listen_port) = reserve_listener_ports();
+    let (broker_config, store_config) = runtime_config(&temp, listen_port, ha_listen_port);
+
+    owner.block_on(async move {
+        let mut runtime = BrokerRuntime::new_with_service_context(broker_config, store_config, broker_context);
+        runtime.initialize().await.expect("initialize Broker cutover runtime");
+        seed_lite_topic_and_group(&mut runtime);
+        let (pre_publish, release_publish) = runtime.install_v2_pre_publish_checkpoint_for_test();
+
+        let start = runtime.start_basic_service();
+        let install_legacy = async move {
+            let snapshot = pre_publish.await.expect("reach Broker V2 pre-publication checkpoint");
+            assert_eq!(snapshot.handoff.default_generation(), DeferredGeneration::Legacy);
+            let service = Arc::clone(snapshot.pop_lite_processor.pop_lite_long_polling_service());
+            PopLiteLongPollingService::start(&service).await;
+            let (handler_context, waiter) = legacy_session(legacy_context, 98_510).await;
+            let mut request = pop_lite_request(LEGACY_OPAQUE, 60_000);
+            assert_eq!(
+                service.polling(
+                    handler_context,
+                    &mut request,
+                    &CheetahString::from_static_str(CLIENT_ID),
+                    i64::try_from(current_millis()).expect("test clock fits the protocol field"),
+                    60_000,
+                ),
+                PollingResult::PollingSuc
+            );
+            let resources = service.legacy_resource_snapshot();
+            assert_eq!(resources.table_entries, 1);
+            assert_eq!(resources.tracked_waiters, 1);
+            assert_eq!(snapshot.handoff.snapshot().occupancy, 1);
+            release_publish.send(()).expect("release Broker V2 publication");
+            (snapshot.handoff, service, waiter)
+        };
+        let (listeners, legacy) = tokio::time::timeout(TEST_TIMEOUT, async { tokio::join!(start, install_legacy) })
+            .await
+            .expect("Broker cutover startup should finish");
+        let (normal_address, fast_address) = listeners.expect("start Broker cutover listeners");
+        let (handoff, legacy_service, mut legacy_waiter) = legacy;
+
+        assert_eq!(
+            normal_address.port(),
+            u16::try_from(listen_port).expect("normal port fits u16")
+        );
+        assert_eq!(fast_address.port(), normal_address.port() - 2);
+        let identity = runtime
+            .v2_dispatcher_identity_snapshot_for_test()
+            .expect("record canonical dispatcher identities");
+        assert!(identity.normal_is_canonical);
+        assert!(identity.fast_is_canonical);
+        assert!(identity.embedded_proxy_is_canonical);
+
+        let mut normal = Connection::new(
+            TcpStream::connect(normal_address)
+                .await
+                .expect("connect normal V2 listener"),
+        );
+        normal
+            .send_command(pop_lite_request(NORMAL_OPAQUE, 60_000))
+            .await
+            .expect("send normal V2 PopLite waiter");
+        wait_until_deferred(
+            &mut normal,
+            || {
+                runtime
+                    .composition
+                    .data_plane
+                    .deferred
+                    .as_ref()
+                    .expect("Broker deferred lifecycle")
+                    .resource_snapshot()
+                    .pop_lite_live
+                    == 1
+            },
+            "normal V2 PopLite waiter",
+        )
+        .await;
+
+        let mut fast = Connection::new(
+            TcpStream::connect(fast_address)
+                .await
+                .expect("connect fast V2 listener"),
+        );
+        fast.send_command(pop_lite_request(FAST_OPAQUE, 60_000))
+            .await
+            .expect("send fast V2 PopLite waiter");
+        wait_until_deferred(
+            &mut fast,
+            || {
+                runtime
+                    .composition
+                    .data_plane
+                    .deferred
+                    .as_ref()
+                    .expect("Broker deferred lifecycle")
+                    .resource_snapshot()
+                    .pop_lite_live
+                    == 2
+            },
+            "normal and fast V2 PopLite waiters",
+        )
+        .await;
+
+        let client_id = CheetahString::from_static_str(CLIENT_ID);
+        let group = CheetahString::from_static_str(GROUP);
+        let first_event = CheetahString::from_static_str("%LMQ%$broker-cutover-topic$legacy-arrival");
+        assert_eq!(
+            runtime.composition.state.lite_event_dispatcher().do_full_dispatch(
+                &client_id,
+                &group,
+                &HashSet::from([first_event])
+            ),
+            1
+        );
+        let legacy_response = receive_one(&mut legacy_waiter.peer, "legacy PopLite response").await;
+        assert_eq!(legacy_response.opaque(), LEGACY_OPAQUE);
+        assert_eq!(ResponseCode::from(legacy_response.code()), ResponseCode::PollingTimeout);
+
+        wait_until(
+            || {
+                let legacy = legacy_service.legacy_resource_snapshot();
+                let deferred = runtime
+                    .composition
+                    .data_plane
+                    .deferred
+                    .as_ref()
+                    .expect("Broker deferred lifecycle")
+                    .resource_snapshot();
+                legacy.table_entries == 0
+                    && legacy.tracked_waiters == 0
+                    && legacy.waking_clients == 0
+                    && legacy.active_executions == 0
+                    && deferred.pop_lite_live == 2
+                    && handoff.generation_for(&DeferredGenerationTarget::pop_lite(client_id.clone()))
+                        == DeferredGeneration::New
+            },
+            "legacy terminal, untouched V2 waiters, and target transition",
+        )
+        .await;
+
+        let second_event = CheetahString::from_static_str("%LMQ%$broker-cutover-topic$new-arrival");
+        assert_eq!(
+            runtime.composition.state.lite_event_dispatcher().do_full_dispatch(
+                &client_id,
+                &group,
+                &HashSet::from([second_event])
+            ),
+            1
+        );
+        let normal_response = receive_one(&mut normal, "normal V2 PopLite response").await;
+        assert_eq!(normal_response.opaque(), NORMAL_OPAQUE);
+        assert_eq!(ResponseCode::from(normal_response.code()), ResponseCode::PollingTimeout);
+        wait_until(
+            || {
+                runtime
+                    .composition
+                    .data_plane
+                    .deferred
+                    .as_ref()
+                    .expect("Broker deferred lifecycle")
+                    .resource_snapshot()
+                    .pop_lite_live
+                    == 1
+            },
+            "one remaining fast V2 PopLite waiter",
+        )
+        .await;
+
+        assert_no_buffered_frame_and_close(&mut fast, "fast V2 peer-close route").await;
+        wait_until(
+            || {
+                runtime
+                    .composition
+                    .data_plane
+                    .deferred
+                    .as_ref()
+                    .expect("Broker deferred lifecycle")
+                    .resource_snapshot()
+                    .pop_lite_live
+                    == 0
+                    && runtime.composition.request_pipeline.v2_session_registry().len() == 1
+            },
+            "fast V2 peer-close cleanup",
+        )
+        .await;
+        let fast_frames = collect_until_close(fast, "fast V2 peer-close").await;
+        assert!(fast_frames.is_empty(), "the peer-closed fast route emitted a frame");
+
+        normal
+            .send_command(pop_lite_request(TIMEOUT_OPAQUE, SHORT_POLL_TIME))
+            .await
+            .expect("send normal V2 protocol-timeout waiter");
+        wait_until_deferred(
+            &mut normal,
+            || {
+                runtime
+                    .composition
+                    .data_plane
+                    .deferred
+                    .as_ref()
+                    .expect("Broker deferred lifecycle")
+                    .resource_snapshot()
+                    .pop_lite_live
+                    == 1
+            },
+            "normal V2 protocol-timeout waiter",
+        )
+        .await;
+        let timeout_response = receive_one(&mut normal, "normal V2 protocol-timeout response").await;
+        assert_eq!(timeout_response.opaque(), TIMEOUT_OPAQUE);
+        assert_eq!(
+            ResponseCode::from(timeout_response.code()),
+            ResponseCode::PollingTimeout
+        );
+        wait_until(
+            || {
+                let resources = runtime
+                    .composition
+                    .data_plane
+                    .deferred
+                    .as_ref()
+                    .expect("Broker deferred lifecycle")
+                    .resource_snapshot();
+                resources.pop_lite_live == 0
+                    && resources.pop_lite_reserved == 0
+                    && resources.pop_lite_candidates == 0
+                    && resources.pop_lite_clients == 0
+                    && resources.pop_lite_event_batches == 0
+                    && resources.pop_lite_event_count == 0
+                    && resources.pop_lite_event_permits == 0
+                    && resources.pop_lite_event_bytes == 0
+                    && resources.pop_lite_active_client_gates == 0
+                    && resources.pop_lite_active_event_producers == 0
+                    && resources.pop_lite_prepared == 0
+                    && resources.pop_lite_pending_claims == 0
+                    && resources.pop_lite_accepted_resumes == 0
+                    && resources.pop_lite_resume_executions == 0
+                    && resources.pop_lite_resume_execution_bytes == 0
+                    && resources.pop_lite_pending_replays == 0
+            },
+            "normal V2 protocol-timeout resource cleanup",
+        )
+        .await;
+
+        legacy_waiter.session.close();
+        let legacy_channel = legacy_waiter.channel.close_with_report(TEST_TIMEOUT).await;
+        assert!(legacy_channel.is_healthy(), "{}", legacy_channel.to_json());
+        drop(legacy_waiter.channel);
+        let legacy_tasks = legacy_waiter
+            .task_group
+            .shutdown_until(ShutdownDeadline::after(TEST_TIMEOUT))
+            .await;
+        assert!(legacy_tasks.is_healthy(), "{}", legacy_tasks.to_json());
+        assert_no_buffered_frame_and_close(&mut legacy_waiter.peer, "legacy route").await;
+
+        let shutdown = runtime.shutdown_basic_service_until(ShutdownDeadline::after(TEST_TIMEOUT));
+        let (report, normal_trailing) = tokio::join!(shutdown, collect_until_close(normal, "normal V2"));
+        assert!(normal_trailing.is_empty(), "normal V2 route emitted duplicate frames");
+        assert!(report.is_healthy(), "{report:?}");
+        assert!(report
+            .deferred_resources
+            .expect("terminal Broker deferred snapshot")
+            .is_zero());
+        assert!(report
+            .legacy_service_shutdown
+            .iter()
+            .all(crate::long_polling::long_polling_service::LegacyServiceShutdownReport::is_healthy));
+        assert!(runtime.composition.request_pipeline.v2_session_registry().is_empty());
+        drop(runtime);
+    });
+
+    let tasks = owner.block_on(owner.shutdown_tasks());
+    assert!(tasks.is_healthy(), "{}", tasks.to_json());
+    let background = owner.shutdown_background();
+    assert!(background.is_healthy(), "{}", background.to_json());
+}

--- a/rocketmq-broker/src/client/client_housekeeping_service.rs
+++ b/rocketmq-broker/src/client/client_housekeeping_service.rs
@@ -28,6 +28,9 @@ use rocketmq_runtime::TaskGroupLifecycleState;
 use rocketmq_store::BrokerStatsManager;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ChannelEventListener;
+use rocketmq_transport::api::v2::SessionId;
+use rocketmq_transport::api::v2::SessionView;
+use rocketmq_transport::api::v2::V2SessionLifecycleListener;
 use tokio::sync::Notify;
 use tracing::debug;
 use tracing::warn;
@@ -207,15 +210,34 @@ impl ChannelEventListener for ClientHousekeepingService {
     }
 }
 
+impl V2SessionLifecycleListener for ClientHousekeepingService {
+    fn on_session_connected(&self, _session: &SessionView) {
+        self.broker_stats_manager.inc_channel_connect_num()
+    }
+
+    fn on_session_disconnected(&self, session_id: SessionId) {
+        self.producer_housekeeping.do_session_close_event(session_id);
+        self.consumer_housekeeping.do_session_close_event(session_id);
+        self.broker_stats_manager.inc_channel_close_num()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use crate::config::broker_config::BrokerConfig;
+    use cheetah_string::CheetahString;
+    use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
+    use rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType;
+    use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
+    use rocketmq_protocol::protocol::LanguageCode;
     use rocketmq_runtime::RuntimeContext;
     use rocketmq_store::MessageStoreConfig;
+    use rocketmq_transport::test_support::session_id_for_test;
 
     use crate::broker_runtime::BrokerRuntime;
+    use crate::client::client_channel_info::ClientSessionInfo;
 
     use super::*;
 
@@ -279,6 +301,46 @@ mod tests {
         assert!(report.is_healthy(), "{}", report.to_json());
         let broker_report = broker_service.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(broker_report.is_healthy(), "{}", broker_report.to_json());
+    }
+
+    #[test]
+    fn typed_v2_disconnect_cleans_producer_and_consumer_session_state() {
+        let mut broker_runtime = BrokerRuntime::new(
+            Arc::new(BrokerConfig::default()),
+            Arc::new(MessageStoreConfig::default()),
+        );
+        let inner = broker_runtime.runtime_state_mut();
+        let producer = inner.producer_manager().clone_shared_state();
+        let consumer = inner.consumer_manager().clone_shared_state();
+        let service = ClientHousekeepingService::new(
+            producer.connection_housekeeping(),
+            consumer.connection_housekeeping(),
+            inner.broker_stats_manager_handle(),
+            inner.broker_service_context(),
+        );
+        let session_id = session_id_for_test(9_851);
+        let client_id = CheetahString::from_static_str("v2-housekeeping-client");
+        let producer_group = CheetahString::from_static_str("v2-housekeeping-producer");
+        let consumer_group = CheetahString::from_static_str("v2-housekeeping-consumer");
+        producer.client_registration().register_producer_session(
+            &producer_group,
+            ClientSessionInfo::new(session_id, client_id.clone(), None, LanguageCode::RUST, 1),
+        );
+        assert!(consumer.client_registration().register_consumer_session_without_sub(
+            &consumer_group,
+            ClientSessionInfo::new(session_id, client_id, None, LanguageCode::RUST, 1),
+            ConsumeType::ConsumePassively,
+            MessageModel::Clustering,
+            ConsumeFromWhere::ConsumeFromLastOffset,
+            false,
+        ));
+        assert!(producer.group_online(producer_group.as_str()));
+        assert!(consumer.get_consumer_group_info(&consumer_group).is_some());
+
+        V2SessionLifecycleListener::on_session_disconnected(&service, session_id);
+
+        assert!(!producer.group_online(producer_group.as_str()));
+        assert!(consumer.get_consumer_group_info(&consumer_group).is_none());
     }
 
     #[test]

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
@@ -591,19 +591,40 @@ impl<RP: PopLiteLongPollingRequestProcessor + Sync + 'static> PopLiteLongPolling
             return false;
         };
         let Some(wake_claim) = self.begin_wake(&pop_request, route) else {
-            if pop_request.legacy_session_closed() {
-                pop_request.release_resource_permit();
-                pop_request.release_legacy_wait();
-            } else {
-                self.polling_map
-                    .entry(client_id.clone())
-                    .or_default()
-                    .insert(pop_request);
-                restore_published_polling_count(&self.total_polling_num);
-            }
+            self.requeue_claimed_request(client_id, pop_request);
             return false;
         };
         self.wake_up_with_claim(pop_request, Some(claim), wake_claim)
+    }
+
+    fn requeue_claimed_request(&self, client_id: &CheetahString, request: Arc<PopRequest>) {
+        // Restore accounting before publishing the node, matching fresh
+        // registration. A concurrent cleanup can then remove the node without
+        // observing an uncounted waiter.
+        restore_published_polling_count(&self.total_polling_num);
+        self.polling_map
+            .entry(client_id.clone())
+            .or_default()
+            .insert(Arc::clone(&request));
+        let _ = self.retract_terminal_requeue(client_id, &request);
+    }
+
+    fn retract_terminal_requeue(&self, client_id: &CheetahString, request: &Arc<PopRequest>) -> bool {
+        if !request.legacy_session_closed() {
+            return false;
+        }
+        let removed = self
+            .polling_map
+            .get(client_id)
+            .is_some_and(|queue| queue.remove(request).is_some());
+        // Cleanup and terminal reread race to remove the exact Arc. Only the
+        // winner owns count, retained-budget, and handoff release.
+        if removed {
+            release_published_polling_count(&self.total_polling_num);
+            request.release_resource_permit();
+            request.release_legacy_wait();
+        }
+        removed
     }
 
     fn wake_up(&self, pop_request: Arc<PopRequest>) -> bool {
@@ -849,12 +870,8 @@ impl<RP: PopLiteLongPollingRequestProcessor + Sync + 'static> PopLiteLongPolling
             };
             if let Some(wake) = self.begin_wake(&first, route) {
                 self.wake_up_with_claim(first, None, wake);
-            } else if !first.legacy_session_closed() {
-                self.polling_map.entry(client_id.clone()).or_default().insert(first);
-                restore_published_polling_count(&self.total_polling_num);
             } else {
-                first.release_resource_permit();
-                first.release_legacy_wait();
+                self.requeue_claimed_request(client_id, first);
             }
         }
     }
@@ -1128,6 +1145,62 @@ mod tests {
             .read(&mut byte)
             .expect_err("cancelled PopLite session wrote no response bytes");
         assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+    }
+
+    #[tokio::test]
+    async fn pop_lite_terminal_requeue_races_have_one_release_owner() {
+        let processor = Arc::new(ImmediateResponseProcessor {
+            calls: AtomicUsize::new(0),
+        });
+        let service = session_test_service(&processor);
+        let handoff = Arc::new(DeferredGenerationHandoff::new());
+        service
+            .install_handoff(Arc::clone(&handoff))
+            .expect("install PopLite terminal requeue coordinator");
+        let client_id = CheetahString::from_static_str("pop-lite-terminal-requeue");
+
+        let (missed_session, missed_group, missed_context, _missed_peer) =
+            session_execution_test_context(8_411, None).await;
+        let registered = register_session_waiter(&service, missed_context, &client_id);
+        let (request, route) = service
+            .claim_request(&client_id, Some(&registered))
+            .expect("claim PopLite waiter before terminal cleanup misses the table");
+        missed_session.close();
+        service.requeue_claimed_request(&client_id, request);
+        drop(route);
+        assert_eq!(service.get_polling_num(&client_id), 0);
+        assert!(handoff.zero_report().is_zero());
+        let report = missed_group
+            .shutdown_until(ShutdownDeadline::after(Duration::from_secs(1)))
+            .await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+
+        let (winning_session, winning_group, winning_context, _winning_peer) =
+            session_execution_test_context(8_412, None).await;
+        let registered = register_session_waiter(&service, winning_context, &client_id);
+        let (request, route) = service
+            .claim_request(&client_id, Some(&registered))
+            .expect("claim PopLite waiter before terminal publication races the reread");
+        restore_published_polling_count(&service.total_polling_num);
+        service
+            .polling_map
+            .entry(client_id.clone())
+            .or_default()
+            .insert(Arc::clone(&request));
+        winning_session.close();
+        assert!(
+            !service.retract_terminal_requeue(&client_id, &request),
+            "session cleanup already owns the exact published PopLite waiter"
+        );
+        drop(route);
+        assert_eq!(service.get_polling_num(&client_id), 0);
+        assert!(handoff.zero_report().is_zero());
+        let report = winning_group
+            .shutdown_until(ShutdownDeadline::after(Duration::from_secs(1)))
+            .await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+
+        service.shutdown().await;
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -574,13 +574,7 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
                         }
                     }
                     if !match_result {
-                        if pop_request.legacy_session_closed() {
-                            pop_request.release_resource_permit();
-                            pop_request.release_legacy_wait();
-                        } else {
-                            self.polling_map.entry(key).or_default().insert(pop_request);
-                            restore_published_polling_count(&self.total_polling_num);
-                        }
+                        self.requeue_claimed_request(key, pop_request);
                         return None;
                     }
                 }
@@ -589,15 +583,39 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
             if let Some(claim) = self.begin_wake(Arc::clone(&pop_request), route) {
                 return Some(claim);
             }
-            if pop_request.legacy_session_closed() {
-                pop_request.release_resource_permit();
-                pop_request.release_legacy_wait();
-            } else {
-                self.polling_map.entry(key).or_default().insert(pop_request);
-                restore_published_polling_count(&self.total_polling_num);
-            }
+            self.requeue_claimed_request(key, pop_request);
         }
         None
+    }
+
+    fn requeue_claimed_request(&self, key: CheetahString, request: Arc<PopRequest>) {
+        // Restore accounting before publishing the node, matching fresh
+        // registration. A concurrent cleanup can then remove the node without
+        // observing an uncounted waiter.
+        restore_published_polling_count(&self.total_polling_num);
+        self.polling_map
+            .entry(key.clone())
+            .or_default()
+            .insert(Arc::clone(&request));
+        let _ = self.retract_terminal_requeue(&key, &request);
+    }
+
+    fn retract_terminal_requeue(&self, key: &CheetahString, request: &Arc<PopRequest>) -> bool {
+        if !request.legacy_session_closed() {
+            return false;
+        }
+        let removed = self
+            .polling_map
+            .get(key)
+            .is_some_and(|queue| queue.remove(request).is_some());
+        // Cleanup and terminal reread race to remove the exact Arc. Only the
+        // winner owns count, retained-budget, and handoff release.
+        if removed {
+            release_published_polling_count(&self.total_polling_num);
+            request.release_resource_permit();
+            request.release_legacy_wait();
+        }
+        removed
     }
 
     /// Notifies that a message has arrived on a retry topic.
@@ -1140,12 +1158,8 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
             };
             if let Some(claim) = self.begin_wake(Arc::clone(&first), route) {
                 self.wake_up_claim(claim, None);
-            } else if !first.legacy_session_closed() {
-                self.polling_map.entry(key.clone()).or_default().insert(first);
-                restore_published_polling_count(&self.total_polling_num);
             } else {
-                first.release_resource_permit();
-                first.release_legacy_wait();
+                self.requeue_claimed_request(key.clone(), first);
             }
         }
     }
@@ -1501,6 +1515,73 @@ mod tests {
             .read(&mut byte)
             .expect_err("cancelled legacy session wrote no response bytes");
         assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+    }
+
+    async fn assert_terminal_pop_requeue_has_one_release_owner(request_code: RequestCode, owner_id: u64) {
+        let processor = Arc::new(FailingProcessor {
+            calls: AtomicUsize::new(0),
+        });
+        let service = test_service(&processor);
+        let handoff = Arc::new(DeferredGenerationHandoff::new());
+        service
+            .install_handoff(Arc::clone(&handoff))
+            .expect("install terminal requeue coordinator");
+        PopLongPollingService::start(&service).await;
+        let topic = CheetahString::from_string(format!("terminal-requeue-topic-{owner_id}"));
+        let group = CheetahString::from_string(format!("terminal-requeue-group-{owner_id}"));
+
+        let (missed_session, missed_group, missed_context, _missed_peer) =
+            session_execution_test_context(owner_id, request_code, None).await;
+        let (key, registered) = register_session_waiter(&service, missed_context, request_code, &topic, &group);
+        let (request, route) = service
+            .claim_remoting_command(&key, Some(&registered))
+            .expect("claim waiter before terminal cleanup misses the table");
+        missed_session.close();
+        service.requeue_claimed_request(key.clone(), request);
+        drop(route);
+        assert_eq!(service.get_polling_num(&key), 0);
+        assert!(handoff.zero_report().is_zero());
+        let report = missed_group
+            .shutdown_until(ShutdownDeadline::after(Duration::from_secs(1)))
+            .await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+
+        let (winning_session, winning_group, winning_context, _winning_peer) =
+            session_execution_test_context(owner_id + 1, request_code, None).await;
+        let (key, registered) = register_session_waiter(&service, winning_context, request_code, &topic, &group);
+        let (request, route) = service
+            .claim_remoting_command(&key, Some(&registered))
+            .expect("claim waiter before terminal publication races the reread");
+        super::restore_published_polling_count(&service.total_polling_num);
+        service
+            .polling_map
+            .entry(key.clone())
+            .or_default()
+            .insert(Arc::clone(&request));
+        winning_session.close();
+        assert!(
+            !service.retract_terminal_requeue(&key, &request),
+            "session cleanup already owns the exact published waiter"
+        );
+        drop(route);
+        assert_eq!(service.get_polling_num(&key), 0);
+        assert!(handoff.zero_report().is_zero());
+        let report = winning_group
+            .shutdown_until(ShutdownDeadline::after(Duration::from_secs(1)))
+            .await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn pop_terminal_requeue_races_have_one_release_owner() {
+        assert_terminal_pop_requeue_has_one_release_owner(RequestCode::PopMessage, 8_311).await;
+    }
+
+    #[tokio::test]
+    async fn notification_terminal_requeue_races_have_one_release_owner() {
+        assert_terminal_pop_requeue_has_one_release_owner(RequestCode::Notification, 8_313).await;
     }
 
     async fn assert_session_close_after_claim_is_fail_closed(request_code: RequestCode, owner_id: u64) {

--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -562,20 +562,7 @@ where
             }
 
             if !replay_list.is_empty() {
-                replay_list.retain(|request| {
-                    if request.legacy_session_closed() {
-                        request.release_legacy_wait();
-                        false
-                    } else {
-                        true
-                    }
-                });
-                if let Some(deadline) = replay_list.iter().map(PullRequest::deadline_millis).min() {
-                    self.note_request_deadline(deadline);
-                }
-                let mut table = self.pull_request_table.write();
-                let mpr = table.entry(key).or_insert_with(ManyPullRequest::new);
-                mpr.add_pull_requests(replay_list);
+                self.requeue_legacy_requests(key, replay_list);
             }
             deadline_changed = true;
         }
@@ -633,6 +620,28 @@ where
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    fn requeue_legacy_requests(&self, key: String, requests: Vec<PullRequest>) {
+        if let Some(deadline) = requests.iter().map(PullRequest::deadline_millis).min() {
+            self.note_request_deadline(deadline);
+        }
+        let terminal_requests = {
+            let mut table = self.pull_request_table.write();
+            let requests_for_key = table.entry(key.clone()).or_insert_with(ManyPullRequest::new);
+            // Session cleanup publishes terminal before attempting table
+            // removal. Keep both the outer table publication lock and the node
+            // lock through add plus reread so neither cleanup nor another
+            // notifier can claim the just-published node in between.
+            requests_for_key
+                .add_and_drain_with_claim(requests, |request| request.legacy_session_closed().then_some(()))
+                .into_iter()
+                .map(|(request, ())| request)
+                .collect::<Vec<_>>()
+        };
+        for request in terminal_requests {
+            request.release_legacy_wait();
+        }
     }
 
     fn begin_wake(&self, request: &PullRequest, route: Option<RoutePermit>) -> Option<PullWakeupClaim> {
@@ -729,14 +738,18 @@ where
             let Ok(queue_id) = queue_id.parse::<i32>() else {
                 continue;
             };
-            requests.extend(self.claim_legacy_requests(&key, &CheetahString::from(topic), queue_id));
+            requests.extend(
+                self.claim_legacy_requests(&key, &CheetahString::from(topic), queue_id)
+                    .into_iter()
+                    .map(|(request, route)| (key.clone(), request, route)),
+            );
         }
-        for (request, route) in requests {
+        for (key, request, route) in requests {
             info!("notify master online, wakeup {}", request.request_command());
             if let Some(wake) = self.begin_wake(&request, route) {
                 self.submit_wake(&request, wake);
             } else {
-                request.release_legacy_wait();
+                self.requeue_legacy_requests(key, vec![request]);
             }
         }
         self.rebuild_next_deadline();
@@ -971,6 +984,56 @@ mod tests {
             .read(&mut byte)
             .expect_err("cancelled Pull session wrote no response bytes");
         assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+    }
+
+    #[tokio::test]
+    async fn pull_close_between_requeue_publication_and_terminal_reread_releases_once() {
+        let processor = Arc::new(TestPullProcessor);
+        let service = Arc::new(PullRequestHoldService::<StorePorts, _>::new(Arc::downgrade(&processor)));
+        let handoff = Arc::new(DeferredGenerationHandoff::new());
+        service
+            .install_handoff(Arc::clone(&handoff))
+            .expect("install Pull requeue coordinator");
+        PullRequestHoldService::start(&service, task_group("pull-terminal-requeue-service")).await;
+        let topic = CheetahString::from_static_str("pull-terminal-requeue");
+        let key = build_key(topic.as_str(), 0);
+        let (session, session_group, channel, context, _peer) =
+            session_execution_test_channel_context(8_504, None).await;
+        let session = Arc::new(session);
+        register_session_waiter(&service, channel, context, &topic);
+        let (request, route) = claim_session_waiter(&service, &topic);
+        let terminal_view = request.clone();
+
+        let (terminal_requests, closing) = {
+            let mut table = service.pull_request_table.write();
+            let requests = table.entry(key.clone()).or_insert_with(ManyPullRequest::new);
+            requests.add_pull_request(request);
+            let closing_session = Arc::clone(&session);
+            let closing = std::thread::spawn(move || closing_session.close());
+            while !terminal_view.legacy_session_closed() {
+                std::thread::yield_now();
+            }
+            let terminal_requests = requests
+                .drain_with_claim(|request| request.legacy_session_closed().then_some(()))
+                .into_iter()
+                .map(|(request, ())| request)
+                .collect::<Vec<_>>();
+            (terminal_requests, closing)
+        };
+        closing.join().expect("Pull close completes after table publication");
+        assert_eq!(terminal_requests.len(), 1);
+        assert!(service.pull_request_table.read()[&key].is_empty());
+        for request in terminal_requests {
+            request.release_legacy_wait();
+        }
+        drop(route);
+        assert!(handoff.zero_report().is_zero());
+
+        let report = session_group
+            .shutdown_until(ShutdownDeadline::after(Duration::from_secs(1)))
+            .await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        service.shutdown().await;
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/long_polling/many_pull_request.rs
+++ b/rocketmq-broker/src/long_polling/many_pull_request.rs
@@ -39,6 +39,25 @@ impl ManyPullRequest {
         list.extend(many);
     }
 
+    pub(crate) fn add_and_drain_with_claim<T>(
+        &self,
+        many: Vec<PullRequest>,
+        mut acquire: impl FnMut(&PullRequest) -> Option<T>,
+    ) -> Vec<(PullRequest, T)> {
+        let mut list = self.pull_request_list.lock();
+        list.extend(many);
+        let requests = std::mem::take(&mut *list);
+        let mut claimed = Vec::with_capacity(requests.len());
+        for request in requests {
+            if let Some(claim) = acquire(&request) {
+                claimed.push((request, claim));
+            } else {
+                list.push(request);
+            }
+        }
+        claimed
+    }
+
     pub fn clone_list_and_clear(&self) -> Option<Vec<PullRequest>> {
         let mut list = self.pull_request_list.lock();
         if !list.is_empty() {

--- a/rocketmq-broker/src/proxy_facade.rs
+++ b/rocketmq-broker/src/proxy_facade.rs
@@ -328,7 +328,7 @@ impl ProxyBrokerFacade {
         request.make_custom_header_to_net();
         let dispatcher = self
             .runtime
-            .prepared_v2_dispatcher()
+            .canonical_v2_dispatcher()
             .ok_or_else(embedded_broker_v2_request_processor_not_ready)?;
         dispatcher
             .dispatch_embedded_v2_wait_response(

--- a/rocketmq-transport/src/public_api_v2.rs
+++ b/rocketmq-transport/src/public_api_v2.rs
@@ -103,6 +103,7 @@ pub use crate::session_view::SessionId;
 pub use crate::session_view::SessionStateView;
 pub use crate::session_view::SessionView;
 pub use crate::v2_session_registry::V2SessionEvent;
+pub use crate::v2_session_registry::V2SessionLifecycleListener;
 pub use crate::v2_session_registry::V2SessionRegistry;
 
 /// Persistent endpoint client whose omitted processor parameter is V2-native.

--- a/rocketmq-transport/src/v2_session_registry.rs
+++ b/rocketmq-transport/src/v2_session_registry.rs
@@ -14,12 +14,28 @@
 
 //! Composition-owned V2 server session lifecycle control.
 
+use std::sync::Arc;
+
 use dashmap::DashMap;
 use tokio::sync::broadcast;
 
 use crate::server::SessionHandle;
 use crate::session_view::SessionId;
 use crate::session_view::SessionView;
+
+/// Typed lifecycle observer installed by the server composition root.
+///
+/// Callbacks run synchronously after the registry has committed the matching
+/// session-table mutation. Implementations must remain nonblocking and must
+/// not re-enter this registry or retain transport authority; only read-only
+/// session facts are exposed.
+pub trait V2SessionLifecycleListener: Send + Sync + 'static {
+    /// Observes a newly registered canonical network session.
+    fn on_session_connected(&self, session: &SessionView);
+
+    /// Observes removal of a canonical network session.
+    fn on_session_disconnected(&self, session_id: SessionId);
+}
 
 /// Read-only lifecycle event emitted by a V2 server session registry.
 #[derive(Clone)]
@@ -38,6 +54,7 @@ pub enum V2SessionEvent {
 pub struct V2SessionRegistry {
     sessions: DashMap<SessionId, SessionHandle>,
     events: broadcast::Sender<V2SessionEvent>,
+    lifecycle_listener: Option<Arc<dyn V2SessionLifecycleListener>>,
 }
 
 impl V2SessionRegistry {
@@ -48,7 +65,16 @@ impl V2SessionRegistry {
         Self {
             sessions: DashMap::new(),
             events,
+            lifecycle_listener: None,
         }
+    }
+
+    /// Creates an empty registry with one synchronous typed lifecycle observer.
+    #[must_use]
+    pub fn with_lifecycle_listener(listener: Arc<dyn V2SessionLifecycleListener>) -> Self {
+        let mut registry = Self::new();
+        registry.lifecycle_listener = Some(listener);
+        registry
     }
 
     /// Subscribes to typed connected and disconnected events.
@@ -107,19 +133,87 @@ impl V2SessionRegistry {
         let view = session.session_view();
         let id = view.id();
         self.sessions.insert(id, session.clone());
-        let _ = self.events.send(V2SessionEvent::Connected(view));
+        self.publish_connected(&view);
+    }
+
+    fn publish_connected(&self, view: &SessionView) {
+        if let Some(listener) = &self.lifecycle_listener {
+            listener.on_session_connected(view);
+        }
+        let _ = self.events.send(V2SessionEvent::Connected(view.clone()));
     }
 
     pub(crate) fn unregister(&self, session: &SessionHandle) {
         let id = session.session_view().id();
         if self.sessions.remove(&id).is_some() {
-            let _ = self.events.send(V2SessionEvent::Disconnected(id));
+            self.publish_disconnected(id);
         }
+    }
+
+    fn publish_disconnected(&self, id: SessionId) {
+        if let Some(listener) = &self.lifecycle_listener {
+            listener.on_session_disconnected(id);
+        }
+        let _ = self.events.send(V2SessionEvent::Disconnected(id));
     }
 }
 
 impl Default for V2SessionRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::session_view::EmbeddedSessionRecord;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum ObservedEvent {
+        Connected(SessionId),
+        Disconnected(SessionId),
+    }
+
+    #[derive(Default)]
+    struct RecordingListener {
+        events: Mutex<Vec<ObservedEvent>>,
+    }
+
+    impl V2SessionLifecycleListener for RecordingListener {
+        fn on_session_connected(&self, session: &SessionView) {
+            self.events
+                .lock()
+                .expect("lifecycle event lock")
+                .push(ObservedEvent::Connected(session.id()));
+        }
+
+        fn on_session_disconnected(&self, session_id: SessionId) {
+            self.events
+                .lock()
+                .expect("lifecycle event lock")
+                .push(ObservedEvent::Disconnected(session_id));
+        }
+    }
+
+    #[test]
+    fn lifecycle_listener_observes_each_committed_event_once() {
+        let listener = Arc::new(RecordingListener::default());
+        let registry = V2SessionRegistry::with_lifecycle_listener(listener.clone());
+        let record = EmbeddedSessionRecord::new(9_851);
+        let view = record.view();
+
+        registry.publish_connected(&view);
+        registry.publish_disconnected(view.id());
+
+        assert_eq!(
+            *listener.events.lock().expect("lifecycle event lock"),
+            vec![
+                ObservedEvent::Connected(view.id()),
+                ObservedEvent::Disconnected(view.id()),
+            ]
+        );
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9851

### Brief Description

- Publish the Broker's canonical V2 authorized dispatcher through a private single-assignment slot, and inject the same `Arc` into the normal listener, fast listener, and embedded proxy only after legacy acceptance is sealed.
- Add a shared V2 session lifecycle registry so Broker producer and consumer state is removed synchronously by typed `SessionId` when either listener disconnects.
- Make Pull, POP, Notification, and PopLite deferred requeue paths race-safe so cleanup, terminal publication, and waiter release have one exact owner.
- Add a real Broker TCP cutover test covering legacy-first delivery, normal and fast V2 sessions, arrival, protocol timeout, peer close, original opaque preservation, single-frame completion, and final resource cleanup.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check`
- `cargo fmt -p rocketmq-transport -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo check -p rocketmq-broker --tests`
- `cargo test -p rocketmq-transport --lib` (673 passed)
- Focused Broker tests for canonical publication, typed session cleanup, requeue races, installed handoff, and the real TCP cutover scenario passed.
- `cargo doc -p rocketmq-transport --no-deps` passed with one pre-existing private-link warning.
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example/`
- The complete mandatory `rocketmq-tools/rocketmq-mcp/` check, boundary, default/all-feature test, Clippy, and documentation profile passed.
- `cargo test -p rocketmq-broker --lib` has five existing failures; each failed identically on `main` under the same exact single-test invocation.
- `./scripts/check-error-hygiene.ps1` reports the same existing findings as `main`, with no new finding from this change.
- Standalone `cargo fmt --all -- --check` in `rocketmq-example/` and `rocketmq-tools/rocketmq-mcp/` hits Windows path-length error 206; package-scoped format checks passed for both projects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved RocketMQ V2 session lifecycle tracking, including connection and disconnection events.
  * Broker startup now consistently uses the V2 request handling path for normal and fast connections.
* **Bug Fixes**
  * Improved cleanup of disconnected sessions and pending polling requests.
  * Fixed race conditions that could cause duplicate resource releases or stale long-polling requests.
  * Improved reliability during transitions between legacy and V2 broker request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->