### PR TITLE
[ISSUE #9903]🐛Fix RocketMQ MCP Topic overcount and inventory scan cost

### DIFF
--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
@@ -24,7 +24,8 @@ use rocketmq_admin_core::core::consumer::ListConsumerGroupsRequest;
 use rocketmq_admin_core::core::consumer::QueryConsumerLagRequest;
 use rocketmq_admin_core::core::security::AdminCredentials;
 use rocketmq_admin_core::core::topic::GetTopicRouteRequest;
-use rocketmq_admin_core::core::topic::ListTopicsRequest;
+use rocketmq_admin_core::core::topic::TopicInventoryAdmin;
+use rocketmq_admin_core::core::topic::TopicInventoryRequest;
 use rocketmq_admin_core::core::topic::TopicQueryAdmin;
 use rocketmq_admin_core::read_client_adapter::ClientRuntime;
 use rocketmq_admin_core::read_client_adapter::ReadAdminBuilder;
@@ -35,7 +36,6 @@ use crate::tools::cluster_tools::BrokerSummary;
 use crate::tools::consumer_tools::ConsumerGroupSummary;
 use crate::tools::consumer_tools::QueueLag;
 use crate::tools::executor::ToolExecutionError;
-use crate::tools::topic_tools::TopicListEntry;
 use crate::tools::topic_tools::TopicRouteBroker;
 use crate::tools::topic_tools::TopicRouteQueue;
 
@@ -64,7 +64,7 @@ pub(crate) struct SessionConsumerLag {
 pub(crate) trait AdminSession: Send {
     fn broker_rows(&mut self) -> impl Future<Output = Result<Vec<BrokerSummary>, ToolExecutionError>> + Send;
 
-    fn topic_entries(&mut self) -> impl Future<Output = Result<Vec<TopicListEntry>, ToolExecutionError>> + Send;
+    fn topic_inventory(&mut self) -> impl Future<Output = Result<Vec<String>, ToolExecutionError>> + Send;
 
     fn topic_route(
         &mut self,
@@ -153,22 +153,14 @@ impl AdminSession for AdminCoreSession {
         Ok(result.brokers.iter().map(map_broker_summary).collect())
     }
 
-    async fn topic_entries(&mut self) -> Result<Vec<TopicListEntry>, ToolExecutionError> {
-        let request = ListTopicsRequest::new(Some(self.cluster.rocketmq_cluster_name.clone()));
+    async fn topic_inventory(&mut self) -> Result<Vec<String>, ToolExecutionError> {
+        let request = TopicInventoryRequest::new(Some(self.cluster.rocketmq_cluster_name.clone()));
         let result = self
             .admin_mut()?
-            .list_topics(&request)
+            .get_topic_inventory(&request)
             .await
             .map_err(ToolExecutionError::backend)?;
-        Ok(result
-            .topics
-            .iter()
-            .map(|item| TopicListEntry {
-                topic: item.topic.to_string(),
-                cluster: item.cluster.as_ref().map(ToString::to_string),
-                consumer_group: item.consumer_group.as_ref().map(ToString::to_string),
-            })
-            .collect())
+        Ok(result.topics)
     }
 
     async fn topic_route(&mut self, topic: &str) -> Result<SessionTopicRoute, ToolExecutionError> {

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
@@ -193,7 +193,7 @@ where
                     self.run_workflow(cluster, |session, cluster| {
                         Box::pin(async move {
                             let brokers = session.broker_rows().await?;
-                            let topics = session.topic_entries().await?;
+                            let topics = sorted_unique_topic_names(session.topic_inventory().await?);
                             let consumer_groups = session.consumer_groups().await?;
                             Ok(ClusterOverviewOutput {
                                 cluster: cluster.name.clone(),
@@ -231,8 +231,14 @@ where
                 || async {
                     self.run_workflow(cluster, move |session, cluster| {
                         Box::pin(async move {
-                            let mut topics = session.topic_entries().await?;
-                            topics.sort_by(|left, right| left.topic.cmp(&right.topic));
+                            let mut topics = sorted_unique_topic_names(session.topic_inventory().await?)
+                                .into_iter()
+                                .map(|topic| crate::tools::topic_tools::TopicListEntry {
+                                    topic,
+                                    cluster: Some(cluster.rocketmq_cluster_name.clone()),
+                                    consumer_group: None,
+                                })
+                                .collect::<Vec<_>>();
                             if let Some(filter) = normalized_filter(args.filter.as_deref()) {
                                 topics.retain(|entry| entry.topic.to_ascii_lowercase().contains(&filter));
                             }
@@ -752,6 +758,12 @@ fn normalized_filter(filter: Option<&str>) -> Option<String> {
         .map(str::to_ascii_lowercase)
 }
 
+fn sorted_unique_topic_names(mut topics: Vec<String>) -> Vec<String> {
+    topics.sort();
+    topics.dedup();
+    topics
+}
+
 fn normalized_identifier(field: &str, value: &str) -> Result<String, ToolExecutionError> {
     let value = value.trim();
     if value.is_empty() {
@@ -795,7 +807,6 @@ mod tests {
     use crate::tools::consumer_tools::ConsumerGroupSummary;
     use crate::tools::consumer_tools::QueueLag;
     use crate::tools::diagnosis_tools::DiagnoseConsumerLagArgs;
-    use crate::tools::topic_tools::TopicListEntry;
     use crate::tools::topic_tools::TopicRouteBroker;
     use crate::tools::topic_tools::TopicRouteQueue;
 
@@ -806,7 +817,7 @@ mod tests {
         starts: AtomicUsize,
         shutdowns: AtomicUsize,
         broker_queries: AtomicUsize,
-        topic_queries: AtomicUsize,
+        topic_inventory_queries: AtomicUsize,
         consumer_group_queries: AtomicUsize,
         route_queries: AtomicUsize,
         consumer_lag_queries: AtomicUsize,
@@ -818,9 +829,9 @@ mod tests {
         counters: Arc<LifecycleCounters>,
         selected_broker_missing: bool,
         hang_broker_query: bool,
-        hang_topic_query: bool,
-        delay_topic_query: bool,
-        fail_topic_query: bool,
+        hang_topic_inventory: bool,
+        delay_topic_inventory: bool,
+        fail_topic_inventory: bool,
     }
 
     impl AdminSessionFactory for FakeSessionFactory {
@@ -833,9 +844,9 @@ mod tests {
                 counters: self.counters.clone(),
                 selected_broker_missing: self.selected_broker_missing,
                 hang_broker_query: self.hang_broker_query,
-                hang_topic_query: self.hang_topic_query,
-                delay_topic_query: self.delay_topic_query,
-                fail_topic_query: self.fail_topic_query,
+                hang_topic_inventory: self.hang_topic_inventory,
+                delay_topic_inventory: self.delay_topic_inventory,
+                fail_topic_inventory: self.fail_topic_inventory,
             })
         }
     }
@@ -845,9 +856,9 @@ mod tests {
         counters: Arc<LifecycleCounters>,
         selected_broker_missing: bool,
         hang_broker_query: bool,
-        hang_topic_query: bool,
-        delay_topic_query: bool,
-        fail_topic_query: bool,
+        hang_topic_inventory: bool,
+        delay_topic_inventory: bool,
+        fail_topic_inventory: bool,
     }
 
     impl AdminSession for FakeSession {
@@ -864,18 +875,18 @@ mod tests {
             Ok(vec![broker_summary(&self.cluster.name, broker_name)])
         }
 
-        async fn topic_entries(&mut self) -> Result<Vec<TopicListEntry>, ToolExecutionError> {
-            self.counters.topic_queries.fetch_add(1, Ordering::SeqCst);
-            if self.hang_topic_query {
+        async fn topic_inventory(&mut self) -> Result<Vec<String>, ToolExecutionError> {
+            self.counters.topic_inventory_queries.fetch_add(1, Ordering::SeqCst);
+            if self.hang_topic_inventory {
                 std::future::pending::<()>().await;
             }
-            if self.delay_topic_query {
+            if self.delay_topic_inventory {
                 tokio::time::sleep(Duration::from_millis(20)).await;
             }
-            if self.fail_topic_query {
+            if self.fail_topic_inventory {
                 return Err(ToolExecutionError::backend("topic query failed"));
             }
-            Ok(vec![topic_entry("orders"), topic_entry("payments")])
+            Ok(vec!["payments".to_string(), "orders".to_string(), "orders".to_string()])
         }
 
         async fn topic_route(&mut self, _topic: &str) -> Result<SessionTopicRoute, ToolExecutionError> {
@@ -979,10 +990,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn query_facade_cluster_overview_starts_and_shuts_down_one_admin_session() {
+    async fn query_facade_cluster_overview_counts_unique_inventory_with_one_source_call() {
         let factory = FakeSessionFactory::default();
         let counters = factory.counters.clone();
-        let facade = QueryFacade::with_factory(example_config(), factory);
+        let facade = QueryFacade::with_factory(example_config_with_physical_cluster(), factory);
 
         let result = facade
             .cluster_overview(ClusterOverviewArgs {
@@ -996,8 +1007,48 @@ mod tests {
         assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
         assert_eq!(counters.broker_queries.load(Ordering::SeqCst), 1);
-        assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
         assert_eq!(counters.consumer_group_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.route_queries.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn query_facade_list_topics_sorts_deduplicates_and_preserves_null_consumer_group() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config_with_physical_cluster(), factory);
+
+        let result = facade
+            .list_topics(ListTopicsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: None,
+                page: PageRequest::default(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result
+                .page
+                .items
+                .iter()
+                .map(|entry| entry.topic.as_str())
+                .collect::<Vec<_>>(),
+            ["orders", "payments"]
+        );
+        assert!(result
+            .page
+            .items
+            .iter()
+            .all(|entry| entry.cluster.as_deref() == Some("DefaultCluster")));
+        assert!(result.page.items.iter().all(|entry| entry.consumer_group.is_none()));
+        assert_eq!(
+            serde_json::to_value(&result.page.items[0]).unwrap()["consumer_group"],
+            serde_json::Value::Null
+        );
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.route_queries.load(Ordering::SeqCst), 0);
+        assert_eq!(counters.consumer_group_queries.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -1103,7 +1154,7 @@ mod tests {
     #[tokio::test]
     async fn query_facade_backend_failure_shuts_down_the_started_session_once() {
         let factory = FakeSessionFactory {
-            fail_topic_query: true,
+            fail_topic_inventory: true,
             ..Default::default()
         };
         let counters = factory.counters.clone();
@@ -1121,7 +1172,7 @@ mod tests {
         assert!(matches!(error, ToolExecutionError::Backend(_)));
         assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
-        assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -1163,7 +1214,7 @@ mod tests {
         assert_eq!(payload["topics"]["total_count"], 2);
         assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
-        assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -1192,7 +1243,7 @@ mod tests {
         assert_eq!(payload["cache_status"], "hit");
         assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
-        assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
         assert_eq!(
             facade.cache_metrics(),
             CacheMetricsSnapshot {
@@ -1206,7 +1257,7 @@ mod tests {
     #[tokio::test]
     async fn query_facade_singleflight_coalesces_concurrent_identical_misses() {
         let factory = FakeSessionFactory {
-            delay_topic_query: true,
+            delay_topic_inventory: true,
             ..Default::default()
         };
         let counters = factory.counters.clone();
@@ -1239,14 +1290,14 @@ mod tests {
         assert_eq!(statuses.iter().filter(|status| **status == CacheStatus::Hit).count(), 7);
         assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
-        assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
         assert_eq!(facade.cache_metrics().coalesced_waiters, 7);
     }
 
     #[tokio::test]
     async fn query_facade_singleflight_waiter_observes_its_cancellation() {
         let factory = FakeSessionFactory {
-            hang_topic_query: true,
+            hang_topic_inventory: true,
             ..Default::default()
         };
         let counters = factory.counters.clone();
@@ -1260,7 +1311,7 @@ mod tests {
         };
         let leader_facade = facade.clone();
         let leader = tokio::spawn(async move { leader_facade.list_topics(request()).await });
-        while counters.topic_queries.load(Ordering::SeqCst) == 0 {
+        while counters.topic_inventory_queries.load(Ordering::SeqCst) == 0 {
             tokio::task::yield_now().await;
         }
 
@@ -1302,7 +1353,7 @@ mod tests {
         assert_eq!(second.cache_status, CacheStatus::Miss);
         assert_eq!(counters.starts.load(Ordering::SeqCst), 2);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 2);
-        assert_eq!(counters.topic_queries.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]
@@ -1335,6 +1386,12 @@ mod tests {
         .unwrap()
     }
 
+    fn example_config_with_physical_cluster() -> McpConfig {
+        let mut config = example_config();
+        config.clusters[0].rocketmq_cluster_name = Some("DefaultCluster".to_string());
+        config
+    }
+
     fn diagnosis_request() -> DiagnoseConsumerLagArgs {
         DiagnoseConsumerLagArgs {
             cluster: "local-dev".to_string(),
@@ -1357,14 +1414,6 @@ mod tests {
             hour: "0".to_string(),
             space: "1%".to_string(),
             broker_active: true,
-        }
-    }
-
-    fn topic_entry(topic: &str) -> TopicListEntry {
-        TopicListEntry {
-            topic: topic.to_string(),
-            cluster: Some("local-dev".to_string()),
-            consumer_group: None,
         }
     }
 

--- a/rocketmq-client/src/admin.rs
+++ b/rocketmq-client/src/admin.rs
@@ -62,6 +62,8 @@ pub use mq_admin_read_ext::MQAdminMessageReadExt;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::MQAdminReadExt;
 #[cfg(feature = "admin-read")]
+pub use mq_admin_read_ext::MQAdminTopicInventoryReadExt;
+#[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::MessageMetadataRead;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::SubscriptionGroupConfigVersioned;

--- a/rocketmq-client/src/admin/mq_admin_read_ext.rs
+++ b/rocketmq-client/src/admin/mq_admin_read_ext.rs
@@ -18,6 +18,8 @@
 //! integrations. Mutation methods remain unavailable unless the separate
 //! `admin-mutation` capability is enabled.
 
+use std::future::Future;
+
 use cheetah_string::CheetahString;
 use rand::seq::IndexedRandom;
 use rocketmq_model::common::config::TopicConfig;
@@ -184,6 +186,17 @@ pub trait MQAdminReadExt: Send {
     ) -> rocketmq_error::RocketMQResult<ProducerTableInfo>;
 
     async fn query_topic_consume_by_who(&self, topic: CheetahString) -> rocketmq_error::RocketMQResult<GroupList>;
+}
+
+/// Additive read-only capability for a NameServer Topic inventory.
+///
+/// This capability deliberately exposes only the cluster/global inventory
+/// requests. It does not grant route, consumer, or mutation access.
+#[allow(async_fn_in_trait)]
+pub trait MQAdminTopicInventoryReadExt: Send {
+    /// Fetches one cluster inventory when `cluster` is present, or the global
+    /// NameServer inventory otherwise.
+    async fn fetch_topic_inventory(&self, cluster: Option<CheetahString>) -> rocketmq_error::RocketMQResult<TopicList>;
 }
 
 /// Additive read-only capability for fixed, body-free message metadata.
@@ -517,6 +530,19 @@ impl MQAdminReadExt for DefaultMQAdminExt {
     }
 }
 
+impl MQAdminTopicInventoryReadExt for DefaultMQAdminExt {
+    async fn fetch_topic_inventory(&self, cluster: Option<CheetahString>) -> rocketmq_error::RocketMQResult<TopicList> {
+        let client_api = self.inner().mq_client_api()?;
+        let timeout_millis = self.inner().remoting_timeout_millis()?;
+        fetch_topic_inventory_from(
+            cluster,
+            |cluster| client_api.get_topics_by_cluster(cluster, timeout_millis),
+            || client_api.get_all_topic_list_from_name_server(timeout_millis),
+        )
+        .await
+    }
+}
+
 impl MQAdminMessageReadExt for DefaultMQAdminExt {
     async fn query_message_metadata(
         &self,
@@ -562,6 +588,23 @@ impl MQAdminMessageReadExt for DefaultMQAdminExt {
     }
 }
 
+async fn fetch_topic_inventory_from<ClusterFetch, ClusterFuture, GlobalFetch, GlobalFuture>(
+    cluster: Option<CheetahString>,
+    fetch_cluster: ClusterFetch,
+    fetch_global: GlobalFetch,
+) -> rocketmq_error::RocketMQResult<TopicList>
+where
+    ClusterFetch: FnOnce(CheetahString) -> ClusterFuture,
+    ClusterFuture: Future<Output = rocketmq_error::RocketMQResult<TopicList>>,
+    GlobalFetch: FnOnce() -> GlobalFuture,
+    GlobalFuture: Future<Output = rocketmq_error::RocketMQResult<TopicList>>,
+{
+    match cluster {
+        Some(cluster) => fetch_cluster(cluster).await,
+        None => fetch_global().await,
+    }
+}
+
 fn parse_allowlisted_value<T>(
     properties: &std::collections::HashMap<CheetahString, CheetahString>,
     key: &str,
@@ -585,10 +628,74 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
 
     use cheetah_string::CheetahString;
+    use rocketmq_protocol::protocol::body::topic::topic_list::TopicList;
 
+    use super::fetch_topic_inventory_from;
     use super::parse_allowlisted_value;
+
+    #[tokio::test]
+    async fn cluster_topic_inventory_selects_exactly_one_cluster_source_call() {
+        let cluster_calls = Arc::new(AtomicUsize::new(0));
+        let global_calls = Arc::new(AtomicUsize::new(0));
+        let result = fetch_topic_inventory_from(
+            Some(CheetahString::from("cluster-a")),
+            {
+                let cluster_calls = Arc::clone(&cluster_calls);
+                move |cluster| async move {
+                    cluster_calls.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(cluster, CheetahString::from("cluster-a"));
+                    Ok(TopicList::default())
+                }
+            },
+            {
+                let global_calls = Arc::clone(&global_calls);
+                move || async move {
+                    global_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(TopicList::default())
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(result.topic_list.is_empty());
+        assert_eq!(cluster_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(global_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn global_topic_inventory_selects_exactly_one_global_source_call() {
+        let cluster_calls = Arc::new(AtomicUsize::new(0));
+        let global_calls = Arc::new(AtomicUsize::new(0));
+        let result = fetch_topic_inventory_from(
+            None,
+            {
+                let cluster_calls = Arc::clone(&cluster_calls);
+                move |_| async move {
+                    cluster_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(TopicList::default())
+                }
+            },
+            {
+                let global_calls = Arc::clone(&global_calls);
+                move || async move {
+                    global_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(TopicList::default())
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(result.topic_list.is_empty());
+        assert_eq!(cluster_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(global_calls.load(Ordering::SeqCst), 1);
+    }
 
     #[test]
     fn parses_only_the_requested_allowlisted_value() {

--- a/rocketmq-client/src/public_api.rs
+++ b/rocketmq-client/src/public_api.rs
@@ -33,6 +33,8 @@ pub use crate::admin::MQAdminMutationExt;
 #[cfg(feature = "admin-read")]
 pub use crate::admin::MQAdminReadExt;
 #[cfg(feature = "admin-read")]
+pub use crate::admin::MQAdminTopicInventoryReadExt;
+#[cfg(feature = "admin-read")]
 pub use crate::admin::MessageMetadataRead;
 #[cfg(feature = "admin-full")]
 pub use crate::admin::OffsetAdmin;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
@@ -25,6 +25,7 @@ use rocketmq_client_rust::AclClientRPCHook;
 use rocketmq_client_rust::DefaultMQAdminExt;
 use rocketmq_client_rust::MQAdminMessageReadExt;
 use rocketmq_client_rust::MQAdminReadExt;
+use rocketmq_client_rust::MQAdminTopicInventoryReadExt;
 use rocketmq_client_rust::SessionCredentials;
 use rocketmq_client_rust::SigningAlgorithm;
 use rocketmq_error::RocketMQError;
@@ -73,6 +74,9 @@ use crate::core::topic::ListTopicsResult;
 use crate::core::topic::QueryTopicConfigCasRequest;
 use crate::core::topic::TopicBroker;
 use crate::core::topic::TopicConfigCasState;
+use crate::core::topic::TopicInventoryAdmin;
+use crate::core::topic::TopicInventoryRequest;
+use crate::core::topic::TopicInventoryResult;
 use crate::core::topic::TopicQueryAdmin;
 use crate::core::topic::TopicQueue;
 use crate::core::topic::TopicRoute;
@@ -820,6 +824,42 @@ impl TopicQueryAdmin for ReadAdminSession {
     }
 }
 
+impl TopicInventoryAdmin for ReadAdminSession {
+    fn get_topic_inventory<'a>(
+        &'a mut self,
+        request: &'a TopicInventoryRequest,
+    ) -> AdminFuture<'a, TopicInventoryResult> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let topic_list = MQAdminTopicInventoryReadExt::fetch_topic_inventory(
+                &self.inner,
+                request.cluster.as_deref().map(CheetahString::from),
+            )
+            .await
+            .map_err(|error| backend_error("fetch_topic_inventory", error))?;
+            Ok(normalize_topic_inventory(
+                topic_list.topic_list,
+                request.cluster.is_some(),
+            ))
+        })
+    }
+}
+
+fn normalize_topic_inventory(topics: Vec<CheetahString>, cluster_scoped: bool) -> TopicInventoryResult {
+    TopicInventoryResult {
+        topics: topics
+            .into_iter()
+            .filter(|topic| {
+                !cluster_scoped
+                    || !(topic.starts_with(RETRY_GROUP_TOPIC_PREFIX) || topic.starts_with(DLQ_GROUP_TOPIC_PREFIX))
+            })
+            .map(|topic| topic.to_string())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+    }
+}
+
 impl ConsumerQueryAdmin for ReadAdminSession {
     fn query_config_cas_state<'a>(
         &'a mut self,
@@ -1274,6 +1314,39 @@ mod tests {
     use rocketmq_protocol::protocol::LanguageCode;
 
     use super::*;
+
+    #[test]
+    fn cluster_topic_inventory_filters_retry_and_dlq_then_sorts_and_deduplicates() {
+        let result = normalize_topic_inventory(
+            vec![
+                CheetahString::from("topic-b"),
+                CheetahString::from(format!("{RETRY_GROUP_TOPIC_PREFIX}group-a")),
+                CheetahString::from("topic-a"),
+                CheetahString::from(format!("{DLQ_GROUP_TOPIC_PREFIX}group-a")),
+                CheetahString::from("topic-b"),
+            ],
+            true,
+        );
+
+        assert_eq!(result.topics, ["topic-a", "topic-b"]);
+    }
+
+    #[test]
+    fn global_topic_inventory_preserves_retry_and_dlq_names() {
+        let retry_topic = format!("{RETRY_GROUP_TOPIC_PREFIX}group-a");
+        let dlq_topic = format!("{DLQ_GROUP_TOPIC_PREFIX}group-a");
+        let result = normalize_topic_inventory(
+            vec![
+                CheetahString::from("topic-a"),
+                CheetahString::from(retry_topic.clone()),
+                CheetahString::from(dlq_topic.clone()),
+                CheetahString::from("topic-a"),
+            ],
+            false,
+        );
+
+        assert_eq!(result.topics, [dlq_topic, retry_topic, "topic-a".to_string()]);
+    }
 
     #[test]
     fn producer_rows_are_deterministic_and_filter_exact_groups() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/topic.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/topic.rs
@@ -53,6 +53,29 @@ pub struct ListTopicsResult {
     pub topics: Vec<TopicSummary>,
 }
 
+/// Narrow request for Topic names without route or consumer relationships.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopicInventoryRequest {
+    pub cluster: Option<String>,
+}
+
+impl TopicInventoryRequest {
+    pub fn new(cluster: Option<String>) -> Self {
+        Self {
+            cluster: cluster.and_then(|value| {
+                let value = value.trim().to_string();
+                (!value.is_empty()).then_some(value)
+            }),
+        }
+    }
+}
+
+/// Sorted, deduplicated Topic names returned by one inventory source call.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopicInventoryResult {
+    pub topics: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GetTopicRouteRequest {
     pub topic: String,
@@ -922,6 +945,17 @@ pub trait TopicQueryAdmin: Send {
     fn get_topic_consumers<'a>(&'a mut self, topic: &'a str) -> AdminFuture<'a, TopicConsumers>;
 }
 
+/// Additive low-cost Topic inventory capability for read-only callers.
+///
+/// This trait remains separate from [`TopicQueryAdmin`] so existing rich-list
+/// implementations keep their compatibility surface and behavior.
+pub trait TopicInventoryAdmin: Send {
+    fn get_topic_inventory<'a>(
+        &'a mut self,
+        request: &'a TopicInventoryRequest,
+    ) -> AdminFuture<'a, TopicInventoryResult>;
+}
+
 /// Exact parameters for advancing one consumer group's Topic offsets to the
 /// latest available position.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1143,6 +1177,9 @@ mod tests {
     use super::TopicConsumerGroups;
     use super::TopicConsumers;
     use super::TopicCurrentStats;
+    use super::TopicInventoryAdmin;
+    use super::TopicInventoryRequest;
+    use super::TopicInventoryResult;
     use super::TopicMutationOutcome;
     use super::TopicRoute;
     use super::TopicSendRequest;
@@ -1216,6 +1253,24 @@ mod tests {
         let _ = uses_batch_extension::<BatchOnlyFake>;
     }
 
+    #[test]
+    fn topic_inventory_request_normalizes_optional_cluster() {
+        assert_eq!(
+            TopicInventoryRequest::new(Some(" cluster-a ".to_string())).cluster,
+            Some("cluster-a".to_string())
+        );
+        assert_eq!(TopicInventoryRequest::new(Some("   ".to_string())).cluster, None);
+    }
+
+    #[test]
+    fn topic_inventory_is_additive_to_the_legacy_topic_admin_contract() {
+        fn uses_topic_admin<T: TopicAdmin>() {}
+        fn uses_topic_inventory<T: TopicInventoryAdmin>() {}
+
+        uses_topic_admin::<ExistingTopicAdminFake>();
+        uses_topic_inventory::<InventoryOnlyFake>();
+    }
+
     struct ExistingTopicAdminFake;
 
     impl TopicAdmin for ExistingTopicAdminFake {
@@ -1285,6 +1340,17 @@ mod tests {
             &'a mut self,
             _: &'a TopicBatchUpsertRequest,
         ) -> AdminFuture<'a, TopicBatchMutationOutcome> {
+            Box::pin(async { Err(AdminError::SessionClosed) })
+        }
+    }
+
+    struct InventoryOnlyFake;
+
+    impl TopicInventoryAdmin for InventoryOnlyFake {
+        fn get_topic_inventory<'a>(
+            &'a mut self,
+            _: &'a TopicInventoryRequest,
+        ) -> AdminFuture<'a, TopicInventoryResult> {
             Box::pin(async { Err(AdminError::SessionClosed) })
         }
     }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9903
- Fixes #9903

### Brief Description

- [x] Add a narrow read-only RocketMQ client and Admin Core topic inventory capability that selects exactly one cluster or global inventory source call.
- [x] Normalize cluster inventory into sorted, unique user topics while filtering retry and dead-letter topics, without changing global inventory or the legacy relationship-rich Admin Core listing.
- [x] Use the unique inventory for MCP cluster overview counts and topic listings while preserving the physical cluster name and `consumer_group: null` schema.
- [x] Add regression and backend-call-count coverage proving one inventory request and zero per-topic route or consumer scans.

### How Did You Test This Change?

Local validation passed:

- `cargo fmt -p rocketmq-client-rust -- --check`
- `cargo fmt -p rocketmq-admin-core -- --check`
- `cargo test -p rocketmq-client-rust topic_inventory_selects_exactly_one`
- `cargo test -p rocketmq-admin-core`
- `cargo test -p rocketmq-admin-core --features read-client-adapter`
- `cargo clippy -p rocketmq-client-rust -p rocketmq-admin-core --no-deps --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-client-rust -p rocketmq-admin-core --no-deps --all-features`
- `cargo fmt -p rocketmq-mcp -- --check`
- `cargo check --locked`
- `python scripts/check_read_only_boundary.py`
- `cargo test --locked`
- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`
- `cargo doc --locked --no-deps`
- `cargo test --locked snapshot`
- `git diff --check`

Pre-existing clean-main failures reproduced and not caused by this change:

- The MCP `cargo fmt --all -- --check` profile fails on Windows with OS error 206; the affected package-scoped format check passes.
- `cargo test -p rocketmq-client-rust` fails only `windows_consumer_starts_without_stack_overflow` with Windows stack overflow `0xc00000fd`.
- The SRE `cargo test --locked --workspace --all-features` profile has three pre-existing control-plane failures after 255 passed and 54 ignored; focused `semantic_registry_owners_are_mapped_exactly_once` reproduces semantic registry `unknown=["mcp"]`.
- Dashboard web backend `cargo clippy --all-targets --all-features -- -D warnings` and `cargo build --all-targets --all-features` both hit a pre-existing recursion-depth overflow at `src/main.rs:51`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only topic inventory support for retrieving topic names across a selected cluster or the global NameServer.
  * Topic inventories are now deduplicated and sorted for consistent results.
  * Cluster-specific results exclude retry and dead-letter topics, while global results retain them.
  * Added public administrative access to topic inventory queries when the admin-read feature is enabled.
* **Improvements**
  * Cluster names are normalized automatically, including trimming whitespace and handling empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->