### PR TITLE
[ISSUE #9901]📝Document RocketMQ MCP production validation and implementation baseline

### DIFF
--- a/rocketmq-ai/rocketmq-mcp/README.md
+++ b/rocketmq-ai/rocketmq-mcp/README.md
@@ -2,9 +2,12 @@
 
 `rocketmq-mcp` is the Model Context Protocol server for RocketMQ-Rust AI SRE and diagnostics workflows. It exposes read-only RocketMQ context, diagnostic tools, and runbook prompts to MCP clients such as Claude Desktop, Cursor, Codex, and MCP Inspector.
 
-The frozen MCP 2025-11-25 contract is documented in `rocketmq-doc/en/07-rocketmq-mcp-contract-v2.md`.
-Production release gates, external-cluster expectations, and rollback guidance are documented in
-`docs/production-validation.md`.
+The frozen MCP 2025-11-25 contract is documented in the
+[MCP contract](../../rocketmq-doc/en/07-rocketmq-mcp-contract-v2.md).
+Production release gates, external-cluster expectations, and rollback guidance are documented in the
+[production validation guide](docs/production-validation.md).
+The checked-in surface and validation baseline are listed in the
+[implementation baseline](docs/implementation-baseline.md).
 
 ## What It Is
 
@@ -54,24 +57,27 @@ Both surfaces pass through the same authorization, audit, redaction, row-bound, 
 
 ## Build
 
-Run commands from the repository root.
+`rocketmq-mcp` is a standalone Cargo package. Unless a command says otherwise, run the commands below from the
+MCP crate root, `rocketmq-ai/rocketmq-mcp`, after changing to it from the repository root.
 
 ```bash
 cd rocketmq-ai/rocketmq-mcp
+cargo fmt --all -- --check
 cargo check --locked
 python scripts/check_read_only_boundary.py
 cargo test --locked
-cargo clippy --locked --all-targets --features streamable-http,otlp -- -D warnings
+cargo test --locked --all-features
+cargo clippy --locked --all-targets --features streamable-http -- -D warnings
 cargo doc --locked --no-deps
 ```
 
-Build the default stdio binary:
+From that same MCP crate root, build the default stdio binary:
 
 ```bash
 cargo build --locked --release
 ```
 
-Build with Streamable HTTP support:
+From that same MCP crate root, build with Streamable HTTP support:
 
 ```bash
 cargo build --locked --release --features streamable-http,otlp
@@ -82,7 +88,7 @@ cargo build --locked --release --features streamable-http,otlp
 Start from the checked-in example:
 
 ```bash
-rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml
+conf/mcp.example.toml
 ```
 
 Important fields:
@@ -147,8 +153,9 @@ ten-second compatibility wrapper and logs unhealthy reports.
 Command-line overrides:
 
 ```bash
-rocketmq-mcp --config rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml --transport stdio
-rocketmq-mcp --config rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml --transport streamable-http --bind 127.0.0.1:8089 --endpoint /mcp
+# Run from rocketmq-ai/rocketmq-mcp, or use an absolute path to your copied config.
+rocketmq-mcp --config conf/mcp.example.toml --transport stdio
+rocketmq-mcp --config conf/mcp.example.toml --transport streamable-http --bind 127.0.0.1:8089 --endpoint /mcp
 ```
 
 The configuration path is mandatory through `--config` or `ROCKETMQ_MCP_CONFIG`. Relative permission, TLS, JWKS CA, and audit paths are resolved from the configuration file's directory, so startup does not depend on the caller's current working directory.
@@ -171,7 +178,7 @@ For a release binary:
 
 ```bash
 target/release/rocketmq-mcp \
-  --config rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml \
+  --config conf/mcp.example.toml \
   --transport stdio
 ```
 
@@ -235,10 +242,10 @@ Windows example:
 {
   "mcpServers": {
     "rocketmq": {
-      "command": "C:\\path\\to\\rocketmq-rust\\target\\release\\rocketmq-mcp.exe",
+      "command": "<repository-root>/rocketmq-ai/rocketmq-mcp/target/release/rocketmq-mcp.exe",
       "args": [
         "--config",
-        "C:\\path\\to\\rocketmq-rust\\rocketmq-tools\\rocketmq-mcp\\conf\\mcp.example.toml",
+        "<repository-root>/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml",
         "--transport",
         "stdio"
       ]
@@ -253,10 +260,10 @@ macOS or Linux example:
 {
   "mcpServers": {
     "rocketmq": {
-      "command": "/path/to/rocketmq-rust/target/release/rocketmq-mcp",
+      "command": "<repository-root>/rocketmq-ai/rocketmq-mcp/target/release/rocketmq-mcp",
       "args": [
         "--config",
-        "/path/to/rocketmq-rust/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml",
+        "<repository-root>/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml",
         "--transport",
         "stdio"
       ]

--- a/rocketmq-ai/rocketmq-mcp/docs/implementation-baseline.md
+++ b/rocketmq-ai/rocketmq-mcp/docs/implementation-baseline.md
@@ -1,0 +1,209 @@
+# RocketMQ MCP implementation baseline
+
+This document freezes the checked-in MCP surface and records the validation evidence for the current revision.
+It describes implemented behavior; it does not certify a live RocketMQ deployment.
+
+## Revision and sources
+
+| Item | Value |
+| --- | --- |
+| Revision | `a69f712b0e5acc82469aee0d1a7bc57ba9e62c8c` |
+| Revision subject | `[ISSUE #9883]♻️Consolidate AI projects under rocketmq-ai (#9884)` |
+| Baseline captured | 2026-08-31, Windows local checkout |
+| MCP workspace | `rocketmq-ai/rocketmq-mcp` (standalone Cargo workspace) |
+| Protocol source | [`src/protocol/server.rs`](../src/protocol/server.rs) |
+| Tool catalog | [`src/tools/catalog.rs`](../src/tools/catalog.rs) |
+| Resource registry and URI parser | [`src/resources/registry.rs`](../src/resources/registry.rs), [`src/resources/uri.rs`](../src/resources/uri.rs) |
+| Prompt registry | [`src/prompts/registry.rs`](../src/prompts/registry.rs) |
+| Default surface snapshot | [`mcp_protocol_surface.snap`](../src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap) |
+| All-features surface snapshot | [`mcp_protocol_surface_with_change_planning.snap`](../src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap) |
+| Default tool contract snapshot | [`tool_contract_schema_metadata.snap`](../src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap) |
+| All-features tool contract snapshot | [`tool_contract_schema_metadata_with_change_planning.snap`](../src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap) |
+
+The snapshots are generated contract evidence for this revision. Their schemas, descriptions, annotations, and
+ordering remain the source of truth for details not reproduced in this summary.
+
+## Protocol envelope
+
+- MCP protocol version: `2025-11-25`.
+- Business schema: `rocketmq-mcp.v2`.
+- `mutation_supported`: `false` in the capability manifest.
+- Successful tool responses contain `schema_version`, `request_id`, logical cluster, RFC 3339 `observed_at`,
+  `freshness_ms`, `cache_status`, `partial`, `warnings`, and typed `data`.
+- Tool and resource failures use stable sanitized codes, retryability, suggestions where applicable, and a
+  correlation/request identifier. Internal addresses, credentials, bearer tokens, and sensitive assignments are
+  not part of the public output.
+- Initialization rejects a protocol version other than `2025-11-25`.
+
+## Tool surface
+
+### Default features: eight tools
+
+These eight tools are present in the default catalog (`read-only`, `diagnose`, and `stdio`). The `diagnose` feature
+is a capability marker that includes `read-only`; diagnosis execution is controlled by the configured profile and
+required authorization scope, not by a separate feature-gated tool implementation:
+
+| Tool | Risk | Input shape | Implemented behavior |
+| --- | --- | --- | --- |
+| `rocketmq_get_cluster_overview` | ReadOnly | `cluster` | Summarizes brokers, topic count, and consumer-group count for one configured cluster. |
+| `rocketmq_list_topics` | ReadOnly | optional `cluster`, optional `filter`, optional page `limit`/`cursor` | Lists a bounded, filtered, cursor-paginated topic page. |
+| `rocketmq_describe_topic` | ReadOnly | `cluster`, `topic`, optional page `limit`/`cursor` | Describes one topic with bounded queue route information. |
+| `rocketmq_get_topic_route` | ReadOnly | `cluster`, `topic`, optional page `limit`/`cursor` | Returns bounded route data for one topic. |
+| `rocketmq_list_consumer_groups` | ReadOnly | optional `cluster`, optional `filter`, optional page `limit`/`cursor` | Lists a bounded, filtered, cursor-paginated consumer-group page. |
+| `rocketmq_get_consumer_lag` | ReadOnly | `cluster`, `topic`, `consumer_group`, optional page `limit`/`cursor` | Returns bounded per-queue consumer progress and lag. |
+| `rocketmq_describe_broker` | ReadOnly | `cluster`, `broker_name` | Describes broker state for one broker name. |
+| `rocketmq_diagnose_consumer_lag` | Diagnose | `cluster`, `topic`, `consumer_group` | Aggregates read-only lag, topic-route, and broker evidence into a diagnosis report. |
+
+Page `limit` is bounded to 1–200 and defaults to 50. The outer output policy additionally caps arrays at 1,000
+rows and structured output at 1 MiB.
+
+Consumer-lag diagnosis uses a server-owned policy profile and threshold. The request has no historical `time_range`
+or caller-controlled threshold because the checked-in implementation has no historical metrics source.
+
+### Optional `change-planning`: five tools
+
+When compiled with `change-planning`, the all-features catalog has exactly thirteen tools: the eight defaults above
+plus these five planning tools:
+
+| Tool | Plan type | Required request | Result boundary |
+| --- | --- | --- | --- |
+| `rocketmq_plan_create_topic` | `create_topic` | `cluster`, `reason`, desired topic state | Immutable, ephemeral review plan; no mutation. |
+| `rocketmq_plan_update_topic_config` | `update_topic_config` | `cluster`, `reason`, desired topic/config state | Immutable, ephemeral review plan; no mutation. |
+| `rocketmq_plan_update_topic_permissions` | `update_topic_permissions` | `cluster`, `reason`, desired topic/permission state | Immutable, ephemeral review plan; no mutation. |
+| `rocketmq_plan_update_broker_config` | `update_broker_config` | `cluster`, `reason`, desired broker/config state | Immutable, ephemeral review plan; no mutation. |
+| `rocketmq_plan_reset_consumer_offset` | `reset_consumer_offset` | `cluster`, `reason`, desired topic/group offset state | Immutable, ephemeral review plan; no mutation. |
+
+Every planning result has `mutates_cluster = false`, an expiry of 300 seconds, and no Apply mode, operator
+identity, or confirmation token in its schema. Planning requires the feature, `security.allow_change_planning = true`,
+the configured policy, and the `rocketmq:plan` scope. The default runtime setting is false. There is no Apply path
+and no destructive tool in this baseline.
+
+## Resource surface
+
+`resources/list` advertises five cluster roots per authorized configured cluster and two protected system resources.
+The ten cluster Resource forms below are the five listed roots plus the five parameterized forms accepted by
+`resources/read`; parameterized forms are also exposed through the five templates below.
+
+### Ten cluster Resource forms
+
+| Form | Discovery/read behavior |
+| --- | --- |
+| `rocketmq://clusters/{cluster}/capabilities` | Listed cluster root; versioned capability and schema-digest manifest. |
+| `rocketmq://clusters/{cluster}/overview` | Listed cluster root; cluster overview. |
+| `rocketmq://clusters/{cluster}/topics` | Listed cluster root; topic inventory. |
+| `rocketmq://clusters/{cluster}/topics/{topic}` | Parameterized topic details. |
+| `rocketmq://clusters/{cluster}/topics/{topic}/route` | Parameterized topic route. |
+| `rocketmq://clusters/{cluster}/brokers` | Listed cluster root; broker inventory. |
+| `rocketmq://clusters/{cluster}/brokers/{broker}` | Parameterized broker details. |
+| `rocketmq://clusters/{cluster}/consumer-groups` | Listed cluster root; consumer-group inventory. |
+| `rocketmq://clusters/{cluster}/consumer-groups/{group}` | Parameterized consumer-group details. |
+| `rocketmq://clusters/{cluster}/consumer-groups/{group}/lag?topic={topic}` | Parameterized consumer lag for one group/topic. |
+
+Names in URI path and query components use UTF-8 percent encoding. This includes retry topics/groups such as
+`%RETRY%...`. Unknown, incomplete, invalidly encoded, or unauthorized resources fail closed rather than returning
+a placeholder payload.
+
+### Two protected system Resources
+
+These are never cluster-scoped and require diagnostic authorization (`rocketmq:diagnose`) and a valid diagnostic
+role:
+
+- `rocketmq://system/runtime/v1` — bounded, sanitized MCP runtime diagnostics.
+- `rocketmq://system/observability/v1` — sanitized MCP observability status.
+
+### Five Resource templates
+
+`resources/templates/list` publishes exactly these templates:
+
+1. `rocketmq://clusters/{cluster}/topics/{topic}` (`rocketmq_topic`)
+2. `rocketmq://clusters/{cluster}/topics/{topic}/route` (`rocketmq_topic_route`)
+3. `rocketmq://clusters/{cluster}/consumer-groups/{group}` (`rocketmq_consumer_group`)
+4. `rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic}` (`rocketmq_consumer_lag`)
+5. `rocketmq://clusters/{cluster}/brokers/{broker}` (`rocketmq_broker`)
+
+### Two Prompts
+
+`prompts/list` advertises exactly:
+
+- `diagnose_consumer_lag` — guided consumer-lag investigation with `cluster`, `topic`, and `consumer_group`.
+- `broker_health_check` — guided broker-health review with `cluster`, optional `broker_name`, and optional
+  `check_level` (`quick`, `standard`, or `deep`).
+
+## Features and transport availability
+
+The `Cargo.toml` feature graph at this revision is:
+
+| Feature | Default? | Effect |
+| --- | --- | --- |
+| `read-only` | Yes | Base read-only capability marker. |
+| `diagnose` | Yes | Capability marker that includes `read-only`; diagnosis execution is controlled by profile and scope authorization. |
+| `stdio` | Yes | Enables RMCP stdio transport support. |
+| `streamable-http` | No | Enables RMCP Streamable HTTP server, TLS/network dependencies, and the `auth` feature. |
+| `observability` | No | Enables in-process RocketMQ observability support without selecting a remote exporter. |
+| `otlp` | No | Includes `observability` and OTLP metrics, traces, and logs through the OTLP gRPC exporter. |
+| `auth` | No | Internal authentication feature; selected by `streamable-http`. |
+| `change-planning` | No | Registers the five non-mutating planning tools. |
+
+Default feature set: `read-only`, `diagnose`, `stdio`. The default binary is intended for local stdio. HTTPS is
+available only with `streamable-http`; production OAuth requires that transport feature and its TLS/JWKS setup.
+
+## Authorization and read-only adapter boundary
+
+Authorization is applied to discovery and execution. The policy engine combines role includes, tool allow/deny
+patterns, configured cluster allow-lists, principal `rocketmq_clusters`, exact tenant binding, and required scopes.
+The default example profile is `diagnose`: it can use read-only and diagnosis tools, while planning remains disabled
+unless explicitly enabled. HTTP principals are derived from the verified request; they cannot substitute the local
+stdio identity. System resources require diagnostic scope and a valid diagnostic role.
+
+The only RocketMQ admin-core dependency is `rocketmq-admin-core` with `default-features = false` and
+`read-client-adapter`. The read-only boundary checker rejects mutation-client/admin features, mutation imports, and
+forbidden direct dependencies. Credentials are resolved from a mounted bounded YAML file or environment references
+for each new read session and are never serialized into public output.
+
+## Output, cache, and audit behavior
+
+- Redaction removes internal topology and sensitive fields recursively when `security.sanitize_output = true`.
+- Output arrays are capped at 1,000 rows; structured JSON is capped at 1 MiB. Truncation sets `partial = true` and
+  adds `output_rows_truncated`; an oversized result returns `output_too_large`.
+- Cache entries use schema version, visibility class, query kind, resolved cluster, and normalized parameters. The
+  configured TTLs cover overview, topic, broker, and consumer-lag families. Failures are not cached, concurrent
+  identical misses are coalesced, and `cache_status` is `miss`, `hit`, or `bypass`. An explicit invalidation clears
+  all entries.
+- Tool and Resource calls share the query facade, cache, singleflight coordination, authorization, audit, redaction,
+  row, byte, and stable-error policies. Read-only tool results include a ResourceLink for the corresponding live
+  Resource.
+- Audit records use schema version 1, redact control characters and sensitive assignments, bound variable-length
+  fields, and use a bounded non-blocking queue. Shutdown closes admission, drains accepted records FIFO, flushes the
+  sink, and reports drops, sink/flush failures, or pending records/bytes.
+- The default example sets cache enabled with 256 entries and TTLs of 3,000 ms (overview), 5,000 ms (topic),
+  2,000 ms (broker), and 1,000 ms (consumer lag); security rate limit is 60 per minute and cluster concurrency is 8.
+  These are example defaults, not a production capacity recommendation.
+
+## Validation evidence
+
+Evidence below applies exactly to revision `a69f712b0e5acc82469aee0d1a7bc57ba9e62c8c` and was captured on
+2026-08-31 from a Windows local checkout. Commands marked with a relative working directory are run from the
+repository root unless the directory is shown as the command's current directory. The local environment had no
+reachable RocketMQ test cluster and did not provide the four `ROCKETMQ_MCP_E2E_*` variables.
+
+| Command | Working directory | Feature set | Result | Environment | Limitation |
+| --- | --- | --- | --- | --- | --- |
+| `cargo fmt --all -- --check` | `rocketmq-ai/rocketmq-mcp` | Cargo defaults | **failed (exit 1)** | Windows local checkout | Cargo/rustfmt reported `文件名或扩展名太长。 (os error 206)` and printed usage before formatting; no source files were changed by this command. |
+| `cargo fmt -p rocketmq-mcp -- --check` | `rocketmq-ai/rocketmq-mcp` | Package `rocketmq-mcp` only | **passed (exit 0)** | Clean `main` checkout and current documentation worktree on Windows | This narrower package-scoped check does not replace the failed mandatory all-package check; it demonstrates the failure is outside this package's own formatting scope. |
+| `cargo check --locked` | `rocketmq-ai/rocketmq-mcp` | Default: `read-only`, `diagnose`, `stdio` | **passed (exit 0)** | Windows local checkout | Completed with five existing `dead_code` warnings from the path dependency `rocketmq-transport`; no live RocketMQ connection was attempted. |
+| `python scripts/check_read_only_boundary.py` | `rocketmq-ai/rocketmq-mcp` | Metadata/dependency closure | **passed (exit 0)** | Windows local checkout | Printed `MCP read-only dependency boundary passed`; this checks the dependency/source boundary, not a live cluster. |
+| `cargo test --locked` | `rocketmq-ai/rocketmq-mcp` | Default: `read-only`, `diagnose`, `stdio` | **passed (exit 0): 117 passed, 0 failed, 1 ignored; doc-tests 0** | Windows local checkout | 108 library + 5 binary + 1 compatibility integration + 3 non-E2E integration tests passed. The external-cluster test remained ignored because it requires `ROCKETMQ_MCP_E2E_NAMESRV_ADDR`, `ROCKETMQ_MCP_E2E_TOPIC`, `ROCKETMQ_MCP_E2E_CONSUMER_GROUP`, and `ROCKETMQ_MCP_E2E_BROKER`. |
+| `cargo test --locked --all-features` | `rocketmq-ai/rocketmq-mcp` | All declared features, including `streamable-http`, `otlp`, and `change-planning` | **passed (exit 0): 141 passed, 0 failed, 1 ignored; doc-tests 0** | Windows local checkout | 132 library + 5 binary + 1 compatibility integration + 3 non-E2E integration tests passed. The same external-cluster test was ignored; this is not live-cluster evidence. |
+| `cargo clippy --locked --all-targets --features streamable-http -- -D warnings` | `rocketmq-ai/rocketmq-mcp` | `streamable-http` plus default features | **passed (exit 0)** | Windows local checkout | Completed with the same five existing `dead_code` warnings from `rocketmq-transport`; no MCP Clippy warning failed the command. |
+| `cargo doc --locked --no-deps` | `rocketmq-ai/rocketmq-mcp` | Default: `read-only`, `diagnose`, `stdio` | **passed (exit 0)** | Windows local checkout | Documentation generated successfully with the same five path-dependency warnings; generated docs do not exercise a cluster. |
+| `git diff --check` | repository root | Not applicable | **passed (exit 0)** | Windows local checkout | Checks whitespace/error markers only; it does not validate protocol behavior or production deployment. |
+| `cargo test --locked --test integration external_cluster_exercises_mvp_tools_and_resources -- --ignored` | `rocketmq-ai/rocketmq-mcp` | **Default features only**: `read-only`, `diagnose`, `stdio` | **not run** | No reachable RocketMQ cluster; required `ROCKETMQ_MCP_E2E_*` variables absent | This exact command uses Cargo defaults; it is not an all-features run. The same test is also reported ignored by the separate all-features suite above; neither result certifies a production deployment. |
+
+The failed formatter check is retained as evidence rather than hidden. On the clean `main` checkout at this
+revision, `cargo fmt --all -- --check` failed identically with `文件名或扩展名太长。 (os error 206)`, while the
+package-scoped `cargo fmt -p rocketmq-mcp -- --check` passed (exit 0). The mandatory all-package formatter command
+therefore remains failed; the package-scoped result is diagnostic evidence, not a replacement for that gate. The
+passed checks establish only local build, boundary, test, lint, documentation, and whitespace properties for the
+named revision. Production
+qualification remains environment-dependent and must be rerun with the external dependencies and test principal
+listed above.

--- a/rocketmq-ai/rocketmq-mcp/docs/production-validation.md
+++ b/rocketmq-ai/rocketmq-mcp/docs/production-validation.md
@@ -1,0 +1,200 @@
+# RocketMQ MCP production validation
+
+This document is a release-gate checklist for operating `rocketmq-mcp`. It is not a production-readiness
+certificate. Local compilation, unit tests, contract snapshots, and in-process HTTP tests do not prove that a
+RocketMQ deployment is reachable, correctly secured, or ready for an operator workload. Record live-cluster
+evidence separately and keep the limitation next to the result.
+
+The checked-in implementation and local evidence for this revision are listed in
+[implementation-baseline.md](implementation-baseline.md).
+
+## Deployment boundaries
+
+### stdio
+
+Use stdio for a local desktop MCP client. The process reads and writes MCP protocol frames on standard streams;
+application logs go to stderr when `server.stdio.log_to_stderr = true`. Stdio uses the local identity derived from
+`security.profile` and is intended for a trusted local process. It is not a network authentication boundary and
+must not be exposed through a pipe, wrapper, or service that accepts untrusted remote input.
+
+### Streamable HTTPS
+
+Streamable HTTPS is compiled only with the `streamable-http` feature. The listener is TLS-enforcing, requires a
+certificate and private key, applies an HTTP request-body limit of 1 MiB and a 30-second request timeout, and
+validates configured hosts and browser origins. The MCP endpoint is protected by authentication; the OAuth
+protected-resource metadata path remains unauthenticated for client discovery.
+
+The example configuration binds to loopback. `development-token` authentication is valid only for reviewed
+loopback development. It must not be used as production authentication or with a non-loopback bind address.
+Production HTTPS must use `oauth-jwt`, an absolute HTTPS issuer, an absolute HTTPS JWKS URL, RS256, and a
+non-empty required-scope set. The server validates the issuer, audience, expiry, `sub`, `kid`, signature, and
+required scopes, and never forwards the incoming bearer token to RocketMQ.
+
+The MCP process is outside the broker, NameServer, store, and dashboard runtime paths. It queries RocketMQ through
+the read-only admin adapter and does not provide a mutation or Apply endpoint.
+
+## External dependencies and test data
+
+Before a live-cluster smoke test, provide all of the following from the environment in which the MCP process will
+run:
+
+- A reachable RocketMQ NameServer address in `clusters[].namesrv_addr`, plus a reachable broker for every operation
+  being tested.
+- A least-privilege RocketMQ request-signing identity. Configure it by a bounded mounted YAML file or paired
+  access-key/secret-key environment references; do not put secret values in TOML, command lines, logs, or tickets.
+- A trusted server certificate and private key for HTTPS. If the issuer uses a private CA, provide a readable PEM
+  bundle through `server.http.auth.jwks_ca_path`.
+- A production OAuth issuer, audience, HTTPS JWKS endpoint, RS256 signing key with a `kid`, and refresh/staleness
+  windows. The issuer and JWKS endpoint must be reachable from the MCP process.
+- A test principal with the intended roles, scopes, optional exact `rocketmq_tenant`, and optional
+  `rocketmq_clusters` allow-list.
+- A non-sensitive test cluster, topic, consumer group, and broker name that are known to exist. The external test
+  also requires `ROCKETMQ_MCP_E2E_NAMESRV_ADDR`, `ROCKETMQ_MCP_E2E_TOPIC`, `ROCKETMQ_MCP_E2E_CONSUMER_GROUP`, and
+  `ROCKETMQ_MCP_E2E_BROKER`.
+
+Do not substitute a successful local test for any missing dependency. If one is unavailable, mark the live check
+blocked or not run and retain the reason.
+
+## Security and bounded-output gate
+
+Confirm each control in the deployed configuration before exposing the endpoint:
+
+| Control | Required production condition | Evidence to retain |
+| --- | --- | --- |
+| TLS | `server.http.tls.cert_path` and `key_path` resolve to the intended certificate and key; the listener rejects plaintext. | Startup log with the certificate generation (without key material) and an HTTPS-only probe. |
+| Authentication | `server.http.auth.mode = "oauth-jwt"`; development tokens are not used. | Redacted configuration review and probes for missing, invalid, expired, wrong-issuer, wrong-audience, wrong-`kid`, and wrong-algorithm tokens. |
+| JWKS | HTTPS JWKS is reachable, contains bounded RS256 verification keys, and refresh failure retains only a verified last-known-good generation within the configured stale window. | Issuer/JWKS health evidence and key-rotation test, with tokens and key material omitted. |
+| RBAC | `security.permissions_file` defines the intended roles and tool patterns. Claims are intersected with policy rather than trusted as an unrestricted grant. | Policy review plus allowed and denied tool/resource probes. |
+| Scope | Read-only, diagnosis, and planning operations require `rocketmq:read`, `rocketmq:diagnose`, and `rocketmq:plan`, respectively. | Principal claims and redacted authorization results. |
+| Tenant and cluster boundary | A configured `clusters[].tenant` requires an exact `rocketmq_tenant` claim; `rocketmq_clusters` and role allow-lists both constrain cluster access. | Matching and mismatching tenant/cluster probes. |
+| Rate and concurrency | Per-principal, per-cluster, per-operation rate limits and the configured per-cluster concurrency bound are sized for the workload. | 429/denial probe and saturation result; do not increase limits solely to hide client retry problems. |
+| Redaction | `security.sanitize_output = true` in production. Internal addresses, credentials, bearer tokens, and sensitive assignments do not leave through tool/resource output or audit records; audit records may contain bounded principal and client identifiers for accountability. | Sanitized sample output and audit record review. |
+| Row and byte bounds | Arrays are capped at 1,000 rows and structured output at 1 MiB. Row truncation reports `partial = true` and `output_rows_truncated`; oversized output returns `output_too_large`. HTTP request bodies are also capped at 1 MiB. | Boundary probes that verify the stable warning/error without retaining sensitive payloads. |
+| Audit | Keep `audit.enabled = true`; choose `file` or `tracing` for durable operations evidence and size the count and byte queues deliberately. Records are redacted, bounded, and drained FIFO during shutdown. | Sink-health, accepted/written/drop, pending-record, and flush evidence. |
+| Cache | Cache keys include schema version, visibility class, query kind, resolved cluster, and normalized parameters. Failures are not cached; misses are coalesced; TTLs and capacity are reviewed for the workload. | Hit/miss/bypass and invalidation observations, with no secret query values. |
+| Mutation boundary | Keep the RocketMQ user least-privileged and retain the `read-client-adapter` dependency boundary. No Apply path, mutation feature, or mutation admin API is part of the MCP binary. | Read-only boundary check and dependency review. |
+
+## Validation stages
+
+### 1. Build and static checks
+
+From the repository root, change to `rocketmq-ai/rocketmq-mcp`. Run the commands in the evidence table in
+[implementation-baseline.md](implementation-baseline.md). A successful local command proves only the property
+tested by that command and the checked-in revision; it does not qualify a live cluster.
+
+### 2. Configuration review
+
+Start with `conf/mcp.example.toml`, then use a copied, access-restricted configuration for a real deployment.
+Check that:
+
+1. Relative permission, TLS, JWKS CA, audit, and credential paths resolve from the configuration file's directory,
+   not from an incidental caller working directory.
+2. Inline credentials and mixed file/environment credential sources are rejected.
+3. Production HTTP uses an HTTPS public origin and `oauth-jwt`; development-token is loopback-only.
+4. The permission file allows only the intended tools and clusters, and planning remains disabled unless the
+   feature, runtime opt-in, policy, and principal scope are all intentionally enabled.
+5. Audit and cache capacities, TTLs, and diagnosis thresholds are explicit and reviewed.
+
+### 3. Startup checks
+
+For stdio, start the binary with `--config conf/mcp.example.toml --transport stdio` and verify that no wrapper or
+logger writes anything except MCP frames to stdout. For HTTPS, build with `streamable-http`, start with the copied
+configuration, and verify all of the following before sending MCP traffic:
+
+- certificate and key validation succeeds and a certificate generation is active;
+- OAuth JWKS warm-up succeeds in production mode;
+- the protected-resource metadata path returns metadata without a bearer token;
+- the MCP endpoint rejects missing or invalid authentication;
+- the listener is reachable only through the intended TLS and network boundary.
+
+Startup failure is fail-closed. Do not bypass certificate, issuer, JWKS, or authorization errors to get a smoke
+request through.
+
+### 4. MCP smoke checks
+
+Use a test principal and non-sensitive test data. Verify initialization with protocol version `2025-11-25`, then
+check discovery and execution in this order:
+
+1. `tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list` show only the caller-authorized
+   surface.
+2. The eight default read-only/diagnosis tools return the `rocketmq-mcp.v2` envelope or a stable sanitized error.
+3. The five planning tools appear only when compiled and policy-enabled; every result has `mutates_cluster = false`.
+   There is no Apply request to test.
+4. Read the five cluster roots, parameterized topic/route/group/lag/broker forms, and the two system resources only
+   when the principal has the required authorization. Verify unknown, incomplete, unauthorized, and unsupported
+   forms fail closed.
+5. Verify the cache status and freshness fields, bounded rows/bytes, redaction, correlation IDs, and corresponding
+   audit records.
+
+The checked-in external-cluster integration test covers the first eight tools and a parameterized resource when
+run with all four `ROCKETMQ_MCP_E2E_*` variables. The exact command in the evidence table uses Cargo's default
+features only (`read-only`, `diagnose`, and `stdio`); it is ignored by default and remains a separate live-cluster
+qualification gate. The all-features local suite also reports the test as ignored, but no all-features live command
+was attempted here.
+
+### 5. Shutdown and rollback
+
+Request a normal process shutdown after a smoke run. Confirm that admission closes, accepted audit records drain in
+FIFO order, the sink flushes, query/transport tasks stop before the common deadline, and no pending records or
+bytes remain. Treat a timed-out or unhealthy audit drain as a failed operational check.
+
+For rollback, stop the MCP process, preserve the failing evidence, restore the last known-good binary and copied
+configuration, and restart only after rechecking certificate, issuer/JWKS, permissions, cluster identity, and
+credential references. Re-run initialization, authorization, one read-only query, one resource read, and shutdown.
+Because the MCP surface has no Apply path, rollback is a process/configuration rollback; it does not undo a
+cluster mutation.
+
+## Troubleshooting
+
+| Symptom | Checks |
+| --- | --- |
+| HTTPS listener will not start | Verify absolute HTTPS `public_base_url`, loopback/network policy, certificate/key readability, and certificate validity. |
+| 401 or bearer challenge | Verify `Authorization: Bearer`, RS256 signature, `kid`, issuer, audience, expiry, required scopes, and JWKS reachability. |
+| 403 | Check role includes, `allow_tools`/`deny_tools`, required scope, exact tenant, `rocketmq_clusters`, configured cluster name, and allowed origins. |
+| 429 | Inspect per-principal rate and per-cluster concurrency limits, then inspect caller retry behavior. |
+| No cluster data | Verify NameServer reachability, broker reachability, cluster name resolution, least-privilege RocketMQ credentials, and that the test data exists. |
+| Empty or invalid stdio response | Ensure logs and banners go to stderr and that the wrapper does not write to stdout. |
+| JWKS rotation or refresh failure | Verify HTTPS CA trust, key `kid`/algorithm, refresh and stale windows, and last-known-good behavior; do not install a static-key fallback. |
+| Output is partial or rejected | Inspect `partial`, `warnings`, `output_rows_truncated`, and `output_too_large`; reduce query scope rather than removing bounds. |
+| Audit file or drain failure | Check directory permissions, sink health, count/byte drops, oversized records, flush failures, and pending records/bytes. |
+
+## Evidence record
+
+The following command-level evidence was captured for revision `a69f712b0e5acc82469aee0d1a7bc57ba9e62c8c` on
+2026-08-31 from a Windows local checkout. The working directory is relative to the repository root. The local
+environment had no reachable RocketMQ test cluster and no `ROCKETMQ_MCP_E2E_*` variables.
+
+| Exact command | Working directory | Feature set | Status | Environment | Limitation |
+| --- | --- | --- | --- | --- | --- |
+| `cargo fmt --all -- --check` | `rocketmq-ai/rocketmq-mcp` | Cargo defaults | **failed (exit 1)** | Windows local checkout | Reported `文件名或扩展名太长。 (os error 206)` and printed usage before formatting. |
+| `cargo fmt -p rocketmq-mcp -- --check` | `rocketmq-ai/rocketmq-mcp` | Package `rocketmq-mcp` only | **passed (exit 0)** | Clean `main` checkout and current documentation worktree on Windows | This narrower check does not replace the failed mandatory all-package formatter command; it only isolates the package's own formatting scope. |
+| `cargo check --locked` | `rocketmq-ai/rocketmq-mcp` | Default: `read-only`, `diagnose`, `stdio` | **passed (exit 0)** | Windows local checkout | Five existing `dead_code` warnings came from path dependency `rocketmq-transport`; no cluster connection was attempted. |
+| `python scripts/check_read_only_boundary.py` | `rocketmq-ai/rocketmq-mcp` | Metadata/dependency closure | **passed (exit 0)** | Windows local checkout | Printed `MCP read-only dependency boundary passed`; this is not live-cluster evidence. |
+| `cargo test --locked` | `rocketmq-ai/rocketmq-mcp` | Default: `read-only`, `diagnose`, `stdio` | **passed (exit 0): 117 passed, 0 failed, 1 ignored** | Windows local checkout | The ignored test is the external-cluster test requiring four `ROCKETMQ_MCP_E2E_*` variables; doc-tests reported 0. |
+| `cargo test --locked --all-features` | `rocketmq-ai/rocketmq-mcp` | All declared features | **passed (exit 0): 141 passed, 0 failed, 1 ignored** | Windows local checkout | The same external-cluster test remained ignored; doc-tests reported 0. |
+| `cargo clippy --locked --all-targets --features streamable-http -- -D warnings` | `rocketmq-ai/rocketmq-mcp` | `streamable-http` plus defaults | **passed (exit 0)** | Windows local checkout | Five existing path-dependency `dead_code` warnings were emitted; no MCP Clippy warning failed the command. |
+| `cargo doc --locked --no-deps` | `rocketmq-ai/rocketmq-mcp` | Default: `read-only`, `diagnose`, `stdio` | **passed (exit 0)** | Windows local checkout | Generated docs with the same five path-dependency warnings; this does not exercise a cluster. |
+| `git diff --check` | repository root | Not applicable | **passed (exit 0)** | Windows local checkout | Whitespace check only; it does not qualify a deployment. |
+| `cargo test --locked --test integration external_cluster_exercises_mvp_tools_and_resources -- --ignored` | `rocketmq-ai/rocketmq-mcp` | **Default features only**: `read-only`, `diagnose`, `stdio` | **not run** | Required external variables and a reachable cluster were absent | This exact command is not an all-features run; it remains a separate live-cluster qualification gate. |
+
+The mandatory all-package formatter failure is reproducible on the clean `main` checkout at this revision with the
+same `文件名或扩展名太长。 (os error 206)` result. The package-scoped formatter passes, but it is diagnostic evidence
+only and does not change the failed mandatory gate.
+
+The complete baseline, including test-suite breakdown and snapshot links, is in
+[implementation-baseline.md](implementation-baseline.md). These local results do not imply that OAuth, TLS,
+JWKS, RBAC, RocketMQ connectivity, or production rollback has passed.
+
+## Evidence status vocabulary
+
+Use these values in release records:
+
+- **passed**: the exact command or probe completed successfully in the named environment.
+- **failed**: it ran and returned a failure; retain the exact error and revision.
+- **ignored**: the test harness deliberately did not run the test, normally because it is marked ignored.
+- **skipped**: an operator intentionally did not run a possible check.
+- **blocked**: a required dependency or authorization was unavailable.
+- **environment-dependent**: the result is valid only for the named local toolchain, OS, configuration, or cluster.
+- **not run**: no attempt was made.
+
+Never convert a passed local check into a live-cluster or production-readiness claim.


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9901
- Fixes #9901

### Brief Description

- Corrects stale README paths and explicitly documents crate-root command context.
- Adds production validation release-gate guidance and an implementation baseline grounded in the current catalogs and snapshots.
- Records the exact MCP surface, safety and transport boundaries, external-cluster limitations, and local validation evidence.

### How Did You Test This Change?

- `cargo fmt --all -- --check` - failed (exit 1) on Windows with the pre-existing "filename or extension too long" (os error 206); the same failure was reproduced on clean `main`, so this mandatory check is not reported as passed.
- `cargo fmt -p rocketmq-mcp -- --check` - passed (exit 0).
- `cargo check --locked` - passed (exit 0), with five existing `rocketmq-transport` `dead_code` warnings.
- `python scripts/check_read_only_boundary.py` - passed (exit 0).
- `cargo test --locked` - passed (117 passed, 0 failed, 1 ignored; 0 doc-tests).
- `cargo test --locked --all-features` - passed (141 passed, 0 failed, 1 ignored; 0 doc-tests).
- `cargo clippy --locked --all-targets --features streamable-http -- -D warnings` - passed (exit 0), with the same five existing path-dependency warnings.
- `cargo doc --locked --no-deps` - passed (exit 0), with the same five existing path-dependency warnings.
- Focused README/docs path, link, and whitespace checks plus `git diff --check` - passed (exit 0).
- The live-cluster command `cargo test --locked --test integration external_cluster_exercises_mvp_tools_and_resources -- --ignored` was not run because no reachable cluster or required environment variables were available; local results do not certify production readiness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an implementation baseline documenting supported MCP tools, resources, prompts, configuration, authorization, and output behavior.
  * Added a production validation guide covering deployment, security, startup, MCP operations, shutdown, troubleshooting, and known limitations.
  * Updated build, test, formatting, configuration, and desktop integration instructions with clearer crate-relative paths and commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->