### PR TITLE
[ISSUE #9877]♻️Consolidate protocol route tests around production behavior

### DIFF
--- a/rocketmq-protocol/src/protocol/route/route_data_view.rs
+++ b/rocketmq-protocol/src/protocol/route/route_data_view.rs
@@ -208,106 +208,108 @@ mod tests {
     use super::*;
 
     #[test]
-    fn broker_data_new_initializes_correctly() {
-        let cluster = CheetahString::from("test_cluster");
-        let broker_name = CheetahString::from("test_broker");
-        let broker_addrs = HashMap::new();
-        let zone_name = CheetahString::from("test_zone");
-
-        let broker_data = BrokerData::new(
-            cluster.clone(),
-            broker_name.clone(),
-            broker_addrs.clone(),
-            Some(zone_name.clone()),
-        );
-
-        assert_eq!(broker_data.cluster, cluster);
-        assert_eq!(broker_data.broker_name, broker_name);
-        assert_eq!(broker_data.broker_addrs, broker_addrs);
-        if let Some(zone) = &broker_data.zone_name {
-            assert_eq!(zone, &zone_name);
-        }
-        assert!(!broker_data.enable_acting_master);
-    }
-
-    #[test]
-    fn broker_data_setters_work_correctly() {
+    fn broker_data_methods_preserve_route_fields() {
         let mut broker_data = BrokerData::new(
             CheetahString::from("cluster1"),
             CheetahString::from("broker1"),
             HashMap::new(),
             None,
         );
+        assert_eq!(broker_data.cluster(), "cluster1");
+        assert_eq!(broker_data.broker_name(), "broker1");
+        assert!(broker_data.broker_addrs().is_empty());
+        assert_eq!(broker_data.zone_name(), None);
+        assert!(!broker_data.enable_acting_master());
 
         broker_data.set_cluster(CheetahString::from("cluster2"));
         broker_data.set_broker_name(CheetahString::from("broker2"));
         broker_data.set_broker_addrs(HashMap::from([(1, CheetahString::from("127.0.0.1"))]));
+        broker_data
+            .broker_addrs_mut()
+            .insert(2, CheetahString::from("127.0.0.2"));
         broker_data.set_zone_name(Some(CheetahString::from("zone1")));
         broker_data.set_enable_acting_master(true);
 
-        assert_eq!(broker_data.cluster, CheetahString::from("cluster2"));
-        assert_eq!(broker_data.broker_name, CheetahString::from("broker2"));
+        assert_eq!(broker_data.cluster(), "cluster2");
+        assert_eq!(broker_data.broker_name(), "broker2");
         assert_eq!(
-            broker_data.broker_addrs.get(&1).unwrap(),
-            &CheetahString::from("127.0.0.1")
+            broker_data.broker_addrs(),
+            &HashMap::from([
+                (1, CheetahString::from("127.0.0.1")),
+                (2, CheetahString::from("127.0.0.2")),
+            ])
         );
-        if let Some(zone_name) = &broker_data.zone_name {
-            assert_eq!(zone_name, &CheetahString::from("zone1"));
-        }
-        assert!(broker_data.enable_acting_master);
+        assert_eq!(broker_data.zone_name(), Some(&CheetahString::from("zone1")));
+        assert!(broker_data.enable_acting_master());
     }
 
     #[test]
-    fn broker_data_remove_broker_by_addr_works_correctly() {
+    fn remove_broker_by_addr_keeps_the_current_id_only() {
         let mut broker_data = BrokerData::new(
             CheetahString::from("cluster1"),
             CheetahString::from("broker1"),
             HashMap::from([
                 (1, CheetahString::from("127.0.0.1")),
-                (2, CheetahString::from("127.0.0.2")),
+                (2, CheetahString::from("127.0.0.1")),
+                (3, CheetahString::from("127.0.0.3")),
             ]),
             None,
         );
 
         broker_data.remove_broker_by_addr(1, &"127.0.0.1".into());
-        //assert!(broker_data.broker_addrs.get(&1).is_none());
-        assert!(broker_data.broker_addrs.contains_key(&2));
+        assert_eq!(
+            broker_data.broker_addrs(),
+            &HashMap::from([
+                (1, CheetahString::from("127.0.0.1")),
+                (3, CheetahString::from("127.0.0.3")),
+            ])
+        );
     }
 
     #[test]
-    fn broker_data_select_broker_addr_returns_master_if_exists() {
-        let broker_data = BrokerData::new(
+    fn select_broker_addr_prefers_master_and_indexes_slaves() {
+        let mut broker_data = BrokerData::new(
             CheetahString::from("cluster1"),
             CheetahString::from("broker1"),
-            HashMap::from([(MASTER_ID, CheetahString::from("127.0.0.1"))]),
+            HashMap::new(),
             None,
         );
+        assert_eq!(broker_data.select_broker_addr_with_index(0), None);
 
-        let selected_addr = broker_data.select_broker_addr_with_index(0);
-        assert_eq!(selected_addr.unwrap(), CheetahString::from("127.0.0.1"));
+        broker_data.set_broker_addrs(HashMap::from([
+            (4, CheetahString::from("127.0.0.4")),
+            (2, CheetahString::from("127.0.0.2")),
+        ]));
+        assert_eq!(
+            broker_data.select_broker_addr_with_index(0),
+            Some(CheetahString::from("127.0.0.2"))
+        );
+        assert_eq!(
+            broker_data.select_broker_addr_with_index(1),
+            Some(CheetahString::from("127.0.0.4"))
+        );
+        assert_eq!(
+            broker_data.select_broker_addr_with_index(2),
+            Some(CheetahString::from("127.0.0.2"))
+        );
+
+        broker_data
+            .broker_addrs_mut()
+            .insert(MASTER_ID, CheetahString::from("127.0.0.1"));
+        assert_eq!(
+            broker_data.select_broker_addr_with_index(1),
+            Some(CheetahString::from("127.0.0.1"))
+        );
     }
 
     #[test]
-    fn broker_data_select_broker_addr_returns_random_if_no_master() {
-        let broker_data = BrokerData::new(
-            CheetahString::from("cluster1"),
-            CheetahString::from("broker1"),
-            HashMap::from([(2, CheetahString::from("127.0.0.2"))]),
-            None,
-        );
-
-        let selected_addr = broker_data.select_broker_addr_with_index(0);
-        assert_eq!(selected_addr.unwrap(), CheetahString::from("127.0.0.2"));
-    }
-
-    #[test]
-    fn queue_data_new_initializes_correctly() {
+    fn queue_data_methods_preserve_route_fields() {
         let queue_data = QueueData::new(CheetahString::from("broker1"), 4, 4, 6, 0);
 
-        assert_eq!(queue_data.broker_name, CheetahString::from("broker1"));
-        assert_eq!(queue_data.read_queue_nums, 4);
-        assert_eq!(queue_data.write_queue_nums, 4);
-        assert_eq!(queue_data.perm, 6);
-        assert_eq!(queue_data.topic_sys_flag, 0);
+        assert_eq!(queue_data.broker_name(), "broker1");
+        assert_eq!(queue_data.read_queue_nums(), 4);
+        assert_eq!(queue_data.write_queue_nums(), 4);
+        assert_eq!(queue_data.perm(), 6);
+        assert_eq!(queue_data.topic_sys_flag(), 0);
     }
 }

--- a/rocketmq-protocol/src/protocol/route/topic_route_data.rs
+++ b/rocketmq-protocol/src/protocol/route/topic_route_data.rs
@@ -276,37 +276,7 @@ mod tests {
     use crate::protocol::route::route_data_view::BrokerData;
 
     #[test]
-    fn topic_route_data_default_values() {
-        let topic_route_data = TopicRouteData::default();
-        assert!(topic_route_data.order_topic_conf.is_none());
-        assert!(topic_route_data.queue_datas.is_empty());
-        assert!(topic_route_data.broker_datas.is_empty());
-        assert!(topic_route_data.filter_server_table.is_empty());
-        assert!(topic_route_data.topic_queue_mapping_by_broker.is_none());
-    }
-
-    #[test]
-    fn topic_route_data_with_values() {
-        let mut filter_server_table = HashMap::new();
-        filter_server_table.insert(CheetahString::from("key"), vec![CheetahString::from("value")]);
-        let mut topic_queue_mapping_by_broker = HashMap::new();
-        topic_queue_mapping_by_broker.insert(CheetahString::from("broker"), TopicQueueMappingInfo::default());
-        let topic_route_data = TopicRouteData {
-            order_topic_conf: Some(CheetahString::from("conf")),
-            queue_datas: vec![QueueData::default()],
-            broker_datas: vec![BrokerData::default()],
-            filter_server_table,
-            topic_queue_mapping_by_broker: Some(topic_queue_mapping_by_broker),
-        };
-        assert_eq!(topic_route_data.order_topic_conf, Some(CheetahString::from("conf")));
-        assert_eq!(topic_route_data.queue_datas.len(), 1);
-        assert_eq!(topic_route_data.broker_datas.len(), 1);
-        assert_eq!(topic_route_data.filter_server_table.len(), 1);
-        assert!(topic_route_data.topic_queue_mapping_by_broker.is_some());
-    }
-
-    #[test]
-    fn serialize_topic_route_data() {
+    fn serde_preserves_topic_route_data() {
         let mut filter_server_table = HashMap::new();
         filter_server_table.insert(CheetahString::from("key"), vec![CheetahString::from("value")]);
         let mut topic_queue_mapping_by_broker = HashMap::new();
@@ -324,6 +294,9 @@ mod tests {
         assert!(serialized.contains("\"brokerDatas\":["));
         assert!(serialized.contains("\"filterServerTable\":{\"key\":[\"value\"]}"));
         assert!(serialized.contains("\"topicQueueMappingInfo\":{\"broker\":{"));
+
+        let decoded = TopicRouteData::decode(serialized.as_bytes()).unwrap();
+        assert_eq!(decoded, topic_route_data);
     }
 
     #[test]
@@ -402,25 +375,25 @@ mod tests {
     }
 
     #[test]
-    fn topic_route_data_changed_with_none_old_data() {
-        let topic_route_data = TopicRouteData::default();
-        assert!(topic_route_data.topic_route_data_changed(None));
-    }
-
-    #[test]
-    fn topic_route_data_changed_with_different_data() {
-        let topic_route_data = TopicRouteData::default();
-        let old_data = TopicRouteData {
-            order_topic_conf: Some(CheetahString::from("conf")),
+    fn topic_route_data_changed_ignores_broker_and_queue_order() {
+        let queue = |name: &str, count| QueueData::new(name.into(), count, count, 6, 0);
+        let broker = |name: &str| BrokerData::new("cluster".into(), name.into(), HashMap::new(), None);
+        let route_data = TopicRouteData {
+            queue_datas: vec![queue("broker-b", 8), queue("broker-a", 4)],
+            broker_datas: vec![broker("broker-b"), broker("broker-a")],
             ..Default::default()
         };
-        assert!(topic_route_data.topic_route_data_changed(Some(&old_data)));
-    }
 
-    #[test]
-    fn topic_route_data_changed_with_same_data() {
-        let topic_route_data = TopicRouteData::default();
-        let old_data = TopicRouteData::default();
-        assert!(!topic_route_data.topic_route_data_changed(Some(&old_data)));
+        assert!(route_data.topic_route_data_changed(None));
+        assert!(!route_data.topic_route_data_changed(Some(&route_data)));
+
+        let mut reordered = TopicRouteData::from_existing(&route_data);
+        reordered.queue_datas.reverse();
+        reordered.broker_datas.reverse();
+        assert!(!route_data.topic_route_data_changed(Some(&reordered)));
+
+        let mut changed = TopicRouteData::from_existing(&route_data);
+        changed.order_topic_conf = Some(CheetahString::from("changed"));
+        assert!(route_data.topic_route_data_changed(Some(&changed)));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9877 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded route data coverage for broker selection, address removal, empty address maps, and master/slave selection.
  * Updated tests to use public accessors and setters.
  * Added round-trip serialization and deserialization validation for topic route data.
  * Confirmed route changes ignore broker and queue ordering while detecting configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->