### PR TITLE
[ISSUE #9865]✨Complete remoting V2 security, observability, and lifecycle contracts

### DIFF
--- a/rocketmq-broker/src/processor/maintenance_request_processor.rs
+++ b/rocketmq-broker/src/processor/maintenance_request_processor.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use rocketmq_auth::AuthRuntime;
+use rocketmq_auth::RemotingAuthContext;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_protocol::code::request_code::RequestCode;
@@ -49,8 +50,10 @@ use rocketmq_store_api::checkpoint::CheckpointRestoreVerification;
 use rocketmq_store_api::checkpoint::CheckpointStorageIdentity;
 use rocketmq_store_api::ReleaseCheckpointStore;
 use rocketmq_transport::api::v1::request_code_not_supported_with_factory_and_remark;
+use rocketmq_transport::api::v2::EmbeddedCaller;
 use rocketmq_transport::api::v2::HandlerOutcome;
 use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrigin;
 use rocketmq_transport::api::v2::RequestProcessorV2;
 
 use crate::config::broker_config::BrokerConfig;
@@ -123,7 +126,7 @@ impl MaintenanceRequestProcessor {
         Ok(response.set_opaque(request.opaque()))
     }
 
-    fn authorize_v2(
+    async fn authorize_v2(
         &self,
         request: &RemotingRequest,
         original_code: i32,
@@ -133,13 +136,29 @@ impl MaintenanceRequestProcessor {
                 "Broker maintenance API is disabled",
             ));
         }
-        let principal = request
-            .authentication()
-            .principal()
-            .ok_or_else(|| RocketMQError::authentication_failed("maintenance request is anonymous"))?;
         let mut authoritative_command = request.command().clone();
         authoritative_command.set_code_mut(original_code);
-        self.authorize_principal(principal.id(), &authoritative_command)
+        let principal = match request.origin() {
+            RequestOrigin::Network { .. } => {
+                let auth_context = RemotingAuthContext::from_request(request)?;
+                self.auth_runtime
+                    .authenticate_maintenance_principal(&authoritative_command, auth_context.channel_id())
+                    .await?
+            }
+            RequestOrigin::Embedded {
+                caller: EmbeddedCaller::BrokerProxy,
+            } => request
+                .authentication()
+                .principal()
+                .map(|principal| principal.id().into())
+                .ok_or_else(|| RocketMQError::authentication_failed("maintenance request is anonymous"))?,
+            _ => {
+                return Err(RocketMQError::authentication_failed(
+                    "maintenance request origin is not authorized",
+                ));
+            }
+        };
+        self.authorize_principal(principal.as_str(), &authoritative_command)
     }
 
     fn authorize_principal(
@@ -272,7 +291,7 @@ impl MaintenanceRequestProcessor {
     pub(crate) async fn process_v2_shared(&self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
         let original_opaque = request.original_identity().original_opaque();
         let original_code = request.original_identity().original_code();
-        let result = match self.authorize_v2(request, original_code) {
+        let result = match self.authorize_v2(request, original_code).await {
             Ok(grant) => self
                 .process_authorized(&grant, RequestCode::from(original_code), request.command_mut())
                 .await
@@ -439,13 +458,17 @@ mod tests {
     use std::net::SocketAddr;
     use std::path::PathBuf;
     use std::sync::Weak;
+    use std::time::Duration;
 
     use cheetah_string::CheetahString;
     use dashmap::DashMap;
+    use rocketmq_auth::cal_signature;
     use rocketmq_auth::AuthConfig;
     use rocketmq_auth::AuthRuntimeBuilder;
     use rocketmq_model::common::config::TopicConfig;
     use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
     use rocketmq_security_api::AuthenticatedRequestContext;
     use rocketmq_security_api::Decision;
     use rocketmq_security_api::MaintenancePolicy;
@@ -463,10 +486,15 @@ mod tests {
     use rocketmq_transport::api::v1::AdmissionController;
     use rocketmq_transport::api::v1::AdmissionLimits;
     use rocketmq_transport::api::v1::RPCHook;
+    use rocketmq_transport::api::v1::ServerConfig;
     use rocketmq_transport::api::v1::TransportSecurity;
     use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
     use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+    use rocketmq_transport::api::v2::TransportServerV2;
+    use rocketmq_transport::test_support::Connection;
     use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+    use tokio::net::TcpStream;
+    use tokio::sync::oneshot;
 
     use super::*;
 
@@ -521,10 +549,19 @@ mod tests {
         }
     }
 
+    fn maintenance_auth_config() -> AuthConfig {
+        AuthConfig {
+            authentication_enabled: true,
+            authorization_enabled: true,
+            init_authentication_user: CheetahString::from_static_str("release-operator:secret"),
+            ..AuthConfig::default()
+        }
+    }
+
     async fn maintenance_processor_for_test() -> MaintenanceRequestProcessor {
         let service_context = crate::test_service_context("maintenance-v2");
         let auth_runtime = Arc::new(
-            AuthRuntimeBuilder::new(AuthConfig::default(), service_context.component("auth"))
+            AuthRuntimeBuilder::new(maintenance_auth_config(), service_context.component("auth"))
                 .build()
                 .await
                 .expect("build maintenance auth runtime"),
@@ -554,7 +591,7 @@ mod tests {
     ) -> (MaintenanceRequestProcessor, Arc<StorePorts>, tempfile::TempDir) {
         let service_context = crate::test_service_context("maintenance-v2-original-code");
         let auth_runtime = Arc::new(
-            AuthRuntimeBuilder::new(AuthConfig::default(), service_context.component("auth"))
+            AuthRuntimeBuilder::new(maintenance_auth_config(), service_context.component("auth"))
                 .build()
                 .await
                 .expect("build maintenance auth runtime"),
@@ -688,6 +725,30 @@ mod tests {
         .set_opaque(opaque)
     }
 
+    fn sign_maintenance_request(mut command: RemotingCommand, access_key: &str, secret: &str) -> RemotingCommand {
+        command.make_custom_header_to_net();
+        command.ensure_ext_fields_initialized();
+        command.add_ext_field("AccessKey", access_key);
+        let mut fields = command
+            .ext_fields()
+            .cloned()
+            .expect("maintenance request fields")
+            .into_iter()
+            .filter(|(key, _)| key.as_str() != "Signature")
+            .collect::<Vec<_>>();
+        fields.sort_by(|left, right| left.0.cmp(&right.0));
+        let mut content = Vec::new();
+        for (_, value) in fields {
+            content.extend_from_slice(value.as_bytes());
+        }
+        if let Some(body) = command.body() {
+            content.extend_from_slice(body);
+        }
+        let signature = cal_signature(content.as_slice(), secret).expect("maintenance signature");
+        command.add_ext_field("Signature", signature);
+        command
+    }
+
     #[tokio::test]
     async fn maintenance_v2_uses_authenticated_principal_for_authorization() {
         let processor = maintenance_processor_for_test().await;
@@ -710,6 +771,99 @@ mod tests {
         };
         assert_eq!(ResponseCode::from(denied.response_code()), ResponseCode::NoPermission);
         assert_eq!(denied.body_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn network_maintenance_uses_verified_credentials_not_bootstrap_authentication_state() {
+        const AUTHENTICATED_OPAQUE: i32 = 5_508;
+        const FORGED_OPAQUE: i32 = 5_509;
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("maintenance-v2-network-auth"))
+            .expect("maintenance network test runtime");
+        let server_context = owner.root_context().component("maintenance-v2-network-auth.server");
+        let runner_context = owner.root_context().component("maintenance-v2-network-auth.runner");
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            maintenance_processor_for_test().await,
+            Vec::new(),
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        ));
+        let server = TransportServerV2::new_with_authorized_dispatcher(
+            Arc::new(ServerConfig {
+                bind_address: "127.0.0.1".to_owned(),
+                listen_port: 0,
+                ..ServerConfig::default()
+            }),
+            server_context,
+            dispatcher,
+        );
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let (startup_sender, startup_receiver) = oneshot::channel();
+        let (result_sender, result_receiver) = oneshot::channel();
+        runner_context
+            .spawn_service("maintenance-v2-network-server", async move {
+                let result = server
+                    .try_run_with_shutdown_report_and_startup(
+                        async move {
+                            let _ = shutdown_receiver.await;
+                        },
+                        startup_sender,
+                    )
+                    .await;
+                let _ = result_sender.send(result);
+            })
+            .expect("spawn maintenance V2 network server");
+
+        let address = startup_receiver
+            .await
+            .expect("maintenance V2 startup channel")
+            .expect("maintenance V2 server startup");
+        let mut client = Connection::new(
+            TcpStream::connect(address)
+                .await
+                .expect("connect maintenance V2 client"),
+        );
+
+        client
+            .send_command(sign_maintenance_request(
+                verify_request(AUTHENTICATED_OPAQUE),
+                "release-operator",
+                "secret",
+            ))
+            .await
+            .expect("send authenticated maintenance request");
+        let authenticated = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+            .await
+            .expect("authenticated maintenance response deadline")
+            .expect("authenticated maintenance connection remains open")
+            .expect("authenticated maintenance response frame");
+        assert_eq!(authenticated.opaque(), AUTHENTICATED_OPAQUE);
+        assert_eq!(ResponseCode::from(authenticated.code()), ResponseCode::Success);
+
+        let mut forged = verify_request(FORGED_OPAQUE);
+        forged.ensure_ext_fields_initialized();
+        forged.add_ext_field("principal", "release-operator");
+        let forged = sign_maintenance_request(forged, "release-operator", "wrong-secret");
+        client
+            .send_command(forged)
+            .await
+            .expect("send forged maintenance principal");
+        let denied = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+            .await
+            .expect("forged maintenance response deadline")
+            .expect("forged maintenance connection remains open")
+            .expect("forged maintenance response frame");
+        assert_eq!(denied.opaque(), FORGED_OPAQUE);
+        assert_eq!(ResponseCode::from(denied.code()), ResponseCode::NoPermission);
+
+        client.shutdown().await.expect("shutdown maintenance V2 client");
+        let _ = shutdown_sender.send(());
+        let report = tokio::time::timeout(Duration::from_secs(2), result_receiver)
+            .await
+            .expect("maintenance V2 shutdown deadline")
+            .expect("maintenance V2 shutdown result channel")
+            .expect("maintenance V2 shutdown report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(owner.shutdown_tasks().await.is_healthy());
     }
 
     #[tokio::test]

--- a/rocketmq-doc/en/remoting-processor-v2-migration-ledger.md
+++ b/rocketmq-doc/en/remoting-processor-v2-migration-ledger.md
@@ -32,14 +32,15 @@ MIG-07 is complete when every application production consumer listed below is
 only remaining V1 inventory is the explicitly listed Transport compatibility
 surface.
 
-This cutover is an intentional source-breaking API migration. Public
-application-facing V1 registration, lifecycle, and processor entry points are
-not preserved as deprecated shims because doing so would retain the production
-authority this stage removes. Downstream source consumers must migrate to the
-typed V2 contracts before adopting the release that contains MIG-07, and that
-release must be classified and communicated as breaking by the release
-process. Wire-level RocketMQ framing, request codes, headers, and valid-input
-response semantics are unchanged. Controller heartbeat leases are now bounded
+This cutover is an intentional source-breaking API migration. Application
+composition roots do not preserve V1 registration or lifecycle shims because
+doing so would retain the production authority this stage removes. The frozen
+Transport-only compatibility API is deprecated with concrete V2 replacements
+until FIN-05 removes it. Downstream source consumers must migrate to the typed
+V2 contracts before adopting the release that contains MIG-07, and that release
+must be classified and communicated as breaking by the release process.
+Wire-level RocketMQ framing, request codes, headers, and valid-input response
+semantics are unchanged. Controller heartbeat leases are now bounded
 to 24 hours so untrusted values cannot pin the generation-fencing table
 indefinitely. Broker Controller-mode configuration enforces the same shared
 limit at startup; deployments with a larger
@@ -110,6 +111,48 @@ No V1 compatibility item is retained in Broker, Client, Namesrv, Controller,
 Auth, Proxy, or Proxy-local production ownership. FIN-05 may remove the
 Transport inventory as a separate compatibility cleanup without changing the
 V2 application contract.
+
+## V1 deprecation and migration map
+
+The remaining `api::v1` processor surface emits specific deprecation guidance;
+it is not a second production composition choice. Migrate each capability as a
+design change rather than mechanically renaming a parameter:
+
+| Deprecated V1 surface | V2 replacement |
+|---|---|
+| `RequestProcessor` / `LocalRequestProcessor` | `RequestProcessorV2` / `LocalRequestProcessorV2` |
+| `AuthorizedCommandDispatcher` | `AuthorizedCommandDispatcherV2` |
+| `ConnectionHandlerContext` / `ConnectionHandlerContextWrapper` | the owned `RemotingRequest` aggregate |
+| `ConnectionHandlerContext::channel()` / `connection_ref()` | `RemotingRequest::session()` and `RequestControlView` for read-only facts; composition-owned `ServerPushSender` or `SessionCloseHandle` only when that authority is required |
+| swallowing `write_response*` / `write*` methods | return `HandlerOutcome::Reply(ResponsePlan)` or claim one `DeferredResponder` and call `respond` |
+
+An inline processor moves response ownership into its return value:
+
+```rust,ignore
+impl RequestProcessorV2 for Processor {
+    async fn process(
+        &mut self,
+        request: &mut RemotingRequest,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let response = RemotingCommand::create_success_response_command();
+        Ok(HandlerOutcome::Reply(ResponsePlan::command(response)?))
+    }
+}
+```
+
+A deferred processor reserves and transfers exactly one response capability;
+it does not retain a channel or handler context:
+
+```rust,ignore
+let responder = request.take_deferred_responder()?;
+let registration = registry.register(request, responder)?;
+Ok(HandlerOutcome::Deferred(registration))
+```
+
+Server-initiated pushes and closes are resolved from the session registry by a
+composition root and stored only where those explicit capabilities are needed.
+Ordinary processors cannot recover either capability from `RemotingRequest` or
+its extension store.
 
 ## Removed production seams
 

--- a/rocketmq-observability/src/metrics/catalog/generated.rs
+++ b/rocketmq-observability/src/metrics/catalog/generated.rs
@@ -256,127 +256,141 @@ const METRIC_LABELS_35: &[&str] = &[
 ];
 
 const METRIC_LABELS_36: &[&str] = &[
-    labels::EVENT,
-    labels::RESULT,
+    labels::CODE,
+    labels::OUTCOME,
 ];
 
 const METRIC_LABELS_37: &[&str] = &[
     labels::EVENT,
-];
-
-const METRIC_LABELS_38: &[&str] = &[
     labels::RESULT,
 ];
 
+const METRIC_LABELS_38: &[&str] = &[
+    labels::EVENT,
+];
+
 const METRIC_LABELS_39: &[&str] = &[
-    labels::SOURCE_KIND,
     labels::RESULT,
 ];
 
 const METRIC_LABELS_40: &[&str] = &[
     labels::SOURCE_KIND,
-    labels::ADDRESS_FAMILY,
+    labels::RESULT,
 ];
 
 const METRIC_LABELS_41: &[&str] = &[
     labels::SOURCE_KIND,
-    labels::FRESHNESS,
+    labels::ADDRESS_FAMILY,
 ];
 
 const METRIC_LABELS_42: &[&str] = &[
-    labels::REASON,
+    labels::SOURCE_KIND,
+    labels::FRESHNESS,
 ];
 
 const METRIC_LABELS_43: &[&str] = &[
-    labels::STAGE,
+    labels::REASON,
 ];
 
 const METRIC_LABELS_44: &[&str] = &[
-    labels::REQUEST_TYPE,
-    labels::RESULT,
+    labels::STAGE,
 ];
 
 const METRIC_LABELS_45: &[&str] = &[
     labels::REQUEST_TYPE,
+    labels::RESULT,
 ];
 
 const METRIC_LABELS_46: &[&str] = &[
-    labels::STATE,
+    labels::REQUEST_TYPE,
 ];
 
 const METRIC_LABELS_47: &[&str] = &[
+    labels::STATE,
+];
+
+const METRIC_LABELS_48: &[&str] = &[
     labels::OPERATION,
     labels::RESULT,
 ];
 
-const METRIC_LABELS_48: &[&str] = &[
+const METRIC_LABELS_49: &[&str] = &[
     labels::SERVICE,
     labels::RELEASE_COMMIT,
     labels::RELEASE_NONCE,
 ];
 
-const METRIC_LABELS_49: &[&str] = &[
+const METRIC_LABELS_50: &[&str] = &[
     labels::OPERATION_KIND,
     labels::OPERATION,
     labels::RESULT,
 ];
 
-const METRIC_LABELS_50: &[&str] = &[
+const METRIC_LABELS_51: &[&str] = &[
     labels::OPERATION_KIND,
     labels::OPERATION,
 ];
 
-const METRIC_LABELS_51: &[&str] = &[
+const METRIC_LABELS_52: &[&str] = &[
     labels::COMPONENT,
     labels::TASK_TYPE,
 ];
 
-const METRIC_LABELS_52: &[&str] = &[
+const METRIC_LABELS_53: &[&str] = &[
     labels::COMPONENT,
 ];
 
-const METRIC_LABELS_53: &[&str] = &[
+const METRIC_LABELS_54: &[&str] = &[
     labels::COMPONENT,
     labels::BLOCKING_LANE,
 ];
 
-const METRIC_LABELS_54: &[&str] = &[
+const METRIC_LABELS_55: &[&str] = &[
     labels::COMPONENT,
     labels::STATE,
     labels::RESULT,
     labels::REASON,
 ];
 
-const METRIC_LABELS_55: &[&str] = &[
+const METRIC_LABELS_56: &[&str] = &[
     labels::COMPONENT,
     labels::BUDGET,
     labels::LANE,
 ];
 
-const METRIC_LABELS_56: &[&str] = &[
+const METRIC_LABELS_57: &[&str] = &[
     labels::BACKEND,
     labels::OPERATION,
     labels::RESULT,
 ];
 
-const METRIC_LABELS_57: &[&str] = &[
+const METRIC_LABELS_58: &[&str] = &[
     labels::BACKEND,
     labels::OPERATION,
     labels::ERROR_KIND,
 ];
 
-const METRIC_LABELS_58: &[&str] = &[
+const METRIC_LABELS_59: &[&str] = &[
     labels::BACKEND,
 ];
 
-const METRIC_LABELS_59: &[&str] = &[
+const METRIC_LABELS_60: &[&str] = &[
     labels::BACKEND,
     labels::STATE,
 ];
 
-const METRIC_LABELS_60: &[&str] = &[
+const METRIC_LABELS_61: &[&str] = &[
     labels::PROCESSOR,
     labels::REQUEST_CODE,
+];
+
+const METRIC_LABELS_62: &[&str] = &[
+    labels::MODE,
+    labels::RESULT,
+];
+
+const METRIC_LABELS_63: &[&str] = &[
+    labels::CODE,
 ];
 
 pub const JAVA_METRICS: &[MetricDescriptor] = &[
@@ -1087,7 +1101,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::TRANSPORT_REQUESTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{request}",
-        labels: METRIC_LABELS_14,
+        labels: METRIC_LABELS_36,
         source: MetricSource::Remoting,
     },
     MetricDescriptor {
@@ -1129,14 +1143,14 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::TRANSPORT_LIFECYCLE_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_36,
+        labels: METRIC_LABELS_37,
         source: MetricSource::Remoting,
     },
     MetricDescriptor {
         name: metrics::TRANSPORT_LIFECYCLE_LISTENER_LATENCY,
         kind: MetricKind::Histogram,
         unit: "ms",
-        labels: METRIC_LABELS_37,
+        labels: METRIC_LABELS_38,
         source: MetricSource::Remoting,
     },
     MetricDescriptor {
@@ -1206,42 +1220,42 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::CLIENT_ONEWAY_EGRESS_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::Client,
     },
     MetricDescriptor {
         name: metrics::CLIENT_NAMESRV_DISCOVERY_REFRESH_TOTAL,
         kind: MetricKind::Counter,
         unit: "{refresh}",
-        labels: METRIC_LABELS_39,
+        labels: METRIC_LABELS_40,
         source: MetricSource::Client,
     },
     MetricDescriptor {
         name: metrics::CLIENT_NAMESRV_DISCOVERY_ENDPOINT_COUNT,
         kind: MetricKind::Gauge,
         unit: "{endpoint}",
-        labels: METRIC_LABELS_40,
+        labels: METRIC_LABELS_41,
         source: MetricSource::Client,
     },
     MetricDescriptor {
         name: metrics::CLIENT_NAMESRV_DISCOVERY_FRESHNESS,
         kind: MetricKind::Gauge,
         unit: "1",
-        labels: METRIC_LABELS_41,
+        labels: METRIC_LABELS_42,
         source: MetricSource::Client,
     },
     MetricDescriptor {
         name: metrics::CLIENT_NAMESRV_DISCOVERY_SNAPSHOT_AGE,
         kind: MetricKind::Gauge,
         unit: "s",
-        labels: METRIC_LABELS_41,
+        labels: METRIC_LABELS_42,
         source: MetricSource::Client,
     },
     MetricDescriptor {
         name: metrics::CLIENT_NAMESRV_FAILOVER_TOTAL,
         kind: MetricKind::Counter,
         unit: "{failover}",
-        labels: METRIC_LABELS_42,
+        labels: METRIC_LABELS_43,
         source: MetricSource::Client,
     },
     MetricDescriptor {
@@ -1276,7 +1290,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_ROUTE_ERRORS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{error}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1297,7 +1311,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_ROUTE_STAGE_LATENCY,
         kind: MetricKind::Histogram,
         unit: "us",
-        labels: METRIC_LABELS_43,
+        labels: METRIC_LABELS_44,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1311,7 +1325,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_ROUTE_CACHE_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1325,35 +1339,35 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_WORKLOAD_ADMISSION_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_44,
+        labels: METRIC_LABELS_45,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_WORKLOAD_ADMISSION_INFLIGHT,
         kind: MetricKind::ObservableGauge,
         unit: "{request}",
-        labels: METRIC_LABELS_45,
+        labels: METRIC_LABELS_46,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_WORKLOAD_ADMISSION_WAITING,
         kind: MetricKind::ObservableGauge,
         unit: "{request}",
-        labels: METRIC_LABELS_45,
+        labels: METRIC_LABELS_46,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_ROUTE_RESPONSE_WRITE_LATENCY,
         kind: MetricKind::Histogram,
         unit: "us",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_ROUTE_END_TO_END_LATENCY,
         kind: MetricKind::Histogram,
         unit: "us",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1367,7 +1381,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_REGISTRATION_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1381,7 +1395,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_UNREGISTRATION_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1402,42 +1416,42 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_EXPIRY_SCAN_BROKERS,
         kind: MetricKind::Histogram,
         unit: "{broker}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_EXPIRY_SCAN_DURATION,
         kind: MetricKind::Histogram,
         unit: "us",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_REQUESTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{request}",
-        labels: METRIC_LABELS_44,
+        labels: METRIC_LABELS_45,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_REQUEST_HANDLER_LATENCY,
         kind: MetricKind::Histogram,
         unit: "us",
-        labels: METRIC_LABELS_44,
+        labels: METRIC_LABELS_45,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_RESPONSE_BYTES,
         kind: MetricKind::Histogram,
         unit: "By",
-        labels: METRIC_LABELS_45,
+        labels: METRIC_LABELS_46,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_REGISTRATION_BODY_BYTES,
         kind: MetricKind::Histogram,
         unit: "By",
-        labels: METRIC_LABELS_43,
+        labels: METRIC_LABELS_44,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1451,21 +1465,21 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_MUTATION_LATENCY,
         kind: MetricKind::Histogram,
         unit: "us",
-        labels: METRIC_LABELS_43,
+        labels: METRIC_LABELS_44,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_SNAPSHOT_REBUILDS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{snapshot}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_EXPIRY_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1479,7 +1493,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_KV_GENERATION,
         kind: MetricKind::ObservableGauge,
         unit: "{generation}",
-        labels: METRIC_LABELS_46,
+        labels: METRIC_LABELS_47,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1500,7 +1514,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_KV_PERSIST_LATENCY,
         kind: MetricKind::Histogram,
         unit: "us",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1514,21 +1528,21 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::NAMESRV_KV_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_SECURITY_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_47,
+        labels: METRIC_LABELS_48,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
         name: metrics::NAMESRV_CONNECTION_EVENTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{event}",
-        labels: METRIC_LABELS_37,
+        labels: METRIC_LABELS_38,
         source: MetricSource::NameServer,
     },
     MetricDescriptor {
@@ -1619,7 +1633,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::PROXY_GRPC_ERRORS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{error}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::Proxy,
     },
     MetricDescriptor {
@@ -1668,42 +1682,42 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::RELEASE_INFO,
         kind: MetricKind::Gauge,
         unit: "1",
-        labels: METRIC_LABELS_48,
+        labels: METRIC_LABELS_49,
         source: MetricSource::Observability,
     },
     MetricDescriptor {
         name: metrics::MCP_REQUESTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{request}",
-        labels: METRIC_LABELS_49,
+        labels: METRIC_LABELS_50,
         source: MetricSource::Mcp,
     },
     MetricDescriptor {
         name: metrics::MCP_REQUEST_LATENCY,
         kind: MetricKind::Histogram,
         unit: "ms",
-        labels: METRIC_LABELS_50,
+        labels: METRIC_LABELS_51,
         source: MetricSource::Mcp,
     },
     MetricDescriptor {
         name: metrics::MCP_ERRORS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{error}",
-        labels: METRIC_LABELS_49,
+        labels: METRIC_LABELS_50,
         source: MetricSource::Mcp,
     },
     MetricDescriptor {
         name: metrics::MCP_CACHE_OPERATIONS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{operation}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::Mcp,
     },
     MetricDescriptor {
         name: metrics::MCP_RATE_LIMIT_TOTAL,
         kind: MetricKind::Counter,
         unit: "{decision}",
-        labels: METRIC_LABELS_38,
+        labels: METRIC_LABELS_39,
         source: MetricSource::Mcp,
     },
     MetricDescriptor {
@@ -1717,182 +1731,231 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         name: metrics::MCP_AUDIT_DROPPED_TOTAL,
         kind: MetricKind::Counter,
         unit: "{record}",
-        labels: METRIC_LABELS_42,
+        labels: METRIC_LABELS_43,
         source: MetricSource::Mcp,
     },
     MetricDescriptor {
         name: metrics::MCP_AUDIT_FAILURES_TOTAL,
         kind: MetricKind::Counter,
         unit: "{failure}",
-        labels: METRIC_LABELS_42,
+        labels: METRIC_LABELS_43,
         source: MetricSource::Mcp,
     },
     MetricDescriptor {
         name: metrics::RUNTIME_TASKS,
         kind: MetricKind::Gauge,
         unit: "{task}",
-        labels: METRIC_LABELS_51,
+        labels: METRIC_LABELS_52,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RUNTIME_TASK_GROUPS,
         kind: MetricKind::Gauge,
         unit: "{group}",
-        labels: METRIC_LABELS_52,
+        labels: METRIC_LABELS_53,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RUNTIME_LONG_RUNNING_TASKS,
         kind: MetricKind::Gauge,
         unit: "{task}",
-        labels: METRIC_LABELS_51,
+        labels: METRIC_LABELS_52,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RUNTIME_BLOCKING_QUEUED,
         kind: MetricKind::Gauge,
         unit: "{task}",
-        labels: METRIC_LABELS_53,
+        labels: METRIC_LABELS_54,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RUNTIME_BLOCKING_RUNNING,
         kind: MetricKind::Gauge,
         unit: "{task}",
-        labels: METRIC_LABELS_53,
+        labels: METRIC_LABELS_54,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RUNTIME_BLOCKING_TIMEOUTS,
         kind: MetricKind::Gauge,
         unit: "{task}",
-        labels: METRIC_LABELS_53,
+        labels: METRIC_LABELS_54,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RUNTIME_LIFECYCLE_TRANSITIONS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{transition}",
-        labels: METRIC_LABELS_54,
+        labels: METRIC_LABELS_55,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RESOURCE_QUEUE_ITEMS,
         kind: MetricKind::ObservableGauge,
         unit: "{item}",
-        labels: METRIC_LABELS_55,
+        labels: METRIC_LABELS_56,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RESOURCE_QUEUE_BYTES,
         kind: MetricKind::ObservableGauge,
         unit: "By",
-        labels: METRIC_LABELS_55,
+        labels: METRIC_LABELS_56,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RESOURCE_QUEUE_OLDEST_AGE_MILLIS,
         kind: MetricKind::ObservableGauge,
         unit: "ms",
-        labels: METRIC_LABELS_55,
+        labels: METRIC_LABELS_56,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RESOURCE_QUEUE_CAPACITY_ITEMS,
         kind: MetricKind::ObservableGauge,
         unit: "{item}",
-        labels: METRIC_LABELS_55,
+        labels: METRIC_LABELS_56,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RESOURCE_QUEUE_CAPACITY_BYTES,
         kind: MetricKind::ObservableGauge,
         unit: "By",
-        labels: METRIC_LABELS_55,
+        labels: METRIC_LABELS_56,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RESOURCE_QUEUE_ACTIVE,
         kind: MetricKind::ObservableGauge,
         unit: "{operation}",
-        labels: METRIC_LABELS_55,
+        labels: METRIC_LABELS_56,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RESOURCE_QUEUE_REJECTED_TOTAL,
         kind: MetricKind::Counter,
         unit: "{rejection}",
-        labels: METRIC_LABELS_55,
+        labels: METRIC_LABELS_56,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RESOURCE_CACHE_USAGE_BYTES,
         kind: MetricKind::ObservableGauge,
         unit: "By",
-        labels: METRIC_LABELS_55,
+        labels: METRIC_LABELS_56,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RESOURCE_CACHE_BUDGET_BYTES,
         kind: MetricKind::ObservableGauge,
         unit: "By",
-        labels: METRIC_LABELS_55,
+        labels: METRIC_LABELS_56,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RECEIPT_RENEWAL_DUE_LAG_MICROS,
         kind: MetricKind::ObservableGauge,
         unit: "us",
-        labels: METRIC_LABELS_52,
+        labels: METRIC_LABELS_53,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::RECEIPT_RENEWAL_EXPIRED_TOTAL,
         kind: MetricKind::Counter,
         unit: "{receipt}",
-        labels: METRIC_LABELS_52,
+        labels: METRIC_LABELS_53,
         source: MetricSource::Runtime,
     },
     MetricDescriptor {
         name: metrics::DASHBOARD_STORAGE_OPERATIONS_TOTAL,
         kind: MetricKind::Counter,
         unit: "",
-        labels: METRIC_LABELS_56,
+        labels: METRIC_LABELS_57,
         source: MetricSource::Observability,
     },
     MetricDescriptor {
         name: metrics::DASHBOARD_STORAGE_OPERATION_DURATION_MILLISECONDS,
         kind: MetricKind::Histogram,
         unit: "ms",
-        labels: METRIC_LABELS_56,
+        labels: METRIC_LABELS_57,
         source: MetricSource::Observability,
     },
     MetricDescriptor {
         name: metrics::DASHBOARD_STORAGE_OPERATION_ERRORS_TOTAL,
         kind: MetricKind::Counter,
         unit: "",
-        labels: METRIC_LABELS_57,
+        labels: METRIC_LABELS_58,
         source: MetricSource::Observability,
     },
     MetricDescriptor {
         name: metrics::DASHBOARD_STORAGE_CAPACITY_BYTES,
         kind: MetricKind::Gauge,
         unit: "By",
-        labels: METRIC_LABELS_58,
+        labels: METRIC_LABELS_59,
         source: MetricSource::Observability,
     },
     MetricDescriptor {
         name: metrics::DASHBOARD_STORAGE_POOL_CONNECTIONS,
         kind: MetricKind::Gauge,
         unit: "",
-        labels: METRIC_LABELS_59,
+        labels: METRIC_LABELS_60,
         source: MetricSource::Observability,
     },
     MetricDescriptor {
         name: metrics::TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL,
         kind: MetricKind::Counter,
         unit: "{request}",
-        labels: METRIC_LABELS_60,
+        labels: METRIC_LABELS_61,
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::TRANSPORT_REQUEST_DURATION_SECONDS,
+        kind: MetricKind::Histogram,
+        unit: "s",
+        labels: METRIC_LABELS_36,
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::TRANSPORT_RESPONSE_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{response}",
+        labels: METRIC_LABELS_62,
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::TRANSPORT_DEFERRED_INFLIGHT,
+        kind: MetricKind::UpDownCounter,
+        unit: "{request}",
+        labels: METRIC_LABELS_63,
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::TRANSPORT_DEFERRED_RETAINED_BYTES,
+        kind: MetricKind::UpDownCounter,
+        unit: "By",
+        labels: METRIC_LABELS_63,
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::TRANSPORT_RESPONSE_QUEUE_WAIT_SECONDS,
+        kind: MetricKind::Histogram,
+        unit: "s",
+        labels: METRIC_LABELS_14,
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::TRANSPORT_RESPONSE_DUPLICATE_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{response}",
+        labels: METRIC_LABELS_63,
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::TRANSPORT_RESPONSE_ABANDONED_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{response}",
+        labels: METRIC_LABELS_43,
         source: MetricSource::Remoting,
     },
 ];

--- a/rocketmq-observability/src/metrics/catalog/schema/rust/catalog.toml
+++ b/rocketmq-observability/src/metrics/catalog/schema/rust/catalog.toml
@@ -54,7 +54,7 @@ index = 100
 symbol = "TRANSPORT_REQUESTS_TOTAL"
 kind = "Counter"
 unit = "{request}"
-labels = []
+labels = ["CODE", "OUTCOME"]
 source = "Remoting"
 
 [[metric]]
@@ -982,3 +982,59 @@ unit = "{request}"
 labels = ["PROCESSOR", "REQUEST_CODE"]
 source = "Remoting"
 description = "Requests admitted through the V1 processor compatibility adapter"
+
+[[metric]]
+index = 216
+symbol = "TRANSPORT_REQUEST_DURATION_SECONDS"
+kind = "Histogram"
+unit = "s"
+labels = ["CODE", "OUTCOME"]
+source = "Remoting"
+
+[[metric]]
+index = 217
+symbol = "TRANSPORT_RESPONSE_TOTAL"
+kind = "Counter"
+unit = "{response}"
+labels = ["MODE", "RESULT"]
+source = "Remoting"
+
+[[metric]]
+index = 218
+symbol = "TRANSPORT_DEFERRED_INFLIGHT"
+kind = "UpDownCounter"
+unit = "{request}"
+labels = ["CODE"]
+source = "Remoting"
+
+[[metric]]
+index = 219
+symbol = "TRANSPORT_DEFERRED_RETAINED_BYTES"
+kind = "UpDownCounter"
+unit = "By"
+labels = ["CODE"]
+source = "Remoting"
+
+[[metric]]
+index = 220
+symbol = "TRANSPORT_RESPONSE_QUEUE_WAIT_SECONDS"
+kind = "Histogram"
+unit = "s"
+labels = []
+source = "Remoting"
+
+[[metric]]
+index = 221
+symbol = "TRANSPORT_RESPONSE_DUPLICATE_TOTAL"
+kind = "Counter"
+unit = "{response}"
+labels = ["CODE"]
+source = "Remoting"
+
+[[metric]]
+index = 222
+symbol = "TRANSPORT_RESPONSE_ABANDONED_TOTAL"
+kind = "Counter"
+unit = "{response}"
+labels = ["REASON"]
+source = "Remoting"

--- a/rocketmq-observability/src/metrics/catalog/tests.rs
+++ b/rocketmq-observability/src/metrics/catalog/tests.rs
@@ -66,8 +66,8 @@ fn combined_catalog_contains_every_semantic_metric_once() {
         .collect::<HashSet<_>>();
 
     assert_eq!(JAVA_METRICS.len(), 94);
-    assert_eq!(RUST_METRICS.len(), 122);
-    assert_eq!(combined.len(), 216, "duplicate metric names across catalogs");
+    assert_eq!(RUST_METRICS.len(), 129);
+    assert_eq!(combined.len(), 223, "duplicate metric names across catalogs");
 }
 
 #[test]

--- a/rocketmq-observability/src/metrics/remoting.rs
+++ b/rocketmq-observability/src/metrics/remoting.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 pub use crate::semantic::metrics::RPC_LATENCY;
+pub use crate::semantic::metrics::TRANSPORT_DEFERRED_INFLIGHT;
+pub use crate::semantic::metrics::TRANSPORT_DEFERRED_RETAINED_BYTES;
 pub use crate::semantic::metrics::TRANSPORT_DEFERRED_TERMINAL_TOTAL;
 pub use crate::semantic::metrics::TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES;
 pub use crate::semantic::metrics::TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL;
@@ -22,7 +24,12 @@ pub use crate::semantic::metrics::TRANSPORT_OUTBOUND_ACCEPTED_PLAINTEXT_BYTES;
 pub use crate::semantic::metrics::TRANSPORT_OUTBOUND_ATTEMPTED_PLAINTEXT_BYTES;
 pub use crate::semantic::metrics::TRANSPORT_OUTBOUND_WRITTEN_PLAINTEXT_BYTES;
 pub use crate::semantic::metrics::TRANSPORT_REQUESTS_TOTAL;
+pub use crate::semantic::metrics::TRANSPORT_REQUEST_DURATION_SECONDS;
 pub use crate::semantic::metrics::TRANSPORT_REQUEST_LATENCY;
+pub use crate::semantic::metrics::TRANSPORT_RESPONSE_ABANDONED_TOTAL;
+pub use crate::semantic::metrics::TRANSPORT_RESPONSE_DUPLICATE_TOTAL;
+pub use crate::semantic::metrics::TRANSPORT_RESPONSE_QUEUE_WAIT_SECONDS;
+pub use crate::semantic::metrics::TRANSPORT_RESPONSE_TOTAL;
 
 use std::time::Duration;
 use std::time::Instant;
@@ -35,6 +42,178 @@ const RESULT_LEGACY_AMBIGUOUS_NONE: &str = "legacy_ambiguous_none";
 const RESULT_PROCESS_REQUEST_FAILED: &str = "process_request_failed";
 const RESULT_WRITE_CHANNEL_FAILED: &str = "write_channel_failed";
 
+/// Fixed request-code classification used by remoting metric labels.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RequestCodeClass {
+    /// Pull-message requests.
+    PullMessage,
+    /// Pop-message requests.
+    PopMessage,
+    /// Notification requests.
+    Notification,
+    /// Every request code outside the fixed long-polling classes.
+    Other,
+}
+
+impl RequestCodeClass {
+    /// Returns the fixed low-cardinality metric label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PullMessage => "pull_message",
+            Self::PopMessage => "pop_message",
+            Self::Notification => "notification",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// Closed request outcome vocabulary used by remoting metric labels.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RequestOutcome {
+    /// An inline reply with no body.
+    ReplyEmpty,
+    /// An inline reply backed by one byte buffer.
+    ReplyBytes,
+    /// An inline reply backed by multiple byte segments.
+    ReplySegments,
+    /// An inline reply backed by file regions.
+    ReplyFileRegions,
+    /// Deferred ownership was durably registered; this is a lifecycle event, not a terminal response.
+    DeferredRegistered,
+    /// A registered deferred request reached successful response completion.
+    DeferredResumed,
+    /// A one-way request completed without a response by protocol contract.
+    Oneway,
+    /// A request completed with an explicit protocol-level no-response outcome.
+    ProtocolNoResponse,
+    /// A request was cancelled before response completion.
+    Cancelled,
+    /// Processing or delivery failed.
+    Failed,
+    /// A V1 processor produced a legacy reply.
+    LegacyReply,
+    /// A V1 processor returned the legacy ambiguous `None` outcome.
+    LegacyAmbiguousNone,
+}
+
+impl RequestOutcome {
+    /// Returns the fixed low-cardinality metric label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ReplyEmpty => "reply_empty",
+            Self::ReplyBytes => "reply_bytes",
+            Self::ReplySegments => "reply_segments",
+            Self::ReplyFileRegions => "reply_file_regions",
+            Self::DeferredRegistered => "deferred_registered",
+            Self::DeferredResumed => "deferred_resumed",
+            Self::Oneway => "oneway",
+            Self::ProtocolNoResponse => "protocol_no_response",
+            Self::Cancelled => "cancelled",
+            Self::Failed => "failed",
+            Self::LegacyReply => "legacy_reply",
+            Self::LegacyAmbiguousNone => "legacy_ambiguous_none",
+        }
+    }
+}
+
+/// Closed response delivery mode vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ResponseMode {
+    /// Response delivery completed in the original dispatch flow.
+    Inline,
+    /// Response delivery completed after durable deferred registration.
+    Deferred,
+    /// The request completed without a response write.
+    NoResponse,
+}
+
+impl ResponseMode {
+    /// Returns the fixed low-cardinality metric label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Inline => "inline",
+            Self::Deferred => "deferred",
+            Self::NoResponse => "no_response",
+        }
+    }
+}
+
+/// Closed response terminal result vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ResponseResult {
+    /// The canonical transport accepted and wrote the response.
+    TransportWritten,
+    /// An embedded in-process sink accepted the response.
+    InProcessAccepted,
+    /// No response was required for a one-way request.
+    Oneway,
+    /// No response was produced by explicit protocol contract.
+    ProtocolNoResponse,
+    /// Response ownership was cancelled before completion.
+    Cancelled,
+    /// Response binding or delivery failed.
+    Failed,
+}
+
+impl ResponseResult {
+    /// Returns the fixed low-cardinality metric label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TransportWritten => "transport_written",
+            Self::InProcessAccepted => "in_process_accepted",
+            Self::Oneway => "oneway",
+            Self::ProtocolNoResponse => "protocol_no_response",
+            Self::Cancelled => "cancelled",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// Closed abandoned-response reason vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ResponseAbandonedReason {
+    /// The response owner explicitly cancelled it.
+    Explicit,
+    /// The response receiver was dropped.
+    ReceiverDropped,
+    /// The deferred responder was dropped without completion.
+    Abandoned,
+    /// A claimed deferred response was dropped before completion.
+    ClaimDropped,
+    /// The immutable owner deadline expired.
+    OwnerDeadline,
+    /// The parent lifecycle cancelled the response.
+    ParentCancelled,
+    /// The processor required to resume the response was unavailable.
+    ProcessorUnavailable,
+    /// The owning service began shutdown.
+    ServiceStopping,
+    /// The owning session closed.
+    SessionClosed,
+}
+
+impl ResponseAbandonedReason {
+    /// Returns the fixed low-cardinality metric label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::ReceiverDropped => "receiver_dropped",
+            Self::Abandoned => "abandoned",
+            Self::ClaimDropped => "claim_dropped",
+            Self::OwnerDeadline => "owner_deadline",
+            Self::ParentCancelled => "parent_cancelled",
+            Self::ProcessorUnavailable => "processor_unavailable",
+            Self::ServiceStopping => "service_stopping",
+            Self::SessionClosed => "session_closed",
+        }
+    }
+}
+
 #[inline]
 fn duration_millis_u64(duration: Duration) -> u64 {
     duration.as_millis().min(u128::from(u64::MAX)) as u64
@@ -42,68 +221,128 @@ fn duration_millis_u64(duration: Duration) -> u64 {
 
 /// Records the metrics for one remoting request against one explicit telemetry runtime.
 ///
-/// The guard records request volume when it starts. The transport decoder records exact inbound
-/// frame bytes separately. Dropping the guard records request latency and, unless a terminal
-/// outcome was selected explicitly, one cancellation outcome.
+/// The guard records request duration and a classified outcome when the request reaches a terminal
+/// state. A V2 deferred request may additionally record one `deferred_registered` lifecycle event
+/// and one terminal `deferred_resumed`, `cancelled`, or `failed` outcome. Concurrent terminalization
+/// may change exporter observation order, but each lifecycle event is recorded at most once. The
+/// transport decoder records exact inbound frame bytes separately. Dropping an unfinished V1 guard
+/// records cancellation; dropping an unfinished V2 guard records failure.
 pub struct RequestMetricsGuard {
     metrics: RemotingMetrics,
     start: Instant,
     request_code: i32,
     is_long_polling: bool,
     rpc_recorded: bool,
+    deferred_registered_recorded: bool,
+    fallback: RequestOutcome,
+    code_class: RequestCodeClass,
 }
 
 impl RequestMetricsGuard {
     #[inline]
     pub fn start(metrics: RemotingMetrics, request_code: i32, _request_bytes: u64, is_long_polling: bool) -> Self {
-        metrics.record_requests_total(1);
-
         Self {
             metrics,
             start: Instant::now(),
             request_code,
             is_long_polling,
             rpc_recorded: false,
+            deferred_registered_recorded: false,
+            fallback: RequestOutcome::Cancelled,
+            code_class: RequestCodeClass::Other,
         }
+    }
+
+    /// Starts a V2 request guard with its trusted static request-code class.
+    #[inline]
+    pub fn start_v2(
+        metrics: RemotingMetrics,
+        request_code: i32,
+        request_bytes: u64,
+        is_long_polling: bool,
+        code_class: RequestCodeClass,
+    ) -> Self {
+        let mut guard = Self::start(metrics, request_code, request_bytes, is_long_polling);
+        guard.fallback = RequestOutcome::Failed;
+        guard.code_class = code_class;
+        guard
     }
 
     #[inline]
     pub fn complete_response(&mut self, response_code: i32) {
-        self.record_rpc_latency(response_code, RESULT_SUCCESS);
+        self.record_terminal(response_code, RESULT_SUCCESS, RequestOutcome::LegacyReply);
+    }
+
+    /// Completes a V2 request with one terminal classified outcome.
+    #[inline]
+    pub fn complete_v2(&mut self, response_code: i32, outcome: RequestOutcome) {
+        let result = if outcome == RequestOutcome::Failed {
+            RESULT_PROCESS_REQUEST_FAILED
+        } else {
+            RESULT_SUCCESS
+        };
+        self.record_terminal(response_code, result, outcome);
+    }
+
+    /// Records durable deferred registration without completing the request.
+    ///
+    /// A deferred request emits this lifecycle event only after ownership is
+    /// durably transferred to the registry and emits one terminal request
+    /// outcome when it is resumed, cancelled, or fails. A concurrent terminal
+    /// may be observed first; both events remain at-most-once. Response metrics
+    /// remain terminal-only and are not recorded by this method.
+    #[inline]
+    pub fn record_v2_deferred_registered(&mut self) {
+        if self.deferred_registered_recorded {
+            return;
+        }
+        self.metrics.record_classified_request(
+            self.code_class,
+            RequestOutcome::DeferredRegistered,
+            self.start.elapsed().as_secs_f64(),
+        );
+        self.deferred_registered_recorded = true;
     }
 
     #[inline]
     pub fn complete_oneway(&mut self) {
-        self.record_rpc_latency(NO_RESPONSE_CODE, RESULT_ONEWAY);
+        self.record_terminal(NO_RESPONSE_CODE, RESULT_ONEWAY, RequestOutcome::Oneway);
     }
 
     #[inline]
     pub fn complete_cancelled(&mut self) {
-        self.record_rpc_latency(NO_RESPONSE_CODE, RESULT_CANCELED);
+        self.record_terminal(NO_RESPONSE_CODE, RESULT_CANCELED, RequestOutcome::Cancelled);
     }
 
     #[inline]
     pub fn complete_legacy_ambiguous_none(&mut self) {
-        self.record_rpc_latency(NO_RESPONSE_CODE, RESULT_LEGACY_AMBIGUOUS_NONE);
+        self.record_terminal(
+            NO_RESPONSE_CODE,
+            RESULT_LEGACY_AMBIGUOUS_NONE,
+            RequestOutcome::LegacyAmbiguousNone,
+        );
     }
 
     #[inline]
     pub fn complete_process_request_failed(&mut self, response_code: i32) {
-        self.record_rpc_latency(response_code, RESULT_PROCESS_REQUEST_FAILED);
+        self.record_terminal(response_code, RESULT_PROCESS_REQUEST_FAILED, RequestOutcome::Failed);
     }
 
     #[inline]
     pub fn complete_write_channel_failed(&mut self, response_code: i32) {
-        self.record_rpc_latency(response_code, RESULT_WRITE_CHANNEL_FAILED);
+        self.record_terminal(response_code, RESULT_WRITE_CHANNEL_FAILED, RequestOutcome::Failed);
     }
 
     #[inline]
-    fn record_rpc_latency(&mut self, response_code: i32, result: &'static str) {
+    fn record_terminal(&mut self, response_code: i32, result: &'static str, outcome: RequestOutcome) {
         if self.rpc_recorded {
             return;
         }
+        let elapsed = self.start.elapsed();
+        self.metrics
+            .record_classified_request(self.code_class, outcome, elapsed.as_secs_f64());
         self.metrics.record_rpc_latency(
-            duration_millis_u64(self.start.elapsed()),
+            duration_millis_u64(elapsed),
             self.request_code,
             response_code,
             self.is_long_polling,
@@ -118,7 +357,16 @@ impl Drop for RequestMetricsGuard {
         self.metrics
             .record_request_latency(duration_millis_u64(self.start.elapsed()));
         if !self.rpc_recorded {
-            self.complete_cancelled();
+            let fallback = self.fallback;
+            self.record_terminal(
+                NO_RESPONSE_CODE,
+                if fallback == RequestOutcome::Cancelled {
+                    RESULT_CANCELED
+                } else {
+                    RESULT_PROCESS_REQUEST_FAILED
+                },
+                fallback,
+            );
         }
     }
 }
@@ -143,6 +391,31 @@ impl RemotingMetrics {
 
     #[inline]
     pub fn record_requests_total(&self, _count: u64) {}
+
+    /// Records one request lifecycle event and duration using fixed labels.
+    #[inline]
+    pub fn record_classified_request(&self, _code: RequestCodeClass, _outcome: RequestOutcome, _duration_seconds: f64) {
+    }
+
+    /// Records one terminal response using fixed mode and result labels.
+    #[inline]
+    pub fn record_response(&self, _mode: ResponseMode, _result: ResponseResult) {}
+
+    /// Adjusts deferred gauges for one fixed request-code class.
+    #[inline]
+    pub fn adjust_deferred(&self, _code: RequestCodeClass, _inflight_delta: i64, _retained_bytes_delta: i64) {}
+
+    /// Records time spent waiting in the canonical response queue.
+    #[inline]
+    pub fn record_response_queue_wait(&self, _duration_seconds: f64) {}
+
+    /// Records a duplicate terminal response attempt for one fixed code class.
+    #[inline]
+    pub fn record_response_duplicate(&self, _code: RequestCodeClass) {}
+
+    /// Records a terminal response abandonment reason from the closed vocabulary.
+    #[inline]
+    pub fn record_response_abandoned(&self, _reason: ResponseAbandonedReason) {}
 
     #[inline]
     pub fn record_request_latency(&self, _latency_ms: u64) {}
@@ -195,6 +468,13 @@ pub struct RemotingMetrics {
 struct RemotingMetricInstruments {
     requests_total: opentelemetry::metrics::Counter<u64>,
     request_latency: opentelemetry::metrics::Histogram<u64>,
+    request_duration_seconds: opentelemetry::metrics::Histogram<f64>,
+    response_total: opentelemetry::metrics::Counter<u64>,
+    deferred_inflight: opentelemetry::metrics::UpDownCounter<i64>,
+    deferred_retained_bytes: opentelemetry::metrics::UpDownCounter<i64>,
+    response_queue_wait_seconds: opentelemetry::metrics::Histogram<f64>,
+    response_duplicate_total: opentelemetry::metrics::Counter<u64>,
+    response_abandoned_total: opentelemetry::metrics::Counter<u64>,
     outbound_attempted_plaintext_bytes: opentelemetry::metrics::Counter<u64>,
     outbound_accepted_plaintext_bytes: opentelemetry::metrics::Counter<u64>,
     outbound_written_plaintext_bytes: opentelemetry::metrics::Counter<u64>,
@@ -248,7 +528,110 @@ impl RemotingMetrics {
     pub fn record_requests_total(&self, count: u64) {
         if self.is_active() {
             if let Some(instruments) = &self.instruments {
-                instruments.requests_total.add(count, &[]);
+                instruments.requests_total.add(
+                    count,
+                    &[
+                        opentelemetry::KeyValue::new(crate::semantic::labels::CODE, RequestCodeClass::Other.as_str()),
+                        opentelemetry::KeyValue::new(
+                            crate::semantic::labels::OUTCOME,
+                            RequestOutcome::LegacyReply.as_str(),
+                        ),
+                    ],
+                );
+            }
+        }
+    }
+
+    /// Records one request lifecycle event and duration using fixed labels.
+    #[inline]
+    pub fn record_classified_request(&self, code: RequestCodeClass, outcome: RequestOutcome, duration_seconds: f64) {
+        if !self.is_active() {
+            return;
+        }
+        let Some(instruments) = &self.instruments else {
+            return;
+        };
+        let attributes = [
+            opentelemetry::KeyValue::new(crate::semantic::labels::CODE, code.as_str()),
+            opentelemetry::KeyValue::new(crate::semantic::labels::OUTCOME, outcome.as_str()),
+        ];
+        instruments.requests_total.add(1, &attributes);
+        instruments
+            .request_duration_seconds
+            .record(duration_seconds, &attributes);
+    }
+
+    /// Records one terminal response using fixed mode and result labels.
+    #[inline]
+    pub fn record_response(&self, mode: ResponseMode, result: ResponseResult) {
+        if self.is_active() {
+            if let Some(instruments) = &self.instruments {
+                instruments.response_total.add(
+                    1,
+                    &[
+                        opentelemetry::KeyValue::new(crate::semantic::labels::MODE, mode.as_str()),
+                        opentelemetry::KeyValue::new(crate::semantic::labels::RESULT, result.as_str()),
+                    ],
+                );
+            }
+        }
+    }
+
+    /// Adjusts deferred gauges for one fixed request-code class.
+    #[inline]
+    pub fn adjust_deferred(&self, code: RequestCodeClass, inflight_delta: i64, retained_bytes_delta: i64) {
+        if self.is_active() {
+            if let Some(instruments) = &self.instruments {
+                let attributes = [opentelemetry::KeyValue::new(
+                    crate::semantic::labels::CODE,
+                    code.as_str(),
+                )];
+                instruments.deferred_inflight.add(inflight_delta, &attributes);
+                instruments
+                    .deferred_retained_bytes
+                    .add(retained_bytes_delta, &attributes);
+            }
+        }
+    }
+
+    /// Records time spent waiting in the canonical response queue.
+    #[inline]
+    pub fn record_response_queue_wait(&self, duration_seconds: f64) {
+        if self.is_active() {
+            if let Some(instruments) = &self.instruments {
+                instruments.response_queue_wait_seconds.record(duration_seconds, &[]);
+            }
+        }
+    }
+
+    /// Records a duplicate terminal response attempt for one fixed code class.
+    #[inline]
+    pub fn record_response_duplicate(&self, code: RequestCodeClass) {
+        if self.is_active() {
+            if let Some(instruments) = &self.instruments {
+                instruments.response_duplicate_total.add(
+                    1,
+                    &[opentelemetry::KeyValue::new(
+                        crate::semantic::labels::CODE,
+                        code.as_str(),
+                    )],
+                );
+            }
+        }
+    }
+
+    /// Records a terminal response abandonment reason from the closed vocabulary.
+    #[inline]
+    pub fn record_response_abandoned(&self, reason: ResponseAbandonedReason) {
+        if self.is_active() {
+            if let Some(instruments) = &self.instruments {
+                instruments.response_abandoned_total.add(
+                    1,
+                    &[opentelemetry::KeyValue::new(
+                        crate::semantic::labels::REASON,
+                        reason.as_str(),
+                    )],
+                );
             }
         }
     }
@@ -400,6 +783,48 @@ impl RemotingMetricInstruments {
             .with_unit("ms")
             .build();
 
+        let request_duration_seconds = meter
+            .f64_histogram(TRANSPORT_REQUEST_DURATION_SECONDS)
+            .with_description("V2 remoting request duration by fixed code class and terminal outcome")
+            .with_unit("s")
+            .build();
+
+        let response_total = meter
+            .u64_counter(TRANSPORT_RESPONSE_TOTAL)
+            .with_description("Canonical response terminal outcomes by delivery mode")
+            .with_unit("{response}")
+            .build();
+
+        let deferred_inflight = meter
+            .i64_up_down_counter(TRANSPORT_DEFERRED_INFLIGHT)
+            .with_description("V2 deferred responses currently retained by the transport")
+            .with_unit("{request}")
+            .build();
+
+        let deferred_retained_bytes = meter
+            .i64_up_down_counter(TRANSPORT_DEFERRED_RETAINED_BYTES)
+            .with_description("Estimated bytes retained by V2 deferred responses")
+            .with_unit("By")
+            .build();
+
+        let response_queue_wait_seconds = meter
+            .f64_histogram(TRANSPORT_RESPONSE_QUEUE_WAIT_SECONDS)
+            .with_description("Time accepted response writes wait before the canonical writer starts")
+            .with_unit("s")
+            .build();
+
+        let response_duplicate_total = meter
+            .u64_counter(TRANSPORT_RESPONSE_DUPLICATE_TOTAL)
+            .with_description("Duplicate V2 response terminal attempts")
+            .with_unit("{response}")
+            .build();
+
+        let response_abandoned_total = meter
+            .u64_counter(TRANSPORT_RESPONSE_ABANDONED_TOTAL)
+            .with_description("V2 responses terminated without response delivery")
+            .with_unit("{response}")
+            .build();
+
         let outbound_attempted_plaintext_bytes = meter
             .u64_counter(TRANSPORT_OUTBOUND_ATTEMPTED_PLAINTEXT_BYTES)
             .with_description("Plaintext bytes offered to the transport writer")
@@ -454,6 +879,13 @@ impl RemotingMetricInstruments {
         Self {
             requests_total,
             request_latency,
+            request_duration_seconds,
+            response_total,
+            deferred_inflight,
+            deferred_retained_bytes,
+            response_queue_wait_seconds,
+            response_duplicate_total,
+            response_abandoned_total,
             outbound_attempted_plaintext_bytes,
             outbound_accepted_plaintext_bytes,
             outbound_written_plaintext_bytes,
@@ -504,6 +936,13 @@ mod tests {
         let metrics = RemotingMetrics::new(&meter);
 
         metrics.record_requests_total(1);
+        metrics.record_classified_request(RequestCodeClass::PullMessage, RequestOutcome::ReplyBytes, 0.003);
+        metrics.record_response(ResponseMode::Inline, ResponseResult::TransportWritten);
+        metrics.adjust_deferred(RequestCodeClass::PullMessage, 1, 512);
+        metrics.adjust_deferred(RequestCodeClass::PullMessage, -1, -512);
+        metrics.record_response_queue_wait(0.001);
+        metrics.record_response_duplicate(RequestCodeClass::PullMessage);
+        metrics.record_response_abandoned(ResponseAbandonedReason::Abandoned);
         metrics.record_request_latency(3);
         metrics.record_outbound_attempted_plaintext_bytes(256);
         metrics.record_outbound_accepted_plaintext_bytes(256);

--- a/rocketmq-observability/src/metrics/tests/remoting_metric_isolation.rs
+++ b/rocketmq-observability/src/metrics/tests/remoting_metric_isolation.rs
@@ -20,13 +20,25 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use crate::metrics::remoting::RemotingMetrics;
+use crate::metrics::remoting::RequestCodeClass;
 use crate::metrics::remoting::RequestMetricsGuard;
+use crate::metrics::remoting::RequestOutcome;
+use crate::metrics::remoting::ResponseAbandonedReason;
+use crate::metrics::remoting::ResponseMode;
+use crate::metrics::remoting::ResponseResult;
 use crate::metrics::remoting::RPC_LATENCY;
+use crate::metrics::remoting::TRANSPORT_DEFERRED_INFLIGHT;
+use crate::metrics::remoting::TRANSPORT_DEFERRED_RETAINED_BYTES;
 use crate::metrics::remoting::TRANSPORT_DEFERRED_TERMINAL_TOTAL;
 use crate::metrics::remoting::TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES;
 use crate::metrics::remoting::TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL;
 use crate::metrics::remoting::TRANSPORT_REQUESTS_TOTAL;
+use crate::metrics::remoting::TRANSPORT_REQUEST_DURATION_SECONDS;
 use crate::metrics::remoting::TRANSPORT_REQUEST_LATENCY;
+use crate::metrics::remoting::TRANSPORT_RESPONSE_ABANDONED_TOTAL;
+use crate::metrics::remoting::TRANSPORT_RESPONSE_DUPLICATE_TOTAL;
+use crate::metrics::remoting::TRANSPORT_RESPONSE_QUEUE_WAIT_SECONDS;
+use crate::metrics::remoting::TRANSPORT_RESPONSE_TOTAL;
 use crate::TelemetryHandle;
 use opentelemetry::metrics::Meter;
 use opentelemetry::metrics::MeterProvider;
@@ -49,10 +61,23 @@ enum CapturedValue {
     Other,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum CapturedNumber {
+    U64(u64),
+    I64(i64),
+    HistogramCount(u64),
+}
+
+impl PartialEq<u64> for CapturedNumber {
+    fn eq(&self, other: &u64) -> bool {
+        matches!(self, Self::U64(value) | Self::HistogramCount(value) if value == other)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 struct CapturedPoint {
     metric: String,
-    value: u64,
+    value: CapturedNumber,
     attributes: BTreeMap<String, CapturedValue>,
 }
 
@@ -77,7 +102,7 @@ impl PushMetricExporter for CapturingExporter {
                         for point in sum.data_points() {
                             captured.push(CapturedPoint {
                                 metric: metric.name().to_string(),
-                                value: point.value(),
+                                value: CapturedNumber::U64(point.value()),
                                 attributes: attributes(point.attributes()),
                             });
                         }
@@ -86,7 +111,25 @@ impl PushMetricExporter for CapturingExporter {
                         for point in histogram.data_points() {
                             captured.push(CapturedPoint {
                                 metric: metric.name().to_string(),
-                                value: point.count(),
+                                value: CapturedNumber::HistogramCount(point.count()),
+                                attributes: attributes(point.attributes()),
+                            });
+                        }
+                    }
+                    AggregatedMetrics::I64(MetricData::Sum(sum)) => {
+                        for point in sum.data_points() {
+                            captured.push(CapturedPoint {
+                                metric: metric.name().to_string(),
+                                value: CapturedNumber::I64(point.value()),
+                                attributes: attributes(point.attributes()),
+                            });
+                        }
+                    }
+                    AggregatedMetrics::F64(MetricData::Histogram(histogram)) => {
+                        for point in histogram.data_points() {
+                            captured.push(CapturedPoint {
+                                metric: metric.name().to_string(),
+                                value: CapturedNumber::HistogramCount(point.count()),
                                 attributes: attributes(point.attributes()),
                             });
                         }
@@ -137,7 +180,21 @@ fn metric_value(points: &[CapturedPoint], metric: &str) -> u64 {
     points
         .iter()
         .filter(|point| point.metric == metric)
-        .map(|point| point.value)
+        .map(|point| match point.value {
+            CapturedNumber::U64(value) | CapturedNumber::HistogramCount(value) => value,
+            CapturedNumber::I64(_) => 0,
+        })
+        .sum()
+}
+
+fn signed_metric_value(points: &[CapturedPoint], metric: &str) -> i64 {
+    points
+        .iter()
+        .filter(|point| point.metric == metric)
+        .map(|point| match point.value {
+            CapturedNumber::I64(value) => value,
+            CapturedNumber::U64(_) | CapturedNumber::HistogramCount(_) => 0,
+        })
         .sum()
 }
 
@@ -155,6 +212,13 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
     first.record_legacy_processor_request("broker-send", 10);
     first.record_deferred_terminal("pull_message", "owner_deadline");
     first.record_deferred_terminal("pull_message", "owner_deadline");
+    first.record_response(ResponseMode::Inline, ResponseResult::TransportWritten);
+    first.record_response(ResponseMode::Deferred, ResponseResult::TransportWritten);
+    first.record_response_duplicate(RequestCodeClass::PullMessage);
+    first.record_response_abandoned(ResponseAbandonedReason::Abandoned);
+    first.adjust_deferred(RequestCodeClass::PullMessage, 1, 512);
+    first.adjust_deferred(RequestCodeClass::PullMessage, -1, -512);
+    first.record_response_queue_wait(0.125);
     second.record_legacy_processor_request("namesrv-route", 20);
     second.record_deferred_terminal("other", "service_stopping");
 
@@ -170,6 +234,13 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
     legacy_ambiguous_none.complete_cancelled();
     drop(legacy_ambiguous_none);
 
+    let mut deferred = RequestMetricsGuard::start_v2(first.clone(), 11, 13, true, RequestCodeClass::PullMessage);
+    deferred.record_v2_deferred_registered();
+    deferred.record_v2_deferred_registered();
+    deferred.complete_v2(0, RequestOutcome::DeferredResumed);
+    deferred.complete_v2(1, RequestOutcome::Failed);
+    drop(deferred);
+
     let mut failure = RequestMetricsGuard::start(first, 13, 11, false);
     failure.complete_process_request_failed(1);
     failure.complete_response(0);
@@ -184,13 +255,20 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
 
     let first_points = first_exporter.points();
     let second_points = second_exporter.points();
-    assert_eq!(metric_value(&first_points, TRANSPORT_REQUESTS_TOTAL), 4);
+    assert_eq!(metric_value(&first_points, TRANSPORT_REQUESTS_TOTAL), 6);
     assert_eq!(
         metric_value(&first_points, TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES),
         21
     );
-    assert_eq!(metric_value(&first_points, TRANSPORT_REQUEST_LATENCY), 4);
-    assert_eq!(metric_value(&first_points, RPC_LATENCY), 4);
+    assert_eq!(metric_value(&first_points, TRANSPORT_REQUEST_LATENCY), 5);
+    assert_eq!(metric_value(&first_points, TRANSPORT_REQUEST_DURATION_SECONDS), 6);
+    assert_eq!(metric_value(&first_points, TRANSPORT_RESPONSE_QUEUE_WAIT_SECONDS), 1);
+    assert_eq!(signed_metric_value(&first_points, TRANSPORT_DEFERRED_INFLIGHT), 0);
+    assert_eq!(signed_metric_value(&first_points, TRANSPORT_DEFERRED_RETAINED_BYTES), 0);
+    assert_eq!(metric_value(&first_points, RPC_LATENCY), 5);
+    assert_eq!(metric_value(&first_points, TRANSPORT_RESPONSE_TOTAL), 2);
+    assert_eq!(metric_value(&first_points, TRANSPORT_RESPONSE_DUPLICATE_TOTAL), 1);
+    assert_eq!(metric_value(&first_points, TRANSPORT_RESPONSE_ABANDONED_TOTAL), 1);
     assert_eq!(metric_value(&second_points, TRANSPORT_REQUESTS_TOTAL), 1);
     assert_eq!(
         metric_value(&second_points, TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES),
@@ -198,6 +276,55 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
     );
     assert_eq!(metric_value(&second_points, TRANSPORT_REQUEST_LATENCY), 1);
     assert_eq!(metric_value(&second_points, RPC_LATENCY), 1);
+
+    for metric in [TRANSPORT_DEFERRED_INFLIGHT, TRANSPORT_DEFERRED_RETAINED_BYTES] {
+        let matching = first_points
+            .iter()
+            .filter(|point| point.metric == metric)
+            .collect::<Vec<_>>();
+        assert_eq!(matching.len(), 1, "deferred metric {metric}");
+        assert_eq!(matching[0].value, CapturedNumber::I64(0));
+        assert_eq!(
+            matching[0].attributes,
+            BTreeMap::from([("code".to_owned(), CapturedValue::String("pull_message".to_owned()),)])
+        );
+    }
+    let queue_wait = first_points
+        .iter()
+        .filter(|point| point.metric == TRANSPORT_RESPONSE_QUEUE_WAIT_SECONDS)
+        .collect::<Vec<_>>();
+    assert_eq!(queue_wait.len(), 1);
+    assert_eq!(queue_wait[0].value, CapturedNumber::HistogramCount(1));
+    assert!(queue_wait[0].attributes.is_empty());
+
+    let request_outcomes = first_points
+        .iter()
+        .filter(|point| point.metric == TRANSPORT_REQUESTS_TOTAL)
+        .collect::<Vec<_>>();
+    assert!(request_outcomes
+        .iter()
+        .all(|point| point.attributes.contains_key("code")
+            && point.attributes.contains_key("outcome")
+            && point.attributes.len() == 2));
+    for outcome in ["deferred_registered", "deferred_resumed"] {
+        let matching = request_outcomes
+            .iter()
+            .filter(|point| {
+                point.attributes.get("code") == Some(&CapturedValue::String("pull_message".to_owned()))
+                    && point.attributes.get("outcome") == Some(&CapturedValue::String(outcome.to_owned()))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(matching.len(), 1, "request outcome {outcome}");
+        assert_eq!(matching[0].value, 1, "request outcome {outcome}");
+    }
+    let response_outcomes = first_points
+        .iter()
+        .filter(|point| point.metric == TRANSPORT_RESPONSE_TOTAL)
+        .collect::<Vec<_>>();
+    assert!(response_outcomes.iter().any(|point| {
+        point.attributes.get("mode") == Some(&CapturedValue::String("deferred".to_owned()))
+            && point.attributes.get("result") == Some(&CapturedValue::String("transport_written".to_owned()))
+    }));
 
     let first_deferred = first_points
         .iter()
@@ -269,7 +396,7 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
         .iter()
         .filter(|point| point.metric == RPC_LATENCY)
         .collect::<Vec<_>>();
-    assert_eq!(first_rpc.len(), 4);
+    assert_eq!(first_rpc.len(), 5);
     assert!(first_rpc.iter().any(|point| {
         point.attributes.get("request_code") == Some(&CapturedValue::I64(10))
             && point.attributes.get("response_code") == Some(&CapturedValue::I64(0))

--- a/rocketmq-observability/src/semantic.rs
+++ b/rocketmq-observability/src/semantic.rs
@@ -98,6 +98,13 @@ pub mod metrics {
     pub const ROCKSDB_TIMES_READ: &str = "rocketmq_rocksdb_times_read";
     pub const TRANSPORT_REQUESTS_TOTAL: &str = "rocketmq_transport_requests_total";
     pub const TRANSPORT_REQUEST_LATENCY: &str = "rocketmq_transport_request_latency";
+    pub const TRANSPORT_REQUEST_DURATION_SECONDS: &str = "rocketmq_transport_request_duration_seconds";
+    pub const TRANSPORT_RESPONSE_TOTAL: &str = "rocketmq_transport_response_total";
+    pub const TRANSPORT_DEFERRED_INFLIGHT: &str = "rocketmq_transport_deferred_inflight";
+    pub const TRANSPORT_DEFERRED_RETAINED_BYTES: &str = "rocketmq_transport_deferred_retained_bytes";
+    pub const TRANSPORT_RESPONSE_QUEUE_WAIT_SECONDS: &str = "rocketmq_transport_response_queue_wait_seconds";
+    pub const TRANSPORT_RESPONSE_DUPLICATE_TOTAL: &str = "rocketmq_transport_response_duplicate_total";
+    pub const TRANSPORT_RESPONSE_ABANDONED_TOTAL: &str = "rocketmq_transport_response_abandoned_total";
     pub const TRANSPORT_OUTBOUND_ATTEMPTED_PLAINTEXT_BYTES: &str =
         "rocketmq_transport_outbound_attempted_plaintext_bytes";
     pub const TRANSPORT_OUTBOUND_ACCEPTED_PLAINTEXT_BYTES: &str =
@@ -260,6 +267,9 @@ pub mod labels {
     pub const PROTOCOL_TYPE: &str = "protocol_type";
     pub const REQUEST_CODE: &str = "request_code";
     pub const REQUEST_CODE_BUCKET: &str = "request_code_bucket";
+    pub const CODE: &str = "code";
+    pub const OUTCOME: &str = "outcome";
+    pub const MODE: &str = "mode";
     pub const RESPONSE_CODE: &str = "response_code";
     pub const IS_LONG_POLLING: &str = "is_long_polling";
     pub const EVENT: &str = "event";

--- a/rocketmq-observability/tests/fixtures/metric_catalog_descriptors.tsv
+++ b/rocketmq-observability/tests/fixtures/metric_catalog_descriptors.tsv
@@ -98,7 +98,7 @@ rust	96	"rocketmq_store_append_latency"	Histogram	"ms"	[]	Store
 rust	97	"rocketmq_store_flush_latency"	Histogram	"ms"	[]	Store
 rust	98	"rocketmq_store_dispatch_latency"	Histogram	"ms"	[]	Store
 rust	99	"rocketmq_store_disk_usage"	ObservableGauge	"By"	[]	Store
-rust	100	"rocketmq_transport_requests_total"	Counter	"{request}"	[]	Remoting
+rust	100	"rocketmq_transport_requests_total"	Counter	"{request}"	["code","outcome"]	Remoting
 rust	101	"rocketmq_transport_request_latency"	Histogram	"ms"	[]	Remoting
 rust	102	"rocketmq_transport_outbound_attempted_plaintext_bytes"	Counter	"By"	[]	Remoting
 rust	103	"rocketmq_transport_outbound_accepted_plaintext_bytes"	Counter	"By"	[]	Remoting
@@ -214,3 +214,10 @@ rust	212	"rocketmq_dashboard_storage_operation_errors_total"	Counter	""	["backen
 rust	213	"rocketmq_dashboard_storage_capacity_bytes"	Gauge	"By"	["backend"]	Observability
 rust	214	"rocketmq_dashboard_storage_pool_connections"	Gauge	""	["backend","state"]	Observability
 rust	215	"rocketmq_transport_legacy_processor_requests_total"	Counter	"{request}"	["processor","request_code"]	Remoting
+rust	216	"rocketmq_transport_request_duration_seconds"	Histogram	"s"	["code","outcome"]	Remoting
+rust	217	"rocketmq_transport_response_total"	Counter	"{response}"	["mode","result"]	Remoting
+rust	218	"rocketmq_transport_deferred_inflight"	UpDownCounter	"{request}"	["code"]	Remoting
+rust	219	"rocketmq_transport_deferred_retained_bytes"	UpDownCounter	"By"	["code"]	Remoting
+rust	220	"rocketmq_transport_response_queue_wait_seconds"	Histogram	"s"	[]	Remoting
+rust	221	"rocketmq_transport_response_duplicate_total"	Counter	"{response}"	["code"]	Remoting
+rust	222	"rocketmq_transport_response_abandoned_total"	Counter	"{response}"	["reason"]	Remoting

--- a/rocketmq-observability/tests/metric_catalog_contract.rs
+++ b/rocketmq-observability/tests/metric_catalog_contract.rs
@@ -23,9 +23,9 @@ use rocketmq_observability::metrics::catalog::RUST_METRICS;
 
 const FIXTURE: &str = include_str!("fixtures/metric_catalog_descriptors.tsv");
 const JAVA_DESCRIPTOR_COUNT: usize = 94;
-const RUST_DESCRIPTOR_COUNT: usize = 122;
+const RUST_DESCRIPTOR_COUNT: usize = 129;
 const TOTAL_DESCRIPTOR_COUNT: usize = JAVA_DESCRIPTOR_COUNT + RUST_DESCRIPTOR_COUNT;
-const DISTINCT_LABEL_SEQUENCE_COUNT: usize = 61;
+const DISTINCT_LABEL_SEQUENCE_COUNT: usize = 64;
 const DISTINCT_SOURCE_COUNT: usize = 14;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rocketmq-runtime/src/shutdown_report.rs
+++ b/rocketmq-runtime/src/shutdown_report.rs
@@ -37,6 +37,8 @@ pub struct ShutdownReport {
     pub cancelled: usize,
     /// The aborted value.
     pub aborted: usize,
+    /// Lifecycle components that completed with an explicit failure.
+    pub failed: usize,
     /// The panicked value.
     pub panicked: usize,
     /// The timed out value.
@@ -66,6 +68,7 @@ impl ShutdownReport {
             completed: 0,
             cancelled: 0,
             aborted: 0,
+            failed: 0,
             panicked: 0,
             timed_out: 0,
             leaked: 0,
@@ -81,6 +84,7 @@ impl ShutdownReport {
     /// Returns whether healthy.
     pub fn is_healthy(&self) -> bool {
         self.leaked == 0
+            && self.failed == 0
             && self.panicked == 0
             && self.timed_out == 0
             && self.blocking_still_running == 0
@@ -171,5 +175,19 @@ mod duration_millis {
         S: Serializer,
     {
         serializer.serialize_u64(duration.as_millis() as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_component_failure_makes_the_report_unhealthy() {
+        let mut report = ShutdownReport::new("failed-component", Duration::ZERO);
+        report.failed = 1;
+
+        assert!(!report.is_healthy());
+        assert!(report.to_json().contains("\"failed\": 1"));
     }
 }

--- a/rocketmq-transport/src/clients/client.rs
+++ b/rocketmq-transport/src/clients/client.rs
@@ -361,12 +361,21 @@ where
             .is_ok()
     }
 
-    fn close_pending(&self, state: &Self::SessionState, _session: SessionHandle) {
+    fn close_pending(
+        &self,
+        state: &Self::SessionState,
+        _session: SessionHandle,
+    ) -> crate::dispatch::DeferredSessionCleanupReport {
+        let report = state.deferred_cleanup.close();
         self.dispatcher.close_network_session(&state.network_endpoint);
-        let _ = state.deferred_cleanup.close();
+        report
     }
 
-    async fn disconnected(&self, _state: Self::SessionState, _session: SessionHandle) {}
+    async fn disconnected(&self, state: Self::SessionState, _session: SessionHandle) -> usize {
+        let cleanup = state.deferred_cleanup.clone();
+        drop(state);
+        cleanup.remaining_wait_permits()
+    }
 }
 
 #[derive(Clone)]
@@ -753,6 +762,13 @@ impl<PR> TransportSession<PR> {
     ///
     /// The `RemotingCommand` representing the response, wrapped in a `Result`. Returns an error if
     /// the invocation fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when request signing or deadline validation fails, the
+    /// pending-response owner rejects the correlation, the writer cannot send
+    /// the command, the response owner closes, or the deadline expires before a
+    /// response arrives.
     pub async fn send_read(
         &mut self,
         mut request: RemotingCommand,
@@ -811,11 +827,22 @@ impl<PR> TransportSession<PR> {
     }
 
     /// Sends a request using the caller's existing immutable deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when request signing or deadline validation fails, or
+    /// when the session writer rejects or fails the command.
     pub async fn send_until(&mut self, request: RemotingCommand, deadline: RequestDeadline) -> RocketMQResult<()> {
         self.send_transport(request, deadline).await
     }
 
     /// Sends a request under an existing deadline and process reservation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when request signing or deadline validation fails, or
+    /// when the session writer rejects or fails the command. The supplied
+    /// permit is consumed by the attempted send.
     pub async fn send_until_with_permit(
         &mut self,
         request: RemotingCommand,
@@ -905,14 +932,25 @@ impl<PR> TransportSession<PR> {
 
     /// Gracefully stop this client connection and return the task shutdown report.
     pub async fn close_with_report(&self, timeout: Duration) -> rocketmq_runtime::ShutdownReport {
+        let deadline_expired = timeout.is_zero();
+        let deadline = tokio::time::Instant::now() + timeout;
         self.accepting_requests.store(false, Ordering::Release);
         let _ = self.notify_shutdown.send(());
-        let _ = self.session.retire().await;
         let active_before = self.task_lifecycle.operation.active_task_count();
+        self.session.request_close();
+        let (session_close_finished, session_close_failed) =
+            match tokio::time::timeout_at(deadline, self.session.wait_for_close_completion()).await {
+                Ok(Ok(_)) => (true, false),
+                Ok(Err(_)) => (true, true),
+                Err(_) => (false, false),
+            };
         let joined = self
             .task_lifecycle
             .operation
-            .cancel_and_wait(&self.task_lifecycle.task_group, timeout)
+            .cancel_and_wait(
+                &self.task_lifecycle.task_group,
+                deadline.saturating_duration_since(tokio::time::Instant::now()),
+            )
             .await
             .unwrap_or(false);
         let mut report = rocketmq_runtime::ShutdownReport::new("rocketmq.transport.client.connection", Duration::ZERO);
@@ -921,6 +959,15 @@ impl<PR> TransportSession<PR> {
         } else {
             report.aborted = active_before;
             report.timed_out = usize::from(active_before > 0);
+        }
+        if deadline_expired || !session_close_finished {
+            report.timed_out = report.timed_out.max(1);
+        }
+        if session_close_failed {
+            report.failed = 1;
+            report.annotations.push(rocketmq_runtime::ShutdownAnnotation::new(
+                "transport session close completed with an unhealthy lifecycle report",
+            ));
         }
         self.pending_requests.close_owner(&self.pending_request_owner, || {
             RocketMQError::network_connection_failed("client", "connection closed")
@@ -1198,9 +1245,18 @@ mod lifecycle_tests {
             )
             .await
             .is_err());
+        let active_before_close = operation.active_task_count();
         let report = client.close_with_report(Duration::from_secs(1)).await;
 
-        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(!report.is_healthy(), "{}", report.to_json());
+        assert_eq!(report.failed, 1, "{}", report.to_json());
+        assert_eq!(report.completed, active_before_close, "{}", report.to_json());
+        assert_eq!(report.aborted, 0, "{}", report.to_json());
+        assert_eq!(report.timed_out, 0, "{}", report.to_json());
+        assert!(report
+            .annotations
+            .iter()
+            .any(|annotation| annotation.message.contains("unhealthy lifecycle report")));
         assert_eq!(operation.active_task_count(), 0);
         assert_eq!(task_group.lifecycle_state(), TaskGroupLifecycleState::Open);
         server.abort();

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/api.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/api.rs
@@ -76,6 +76,11 @@ where
     }
 
     /// Applies one validated frame profile to every connection created by this client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the frame limits are internally inconsistent or
+    /// exceed the supported protocol envelope.
     pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
         frame_limits.validate()?;
         self.frame_limits = frame_limits;
@@ -89,6 +94,12 @@ where
         self
     }
 
+    /// Builds the legacy-processor transport client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the transport configuration, admission limits,
+    /// frame limits, or owned runtime composition is invalid.
     pub fn build(self) -> RocketMQResult<TransportClient<PR>> {
         let mut client = TransportClient::build_inner(
             self.config,
@@ -138,6 +149,11 @@ where
     }
 
     /// Applies one validated frame profile to every connection created by this client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the frame limits are internally inconsistent or
+    /// exceed the supported protocol envelope.
     pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
         frame_limits.validate()?;
         self.frame_limits = frame_limits;
@@ -151,6 +167,12 @@ where
         self
     }
 
+    /// Builds the V2 transport client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the transport configuration, admission limits,
+    /// frame limits, or owned runtime composition is invalid.
     pub fn build(self) -> RocketMQResult<TransportClient<PR>> {
         let mut client = TransportClient::build_inner_v2(
             self.config,
@@ -215,6 +237,12 @@ where
         Arc::clone(&self.transport)
     }
 
+    /// Starts the nameserver-aware client lifecycle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an owned background service cannot be started or
+    /// the client lifecycle has already entered an incompatible terminal state.
     pub async fn start(self: &Arc<Self>) -> RocketMQResult<ClientStartReport> {
         self.transport.start().await
     }
@@ -223,6 +251,12 @@ where
     ///
     /// This forwards the same deadline without converting it to a new duration,
     /// so nested lifecycle owners share one drain budget.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the canonical transport cannot complete its
+    /// lifecycle transition. Timeout and aborted work remain available in the
+    /// returned report when shutdown itself completes successfully.
     pub async fn shutdown_until(&self, deadline: ShutdownDeadline) -> RocketMQResult<ClientShutdownReport> {
         Ok(self.transport.shutdown_graceful(deadline).await)
     }
@@ -260,6 +294,11 @@ where
     }
 
     /// Applies one validated frame profile to every connection created by this client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the frame limits are internally inconsistent or
+    /// exceed the supported protocol envelope.
     pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
         self.transport = self.transport.frame_limits(frame_limits)?;
         Ok(self)
@@ -272,6 +311,12 @@ where
         self
     }
 
+    /// Builds the legacy-processor nameserver-aware remoting client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the underlying V2 transport configuration,
+    /// admission limits, frame limits, or owned runtime composition is invalid.
     pub fn build(self) -> RocketMQResult<RemotingClient<PR>> {
         Ok(RemotingClient {
             transport: Arc::new(self.transport.build()?),
@@ -303,6 +348,11 @@ where
     }
 
     /// Applies one validated frame profile to every connection created by this client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the frame limits are internally inconsistent or
+    /// exceed the supported protocol envelope.
     pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
         self.transport = self.transport.frame_limits(frame_limits)?;
         Ok(self)
@@ -315,6 +365,12 @@ where
         self
     }
 
+    /// Builds the V2 nameserver-aware remoting client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the underlying V2 transport configuration,
+    /// admission limits, frame limits, or owned runtime composition is invalid.
     pub fn build(self) -> RocketMQResult<RemotingClient<PR>> {
         Ok(RemotingClient {
             transport: Arc::new(self.transport.build()?),
@@ -499,6 +555,12 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
     }
 
     /// Sends one canonical request under an absolute deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the target cannot be resolved or connected, the
+    /// deadline expires, request admission or signing fails, the writer cannot
+    /// send the command, or response correlation terminates without a response.
     pub async fn request(
         &self,
         target: RequestTarget,
@@ -509,6 +571,12 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
     }
 
     /// Sends one command and resolves only after the sole writer has completed it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the target cannot be resolved or connected, the
+    /// deadline expires, request admission or signing fails, or the sole writer
+    /// cannot complete the command.
     pub async fn send_oneway(
         &self,
         target: RequestTarget,
@@ -527,7 +595,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
     /// 3. Record latency / error metrics       (~10ns)
     /// ```
     ///
-    /// # Error Handling
+    /// # Errors
     ///
     /// Returns `RocketMQError` for all failures:
     /// - Client unavailable (no connection)
@@ -567,6 +635,12 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
 
     /// Sends a one-way command while transferring an existing process-budget
     /// reservation into the transport writer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the address cannot be connected, the deadline
+    /// expires, request signing fails, or the session writer rejects or fails
+    /// the command. The supplied permit is consumed by the attempted send.
     pub async fn invoke_oneway_with_permit(
         &self,
         addr: &CheetahString,
@@ -577,6 +651,13 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
         self.invoke_oneway_until(addr, request, deadline, Some(permit)).await
     }
 
+    /// Sends a one-way request under the caller's absolute deadline.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the address cannot be connected, the deadline
+    /// expires, request admission or signing fails, or the session writer
+    /// rejects or fails the command.
     pub async fn invoke_request_oneway_with_deadline(
         &self,
         addr: &CheetahString,
@@ -586,6 +667,13 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
         self.invoke_oneway_until(addr, request, deadline, None).await
     }
 
+    /// Sends a one-way request under a timeout relative to the current instant.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the address cannot be connected, request admission
+    /// or signing fails, the timeout expires, or the session writer rejects or
+    /// fails the command.
     pub async fn invoke_request_oneway(
         &self,
         addr: &CheetahString,

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -58,6 +58,7 @@ use crate::write_strategy::OutboundPayload;
 use crate::write_strategy::QueuedWrite;
 use crate::write_strategy::QueuedWriteCancellation;
 use crate::write_strategy::QueuedWriteProgress;
+use crate::write_strategy::ResponseQueueWaitObservation;
 use crate::writer_runtime::WriterLanes;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::BlockingExecutor;
@@ -961,6 +962,32 @@ impl Connection {
         deferred_drop: Option<DeferredTransportDropHandle>,
         target: String,
     ) -> Result<(), SendFailure> {
+        self.send_payload_inner_with_response_observation(
+            payload,
+            class,
+            reservation,
+            deadline,
+            control,
+            stop_policy,
+            deferred_drop,
+            ResponseQueueWaitObservation::Ineligible,
+            target,
+        )
+        .await
+    }
+
+    async fn send_payload_inner_with_response_observation(
+        &mut self,
+        payload: OutboundPayload,
+        class: AdmissionClass,
+        reservation: Option<ResourcePermit>,
+        deadline: Option<RequestDeadline>,
+        control: Option<&RequestControlView>,
+        stop_policy: RequestStopPolicy,
+        deferred_drop: Option<DeferredTransportDropHandle>,
+        response_queue_wait_observation: ResponseQueueWaitObservation,
+        target: String,
+    ) -> Result<(), SendFailure> {
         let response_plan_drop = self.response_plan_drop.clone();
         let encoded_len = payload.encoded_len();
         let legacy_reason = match &self.outbound {
@@ -1039,7 +1066,8 @@ impl Connection {
                     target.clone(),
                     progress.clone(),
                     enqueued_at,
-                ),
+                )
+                .with_response_queue_wait_observation(response_queue_wait_observation),
             ) {
                 Ok(()) => {
                     queued.writer_diagnostics.record_accepted();
@@ -1216,7 +1244,7 @@ impl Connection {
             return Err(ResponseError::SessionClosed);
         };
         let (_, payload) = prepared.into_parts();
-        self.send_payload_inner(
+        self.send_payload_inner_with_response_observation(
             payload,
             class,
             None,
@@ -1224,6 +1252,7 @@ impl Connection {
             Some(control),
             RequestStopPolicy::All,
             None,
+            ResponseQueueWaitObservation::Response,
             "transport-session-writer".to_string(),
         )
         .await
@@ -1246,7 +1275,7 @@ impl Connection {
             return Err(ResponseError::SessionClosed);
         };
         let (_, payload) = prepared.into_parts();
-        self.send_payload_inner(
+        self.send_payload_inner_with_response_observation(
             payload,
             class,
             None,
@@ -1254,6 +1283,7 @@ impl Connection {
             Some(control),
             RequestStopPolicy::All,
             Some(deferred_drop),
+            ResponseQueueWaitObservation::Response,
             "transport-session-writer".to_string(),
         )
         .await
@@ -1271,7 +1301,7 @@ impl Connection {
             .limits
             .encode_command(command)
             .map_err(|source| ResponseError::Encode { source })?;
-        self.send_payload_inner(
+        self.send_payload_inner_with_response_observation(
             OutboundPayload::Frame(frame),
             class,
             None,
@@ -1279,6 +1309,7 @@ impl Connection {
             None,
             RequestStopPolicy::All,
             None,
+            ResponseQueueWaitObservation::Response,
             "transport-session-writer".to_string(),
         )
         .await
@@ -1296,7 +1327,7 @@ impl Connection {
             .encode_command(command.clone())
             .map_err(|source| ResponseError::Encode { source })?;
         let _ = command.take_body();
-        self.send_payload_inner(
+        self.send_payload_inner_with_response_observation(
             OutboundPayload::Frame(frame),
             class,
             None,
@@ -1304,6 +1335,7 @@ impl Connection {
             None,
             RequestStopPolicy::All,
             None,
+            ResponseQueueWaitObservation::Response,
             "transport-session-writer".to_string(),
         )
         .await

--- a/rocketmq-transport/src/connection/issue_9754_tests.rs
+++ b/rocketmq-transport/src/connection/issue_9754_tests.rs
@@ -364,6 +364,62 @@ async fn typed_response_admission_saturation_is_not_started_before_lane_enqueue(
 }
 
 #[tokio::test]
+async fn queued_legacy_response_apis_record_queue_wait_but_generic_commands_do_not() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let physical_connection = Connection::new_with_plaintext_stream(CountingTransport {
+        writes: Arc::new(AtomicUsize::new(0)),
+        flushes: Arc::new(AtomicUsize::new(0)),
+    });
+    let (frame_writer, _reader) = physical_connection.into_session_io(admission.clone());
+    let config = WriterQueueConfig::default();
+    let diagnostics = Arc::new(super::SessionWriterDiagnostics::new(config.total_capacity()));
+    let (lanes, receivers) = writer_lanes(config);
+    let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+    let (telemetry, capture) = TransportTelemetry::with_v2_boundary_metric_capture();
+    let mut connection = Connection::new_queued(
+        lanes,
+        Arc::clone(&diagnostics),
+        admission,
+        state_tx.clone(),
+        state_rx,
+        CheetahString::from_string("queued-response-observation-test".to_string()),
+        FrameLimits::default(),
+        Some(AdmissionClass::Data),
+        Arc::new(SessionLifecycle::new()),
+        telemetry.clone(),
+    );
+    let writer = tokio::spawn(run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state_tx,
+        CancellationToken::new(),
+        telemetry,
+    ));
+
+    connection
+        .send_command(RemotingCommand::create_remoting_command(7))
+        .await
+        .expect("generic command write");
+    connection
+        .send_response(RemotingCommand::create_response_command_with_code(0))
+        .await
+        .expect("owned legacy response write");
+    let mut borrowed = RemotingCommand::create_response_command_with_code(0);
+    connection
+        .send_response_ref(&mut borrowed)
+        .await
+        .expect("borrowed legacy response write");
+
+    assert_eq!(capture.response_queue_waits(), 2);
+    drop(connection);
+    writer.await.expect("writer exits after the last queue handle drops");
+}
+
+#[tokio::test]
 async fn actual_dropped_queued_completion_before_start_maps_to_typed_not_started() {
     let controller = AdmissionController::new(AdmissionLimits::default());
     let admission = controller

--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -114,6 +114,7 @@ pub(crate) use deferred_response::ResponseStateSnapshot;
 pub(crate) use deferred_session_cleanup::DeferredSessionCleanupCloseOutcome;
 pub(crate) use deferred_session_cleanup::DeferredSessionCleanupOwner;
 pub(crate) use deferred_session_cleanup::DeferredSessionCleanupRegistration;
+pub(crate) use deferred_session_cleanup::DeferredSessionCleanupReport;
 pub(crate) use deferred_session_cleanup::LegacySessionCleanupCapability;
 pub use deferred_session_cleanup::LegacySessionCleanupEnrollment;
 pub use deferred_session_cleanup::LegacySessionCleanupInstallError;

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -212,7 +212,11 @@ where
     ) -> Self {
         Self {
             boundary: Arc::new(AuthorizedDispatchBoundary::new(security, admission)),
-            core: Arc::new(AuthorizedDispatcherCore::new(request_processor, rpc_hooks)),
+            core: Arc::new(AuthorizedDispatcherCore::new_with_telemetry(
+                request_processor,
+                rpc_hooks,
+                telemetry.clone(),
+            )),
             telemetry,
         }
     }
@@ -241,10 +245,11 @@ where
         )?;
         Ok(Self {
             boundary: Arc::new(AuthorizedDispatchBoundary::new(security, admission)),
-            core: Arc::new(AuthorizedDispatcherCore::new_with_pending_requests(
+            core: Arc::new(AuthorizedDispatcherCore::new_with_pending_requests_and_telemetry(
                 request_processor,
                 rpc_hooks,
                 response_table,
+                telemetry.clone(),
             )),
             telemetry,
         })
@@ -426,6 +431,13 @@ impl AuthorizedDispatchSession {
 
     pub(crate) async fn drain_until(&self, deadline: ShutdownDeadline) -> ShutdownReport {
         self.executor.drain_until(deadline).await
+    }
+
+    pub(crate) async fn drain_report_until(
+        &self,
+        deadline: ShutdownDeadline,
+    ) -> crate::session_executor::SessionExecutorDrainReport {
+        self.executor.drain_report_until(deadline).await
     }
 }
 

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2.rs
@@ -23,6 +23,7 @@ use rocketmq_security_api::Action;
 use rocketmq_security_api::Decision;
 use rocketmq_security_api::Resource;
 use rocketmq_security_api::ResourceKind;
+use tracing::Instrument;
 
 use super::admission_response;
 use super::deadline_response;
@@ -33,6 +34,7 @@ use crate::admission::AdmissionError;
 use crate::admission::FullPolicy;
 use crate::admission::PartialFramePermit;
 use crate::base::pending_request_table::PendingRequestTable;
+use crate::dispatch::legacy_processor_adapter::AdmittedProcessorObserver;
 use crate::dispatch::remoting_request::RemotingRequestBuildError;
 use crate::dispatch::remoting_request::RemotingRequestBuilder;
 use crate::dispatch::remoting_request::RequestLifecycleProvenance;
@@ -61,6 +63,7 @@ use crate::runtime::processor_v2::RequestProcessorV2;
 use crate::runtime::RPCHook;
 use crate::server::SessionHandle;
 use crate::session_executor::SessionDispatchError;
+use crate::telemetry::V2BoundaryRejectionReason;
 
 /// Stable private failure from scheduling or executing one V2 dispatch.
 #[derive(Debug, thiserror::Error)]
@@ -155,6 +158,21 @@ where
         Self::from_dispatch_processor(ExplicitV2Processor::new(processor), rpc_hooks)
     }
 
+    pub(crate) fn new_with_telemetry(
+        processor: P,
+        rpc_hooks: Vec<Arc<dyn RPCHook>>,
+        telemetry: crate::telemetry::TransportTelemetry,
+    ) -> Self {
+        Self::from_dispatch_processor(
+            ExplicitV2Processor::with_response_table_and_telemetry(processor, PendingRequestTable::new(), telemetry),
+            rpc_hooks,
+        )
+    }
+
+    #[allow(
+        dead_code,
+        reason = "test and compatibility constructors may omit telemetry explicitly"
+    )]
     pub(crate) fn new_with_pending_requests(
         processor: P,
         rpc_hooks: Vec<Arc<dyn RPCHook>>,
@@ -162,6 +180,18 @@ where
     ) -> Self {
         Self::from_dispatch_processor(
             ExplicitV2Processor::with_response_table(processor, response_table),
+            rpc_hooks,
+        )
+    }
+
+    pub(crate) fn new_with_pending_requests_and_telemetry(
+        processor: P,
+        rpc_hooks: Vec<Arc<dyn RPCHook>>,
+        response_table: PendingRequestTable,
+        telemetry: crate::telemetry::TransportTelemetry,
+    ) -> Self {
+        Self::from_dispatch_processor(
+            ExplicitV2Processor::with_response_table_and_telemetry(processor, response_table, telemetry),
             rpc_hooks,
         )
     }
@@ -262,92 +292,142 @@ where
         let class = AdmissionClass::for_request_code(original.original_code());
         let lifecycle = RequestLifecycleProvenance::from_network_session(&session);
         let builder = RemotingRequestBuilder::new(original, request_started, context, lifecycle, command);
-        let ordering = self.processor.request_ordering(&builder);
-        let resume_executor = authorized_session.executor.deferred_resume_executor();
+        let request_bytes = builder.command().body().map_or(0, |body| body.len() as u64);
+        let observation = self.processor.begin_boundary_observation(&builder, request_bytes);
+        let span = observation
+            .as_ref()
+            .map_or_else(tracing::Span::none, crate::telemetry::V2RequestObservation::span);
 
-        if builder.deadline().is_some_and(|deadline| deadline.is_expired()) {
-            send_boundary_response(&session, original, deadline_response(original.original_opaque())).await?;
-            return Ok(DispatchOutcome::Rejected);
-        }
-        if let Decision::Deny { reason } = authorized_session.boundary.security.authorize_for_dispatch(
-            builder.command(),
-            builder.peer(),
-            builder.principal(),
-            Resource::new(ResourceKind::Other, original.original_code().to_string()),
-            Action::Manage,
-        ) {
-            let response = RemotingCommand::create_response_command_with_code_remark(
-                rocketmq_protocol::code::response_code::ResponseCode::NoPermission,
-                reason.to_string(),
-            );
-            send_boundary_response(&session, original, response).await?;
-            return Ok(DispatchOutcome::Rejected);
-        }
+        async {
+            let ordering = self.processor.request_ordering(&builder);
+            let resume_executor = authorized_session.executor.deferred_resume_executor();
 
-        let admitted_dispatcher = Arc::clone(self);
-        let admitted_session = session.clone();
-        let remote_address = session.remote_addr();
-        let rejected_session = session.clone();
-        let rejected_original = original;
-        match authorized_session.executor.try_execute(
-            retained_bytes,
-            class,
-            partial_frame_permit,
-            ordering,
-            move |_operation| async move {
-                let processor = admitted_dispatcher.processor.clone();
-                if let Err(error) = admitted_dispatcher
-                    .execute_admitted_network(
-                        processor,
-                        admitted_session,
-                        network_session,
-                        class,
-                        original,
-                        remote_address,
+            if builder.deadline().is_some_and(|deadline| deadline.is_expired()) {
+                send_boundary_response(
+                    &session,
+                    original,
+                    request_started,
+                    builder.control().clone(),
+                    V2BoundaryRejectionReason::DeadlineExpired,
+                    deadline_response(original.original_opaque()),
+                    observation.clone(),
+                )
+                .await?;
+                return Ok(DispatchOutcome::Rejected);
+            }
+            if let Decision::Deny { reason } = authorized_session.boundary.security.authorize_for_dispatch(
+                builder.command(),
+                builder.peer(),
+                builder.principal(),
+                Resource::new(ResourceKind::Other, original.original_code().to_string()),
+                Action::Manage,
+            ) {
+                let response = RemotingCommand::create_response_command_with_code_remark(
+                    rocketmq_protocol::code::response_code::ResponseCode::NoPermission,
+                    reason.to_string(),
+                );
+                send_boundary_response(
+                    &session,
+                    original,
+                    request_started,
+                    builder.control().clone(),
+                    V2BoundaryRejectionReason::SecurityDenied,
+                    response,
+                    observation.clone(),
+                )
+                .await?;
+                return Ok(DispatchOutcome::Rejected);
+            }
+
+            let admitted_dispatcher = Arc::clone(self);
+            let admitted_session = session.clone();
+            let admitted_observation = observation.clone();
+            let remote_address = session.remote_addr();
+            let rejected_session = session.clone();
+            let rejected_original = original;
+            let rejected_control = builder.control().clone();
+            let rejected_observation = observation.clone();
+            let boundary_control = builder.control().clone();
+            match authorized_session.executor.try_execute(
+                retained_bytes,
+                class,
+                partial_frame_permit,
+                ordering,
+                move |_operation| async move {
+                    let processor = admitted_dispatcher.processor.clone();
+                    if let Err(error) = admitted_dispatcher
+                        .execute_admitted_network(
+                            processor,
+                            admitted_session,
+                            network_session,
+                            class,
+                            original,
+                            remote_address,
+                            request_started,
+                            builder,
+                            ordering,
+                            resume_executor,
+                            retained_bytes,
+                            session_cleanup,
+                            admitted_observation,
+                        )
+                        .await
+                    {
+                        admitted_dispatcher.report_admitted_failure(&error);
+                    }
+                },
+                move |_operation, error| async move {
+                    let response = admission_response(rejected_original.original_opaque(), &error);
+                    if send_boundary_response(
+                        &rejected_session,
+                        rejected_original,
                         request_started,
-                        builder,
-                        ordering,
-                        resume_executor,
-                        retained_bytes,
-                        session_cleanup,
+                        rejected_control,
+                        V2BoundaryRejectionReason::AdmissionRejected,
+                        response,
+                        rejected_observation,
                     )
                     .await
-                {
-                    admitted_dispatcher.report_admitted_failure(&error);
-                }
-            },
-            move |_operation, error| async move {
-                let response = admission_response(rejected_original.original_opaque(), &error);
-                if send_boundary_response(&rejected_session, rejected_original, response)
-                    .await
                     .is_err()
-                {
-                    tracing::warn!(
-                        failure = "admission_boundary_response",
-                        "V2 admission rejection response could not be written"
-                    );
+                    {
+                        tracing::warn!(
+                            failure = "admission_boundary_response",
+                            "V2 admission rejection response could not be written"
+                        );
+                    }
+                },
+            ) {
+                Ok(task_id) => Ok(DispatchOutcome::Accepted(task_id)),
+                Err(SessionDispatchError::Admission {
+                    error,
+                    retained_partial,
+                }) if error.policy() == FullPolicy::Reject => {
+                    drop(retained_partial);
+                    let response = admission_response(original.original_opaque(), &error);
+                    send_boundary_response(
+                        &session,
+                        original,
+                        request_started,
+                        boundary_control,
+                        V2BoundaryRejectionReason::AdmissionRejected,
+                        response,
+                        observation.clone(),
+                    )
+                    .await?;
+                    Ok(DispatchOutcome::Rejected)
                 }
-            },
-        ) {
-            Ok(task_id) => Ok(DispatchOutcome::Accepted(task_id)),
-            Err(SessionDispatchError::Admission {
-                error,
-                retained_partial,
-            }) if error.policy() == FullPolicy::Reject => {
-                drop(retained_partial);
-                let response = admission_response(original.original_opaque(), &error);
-                send_boundary_response(&session, original, response).await?;
-                Ok(DispatchOutcome::Rejected)
+                Err(SessionDispatchError::Admission {
+                    error,
+                    retained_partial,
+                }) => {
+                    drop(retained_partial);
+                    Err(AuthorizedDispatchV2Error::Admission(error))
+                }
+                Err(SessionDispatchError::Closing(error)) => Err(AuthorizedDispatchV2Error::Closing(error.to_string())),
             }
-            Err(SessionDispatchError::Admission {
-                error,
-                retained_partial,
-            }) => {
-                drop(retained_partial);
-                Err(AuthorizedDispatchV2Error::Admission(error))
-            }
-            Err(SessionDispatchError::Closing(error)) => Err(AuthorizedDispatchV2Error::Closing(error.to_string())),
         }
+        .instrument(span)
+        .await
     }
 
     #[allow(
@@ -360,7 +440,7 @@ where
     )]
     async fn execute_admitted_network(
         &self,
-        mut processor: D,
+        processor: D,
         session: SessionHandle,
         network_session: D::NetworkSession,
         class: AdmissionClass,
@@ -372,70 +452,103 @@ where
         resume_executor: crate::session_executor::DeferredResumeExecutor,
         retained_bytes: usize,
         session_cleanup: Option<crate::dispatch::DeferredSessionCleanupRegistration>,
+        observation: Option<crate::telemetry::V2RequestObservation>,
     ) -> Result<(), AuthorizedDispatchV2Error> {
         let request_bytes = builder.command().body().map_or(0, |body| body.len() as u64);
-        let mut metrics = processor.begin_admitted(original, request_bytes);
-        let response = ResponseSink::network_plan(session.clone(), class, builder.control().clone());
-
-        if builder.deadline().is_some_and(|deadline| deadline.is_expired()) {
-            let plan = ResponsePlan::command(deadline_response(original.original_opaque()))?;
-            let candidate = processor.deadline_candidate(plan);
-            return self
-                .finish_candidate(&processor, response, original, request_started, candidate, &mut metrics)
-                .await;
-        }
-
-        if let Some(candidate) = processor.reject_request(original.original_code())? {
-            return self
-                .finish_candidate(&processor, response, original, request_started, candidate, &mut metrics)
-                .await;
-        }
-
-        let builder = if original.is_one_way() {
-            builder
-        } else {
-            processor.install_deferred_response(
-                builder,
-                &response,
-                &session,
-                ordering,
-                class,
-                resume_executor,
-                retained_bytes,
-                session_cleanup,
-            )?
+        let mut metrics = processor.begin_admitted(&builder, request_bytes, observation);
+        let span = metrics.span();
+        let observation = metrics.v2_observation().cloned();
+        let mut observer_owner = AdmittedProcessorObserver::new(processor, observation);
+        let Some(processor) = observer_owner.processor_mut() else {
+            return Err(AuthorizedDispatchV2Error::Closing(
+                "admitted response observer owner is unavailable".to_owned(),
+            ));
         };
-        let mut request = builder.build()?;
-        let hook_snapshot = self.rpc_hooks.snapshot();
-        let candidate = processor
-            .process(
-                &mut request,
-                hook_snapshot.as_deref(),
-                remote_address,
-                &session,
-                &network_session,
-                &response,
-            )
-            .await?;
-        let InternalProcessorCandidate {
-            outcome,
-            failure,
-            observe_write,
-        } = candidate;
-        let outcome = processor.resolve_outcome(&mut request, outcome)?;
-        self.finish_candidate(
-            &processor,
-            response,
-            original,
-            request_started,
-            InternalProcessorCandidate {
+        let result = async {
+            let response = ResponseSink::network_plan(session.clone(), class, builder.control().clone());
+
+            if builder.deadline().is_some_and(|deadline| deadline.is_expired()) {
+                let plan = ResponsePlan::command(deadline_response(original.original_opaque()))?;
+                let candidate = processor.deadline_candidate(plan);
+                return self
+                    .finish_candidate(
+                        processor,
+                        response,
+                        original,
+                        request_started,
+                        candidate,
+                        retained_bytes,
+                        &mut metrics,
+                    )
+                    .await;
+            }
+
+            if let Some(candidate) = processor.reject_request(original.original_code())? {
+                return self
+                    .finish_candidate(
+                        processor,
+                        response,
+                        original,
+                        request_started,
+                        candidate,
+                        retained_bytes,
+                        &mut metrics,
+                    )
+                    .await;
+            }
+
+            let builder = if original.is_one_way() {
+                builder
+            } else {
+                processor.install_deferred_response(
+                    builder,
+                    &response,
+                    &session,
+                    ordering,
+                    class,
+                    resume_executor,
+                    retained_bytes,
+                    session_cleanup,
+                    metrics.v2_observation().cloned(),
+                )?
+            };
+            let mut request = builder.build()?;
+            let hook_snapshot = self.rpc_hooks.snapshot();
+            let candidate = processor
+                .process(
+                    &mut request,
+                    hook_snapshot.as_deref(),
+                    remote_address,
+                    &session,
+                    &network_session,
+                    &response,
+                )
+                .await?;
+            let InternalProcessorCandidate {
                 outcome,
                 failure,
                 observe_write,
-            },
-            &mut metrics,
-        )
-        .await
+            } = candidate;
+            let outcome = processor.resolve_outcome(&mut request, outcome)?;
+            self.finish_candidate(
+                processor,
+                response,
+                original,
+                request_started,
+                InternalProcessorCandidate {
+                    outcome,
+                    failure,
+                    observe_write,
+                },
+                retained_bytes,
+                &mut metrics,
+            )
+            .await
+        }
+        .instrument(span)
+        .await;
+        observer_owner.bind();
+        result
     }
 
     async fn finish_candidate(
@@ -445,6 +558,7 @@ where
         original: OriginalRequestIdentity,
         request_started: Instant,
         candidate: InternalProcessorCandidate,
+        retained_bytes: usize,
         metrics: &mut crate::dispatch::DispatchMetricsGuard,
     ) -> Result<(), AuthorizedDispatchV2Error> {
         let InternalProcessorCandidate {
@@ -517,7 +631,9 @@ where
                     drop(registration);
                     return Err(AuthorizedDispatchV2Error::OneWayOutcome { outcome: "deferred" });
                 }
+                metrics.arm_deferred_metrics(retained_bytes);
                 registration.commit()?;
+                metrics.record_deferred_registered();
                 Ok(())
             }
             InternalProcessorOutcome::V2(crate::dispatch::HandlerOutcome::NoReply(marker)) => {
@@ -526,13 +642,14 @@ where
                     return Err(AuthorizedDispatchV2Error::OneWayOutcome { outcome: "no_reply" });
                 }
                 drop(marker);
+                metrics.complete_protocol_no_response();
                 Ok(())
             }
             InternalProcessorOutcome::LegacyAmbiguousNone => {
                 if original.is_one_way() {
                     metrics.complete_oneway();
                 } else {
-                    metrics.complete_legacy_ambiguous_none();
+                    metrics.complete_legacy_ambiguous_none(&response);
                 }
                 Ok(())
             }
@@ -574,6 +691,7 @@ where
             crate::request_ordering::RequestOrdering::Concurrent,
             crate::session_executor::DeferredResumeExecutor::retired(),
             0,
+            None,
             None,
         )
         .await
@@ -670,6 +788,13 @@ where
         .as_ref()
         .err()
         .map(|error| (error.kind(), error.write_progress()));
+    let legacy_outcome = match result.as_ref() {
+        Ok(receipt) => crate::runtime::processor_v2::ResponseObservationOutcomeV2::Written(*receipt),
+        Err(error) => crate::runtime::processor_v2::ResponseObservationOutcomeV2::Failed {
+            kind: Some(error.kind()),
+            progress: error.write_progress(),
+        },
+    };
     if !failure_recorded {
         if failure.is_some() {
             metrics.complete_write_channel_failed(response_code);
@@ -677,7 +802,18 @@ where
             metrics.complete_response(response_code);
         }
     }
-    if observe_write {
+    if let Some(observation) = metrics.v2_observation() {
+        observation.complete_reply(
+            crate::runtime::processor_v2::ResponseObservationModeV2::Inline,
+            response_code,
+            body_kind,
+            write_elapsed,
+            match result.as_ref() {
+                Ok(receipt) => Ok(*receipt),
+                Err(error) => Err((error.kind(), error.write_progress())),
+            },
+        );
+    } else if observe_write {
         processor.observe_response_write(
             original,
             response_code,
@@ -687,6 +823,7 @@ where
             result,
         );
     }
+    metrics.record_legacy_reply(response_code, body_kind, legacy_outcome);
     match failure {
         Some((kind, progress)) => Err(AuthorizedDispatchV2Error::Response { kind, progress }),
         None => Ok(()),
@@ -700,10 +837,57 @@ where
 async fn send_boundary_response(
     session: &SessionHandle,
     original: OriginalRequestIdentity,
+    _request_started: Instant,
+    control: crate::dispatch::RequestControlView,
+    reason: V2BoundaryRejectionReason,
     response: RemotingCommand,
+    observation: Option<crate::telemetry::V2RequestObservation>,
 ) -> Result<(), AuthorizedDispatchV2Error> {
     if original.is_one_way() {
+        if let Some(observation) = observation {
+            observation.complete_boundary_rejection(
+                reason,
+                None,
+                None,
+                None,
+                crate::runtime::processor_v2::ResponseObservationOutcomeV2::Failed {
+                    kind: None,
+                    progress: Some(WriteProgress::NotStarted),
+                },
+            );
+        }
         return Ok(());
+    }
+    if let Some(observation) = observation {
+        let plan = ResponsePlan::command(response)?;
+        let response_code = plan.response_code();
+        let body_kind = plan.body_kind();
+        let bound = plan.bind(original)?;
+        let response = ResponseSink::network_plan(
+            session.clone(),
+            AdmissionClass::Control,
+            control.boundary_response_control(),
+        );
+        let write_started = Instant::now();
+        let result = response.send_plan(bound).await;
+        let write_elapsed = write_started.elapsed();
+        observation.complete_boundary_rejection(
+            reason,
+            Some(response_code),
+            Some(body_kind),
+            Some(write_elapsed),
+            match result.as_ref() {
+                Ok(receipt) => crate::runtime::processor_v2::ResponseObservationOutcomeV2::Written(*receipt),
+                Err(error) => crate::runtime::processor_v2::ResponseObservationOutcomeV2::Failed {
+                    kind: Some(error.kind()),
+                    progress: error.write_progress(),
+                },
+            },
+        );
+        return result.map(|_| ()).map_err(|error| AuthorizedDispatchV2Error::Response {
+            kind: error.kind(),
+            progress: error.write_progress(),
+        });
     }
     session
         .clone()

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/boundary_identity.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/boundary_identity.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use super::harness::*;
+use crate::telemetry::TransportTelemetry;
 #[tokio::test]
-async fn pre_admission_deadline_and_admission_rejection_never_clone_or_observe_processor() {
+async fn pre_admission_deadline_and_admission_rejection_record_one_terminal_span_without_processor_clone() {
     let limits = AdmissionLimits {
         queued: crate::admission::ResourceLimit { count: 2, bytes: 1024 },
         control_reserve: crate::admission::ResourceLimit { count: 1, bytes: 0 },
@@ -22,7 +23,12 @@ async fn pre_admission_deadline_and_admission_rejection_never_clone_or_observe_p
     };
     let mut harness = DispatchHarness::new_with_limits("dispatch-v2-pre-admission", limits).await;
     let (processor, state) = TestProcessor::new(Behavior::Reply);
-    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+    let (telemetry, boundary_metrics) = TransportTelemetry::with_v2_boundary_metric_capture();
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new_with_telemetry(
+        processor,
+        Vec::new(),
+        telemetry,
+    ));
     let command = request(false);
     let (session, _) = harness.request_session(&command);
 
@@ -42,6 +48,11 @@ async fn pre_admission_deadline_and_admission_rejection_never_clone_or_observe_p
     assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
     assert_eq!(state.clones.load(Ordering::SeqCst), 0);
     assert!(state.observations.lock().expect("observation lock").is_empty());
+    assert_eq!(boundary_metrics.snapshot(), (1, 1, 1, 1));
+    assert_eq!(
+        boundary_metrics.rejections(),
+        vec![("deadline_expired", "failed", "rejected", "inline", "transport_written",)]
+    );
 
     let queued = harness
         .admission_scope
@@ -59,19 +70,35 @@ async fn pre_admission_deadline_and_admission_rejection_never_clone_or_observe_p
     assert_eq!(state.clones.load(Ordering::SeqCst), 0);
     assert_eq!(state.processes.load(Ordering::SeqCst), 0);
     assert!(state.observations.lock().expect("observation lock").is_empty());
+    assert_eq!(boundary_metrics.snapshot(), (2, 2, 2, 2));
+    assert_eq!(
+        boundary_metrics.rejections(),
+        vec![
+            ("deadline_expired", "failed", "rejected", "inline", "transport_written",),
+            (
+                "admission_rejected",
+                "failed",
+                "rejected",
+                "inline",
+                "transport_written",
+            ),
+        ]
+    );
     drop(queued);
     harness.shutdown().await;
 }
 
 #[tokio::test]
-async fn authorization_denial_runs_after_ordering_without_clone_hook_process_or_observation() {
+async fn authorization_denial_records_one_terminal_span_without_clone_hook_or_processor_observation() {
     let security = Arc::new(TransportSecurity::secure_enforced(None, None));
     let mut harness = DispatchHarness::new_with_security("dispatch-v2-auth-denial", security).await;
     let (processor, state) = TestProcessor::new(Behavior::Reply);
     let hook_events = Arc::new(Mutex::new(Vec::new()));
-    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+    let (telemetry, boundary_metrics) = TransportTelemetry::with_v2_boundary_metric_capture();
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new_with_telemetry(
         processor,
         vec![Arc::new(hook(false, false, Arc::clone(&hook_events)))],
+        telemetry,
     ));
     let command = request(false);
     let (session, _) = harness.request_session(&command);
@@ -90,6 +117,48 @@ async fn authorization_denial_runs_after_ordering_without_clone_hook_process_or_
     assert_eq!(state.events.lock().expect("event lock").as_slice(), ["ordering"]);
     assert!(state.observations.lock().expect("observation lock").is_empty());
     assert!(hook_events.lock().expect("hook events").is_empty());
+    assert_eq!(boundary_metrics.snapshot(), (1, 1, 1, 1));
+    assert_eq!(
+        boundary_metrics.rejections(),
+        vec![("security_denied", "failed", "rejected", "inline", "transport_written",)]
+    );
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn one_way_boundary_rejection_is_failed_without_a_response_write() {
+    let mut harness = DispatchHarness::new("dispatch-v2-oneway-deadline-rejection").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let (telemetry, boundary_metrics) = TransportTelemetry::with_v2_boundary_metric_capture();
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new_with_telemetry(
+        processor,
+        Vec::new(),
+        telemetry,
+    ));
+    let command = request(true);
+    let (session, _) = harness.request_session(&command);
+
+    let outcome = dispatcher
+        .dispatch(
+            &harness.authorized,
+            session,
+            harness.context(Some(RequestDeadline::after(Duration::ZERO))),
+            command,
+            256,
+            None,
+        )
+        .await
+        .expect("expired one-way request is rejected without a response write");
+
+    assert_eq!(outcome, DispatchOutcome::Rejected);
+    assert_eq!(state.clones.load(Ordering::SeqCst), 0);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 0);
+    harness.assert_no_response().await;
+    assert_eq!(boundary_metrics.snapshot(), (1, 1, 1, 1));
+    assert_eq!(
+        boundary_metrics.rejections(),
+        vec![("deadline_expired", "failed", "rejected", "no_response", "failed",)]
+    );
     harness.shutdown().await;
 }
 

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/harness.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/harness.rs
@@ -86,6 +86,7 @@ pub(super) struct ProcessorState {
     pub(super) request_body_pointer: Mutex<Option<usize>>,
     pub(super) events: Mutex<Vec<&'static str>>,
     pub(super) observations: Mutex<Vec<ResponseWriteObservationV2>>,
+    pub(super) terminal_observations: Mutex<Vec<crate::runtime::processor_v2::ResponseObservationV2>>,
     pub(super) observed: tokio::sync::Notify,
     pub(super) entered: tokio::sync::Notify,
     pub(super) resume: tokio::sync::Notify,
@@ -208,6 +209,18 @@ impl RequestProcessorV2 for TestProcessor {
             .observations
             .lock()
             .expect("observation lock")
+            .push(observation);
+        self.state.observed.notify_one();
+    }
+
+    fn observe_response(&self, observation: crate::runtime::processor_v2::ResponseObservationV2) {
+        if let Some(write) = observation.write_projection() {
+            self.observe_response_write(write);
+        }
+        self.state
+            .terminal_observations
+            .lock()
+            .expect("terminal observation lock")
             .push(observation);
         self.state.observed.notify_one();
     }

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/legacy_adapter.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/legacy_adapter.rs
@@ -432,6 +432,59 @@ async fn admitted_reply_preserves_order_clone_hooks_body_and_immutable_binding()
 }
 
 #[tokio::test]
+async fn legacy_reply_direct_write_and_ambiguous_none_record_one_response_terminal_each() {
+    for (name, behavior, expected_frame, expected_metric) in [
+        (
+            "dsp05-observe-returned-reply",
+            LegacyBehavior::Reply,
+            true,
+            ("inline", "transport_written"),
+        ),
+        (
+            "dsp05-observe-direct-write",
+            LegacyBehavior::DirectChannelThenNone,
+            true,
+            ("inline", "transport_written"),
+        ),
+        (
+            "dsp05-observe-ambiguous-none",
+            LegacyBehavior::NoneThenSentinel,
+            false,
+            ("no_response", "protocol_no_response"),
+        ),
+    ] {
+        let mut harness = DispatchHarness::new(name).await;
+        let state = Arc::new(LegacyState::default());
+        let processor = LegacyProcessor {
+            behavior,
+            state: Arc::clone(&state),
+        };
+        let (telemetry, response_metrics) = TransportTelemetry::with_v2_boundary_metric_capture();
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new_legacy(
+            LegacyProcessorAdapter::new(processor, PROCESSOR_NAME, telemetry, PendingRequestTable::new()),
+            Vec::new(),
+        ));
+
+        let (outcome, _) = dispatch(&harness, &dispatcher, command(PRIMARY_CODE, false), None).await;
+        assert!(matches!(outcome, DispatchOutcome::Accepted(_)));
+        harness.drain_requests().await;
+        if expected_frame {
+            let response = harness.receive().await;
+            assert!(response.is_response_type());
+        } else {
+            harness.assert_no_response().await;
+        }
+
+        assert_eq!(response_metrics.response_events(), vec![expected_metric]);
+        assert_eq!(response_metrics.snapshot().3, 1);
+        assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+
+        finish_harness(&mut harness).await;
+        harness.shutdown().await;
+    }
+}
+
+#[tokio::test]
 async fn rejection_tuple_is_exact_and_each_admitted_path_records_one_metric_and_observation() {
     for (name, behavior, expected_code, expected_processes) in [
         (

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/outcomes_deadlines.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/outcomes_deadlines.rs
@@ -22,6 +22,9 @@ use crate::dispatch::OriginalRequestIdentity;
 use crate::dispatch::RequestControlView;
 use crate::dispatch::RequestMeta;
 use crate::dispatch::ResponseSink;
+use crate::runtime::processor_v2::ResponseObservationModeV2;
+use crate::runtime::processor_v2::ResponseObservationOutcomeV2;
+use crate::runtime::processor_v2::ResponseObservationV2;
 use crate::session_view::EmbeddedSessionRecord;
 use crate::telemetry::TransportTelemetry;
 
@@ -35,6 +38,8 @@ struct RegistryDeferredProcessor {
     registry: DeferredRegistry<String>,
     admission: DeferredAdmission,
     registered_id: Arc<Mutex<Option<DeferredId>>>,
+    observations: Arc<Mutex<Vec<ResponseObservationV2>>>,
+    commit_checkpoint: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
 }
 
 #[derive(Clone)]
@@ -121,15 +126,25 @@ impl RequestProcessorV2 for RegistryDeferredProcessor {
             .admission
             .try_reserve(retained)
             .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
-        let registration = self
+        let mut registration = self
             .registry
             .register(DeferredRequest::new(
                 "dispatcher-owned deferred resume".to_owned(),
                 DeferredParts::new(responder, permit),
             ))
             .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        if let Some(checkpoint) = self.commit_checkpoint.clone() {
+            registration.set_commit_checkpoint(move || checkpoint());
+        }
         *self.registered_id.lock().expect("registered deferred id lock") = Some(registration.deferred_id());
         Ok(HandlerOutcome::Deferred(registration))
+    }
+
+    fn observe_response(&self, observation: ResponseObservationV2) {
+        self.observations
+            .lock()
+            .expect("deferred observation lock")
+            .push(observation);
     }
 }
 
@@ -195,11 +210,14 @@ async fn dispatcher_commits_a_real_registry_registration_before_returning_deferr
     .expect("configure deferred registry admission");
     let registry = DeferredRegistry::<String>::new();
     let registered_id = Arc::new(Mutex::new(None));
+    let observations = Arc::new(Mutex::new(Vec::new()));
     let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
         RegistryDeferredProcessor {
             registry: registry.clone(),
             admission: admission.clone(),
             registered_id: Arc::clone(&registered_id),
+            observations: Arc::clone(&observations),
+            commit_checkpoint: None,
         },
         Vec::new(),
     ));
@@ -226,6 +244,10 @@ async fn dispatcher_commits_a_real_registry_registration_before_returning_deferr
     assert_eq!(registry.test_claim_marker_count(), 0);
     assert_eq!(admission.snapshot().waiting_count(), 1);
     assert!(admission.snapshot().retained_bytes() > 0);
+    assert!(
+        observations.lock().expect("deferred observation lock").is_empty(),
+        "durable registration is not a terminal response observation"
+    );
     let claimed = registry
         .claim(id, crate::dispatch::DeferredWakeReason::MessageArrived)
         .await
@@ -264,6 +286,15 @@ async fn dispatcher_commits_a_real_registry_registration_before_returning_deferr
         .expect("resume should use the same session executor and writer");
     assert_eq!(receipt.request_id(), original.request_id());
     assert_eq!(handler_calls.load(Ordering::SeqCst), 1);
+    {
+        let observed = observations.lock().expect("deferred observation lock");
+        assert_eq!(observed.len(), 1, "deferred completion is observed exactly once");
+        assert_eq!(observed[0].metadata().mode(), ResponseObservationModeV2::Deferred);
+        assert!(matches!(
+            observed[0].metadata().outcome(),
+            ResponseObservationOutcomeV2::Written(observed_receipt) if observed_receipt == receipt
+        ));
+    }
     assert_eq!(registry.test_index_counts(), (0, 0, 0));
     assert_eq!(registry.test_claim_marker_count(), 0);
     assert_eq!(admission.snapshot().waiting_count(), 0);
@@ -289,6 +320,65 @@ async fn dispatcher_commits_a_real_registry_registration_before_returning_deferr
     harness.shutdown().await;
 }
 
+#[tokio::test]
+async fn deferred_commit_session_close_balances_armed_metrics_without_recording_registration() {
+    let harness = DispatchHarness::new("dispatch-v2-deferred-commit-session-close").await;
+    let admission = DeferredAdmission::try_configure(
+        harness.admission_controller.as_ref(),
+        DeferredWaitLimits::new(4, 1024 * 1024),
+    )
+    .expect("configure deferred registry admission");
+    let registry = DeferredRegistry::<String>::new();
+    let registered_id = Arc::new(Mutex::new(None));
+    let observations = Arc::new(Mutex::new(Vec::new()));
+    let (telemetry, metric_adjustments, registered_events) = TransportTelemetry::with_v2_deferred_metric_capture();
+    let commit_session = harness.session.clone();
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new_with_telemetry(
+        RegistryDeferredProcessor {
+            registry: registry.clone(),
+            admission: admission.clone(),
+            registered_id: Arc::clone(&registered_id),
+            observations: Arc::clone(&observations),
+            commit_checkpoint: Some(Arc::new(move || commit_session.abort())),
+        },
+        Vec::new(),
+        telemetry,
+    ));
+    let command = request(false);
+    let (session, _original) = harness.request_session(&command);
+
+    let outcome = dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("request admission succeeds before deferred commit");
+    assert!(matches!(outcome, DispatchOutcome::Accepted(_)));
+    dispatcher.wait_for_failure_report().await;
+    harness.drain_requests().await;
+
+    assert_eq!(dispatcher.reported_failure_categories(), ["session_closed"]);
+    assert_eq!(registered_events.load(Ordering::SeqCst), 0);
+    {
+        let adjustments = metric_adjustments.lock();
+        assert_eq!(adjustments.as_slice(), &[(1, 256), (-1, -256)]);
+        assert_eq!(adjustments.iter().map(|(inflight, _)| inflight).sum::<i64>(), 0);
+        assert_eq!(adjustments.iter().map(|(_, bytes)| bytes).sum::<i64>(), 0);
+    }
+    {
+        let observed = observations.lock().expect("deferred observation lock");
+        assert_eq!(observed.len(), 1, "commit failure publishes one terminal observation");
+        assert!(matches!(
+            observed[0].metadata().outcome(),
+            ResponseObservationOutcomeV2::Cancelled(crate::dispatch::DeferredTerminalReason::SessionClosed)
+        ));
+    }
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(admission.snapshot().waiting_count(), 0);
+    assert_eq!(admission.snapshot().retained_bytes(), 0);
+    drop(dispatcher);
+    drop(registry);
+    harness.shutdown().await;
+}
+
 #[tokio::test(start_paused = true)]
 async fn expired_resume_cancels_without_polling_the_handler_or_writing_a_response() {
     let mut harness = DispatchHarness::new("dispatch-v2-deferred-resume-deadline").await;
@@ -299,11 +389,14 @@ async fn expired_resume_cancels_without_polling_the_handler_or_writing_a_respons
     .expect("configure deferred registry admission");
     let registry = DeferredRegistry::<String>::new();
     let registered_id = Arc::new(Mutex::new(None));
+    let observations = Arc::new(Mutex::new(Vec::new()));
     let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
         RegistryDeferredProcessor {
             registry: registry.clone(),
             admission: admission.clone(),
             registered_id: Arc::clone(&registered_id),
+            observations: Arc::clone(&observations),
+            commit_checkpoint: None,
         },
         Vec::new(),
     ));
@@ -552,6 +645,77 @@ async fn queued_deadline_expiry_suppresses_original_oneway_before_binding_or_wri
     assert_eq!(state.clones.load(Ordering::SeqCst), 2);
     assert_eq!(state.processes.load(Ordering::SeqCst), 1);
     assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn cancellation_during_processor_wait_binds_one_terminal_observer_without_an_extra_clone() {
+    let mut harness = DispatchHarness::new("dispatch-v2-cancel-in-process-observation").await;
+    let (processor, state) = TestProcessor::new(Behavior::WaitReply);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        TestProcessor::new(Behavior::Reply).0,
+        Vec::new(),
+    ));
+    let command = request(false);
+    let (session, original) = harness.request_session(&command);
+    let builder = RemotingRequestBuilder::new(
+        original,
+        Instant::now(),
+        harness.context(None),
+        RequestLifecycleProvenance::from_network_session(&session),
+        command,
+    );
+    let per_request_processor = processor.clone();
+    let remote_address = session.remote_addr();
+    let execution = tokio::spawn(async move {
+        dispatcher
+            .execute_admitted(
+                ExplicitV2Processor::new(per_request_processor),
+                session,
+                AdmissionClass::Data,
+                original,
+                remote_address,
+                Instant::now(),
+                builder,
+            )
+            .await
+    });
+    state.entered.notified().await;
+    execution.abort();
+    assert!(execution.await.expect_err("cancel admitted task").is_cancelled());
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let notified = state.observed.notified();
+            if state
+                .terminal_observations
+                .lock()
+                .expect("terminal observation lock")
+                .len()
+                == 1
+            {
+                break;
+            }
+            notified.await;
+        }
+    })
+    .await
+    .expect("cancelled terminal observation");
+
+    {
+        let observations = state.terminal_observations.lock().expect("terminal observation lock");
+        assert_eq!(observations.len(), 1);
+        assert!(matches!(
+            observations[0].metadata().outcome(),
+            ResponseObservationOutcomeV2::Failed {
+                kind: None,
+                progress: Some(WriteProgress::NotStarted),
+            }
+        ));
+    }
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+
+    harness.assert_no_response().await;
     harness.shutdown().await;
 }
 

--- a/rocketmq-transport/src/dispatch/deferred_registry/internal.rs
+++ b/rocketmq-transport/src/dispatch/deferred_registry/internal.rs
@@ -550,13 +550,13 @@ where
         Some(entry)
     }
 
-    pub(in crate::dispatch) fn remove_session(&self, session_id: SessionId) {
+    pub(in crate::dispatch) fn remove_session(&self, session_id: SessionId) -> usize {
         #[cfg(test)]
         self.session_cleanup_calls.fetch_add(1, Ordering::SeqCst);
         let batch = {
             let mut state = self.state.lock();
             let Some(ids) = state.session_index.remove(&session_id) else {
-                return;
+                return 0;
             };
             let mut batch = DetachedBatch::default();
             for id in ids {
@@ -574,7 +574,9 @@ where
             }
             batch
         };
+        let removed_waiters = batch.waiter_count();
         let _ = batch.finish();
+        removed_waiters
     }
 
     pub(super) fn shutdown(&self) -> DeferredRegistryShutdownOutcome {
@@ -964,6 +966,10 @@ impl<R> DetachedBatch<R>
 where
     R: Send + 'static,
 {
+    fn waiter_count(&self) -> usize {
+        self.entries.len().saturating_add(self.markers.len())
+    }
+
     pub(super) fn push_entry(&mut self, entry: Entry<R>, fallback: CleanupCause) {
         let cause = match fallback {
             CleanupCause::SessionClosed if entry.control.parent_is_cancelled() => CleanupCause::ParentCancelled,

--- a/rocketmq-transport/src/dispatch/deferred_registry/tests.rs
+++ b/rocketmq-transport/src/dispatch/deferred_registry/tests.rs
@@ -1054,10 +1054,14 @@ fn session_cleanup_detaches_multiple_registries_once_and_preserves_other_session
     other_registration.commit().expect("other session commit");
 
     harness.session.close();
+    let cleanup_report = cleanup.close();
     assert_eq!(
-        cleanup.close(),
+        cleanup_report.outcome,
         crate::dispatch::deferred_session_cleanup::DeferredSessionCleanupCloseOutcome::Completed
     );
+    assert_eq!(cleanup_report.registered_waiters, 3);
+    assert_eq!(cleanup_report.removed_waiters, 3);
+    assert_eq!(cleanup_report.remaining_wait_permits, 0);
     assert_eq!(first.inner.session_member_count(harness.session.view().id()), 0);
     assert_eq!(second.inner.session_member_count(harness.session.view().id()), 0);
     assert_eq!(first.inner.session_cleanup_call_count(), 1);

--- a/rocketmq-transport/src/dispatch/deferred_responder.rs
+++ b/rocketmq-transport/src/dispatch/deferred_responder.rs
@@ -18,6 +18,8 @@ use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
 
+use tracing::Instrument;
+
 use super::deferred_response::DeferredSystemCancellationReason;
 use super::deferred_response::DeferredSystemCloseReason;
 use super::deferred_response::DeferredTerminalReason;
@@ -264,6 +266,7 @@ pub(crate) struct DeferredResponseSeed {
     control: RequestControlView,
     resume: Option<DeferredResumeContext>,
     session_cleanup: Option<super::DeferredSessionCleanupRegistration>,
+    observation: Option<crate::telemetry::V2RequestObservation>,
 }
 
 #[derive(Clone)]
@@ -287,6 +290,7 @@ impl DeferredResponseSeed {
             control,
             resume: None,
             session_cleanup: None,
+            observation: None,
         }
     }
 
@@ -309,6 +313,11 @@ impl DeferredResponseSeed {
         self
     }
 
+    pub(crate) fn with_observation(mut self, observation: crate::telemetry::V2RequestObservation) -> Self {
+        self.observation = Some(observation);
+        self
+    }
+
     pub(crate) fn into_responder(self, original: OriginalRequestIdentity) -> DeferredResponder {
         #[cfg(test)]
         {
@@ -324,6 +333,7 @@ impl DeferredResponseSeed {
             control: self.control,
             resume: self.resume,
             session_cleanup: self.session_cleanup,
+            observation: self.observation,
             active: true,
         }
     }
@@ -351,6 +361,7 @@ pub struct DeferredResponder {
     control: RequestControlView,
     resume: Option<DeferredResumeContext>,
     session_cleanup: Option<super::DeferredSessionCleanupRegistration>,
+    observation: Option<crate::telemetry::V2RequestObservation>,
     active: bool,
 }
 
@@ -396,6 +407,12 @@ impl DeferredResponder {
         &self.state
     }
 
+    pub(crate) fn request_span(&self) -> tracing::Span {
+        self.observation
+            .as_ref()
+            .map_or_else(tracing::Span::none, crate::telemetry::V2RequestObservation::span)
+    }
+
     pub(crate) fn take_session_cleanup(&mut self) -> Option<super::DeferredSessionCleanupRegistration> {
         self.session_cleanup.take()
     }
@@ -413,6 +430,11 @@ impl DeferredResponder {
             .close_with_reason(reason)
             .map_err(DeferredResponseError::from_state);
         self.active = false;
+        if result.is_ok() {
+            if let Some(observation) = &self.observation {
+                observation.complete_cancelled(reason.terminal_reason());
+            }
+        }
         result
     }
 
@@ -425,6 +447,11 @@ impl DeferredResponder {
             .cancel_with_reason(reason)
             .map_err(DeferredResponseError::from_state);
         self.active = false;
+        if result.is_ok() {
+            if let Some(observation) = &self.observation {
+                observation.complete_cancelled(reason.terminal_reason());
+            }
+        }
         result
     }
 
@@ -438,6 +465,11 @@ impl DeferredResponder {
             .close_with_reason(reason)
             .map_err(DeferredResponseError::from_state);
         self.active = false;
+        if result.is_ok() {
+            if let Some(observation) = &self.observation {
+                observation.complete_cancelled(reason.terminal_reason());
+            }
+        }
         result
     }
 
@@ -450,6 +482,11 @@ impl DeferredResponder {
             .cancel_with_reason(reason)
             .map_err(DeferredResponseError::from_state);
         self.active = false;
+        if result.is_ok() {
+            if let Some(observation) = &self.observation {
+                observation.complete_cancelled(reason.terminal_reason());
+            }
+        }
         result
     }
 
@@ -459,7 +496,15 @@ impl DeferredResponder {
     ///
     /// Returns a typed, redacted error for lifecycle, immutable binding,
     /// encoding, queue, cancellation, deadline, session, or transport failure.
-    pub async fn respond(mut self, plan: ResponsePlan) -> Result<ResponseReceipt, DeferredResponseError> {
+    pub async fn respond(self, plan: ResponsePlan) -> Result<ResponseReceipt, DeferredResponseError> {
+        let span = self.request_span();
+        self.respond_in_request_span(plan).instrument(span).await
+    }
+
+    async fn respond_in_request_span(mut self, plan: ResponsePlan) -> Result<ResponseReceipt, DeferredResponseError> {
+        let response_code = plan.response_code();
+        let plan_kind = plan.body_kind();
+        let write_started = std::time::Instant::now();
         let mut claim = self.state.begin_sending().map_err(DeferredResponseError::from_state)?;
         self.active = false;
         let bound = match plan.bind(self.original) {
@@ -468,6 +513,14 @@ impl DeferredResponder {
                 claim
                     .fail(WriteProgress::NotStarted)
                     .map_err(DeferredResponseError::from_state)?;
+                if let Some(observation) = &self.observation {
+                    observation.complete_failure_without_kind(
+                        crate::runtime::processor_v2::ResponseObservationModeV2::Deferred,
+                        Some(response_code),
+                        Some(plan_kind),
+                        Some(WriteProgress::NotStarted),
+                    );
+                }
                 return Err(DeferredResponseError::from_binding(source));
             }
         };
@@ -481,11 +534,30 @@ impl DeferredResponder {
         match result {
             Ok(receipt) => {
                 claim.complete().map_err(DeferredResponseError::from_state)?;
+                if let Some(observation) = &self.observation {
+                    observation.complete_reply(
+                        crate::runtime::processor_v2::ResponseObservationModeV2::Deferred,
+                        response_code,
+                        plan_kind,
+                        write_started.elapsed(),
+                        Ok(receipt),
+                    );
+                }
                 Ok(receipt)
             }
             Err(error) => {
                 let progress = error.write_progress().unwrap_or(WriteProgress::NotStarted);
+                let kind = error.kind();
                 claim.fail(progress).map_err(DeferredResponseError::from_state)?;
+                if let Some(observation) = &self.observation {
+                    observation.complete_reply(
+                        crate::runtime::processor_v2::ResponseObservationModeV2::Deferred,
+                        response_code,
+                        plan_kind,
+                        write_started.elapsed(),
+                        Err((kind, Some(progress))),
+                    );
+                }
                 Err(DeferredResponseError::from_response(error))
             }
         }
@@ -500,6 +572,11 @@ impl DeferredResponder {
     pub fn cancel(mut self) -> Result<(), DeferredResponseError> {
         let result = self.state.cancel().map_err(DeferredResponseError::from_state);
         self.active = false;
+        if result.is_ok() {
+            if let Some(observation) = &self.observation {
+                observation.complete_cancelled(DeferredTerminalReason::Explicit);
+            }
+        }
         result
     }
 
@@ -517,6 +594,11 @@ impl DeferredResponder {
         }
         .map_err(DeferredResponseError::from_state);
         self.active = false;
+        if result.is_ok() {
+            if let Some(observation) = &self.observation {
+                observation.complete_cancelled(DeferredTerminalReason::ReceiverDropped);
+            }
+        }
         result
     }
 }
@@ -532,8 +614,10 @@ impl fmt::Debug for DeferredResponder {
 
 impl Drop for DeferredResponder {
     fn drop(&mut self) {
-        if self.active {
-            let _ = self.state.cancel_abandoned();
+        if self.active && self.state.cancel_abandoned().is_ok() {
+            if let Some(observation) = &self.observation {
+                observation.complete_cancelled(DeferredTerminalReason::Abandoned);
+            }
         }
         self.active = false;
     }

--- a/rocketmq-transport/src/dispatch/deferred_response.rs
+++ b/rocketmq-transport/src/dispatch/deferred_response.rs
@@ -113,6 +113,10 @@ impl DeferredSystemCancellationReason {
     pub(crate) const PARENT_CANCELLED: Self = Self(DeferredTerminalReason::ParentCancelled);
     pub(crate) const PROCESSOR_UNAVAILABLE: Self = Self(DeferredTerminalReason::ProcessorUnavailable);
     pub(crate) const SERVICE_STOPPING: Self = Self(DeferredTerminalReason::ServiceStopping);
+
+    pub(crate) const fn terminal_reason(self) -> DeferredTerminalReason {
+        self.0
+    }
 }
 
 /// Sealed system-owned reasons that project to `Closed`.
@@ -121,6 +125,10 @@ pub(crate) struct DeferredSystemCloseReason(DeferredTerminalReason);
 
 impl DeferredSystemCloseReason {
     pub(crate) const SESSION_CLOSED: Self = Self(DeferredTerminalReason::SessionClosed);
+
+    pub(crate) const fn terminal_reason(self) -> DeferredTerminalReason {
+        self.0
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/rocketmq-transport/src/dispatch/deferred_resume.rs
+++ b/rocketmq-transport/src/dispatch/deferred_resume.rs
@@ -26,6 +26,7 @@ use parking_lot::Mutex;
 use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::OperationContext;
 use tokio::sync::Notify;
+use tracing::Instrument;
 
 use super::authorized_dispatcher::admission_response;
 use super::deferred_registry::ClaimExecutionParts;
@@ -524,11 +525,18 @@ where
     }
 
     fn execute(mut self: Box<Self>) -> WorkFuture {
-        Box::pin(async move {
-            let parts = self.parts.take().expect("resume work owns claimed parts");
-            let handler = self.handler.take().expect("resume work owns its handler");
-            execute_work(parts, handler, self.stop_view.clone()).await
-        })
+        let span = self
+            .parts
+            .as_ref()
+            .map_or_else(tracing::Span::none, |parts| parts.responder.request_span());
+        Box::pin(
+            async move {
+                let parts = self.parts.take().expect("resume work owns claimed parts");
+                let handler = self.handler.take().expect("resume work owns its handler");
+                execute_work(parts, handler, self.stop_view.clone()).await
+            }
+            .instrument(span),
+        )
     }
 
     fn reject(mut self: Box<Self>, error: AdmissionError) -> WorkFuture {
@@ -1339,14 +1347,25 @@ mod tests {
         assert!(submitted.is_ok(), "resume task must be accepted");
         drop(cell);
         first_poll_entered.notified().await;
-        let report = executor.drain_until(ShutdownDeadline::after(Duration::ZERO)).await;
-        assert_eq!(report.aborted, 1);
+        let report = executor
+            .drain_report_until(ShutdownDeadline::after(Duration::ZERO))
+            .await;
+        assert_eq!(report.active_inline_tasks, 0);
+        assert_eq!(report.active_resume_tasks, 1);
+        assert_eq!(report.remaining_inline_tasks, 0);
+        assert_eq!(report.remaining_resume_tasks, 1);
+        assert_eq!(report.shutdown.aborted, 1);
         let error = completion.wait().await.expect_err("aborted owner terminalizes the job");
         assert_eq!(error.kind(), DeferredResumeErrorKind::ExecutorClosing);
         assert_eq!(
             error.prior_terminal_reason(),
             Some(DeferredTerminalReason::ServiceStopping)
         );
+        let settled = executor
+            .drain_report_until(ShutdownDeadline::after(Duration::from_secs(1)))
+            .await;
+        assert_eq!(settled.remaining_inline_tasks, 0);
+        assert_eq!(settled.remaining_resume_tasks, 0);
     }
 
     #[tokio::test]
@@ -1368,6 +1387,69 @@ mod tests {
             .drain_until(ShutdownDeadline::after(Duration::from_secs(1)))
             .await;
         assert_eq!(report.aborted, 0);
+    }
+
+    #[tokio::test]
+    async fn drain_report_separates_inline_and_resume_tasks_and_joins_both() {
+        let (_runtime, controller, executor) =
+            executor_with_limits("session-drain-composite-counts", AdmissionLimits::default());
+        let inline_entered = Arc::new(Notify::new());
+        let inline_release = Arc::new(Notify::new());
+        let task_inline_entered = Arc::clone(&inline_entered);
+        let task_inline_release = Arc::clone(&inline_release);
+        executor
+            .try_execute(
+                128,
+                AdmissionClass::Data,
+                None,
+                RequestOrdering::Concurrent,
+                move |_operation| async move {
+                    task_inline_entered.notify_one();
+                    task_inline_release.notified().await;
+                },
+                move |_operation, _error| async {},
+            )
+            .expect("inline request accepted");
+        inline_entered.notified().await;
+
+        let resume_release = Arc::new(Notify::new());
+        let (job, completion, _wait_released, resume_entered, _executions) =
+            probe_job(128, RequestOrdering::Concurrent, Some(Arc::clone(&resume_release)));
+        let cell = Arc::new(ResumeJobCell::new(job));
+        cell.release_wait_permit();
+        assert!(
+            executor
+                .deferred_resume_executor()
+                .try_execute_resume(Arc::clone(&cell))
+                .is_ok(),
+            "resume accepted"
+        );
+        drop(cell);
+        resume_entered.notified().await;
+
+        let release = tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            inline_release.notify_one();
+            resume_release.notify_one();
+        });
+        let report = executor
+            .drain_report_until(ShutdownDeadline::after(Duration::from_secs(1)))
+            .await;
+        release.await.expect("release task");
+        assert_eq!(report.active_inline_tasks, 1);
+        assert_eq!(report.active_resume_tasks, 1);
+        assert_eq!(report.remaining_inline_tasks, 0);
+        assert_eq!(report.remaining_resume_tasks, 0);
+        assert_eq!(report.shutdown.completed, 2);
+        assert!(report.is_healthy());
+        assert_eq!(
+            completion.wait().await.expect_err("probe response").kind(),
+            DeferredResumeErrorKind::Response
+        );
+        let snapshot = controller.snapshot();
+        assert_eq!(snapshot.queued.current_count, 0);
+        assert_eq!(snapshot.inflight.current_count, 0);
+        assert_eq!(snapshot.processors.current_count, 0);
     }
 
     #[tokio::test]

--- a/rocketmq-transport/src/dispatch/deferred_resume/terminal_ownership_tests.rs
+++ b/rocketmq-transport/src/dispatch/deferred_resume/terminal_ownership_tests.rs
@@ -27,14 +27,24 @@ use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
 use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_runtime::TaskKind;
+use rocketmq_security_api::PeerInfo;
 use tokio::sync::Notify;
+use tracing::span::Attributes;
+use tracing::span::Id;
+use tracing::span::Record;
+use tracing::Event;
+use tracing::Metadata;
+use tracing::Subscriber;
 
 use super::execute_work;
+use super::DeferredResumeWork;
 use super::ResumeStopView;
+use super::ResumeWorkImpl;
 use crate::admission::AdmissionClass;
 use crate::admission::AdmissionController;
 use crate::admission::AdmissionLimits;
 use crate::admission::AdmissionScope;
+use crate::dispatch::AuthenticationState;
 use crate::dispatch::ClaimedDeferred;
 use crate::dispatch::DeferredAdmission;
 use crate::dispatch::DeferredParts;
@@ -47,6 +57,7 @@ use crate::dispatch::DeferredWakeReason;
 use crate::dispatch::OriginalRequestIdentity;
 use crate::dispatch::RequestControlView;
 use crate::dispatch::RequestMeta;
+use crate::dispatch::RequestOrigin;
 use crate::dispatch::ResponsePlan;
 use crate::dispatch::ResponseSink;
 use crate::request_ordering::RequestOrdering;
@@ -54,6 +65,32 @@ use crate::session_executor::DeferredResumeExecutor;
 use crate::session_executor::SessionExecutor;
 use crate::session_view::EmbeddedSessionRecord;
 use crate::telemetry::TransportTelemetry;
+
+struct FixedSpanSubscriber {
+    entered: Arc<AtomicUsize>,
+}
+
+impl Subscriber for FixedSpanSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _attributes: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, _event: &Event<'_>) {}
+
+    fn enter(&self, _span: &Id) {
+        self.entered.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn exit(&self, _span: &Id) {}
+}
 
 async fn claimed_for_terminal_test(
     sink: ResponseSink,
@@ -97,6 +134,78 @@ fn response_plan() -> RocketMQResult<ResponsePlan> {
         ResponsePlan::command(RemotingCommand::create_response_command_with_code(0))
             .expect("terminal ownership response plan"),
     )
+}
+
+#[tokio::test]
+async fn claimed_resume_handler_reenters_the_original_request_span() {
+    let runtime =
+        RuntimeOwner::new(RuntimeConfig::server_default("deferred-resume-request-span")).expect("request span runtime");
+    let parent = runtime.root_context().component("request-span").task_group().clone();
+    let session = EmbeddedSessionRecord::new(98_332);
+    let control = RequestControlView::from_meta(
+        &RequestMeta::new(Instant::now(), None),
+        session.view().state().clone(),
+        &parent,
+    );
+    let original = OriginalRequestIdentity::capture(
+        98_332,
+        &AtomicU64::new(1),
+        &RemotingCommand::create_remoting_command(39).set_opaque(835),
+    )
+    .expect("request span identity");
+    let entered = Arc::new(AtomicUsize::new(0));
+    let dispatch = tracing::Dispatch::new(FixedSpanSubscriber {
+        entered: Arc::clone(&entered),
+    });
+    let span = tracing::dispatcher::with_default(&dispatch, || tracing::info_span!("test-v2-request"));
+    assert_eq!(span.id().expect("test request span id").into_u64(), 1);
+    let observation = TransportTelemetry::noop()
+        .begin_v2_observation(
+            original,
+            Instant::now(),
+            &RequestOrigin::Network {
+                peer: PeerInfo::new("127.0.0.1:10911".parse().expect("test peer"), false),
+            },
+            &AuthenticationState::Anonymous,
+            None,
+            0,
+        )
+        .with_span_for_test(span);
+    observation.bind_response_observer(|_| {});
+    let (sink, _receiver) = ResponseSink::local_plan(control.clone());
+    let responder = sink
+        .deferred_seed_for_test(TransportTelemetry::noop(), session.view().id(), control)
+        .with_observation(observation)
+        .into_responder(original);
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = DeferredAdmission::try_configure(&controller, DeferredWaitLimits::new(1, 4096))
+        .expect("request span admission");
+    let retained = DeferredRegistry::<()>::try_retained_size(DeferredRetainedSizeParts::new(0))
+        .expect("request span retained size");
+    let permit = admission.try_reserve(retained).expect("request span wait permit");
+    let registry = DeferredRegistry::new();
+    let registration = registry
+        .register(DeferredRequest::new((), DeferredParts::new(responder, permit)))
+        .expect("request span registration");
+    let id = registration.deferred_id();
+    registration.commit().expect("publish request span registration");
+    let claim = registry
+        .claim(id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("claim request span registration");
+    let parts = claim.into_execution_parts();
+    let stop_view = ResumeStopView::from_execution_parts(&parts);
+    let work: Box<dyn DeferredResumeWork> = Box::new(ResumeWorkImpl {
+        parts: Some(parts),
+        handler: Some(move |(), _reason| async move { response_plan() }),
+        stop_view,
+    });
+
+    work.execute().await.expect("claimed resume response");
+    assert!(
+        entered.load(Ordering::Acquire) > 0,
+        "claimed resume work must enter the observation's original request span"
+    );
 }
 
 struct ReadyRetainedFuture {

--- a/rocketmq-transport/src/dispatch/deferred_resume/tests/stop.rs
+++ b/rocketmq-transport/src/dispatch/deferred_resume/tests/stop.rs
@@ -113,7 +113,6 @@ async fn owner_cutoff_cancels_an_ordered_waiter_before_processor_execution() {
     );
     assert_eq!(first_executions.load(Ordering::Acquire), 1);
     assert_eq!(second_executions.load(Ordering::Acquire), 0);
-
     release_first.notify_one();
     assert_eq!(
         first_completion.wait().await.expect_err("probe response").kind(),

--- a/rocketmq-transport/src/dispatch/deferred_session_cleanup.rs
+++ b/rocketmq-transport/src/dispatch/deferred_session_cleanup.rs
@@ -37,7 +37,7 @@ mod sealed {
 pub(crate) trait DeferredSessionCleanupTarget: sealed::Sealed + Send + Sync + 'static {
     fn key(&self) -> usize;
 
-    fn remove_session(&self, session_id: SessionId);
+    fn remove_session(&self, session_id: SessionId) -> usize;
 }
 
 #[derive(Clone)]
@@ -155,13 +155,17 @@ impl DeferredSessionCleanupTarget for LegacyCallbackCleanupTarget {
         self.key
     }
 
-    fn remove_session(&self, _session_id: SessionId) {
+    fn remove_session(&self, _session_id: SessionId) -> usize {
         if !self.completed.swap(true, Ordering::AcqRel) {
             (self.cleanup)();
+            1
+        } else {
+            0
         }
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct DeferredSessionCleanupOwner {
     registration: DeferredSessionCleanupRegistration,
 }
@@ -180,8 +184,12 @@ impl DeferredSessionCleanupOwner {
         self.registration.clone()
     }
 
-    pub(crate) fn close(&self) -> DeferredSessionCleanupCloseOutcome {
+    pub(crate) fn close(&self) -> DeferredSessionCleanupReport {
         self.registration.coordinator.close(self.registration.session_id)
+    }
+
+    pub(crate) fn remaining_wait_permits(&self) -> usize {
+        self.registration.coordinator.live_enrollment_count()
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -209,6 +217,43 @@ pub(crate) enum DeferredSessionCleanupCloseOutcome {
     Completed,
     InProgress,
     AlreadyClosed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DeferredSessionCleanupReport {
+    pub(crate) outcome: DeferredSessionCleanupCloseOutcome,
+    pub(crate) registered_waiters: usize,
+    pub(crate) removed_waiters: usize,
+    pub(crate) remaining_wait_permits: usize,
+    pub(crate) panicked_targets: usize,
+}
+
+impl PartialEq<DeferredSessionCleanupCloseOutcome> for DeferredSessionCleanupReport {
+    fn eq(&self, other: &DeferredSessionCleanupCloseOutcome) -> bool {
+        self.outcome == *other
+    }
+}
+
+impl PartialEq<DeferredSessionCleanupReport> for DeferredSessionCleanupCloseOutcome {
+    fn eq(&self, other: &DeferredSessionCleanupReport) -> bool {
+        *self == other.outcome
+    }
+}
+
+impl DeferredSessionCleanupReport {
+    pub(crate) const fn empty_completed() -> Self {
+        Self {
+            outcome: DeferredSessionCleanupCloseOutcome::Completed,
+            registered_waiters: 0,
+            removed_waiters: 0,
+            remaining_wait_permits: 0,
+            panicked_targets: 0,
+        }
+    }
+
+    pub(crate) const fn is_healthy(self) -> bool {
+        matches!(self.outcome, DeferredSessionCleanupCloseOutcome::Completed) && self.panicked_targets == 0
+    }
 }
 
 pub(crate) struct CleanupEnrollment {
@@ -357,8 +402,8 @@ impl CleanupCoordinator {
         }
     }
 
-    fn close(&self, session_id: SessionId) -> DeferredSessionCleanupCloseOutcome {
-        let mut targets = {
+    fn close(&self, session_id: SessionId) -> DeferredSessionCleanupReport {
+        let (mut targets, registered_waiters) = {
             let mut state = self.state.lock();
             #[cfg(test)]
             if let Some(checkpoint) = self.close_acquired_checkpoint.lock().clone() {
@@ -366,32 +411,47 @@ impl CleanupCoordinator {
             }
             match state.lifecycle {
                 CleanupLifecycle::Open => state.lifecycle = CleanupLifecycle::Closing,
-                CleanupLifecycle::Closing => return DeferredSessionCleanupCloseOutcome::InProgress,
-                CleanupLifecycle::Closed => return DeferredSessionCleanupCloseOutcome::AlreadyClosed,
+                CleanupLifecycle::Closing => {
+                    return cleanup_report(DeferredSessionCleanupCloseOutcome::InProgress, &state, 0);
+                }
+                CleanupLifecycle::Closed => {
+                    return cleanup_report(DeferredSessionCleanupCloseOutcome::AlreadyClosed, &state, 0);
+                }
             }
-            state
-                .targets
-                .values()
-                .filter_map(|record| record.target.upgrade())
-                .collect::<Vec<_>>()
+            (
+                state
+                    .targets
+                    .values()
+                    .filter_map(|record| record.target.upgrade())
+                    .collect::<Vec<_>>(),
+                live_enrollment_count(&state),
+            )
         };
         targets.sort_unstable_by_key(|target| target.key());
         let completion = CleanupCloseCompletion::new(self);
-        let mut first_panic = None;
+        let mut removed_waiters = 0usize;
+        let mut panicked_targets = 0usize;
 
         for target in targets {
-            if let Err(payload) = std::panic::catch_unwind(AssertUnwindSafe(|| target.remove_session(session_id))) {
-                if first_panic.is_none() {
-                    first_panic = Some(payload);
-                }
+            match std::panic::catch_unwind(AssertUnwindSafe(|| target.remove_session(session_id))) {
+                Ok(removed) => removed_waiters = removed_waiters.saturating_add(removed),
+                Err(_) => panicked_targets = panicked_targets.saturating_add(1),
             }
         }
 
         completion.complete();
-        if let Some(payload) = first_panic {
-            std::panic::resume_unwind(payload);
+        let remaining_wait_permits = self.live_enrollment_count();
+        DeferredSessionCleanupReport {
+            outcome: DeferredSessionCleanupCloseOutcome::Completed,
+            registered_waiters,
+            removed_waiters,
+            remaining_wait_permits,
+            panicked_targets,
         }
-        DeferredSessionCleanupCloseOutcome::Completed
+    }
+
+    fn live_enrollment_count(&self) -> usize {
+        live_enrollment_count(&self.state.lock())
     }
 }
 
@@ -464,6 +524,28 @@ fn release_enrollment(state: &mut CleanupState, key: usize) {
     }
 }
 
+fn live_enrollment_count(state: &CleanupState) -> usize {
+    state
+        .targets
+        .values()
+        .fold(0usize, |total, record| total.saturating_add(record.live_enrollments))
+}
+
+fn cleanup_report(
+    outcome: DeferredSessionCleanupCloseOutcome,
+    state: &CleanupState,
+    removed_waiters: usize,
+) -> DeferredSessionCleanupReport {
+    let remaining_wait_permits = live_enrollment_count(state);
+    DeferredSessionCleanupReport {
+        outcome,
+        registered_waiters: remaining_wait_permits,
+        removed_waiters,
+        remaining_wait_permits,
+        panicked_targets: 0,
+    }
+}
+
 pub(crate) struct RegistryCleanupTarget<R>
 where
     R: Send + 'static,
@@ -499,9 +581,11 @@ where
         self.key
     }
 
-    fn remove_session(&self, session_id: SessionId) {
+    fn remove_session(&self, session_id: SessionId) -> usize {
         if let Some(registry) = self.registry.upgrade() {
-            registry.remove_session(session_id);
+            registry.remove_session(session_id)
+        } else {
+            0
         }
     }
 }
@@ -528,8 +612,9 @@ mod tests {
             self.key
         }
 
-        fn remove_session(&self, _session_id: SessionId) {
+        fn remove_session(&self, _session_id: SessionId) -> usize {
             self.calls.fetch_add(1, Ordering::SeqCst);
+            0
         }
     }
 
@@ -570,12 +655,17 @@ mod tests {
 
         assert_eq!(factory_calls.load(Ordering::SeqCst), 1);
         assert_eq!(owner.target_counts(), (1, 2));
-        assert_eq!(owner.close(), DeferredSessionCleanupCloseOutcome::Completed);
+        let report = owner.close();
+        assert_eq!(report.outcome, DeferredSessionCleanupCloseOutcome::Completed);
+        assert_eq!(report.registered_waiters, 2);
+        assert_eq!(report.removed_waiters, 0);
+        assert_eq!(report.remaining_wait_permits, 2);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         drop(first);
         assert_eq!(owner.target_counts(), (1, 1));
         drop(second);
         assert_eq!(owner.target_counts(), (0, 0));
+        assert_eq!(owner.remaining_wait_permits(), 0);
         assert_eq!(owner.close(), DeferredSessionCleanupCloseOutcome::AlreadyClosed);
     }
 
@@ -746,8 +836,8 @@ mod tests {
             self.key
         }
 
-        fn remove_session(&self, session_id: SessionId) {
-            let observed = match self.registration.coordinator.close(session_id) {
+        fn remove_session(&self, session_id: SessionId) -> usize {
+            let observed = match self.registration.coordinator.close(session_id).outcome {
                 DeferredSessionCleanupCloseOutcome::InProgress => 1,
                 DeferredSessionCleanupCloseOutcome::Completed | DeferredSessionCleanupCloseOutcome::AlreadyClosed => 2,
             };
@@ -833,8 +923,10 @@ mod tests {
         assert_eq!(registry.test_index_counts(), (1, 1, 1));
         assert_eq!(admission.snapshot().waiting_count(), 1);
 
-        let panic = std::panic::catch_unwind(AssertUnwindSafe(|| owner.close()));
-        assert!(panic.is_err());
+        let report = owner.close();
+        assert_eq!(report.outcome, DeferredSessionCleanupCloseOutcome::Completed);
+        assert_eq!(report.panicked_targets, 1);
+        assert!(!report.is_healthy());
         assert_eq!(observed.load(Ordering::SeqCst), 1);
         assert_eq!(registry.test_index_counts(), (0, 0, 0));
         assert_eq!(

--- a/rocketmq-transport/src/dispatch/legacy_processor_adapter.rs
+++ b/rocketmq-transport/src/dispatch/legacy_processor_adapter.rs
@@ -32,11 +32,13 @@ use super::OriginalRequestIdentity;
 use super::RemotingRequest;
 use super::RequestOrigin;
 use super::ResponseBodyKind;
+use super::ResponseDisposition;
 use super::ResponseError;
 use super::ResponsePlan;
 use super::ResponsePlanError;
 use super::ResponseReceipt;
 use super::ResponseSink;
+use super::ResponseTerminalState;
 use crate::base::pending_request_table::PendingRequestOwner;
 use crate::base::pending_request_table::PendingRequestTable;
 use crate::hook_registry::HookSnapshot;
@@ -55,6 +57,9 @@ use crate::runtime::processor::ResponseWriteObservation;
 use crate::runtime::processor::ResponseWriteOutcome;
 use crate::runtime::processor_v2::RejectRequestDecision;
 use crate::runtime::processor_v2::RequestProcessorV2;
+use crate::runtime::processor_v2::ResponseMetadataV2;
+use crate::runtime::processor_v2::ResponseObservationModeV2;
+use crate::runtime::processor_v2::ResponseObservationOutcomeV2;
 use crate::runtime::processor_v2::ResponseWriteObservationV2;
 use crate::runtime::processor_v2::ResponseWritePath;
 use crate::server::SessionHandle;
@@ -216,7 +221,7 @@ impl LegacyRequestBridge {
     ) -> Result<(), LegacyProcessorAdapterError> {
         if self.canonical_session_id != SessionId::from_session_owner(session.session_id())
             || self.channel.canonical_session_id() != Some(self.canonical_session_id)
-            || self.context.channel().canonical_session_id() != Some(self.canonical_session_id)
+            || self.context.legacy_channel().canonical_session_id() != Some(self.canonical_session_id)
         {
             return Err(LegacyProcessorAdapterError::SessionMismatch);
         }
@@ -229,13 +234,13 @@ impl LegacyRequestBridge {
         if !response.is_network_owner(session) {
             return Err(LegacyProcessorAdapterError::CompletionOwnerMismatch);
         }
-        if !self.channel.shares_inner(self.context.channel()) {
+        if !self.channel.shares_inner(self.context.legacy_channel()) {
             return Err(LegacyProcessorAdapterError::ChannelContextMismatch);
         }
-        debug_assert!(self.channel.shares_inner(self.context.channel()));
+        debug_assert!(self.channel.shares_inner(self.context.legacy_channel()));
         debug_assert_eq!(self.channel.canonical_session_id(), Some(self.canonical_session_id));
         debug_assert_eq!(
-            self.context.channel().canonical_session_id(),
+            self.context.legacy_channel().canonical_session_id(),
             Some(self.canonical_session_id)
         );
         debug_assert!(self.channel.is_network_transport());
@@ -252,7 +257,7 @@ impl LegacyRequestBridge {
         let session_view = session.view();
         if self.canonical_session_id != session_view.id()
             || self.channel.canonical_session_id() != Some(self.canonical_session_id)
-            || self.context.channel().canonical_session_id() != Some(self.canonical_session_id)
+            || self.context.legacy_channel().canonical_session_id() != Some(self.canonical_session_id)
         {
             return Err(LegacyProcessorAdapterError::SessionMismatch);
         }
@@ -270,13 +275,13 @@ impl LegacyRequestBridge {
         ) {
             return Err(LegacyProcessorAdapterError::CompletionOwnerMismatch);
         }
-        if !self.channel.shares_inner(self.context.channel()) {
+        if !self.channel.shares_inner(self.context.legacy_channel()) {
             return Err(LegacyProcessorAdapterError::ChannelContextMismatch);
         }
-        debug_assert!(self.channel.shares_inner(self.context.channel()));
+        debug_assert!(self.channel.shares_inner(self.context.legacy_channel()));
         debug_assert_eq!(self.channel.canonical_session_id(), Some(self.canonical_session_id));
         debug_assert_eq!(
-            self.context.channel().canonical_session_id(),
+            self.context.legacy_channel().canonical_session_id(),
             Some(self.canonical_session_id)
         );
         debug_assert!(!self.channel.is_network_transport());
@@ -402,6 +407,7 @@ where
 pub(crate) struct ExplicitV2Processor<P> {
     processor: P,
     response_table: PendingRequestTable,
+    telemetry: TransportTelemetry,
 }
 
 impl<P> ExplicitV2Processor<P> {
@@ -409,10 +415,19 @@ impl<P> ExplicitV2Processor<P> {
         Self::with_response_table(processor, PendingRequestTable::new())
     }
 
-    pub(crate) const fn with_response_table(processor: P, response_table: PendingRequestTable) -> Self {
+    pub(crate) fn with_response_table(processor: P, response_table: PendingRequestTable) -> Self {
+        Self::with_response_table_and_telemetry(processor, response_table, TransportTelemetry::noop())
+    }
+
+    pub(crate) const fn with_response_table_and_telemetry(
+        processor: P,
+        response_table: PendingRequestTable,
+        telemetry: TransportTelemetry,
+    ) -> Self {
         Self {
             processor,
             response_table,
+            telemetry,
         }
     }
 }
@@ -429,6 +444,7 @@ where
         Self {
             processor: self.processor.clone(),
             response_table: self.response_table.clone(),
+            telemetry: self.telemetry.clone(),
         }
     }
 }
@@ -560,41 +576,176 @@ pub(crate) enum DispatchProcessorError {
 
 #[allow(dead_code, reason = "legacy metrics remain dormant until DSP-06 coexistence routing")]
 pub(crate) enum DispatchMetricsGuard {
-    ExplicitV2,
-    Legacy(TransportRequestMetricsGuard),
+    ExplicitV2 {
+        observation: crate::telemetry::V2RequestObservation,
+    },
+    Legacy {
+        metrics: TransportRequestMetricsGuard,
+        span: tracing::Span,
+        telemetry: Box<TransportTelemetry>,
+        original: OriginalRequestIdentity,
+        response_observed: bool,
+    },
 }
 
 impl DispatchMetricsGuard {
     pub(crate) fn complete_response(&mut self, response_code: i32) {
-        if let Self::Legacy(guard) = self {
-            guard.complete_response(response_code);
+        match self {
+            Self::ExplicitV2 { .. } => {}
+            Self::Legacy { metrics, .. } => metrics.complete_response(response_code),
         }
     }
 
     pub(crate) fn complete_oneway(&mut self) {
-        if let Self::Legacy(guard) = self {
-            guard.complete_oneway();
+        match self {
+            Self::ExplicitV2 { observation } => {
+                observation.complete_no_response(ResponseObservationOutcomeV2::Oneway);
+            }
+            Self::Legacy { metrics, .. } => {
+                metrics.complete_oneway();
+                self.record_legacy_response(
+                    None,
+                    None,
+                    ResponseObservationModeV2::NoResponse,
+                    ResponseObservationOutcomeV2::Oneway,
+                );
+            }
         }
     }
 
-    pub(crate) fn complete_legacy_ambiguous_none(&mut self) {
-        if let Self::Legacy(guard) = self {
-            guard.complete_legacy_ambiguous_none();
+    pub(crate) fn complete_protocol_no_response(&mut self) {
+        if let Self::ExplicitV2 { observation } = self {
+            observation.complete_no_response(ResponseObservationOutcomeV2::ProtocolNoResponse);
         }
+    }
+
+    pub(crate) fn arm_deferred_metrics(&mut self, retained_bytes: usize) {
+        if let Self::ExplicitV2 { observation } = self {
+            observation.arm_deferred_metrics(retained_bytes);
+        }
+    }
+
+    pub(crate) fn record_deferred_registered(&mut self) {
+        if let Self::ExplicitV2 { observation } = self {
+            observation.record_deferred_registered();
+        }
+    }
+
+    pub(crate) fn v2_observation(&self) -> Option<&crate::telemetry::V2RequestObservation> {
+        match self {
+            Self::ExplicitV2 { observation, .. } => Some(observation),
+            Self::Legacy { .. } => None,
+        }
+    }
+
+    pub(crate) fn span(&self) -> tracing::Span {
+        match self {
+            Self::ExplicitV2 { observation } => observation.span(),
+            Self::Legacy { span, .. } => span.clone(),
+        }
+    }
+
+    pub(crate) fn complete_legacy_ambiguous_none(&mut self, response: &ResponseSink) {
+        if let Self::Legacy { metrics, .. } = self {
+            metrics.complete_legacy_ambiguous_none();
+        }
+        let (mode, outcome) = match response.terminal_state() {
+            Some(ResponseTerminalState::Completed) => (
+                ResponseObservationModeV2::Inline,
+                ResponseObservationOutcomeV2::Written(ResponseReceipt::new(
+                    match self {
+                        Self::Legacy { original, .. } => original.request_id(),
+                        Self::ExplicitV2 { .. } => return,
+                    },
+                    if response.is_local() {
+                        ResponseDisposition::InProcessAccepted
+                    } else {
+                        ResponseDisposition::TransportWritten
+                    },
+                )),
+            ),
+            Some(ResponseTerminalState::Failed { progress }) => (
+                ResponseObservationModeV2::Inline,
+                ResponseObservationOutcomeV2::Failed {
+                    kind: None,
+                    progress: Some(progress),
+                },
+            ),
+            Some(ResponseTerminalState::Cancelled | ResponseTerminalState::Closed) => (
+                ResponseObservationModeV2::Inline,
+                ResponseObservationOutcomeV2::Failed {
+                    kind: None,
+                    progress: Some(crate::dispatch::WriteProgress::NotStarted),
+                },
+            ),
+            None => (
+                ResponseObservationModeV2::NoResponse,
+                ResponseObservationOutcomeV2::ProtocolNoResponse,
+            ),
+        };
+        self.record_legacy_response(None, None, mode, outcome);
+    }
+
+    pub(crate) fn record_legacy_reply(
+        &mut self,
+        response_code: i32,
+        body_kind: ResponseBodyKind,
+        outcome: ResponseObservationOutcomeV2,
+    ) {
+        self.record_legacy_response(
+            Some(response_code),
+            Some(body_kind),
+            ResponseObservationModeV2::Inline,
+            outcome,
+        );
+    }
+
+    fn record_legacy_response(
+        &mut self,
+        response_code: Option<i32>,
+        plan_kind: Option<ResponseBodyKind>,
+        mode: ResponseObservationModeV2,
+        outcome: ResponseObservationOutcomeV2,
+    ) {
+        let Self::Legacy {
+            telemetry,
+            original,
+            response_observed,
+            ..
+        } = self
+        else {
+            return;
+        };
+        if *response_observed {
+            return;
+        }
+        *response_observed = true;
+        telemetry.record_v2_response(ResponseMetadataV2::new(
+            original.request_id(),
+            original.original_code(),
+            response_code,
+            plan_kind,
+            mode,
+            outcome,
+        ));
     }
 
     pub(crate) fn complete_process_request_failed(&mut self, response_code: i32) {
-        if let Self::Legacy(guard) = self {
-            let _ = response_code;
-            guard.complete_process_request_failed(
-                rocketmq_protocol::code::response_code::ResponseCode::SystemError.to_i32(),
-            );
+        match self {
+            Self::ExplicitV2 { observation } => observation.complete_request_failed(response_code),
+            Self::Legacy { metrics, .. } => {
+                let _ = response_code;
+                metrics.complete_process_request_failed(
+                    rocketmq_protocol::code::response_code::ResponseCode::SystemError.to_i32(),
+                );
+            }
         }
     }
 
     pub(crate) fn complete_write_channel_failed(&mut self, response_code: i32) {
-        if let Self::Legacy(guard) = self {
-            guard.complete_write_channel_failed(response_code);
+        match self {
+            Self::ExplicitV2 { observation } => observation.complete_write_failed(response_code),
+            Self::Legacy { metrics, .. } => metrics.complete_write_channel_failed(response_code),
         }
     }
 }
@@ -611,7 +762,20 @@ pub(crate) trait DispatchProcessor: sealed::Sealed + Clone + Send + Sync + 'stat
 
     fn request_ordering(&self, builder: &RemotingRequestBuilder) -> RequestOrdering;
 
-    fn begin_admitted(&self, original: OriginalRequestIdentity, request_bytes: u64) -> DispatchMetricsGuard;
+    fn begin_boundary_observation(
+        &self,
+        builder: &RemotingRequestBuilder,
+        request_bytes: u64,
+    ) -> Option<crate::telemetry::V2RequestObservation>;
+
+    fn begin_admitted(
+        &self,
+        builder: &RemotingRequestBuilder,
+        request_bytes: u64,
+        observation: Option<crate::telemetry::V2RequestObservation>,
+    ) -> DispatchMetricsGuard;
+
+    fn bind_response_observer(self, observation: Option<crate::telemetry::V2RequestObservation>);
 
     fn reject_request(&self, request_code: i32) -> Result<Option<InternalProcessorCandidate>, DispatchProcessorError>;
 
@@ -627,6 +791,7 @@ pub(crate) trait DispatchProcessor: sealed::Sealed + Clone + Send + Sync + 'stat
         resume_executor: crate::session_executor::DeferredResumeExecutor,
         retained_bytes: usize,
         session_cleanup: Option<crate::dispatch::DeferredSessionCleanupRegistration>,
+        observation: Option<crate::telemetry::V2RequestObservation>,
     ) -> Result<RemotingRequestBuilder, super::remoting_request::RemotingRequestBuildError>;
 
     fn process(
@@ -654,6 +819,45 @@ pub(crate) trait DispatchProcessor: sealed::Sealed + Clone + Send + Sync + 'stat
         end_to_end_elapsed: Duration,
         result: Result<ResponseReceipt, ResponseError>,
     );
+}
+
+pub(crate) struct AdmittedProcessorObserver<D>
+where
+    D: DispatchProcessor,
+{
+    processor: Option<D>,
+    observation: Option<crate::telemetry::V2RequestObservation>,
+}
+
+impl<D> AdmittedProcessorObserver<D>
+where
+    D: DispatchProcessor,
+{
+    pub(crate) fn new(processor: D, observation: Option<crate::telemetry::V2RequestObservation>) -> Self {
+        Self {
+            processor: Some(processor),
+            observation,
+        }
+    }
+
+    pub(crate) fn processor_mut(&mut self) -> Option<&mut D> {
+        self.processor.as_mut()
+    }
+
+    pub(crate) fn bind(&mut self) {
+        if let Some(processor) = self.processor.take() {
+            processor.bind_response_observer(self.observation.take());
+        }
+    }
+}
+
+impl<D> Drop for AdmittedProcessorObserver<D>
+where
+    D: DispatchProcessor,
+{
+    fn drop(&mut self) {
+        self.bind();
+    }
 }
 
 impl<P> sealed::Sealed for ExplicitV2Processor<P> {}
@@ -697,8 +901,46 @@ where
         self.processor.request_ordering(builder.ingress_view())
     }
 
-    fn begin_admitted(&self, _original: OriginalRequestIdentity, _request_bytes: u64) -> DispatchMetricsGuard {
-        DispatchMetricsGuard::ExplicitV2
+    fn begin_boundary_observation(
+        &self,
+        builder: &RemotingRequestBuilder,
+        request_bytes: u64,
+    ) -> Option<crate::telemetry::V2RequestObservation> {
+        let original = builder.ingress_view().original_identity();
+        Some(self.telemetry.begin_v2_observation(
+            original,
+            builder.received_at(),
+            builder.origin(),
+            builder.authentication(),
+            builder.deadline(),
+            request_bytes,
+        ))
+    }
+
+    fn begin_admitted(
+        &self,
+        builder: &RemotingRequestBuilder,
+        request_bytes: u64,
+        observation: Option<crate::telemetry::V2RequestObservation>,
+    ) -> DispatchMetricsGuard {
+        let observation = observation.unwrap_or_else(|| {
+            self.telemetry.begin_v2_observation(
+                builder.ingress_view().original_identity(),
+                builder.received_at(),
+                builder.origin(),
+                builder.authentication(),
+                builder.deadline(),
+                request_bytes,
+            )
+        });
+        DispatchMetricsGuard::ExplicitV2 { observation }
+    }
+
+    fn bind_response_observer(self, observation: Option<crate::telemetry::V2RequestObservation>) {
+        if let Some(observation) = observation {
+            let processor = self.processor;
+            observation.bind_response_observer(move |observation| processor.observe_response(observation));
+        }
     }
 
     fn reject_request(&self, request_code: i32) -> Result<Option<InternalProcessorCandidate>, DispatchProcessorError> {
@@ -727,12 +969,16 @@ where
         resume_executor: crate::session_executor::DeferredResumeExecutor,
         _retained_bytes: usize,
         session_cleanup: Option<crate::dispatch::DeferredSessionCleanupRegistration>,
+        observation: Option<crate::telemetry::V2RequestObservation>,
     ) -> Result<RemotingRequestBuilder, super::remoting_request::RemotingRequestBuildError> {
         let mut seed = response
             .network_deferred_seed_with_resume(session, ordering, class, resume_executor)
             .ok_or(super::remoting_request::RemotingRequestBuildError::DeferredResponseOwnerMismatch)?;
         if let Some(session_cleanup) = session_cleanup {
             seed = seed.with_session_cleanup(session_cleanup);
+        }
+        if let Some(observation) = observation {
+            seed = seed.with_observation(observation);
         }
         Ok(builder.with_deferred_response_seed(seed))
     }
@@ -843,15 +1089,37 @@ where
         self.processor.request_ordering(builder.command())
     }
 
-    fn begin_admitted(&self, original: OriginalRequestIdentity, request_bytes: u64) -> DispatchMetricsGuard {
+    fn begin_boundary_observation(
+        &self,
+        _builder: &RemotingRequestBuilder,
+        _request_bytes: u64,
+    ) -> Option<crate::telemetry::V2RequestObservation> {
+        None
+    }
+
+    fn begin_admitted(
+        &self,
+        builder: &RemotingRequestBuilder,
+        request_bytes: u64,
+        _observation: Option<crate::telemetry::V2RequestObservation>,
+    ) -> DispatchMetricsGuard {
+        let original = builder.ingress_view().original_identity();
         self.telemetry
             .record_legacy_processor_request(self.processor_name, original.original_code());
-        DispatchMetricsGuard::Legacy(self.telemetry.request_guard(
-            original.original_code(),
-            request_bytes,
-            is_long_polling_request(original.original_code()),
-        ))
+        DispatchMetricsGuard::Legacy {
+            metrics: self.telemetry.request_guard(
+                original.original_code(),
+                request_bytes,
+                is_long_polling_request(original.original_code()),
+            ),
+            span: self.telemetry.request_span(original),
+            telemetry: Box::new(self.telemetry.clone()),
+            original,
+            response_observed: false,
+        }
     }
+
+    fn bind_response_observer(self, _observation: Option<crate::telemetry::V2RequestObservation>) {}
 
     fn reject_request(&self, request_code: i32) -> Result<Option<InternalProcessorCandidate>, DispatchProcessorError> {
         Ok(
@@ -881,6 +1149,7 @@ where
         resume_executor: crate::session_executor::DeferredResumeExecutor,
         retained_bytes: usize,
         session_cleanup: Option<crate::dispatch::DeferredSessionCleanupRegistration>,
+        _observation: Option<crate::telemetry::V2RequestObservation>,
     ) -> Result<RemotingRequestBuilder, super::remoting_request::RemotingRequestBuildError> {
         Ok(match session_cleanup {
             Some(session_cleanup) => {

--- a/rocketmq-transport/src/dispatch/legacy_processor_adapter/tests.rs
+++ b/rocketmq-transport/src/dispatch/legacy_processor_adapter/tests.rs
@@ -154,7 +154,7 @@ async fn network_bridge_uses_one_real_session_and_the_adapter_stable_response_ta
         bridge.canonical_session_id,
         SessionId::from_session_owner(harness.first.session_id())
     );
-    assert!(bridge.channel.shares_inner(bridge.context.channel()));
+    assert!(bridge.channel.shares_inner(bridge.context.legacy_channel()));
     assert!(bridge.channel.is_canonical_network_owner(&harness.first));
 
     let owner = bridge

--- a/rocketmq-transport/src/dispatch/remoting_request/builder.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request/builder.rs
@@ -204,6 +204,10 @@ impl RemotingRequestBuilder {
         self.meta.deadline()
     }
 
+    pub(crate) const fn received_at(&self) -> Instant {
+        self.meta.received_at()
+    }
+
     pub(crate) const fn command(&self) -> &RemotingCommand {
         &self.command
     }
@@ -217,6 +221,14 @@ impl RemotingRequestBuilder {
 
     pub(crate) const fn principal(&self) -> Option<&rocketmq_security_api::Principal> {
         self.authentication.principal()
+    }
+
+    pub(crate) const fn origin(&self) -> &crate::dispatch::RequestOrigin {
+        &self.origin
+    }
+
+    pub(crate) const fn authentication(&self) -> &crate::dispatch::AuthenticationState {
+        &self.authentication
     }
 
     pub(crate) fn build(self) -> Result<RemotingRequest, RemotingRequestBuildError> {

--- a/rocketmq-transport/src/dispatch/request_control.rs
+++ b/rocketmq-transport/src/dispatch/request_control.rs
@@ -213,6 +213,19 @@ impl RequestControlView {
         self.parent_cancellation.is_cancelled()
     }
 
+    /// Derives the lifecycle-only control used to deliver a boundary rejection.
+    ///
+    /// The rejected request deadline has already reached its terminal decision,
+    /// so it must not suppress the corresponding protocol response. Session and
+    /// parent cancellation remain authoritative for the write.
+    pub(crate) fn boundary_response_control(&self) -> Self {
+        Self {
+            deadline: None,
+            session: self.session.clone(),
+            parent_cancellation: self.parent_cancellation.clone(),
+        }
+    }
+
     /// Waits until the deadline expires, the session closes, or the parent
     /// task group is cancelled.
     ///

--- a/rocketmq-transport/src/dispatch/response.rs
+++ b/rocketmq-transport/src/dispatch/response.rs
@@ -392,6 +392,17 @@ pub enum ResponseDisposition {
     InProcessAccepted,
 }
 
+impl ResponseDisposition {
+    /// Returns the stable low-cardinality delivery label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TransportWritten => "transport_written",
+            Self::InProcessAccepted => "in_process_accepted",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::error::Error;

--- a/rocketmq-transport/src/dispatch/response_plan.rs
+++ b/rocketmq-transport/src/dispatch/response_plan.rs
@@ -406,6 +406,19 @@ pub enum ResponseBodyKind {
     FileRegions,
 }
 
+impl ResponseBodyKind {
+    /// Returns the stable low-cardinality response-plan label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::Bytes => "bytes",
+            Self::Segments => "segments",
+            Self::FileRegions => "file_regions",
+        }
+    }
+}
+
 /// Internal storage owned by a [`ResponsePlan`].
 ///
 /// This type remains crate-private so V2 processors can choose an explicit

--- a/rocketmq-transport/src/dispatch/response_sink.rs
+++ b/rocketmq-transport/src/dispatch/response_sink.rs
@@ -382,7 +382,6 @@ impl ResponseSink {
         DeferredResponseSeed::new(self.clone(), telemetry, session_id, control)
     }
 
-    #[cfg(test)]
     pub(crate) fn terminal_state(&self) -> Option<ResponseTerminalState> {
         match self {
             Self::Network(session) => session.response_plan_context()?.terminal_state(),

--- a/rocketmq-transport/src/dispatch/response_sink/plan.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan.rs
@@ -78,7 +78,6 @@ impl NetworkResponsePlanContext {
             .same_lifecycle_owner(session.session_view().state(), session.task_group())
     }
 
-    #[cfg(test)]
     pub(crate) fn terminal_state(&self) -> Option<ResponseTerminalState> {
         self.slot.terminal_state()
     }
@@ -150,7 +149,6 @@ impl LocalPlanSenderState {
         &self.control
     }
 
-    #[cfg(test)]
     pub(super) fn terminal_state(&self) -> Option<ResponseTerminalState> {
         self.slot.terminal_state()
     }
@@ -622,7 +620,6 @@ impl ResponseCompletionSlot {
         }
     }
 
-    #[cfg(test)]
     fn terminal_state(&self) -> Option<ResponseTerminalState> {
         match &*self.state.lock() {
             ResponseCompletionState::Terminal { state, .. } => Some(*state),

--- a/rocketmq-transport/src/prelude.rs
+++ b/rocketmq-transport/src/prelude.rs
@@ -17,6 +17,11 @@
 pub use crate::api::v1::OneShotTransportClient;
 pub use crate::api::v1::RemotingClient;
 pub use crate::api::v1::RequestDeadline;
+#[allow(
+    deprecated,
+    reason = "the legacy prelude remains source-compatible until the V1 processor removal"
+)]
+#[deprecated(since = "1.0.0", note = "Import `api::v2::RequestProcessorV2` explicitly instead")]
 pub use crate::api::v1::RequestProcessor;
 pub use crate::api::v1::ServerConfig;
 pub use crate::api::v1::TransportClient;

--- a/rocketmq-transport/src/public_api.rs
+++ b/rocketmq-transport/src/public_api.rs
@@ -65,6 +65,7 @@ pub use crate::discovery::http_tiny_client::HttpResult;
 pub use crate::discovery::http_tiny_client::HttpTinyClient;
 pub use crate::discovery::name_server_update_callback::NameServerUpdateCallback;
 pub use crate::discovery::top_addressing::TopAddressing;
+#[deprecated(since = "1.0.0", note = "Use `api::v2::AuthorizedCommandDispatcherV2` instead")]
 pub use crate::dispatch::AuthorizedCommandDispatcher;
 pub use crate::dispatch::AuthorizedDispatchBoundary;
 pub use crate::dispatch::DispatchError;
@@ -115,14 +116,18 @@ pub use crate::runtime::config::client_config::ConnectConfig;
 pub use crate::runtime::config::client_config::GoAwayPolicy;
 pub use crate::runtime::config::client_config::MaintenanceConfig;
 pub use crate::runtime::config::client_config::TransportClientConfig;
+#[deprecated(since = "1.0.0", note = "Use `api::v2::RemotingRequest` instead")]
 pub use crate::runtime::connection_handler_context::ConnectionHandlerContext;
+#[deprecated(since = "1.0.0", note = "Use `api::v2::RemotingRequest` instead")]
 pub use crate::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
 pub use crate::runtime::connection_handler_context::LegacySessionCleanupEnrollment;
 pub use crate::runtime::connection_handler_context::LegacySessionCleanupInstallError;
 pub use crate::runtime::connection_handler_context::LegacySessionExecutionEnrollment;
 pub use crate::runtime::connection_handler_context::LegacySessionExecutionSubmitError;
+#[deprecated(since = "1.0.0", note = "Use `api::v2::LocalRequestProcessorV2` instead")]
 pub use crate::runtime::processor::LocalRequestProcessor;
 pub use crate::runtime::processor::RejectRequestResponse;
+#[deprecated(since = "1.0.0", note = "Use `api::v2::RequestProcessorV2` instead")]
 pub use crate::runtime::processor::RequestProcessor;
 pub use crate::runtime::processor::ResponseWriteObservation;
 pub use crate::runtime::processor::ResponseWriteOutcome;

--- a/rocketmq-transport/src/public_api_v2.rs
+++ b/rocketmq-transport/src/public_api_v2.rs
@@ -99,6 +99,10 @@ pub use crate::request_processor::default_request_processor::DefaultRequestProce
 pub use crate::runtime::processor_v2::LocalRequestProcessorV2;
 pub use crate::runtime::processor_v2::RejectRequestDecision;
 pub use crate::runtime::processor_v2::RequestProcessorV2;
+pub use crate::runtime::processor_v2::ResponseMetadataV2;
+pub use crate::runtime::processor_v2::ResponseObservationModeV2;
+pub use crate::runtime::processor_v2::ResponseObservationOutcomeV2;
+pub use crate::runtime::processor_v2::ResponseObservationV2;
 pub use crate::runtime::processor_v2::ResponseWriteObservationV2;
 pub use crate::runtime::processor_v2::ResponseWriteOutcomeV2;
 pub use crate::runtime::processor_v2::ResponseWritePath;

--- a/rocketmq-transport/src/remoting.rs
+++ b/rocketmq-transport/src/remoting.rs
@@ -165,7 +165,7 @@ pub(crate) mod inner {
             if let Some(response) = legacy_rejection_response(request_processor.reject_request(request_code)) {
                 let response_code = response.code();
                 let write_started = Instant::now();
-                let result = ctx.channel().send_command(response.set_opaque(opaque)).await;
+                let result = ctx.legacy_channel().send_command(response.set_opaque(opaque)).await;
                 request_processor.observe_response_write(ResponseWriteObservation {
                     request_code,
                     response_code,
@@ -194,7 +194,7 @@ pub(crate) mod inner {
             let exception = self
                 .do_before_rpc_hooks_with_snapshot(
                     hook_snapshot.as_deref(),
-                    ctx.channel().remote_address(),
+                    ctx.legacy_channel().remote_address(),
                     Some(&mut cmd),
                 )
                 .err();
@@ -208,7 +208,7 @@ pub(crate) mod inner {
             }
 
             let mut response = {
-                let channel = ctx.channel().clone();
+                let channel = ctx.legacy_channel().clone();
                 let ctx = ctx.clone();
                 match request_processor.process_request(channel, ctx, &mut cmd).await {
                     Ok(result) => result,
@@ -222,7 +222,7 @@ pub(crate) mod inner {
             let exception = self
                 .do_after_rpc_hooks_with_snapshot(
                     hook_snapshot.as_deref(),
-                    ctx.channel().remote_address(),
+                    ctx.legacy_channel().remote_address(),
                     &cmd,
                     response.as_mut(),
                 )
@@ -245,7 +245,7 @@ pub(crate) mod inner {
             };
             let response_code = response.code();
             let write_started = Instant::now();
-            let result = ctx.channel().send_command(response.set_opaque(opaque)).await;
+            let result = ctx.legacy_channel().send_command(response.set_opaque(opaque)).await;
             request_processor.observe_response_write(ResponseWriteObservation {
                 request_code,
                 response_code,
@@ -279,15 +279,15 @@ pub(crate) mod inner {
         fn process_response_command(&self, ctx: &ConnectionHandlerContext, cmd: RemotingCommand) {
             let opaque = cmd.opaque();
             let code = cmd.code();
-            let completed = match ctx.channel().pending_request_owner() {
+            let completed = match ctx.legacy_channel().pending_request_owner() {
                 Some(owner) => self.response_table.complete_response_for_owner(owner, opaque, cmd),
                 None => self.response_table.complete_response(opaque, cmd),
             };
             if !completed {
                 warn!(
                     code,
-                    address = %ctx.channel().remote_address(),
-                    channel_id = %ctx.channel().channel_id(),
+                    address = %ctx.legacy_channel().remote_address(),
+                    channel_id = %ctx.legacy_channel().channel_id(),
                     "received response without a matching pending request",
                 );
             }
@@ -354,7 +354,7 @@ pub(crate) mod inner {
             if !oneway_rpc {
                 let response = crate::error_response::command_from_error(&exception_inner);
                 tokio::select! {
-                    result =ctx.channel().send_command(response.set_opaque(opaque)) => match result{
+                    result =ctx.legacy_channel().send_command(response.set_opaque(opaque)) => match result{
                         Ok(_) =>{},
                         Err(err) => {
                             match err {

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_handler.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_handler.rs
@@ -87,6 +87,8 @@ pub(crate) struct V2NetworkRouteState {
     _shutdown_complete: mpsc::Sender<()>,
     endpoint: V2NetworkSession,
     deferred_cleanup: crate::dispatch::DeferredSessionCleanupOwner,
+    #[cfg(test)]
+    _panicking_cleanup: Option<crate::dispatch::LegacySessionCleanupEnrollment>,
 }
 
 impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
@@ -113,7 +115,7 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
             endpoint: endpoint.clone(),
             _shutdown_complete: self.shutdown_complete_tx.clone(),
         };
-        let event_channel = context.channel().clone();
+        let event_channel = context.legacy_channel().clone();
         self.sessions.insert(session.session_id(), remoting_session);
         if let Some(publisher) = &self.event_publisher {
             let outcome = publisher
@@ -151,7 +153,7 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
             if command_interceptor.intercept(
                 command.code(),
                 command.opaque(),
-                state.context.channel().clone(),
+                state.context.legacy_channel().clone(),
                 session.task_group().clone(),
             ) {
                 return true;
@@ -182,7 +184,7 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
         debug_assert!(remoting_session.endpoint.owner().same_owner(state.endpoint.owner()));
         let channel_report = remoting_session
             .context
-            .channel()
+            .legacy_channel()
             .close_with_report(Duration::from_secs(3))
             .await;
         channel_report.log_if_unhealthy();
@@ -194,7 +196,7 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
                 .publish(TokioEvent::new(
                     ConnectionNetEvent::DISCONNECTED,
                     session.remote_addr(),
-                    remoting_session.context.channel().clone(),
+                    remoting_session.context.legacy_channel().clone(),
                 ))
                 .await;
             if !outcome.is_queued() {
@@ -250,13 +252,20 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> AuthorizedFrameRoute for Con
         .await
     }
 
-    fn close_pending(&self, state: &Self::SessionState, _session: crate::server::SessionHandle) {
-        let _ = state.deferred_cleanup.close();
+    fn close_pending(
+        &self,
+        state: &Self::SessionState,
+        _session: crate::server::SessionHandle,
+    ) -> crate::dispatch::DeferredSessionCleanupReport {
+        let report = state.deferred_cleanup.close();
         self.dispatcher.close_network_session(&state.endpoint);
+        report
     }
 
-    async fn disconnected(&self, state: Self::SessionState, session: crate::server::SessionHandle) {
+    async fn disconnected(&self, state: Self::SessionState, session: crate::server::SessionHandle) -> usize {
+        let cleanup = state.deferred_cleanup.clone();
         self.disconnected_state(state, session).await;
+        cleanup.remaining_wait_permits()
     }
 }
 
@@ -268,13 +277,39 @@ where
 
     async fn connected(&self, session: crate::server::SessionHandle) -> Option<Self::SessionState> {
         let endpoint = self.dispatcher.open_network_session();
+        let deferred_cleanup = crate::dispatch::DeferredSessionCleanupOwner::new(session.session_view().id());
+        #[cfg(test)]
+        let panicking_cleanup = if self
+            .session_registry
+            .as_ref()
+            .is_some_and(|registry| registry.take_cleanup_panic_for_test())
+        {
+            let capability = crate::dispatch::LegacySessionCleanupCapability::new(deferred_cleanup.registration());
+            let mut enrollment = None;
+            capability
+                .install(
+                    || panic!("test legacy session cleanup panic"),
+                    |cleanup| {
+                        enrollment = Some(cleanup);
+                        Ok::<_, ((), crate::dispatch::LegacySessionCleanupEnrollment)>(())
+                    },
+                )
+                .expect("test cleanup panic enrollment");
+            enrollment
+        } else {
+            None
+        };
         if let Some(registry) = &self.session_registry {
-            registry.register(&session, endpoint.response_table().clone(), endpoint.owner().clone());
+            if !registry.register(&session, endpoint.response_table().clone(), endpoint.owner().clone()) {
+                return None;
+            }
         }
         Some(V2NetworkRouteState {
             _shutdown_complete: self.shutdown_complete_tx.clone(),
             endpoint,
-            deferred_cleanup: crate::dispatch::DeferredSessionCleanupOwner::new(session.session_view().id()),
+            deferred_cleanup,
+            #[cfg(test)]
+            _panicking_cleanup: panicking_cleanup,
         })
     }
 
@@ -314,18 +349,26 @@ where
             .is_ok()
     }
 
-    fn close_pending(&self, state: &Self::SessionState, _session: crate::server::SessionHandle) {
+    fn close_pending(
+        &self,
+        state: &Self::SessionState,
+        _session: crate::server::SessionHandle,
+    ) -> crate::dispatch::DeferredSessionCleanupReport {
+        let report = state.deferred_cleanup.close();
         self.dispatcher.close_network_session(&state.endpoint);
-        let _ = state.deferred_cleanup.close();
+        report
     }
 
-    async fn disconnected(&self, _state: Self::SessionState, session: crate::server::SessionHandle) {
+    async fn disconnected(&self, state: Self::SessionState, session: crate::server::SessionHandle) -> usize {
+        let cleanup = state.deferred_cleanup.clone();
+        drop(state);
         if let Some(registry) = &self.session_registry {
             registry.unregister(&session);
         }
         if let Some(notify) = &self.conn_disconnect_notify {
             let _ = notify.send(session.remote_addr());
         }
+        cleanup.remaining_wait_permits()
     }
 }
 
@@ -374,12 +417,19 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> AuthorizedFrameRoute for Int
             .await
     }
 
-    fn close_pending(&self, state: &Self::SessionState, _session: crate::server::SessionHandle) {
-        let _ = state.deferred_cleanup.close();
+    fn close_pending(
+        &self,
+        state: &Self::SessionState,
+        _session: crate::server::SessionHandle,
+    ) -> crate::dispatch::DeferredSessionCleanupReport {
+        let report = state.deferred_cleanup.close();
         self.inner.dispatcher.close_network_session(&state.endpoint);
+        report
     }
 
-    async fn disconnected(&self, state: Self::SessionState, session: crate::server::SessionHandle) {
+    async fn disconnected(&self, state: Self::SessionState, session: crate::server::SessionHandle) -> usize {
+        let cleanup = state.deferred_cleanup.clone();
         self.inner.disconnected_state(state, session).await;
+        cleanup.remaining_wait_permits()
     }
 }

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests.rs
@@ -576,14 +576,337 @@ async fn registry_capabilities_write_typed_push_and_close_the_same_canonical_ses
     assert_eq!(reset.body(), Some(&Bytes::from_static(b"reset-offsets")));
     assert!(reset.is_oneway_rpc());
 
+    let concurrent_close = close.clone();
+    let (first_close, second_close) = tokio::join!(
+        close.close(SessionCloseReason::Administrative),
+        concurrent_close.close(SessionCloseReason::HeartbeatTimeout),
+    );
+    first_close.expect("first typed close should complete the server-owned finalizer");
+    second_close.expect("cloned typed close should share the same completion");
+    let completion = close.completion_snapshot().await;
+    assert!(completion.healthy);
+    assert_eq!(completion.remaining_inline_tasks, 0);
+    assert_eq!(completion.remaining_resume_tasks, 0);
+    assert_eq!(completion.removed_waiters, 0);
+    assert_eq!(completion.cleanup_panicked_targets, 0);
+    assert_eq!(completion.remaining_wait_permits, 0);
+    assert_eq!(completion.remaining_server_outbound_leases, 0);
+    assert!(!completion.disconnected_panicked);
+    assert!(completion.writer_healthy);
+    assert_eq!(completion.writer_queued_items, 0);
+    assert_eq!(completion.writer_queued_bytes, 0);
+    assert!(!registry.contains(session_id));
     close
         .close(SessionCloseReason::Administrative)
         .await
-        .expect("typed close should retire the canonical writer");
+        .expect("repeated typed close should reuse completed shutdown");
     let eof = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
         .await
         .expect("typed close EOF deadline");
     assert!(eof.is_none());
+
+    running.begin_shutdown();
+    running.finish().await;
+}
+
+struct PanickingDisconnectListener;
+
+impl crate::v2_session_registry::V2SessionLifecycleListener for PanickingDisconnectListener {
+    fn on_session_connected(&self, _session: &crate::session_view::SessionView) {}
+
+    fn on_session_disconnected(&self, _session_id: SessionId) {
+        panic!("test disconnected listener panic");
+    }
+}
+
+struct PanickingConnectListener;
+
+impl crate::v2_session_registry::V2SessionLifecycleListener for PanickingConnectListener {
+    fn on_session_connected(&self, _session: &crate::session_view::SessionView) {
+        panic!("test connected listener panic");
+    }
+
+    fn on_session_disconnected(&self, _session_id: SessionId) {}
+}
+
+#[tokio::test]
+async fn connected_listener_panic_rolls_back_registration_and_finishes_session() {
+    let runtime = V2TestRuntime::new("transport-v2-connected-listener-panic");
+    let state = Arc::new(ProcessorState::default());
+    let registry = Arc::new(V2SessionRegistry::with_lifecycle_listener(Arc::new(
+        PanickingConnectListener,
+    )));
+    let processor = TcpV2Processor { state, admission: None };
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_session_registry(Arc::clone(&registry));
+    let (mut client, _address, mut running) = start_server(runtime, server).await;
+
+    let _ = client.send_command(RemotingCommand::create_remoting_command(701)).await;
+    let eof = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("connected-listener panic session completion deadline");
+    assert!(eof.is_none());
+    assert!(registry.is_empty());
+
+    running.begin_shutdown();
+    tokio::time::timeout(Duration::from_secs(1), running.finish())
+        .await
+        .expect("connected-listener panic server shutdown deadline");
+}
+
+struct BlockingDisconnectListener {
+    entered: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    release: Mutex<std::sync::mpsc::Receiver<()>>,
+}
+
+impl crate::v2_session_registry::V2SessionLifecycleListener for BlockingDisconnectListener {
+    fn on_session_connected(&self, _session: &crate::session_view::SessionView) {}
+
+    fn on_session_disconnected(&self, _session_id: SessionId) {
+        if let Some(entered) = self.entered.lock().expect("blocking listener entered lock").take() {
+            let _ = entered.send(());
+        }
+        self.release
+            .lock()
+            .expect("blocking listener release lock")
+            .recv()
+            .expect("release blocked disconnect listener");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn close_transition_rejects_retained_push_and_request_capabilities() {
+    let runtime = V2TestRuntime::new("transport-v2-close-outbound-admission");
+    let state = Arc::new(ProcessorState::default());
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let registry = Arc::new(V2SessionRegistry::with_lifecycle_listener(Arc::new(
+        BlockingDisconnectListener {
+            entered: Mutex::new(Some(entered_tx)),
+            release: Mutex::new(release_rx),
+        },
+    )));
+    let processor = TcpV2Processor {
+        state: Arc::clone(&state),
+        admission: None,
+    };
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_session_registry(Arc::clone(&registry));
+    let (mut client, _address, mut running) = start_server(runtime, server).await;
+    establish_v2_session(&mut client).await;
+    let session_id = state
+        .session
+        .lock()
+        .expect("outbound admission session lock")
+        .expect("outbound admission session id");
+    let (push, close) = registry.capabilities(session_id).expect("retained push capability");
+    let request = registry
+        .server_request_sender(session_id)
+        .expect("retained request capability");
+    let close_task = tokio::spawn(async move { close.close(SessionCloseReason::Administrative).await });
+
+    tokio::time::timeout(Duration::from_secs(1), entered_rx)
+        .await
+        .expect("close must reach blocked disconnect listener")
+        .expect("blocked disconnect listener entry signal");
+    push.send(
+        ServerPushCommand::NotifyConsumerIdsChanged {
+            header: NotifyConsumerIdsChangedRequestHeader {
+                consumer_group: CheetahString::from_static_str("GroupA"),
+                rpc_request_header: None,
+            },
+            opaque: Some(9_860),
+        },
+        Duration::from_secs(1),
+    )
+    .await
+    .expect_err("retained push must fail after the close transition");
+    let request_error = request
+        .request(consumer_status_request(), Duration::from_secs(1))
+        .await
+        .expect_err("retained request must fail after the close transition");
+    assert_eq!(request_error.stage(), ServerRequestErrorStage::Register);
+    assert_eq!(request.pending_usage().count, 0);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), client.receive_command())
+            .await
+            .is_err(),
+        "rejected retained capabilities must not enqueue a client frame"
+    );
+
+    release_tx.send(()).expect("release blocked disconnect listener");
+    close_task
+        .await
+        .expect("close task join")
+        .expect("ordered close after listener release");
+    assert!(client.receive_command().await.is_none());
+    running.begin_shutdown();
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn typed_close_waits_for_deferred_cleanup_executor_drain_and_writer_completion() {
+    const OPAQUE: i32 = 9_859;
+
+    let runtime = V2TestRuntime::new("transport-v2-typed-close-coordinator");
+    let deferred_registry = DeferredRegistry::<usize>::new();
+    let admission_controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let deferred_admission =
+        DeferredAdmission::try_configure(&admission_controller, DeferredWaitLimits::new(4, 4 * 1024 * 1024))
+            .expect("typed-close deferred admission");
+    let session_registry = Arc::new(V2SessionRegistry::new());
+    let (registered_tx, mut registered_rx) = tokio::sync::mpsc::unbounded_channel();
+    let processor = NetworkDeferredCleanupProcessor {
+        registry: deferred_registry.clone(),
+        admission: deferred_admission.clone(),
+        registered: registered_tx,
+        precommit_opaque: -1,
+        release_precommit: Arc::new(tokio::sync::Notify::new()),
+    };
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_admission_controller(Arc::clone(&admission_controller))
+        .with_session_registry(Arc::clone(&session_registry));
+    let (mut client, _address, mut running) = start_server(runtime, server).await;
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(705).set_opaque(OPAQUE))
+        .await
+        .expect("send typed-close deferred request");
+    let registered = receive_deferred_registration(&mut registered_rx, OPAQUE).await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !deferred_registry.test_contains(registered.id) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("deferred registration commit deadline");
+    let (_, close) = session_registry
+        .capabilities(registered.session_id)
+        .expect("typed close capability");
+    let cloned = close.clone();
+
+    let (first, second) = tokio::join!(
+        close.close(SessionCloseReason::Administrative),
+        cloned.close(SessionCloseReason::ServiceShutdown),
+    );
+    first.expect("first typed close completion");
+    second.expect("cloned typed close completion");
+    let completion = close.completion_snapshot().await;
+    assert!(completion.healthy);
+    assert_eq!(completion.remaining_inline_tasks, 0);
+    assert_eq!(completion.remaining_resume_tasks, 0);
+    assert_eq!(completion.removed_waiters, 1);
+    assert_eq!(completion.cleanup_panicked_targets, 0);
+    assert_eq!(completion.remaining_wait_permits, 0);
+    assert_eq!(completion.remaining_server_outbound_leases, 0);
+    assert!(!completion.disconnected_panicked);
+    assert!(completion.writer_healthy);
+    assert_eq!(completion.writer_queued_items, 0);
+    assert_eq!(completion.writer_queued_bytes, 0);
+    assert!(!session_registry.contains(registered.session_id));
+    assert_eq!(deferred_registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(deferred_registry.test_claim_marker_count(), 0);
+    assert_eq!(deferred_admission.snapshot().waiting_count(), 0);
+    assert_eq!(deferred_admission.snapshot().retained_bytes(), 0);
+    let admission = admission_controller.snapshot();
+    assert_eq!(admission.queued.current_count, 0);
+    assert_eq!(admission.inflight.current_count, 0);
+    assert_eq!(admission.processors.current_count, 0);
+    assert!(client.receive_command().await.is_none());
+
+    close
+        .close(SessionCloseReason::Administrative)
+        .await
+        .expect("repeated typed close completion");
+    running.begin_shutdown();
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn cleanup_callback_panic_returns_typed_unhealthy_close_after_writer_completion() {
+    let runtime = V2TestRuntime::new("transport-v2-cleanup-panic-close");
+    let state = Arc::new(ProcessorState::default());
+    let registry = Arc::new(V2SessionRegistry::new());
+    registry.panic_next_cleanup_for_test();
+    let processor = TcpV2Processor {
+        state: Arc::clone(&state),
+        admission: None,
+    };
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_session_registry(Arc::clone(&registry));
+    let (mut client, _address, mut running) = start_server(runtime, server).await;
+    establish_v2_session(&mut client).await;
+    let session_id = state
+        .session
+        .lock()
+        .expect("cleanup panic session lock")
+        .expect("cleanup panic session id");
+    let (_, close) = registry
+        .capabilities(session_id)
+        .expect("cleanup panic close capability");
+
+    let error = tokio::time::timeout(Duration::from_secs(1), close.close(SessionCloseReason::Administrative))
+        .await
+        .expect("cleanup panic typed close deadline")
+        .expect_err("cleanup panic must produce typed unhealthy close");
+    assert_eq!(error.session_id(), session_id);
+    assert_eq!(error.reason(), SessionCloseReason::Administrative);
+    let completion = close.completion_snapshot().await;
+    assert!(!completion.healthy);
+    assert_eq!(completion.cleanup_panicked_targets, 1);
+    assert_eq!(completion.remaining_inline_tasks, 0);
+    assert_eq!(completion.remaining_resume_tasks, 0);
+    assert_eq!(completion.remaining_wait_permits, 0);
+    assert_eq!(completion.remaining_server_outbound_leases, 0);
+    assert!(!completion.disconnected_panicked);
+    assert!(completion.writer_healthy);
+    assert_eq!(completion.writer_queued_items, 0);
+    assert_eq!(completion.writer_queued_bytes, 0);
+    assert!(!registry.contains(session_id));
+    assert!(client.receive_command().await.is_none());
+
+    running.begin_shutdown();
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn disconnected_panic_cannot_leave_typed_close_waiting_forever() {
+    let runtime = V2TestRuntime::new("transport-v2-disconnected-panic-close");
+    let state = Arc::new(ProcessorState::default());
+    let registry = Arc::new(V2SessionRegistry::with_lifecycle_listener(Arc::new(
+        PanickingDisconnectListener,
+    )));
+    let processor = TcpV2Processor {
+        state: Arc::clone(&state),
+        admission: None,
+    };
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_session_registry(Arc::clone(&registry));
+    let (mut client, _address, mut running) = start_server(runtime, server).await;
+    establish_v2_session(&mut client).await;
+    let session_id = state
+        .session
+        .lock()
+        .expect("disconnect panic session lock")
+        .expect("disconnect panic session id");
+    let (_, close) = registry
+        .capabilities(session_id)
+        .expect("disconnect panic close capability");
+
+    let error = tokio::time::timeout(Duration::from_secs(1), close.close(SessionCloseReason::Administrative))
+        .await
+        .expect("finalizer guard must bound typed close")
+        .expect_err("disconnected panic must publish unhealthy completion");
+    assert_eq!(error.session_id(), session_id);
+    let completion = close.completion_snapshot().await;
+    assert!(!completion.healthy);
+    assert!(completion.disconnected_panicked);
+    assert_eq!(completion.remaining_server_outbound_leases, 0);
+    assert!(completion.writer_healthy);
+    assert_eq!(completion.writer_queued_items, 0);
+    assert_eq!(completion.writer_queued_bytes, 0);
+    assert!(!registry.contains(session_id));
+    assert!(client.receive_command().await.is_none());
 
     running.begin_shutdown();
     running.finish().await;
@@ -730,10 +1053,6 @@ async fn server_requests_correlate_by_session_owner_and_fail_on_disconnect_and_d
     std::future::poll_fn(|context| match timed_out.as_mut().poll(context) {
         Poll::Pending if registry.capabilities(first_session).is_some() => Poll::Pending,
         Poll::Pending => {
-            assert!(
-                registry.contains(first_session),
-                "timeout transition must fail closed before disconnect cleanup"
-            );
             assert!(registry.server_request_sender(first_session).is_none());
             Poll::Ready(())
         }
@@ -786,6 +1105,62 @@ async fn server_requests_correlate_by_session_owner_and_fail_on_disconnect_and_d
 }
 
 #[tokio::test]
+async fn typed_close_completes_healthily_with_a_written_pending_server_request() {
+    let runtime = V2TestRuntime::new("transport-v2-close-pending-server-request");
+    let state = Arc::new(ProcessorState::default());
+    let registry = Arc::new(V2SessionRegistry::new());
+    let mut events = registry.subscribe();
+    let processor = TcpV2Processor { state, admission: None };
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_session_registry(Arc::clone(&registry));
+    let (mut client, _address, mut running) = start_server(runtime, server).await;
+    establish_v2_session(&mut client).await;
+    let session_id = next_connected_session(&mut events).await;
+    let (_, close) = registry
+        .capabilities(session_id)
+        .expect("pending request close capability");
+    let sender = registry
+        .server_request_sender(session_id)
+        .expect("pending request sender");
+    let request_task = {
+        let sender = sender.clone();
+        tokio::spawn(async move { sender.request(consumer_status_request(), Duration::from_secs(5)).await })
+    };
+    let wire = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("pending server request write deadline")
+        .expect("pending server request connection")
+        .expect("pending server request frame");
+    assert_eq!(RequestCode::from(wire.code()), RequestCode::GetConsumerStatusFromClient);
+    assert_eq!(sender.pending_usage().count, 1);
+
+    close
+        .close(SessionCloseReason::Administrative)
+        .await
+        .expect("pending server request must not make ordered close unhealthy");
+    let request_error = tokio::time::timeout(Duration::from_secs(1), request_task)
+        .await
+        .expect("pending request close completion deadline")
+        .expect("pending request task join")
+        .expect_err("session close must fail the pending response wait");
+    assert_eq!(request_error.stage(), ServerRequestErrorStage::AwaitResponse);
+    assert_eq!(request_error.session_id(), session_id);
+    let completion = close.completion_snapshot().await;
+    assert!(completion.healthy);
+    assert_eq!(completion.remaining_server_outbound_leases, 0);
+    assert!(!completion.disconnected_panicked);
+    assert!(completion.writer_healthy);
+    assert_eq!(completion.writer_queued_items, 0);
+    assert_eq!(completion.writer_queued_bytes, 0);
+    assert_eq!(sender.pending_usage().count, 0);
+    assert!(!registry.contains(session_id));
+    assert!(client.receive_command().await.is_none());
+
+    running.begin_shutdown();
+    running.finish().await;
+}
+
+#[tokio::test]
 async fn aborting_a_written_server_request_retires_its_owner_and_rejects_late_response_reuse() {
     let runtime = V2TestRuntime::new("transport-v2-server-request-cancellation");
     let state = Arc::new(ProcessorState::default());
@@ -816,7 +1191,6 @@ async fn aborting_a_written_server_request_retires_its_owner_and_rejects_late_re
         .await
         .expect_err("request caller must be aborted")
         .is_cancelled());
-    assert!(registry.contains(session_id));
     assert!(registry.capabilities(session_id).is_none());
     assert!(registry.server_request_sender(session_id).is_none());
     assert_eq!(sender.pending_usage().count, 0);
@@ -835,7 +1209,9 @@ async fn aborting_a_written_server_request_retires_its_owner_and_rejects_late_re
                 .set_body(Bytes::from_static(b"late-response")),
         )
         .await;
-    assert!(client.receive_command().await.is_none());
+    if let Some(Ok(_frame)) = client.receive_command().await {
+        panic!("cancelled request owner produced an unexpected frame");
+    }
     loop {
         let event = events.recv().await.expect("V2 session event stream");
         if matches!(event, V2SessionEvent::Disconnected(id) if id == session_id) {

--- a/rocketmq-transport/src/runtime/connection_handler_context.rs
+++ b/rocketmq-transport/src/runtime/connection_handler_context.rs
@@ -169,6 +169,10 @@ impl ConnectionHandlerContextWrapper {
     /// # Use Case
     ///
     /// Checking connection health, reading connection ID, etc.
+    #[deprecated(
+        since = "1.0.0",
+        note = "Use `api::v2::RemotingRequest::session()` and `RequestControlView` instead"
+    )]
     pub fn connection_ref(&self) -> &ConnectionStateHandle {
         self.channel.connection_ref()
     }
@@ -234,6 +238,10 @@ impl ConnectionHandlerContextWrapper {
     ///     ctx.write(response).await;
     /// }
     /// ```
+    #[deprecated(
+        since = "1.0.0",
+        note = "Return `HandlerOutcome::Reply(ResponsePlan)` or use `DeferredResponder::respond` instead"
+    )]
     pub async fn write_response(&self, cmd: RemotingCommand) {
         match self.try_write_response(cmd).await {
             Ok(_) => {}
@@ -265,6 +273,10 @@ impl ConnectionHandlerContextWrapper {
     /// # Note
     ///
     /// The command's body may be consumed during sending (`take_body()`).
+    #[deprecated(
+        since = "1.0.0",
+        note = "Return `HandlerOutcome::Reply(ResponsePlan)` or use `DeferredResponder::respond` instead"
+    )]
     pub async fn write_response_ref(&self, cmd: &mut RemotingCommand) {
         match self.try_write_response_ref(cmd).await {
             Ok(_) => {}
@@ -283,20 +295,50 @@ impl ConnectionHandlerContextWrapper {
     ///
     /// # Deprecated
     ///
-    /// Use `write_response()` for clearer semantics.
-    #[deprecated(since = "0.6.0", note = "Use `write_response()` instead")]
+    /// Return a V2 [`crate::api::v2::ResponsePlan`] through
+    /// [`crate::api::v2::HandlerOutcome::Reply`], or claim a
+    /// [`crate::api::v2::DeferredResponder`] for deferred completion.
+    #[deprecated(
+        since = "1.0.0",
+        note = "Return `HandlerOutcome::Reply(ResponsePlan)` or use `DeferredResponder::respond` instead"
+    )]
     pub async fn write(&self, cmd: RemotingCommand) {
-        self.write_response(cmd).await;
+        match self.try_write_response(cmd).await {
+            Ok(_) => {}
+            Err(error) => {
+                error!(
+                    kind = error.kind().as_str(),
+                    progress = error.write_progress().map_or("none", |progress| progress.as_str()),
+                    retryable = error.retryable(),
+                    "response write failed"
+                );
+            }
+        }
     }
 
     /// Legacy alias for `write_response_ref()` - kept for backward compatibility.
     ///
     /// # Deprecated
     ///
-    /// Use `write_response_ref()` for clearer semantics.
-    #[deprecated(since = "0.6.0", note = "Use `write_response_ref()` instead")]
+    /// Return a V2 [`crate::api::v2::ResponsePlan`] through
+    /// [`crate::api::v2::HandlerOutcome::Reply`], or claim a
+    /// [`crate::api::v2::DeferredResponder`] for deferred completion.
+    #[deprecated(
+        since = "1.0.0",
+        note = "Return `HandlerOutcome::Reply(ResponsePlan)` or use `DeferredResponder::respond` instead"
+    )]
     pub async fn write_ref(&self, cmd: &mut RemotingCommand) {
-        self.write_response_ref(cmd).await;
+        match self.try_write_response_ref(cmd).await {
+            Ok(_) => {}
+            Err(error) => {
+                error!(
+                    kind = error.kind().as_str(),
+                    progress = error.write_progress().map_or("none", |progress| progress.as_str()),
+                    retryable = error.retryable(),
+                    "response write failed"
+                );
+            }
+        }
     }
 
     // === Channel Access ===
@@ -310,7 +352,15 @@ impl ConnectionHandlerContextWrapper {
     /// # Use Case
     ///
     /// Accessing channel metadata (ID, addresses, etc.)
+    #[deprecated(
+        since = "1.0.0",
+        note = "Use `api::v2::RemotingRequest::session()` for read-only facts and composition-owned session capabilities for push or close"
+    )]
     pub fn channel(&self) -> &Channel {
+        &self.channel
+    }
+
+    pub(crate) const fn legacy_channel(&self) -> &Channel {
         &self.channel
     }
 
@@ -436,8 +486,8 @@ mod tests {
         opaque_ids.sort_unstable();
         assert_eq!(opaque_ids, [101, 101]);
 
-        context.connection_ref().close();
-        assert!(!context_clone.connection_ref().is_healthy());
+        channel.connection_ref().close();
+        assert!(!channel.connection_ref().is_healthy());
         let report = channel.close_with_report(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
     }
@@ -461,6 +511,10 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(
+        deprecated,
+        reason = "the compatibility test intentionally verifies the deprecated swallow-error facade"
+    )]
     async fn borrowed_response_write_consumes_the_body_before_a_late_error() {
         let runtime = rocketmq_runtime::RuntimeContext::from_current("borrowed-context-receipt-test");
         let (context, receiver) = embedded_context(&runtime, "borrowed-context-success");

--- a/rocketmq-transport/src/runtime/processor_v2.rs
+++ b/rocketmq-transport/src/runtime/processor_v2.rs
@@ -16,6 +16,7 @@
 
 use std::time::Duration;
 
+use crate::dispatch::DeferredTerminalReason;
 use crate::dispatch::HandlerOutcome;
 use crate::dispatch::IngressRequestView;
 use crate::dispatch::RemotingRequest;
@@ -61,6 +62,175 @@ pub enum ResponseWritePath {
     Inline,
     /// A deferred registration completed the response later.
     Deferred,
+}
+
+/// Lifecycle mode for a body-free V2 response observation.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ResponseObservationModeV2 {
+    /// The request completed during inline dispatch.
+    Inline,
+    /// The request transferred response ownership and completed later.
+    Deferred,
+    /// The request intentionally produced no response frame.
+    NoResponse,
+}
+
+/// One typed V2 response lifecycle event.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ResponseObservationOutcomeV2 {
+    /// The canonical response owner reached its transport disposition.
+    Written(ResponseReceipt),
+    /// The immutable ingress request was one-way.
+    Oneway,
+    /// Protocol policy explicitly permits no response.
+    ProtocolNoResponse,
+    /// A deferred response ended without attempting a response plan.
+    Cancelled(DeferredTerminalReason),
+    /// Response processing or delivery failed with redacted metadata.
+    Failed {
+        /// Stable response failure category, when a response attempt existed.
+        kind: Option<ResponseErrorKind>,
+        /// Socket-write progress, when known.
+        progress: Option<WriteProgress>,
+    },
+}
+
+/// Body-free metadata for one V2 response lifecycle observation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResponseMetadataV2 {
+    request_id: RequestId,
+    original_code: i32,
+    response_code: Option<i32>,
+    plan_kind: Option<ResponseBodyKind>,
+    mode: ResponseObservationModeV2,
+    outcome: ResponseObservationOutcomeV2,
+}
+
+impl ResponseMetadataV2 {
+    pub(crate) const fn new(
+        request_id: RequestId,
+        original_code: i32,
+        response_code: Option<i32>,
+        plan_kind: Option<ResponseBodyKind>,
+        mode: ResponseObservationModeV2,
+        outcome: ResponseObservationOutcomeV2,
+    ) -> Self {
+        Self {
+            request_id,
+            original_code,
+            response_code,
+            plan_kind,
+            mode,
+            outcome,
+        }
+    }
+
+    /// Returns the immutable process-local request identity.
+    #[must_use]
+    pub const fn request_id(self) -> RequestId {
+        self.request_id
+    }
+
+    /// Returns the original raw request code captured at ingress.
+    #[must_use]
+    pub const fn original_code(self) -> i32 {
+        self.original_code
+    }
+
+    /// Returns the response code without exposing a response command.
+    #[must_use]
+    pub const fn response_code(self) -> Option<i32> {
+        self.response_code
+    }
+
+    /// Returns the response plan's storage category without exposing its body.
+    #[must_use]
+    pub const fn plan_kind(self) -> Option<ResponseBodyKind> {
+        self.plan_kind
+    }
+
+    /// Returns the response lifecycle mode.
+    #[must_use]
+    pub const fn mode(self) -> ResponseObservationModeV2 {
+        self.mode
+    }
+
+    /// Returns the typed response lifecycle outcome.
+    #[must_use]
+    pub const fn outcome(self) -> ResponseObservationOutcomeV2 {
+        self.outcome
+    }
+}
+
+/// Body-free V2 response observation correlated to one request span.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResponseObservationV2 {
+    metadata: ResponseMetadataV2,
+    write_elapsed: Option<Duration>,
+    end_to_end_elapsed: Duration,
+}
+
+impl ResponseObservationV2 {
+    pub(crate) const fn new(
+        metadata: ResponseMetadataV2,
+        write_elapsed: Option<Duration>,
+        end_to_end_elapsed: Duration,
+    ) -> Self {
+        Self {
+            metadata,
+            write_elapsed,
+            end_to_end_elapsed,
+        }
+    }
+
+    /// Returns body-free response metadata.
+    #[must_use]
+    pub const fn metadata(self) -> ResponseMetadataV2 {
+        self.metadata
+    }
+
+    /// Returns canonical delivery time when a write was attempted.
+    #[must_use]
+    pub const fn write_elapsed(self) -> Option<Duration> {
+        self.write_elapsed
+    }
+
+    /// Returns elapsed time from trusted ingress to this observation.
+    #[must_use]
+    pub const fn end_to_end_elapsed(self) -> Duration {
+        self.end_to_end_elapsed
+    }
+
+    pub(crate) fn write_projection(self) -> Option<ResponseWriteObservationV2> {
+        let response_code = self.metadata.response_code?;
+        let body_kind = self.metadata.plan_kind?;
+        let path = match self.metadata.mode {
+            ResponseObservationModeV2::Inline => ResponseWritePath::Inline,
+            ResponseObservationModeV2::Deferred => ResponseWritePath::Deferred,
+            ResponseObservationModeV2::NoResponse => return None,
+        };
+        let outcome = match self.metadata.outcome {
+            ResponseObservationOutcomeV2::Written(receipt) => ResponseWriteOutcomeV2::Written(receipt),
+            ResponseObservationOutcomeV2::Failed {
+                kind: Some(kind),
+                progress,
+            } => ResponseWriteOutcomeV2::Failed { kind, progress },
+            ResponseObservationOutcomeV2::Oneway
+            | ResponseObservationOutcomeV2::ProtocolNoResponse
+            | ResponseObservationOutcomeV2::Cancelled(_)
+            | ResponseObservationOutcomeV2::Failed { kind: None, .. } => return None,
+        };
+        Some(ResponseWriteObservationV2 {
+            request_id: self.metadata.request_id,
+            original_code: self.metadata.original_code,
+            response_code,
+            body_kind,
+            path,
+            write_elapsed: self.write_elapsed.unwrap_or(Duration::ZERO),
+            end_to_end_elapsed: self.end_to_end_elapsed,
+            outcome,
+        })
+    }
 }
 
 /// Typed result recorded at the canonical response-write boundary.
@@ -295,6 +465,17 @@ pub trait LocalRequestProcessorV2 {
     /// contains no request body.
     fn request_ordering(&self, _ingress: IngressRequestView<'_>) -> RequestOrdering {
         default_request_ordering()
+    }
+
+    /// Observes V2 response lifecycle metadata without access to request or response bodies.
+    ///
+    /// The default preserves the existing write-observation callback for write
+    /// outcomes while allowing new implementations to observe deferred and
+    /// no-response terminal states exactly once.
+    fn observe_response(&self, observation: ResponseObservationV2) {
+        if let Some(write) = observation.write_projection() {
+            self.observe_response_write(write);
+        }
     }
 
     /// Observes one completed response write without retaining its payload.

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -25,9 +25,11 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
+use futures_util::FutureExt;
 use futures_util::StreamExt;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::SharedRocketMQError;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingCommandType;
 use rocketmq_runtime::BlockingExecutor;
@@ -65,6 +67,7 @@ use crate::connection::SessionWriterSnapshot;
 use crate::dispatch::reserve_session_owner;
 use crate::dispatch::AuthorizedDispatchBoundary;
 use crate::dispatch::AuthorizedDispatchSession;
+use crate::dispatch::DeferredSessionCleanupReport;
 use crate::dispatch::NetworkResponsePlanContext;
 use crate::dispatch::OriginalRequestIdentity;
 use crate::dispatch::RequestContext;
@@ -77,6 +80,7 @@ use crate::proxy_protocol::ProxyProtocolConfig;
 use crate::proxy_protocol::ProxyProtocolMetadata;
 use crate::request_ordering::RequestOrdering;
 use crate::security::TransportSecurity;
+use crate::session_executor::SessionExecutorDrainReport;
 use crate::session_view::SessionView;
 use crate::telemetry::TransportTelemetry;
 use crate::tls::NegotiatedConnection;
@@ -87,6 +91,315 @@ use crate::writer_runtime::WriterLanes;
 use crate::writer_runtime::WriterQueueConfig;
 
 const SESSION_RETIREMENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SessionWriterCompletionHealth {
+    Completed,
+    Failed,
+}
+
+#[derive(Debug)]
+struct SessionWriterCompletionReport {
+    health: SessionWriterCompletionHealth,
+    snapshot: SessionWriterSnapshot,
+    failure: Option<SharedRocketMQError>,
+}
+
+impl SessionWriterCompletionReport {
+    fn new(result: RocketMQResult<()>, snapshot: SessionWriterSnapshot) -> Self {
+        let failure = result.err().map(SharedRocketMQError::new);
+        Self {
+            health: if failure.is_some() {
+                SessionWriterCompletionHealth::Failed
+            } else {
+                SessionWriterCompletionHealth::Completed
+            },
+            snapshot,
+            failure,
+        }
+    }
+
+    fn is_healthy(&self) -> bool {
+        self.health == SessionWriterCompletionHealth::Completed
+            && self.snapshot.queued_items == 0
+            && self.snapshot.queued_bytes == 0
+            && self.snapshot.control_queued_items == 0
+            && self.snapshot.control_queued_bytes == 0
+            && self.snapshot.data_queued_items == 0
+            && self.snapshot.data_queued_bytes == 0
+    }
+}
+
+#[derive(Debug)]
+struct SessionCloseReport {
+    executor: SessionExecutorDrainReport,
+    deferred_cleanup: DeferredSessionCleanupReport,
+    remaining_wait_permits: usize,
+    remaining_server_outbound_leases: usize,
+    disconnected_panicked: bool,
+    writer: SessionWriterCompletionReport,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SessionCloseCompletionSnapshot {
+    pub(crate) healthy: bool,
+    pub(crate) active_inline_tasks: usize,
+    pub(crate) active_resume_tasks: usize,
+    pub(crate) remaining_inline_tasks: usize,
+    pub(crate) remaining_resume_tasks: usize,
+    pub(crate) removed_waiters: usize,
+    pub(crate) cleanup_panicked_targets: usize,
+    pub(crate) remaining_wait_permits: usize,
+    pub(crate) remaining_server_outbound_leases: usize,
+    pub(crate) disconnected_panicked: bool,
+    pub(crate) writer_healthy: bool,
+    pub(crate) writer_queued_items: usize,
+    pub(crate) writer_queued_bytes: usize,
+}
+
+#[derive(Clone)]
+struct SessionCloseCompletion {
+    snapshot: SessionCloseCompletionSnapshot,
+    error: Option<SharedRocketMQError>,
+}
+
+struct SessionCloseCoordinator {
+    completion: tokio::sync::watch::Sender<Option<Arc<SessionCloseCompletion>>>,
+}
+
+struct SessionCloseCompletionGuard {
+    session: SessionHandle,
+    armed: bool,
+}
+
+struct ServerOutboundAdmission {
+    accepting: AtomicBool,
+    active: AtomicUsize,
+}
+
+pub(crate) struct ServerOutboundLease {
+    admission: Arc<ServerOutboundAdmission>,
+}
+
+impl ServerOutboundAdmission {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            accepting: AtomicBool::new(true),
+            active: AtomicUsize::new(0),
+        })
+    }
+
+    fn acquire(self: &Arc<Self>) -> Option<ServerOutboundLease> {
+        if !self.accepting.load(Ordering::Acquire) {
+            return None;
+        }
+        self.active.fetch_add(1, Ordering::AcqRel);
+        if self.accepting.load(Ordering::Acquire) {
+            Some(ServerOutboundLease {
+                admission: Arc::clone(self),
+            })
+        } else {
+            self.active.fetch_sub(1, Ordering::AcqRel);
+            None
+        }
+    }
+
+    fn close(&self) {
+        self.accepting.store(false, Ordering::Release);
+    }
+
+    fn active(&self) -> usize {
+        self.active.load(Ordering::Acquire)
+    }
+
+    fn is_closed(&self) -> bool {
+        !self.accepting.load(Ordering::Acquire)
+    }
+}
+
+impl Drop for ServerOutboundLease {
+    fn drop(&mut self) {
+        self.admission.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+impl SessionCloseCompletionGuard {
+    fn new(session: SessionHandle) -> Self {
+        Self { session, armed: true }
+    }
+
+    fn complete(&mut self, report: &SessionCloseReport) {
+        self.session.complete_close(report);
+        self.armed = false;
+    }
+}
+
+impl Drop for SessionCloseCompletionGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.session.abort();
+        let writer = self.session.writer_snapshot();
+        let error = SharedRocketMQError::new(RocketMQError::network_connection_failed(
+            "transport-session-close",
+            "session finalizer exited before ordered close completion",
+        ));
+        self.session.send.close_coordinator.complete(SessionCloseCompletion {
+            snapshot: SessionCloseCompletionSnapshot {
+                healthy: false,
+                active_inline_tasks: 0,
+                active_resume_tasks: 0,
+                remaining_inline_tasks: self.session.request_operation.active_task_count(),
+                remaining_resume_tasks: 0,
+                removed_waiters: 0,
+                cleanup_panicked_targets: 0,
+                remaining_wait_permits: 0,
+                remaining_server_outbound_leases: self.session.send.server_outbound.active(),
+                disconnected_panicked: false,
+                writer_healthy: false,
+                writer_queued_items: writer.queued_items,
+                writer_queued_bytes: writer.queued_bytes,
+            },
+            error: Some(error),
+        });
+    }
+}
+
+impl SessionCloseCoordinator {
+    fn new() -> Self {
+        let (completion, _) = tokio::sync::watch::channel(None);
+        Self { completion }
+    }
+
+    fn complete(&self, completion: SessionCloseCompletion) {
+        self.completion.send_replace(Some(Arc::new(completion)));
+    }
+
+    async fn completed(&self) -> RocketMQResult<Arc<SessionCloseCompletion>> {
+        let mut completion = self.completion.subscribe();
+        loop {
+            if let Some(completed) = completion.borrow().clone() {
+                tracing::debug!(
+                    healthy = completed.snapshot.healthy,
+                    active_inline_tasks = completed.snapshot.active_inline_tasks,
+                    active_resume_tasks = completed.snapshot.active_resume_tasks,
+                    remaining_inline_tasks = completed.snapshot.remaining_inline_tasks,
+                    remaining_resume_tasks = completed.snapshot.remaining_resume_tasks,
+                    removed_waiters = completed.snapshot.removed_waiters,
+                    cleanup_panicked_targets = completed.snapshot.cleanup_panicked_targets,
+                    remaining_wait_permits = completed.snapshot.remaining_wait_permits,
+                    remaining_server_outbound_leases = completed.snapshot.remaining_server_outbound_leases,
+                    disconnected_panicked = completed.snapshot.disconnected_panicked,
+                    writer_healthy = completed.snapshot.writer_healthy,
+                    writer_queued_items = completed.snapshot.writer_queued_items,
+                    writer_queued_bytes = completed.snapshot.writer_queued_bytes,
+                    "transport session close waiter observed completion"
+                );
+                return Ok(completed);
+            }
+            completion.changed().await.map_err(|_| {
+                RocketMQError::network_connection_failed(
+                    "transport-session-close",
+                    "session close coordinator retired before completion",
+                )
+            })?;
+        }
+    }
+
+    async fn wait(&self) -> RocketMQResult<SessionCloseCompletionSnapshot> {
+        let completed = self.completed().await?;
+        match &completed.error {
+            Some(error) => Err(error.clone().into_error()),
+            None => Ok(completed.snapshot),
+        }
+    }
+}
+
+impl SessionCloseReport {
+    fn is_healthy(&self) -> bool {
+        self.executor.is_healthy()
+            && self.deferred_cleanup.is_healthy()
+            && self.remaining_wait_permits == 0
+            && self.remaining_server_outbound_leases == 0
+            && !self.disconnected_panicked
+            && self.writer.is_healthy()
+    }
+
+    fn log(&self, session_id: u64) {
+        if self.is_healthy() {
+            tracing::debug!(
+                session_id,
+                active_inline_tasks = self.executor.active_inline_tasks,
+                active_resume_tasks = self.executor.active_resume_tasks,
+                remaining_inline_tasks = self.executor.remaining_inline_tasks,
+                remaining_resume_tasks = self.executor.remaining_resume_tasks,
+                cleanup_outcome = ?self.deferred_cleanup.outcome,
+                registered_waiters = self.deferred_cleanup.registered_waiters,
+                removed_waiters = self.deferred_cleanup.removed_waiters,
+                cleanup_panicked_targets = self.deferred_cleanup.panicked_targets,
+                cleanup_remaining_wait_permits = self.deferred_cleanup.remaining_wait_permits,
+                remaining_wait_permits = self.remaining_wait_permits,
+                remaining_server_outbound_leases = self.remaining_server_outbound_leases,
+                disconnected_panicked = self.disconnected_panicked,
+                writer_completion_healthy = true,
+                writer_queued_items = self.writer.snapshot.queued_items,
+                writer_queued_bytes = self.writer.snapshot.queued_bytes,
+                writer_failed_writes = self.writer.snapshot.failed,
+                "transport session shutdown report completed"
+            );
+        } else {
+            self.executor.shutdown.log_if_unhealthy();
+            tracing::warn!(
+                session_id,
+                active_inline_tasks = self.executor.active_inline_tasks,
+                active_resume_tasks = self.executor.active_resume_tasks,
+                remaining_inline_tasks = self.executor.remaining_inline_tasks,
+                remaining_resume_tasks = self.executor.remaining_resume_tasks,
+                cleanup_outcome = ?self.deferred_cleanup.outcome,
+                registered_waiters = self.deferred_cleanup.registered_waiters,
+                removed_waiters = self.deferred_cleanup.removed_waiters,
+                cleanup_panicked_targets = self.deferred_cleanup.panicked_targets,
+                cleanup_remaining_wait_permits = self.deferred_cleanup.remaining_wait_permits,
+                remaining_wait_permits = self.remaining_wait_permits,
+                remaining_server_outbound_leases = self.remaining_server_outbound_leases,
+                disconnected_panicked = self.disconnected_panicked,
+                writer_completion_healthy = self.writer.is_healthy(),
+                writer_queued_items = self.writer.snapshot.queued_items,
+                writer_queued_bytes = self.writer.snapshot.queued_bytes,
+                writer_failed_writes = self.writer.snapshot.failed,
+                "transport session shutdown report is unhealthy"
+            );
+        }
+    }
+
+    fn completion(&self) -> SessionCloseCompletion {
+        let snapshot = SessionCloseCompletionSnapshot {
+            healthy: self.is_healthy(),
+            active_inline_tasks: self.executor.active_inline_tasks,
+            active_resume_tasks: self.executor.active_resume_tasks,
+            remaining_inline_tasks: self.executor.remaining_inline_tasks,
+            remaining_resume_tasks: self.executor.remaining_resume_tasks,
+            removed_waiters: self.deferred_cleanup.removed_waiters,
+            cleanup_panicked_targets: self.deferred_cleanup.panicked_targets,
+            remaining_wait_permits: self.remaining_wait_permits,
+            remaining_server_outbound_leases: self.remaining_server_outbound_leases,
+            disconnected_panicked: self.disconnected_panicked,
+            writer_healthy: self.writer.is_healthy(),
+            writer_queued_items: self.writer.snapshot.queued_items,
+            writer_queued_bytes: self.writer.snapshot.queued_bytes,
+        };
+        let error = self.writer.failure.clone().or_else(|| {
+            (!snapshot.healthy).then(|| {
+                SharedRocketMQError::new(RocketMQError::network_connection_failed(
+                    "transport-session-close",
+                    "session close report is unhealthy",
+                ))
+            })
+        });
+        SessionCloseCompletion { snapshot, error }
+    }
+}
 
 /// Bounded I/O budgets applied to every transport session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -152,6 +465,8 @@ struct SessionSendHandle {
     session_view: SessionView,
     task_group: TaskGroup,
     reader_cancellation: CancellationToken,
+    server_outbound: Arc<ServerOutboundAdmission>,
+    close_coordinator: SessionCloseCoordinator,
     writer_operation: OperationContext,
     lifecycle: Arc<SessionLifecycle>,
     writer_task_id: TaskId,
@@ -288,7 +603,12 @@ impl SessionHandle {
         self.original_request_identity
     }
 
+    pub(crate) fn is_same_session(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.send, &other.send)
+    }
+
     pub(crate) fn abort(&self) {
+        self.send.server_outbound.close();
         let _ = self.send.session_closed_tx.send(true);
         let _ = self.send.state_tx.send(ConnectionState::Closed);
         self.send.reader_cancellation.cancel();
@@ -300,6 +620,7 @@ impl SessionHandle {
     /// Cancels both socket halves and waits for the owned writer task to exit.
     /// A stuck writer is force-aborted after the normal retirement deadline.
     pub(crate) async fn terminate(&self) {
+        self.send.server_outbound.close();
         let _ = self.send.session_closed_tx.send(true);
         let _ = self.send.state_tx.send(ConnectionState::Closed);
         self.send.reader_cancellation.cancel();
@@ -347,14 +668,51 @@ impl SessionHandle {
         self.response_plan_context.as_ref()
     }
 
-    /// Closes the session writer after all sends that already entered the lifecycle gate finish.
-    /// Retirement has a five-second absolute deadline and aborts a writer blocked past it.
+    /// Requests the server-owned ordered session close and waits for its full completion.
+    ///
+    /// The reader owner performs deferred cleanup, executor drain, disconnect notification, and
+    /// the sole writer retirement before this method completes. Concurrent or repeated calls wait
+    /// for the same completion.
     ///
     /// # Errors
     ///
-    /// Returns an error if the writer queue or close completion channel has already terminated, if
-    /// closing the framed socket fails, or if the absolute retirement deadline expires.
+    /// Returns an error if any stage of the server-owned close report is unhealthy or if the close
+    /// coordinator terminates without publishing completion.
     pub async fn retire(&self) -> rocketmq_error::RocketMQResult<()> {
+        self.request_close();
+        self.wait_for_close_completion().await.map(|_| ())
+    }
+
+    pub(crate) fn request_close(&self) {
+        self.send.server_outbound.close();
+        let _ = self.send.session_closed_tx.send(true);
+        self.send.reader_cancellation.cancel();
+    }
+
+    pub(crate) fn acquire_server_outbound(&self, target: &'static str) -> RocketMQResult<ServerOutboundLease> {
+        self.send.server_outbound.acquire().ok_or_else(|| {
+            RocketMQError::network_connection_failed(target, "server-originated outbound admission is closed")
+        })
+    }
+
+    pub(crate) fn close_requested(&self) -> bool {
+        self.send.server_outbound.is_closed()
+    }
+
+    pub(crate) async fn wait_for_close_completion(&self) -> RocketMQResult<SessionCloseCompletionSnapshot> {
+        self.send.close_coordinator.wait().await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn close_completion_snapshot(&self) -> RocketMQResult<SessionCloseCompletionSnapshot> {
+        Ok(self.send.close_coordinator.completed().await?.snapshot)
+    }
+
+    fn complete_close(&self, report: &SessionCloseReport) {
+        self.send.close_coordinator.complete(report.completion());
+    }
+
+    async fn retire_writer_owned(&self) -> rocketmq_error::RocketMQResult<()> {
         self.retire_with_timeout_inner(SESSION_RETIREMENT_TIMEOUT, None).await
     }
 
@@ -491,9 +849,9 @@ pub(crate) trait AuthorizedFrameRoute: Send + Sync + 'static {
         partial_frame_permit: Option<PartialFramePermit>,
     ) -> impl Future<Output = bool> + Send;
 
-    fn close_pending(&self, state: &Self::SessionState, session: SessionHandle);
+    fn close_pending(&self, state: &Self::SessionState, session: SessionHandle) -> DeferredSessionCleanupReport;
 
-    fn disconnected(&self, state: Self::SessionState, session: SessionHandle) -> impl Future<Output = ()> + Send;
+    fn disconnected(&self, state: Self::SessionState, session: SessionHandle) -> impl Future<Output = usize> + Send;
 }
 
 struct CompatibilityFrameRoute<H> {
@@ -553,10 +911,13 @@ where
             .is_ok()
     }
 
-    fn close_pending(&self, _state: &Self::SessionState, _session: SessionHandle) {}
+    fn close_pending(&self, _state: &Self::SessionState, _session: SessionHandle) -> DeferredSessionCleanupReport {
+        DeferredSessionCleanupReport::empty_completed()
+    }
 
-    async fn disconnected(&self, _state: Self::SessionState, session: SessionHandle) {
+    async fn disconnected(&self, _state: Self::SessionState, session: SessionHandle) -> usize {
         self.handler.disconnected(session).await;
+        0
     }
 }
 
@@ -1134,6 +1495,8 @@ async fn run_authorized_framed_session_with_request_sequence<R>(
             session_view,
             task_group: task_group.clone(),
             reader_cancellation: reader_cancellation.clone(),
+            server_outbound: ServerOutboundAdmission::new(),
+            close_coordinator: SessionCloseCoordinator::new(),
             writer_operation,
             lifecycle,
             writer_task_id,
@@ -1144,10 +1507,24 @@ async fn run_authorized_framed_session_with_request_sequence<R>(
         original_request_identity: None,
         response_plan_context: None,
     };
+    let mut close_completion = SessionCloseCompletionGuard::new(session.clone());
 
     let Some(route_state) = route.connected(session.clone()).await else {
-        let _ = session.send.session_closed_tx.send(true);
-        let _ = session.retire().await;
+        session.request_close();
+        executor.begin_close();
+        let request_deadline = task_group
+            .shutdown_deadline()
+            .unwrap_or_else(|| ShutdownDeadline::after(SESSION_RETIREMENT_TIMEOUT));
+        let report = SessionCloseReport {
+            executor: executor.drain_report_until(request_deadline).await,
+            deferred_cleanup: DeferredSessionCleanupReport::empty_completed(),
+            remaining_wait_permits: 0,
+            remaining_server_outbound_leases: session.send.server_outbound.active(),
+            disconnected_panicked: false,
+            writer: SessionWriterCompletionReport::new(session.retire_writer_owned().await, session.writer_snapshot()),
+        };
+        report.log(session.session_id());
+        close_completion.complete(&report);
         return;
     };
     let cancellation = task_group.cancellation_token();
@@ -1222,15 +1599,32 @@ async fn run_authorized_framed_session_with_request_sequence<R>(
     // Request dispatchers may still be draining accepted work, but the reader
     // no longer accepts frames. Publish the session-close transition now so
     // read-only views observe shutdown without closing the response writer.
-    let _ = session.send.session_closed_tx.send(true);
+    session.request_close();
     executor.begin_close();
-    route.close_pending(&route_state, session.clone());
+    let deferred_cleanup = route.close_pending(&route_state, session.clone());
     let request_deadline = task_group
         .shutdown_deadline()
         .unwrap_or_else(|| ShutdownDeadline::after(SESSION_RETIREMENT_TIMEOUT));
-    executor.drain_until(request_deadline).await.log_if_unhealthy();
-    route.disconnected(route_state, session.clone()).await;
-    let _ = session.retire().await;
+    let executor_drain = executor.drain_report_until(request_deadline).await;
+    let disconnected = std::panic::AssertUnwindSafe(route.disconnected(route_state, session.clone()))
+        .catch_unwind()
+        .await;
+    let (remaining_wait_permits, disconnected_panicked) = match disconnected {
+        Ok(remaining_wait_permits) => (remaining_wait_permits, false),
+        Err(_) => (0, true),
+    };
+    let writer_completion =
+        SessionWriterCompletionReport::new(session.retire_writer_owned().await, session.writer_snapshot());
+    let report = SessionCloseReport {
+        executor: executor_drain,
+        deferred_cleanup,
+        remaining_wait_permits,
+        remaining_server_outbound_leases: session.send.server_outbound.active(),
+        disconnected_panicked,
+        writer: writer_completion,
+    };
+    report.log(session.session_id());
+    close_completion.complete(&report);
 }
 
 /// Runs an already-connected client or compatibility socket through the canonical framed session
@@ -1810,7 +2204,9 @@ mod retirement_tests {
     use tokio::sync::Notify;
 
     use super::ConnectionHandler;
+    use super::SessionCloseReport;
     use super::SessionHandle;
+    use super::SessionWriterCompletionReport;
     use super::TransportListener;
     use crate::admission::AdmissionController;
     use crate::admission::AdmissionLimits;
@@ -1818,12 +2214,50 @@ mod retirement_tests {
     #[cfg(feature = "tls")]
     use crate::config::TlsMode;
     use crate::connection::Connection;
+    use crate::connection::SessionWriterSnapshot;
     use crate::deadline::RequestDeadline;
     use crate::proxy_protocol::ProxyProtocolConfig;
     use crate::security::TransportSecurity;
+    use crate::session_executor::SessionExecutorDrainReport;
     use crate::session_view::SessionId;
     use crate::session_view::SessionView;
     use crate::tls::TlsServerRuntime;
+
+    #[test]
+    fn composite_close_report_requires_drained_tasks_waiters_and_writer() {
+        let healthy = SessionCloseReport {
+            executor: SessionExecutorDrainReport {
+                shutdown: rocketmq_runtime::ShutdownReport::new("test.session", Duration::ZERO),
+                active_inline_tasks: 1,
+                active_resume_tasks: 1,
+                remaining_inline_tasks: 0,
+                remaining_resume_tasks: 0,
+            },
+            deferred_cleanup: crate::dispatch::DeferredSessionCleanupReport::empty_completed(),
+            remaining_wait_permits: 0,
+            remaining_server_outbound_leases: 0,
+            disconnected_panicked: false,
+            writer: SessionWriterCompletionReport::new(Ok(()), SessionWriterSnapshot::default()),
+        };
+        assert!(healthy.is_healthy());
+
+        let failed_writer = SessionWriterCompletionReport::new(
+            Err(RocketMQError::network_connection_failed(
+                "test-session-writer",
+                "writer completion failed",
+            )),
+            SessionWriterSnapshot::default(),
+        );
+        assert!(!failed_writer.is_healthy());
+        let queued_writer = SessionWriterCompletionReport::new(
+            Ok(()),
+            SessionWriterSnapshot {
+                queued_items: 1,
+                ..SessionWriterSnapshot::default()
+            },
+        );
+        assert!(!queued_writer.is_healthy());
+    }
 
     struct CaptureSession {
         sender: std::sync::Mutex<Option<oneshot::Sender<SessionHandle>>>,

--- a/rocketmq-transport/src/session_executor.rs
+++ b/rocketmq-transport/src/session_executor.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Weak;
@@ -99,6 +100,7 @@ struct SessionExecutorInner {
     operation: OperationContext,
     sequencer: RequestSequencer,
     accepting: AtomicBool,
+    task_counts: Arc<SessionTaskCounts>,
     #[cfg(test)]
     close_resume_operation_before_spawn: AtomicBool,
     #[cfg(any(test, feature = "test-support"))]
@@ -114,6 +116,7 @@ impl SessionExecutor {
                 operation: OperationContext::without_deadline(TaskKind::Worker),
                 sequencer: RequestSequencer::default(),
                 accepting: AtomicBool::new(true),
+                task_counts: Arc::new(SessionTaskCounts::default()),
                 #[cfg(test)]
                 close_resume_operation_before_spawn: AtomicBool::new(false),
                 #[cfg(any(test, feature = "test-support"))]
@@ -178,8 +181,10 @@ impl SessionExecutor {
         let request_operation = self.inner.operation.clone();
         let request_operation_for_task = request_operation.clone();
         let spawn_group = self.inner.request_group.clone();
+        let task_count = SessionTaskCountGuard::inline(Arc::clone(&self.inner.task_counts));
         spawn_group
             .spawn_draining_operation(&request_operation, "rocketmq.transport.session.request", async move {
+                let _task_count = task_count;
                 let ordering_guard = sequencer.acquire(ordering).await;
                 let processor = match admission.try_acquire(AdmissionResource::Processor, retained_bytes, class) {
                     Ok(processor) => processor,
@@ -234,10 +239,12 @@ impl SessionExecutor {
         *self.inner.legacy_execution_first_poll_gate.lock() = Some((entered, release));
     }
 
-    pub(crate) async fn drain_until(&self, deadline: ShutdownDeadline) -> ShutdownReport {
+    pub(crate) async fn drain_report_until(&self, deadline: ShutdownDeadline) -> SessionExecutorDrainReport {
         let started_at = Instant::now();
         self.stop_admission();
-        let active_before = self.inner.operation.active_task_count();
+        let active_inline_tasks = self.inner.task_counts.inline.load(Ordering::Acquire);
+        let active_resume_tasks = self.inner.task_counts.resume.load(Ordering::Acquire);
+        let active_before = active_inline_tasks.saturating_add(active_resume_tasks);
         let joined = self
             .inner
             .operation
@@ -251,7 +258,77 @@ impl SessionExecutor {
             report.aborted = active_before;
             report.timed_out = usize::from(active_before > 0);
         }
-        report
+        SessionExecutorDrainReport {
+            shutdown: report,
+            active_inline_tasks,
+            active_resume_tasks,
+            remaining_inline_tasks: self.inner.task_counts.inline.load(Ordering::Acquire),
+            remaining_resume_tasks: self.inner.task_counts.resume.load(Ordering::Acquire),
+        }
+    }
+
+    pub(crate) async fn drain_until(&self, deadline: ShutdownDeadline) -> ShutdownReport {
+        self.drain_report_until(deadline).await.shutdown
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SessionExecutorDrainReport {
+    pub(crate) shutdown: ShutdownReport,
+    pub(crate) active_inline_tasks: usize,
+    pub(crate) active_resume_tasks: usize,
+    pub(crate) remaining_inline_tasks: usize,
+    pub(crate) remaining_resume_tasks: usize,
+}
+
+impl SessionExecutorDrainReport {
+    pub(crate) fn is_healthy(&self) -> bool {
+        self.shutdown.is_healthy() && self.remaining_inline_tasks == 0 && self.remaining_resume_tasks == 0
+    }
+}
+
+#[derive(Default)]
+struct SessionTaskCounts {
+    inline: AtomicUsize,
+    resume: AtomicUsize,
+}
+
+enum SessionTaskCountKind {
+    Inline,
+    Resume,
+}
+
+struct SessionTaskCountGuard {
+    counts: Arc<SessionTaskCounts>,
+    kind: SessionTaskCountKind,
+}
+
+impl SessionTaskCountGuard {
+    fn inline(counts: Arc<SessionTaskCounts>) -> Self {
+        counts.inline.fetch_add(1, Ordering::AcqRel);
+        Self {
+            counts,
+            kind: SessionTaskCountKind::Inline,
+        }
+    }
+
+    fn resume(counts: Arc<SessionTaskCounts>) -> Self {
+        counts.resume.fetch_add(1, Ordering::AcqRel);
+        Self {
+            counts,
+            kind: SessionTaskCountKind::Resume,
+        }
+    }
+}
+
+impl Drop for SessionTaskCountGuard {
+    fn drop(&mut self) {
+        let counter = match self.kind {
+            SessionTaskCountKind::Inline => &self.counts.inline,
+            SessionTaskCountKind::Resume => &self.counts.resume,
+        };
+        let previous = counter.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "session task count guard owns one active count");
     }
 }
 
@@ -308,12 +385,14 @@ impl DeferredResumeExecutor {
         let operation_for_task = operation.clone();
         let spawn_group = inner.request_group.clone();
         let task_cell = Arc::clone(&cell);
+        let task_count = SessionTaskCountGuard::resume(Arc::clone(&inner.task_counts));
         #[cfg(test)]
         if inner.close_resume_operation_before_spawn.swap(false, Ordering::AcqRel) {
             operation.close_admission();
         }
         spawn_group
             .spawn_draining_operation(&operation, "rocketmq.transport.session.deferred-resume", async move {
+                let _task_count = task_count;
                 #[cfg(test)]
                 task_cell.wait_first_poll_gate().await;
                 let Some(job) = task_cell.take() else {

--- a/rocketmq-transport/src/telemetry.rs
+++ b/rocketmq-transport/src/telemetry.rs
@@ -12,15 +12,615 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use rocketmq_protocol::code::request_code::RequestCode;
+
+use parking_lot::Mutex;
+
+use crate::dispatch::AuthenticationState;
+use crate::dispatch::DeferredTerminalReason;
+use crate::dispatch::OriginalRequestIdentity;
+use crate::dispatch::RequestOrigin;
+use crate::dispatch::ResponseBodyKind;
+#[cfg(any(test, feature = "observability"))]
+use crate::dispatch::ResponseDisposition;
+use crate::dispatch::ResponseErrorKind;
+use crate::dispatch::ResponseReceipt;
+use crate::dispatch::WriteProgress;
+use crate::runtime::processor_v2::ResponseMetadataV2;
+use crate::runtime::processor_v2::ResponseObservationModeV2;
+use crate::runtime::processor_v2::ResponseObservationOutcomeV2;
+use crate::runtime::processor_v2::ResponseObservationV2;
+
+#[cfg(feature = "observability")]
+const NO_RESPONSE_CODE: i32 = -1;
+
 #[cfg(any(test, feature = "observability", feature = "observability-traces"))]
 #[inline]
 fn request_identity_span(identity: crate::dispatch::OriginalRequestIdentity) -> tracing::Span {
     tracing::info_span!(
         "RocketMQ REMOTING REQUEST",
+        rocketmq.request.generation = "v1_compatibility",
         rocketmq.request.code = identity.original_code(),
         rocketmq.request.owner_id = identity.request_id().owner_id(),
         rocketmq.request.sequence = identity.request_id().sequence(),
     )
+}
+
+#[cfg(any(test, feature = "observability", feature = "observability-traces"))]
+fn v2_request_span(
+    identity: OriginalRequestIdentity,
+    code_class: TransportRequestCodeClass,
+    origin: &RequestOrigin,
+    authentication: &AuthenticationState,
+    deadline: Option<crate::deadline::RequestDeadline>,
+) -> tracing::Span {
+    tracing::info_span!(
+        "RocketMQ REMOTING V2 REQUEST",
+        rocketmq.request.owner_id = identity.request_id().owner_id(),
+        rocketmq.request.sequence = identity.request_id().sequence(),
+        rocketmq.request.original_code = identity.original_code(),
+        rocketmq.request.operation_name = code_class.as_str(),
+        rocketmq.request.session_id = identity.request_id().owner_id(),
+        rocketmq.request.origin_kind = origin_kind(origin),
+        rocketmq.request.peer_class = peer_class(origin),
+        rocketmq.request.authentication_state = authentication_state(authentication),
+        rocketmq.request.principal_kind = principal_kind(authentication),
+        rocketmq.request.deadline_bucket = deadline_bucket(deadline),
+        outcome = tracing::field::Empty,
+        response_plan_kind = tracing::field::Empty,
+        response_disposition = tracing::field::Empty,
+        error_kind = tracing::field::Empty,
+        write_progress = tracing::field::Empty,
+    )
+}
+
+#[cfg(any(test, feature = "observability", feature = "observability-traces"))]
+const fn origin_kind(origin: &RequestOrigin) -> &'static str {
+    match origin {
+        RequestOrigin::Network { .. } => "network",
+        RequestOrigin::Embedded { .. } => "embedded_proxy",
+    }
+}
+
+#[cfg(any(test, feature = "observability", feature = "observability-traces"))]
+fn peer_class(origin: &RequestOrigin) -> &'static str {
+    let RequestOrigin::Network { peer } = origin else {
+        return "not_applicable";
+    };
+    let ip = peer.address().ip();
+    if ip.is_loopback() {
+        "loopback"
+    } else if match ip {
+        std::net::IpAddr::V4(ip) => ip.is_private() || ip.is_link_local(),
+        std::net::IpAddr::V6(ip) => ip.is_unique_local() || ip.is_unicast_link_local(),
+    } {
+        "private"
+    } else {
+        "public"
+    }
+}
+
+#[cfg(any(test, feature = "observability", feature = "observability-traces"))]
+const fn authentication_state(authentication: &AuthenticationState) -> &'static str {
+    match authentication {
+        AuthenticationState::Authenticated(..) => "authenticated",
+        AuthenticationState::Anonymous => "anonymous",
+        AuthenticationState::SecurityDisabled => "security_disabled",
+    }
+}
+
+#[cfg(any(test, feature = "observability", feature = "observability-traces"))]
+const fn principal_kind(authentication: &AuthenticationState) -> &'static str {
+    match authentication {
+        AuthenticationState::Authenticated(..) => "trusted_principal",
+        AuthenticationState::Anonymous => "anonymous",
+        AuthenticationState::SecurityDisabled => "not_applicable",
+    }
+}
+
+#[cfg(any(test, feature = "observability", feature = "observability-traces"))]
+fn deadline_bucket(deadline: Option<crate::deadline::RequestDeadline>) -> &'static str {
+    let Some(deadline) = deadline else {
+        return "none";
+    };
+    let remaining = deadline.remaining();
+    if remaining.is_zero() {
+        "expired"
+    } else if remaining <= Duration::from_secs(1) {
+        "le_1s"
+    } else if remaining <= Duration::from_secs(10) {
+        "le_10s"
+    } else {
+        "gt_10s"
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TransportRequestCodeClass {
+    PullMessage,
+    PopMessage,
+    Notification,
+    Other,
+}
+
+impl TransportRequestCodeClass {
+    pub(crate) fn from_code(code: i32) -> Self {
+        match RequestCode::from(code) {
+            RequestCode::PullMessage => Self::PullMessage,
+            RequestCode::PopMessage => Self::PopMessage,
+            RequestCode::Notification => Self::Notification,
+            _ => Self::Other,
+        }
+    }
+
+    #[cfg(any(test, feature = "observability", feature = "observability-traces"))]
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::PullMessage => "pull_message",
+            Self::PopMessage => "pop_message",
+            Self::Notification => "notification",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum V2BoundaryRejectionReason {
+    DeadlineExpired,
+    SecurityDenied,
+    AdmissionRejected,
+}
+
+impl V2BoundaryRejectionReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::DeadlineExpired => "deadline_expired",
+            Self::SecurityDenied => "security_denied",
+            Self::AdmissionRejected => "admission_rejected",
+        }
+    }
+}
+
+type V2ResponseObservationCallback = Box<dyn FnOnce(ResponseObservationV2) + Send + 'static>;
+
+#[derive(Default)]
+struct V2ResponseObservationCallbackState {
+    callback: Option<V2ResponseObservationCallback>,
+    pending: Option<ResponseObservationV2>,
+    delivered: bool,
+}
+
+#[derive(Default)]
+struct V2DeferredMetricState {
+    armed: bool,
+    retained_bytes: usize,
+}
+
+struct V2RequestObservationInner {
+    telemetry: TransportTelemetry,
+    callback: Mutex<V2ResponseObservationCallbackState>,
+    span: tracing::Span,
+    original: OriginalRequestIdentity,
+    started: Instant,
+    code_class: TransportRequestCodeClass,
+    request_metrics: Mutex<TransportRequestMetricsGuard>,
+    terminal: AtomicBool,
+    deferred_registration_recorded: AtomicBool,
+    deferred_metrics: Mutex<V2DeferredMetricState>,
+}
+
+impl Drop for V2RequestObservationInner {
+    fn drop(&mut self) {
+        if self.terminal.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let deferred_metrics = self.deferred_metrics.get_mut();
+        if deferred_metrics.armed {
+            deferred_metrics.armed = false;
+            self.telemetry.adjust_v2_deferred(
+                self.code_class,
+                -1,
+                -retained_bytes_delta(deferred_metrics.retained_bytes),
+            );
+            deferred_metrics.retained_bytes = 0;
+        }
+        let metadata = ResponseMetadataV2::new(
+            self.original.request_id(),
+            self.original.original_code(),
+            None,
+            None,
+            ResponseObservationModeV2::NoResponse,
+            ResponseObservationOutcomeV2::Failed {
+                kind: None,
+                progress: Some(WriteProgress::NotStarted),
+            },
+        );
+        self.request_metrics
+            .get_mut()
+            .complete_process_request_failed(metadata.response_code().unwrap_or(-1));
+        self.telemetry.record_v2_request_lifecycle();
+        self.telemetry.record_v2_response(metadata);
+        self.span.record("outcome", "failed");
+        self.span.record("write_progress", WriteProgress::NotStarted.as_str());
+        let observation = ResponseObservationV2::new(metadata, None, self.started.elapsed());
+        if let Some((callback, observation)) = take_or_defer_response_observation(self.callback.get_mut(), observation)
+        {
+            self.span.in_scope(|| callback(observation));
+        }
+    }
+}
+
+/// Shared observation owner retained across inline dispatch and deferred resume.
+#[derive(Clone)]
+pub(crate) struct V2RequestObservation {
+    inner: Arc<V2RequestObservationInner>,
+}
+
+impl V2RequestObservation {
+    fn new(
+        telemetry: TransportTelemetry,
+        original: OriginalRequestIdentity,
+        started: Instant,
+        origin: &RequestOrigin,
+        authentication: &AuthenticationState,
+        deadline: Option<crate::deadline::RequestDeadline>,
+        request_bytes: u64,
+    ) -> Self {
+        let code_class = TransportRequestCodeClass::from_code(original.original_code());
+        let span = telemetry.v2_request_span(original, code_class, origin, authentication, deadline);
+        let request_metrics = telemetry.v2_request_guard(original.original_code(), request_bytes);
+        telemetry.record_v2_span_started();
+        Self {
+            inner: Arc::new(V2RequestObservationInner {
+                telemetry,
+                callback: Mutex::new(V2ResponseObservationCallbackState::default()),
+                span,
+                original,
+                started,
+                code_class,
+                request_metrics: Mutex::new(request_metrics),
+                terminal: AtomicBool::new(false),
+                deferred_registration_recorded: AtomicBool::new(false),
+                deferred_metrics: Mutex::new(V2DeferredMetricState::default()),
+            }),
+        }
+    }
+
+    pub(crate) fn span(&self) -> tracing::Span {
+        self.inner.span.clone()
+    }
+
+    pub(crate) fn bind_response_observer(&self, callback: impl FnOnce(ResponseObservationV2) + Send + 'static) {
+        let delivery = {
+            let mut state = self.inner.callback.lock();
+            if state.delivered || state.callback.is_some() {
+                None
+            } else if let Some(observation) = state.pending.take() {
+                state.delivered = true;
+                Some((Box::new(callback) as V2ResponseObservationCallback, observation))
+            } else {
+                state.callback = Some(Box::new(callback));
+                None
+            }
+        };
+        if let Some((callback, observation)) = delivery {
+            self.inner.span.in_scope(|| callback(observation));
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_span_for_test(mut self, span: tracing::Span) -> Self {
+        Arc::get_mut(&mut self.inner)
+            .expect("a test observation must be uniquely owned before span injection")
+            .span = span;
+        self
+    }
+
+    pub(crate) fn arm_deferred_metrics(&self, retained_bytes: usize) {
+        let mut deferred_metrics = self.inner.deferred_metrics.lock();
+        if deferred_metrics.armed || self.inner.terminal.load(Ordering::Acquire) {
+            return;
+        }
+        deferred_metrics.armed = true;
+        deferred_metrics.retained_bytes = retained_bytes;
+        self.inner
+            .telemetry
+            .adjust_v2_deferred(self.inner.code_class, 1, retained_bytes_delta(retained_bytes));
+    }
+
+    pub(crate) fn record_deferred_registered(&self) {
+        if self
+            .inner
+            .deferred_registration_recorded
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        self.inner.request_metrics.lock().record_deferred_registered();
+        self.inner.telemetry.record_v2_request_lifecycle();
+        self.inner.telemetry.record_v2_deferred_registration();
+    }
+
+    pub(crate) fn complete_reply(
+        &self,
+        mode: ResponseObservationModeV2,
+        response_code: i32,
+        plan_kind: ResponseBodyKind,
+        write_elapsed: Duration,
+        result: Result<ResponseReceipt, (ResponseErrorKind, Option<WriteProgress>)>,
+    ) {
+        let outcome = match result {
+            Ok(receipt) => ResponseObservationOutcomeV2::Written(receipt),
+            Err((kind, progress)) => ResponseObservationOutcomeV2::Failed {
+                kind: Some(kind),
+                progress,
+            },
+        };
+        self.complete(
+            ResponseMetadataV2::new(
+                self.inner.original.request_id(),
+                self.inner.original.original_code(),
+                Some(response_code),
+                Some(plan_kind),
+                mode,
+                outcome,
+            ),
+            Some(write_elapsed),
+        );
+    }
+
+    pub(crate) fn complete_boundary_rejection(
+        &self,
+        reason: V2BoundaryRejectionReason,
+        response_code: Option<i32>,
+        plan_kind: Option<ResponseBodyKind>,
+        write_elapsed: Option<Duration>,
+        outcome: ResponseObservationOutcomeV2,
+    ) {
+        self.complete_with_rejection(
+            ResponseMetadataV2::new(
+                self.inner.original.request_id(),
+                self.inner.original.original_code(),
+                response_code,
+                plan_kind,
+                if response_code.is_some() {
+                    ResponseObservationModeV2::Inline
+                } else {
+                    ResponseObservationModeV2::NoResponse
+                },
+                outcome,
+            ),
+            write_elapsed,
+            reason,
+        );
+    }
+
+    pub(crate) fn complete_no_response(&self, outcome: ResponseObservationOutcomeV2) {
+        self.complete(
+            ResponseMetadataV2::new(
+                self.inner.original.request_id(),
+                self.inner.original.original_code(),
+                None,
+                None,
+                ResponseObservationModeV2::NoResponse,
+                outcome,
+            ),
+            None,
+        );
+    }
+
+    pub(crate) fn complete_failure_without_kind(
+        &self,
+        mode: ResponseObservationModeV2,
+        response_code: Option<i32>,
+        plan_kind: Option<ResponseBodyKind>,
+        progress: Option<WriteProgress>,
+    ) {
+        self.complete(
+            ResponseMetadataV2::new(
+                self.inner.original.request_id(),
+                self.inner.original.original_code(),
+                response_code,
+                plan_kind,
+                mode,
+                ResponseObservationOutcomeV2::Failed { kind: None, progress },
+            ),
+            None,
+        );
+    }
+
+    pub(crate) fn complete_cancelled(&self, reason: DeferredTerminalReason) {
+        self.complete_no_response(ResponseObservationOutcomeV2::Cancelled(reason));
+    }
+
+    pub(crate) fn complete_request_failed(&self, response_code: i32) {
+        self.inner
+            .request_metrics
+            .lock()
+            .complete_process_request_failed(response_code);
+    }
+
+    pub(crate) fn complete_write_failed(&self, response_code: i32) {
+        self.inner
+            .request_metrics
+            .lock()
+            .complete_write_channel_failed(response_code);
+    }
+
+    fn complete(&self, metadata: ResponseMetadataV2, write_elapsed: Option<Duration>) {
+        self.complete_inner(metadata, write_elapsed, None);
+    }
+
+    fn complete_with_rejection(
+        &self,
+        metadata: ResponseMetadataV2,
+        write_elapsed: Option<Duration>,
+        reason: V2BoundaryRejectionReason,
+    ) {
+        self.complete_inner(metadata, write_elapsed, Some(reason));
+    }
+
+    fn complete_inner(
+        &self,
+        metadata: ResponseMetadataV2,
+        write_elapsed: Option<Duration>,
+        rejection: Option<V2BoundaryRejectionReason>,
+    ) {
+        if self
+            .inner
+            .terminal
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            self.inner.telemetry.record_v2_response_duplicate(self.inner.code_class);
+            return;
+        }
+        let mut deferred_metrics = self.inner.deferred_metrics.lock();
+        if deferred_metrics.armed {
+            deferred_metrics.armed = false;
+            self.inner.telemetry.adjust_v2_deferred(
+                self.inner.code_class,
+                -1,
+                -retained_bytes_delta(deferred_metrics.retained_bytes),
+            );
+            deferred_metrics.retained_bytes = 0;
+        }
+        drop(deferred_metrics);
+        let mut request_metrics = self.inner.request_metrics.lock();
+        if rejection.is_some() {
+            request_metrics.complete_process_request_failed(metadata.response_code().unwrap_or(-1));
+        } else {
+            complete_v2_request_metrics(&mut request_metrics, metadata);
+        }
+        drop(request_metrics);
+        self.inner.telemetry.record_v2_request_lifecycle();
+        self.inner.telemetry.record_v2_response(metadata);
+        self.inner.span.record(
+            "outcome",
+            rejection.map_or_else(|| observation_outcome_label(metadata.outcome()), |_| "rejected"),
+        );
+        if let Some(plan_kind) = metadata.plan_kind() {
+            self.inner.span.record("response_plan_kind", plan_kind.as_str());
+        }
+        match metadata.outcome() {
+            ResponseObservationOutcomeV2::Written(receipt) => {
+                self.inner
+                    .span
+                    .record("response_disposition", receipt.disposition().as_str());
+            }
+            ResponseObservationOutcomeV2::Failed { kind, progress } => {
+                if rejection.is_none() {
+                    if let Some(kind) = kind {
+                        self.inner.span.record("error_kind", kind.as_str());
+                    }
+                }
+                if let Some(progress) = progress {
+                    self.inner.span.record("write_progress", progress.as_str());
+                }
+            }
+            ResponseObservationOutcomeV2::Cancelled(reason) => {
+                self.inner.span.record("error_kind", reason.as_str());
+                self.inner
+                    .span
+                    .record("write_progress", WriteProgress::NotStarted.as_str());
+            }
+            ResponseObservationOutcomeV2::Oneway | ResponseObservationOutcomeV2::ProtocolNoResponse => {}
+        }
+        if let Some(reason) = rejection {
+            self.inner.span.record("error_kind", reason.as_str());
+            self.inner.telemetry.record_v2_boundary_rejection(reason, metadata);
+        }
+        let observation = ResponseObservationV2::new(metadata, write_elapsed, self.inner.started.elapsed());
+        let delivery = {
+            let mut callback = self.inner.callback.lock();
+            take_or_defer_response_observation(&mut callback, observation)
+        };
+        if let Some((callback, observation)) = delivery {
+            self.inner.span.in_scope(|| callback(observation));
+        }
+    }
+}
+
+fn take_or_defer_response_observation(
+    state: &mut V2ResponseObservationCallbackState,
+    observation: ResponseObservationV2,
+) -> Option<(V2ResponseObservationCallback, ResponseObservationV2)> {
+    if state.delivered {
+        return None;
+    }
+    let Some(callback) = state.callback.take() else {
+        state.pending = Some(observation);
+        return None;
+    };
+    state.delivered = true;
+    Some((callback, observation))
+}
+
+fn complete_v2_request_metrics(metrics: &mut TransportRequestMetricsGuard, metadata: ResponseMetadataV2) {
+    match metadata.outcome() {
+        ResponseObservationOutcomeV2::Written(_) if metadata.mode() == ResponseObservationModeV2::Deferred => {
+            metrics.complete_deferred_resumed(metadata.response_code().unwrap_or(-1));
+        }
+        ResponseObservationOutcomeV2::Written(_) => {
+            if let (Some(response_code), Some(body_kind)) = (metadata.response_code(), metadata.plan_kind()) {
+                metrics.complete_v2_reply(response_code, body_kind);
+            } else {
+                metrics.complete_process_request_failed(metadata.response_code().unwrap_or(-1));
+            }
+        }
+        ResponseObservationOutcomeV2::Oneway => metrics.complete_oneway(),
+        ResponseObservationOutcomeV2::ProtocolNoResponse => {
+            metrics.complete_protocol_no_response();
+        }
+        ResponseObservationOutcomeV2::Cancelled(_) => metrics.complete_cancelled(),
+        ResponseObservationOutcomeV2::Failed { .. } => {
+            metrics.complete_process_request_failed(metadata.response_code().unwrap_or(-1));
+        }
+    }
+}
+
+fn retained_bytes_delta(retained_bytes: usize) -> i64 {
+    retained_bytes.min(i64::MAX as usize) as i64
+}
+
+const fn observation_outcome_label(outcome: ResponseObservationOutcomeV2) -> &'static str {
+    match outcome {
+        ResponseObservationOutcomeV2::Written(_) => "written",
+        ResponseObservationOutcomeV2::Oneway => "oneway",
+        ResponseObservationOutcomeV2::ProtocolNoResponse => "protocol_no_response",
+        ResponseObservationOutcomeV2::Cancelled(_) => "cancelled",
+        ResponseObservationOutcomeV2::Failed { .. } => "failed",
+    }
+}
+
+#[cfg(test)]
+const fn response_mode_label(mode: ResponseObservationModeV2) -> &'static str {
+    match mode {
+        ResponseObservationModeV2::Inline => "inline",
+        ResponseObservationModeV2::Deferred => "deferred",
+        ResponseObservationModeV2::NoResponse => "no_response",
+    }
+}
+
+#[cfg(test)]
+const fn response_result_label(outcome: ResponseObservationOutcomeV2) -> &'static str {
+    match outcome {
+        ResponseObservationOutcomeV2::Written(receipt) => match receipt.disposition() {
+            ResponseDisposition::TransportWritten => "transport_written",
+            ResponseDisposition::InProcessAccepted => "in_process_accepted",
+        },
+        ResponseObservationOutcomeV2::Oneway => "oneway",
+        ResponseObservationOutcomeV2::ProtocolNoResponse => "protocol_no_response",
+        ResponseObservationOutcomeV2::Cancelled(_) => "cancelled",
+        ResponseObservationOutcomeV2::Failed { .. } => "failed",
+    }
 }
 
 #[cfg(test)]
@@ -31,6 +631,47 @@ type LifecycleEventCapture = std::sync::Arc<parking_lot::Mutex<Vec<(&'static str
 type DeferredTerminalCapture = std::sync::Arc<parking_lot::Mutex<Vec<(&'static str, &'static str)>>>;
 #[cfg(test)]
 type DeferredStateConstructionCapture = std::sync::Arc<std::sync::atomic::AtomicUsize>;
+#[cfg(test)]
+type DeferredMetricAdjustmentCapture = std::sync::Arc<parking_lot::Mutex<Vec<(i64, i64)>>>;
+#[cfg(test)]
+type DeferredRegistrationCapture = std::sync::Arc<std::sync::atomic::AtomicUsize>;
+#[cfg(test)]
+type V2BoundaryRejectionCapture = (&'static str, &'static str, &'static str, &'static str, &'static str);
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct V2BoundaryMetricCapture {
+    spans: std::sync::atomic::AtomicUsize,
+    requests: std::sync::atomic::AtomicUsize,
+    request_durations: std::sync::atomic::AtomicUsize,
+    responses: std::sync::atomic::AtomicUsize,
+    response_queue_waits: std::sync::atomic::AtomicUsize,
+    response_events: parking_lot::Mutex<Vec<(&'static str, &'static str)>>,
+    rejections: parking_lot::Mutex<Vec<V2BoundaryRejectionCapture>>,
+}
+
+#[cfg(test)]
+impl V2BoundaryMetricCapture {
+    pub(crate) fn snapshot(&self) -> (usize, usize, usize, usize) {
+        (
+            self.spans.load(std::sync::atomic::Ordering::SeqCst),
+            self.requests.load(std::sync::atomic::Ordering::SeqCst),
+            self.request_durations.load(std::sync::atomic::Ordering::SeqCst),
+            self.responses.load(std::sync::atomic::Ordering::SeqCst),
+        )
+    }
+
+    pub(crate) fn rejections(&self) -> Vec<V2BoundaryRejectionCapture> {
+        self.rejections.lock().clone()
+    }
+
+    pub(crate) fn response_queue_waits(&self) -> usize {
+        self.response_queue_waits.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    pub(crate) fn response_events(&self) -> Vec<(&'static str, &'static str)> {
+        self.response_events.lock().clone()
+    }
+}
 
 /// Cloneable metrics and tracing capability for one transport composition.
 ///
@@ -51,6 +692,12 @@ pub struct TransportTelemetry {
     deferred_terminals: Option<DeferredTerminalCapture>,
     #[cfg(test)]
     deferred_state_constructions: Option<DeferredStateConstructionCapture>,
+    #[cfg(test)]
+    deferred_metric_adjustments: Option<DeferredMetricAdjustmentCapture>,
+    #[cfg(test)]
+    deferred_registrations: Option<DeferredRegistrationCapture>,
+    #[cfg(test)]
+    v2_boundary_metrics: Option<std::sync::Arc<V2BoundaryMetricCapture>>,
 }
 
 impl TransportTelemetry {
@@ -78,6 +725,12 @@ impl TransportTelemetry {
             deferred_terminals: None,
             #[cfg(test)]
             deferred_state_constructions: None,
+            #[cfg(test)]
+            deferred_metric_adjustments: None,
+            #[cfg(test)]
+            deferred_registrations: None,
+            #[cfg(test)]
+            v2_boundary_metrics: None,
         }
     }
 
@@ -95,6 +748,9 @@ impl TransportTelemetry {
             lifecycle_events: None,
             deferred_terminals: None,
             deferred_state_constructions: None,
+            deferred_metric_adjustments: None,
+            deferred_registrations: None,
+            v2_boundary_metrics: None,
         };
         (telemetry, capture)
     }
@@ -113,6 +769,9 @@ impl TransportTelemetry {
             lifecycle_events: Some(std::sync::Arc::clone(&capture)),
             deferred_terminals: None,
             deferred_state_constructions: None,
+            deferred_metric_adjustments: None,
+            deferred_registrations: None,
+            v2_boundary_metrics: None,
         };
         (telemetry, capture)
     }
@@ -131,6 +790,9 @@ impl TransportTelemetry {
             lifecycle_events: None,
             deferred_terminals: Some(std::sync::Arc::clone(&capture)),
             deferred_state_constructions: None,
+            deferred_metric_adjustments: None,
+            deferred_registrations: None,
+            v2_boundary_metrics: None,
         };
         (telemetry, capture)
     }
@@ -149,6 +811,53 @@ impl TransportTelemetry {
             lifecycle_events: None,
             deferred_terminals: None,
             deferred_state_constructions: Some(std::sync::Arc::clone(&capture)),
+            deferred_metric_adjustments: None,
+            deferred_registrations: None,
+            v2_boundary_metrics: None,
+        };
+        (telemetry, capture)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_v2_deferred_metric_capture(
+    ) -> (Self, DeferredMetricAdjustmentCapture, DeferredRegistrationCapture) {
+        let adjustments = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let registrations = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let telemetry = Self {
+            #[cfg(feature = "observability")]
+            remoting: Default::default(),
+            #[cfg(feature = "observability")]
+            client: Default::default(),
+            #[cfg(any(feature = "observability", feature = "observability-traces"))]
+            handle: None,
+            legacy_processor_requests: None,
+            lifecycle_events: None,
+            deferred_terminals: None,
+            deferred_state_constructions: None,
+            deferred_metric_adjustments: Some(std::sync::Arc::clone(&adjustments)),
+            deferred_registrations: Some(std::sync::Arc::clone(&registrations)),
+            v2_boundary_metrics: None,
+        };
+        (telemetry, adjustments, registrations)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_v2_boundary_metric_capture() -> (Self, std::sync::Arc<V2BoundaryMetricCapture>) {
+        let capture = std::sync::Arc::new(V2BoundaryMetricCapture::default());
+        let telemetry = Self {
+            #[cfg(feature = "observability")]
+            remoting: Default::default(),
+            #[cfg(feature = "observability")]
+            client: Default::default(),
+            #[cfg(any(feature = "observability", feature = "observability-traces"))]
+            handle: None,
+            legacy_processor_requests: None,
+            lifecycle_events: None,
+            deferred_terminals: None,
+            deferred_state_constructions: None,
+            deferred_metric_adjustments: None,
+            deferred_registrations: None,
+            v2_boundary_metrics: Some(std::sync::Arc::clone(&capture)),
         };
         (telemetry, capture)
     }
@@ -174,6 +883,180 @@ impl TransportTelemetry {
 
         let _ = identity;
         tracing::Span::none()
+    }
+
+    pub(crate) fn begin_v2_observation(
+        &self,
+        original: OriginalRequestIdentity,
+        started: Instant,
+        origin: &RequestOrigin,
+        authentication: &AuthenticationState,
+        deadline: Option<crate::deadline::RequestDeadline>,
+        request_bytes: u64,
+    ) -> V2RequestObservation {
+        V2RequestObservation::new(
+            self.clone(),
+            original,
+            started,
+            origin,
+            authentication,
+            deadline,
+            request_bytes,
+        )
+    }
+
+    fn v2_request_span(
+        &self,
+        original: OriginalRequestIdentity,
+        code_class: TransportRequestCodeClass,
+        origin: &RequestOrigin,
+        authentication: &AuthenticationState,
+        deadline: Option<crate::deadline::RequestDeadline>,
+    ) -> tracing::Span {
+        #[cfg(any(feature = "observability", feature = "observability-traces"))]
+        if self
+            .handle
+            .as_ref()
+            .is_some_and(|handle| handle.is_active() && handle.trace_policy().enabled)
+        {
+            return v2_request_span(original, code_class, origin, authentication, deadline);
+        }
+
+        let _ = (original, code_class, origin, authentication, deadline);
+        tracing::Span::none()
+    }
+
+    pub(crate) fn record_response_queue_wait(&self, duration: Duration) {
+        #[cfg(test)]
+        if let Some(capture) = &self.v2_boundary_metrics {
+            capture
+                .response_queue_waits
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        #[cfg(feature = "observability")]
+        self.remoting.record_response_queue_wait(duration.as_secs_f64());
+
+        #[cfg(not(feature = "observability"))]
+        let _ = duration;
+    }
+
+    fn adjust_v2_deferred(&self, code: TransportRequestCodeClass, inflight_delta: i64, retained_bytes_delta: i64) {
+        #[cfg(test)]
+        if let Some(capture) = &self.deferred_metric_adjustments {
+            capture.lock().push((inflight_delta, retained_bytes_delta));
+        }
+
+        #[cfg(feature = "observability")]
+        self.remoting
+            .adjust_deferred(observable_code_class(code), inflight_delta, retained_bytes_delta);
+
+        #[cfg(not(feature = "observability"))]
+        let _ = (code, inflight_delta, retained_bytes_delta);
+    }
+
+    #[inline]
+    fn record_v2_deferred_registration(&self) {
+        #[cfg(test)]
+        if let Some(capture) = &self.deferred_registrations {
+            capture.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[inline]
+    fn record_v2_span_started(&self) {
+        #[cfg(test)]
+        if let Some(capture) = &self.v2_boundary_metrics {
+            capture.spans.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[inline]
+    fn record_v2_request_lifecycle(&self) {
+        #[cfg(test)]
+        if let Some(capture) = &self.v2_boundary_metrics {
+            capture.requests.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            capture
+                .request_durations
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    fn record_v2_response_duplicate(&self, code: TransportRequestCodeClass) {
+        #[cfg(feature = "observability")]
+        self.remoting.record_response_duplicate(observable_code_class(code));
+
+        #[cfg(not(feature = "observability"))]
+        let _ = code;
+    }
+
+    pub(crate) fn record_v2_response(&self, metadata: ResponseMetadataV2) {
+        #[cfg(test)]
+        if let Some(capture) = &self.v2_boundary_metrics {
+            capture.responses.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            capture.response_events.lock().push((
+                response_mode_label(metadata.mode()),
+                response_result_label(metadata.outcome()),
+            ));
+        }
+
+        #[cfg(feature = "observability")]
+        {
+            use rocketmq_observability::metrics::remoting::ResponseAbandonedReason;
+            use rocketmq_observability::metrics::remoting::ResponseMode;
+            use rocketmq_observability::metrics::remoting::ResponseResult;
+
+            let mode = match metadata.mode() {
+                ResponseObservationModeV2::Inline => ResponseMode::Inline,
+                ResponseObservationModeV2::Deferred => ResponseMode::Deferred,
+                ResponseObservationModeV2::NoResponse => ResponseMode::NoResponse,
+            };
+            let result = match metadata.outcome() {
+                ResponseObservationOutcomeV2::Written(receipt) => match receipt.disposition() {
+                    ResponseDisposition::TransportWritten => ResponseResult::TransportWritten,
+                    ResponseDisposition::InProcessAccepted => ResponseResult::InProcessAccepted,
+                },
+                ResponseObservationOutcomeV2::Oneway => ResponseResult::Oneway,
+                ResponseObservationOutcomeV2::ProtocolNoResponse => ResponseResult::ProtocolNoResponse,
+                ResponseObservationOutcomeV2::Cancelled(reason) => {
+                    let reason = match reason {
+                        DeferredTerminalReason::Explicit => ResponseAbandonedReason::Explicit,
+                        DeferredTerminalReason::ReceiverDropped => ResponseAbandonedReason::ReceiverDropped,
+                        DeferredTerminalReason::Abandoned => ResponseAbandonedReason::Abandoned,
+                        DeferredTerminalReason::ClaimDropped => ResponseAbandonedReason::ClaimDropped,
+                        DeferredTerminalReason::OwnerDeadline => ResponseAbandonedReason::OwnerDeadline,
+                        DeferredTerminalReason::ParentCancelled => ResponseAbandonedReason::ParentCancelled,
+                        DeferredTerminalReason::ProcessorUnavailable => ResponseAbandonedReason::ProcessorUnavailable,
+                        DeferredTerminalReason::ServiceStopping => ResponseAbandonedReason::ServiceStopping,
+                        DeferredTerminalReason::SessionClosed => ResponseAbandonedReason::SessionClosed,
+                    };
+                    self.remoting.record_response_abandoned(reason);
+                    ResponseResult::Cancelled
+                }
+                ResponseObservationOutcomeV2::Failed { .. } => ResponseResult::Failed,
+            };
+            self.remoting.record_response(mode, result);
+        }
+
+        #[cfg(not(feature = "observability"))]
+        let _ = metadata;
+    }
+
+    #[inline]
+    fn record_v2_boundary_rejection(&self, reason: V2BoundaryRejectionReason, metadata: ResponseMetadataV2) {
+        #[cfg(test)]
+        if let Some(capture) = &self.v2_boundary_metrics {
+            capture.rejections.lock().push((
+                reason.as_str(),
+                "failed",
+                "rejected",
+                response_mode_label(metadata.mode()),
+                response_result_label(metadata.outcome()),
+            ));
+        }
+
+        #[cfg(not(test))]
+        let _ = (reason, metadata);
     }
 
     #[inline]
@@ -320,6 +1203,48 @@ impl TransportTelemetry {
             TransportRequestMetricsGuard {}
         }
     }
+
+    #[inline]
+    pub(crate) fn v2_request_guard(&self, request_code: i32, request_bytes: u64) -> TransportRequestMetricsGuard {
+        #[cfg(feature = "observability")]
+        {
+            let code_class = TransportRequestCodeClass::from_code(request_code);
+            TransportRequestMetricsGuard {
+                inner: rocketmq_observability::metrics::remoting::RequestMetricsGuard::start_v2(
+                    self.remoting.clone(),
+                    request_code,
+                    request_bytes,
+                    matches!(
+                        code_class,
+                        TransportRequestCodeClass::PullMessage
+                            | TransportRequestCodeClass::PopMessage
+                            | TransportRequestCodeClass::Notification
+                    ),
+                    observable_code_class(code_class),
+                ),
+            }
+        }
+
+        #[cfg(not(feature = "observability"))]
+        {
+            let _ = (request_code, request_bytes);
+            TransportRequestMetricsGuard {}
+        }
+    }
+}
+
+#[cfg(feature = "observability")]
+const fn observable_code_class(
+    code: TransportRequestCodeClass,
+) -> rocketmq_observability::metrics::remoting::RequestCodeClass {
+    use rocketmq_observability::metrics::remoting::RequestCodeClass;
+
+    match code {
+        TransportRequestCodeClass::PullMessage => RequestCodeClass::PullMessage,
+        TransportRequestCodeClass::PopMessage => RequestCodeClass::PopMessage,
+        TransportRequestCodeClass::Notification => RequestCodeClass::Notification,
+        TransportRequestCodeClass::Other => RequestCodeClass::Other,
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -369,6 +1294,58 @@ impl TransportRequestMetricsGuard {
     }
 
     #[inline]
+    pub(crate) fn complete_v2_reply(&mut self, response_code: i32, body_kind: ResponseBodyKind) {
+        #[cfg(feature = "observability")]
+        self.inner.complete_v2(
+            response_code,
+            match body_kind {
+                ResponseBodyKind::Empty => rocketmq_observability::metrics::remoting::RequestOutcome::ReplyEmpty,
+                ResponseBodyKind::Bytes => rocketmq_observability::metrics::remoting::RequestOutcome::ReplyBytes,
+                ResponseBodyKind::Segments => rocketmq_observability::metrics::remoting::RequestOutcome::ReplySegments,
+                ResponseBodyKind::FileRegions => {
+                    rocketmq_observability::metrics::remoting::RequestOutcome::ReplyFileRegions
+                }
+            },
+        );
+
+        #[cfg(not(feature = "observability"))]
+        let _ = (response_code, body_kind);
+    }
+
+    #[inline]
+    pub(crate) fn record_deferred_registered(&mut self) {
+        #[cfg(feature = "observability")]
+        self.inner.record_v2_deferred_registered();
+    }
+
+    #[inline]
+    pub(crate) fn complete_deferred_resumed(&mut self, response_code: i32) {
+        #[cfg(feature = "observability")]
+        self.inner.complete_v2(
+            response_code,
+            rocketmq_observability::metrics::remoting::RequestOutcome::DeferredResumed,
+        );
+
+        #[cfg(not(feature = "observability"))]
+        let _ = response_code;
+    }
+
+    #[inline]
+    pub(crate) fn complete_protocol_no_response(&mut self) {
+        #[cfg(feature = "observability")]
+        self.inner.complete_v2(
+            NO_RESPONSE_CODE,
+            rocketmq_observability::metrics::remoting::RequestOutcome::ProtocolNoResponse,
+        );
+    }
+
+    #[inline]
+    pub(crate) fn complete_cancelled(&mut self) {
+        #[cfg(feature = "observability")]
+        self.inner.complete_cancelled();
+    }
+
+    #[inline]
     pub(crate) fn complete_legacy_ambiguous_none(&mut self) {
         #[cfg(feature = "observability")]
         self.inner.complete_legacy_ambiguous_none();
@@ -402,6 +1379,8 @@ mod tests {
     use std::sync::Mutex;
 
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_security_api::PeerInfo;
+    use rocketmq_security_api::Principal;
     use tracing::field::Field;
     use tracing::field::Visit;
     use tracing::span::Attributes;
@@ -412,9 +1391,15 @@ mod tests {
     use tracing::Subscriber;
 
     use super::request_identity_span;
+    use super::v2_request_span;
     use super::TransportGoAwayOutcome;
     use super::TransportNameServerFailoverReason;
+    use super::TransportRequestCodeClass;
     use super::TransportTelemetry;
+    use crate::dispatch::AuthenticationState;
+    use crate::dispatch::DeferredTerminalReason;
+    use crate::dispatch::RequestOrigin;
+    use crate::runtime::processor_v2::ResponseObservationOutcomeV2;
 
     struct FieldCapture<'a> {
         fields: &'a mut BTreeMap<String, String>,
@@ -427,6 +1412,10 @@ mod tests {
 
         fn record_u64(&mut self, field: &Field, value: u64) {
             self.fields.insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields.insert(field.name().to_owned(), value.to_owned());
         }
 
         fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
@@ -449,7 +1438,10 @@ mod tests {
             Id::from_u64(1)
         }
 
-        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+        fn record(&self, _span: &Id, values: &Record<'_>) {
+            let mut fields = self.fields.lock().expect("span field capture lock");
+            values.record(&mut FieldCapture { fields: &mut fields });
+        }
 
         fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
 
@@ -492,7 +1484,7 @@ mod tests {
     }
 
     #[test]
-    fn request_span_records_only_original_low_cardinality_identity_fields() {
+    fn v1_compatibility_span_marks_generation_and_uses_only_original_identity_fields() {
         let identity = crate::dispatch::OriginalRequestIdentity::capture(
             73,
             &AtomicU64::new(41),
@@ -510,10 +1502,153 @@ mod tests {
         });
 
         let fields = fields.lock().expect("captured request span fields");
+        assert_eq!(
+            fields.get("rocketmq.request.generation").map(String::as_str),
+            Some("v1_compatibility")
+        );
         assert_eq!(fields.get("rocketmq.request.code").map(String::as_str), Some("-91764"));
         assert_eq!(fields.get("rocketmq.request.owner_id").map(String::as_str), Some("73"));
         assert_eq!(fields.get("rocketmq.request.sequence").map(String::as_str), Some("41"));
-        assert_eq!(fields.len(), 3, "request span fields: {fields:?}");
+        assert_eq!(fields.len(), 4, "request span fields: {fields:?}");
         assert!(fields.keys().all(|field| !field.contains("opaque")));
+    }
+
+    #[test]
+    fn v2_span_uses_only_trusted_classifications_and_redacted_terminal_fields() {
+        let identity = crate::dispatch::OriginalRequestIdentity::capture(
+            83,
+            &AtomicU64::new(5),
+            &RemotingCommand::create_remoting_command(-99_001).set_opaque(777),
+        )
+        .expect("test request identity");
+        let origin = RequestOrigin::Network {
+            peer: PeerInfo::new("192.168.10.4:10911".parse().expect("test address"), true),
+        };
+        let authentication = AuthenticationState::authenticated(Principal::new("must-not-appear"));
+        let fields = Arc::new(Mutex::new(BTreeMap::new()));
+        let subscriber = SpanCapture {
+            fields: Arc::clone(&fields),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = v2_request_span(
+                identity,
+                TransportRequestCodeClass::Other,
+                &origin,
+                &authentication,
+                None,
+            );
+            span.record("outcome", "failed");
+            span.record("error_kind", "transport");
+            span.record("write_progress", "not_started");
+        });
+
+        let fields = fields.lock().expect("captured V2 request span fields");
+        assert_eq!(
+            fields.get("rocketmq.request.origin_kind").map(String::as_str),
+            Some("network")
+        );
+        assert_eq!(
+            fields.get("rocketmq.request.peer_class").map(String::as_str),
+            Some("private")
+        );
+        assert_eq!(
+            fields.get("rocketmq.request.authentication_state").map(String::as_str),
+            Some("authenticated")
+        );
+        assert_eq!(fields.get("outcome").map(String::as_str), Some("failed"));
+        assert_eq!(fields.get("error_kind").map(String::as_str), Some("transport"));
+        assert!(fields.keys().all(|field| {
+            ![
+                "opaque",
+                "topic",
+                "group",
+                "client",
+                "principal",
+                "body",
+                "credential",
+                "token",
+                "config",
+            ]
+            .iter()
+            .any(|forbidden| field.contains(forbidden))
+                || field == "rocketmq.request.principal_kind"
+        }));
+        assert!(!fields
+            .values()
+            .any(|value| value.contains("must-not-appear") || value.contains("777")));
+    }
+
+    #[test]
+    fn deferred_registration_is_not_a_terminal_callback_and_completion_is_exactly_once() {
+        let identity = crate::dispatch::OriginalRequestIdentity::capture(
+            89,
+            &AtomicU64::new(7),
+            &RemotingCommand::create_remoting_command(11).set_opaque(991),
+        )
+        .expect("test request identity");
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let callback_observed = Arc::clone(&observed);
+        let observation = TransportTelemetry::noop().begin_v2_observation(
+            identity,
+            std::time::Instant::now(),
+            &RequestOrigin::Network {
+                peer: PeerInfo::new("127.0.0.1:10911".parse().expect("test address"), false),
+            },
+            &AuthenticationState::Anonymous,
+            None,
+            0,
+        );
+        observation.bind_response_observer(move |event| {
+            callback_observed.lock().expect("observation capture").push(event);
+        });
+
+        observation.arm_deferred_metrics(128);
+        observation.record_deferred_registered();
+        assert!(observed.lock().expect("observation capture").is_empty());
+
+        observation.complete_no_response(ResponseObservationOutcomeV2::ProtocolNoResponse);
+        observation.complete_cancelled(DeferredTerminalReason::Abandoned);
+        let observed = observed.lock().expect("observation capture");
+        assert_eq!(observed.len(), 1);
+        assert_eq!(
+            observed[0].metadata().outcome(),
+            ResponseObservationOutcomeV2::ProtocolNoResponse
+        );
+    }
+
+    #[test]
+    fn terminal_observation_waits_for_late_processor_binding_and_delivers_once() {
+        let identity = crate::dispatch::OriginalRequestIdentity::capture(
+            97,
+            &AtomicU64::new(3),
+            &RemotingCommand::create_remoting_command(12).set_opaque(19),
+        )
+        .expect("test request identity");
+        let observation = TransportTelemetry::noop().begin_v2_observation(
+            identity,
+            std::time::Instant::now(),
+            &RequestOrigin::Network {
+                peer: PeerInfo::new("127.0.0.1:10911".parse().expect("test address"), false),
+            },
+            &AuthenticationState::Anonymous,
+            None,
+            0,
+        );
+        observation.complete_no_response(ResponseObservationOutcomeV2::ProtocolNoResponse);
+
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let callback_observed = Arc::clone(&observed);
+        observation.bind_response_observer(move |event| {
+            callback_observed.lock().expect("observation capture").push(event);
+        });
+        observation.bind_response_observer(|_| panic!("terminal observation callback must remain exactly once"));
+
+        let observed = observed.lock().expect("observation capture");
+        assert_eq!(observed.len(), 1);
+        assert_eq!(
+            observed[0].metadata().outcome(),
+            ResponseObservationOutcomeV2::ProtocolNoResponse
+        );
     }
 }

--- a/rocketmq-transport/src/v2_session_registry.rs
+++ b/rocketmq-transport/src/v2_session_registry.rs
@@ -14,6 +14,10 @@
 
 //! Composition-owned V2 server session lifecycle control.
 
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
+#[cfg(test)]
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -228,7 +232,7 @@ impl SessionCloseError {
 /// Narrow sender for explicitly typed server pushes on one canonical V2 session.
 ///
 /// This capability cannot expose the session writer, send arbitrary commands,
-/// close the session, or recover a raw [`SessionHandle`].
+/// close the session, or recover a raw `SessionHandle`.
 #[derive(Clone)]
 pub struct ServerPushSender {
     session: SessionHandle,
@@ -254,6 +258,10 @@ impl ServerPushSender {
     ) -> Result<ServerPushReceipt, ServerPushError> {
         let session_id = self.session_id();
         let kind = command.kind();
+        let _outbound_lease = self
+            .session
+            .acquire_server_outbound("v2-server-push")
+            .map_err(|source| ServerPushError { session_id, source })?;
         let mut connection = self.session.connection();
         connection
             .send_command_with_deadline(
@@ -499,7 +507,9 @@ impl Drop for ServerRequestFailClosedGuard {
     fn drop(&mut self) {
         if self.armed {
             self.response_table.retire_owner(&self.response_owner);
-            self.session.abort();
+            if !self.session.close_requested() {
+                self.session.abort();
+            }
         }
     }
 }
@@ -546,6 +556,15 @@ impl ServerRequestSender {
     ) -> Result<ServerRequestResponse, ServerRequestError> {
         let session_id = self.session_id();
         let kind = command.kind();
+        let outbound_lease = self
+            .session
+            .acquire_server_outbound("v2-server-request")
+            .map_err(|source| ServerRequestError {
+                session_id,
+                kind,
+                stage: ServerRequestErrorStage::Register,
+                source,
+            })?;
         let deadline = RequestDeadline::after(timeout);
         let mut command = command.into_command();
         let opaque = command.opaque();
@@ -566,6 +585,7 @@ impl ServerRequestSender {
         let write_result = connection
             .send_command_with_deadline(command, deadline, "v2-server-request")
             .await;
+        drop(outbound_lease);
         if let Err(source) = write_result {
             if !write_failure_may_have_reached_socket(&source) {
                 fail_closed.complete();
@@ -619,7 +639,7 @@ impl ServerRequestSender {
 /// Narrow close authority for one canonical V2 session.
 ///
 /// This capability cannot send data, recover a writer, or expose a raw
-/// [`SessionHandle`]. Graceful close reuses the transport session's existing
+/// `SessionHandle`. Graceful close reuses the transport session's existing
 /// close owner.
 #[derive(Clone)]
 pub struct SessionCloseHandle {
@@ -633,19 +653,32 @@ impl SessionCloseHandle {
         self.session.session_view().id()
     }
 
-    /// Gracefully retires the session writer.
+    /// Requests the server-owned ordered close and waits for its full completion.
     ///
     /// # Errors
     ///
-    /// Returns [`SessionCloseError`] when the canonical writer cannot finish
-    /// retirement before its transport-owned deadline.
+    /// Returns [`SessionCloseError`] when deferred cleanup, executor drain, disconnect handling,
+    /// or the canonical writer cannot complete healthily.
     pub async fn close(&self, reason: SessionCloseReason) -> Result<(), SessionCloseError> {
         let session_id = self.session_id();
-        self.session.retire().await.map_err(|source| SessionCloseError {
-            session_id,
-            reason,
-            source,
-        })
+        self.session.request_close();
+        self.session
+            .wait_for_close_completion()
+            .await
+            .map(|_| ())
+            .map_err(|source| SessionCloseError {
+                session_id,
+                reason,
+                source,
+            })
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn completion_snapshot(&self) -> crate::server::SessionCloseCompletionSnapshot {
+        self.session
+            .close_completion_snapshot()
+            .await
+            .expect("test close coordinator must publish completion")
     }
 }
 
@@ -686,6 +719,8 @@ pub struct V2SessionRegistry {
     sessions: DashMap<SessionId, RegisteredV2Session>,
     events: broadcast::Sender<V2SessionEvent>,
     lifecycle_listener: Option<Arc<dyn V2SessionLifecycleListener>>,
+    #[cfg(test)]
+    panic_next_cleanup: AtomicBool,
 }
 
 impl V2SessionRegistry {
@@ -697,6 +732,8 @@ impl V2SessionRegistry {
             sessions: DashMap::new(),
             events,
             lifecycle_listener: None,
+            #[cfg(test)]
+            panic_next_cleanup: AtomicBool::new(false),
         }
     }
 
@@ -730,6 +767,16 @@ impl V2SessionRegistry {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.sessions.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn panic_next_cleanup_for_test(&self) {
+        self.panic_next_cleanup.store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_cleanup_panic_for_test(&self) -> bool {
+        self.panic_next_cleanup.swap(false, Ordering::AcqRel)
     }
 
     /// Resolves the independent push and close capabilities for `id`.
@@ -768,16 +815,15 @@ impl V2SessionRegistry {
 
     /// Closes the session identified by `id` when it is still registered.
     ///
-    /// Returns `false` when the session is already absent. A retirement error
-    /// falls back to aborting the same canonical session before returning
-    /// `true`, so the caller never receives raw transport authority.
+    /// Returns `false` when the session is already absent. The close
+    /// coordinator publishes an unhealthy typed completion and aborts the
+    /// canonical session if ordered finalization cannot finish.
     pub async fn close(&self, id: SessionId) -> bool {
         let Some(session) = self.sessions.get(&id).map(|entry| entry.value().handle.clone()) else {
             return false;
         };
-        if session.retire().await.is_err() {
-            session.abort();
-        }
+        let close = SessionCloseHandle { session };
+        let _ = close.close(SessionCloseReason::Administrative).await;
         true
     }
 
@@ -799,7 +845,7 @@ impl V2SessionRegistry {
         session: &SessionHandle,
         response_table: PendingRequestTable,
         response_owner: PendingRequestOwner,
-    ) {
+    ) -> bool {
         let view = session.session_view();
         let id = view.id();
         self.sessions.insert(
@@ -813,7 +859,16 @@ impl V2SessionRegistry {
                 },
             },
         );
-        self.publish_connected(&view);
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.publish_connected(&view))).is_err() {
+            self.sessions
+                .remove_if(&id, |_, registered| registered.handle.is_same_session(session));
+            tracing::warn!(
+                session_id = ?id,
+                "V2 session connected listener panicked; rolled back exact registration"
+            );
+            return false;
+        }
+        true
     }
 
     fn publish_connected(&self, view: &SessionView) {

--- a/rocketmq-transport/src/write_strategy.rs
+++ b/rocketmq-transport/src/write_strategy.rs
@@ -165,6 +165,13 @@ pub(crate) struct QueuedWrite {
     pub(crate) target: String,
     pub(crate) progress: Arc<QueuedWriteProgress>,
     pub(crate) enqueued_at: Option<Instant>,
+    pub(crate) response_queue_wait_observation: ResponseQueueWaitObservation,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResponseQueueWaitObservation {
+    Ineligible,
+    Response,
 }
 
 impl QueuedWrite {
@@ -185,7 +192,13 @@ impl QueuedWrite {
             target,
             progress,
             enqueued_at: Some(enqueued_at),
+            response_queue_wait_observation: ResponseQueueWaitObservation::Ineligible,
         }
+    }
+
+    pub(crate) fn with_response_queue_wait_observation(mut self, observation: ResponseQueueWaitObservation) -> Self {
+        self.response_queue_wait_observation = observation;
+        self
     }
 
     pub(crate) fn encoded_len(&self) -> usize {

--- a/rocketmq-transport/src/writer_runtime.rs
+++ b/rocketmq-transport/src/writer_runtime.rs
@@ -35,6 +35,7 @@ use crate::write_result::WriterFailure;
 use crate::write_strategy::OutboundPayload;
 use crate::write_strategy::QueuedWrite;
 use crate::write_strategy::QueuedWriteCancellation;
+use crate::write_strategy::ResponseQueueWaitObservation;
 use crate::write_strategy::WriterOperation;
 
 /// Hard bounds for one writer micro-batch.
@@ -606,6 +607,7 @@ async fn write_batch(
             progress: &write.progress,
             enqueued_at: write.enqueued_at,
             encoded_len: write.encoded_len(),
+            response_queue_wait_observation: write.response_queue_wait_observation,
         })
         .collect::<Vec<_>>();
     let mut started_at = vec![None; ready.len()];
@@ -618,6 +620,11 @@ async fn write_batch(
             write_started = true;
             for (start, started_at) in start_data.iter().zip(started_at.iter_mut()) {
                 start.progress.start_write();
+                if let (ResponseQueueWaitObservation::Response, Some(enqueued_at)) =
+                    (start.response_queue_wait_observation, start.enqueued_at)
+                {
+                    telemetry.record_response_queue_wait(Instant::now().saturating_duration_since(enqueued_at));
+                }
                 *started_at = Some(diagnostics.start_write(start.enqueued_at, start.encoded_len));
             }
         };
@@ -687,6 +694,7 @@ struct ActiveWriteStart<'a> {
     progress: &'a crate::write_strategy::QueuedWriteProgress,
     enqueued_at: Option<Instant>,
     encoded_len: usize,
+    response_queue_wait_observation: ResponseQueueWaitObservation,
 }
 
 #[cfg(test)]

--- a/rocketmq-transport/src/writer_runtime/issue_9754_tests.rs
+++ b/rocketmq-transport/src/writer_runtime/issue_9754_tests.rs
@@ -60,6 +60,7 @@ use crate::write_result::WriterFailure;
 use crate::write_strategy::OutboundPayload;
 use crate::write_strategy::QueuedWrite;
 use crate::write_strategy::QueuedWriteProgress;
+use crate::write_strategy::ResponseQueueWaitObservation;
 
 struct DropLease {
     file: std::fs::File,
@@ -500,6 +501,68 @@ async fn successful_file_write_releases_its_lease_once_after_completion() {
     );
     assert_eq!(drops.load(Ordering::SeqCst), 1);
     assert_eq!(controller.snapshot().queued.current_count, 0);
+}
+
+#[tokio::test]
+async fn response_queue_wait_metric_excludes_non_response_writes() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let connection = Connection::new_with_plaintext_stream(SuccessfulTransport {
+        attempts: Arc::clone(&attempts),
+    });
+    let (frame_writer, _reader) = connection.into_session_io(admission.clone());
+    let mut config = queue_config();
+    config.batch.max_items = NonZeroUsize::new(2).expect("non-zero");
+    let (lanes, receivers) = writer_lanes(config);
+    let (generic, generic_completion) = queued_write_with_completion(
+        &admission,
+        "generic-request-write",
+        16,
+        Arc::new(QueuedWriteProgress::waiting()),
+    );
+    let (response, response_completion) = queued_write_with_completion(
+        &admission,
+        "response-write",
+        16,
+        Arc::new(QueuedWriteProgress::waiting()),
+    );
+    lanes
+        .try_send(AdmissionClass::Data, generic)
+        .expect("generic write queued");
+    lanes
+        .try_send(
+            AdmissionClass::Data,
+            response.with_response_queue_wait_observation(ResponseQueueWaitObservation::Response),
+        )
+        .expect("response write queued");
+    drop(lanes);
+    let diagnostics = Arc::new(SessionWriterDiagnostics::new(config.total_capacity()));
+    let (state, _) = watch::channel(ConnectionState::Healthy);
+    let (telemetry, capture) = TransportTelemetry::with_v2_boundary_metric_capture();
+
+    run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state,
+        CancellationToken::new(),
+        telemetry,
+    )
+    .await;
+
+    generic_completion
+        .await
+        .expect("generic completion")
+        .expect("generic write succeeds");
+    response_completion
+        .await
+        .expect("response completion")
+        .expect("response write succeeds");
+    assert_eq!(capture.response_queue_waits(), 1);
+    assert!(attempts.load(Ordering::Acquire) >= 1);
 }
 
 #[tokio::test]

--- a/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
+++ b/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #![cfg(feature = "test-support")]
+#![allow(
+    deprecated,
+    reason = "this conformance test intentionally compares the deprecated V1 dispatcher with V2"
+)]
 
 use std::future;
 use std::net::IpAddr;

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -986,6 +986,22 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
         },
         PublicUse {
             module_path: String::new(),
+            use_tree: "crate::runtime::processor_v2::ResponseMetadataV2".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::runtime::processor_v2::ResponseObservationModeV2".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::runtime::processor_v2::ResponseObservationOutcomeV2".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::runtime::processor_v2::ResponseObservationV2".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
             use_tree: "crate::runtime::processor_v2::ResponseWriteObservationV2".to_owned(),
         },
         PublicUse {

--- a/rocketmq-transport/tests/public_api_v1.rs
+++ b/rocketmq-transport/tests/public_api_v1.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(
+    deprecated,
+    reason = "this integration test intentionally freezes the deprecated V1 public compatibility surface"
+)]
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -127,6 +132,10 @@ fn assert_v1_request_context_method_signatures(context: &RequestContext) {
     let _ = context;
 }
 
+#[allow(
+    deprecated,
+    reason = "the V1 public API contract intentionally freezes deprecated compatibility signatures"
+)]
 fn assert_v1_response_context_method_signatures(context: &ConnectionHandlerContext) {
     let command = rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(1);
     let write = context.try_write_response(command);

--- a/rocketmq-transport/tests/v1_processor_contract_tests.rs
+++ b/rocketmq-transport/tests/v1_processor_contract_tests.rs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #![cfg(feature = "test-support")]
+#![allow(
+    deprecated,
+    reason = "this integration test intentionally freezes deprecated V1 processor behavior"
+)]
 
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/scripts/generate_metric_catalog.py
+++ b/scripts/generate_metric_catalog.py
@@ -30,7 +30,7 @@ SCHEMA_DIR = ROOT / "rocketmq-observability" / "src" / "metrics" / "catalog" / "
 GENERATED_PATH = ROOT / "rocketmq-observability" / "src" / "metrics" / "catalog" / "generated.rs"
 SEMANTIC_PATH = ROOT / "rocketmq-observability" / "src" / "semantic.rs"
 SCHEMA_VERSION = 1
-PARTITIONS = (("java", 0, 94), ("rust", 94, 122))
+PARTITIONS = (("java", 0, 94), ("rust", 94, 129))
 KIND_NAMES = {"Counter", "Gauge", "Histogram", "ObservableGauge", "UpDownCounter"}
 SOURCE_NAMES = {
     "Broker",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9865

### Brief Description

Complete the remoting V2 security, observability, and lifecycle contracts across transport, broker maintenance handling, runtime shutdown reporting, and the observability metric catalog.

- Authenticate network maintenance requests from the canonical V2 request origin and keep embedded broker proxy identity explicit.
- Add body-free response observation contracts, bounded remoting metrics, and exactly-once coverage for direct, queued, legacy, and deferred response paths.
- Make connection retirement server-owned and ordered, expose narrow push/request/close capabilities, isolate listener panics, and report incomplete shutdown cleanup as typed failures.
- Update the V2 public API contract, migration ledger, metric catalog, and focused security/lifecycle regression coverage.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -p rocketmq-runtime -p rocketmq-broker -- --check` - passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed.
- `cargo clippy -p rocketmq-transport -p rocketmq-runtime -p rocketmq-broker --all-targets --all-features -- -D warnings` - passed.
- `cargo test -p rocketmq-transport` - passed, including 671 library tests, integration tests, and 95 doc tests.
- Repeated the ordered deferred owner-cutoff regression 100 times - passed 100/100.
- `cargo test -p rocketmq-transport --lib --features observability` - passed, 671/671.
- Broker maintenance V2 authentication and embedded identity focused tests - passed, 5/5.
- RocketMQ observability Clippy and unit-test matrix for default, metrics, Prometheus, traces, logs, and combined features - passed; the package-level architecture guard reports the same pre-existing subscriber site on this branch and `main`.
- `python scripts/generate_metric_catalog.py --check` - passed.
- `cargo doc -p rocketmq-transport --no-deps` - passed with one pre-existing private-link warning in `tls.rs`.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` - passed.
- `.\scripts\check-error-hygiene.ps1` - reports the same pre-existing findings as `main`; this change adds no finding.
- `git diff --check` - passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed transport metrics for request outcomes, response handling, deferred requests, queue wait times, duplicates, and abandoned responses.
  * Added V2 response observation data for monitoring request and response lifecycles.
  * Improved shutdown reporting with task, waiter, writer, and cleanup health details.

* **Bug Fixes**
  * Strengthened maintenance-request authorization and rejected forged or unsupported requests.
  * Improved session-close handling, including timeout detection, cleanup failures, and listener panics.

* **Documentation**
  * Added V1-to-V2 migration guidance and marked legacy transport APIs as deprecated, with recommended replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->