### PR TITLE
[ISSUE #9868]🐛Release deferred Lite events after capacity is consumed

### DIFF
--- a/rocketmq-broker/src/lite/lite_event_dispatcher.rs
+++ b/rocketmq-broker/src/lite/lite_event_dispatcher.rs
@@ -95,7 +95,10 @@ impl ClientEventState {
         if self.event_set.contains(&event) {
             return true;
         }
-        if self.event_set.len() >= self.max_event_count {
+        // `event_set` also retains reserved and committed records for
+        // deduplication. Only queued records occupy the client pending-event
+        // limit, so deferred records can join the batch that just freed space.
+        if self.events.len() >= self.max_event_count {
             return false;
         }
         self.event_set.insert(event.clone());


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9868

### Brief Description

Uses the queued Lite event count, rather than the deduplication set size, to enforce the per-client event limit. Reserved and committed events remain deduplicated without blocking deferred overflow events from joining the batch that has just freed queue capacity.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check` (passed)
- `cargo test -p rocketmq-broker --lib bounded_dispatch_defers_overflow_and_releases_it_on_consume` (passed)
- `cargo test -p rocketmq-broker --lib trigger_lite_dispatch_respects_broker_max_client_event_count_fallback` (passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- `cargo test -p rocketmq-broker --lib -- --quiet` with a larger Rust test stack: 1016 passed and 1 unrelated parallel runtime shutdown test failed; that test passes when run individually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pending-event limit enforcement so it reflects only events currently waiting in the queue.
  * Deferred events can now be added after queued items are processed, preventing unnecessary rejection when capacity becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->