### PR TITLE
[ISSUE #9875]♻️Consolidate protocol admin tests around production behavior

### DIFF
--- a/rocketmq-protocol/src/protocol/admin/consume_stats.rs
+++ b/rocketmq-protocol/src/protocol/admin/consume_stats.rs
@@ -346,52 +346,25 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_total_diff() {
+    fn methods_compute_consumer_lag() {
         let mut stats = ConsumeStats::new();
-        let mut map = HashMap::new();
-
-        // queue 1
-        map.insert(create_mq("topic_a", 0), create_offset_wrapper(500, 400, 450));
-        // queue 2
-        map.insert(create_mq("topic_a", 1), create_offset_wrapper(200, 150, 180));
-
-        stats.set_offset_table(map);
-
-        assert_eq!(stats.compute_total_diff(), 150);
-    }
-
-    #[test]
-    fn test_compute_inflight_total_diff() {
-        let mut stats = ConsumeStats::new();
-        let mut map = HashMap::new();
-        map.insert(create_mq("topic_b", 0), create_offset_wrapper(500, 400, 450));
-        map.insert(create_mq("topic_b", 1), create_offset_wrapper(200, 150, 180));
-
-        stats.set_offset_table(map);
-
-        assert_eq!(stats.compute_inflight_total_diff(), 80);
-    }
-
-    #[test]
-    fn test_getters_and_setters() {
-        let mut stats = ConsumeStats::new();
-        stats.set_consume_tps(5.67);
-
-        assert_eq!(stats.get_consume_tps(), 5.67);
+        assert_eq!(stats.get_consume_tps(), 0.0);
         assert!(stats.get_offset_table().is_empty());
-
-        stats
-            .get_offset_table_mut()
-            .insert(create_mq("test", 0), OffsetWrapper::new());
-        assert_eq!(stats.get_offset_table().len(), 1);
-    }
-
-    #[test]
-    fn test_empty_stats_diff() {
-        let stats = ConsumeStats::new();
-
         assert_eq!(stats.compute_total_diff(), 0);
         assert_eq!(stats.compute_inflight_total_diff(), 0);
+
+        stats.set_consume_tps(5.67);
+        let mut map = HashMap::new();
+        map.insert(create_mq("topic_a", 0), create_offset_wrapper(500, 400, 450));
+        stats.set_offset_table(map);
+        stats
+            .get_offset_table_mut()
+            .insert(create_mq("topic_a", 1), create_offset_wrapper(200, 150, 180));
+
+        assert_eq!(stats.get_consume_tps(), 5.67);
+        assert_eq!(stats.get_offset_table().len(), 2);
+        assert_eq!(stats.compute_total_diff(), 150);
+        assert_eq!(stats.compute_inflight_total_diff(), 80);
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/admin/offset_wrapper.rs
+++ b/rocketmq-protocol/src/protocol/admin/offset_wrapper.rs
@@ -72,37 +72,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_offset_wrapper_default_and_new() {
-        let wrapper = OffsetWrapper::default();
-        assert_eq!(wrapper.get_broker_offset(), 0);
-        assert_eq!(wrapper.get_consumer_offset(), 0);
-        assert_eq!(wrapper.get_pull_offset(), 0);
-        assert_eq!(wrapper.get_last_timestamp(), 0);
-
-        let wrapper = OffsetWrapper::new();
-        assert_eq!(wrapper.get_broker_offset(), 0);
-        assert_eq!(wrapper.get_consumer_offset(), 0);
-        assert_eq!(wrapper.get_pull_offset(), 0);
-        assert_eq!(wrapper.get_last_timestamp(), 0);
-    }
-
-    #[test]
-    fn test_offset_wrapper_setters_and_getters() {
+    fn methods_and_serde_preserve_offsets() {
         let mut wrapper = OffsetWrapper::new();
-        wrapper.set_broker_offset(100);
-        wrapper.set_consumer_offset(200);
-        wrapper.set_pull_offset(300);
-        wrapper.set_last_timestamp(400);
-
-        assert_eq!(wrapper.get_broker_offset(), 100);
-        assert_eq!(wrapper.get_consumer_offset(), 200);
-        assert_eq!(wrapper.get_pull_offset(), 300);
-        assert_eq!(wrapper.get_last_timestamp(), 400);
-    }
-
-    #[test]
-    fn test_offset_wrapper_serialization_and_deserialization() {
-        let mut wrapper = OffsetWrapper::new();
+        assert_eq!(
+            (
+                wrapper.get_broker_offset(),
+                wrapper.get_consumer_offset(),
+                wrapper.get_pull_offset(),
+                wrapper.get_last_timestamp(),
+            ),
+            (0, 0, 0, 0)
+        );
         wrapper.set_broker_offset(-100);
         wrapper.set_consumer_offset(-200);
         wrapper.set_pull_offset(-300);
@@ -113,9 +93,14 @@ mod tests {
         assert_eq!(serialized, expected);
 
         let deserialized: OffsetWrapper = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized.get_broker_offset(), -100);
-        assert_eq!(deserialized.get_consumer_offset(), -200);
-        assert_eq!(deserialized.get_pull_offset(), -300);
-        assert_eq!(deserialized.get_last_timestamp(), -400);
+        assert_eq!(
+            (
+                deserialized.get_broker_offset(),
+                deserialized.get_consumer_offset(),
+                deserialized.get_pull_offset(),
+                deserialized.get_last_timestamp(),
+            ),
+            (-100, -200, -300, -400)
+        );
     }
 }

--- a/rocketmq-protocol/src/protocol/admin/rollback_stats.rs
+++ b/rocketmq-protocol/src/protocol/admin/rollback_stats.rs
@@ -52,18 +52,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn rollback_stats_default_values() {
-        let stats: RollbackStats = Default::default();
-        assert_eq!(stats.broker_name, CheetahString::from(""));
-        assert_eq!(stats.queue_id, 0);
-        assert_eq!(stats.broker_offset, 0);
-        assert_eq!(stats.consumer_offset, 0);
-        assert_eq!(stats.timestamp_offset, 0);
-        assert_eq!(stats.rollback_offset, 0);
-    }
-
-    #[test]
-    fn rollback_stats_serialization() {
+    fn serde_and_display_preserve_rollback_stats() {
         let stats = RollbackStats {
             broker_name: CheetahString::from("broker1"),
             queue_id: 1,
@@ -77,33 +66,21 @@ mod tests {
             serialized,
             r#"{"brokerName":"broker1","queueId":1,"brokerOffset":100,"consumerOffset":200,"timestampOffset":300,"rollbackOffset":400}"#
         );
-    }
 
-    #[test]
-    fn rollback_stats_deserialization() {
-        let json = r#"{"brokerName":"broker1","queueId":1,"brokerOffset":100,"consumerOffset":200,"timestampOffset":300,"rollbackOffset":400}"#;
-        let deserialized: RollbackStats = serde_json::from_str(json).unwrap();
-        assert_eq!(deserialized.broker_name, CheetahString::from("broker1"));
-        assert_eq!(deserialized.queue_id, 1);
-        assert_eq!(deserialized.broker_offset, 100);
-        assert_eq!(deserialized.consumer_offset, 200);
-        assert_eq!(deserialized.timestamp_offset, 300);
-        assert_eq!(deserialized.rollback_offset, 400);
-    }
-
-    #[test]
-    fn rollback_stats_display_format() {
-        let stats = RollbackStats {
-            broker_name: CheetahString::from("broker1"),
-            queue_id: 1,
-            broker_offset: 100,
-            consumer_offset: 200,
-            timestamp_offset: 300,
-            rollback_offset: 400,
-        };
-        let display = format!("{}", stats);
+        let deserialized: RollbackStats = serde_json::from_str(&serialized).unwrap();
         assert_eq!(
-            display,
+            (
+                deserialized.broker_name.as_str(),
+                deserialized.queue_id,
+                deserialized.broker_offset,
+                deserialized.consumer_offset,
+                deserialized.timestamp_offset,
+                deserialized.rollback_offset,
+            ),
+            ("broker1", 1, 100, 200, 300, 400)
+        );
+        assert_eq!(
+            deserialized.to_string(),
             "RollbackStats [brokerName=broker1, queueId=1, brokerOffset=100, consumerOffset=200, timestampOffset=300, \
              rollbackOffset=400]"
         );

--- a/rocketmq-protocol/src/protocol/admin/topic_offset.rs
+++ b/rocketmq-protocol/src/protocol/admin/topic_offset.rs
@@ -72,33 +72,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_topic_offset_default_and_new() {
-        let offset = TopicOffset::default();
-        assert_eq!(offset.get_min_offset(), 0);
-        assert_eq!(offset.get_max_offset(), 0);
-        assert_eq!(offset.get_last_update_timestamp(), 0);
-
-        let offset = TopicOffset::new();
-        assert_eq!(offset.get_min_offset(), 0);
-        assert_eq!(offset.get_max_offset(), 0);
-        assert_eq!(offset.get_last_update_timestamp(), 0);
-    }
-
-    #[test]
-    fn test_topic_offset_setters_and_getters() {
+    fn methods_serde_and_display_preserve_the_offset() {
         let mut offset = TopicOffset::new();
-        offset.set_min_offset(10);
-        offset.set_max_offset(20);
-        offset.set_last_update_timestamp(1000);
-
-        assert_eq!(offset.get_min_offset(), 10);
-        assert_eq!(offset.get_max_offset(), 20);
-        assert_eq!(offset.get_last_update_timestamp(), 1000);
-    }
-
-    #[test]
-    fn test_topic_offset_serialization_and_deserialization() {
-        let mut offset = TopicOffset::new();
+        assert_eq!(
+            (
+                offset.get_min_offset(),
+                offset.get_max_offset(),
+                offset.get_last_update_timestamp(),
+            ),
+            (0, 0, 0)
+        );
         offset.set_min_offset(-10);
         offset.set_max_offset(-20);
         offset.set_last_update_timestamp(-1000);
@@ -108,22 +91,17 @@ mod tests {
         assert_eq!(serialized, expected);
 
         let deserialized: TopicOffset = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized.get_min_offset(), -10);
-        assert_eq!(deserialized.get_max_offset(), -20);
-        assert_eq!(deserialized.get_last_update_timestamp(), -1000);
-    }
-
-    #[test]
-    fn test_topic_offset_display() {
-        let mut offset = TopicOffset::new();
-        offset.set_min_offset(10);
-        offset.set_max_offset(20);
-        offset.set_last_update_timestamp(1000);
-
-        let display = format!("{}", offset);
         assert_eq!(
-            display,
-            "TopicOffset{min_offset=10, max_offset=20, last_update_timestamp=1000}"
+            (
+                deserialized.get_min_offset(),
+                deserialized.get_max_offset(),
+                deserialized.get_last_update_timestamp(),
+            ),
+            (-10, -20, -1000)
+        );
+        assert_eq!(
+            deserialized.to_string(),
+            "TopicOffset{min_offset=-10, max_offset=-20, last_update_timestamp=-1000}"
         );
     }
 }

--- a/rocketmq-protocol/src/protocol/admin/topic_stats_table.rs
+++ b/rocketmq-protocol/src/protocol/admin/topic_stats_table.rs
@@ -93,60 +93,35 @@ mod tests {
     }
 
     #[test]
-    fn test_topic_stats_table_initialization() {
-        let table = TopicStatsTable::new();
-        assert!(table.get_offset_table().is_empty());
-    }
-
-    #[test]
-    fn test_message_queue_default_new() {
-        let mq = MessageQueue::new();
-        let json = serde_json::to_value(&mq).unwrap();
-        assert_eq!(json["queueId"], 0);
-        assert_eq!(json["topic"], "");
-    }
-
-    #[test]
-    fn test_set_and_get_offsets() {
+    fn methods_and_serde_preserve_topic_stats() {
         let mut table = TopicStatsTable::new();
-        let mut map = HashMap::new();
+        assert_eq!(table.get_topic_put_tps(), 0.0);
+        assert!(table.get_offset_table().is_empty());
 
-        let mq = create_custom_mq("test_topic", 5);
+        table.set_topic_put_tps(2.5);
+        let mut map = HashMap::new();
+        let mq = create_custom_mq("order_topic", 5);
         let mut offset = TopicOffset::new();
         offset.set_min_offset(100);
         offset.set_max_offset(200);
-
         map.insert(mq.clone(), offset);
         table.set_offset_table(map);
-        let result_table = table.get_offset_table();
-        assert_eq!(result_table.len(), 1);
-
-        let retrieved_offset = result_table.get(&mq).expect("MQ should exist in map");
-        assert_eq!(retrieved_offset.get_min_offset(), 100);
-        assert_eq!(retrieved_offset.get_max_offset(), 200);
-    }
-
-    #[test]
-    fn test_serialization_cycle_with_any_key() {
-        let mut table = TopicStatsTable::new();
-        let mut map = HashMap::new();
-
-        let mq = create_custom_mq("order_topic", 1);
-        let mut offset = TopicOffset::new();
-        offset.set_last_update_timestamp(11111111);
-
-        map.insert(mq, offset);
-        table.set_offset_table(map);
+        table
+            .get_offset_table_mut()
+            .get_mut(&mq)
+            .expect("queue offset")
+            .set_last_update_timestamp(11_111_111);
 
         let serialized = serde_json::to_string(&table).expect("Serialization failed");
-
         assert!(serialized.contains("offsetTable"));
 
         let deserialized: TopicStatsTable = serde_json::from_str(&serialized).expect("Deserialization failed");
-        assert_eq!(deserialized.get_offset_table().len(), 1);
-
-        let offset_val = deserialized.get_offset_table().values().next().unwrap().clone();
-        assert_eq!(offset_val.get_last_update_timestamp(), 11111111);
+        assert_eq!(deserialized.get_topic_put_tps(), 2.5);
+        let offsets = deserialized.into_offset_table();
+        let offset = offsets.get(&mq).expect("queue offset should round-trip");
+        assert_eq!(offset.get_min_offset(), 100);
+        assert_eq!(offset.get_max_offset(), 200);
+        assert_eq!(offset.get_last_update_timestamp(), 11_111_111);
     }
 
     #[test]
@@ -163,16 +138,5 @@ mod tests {
         assert_eq!(offset.get_min_offset(), 0);
         assert_eq!(offset.get_max_offset(), 0);
         assert_eq!(table.get_topic_put_tps(), 1.5);
-    }
-
-    #[test]
-    fn test_topic_offset_display_format() {
-        let mut offset = TopicOffset::new();
-        offset.set_min_offset(5);
-        offset.set_max_offset(15);
-
-        let output = format!("{}", offset);
-        let expected = "TopicOffset{min_offset=5, max_offset=15, last_update_timestamp=0}";
-        assert_eq!(output, expected);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9875 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated protocol unit tests covering consumer lag calculations, offset accessors, serialization, deserialization, and display formatting.
  * Expanded round-trip validation with negative offsets and topic statistics updates.
  * Removed redundant standalone test cases while preserving core behavior coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->