### PR TITLE
[ISSUE #9905]🐛Preserve partial source failures in Admin Core and RocketMQ MCP queries

### DIFF
--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
@@ -17,8 +17,9 @@ use std::future::Future;
 use std::sync::Arc;
 
 use rocketmq_admin_core::core::broker::BrokerQueryAdmin;
+use rocketmq_admin_core::core::broker::BrokerRuntimeTargetStatus;
 use rocketmq_admin_core::core::broker::ListBrokersRequest;
-use rocketmq_admin_core::core::broker::ProbeBrokerRuntimeRequest;
+use rocketmq_admin_core::core::broker::ProbeBrokerRuntimeTargetRequest;
 use rocketmq_admin_core::core::consumer::ConsumerQueryAdmin;
 use rocketmq_admin_core::core::consumer::ListConsumerGroupsRequest;
 use rocketmq_admin_core::core::consumer::QueryConsumerLagRequest;
@@ -32,6 +33,7 @@ use rocketmq_admin_core::read_client_adapter::ReadAdminBuilder;
 use rocketmq_admin_core::read_client_adapter::ReadAdminGuard;
 
 use crate::model::contract::observed_at_from_millis;
+use crate::model::contract::QueryPayload;
 use crate::tools::cluster_tools::BrokerSummary;
 use crate::tools::consumer_tools::ConsumerGroupSummary;
 use crate::tools::consumer_tools::QueueLag;
@@ -62,7 +64,9 @@ pub(crate) struct SessionConsumerLag {
 }
 
 pub(crate) trait AdminSession: Send {
-    fn broker_rows(&mut self) -> impl Future<Output = Result<Vec<BrokerSummary>, ToolExecutionError>> + Send;
+    fn broker_rows(
+        &mut self,
+    ) -> impl Future<Output = Result<QueryPayload<Vec<BrokerSummary>>, ToolExecutionError>> + Send;
 
     fn topic_inventory(&mut self) -> impl Future<Output = Result<Vec<String>, ToolExecutionError>> + Send;
 
@@ -71,16 +75,20 @@ pub(crate) trait AdminSession: Send {
         topic: &str,
     ) -> impl Future<Output = Result<SessionTopicRoute, ToolExecutionError>> + Send;
 
-    fn consumer_groups(&mut self)
-        -> impl Future<Output = Result<Vec<ConsumerGroupSummary>, ToolExecutionError>> + Send;
+    fn consumer_groups(
+        &mut self,
+    ) -> impl Future<Output = Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError>> + Send;
 
     fn consumer_lag(
         &mut self,
         topic: &str,
         consumer_group: &str,
-    ) -> impl Future<Output = Result<SessionConsumerLag, ToolExecutionError>> + Send;
+    ) -> impl Future<Output = Result<QueryPayload<SessionConsumerLag>, ToolExecutionError>> + Send;
 
-    fn probe_broker_runtime(&mut self) -> impl Future<Output = Result<(), ToolExecutionError>> + Send;
+    fn probe_broker_runtime_target(
+        &mut self,
+        broker_name: &str,
+    ) -> impl Future<Output = Result<BrokerRuntimeTargetStatus, ToolExecutionError>> + Send;
 
     fn shutdown(self) -> impl Future<Output = Result<(), ToolExecutionError>> + Send;
 }
@@ -142,15 +150,15 @@ impl AdminCoreSession {
 }
 
 impl AdminSession for AdminCoreSession {
-    async fn broker_rows(&mut self) -> Result<Vec<BrokerSummary>, ToolExecutionError> {
+    async fn broker_rows(&mut self) -> Result<QueryPayload<Vec<BrokerSummary>>, ToolExecutionError> {
         let request = ListBrokersRequest::try_new(self.cluster.rocketmq_cluster_name.clone())
             .map_err(ToolExecutionError::backend)?;
         let result = self
             .admin_mut()?
-            .list_brokers(&request)
+            .list_brokers_with_evidence(&request)
             .await
             .map_err(ToolExecutionError::backend)?;
-        Ok(result.brokers.iter().map(map_broker_summary).collect())
+        Ok(QueryPayload::from_admin(result).map(|result| result.brokers.iter().map(map_broker_summary).collect()))
     }
 
     async fn topic_inventory(&mut self) -> Result<Vec<String>, ToolExecutionError> {
@@ -202,74 +210,83 @@ impl AdminSession for AdminCoreSession {
         Ok(SessionTopicRoute { brokers, queues })
     }
 
-    async fn consumer_groups(&mut self) -> Result<Vec<ConsumerGroupSummary>, ToolExecutionError> {
+    async fn consumer_groups(&mut self) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
         let result = self
             .admin_mut()?
-            .list_consumer_groups(&ListConsumerGroupsRequest)
+            .list_consumer_groups_with_evidence(&ListConsumerGroupsRequest)
             .await
             .map_err(ToolExecutionError::backend)?;
-        Ok(result
-            .groups
-            .into_iter()
-            .map(|group| ConsumerGroupSummary {
-                group: group.group,
-                version: group.version,
-                client_count: group.client_count,
-                consume_type: group.consume_type,
-                message_model: group.message_model,
-                consume_tps: group.consume_tps,
-                diff_total: group.diff_total,
-            })
-            .collect())
+        Ok(QueryPayload::from_admin(result).map(|result| {
+            result
+                .groups
+                .into_iter()
+                .map(|group| ConsumerGroupSummary {
+                    group: group.group,
+                    version: group.version,
+                    client_count: group.client_count,
+                    consume_type: group.consume_type,
+                    message_model: group.message_model,
+                    consume_tps: group.consume_tps,
+                    diff_total: group.diff_total,
+                })
+                .collect()
+        }))
     }
 
     async fn consumer_lag(
         &mut self,
         topic: &str,
         consumer_group: &str,
-    ) -> Result<SessionConsumerLag, ToolExecutionError> {
+    ) -> Result<QueryPayload<SessionConsumerLag>, ToolExecutionError> {
         let request =
             QueryConsumerLagRequest::try_new(topic, consumer_group, false).map_err(ToolExecutionError::backend)?;
         let result = self
             .admin_mut()?
-            .query_consumer_lag(&request)
+            .query_consumer_lag_with_evidence(&request)
             .await
             .map_err(ToolExecutionError::backend)?;
-        let mut queues = result
-            .rows
-            .iter()
-            .map(|row| QueueLag {
-                topic: row.topic.to_string(),
-                broker_name: row.broker_name.to_string(),
-                queue_id: row.queue_id,
-                broker_offset: row.broker_offset,
-                consumer_offset: row.consumer_offset,
-                lag: row.lag,
-                inflight: row.inflight,
-                last_observed_at: observed_at_from_millis(row.last_timestamp),
-                client_ip: row.client_ip.clone(),
-            })
-            .collect::<Vec<_>>();
-        queues.sort_by(|left, right| {
-            left.broker_name
-                .cmp(&right.broker_name)
-                .then(left.queue_id.cmp(&right.queue_id))
-        });
-        Ok(SessionConsumerLag {
-            queues,
-            total_lag: result.total_lag,
-            consume_tps: result.consume_tps,
-            inflight_total: result.inflight_total,
-        })
+        Ok(QueryPayload::from_admin(result).map(|result| {
+            let mut queues = result
+                .rows
+                .iter()
+                .map(|row| QueueLag {
+                    topic: row.topic.to_string(),
+                    broker_name: row.broker_name.to_string(),
+                    queue_id: row.queue_id,
+                    broker_offset: row.broker_offset,
+                    consumer_offset: row.consumer_offset,
+                    lag: row.lag,
+                    inflight: row.inflight,
+                    last_observed_at: observed_at_from_millis(row.last_timestamp),
+                    client_ip: row.client_ip.clone(),
+                })
+                .collect::<Vec<_>>();
+            queues.sort_by(|left, right| {
+                left.broker_name
+                    .cmp(&right.broker_name)
+                    .then(left.queue_id.cmp(&right.queue_id))
+            });
+            SessionConsumerLag {
+                queues,
+                total_lag: result.total_lag,
+                consume_tps: result.consume_tps,
+                inflight_total: result.inflight_total,
+            }
+        }))
     }
 
-    async fn probe_broker_runtime(&mut self) -> Result<(), ToolExecutionError> {
-        let request = ProbeBrokerRuntimeRequest::try_new(self.cluster.rocketmq_cluster_name.clone())
-            .map_err(ToolExecutionError::backend)?;
+    async fn probe_broker_runtime_target(
+        &mut self,
+        broker_name: &str,
+    ) -> Result<BrokerRuntimeTargetStatus, ToolExecutionError> {
+        let request = ProbeBrokerRuntimeTargetRequest::try_new(
+            self.cluster.rocketmq_cluster_name.clone(),
+            broker_name.to_string(),
+        )
+        .map_err(ToolExecutionError::backend)?;
         self.admin_mut()?
-            .probe_broker_runtime(&request)
+            .probe_broker_runtime_target(&request)
             .await
-            .map(|_| ())
             .map_err(ToolExecutionError::backend)
     }
 

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
@@ -17,6 +17,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
+use rocketmq_admin_core::core::broker::BrokerRuntimeTargetStatus;
 use tokio_util::sync::CancellationToken;
 
 use crate::adapter::admin_session::AdminCoreSessionFactory;
@@ -31,7 +32,12 @@ use crate::infrastructure::cache::QueryCache;
 use crate::model::contract::observed_at;
 use crate::model::contract::paginate;
 use crate::model::contract::PageRequest;
+use crate::model::contract::QueryCompleteness;
+use crate::model::contract::QueryPayload;
 use crate::model::contract::QueryResult;
+use crate::model::contract::QuerySource;
+use crate::model::contract::SourceFailure;
+use crate::model::contract::SourceFailureCode;
 use crate::model::contract::DEFAULT_PAGE_LIMIT;
 use crate::model::contract::SCHEMA_VERSION;
 use crate::model::diagnosis::DiagnosisReport;
@@ -193,16 +199,18 @@ where
                     self.run_workflow(cluster, |session, cluster| {
                         Box::pin(async move {
                             let brokers = session.broker_rows().await?;
+                            let mut completeness = brokers.completeness();
                             let topics = sorted_unique_topic_names(session.topic_inventory().await?);
                             let consumer_groups = session.consumer_groups().await?;
-                            Ok(ClusterOverviewOutput {
+                            completeness.merge(consumer_groups.completeness());
+                            Ok(completeness.wrap(ClusterOverviewOutput {
                                 cluster: cluster.name.clone(),
                                 namesrv_addr: cluster.namesrv_addr.clone(),
-                                brokers,
+                                brokers: brokers.data,
                                 topic_count: topics.len(),
-                                consumer_group_count: consumer_groups.len(),
+                                consumer_group_count: consumer_groups.data.len(),
                                 generated_at: observed_at(),
-                            })
+                            }))
                         })
                     })
                     .await
@@ -244,12 +252,12 @@ where
                             }
                             let page = paginate(topics, &args.page)
                                 .map_err(|error| ToolExecutionError::InvalidArguments(error.to_string()))?;
-                            Ok(ListTopicsOutput {
+                            Ok(QueryPayload::complete(ListTopicsOutput {
                                 cluster: cluster.name.clone(),
                                 namesrv_addr: cluster.namesrv_addr.clone(),
                                 page,
                                 generated_at: observed_at(),
-                            })
+                            }))
                         })
                     })
                     .await
@@ -281,7 +289,7 @@ where
                         Box::pin(async move {
                             let route = session.topic_route(&args.topic).await?;
                             let route = topic_route_output(cluster, &args.topic, route, &args.page)?;
-                            Ok(describe_topic_output(&route))
+                            Ok(QueryPayload::complete(describe_topic_output(&route)))
                         })
                     })
                     .await
@@ -312,7 +320,7 @@ where
                     self.run_workflow(cluster, move |session, cluster| {
                         Box::pin(async move {
                             let route = session.topic_route(&args.topic).await?;
-                            topic_route_output(cluster, &args.topic, route, &args.page)
+                            topic_route_output(cluster, &args.topic, route, &args.page).map(QueryPayload::complete)
                         })
                     })
                     .await
@@ -341,19 +349,21 @@ where
                 move || async {
                     self.run_workflow(cluster, move |session, cluster| {
                         Box::pin(async move {
-                            let mut groups = session.consumer_groups().await?;
+                            let groups = session.consumer_groups().await?;
+                            let completeness = groups.completeness();
+                            let mut groups = groups.data;
                             groups.sort_by(|left, right| left.group.cmp(&right.group));
                             if let Some(filter) = normalized_filter(args.filter.as_deref()) {
                                 groups.retain(|entry| entry.group.to_ascii_lowercase().contains(&filter));
                             }
                             let page = paginate(groups, &args.page)
                                 .map_err(|error| ToolExecutionError::InvalidArguments(error.to_string()))?;
-                            Ok(ListConsumerGroupsOutput {
+                            Ok(completeness.wrap(ListConsumerGroupsOutput {
                                 cluster: cluster.name.clone(),
                                 namesrv_addr: cluster.namesrv_addr.clone(),
                                 page,
                                 generated_at: observed_at(),
-                            })
+                            }))
                         })
                     })
                     .await
@@ -390,7 +400,9 @@ where
                     self.run_workflow(cluster, move |session, cluster| {
                         Box::pin(async move {
                             let lag = session.consumer_lag(&args.topic, &args.consumer_group).await?;
-                            consumer_lag_output(cluster, args.topic, args.consumer_group, &args.page, lag)
+                            let completeness = lag.completeness();
+                            consumer_lag_output(cluster, args.topic, args.consumer_group, &args.page, lag.data)
+                                .map(|output| completeness.wrap(output))
                         })
                     })
                     .await
@@ -450,19 +462,27 @@ where
                 move || async {
                     self.run_workflow(cluster, move |session, cluster| {
                         Box::pin(async move {
-                            let lag_result =
-                                session
-                                    .consumer_lag(&args.topic, &args.consumer_group)
-                                    .await
-                                    .and_then(|lag| {
-                                        consumer_lag_output(
-                                            cluster,
-                                            args.topic.clone(),
-                                            args.consumer_group.clone(),
-                                            &PageRequest::default(),
-                                            lag,
-                                        )
-                                    });
+                            let mut completeness = QueryCompleteness::default();
+                            let lag_result = match session.consumer_lag(&args.topic, &args.consumer_group).await {
+                                Ok(lag) => {
+                                    completeness.merge(lag.completeness());
+                                    consumer_lag_output(
+                                        cluster,
+                                        args.topic.clone(),
+                                        args.consumer_group.clone(),
+                                        &PageRequest::default(),
+                                        lag.data,
+                                    )
+                                }
+                                Err(error) => {
+                                    completeness.merge(completeness_for_error(
+                                        QuerySource::ConsumerStatistics,
+                                        &args.consumer_group,
+                                        &error,
+                                    ));
+                                    Err(error)
+                                }
+                            };
                             let (topic_result, route_result) = match session.topic_route(&args.topic).await {
                                 Ok(route) => {
                                     let route =
@@ -470,18 +490,40 @@ where
                                     (Ok(describe_topic_output(&route)), Ok(route))
                                 }
                                 Err(error) => {
-                                    let message = error.to_string();
-                                    (Err(ToolExecutionError::backend(&message)), Err(error))
+                                    completeness.merge(completeness_for_error(
+                                        QuerySource::TopicRoute,
+                                        &args.topic,
+                                        &error,
+                                    ));
+                                    (
+                                        Err(ToolExecutionError::Backend(
+                                            "topic route source is unavailable".to_string(),
+                                        )),
+                                        Err(error),
+                                    )
                                 }
                             };
                             let broker_result = match top_lag_broker(lag_result.as_ref().ok()) {
                                 Some(broker_name) => {
-                                    Some(describe_broker_in_session(session, cluster, broker_name).await)
+                                    match describe_broker_in_session(session, cluster, broker_name.clone()).await {
+                                        Ok(broker) => {
+                                            completeness.merge(broker.completeness());
+                                            Some(Ok(broker.data))
+                                        }
+                                        Err(error) => {
+                                            completeness.merge(completeness_for_error(
+                                                QuerySource::BrokerRuntime,
+                                                &broker_name,
+                                                &error,
+                                            ));
+                                            Some(Err(error))
+                                        }
+                                    }
                                 }
                                 None => None,
                             };
 
-                            Ok(diagnosis_rules::evaluate(
+                            let report = diagnosis_rules::evaluate(
                                 &args,
                                 ConsumerLagEvidence {
                                     lag: lag_result,
@@ -490,7 +532,12 @@ where
                                     broker: broker_result,
                                 },
                                 &policy,
-                            ))
+                            );
+                            if report.partial {
+                                completeness.partial = true;
+                                completeness.warnings.push("diagnosis_evidence_incomplete".to_string());
+                            }
+                            Ok(completeness.wrap(report))
                         })
                     })
                     .await
@@ -715,30 +762,59 @@ async fn describe_broker_in_session<S>(
     session: &mut S,
     cluster: &ResolvedCluster,
     broker_name: String,
-) -> Result<DescribeBrokerOutput, ToolExecutionError>
+) -> Result<QueryPayload<DescribeBrokerOutput>, ToolExecutionError>
 where
     S: AdminSession,
 {
-    let brokers = session
-        .broker_rows()
-        .await?
+    let broker_payload = session.broker_rows().await?;
+    let completeness = broker_payload.completeness();
+    let brokers = broker_payload
+        .data
         .into_iter()
         .filter(|broker| broker.broker_name == broker_name)
         .collect::<Vec<_>>();
     if brokers.is_empty() {
-        session.probe_broker_runtime().await?;
+        match session.probe_broker_runtime_target(&broker_name).await? {
+            BrokerRuntimeTargetStatus::Available | BrokerRuntimeTargetStatus::SourceUnavailable => {
+                return Err(ToolExecutionError::Backend(
+                    "selected broker source is unavailable".to_string(),
+                ));
+            }
+            BrokerRuntimeTargetStatus::NotFound => {}
+        }
         return Err(ToolExecutionError::InvalidArguments(format!(
             "broker not found in cluster {}: {broker_name}",
             cluster.name
         )));
     }
-    Ok(DescribeBrokerOutput {
+    Ok(completeness.wrap(DescribeBrokerOutput {
         cluster: cluster.name.clone(),
         namesrv_addr: cluster.namesrv_addr.clone(),
         broker_name,
         brokers,
         generated_at: observed_at(),
-    })
+    }))
+}
+
+fn completeness_for_error(source: QuerySource, logical_target: &str, error: &ToolExecutionError) -> QueryCompleteness {
+    let (code, retryable) = match error {
+        ToolExecutionError::TimedOut { .. } => (SourceFailureCode::Timeout, true),
+        ToolExecutionError::RateLimited(_) => (SourceFailureCode::RateLimited, true),
+        ToolExecutionError::PermissionDenied(_)
+        | ToolExecutionError::UnauthorizedScope(_)
+        | ToolExecutionError::TenantMismatch(_)
+        | ToolExecutionError::ClusterNotAllowed(_) => (SourceFailureCode::PermissionDenied, false),
+        ToolExecutionError::InvalidArguments(_) => (SourceFailureCode::NotFound, false),
+        ToolExecutionError::Backend(_) | ToolExecutionError::Cancelled => (SourceFailureCode::SourceUnavailable, true),
+        ToolExecutionError::OutputTooLarge { .. }
+        | ToolExecutionError::ChangePlanningDisabled(_)
+        | ToolExecutionError::Internal(_) => (SourceFailureCode::InvalidResponse, false),
+    };
+    QueryCompleteness {
+        partial: true,
+        warnings: vec!["source_failures_present".to_string()],
+        source_failures: vec![SourceFailure::new(source, code, retryable, logical_target)],
+    }
 }
 
 fn top_lag_broker(lag: Option<&QueryConsumerLagOutput>) -> Option<String> {
@@ -828,6 +904,9 @@ mod tests {
     struct FakeSessionFactory {
         counters: Arc<LifecycleCounters>,
         selected_broker_missing: bool,
+        failed_selected_broker: bool,
+        overflow_failed_selected_broker: bool,
+        partial_sources: bool,
         hang_broker_query: bool,
         hang_topic_inventory: bool,
         delay_topic_inventory: bool,
@@ -843,6 +922,9 @@ mod tests {
                 cluster,
                 counters: self.counters.clone(),
                 selected_broker_missing: self.selected_broker_missing,
+                failed_selected_broker: self.failed_selected_broker,
+                overflow_failed_selected_broker: self.overflow_failed_selected_broker,
+                partial_sources: self.partial_sources,
                 hang_broker_query: self.hang_broker_query,
                 hang_topic_inventory: self.hang_topic_inventory,
                 delay_topic_inventory: self.delay_topic_inventory,
@@ -855,6 +937,9 @@ mod tests {
         cluster: ResolvedCluster,
         counters: Arc<LifecycleCounters>,
         selected_broker_missing: bool,
+        failed_selected_broker: bool,
+        overflow_failed_selected_broker: bool,
+        partial_sources: bool,
         hang_broker_query: bool,
         hang_topic_inventory: bool,
         delay_topic_inventory: bool,
@@ -862,17 +947,44 @@ mod tests {
     }
 
     impl AdminSession for FakeSession {
-        async fn broker_rows(&mut self) -> Result<Vec<BrokerSummary>, ToolExecutionError> {
+        async fn broker_rows(&mut self) -> Result<QueryPayload<Vec<BrokerSummary>>, ToolExecutionError> {
             self.counters.broker_queries.fetch_add(1, Ordering::SeqCst);
             if self.hang_broker_query {
                 std::future::pending::<()>().await;
+            }
+            if self.failed_selected_broker {
+                return Ok(partial_payload(Vec::new(), QuerySource::BrokerRuntime, "broker-a"));
+            }
+            if self.overflow_failed_selected_broker {
+                let failures = (0..crate::model::contract::MAX_SOURCE_FAILURES)
+                    .map(|index| {
+                        SourceFailure::new(
+                            QuerySource::BrokerRuntime,
+                            SourceFailureCode::SourceUnavailable,
+                            true,
+                            format!("broker-{index:02}"),
+                        )
+                    })
+                    .chain(std::iter::once(SourceFailure::new(
+                        QuerySource::BrokerRuntime,
+                        SourceFailureCode::SourceUnavailable,
+                        true,
+                        "broker-z",
+                    )))
+                    .collect();
+                return Ok(QueryPayload::new(Vec::new(), true, Vec::new(), failures));
             }
             let broker_name = if self.selected_broker_missing {
                 "broker-b"
             } else {
                 "broker-a"
             };
-            Ok(vec![broker_summary(&self.cluster.name, broker_name)])
+            let brokers = vec![broker_summary(&self.cluster.name, broker_name)];
+            Ok(if self.partial_sources {
+                partial_payload(brokers, QuerySource::BrokerRuntime, "broker-b")
+            } else {
+                QueryPayload::complete(brokers)
+            })
         }
 
         async fn topic_inventory(&mut self) -> Result<Vec<String>, ToolExecutionError> {
@@ -897,34 +1009,67 @@ mod tests {
             })
         }
 
-        async fn consumer_groups(&mut self) -> Result<Vec<ConsumerGroupSummary>, ToolExecutionError> {
+        async fn consumer_groups(&mut self) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
             self.counters.consumer_group_queries.fetch_add(1, Ordering::SeqCst);
-            Ok(vec![consumer_group("order-service")])
+            let groups = vec![consumer_group("order-service")];
+            Ok(if self.partial_sources {
+                partial_payload(groups, QuerySource::ConsumerConnection, "broker-b")
+            } else {
+                QueryPayload::complete(groups)
+            })
         }
 
         async fn consumer_lag(
             &mut self,
             _topic: &str,
             _consumer_group: &str,
-        ) -> Result<SessionConsumerLag, ToolExecutionError> {
+        ) -> Result<QueryPayload<SessionConsumerLag>, ToolExecutionError> {
             self.counters.consumer_lag_queries.fetch_add(1, Ordering::SeqCst);
-            Ok(SessionConsumerLag {
+            let lag = SessionConsumerLag {
                 queues: vec![queue_lag("broker-a")],
                 total_lag: 10_000,
                 consume_tps: 0.5,
                 inflight_total: 5,
+            };
+            Ok(if self.partial_sources {
+                partial_payload(lag, QuerySource::ConsumerStatistics, "broker-b")
+            } else {
+                QueryPayload::complete(lag)
             })
         }
 
-        async fn probe_broker_runtime(&mut self) -> Result<(), ToolExecutionError> {
+        async fn probe_broker_runtime_target(
+            &mut self,
+            _broker_name: &str,
+        ) -> Result<BrokerRuntimeTargetStatus, ToolExecutionError> {
             self.counters.runtime_probes.fetch_add(1, Ordering::SeqCst);
-            Ok(())
+            if self.failed_selected_broker || self.overflow_failed_selected_broker {
+                Ok(BrokerRuntimeTargetStatus::SourceUnavailable)
+            } else if self.selected_broker_missing {
+                Ok(BrokerRuntimeTargetStatus::NotFound)
+            } else {
+                Ok(BrokerRuntimeTargetStatus::Available)
+            }
         }
 
         async fn shutdown(self) -> Result<(), ToolExecutionError> {
             self.counters.shutdowns.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
+    }
+
+    fn partial_payload<T>(data: T, source: QuerySource, logical_target: &str) -> QueryPayload<T> {
+        QueryPayload::new(
+            data,
+            true,
+            Vec::new(),
+            vec![SourceFailure::new(
+                source,
+                SourceFailureCode::SourceUnavailable,
+                true,
+                logical_target,
+            )],
+        )
     }
 
     #[test]
@@ -1010,6 +1155,138 @@ mod tests {
         assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
         assert_eq!(counters.consumer_group_queries.load(Ordering::SeqCst), 1);
         assert_eq!(counters.route_queries.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn query_facade_composes_partial_evidence_for_overview_lists_lag_broker_and_diagnosis() {
+        let facade = QueryFacade::with_factory(
+            example_config(),
+            FakeSessionFactory {
+                partial_sources: true,
+                ..Default::default()
+            },
+        );
+
+        let overview = facade
+            .cluster_overview(ClusterOverviewArgs {
+                cluster: "local-dev".to_string(),
+            })
+            .await
+            .unwrap();
+        assert!(overview.partial);
+        assert_eq!(overview.source_failures.len(), 2);
+
+        let groups = facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: None,
+                page: PageRequest::default(),
+            })
+            .await
+            .unwrap();
+        assert!(groups.partial);
+        assert_eq!(groups.source_failures[0].source, QuerySource::ConsumerConnection);
+
+        let lag = facade
+            .query_consumer_lag(QueryConsumerLagArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                consumer_group: "order-service".to_string(),
+                page: PageRequest::default(),
+            })
+            .await
+            .unwrap();
+        assert!(lag.partial);
+        assert_eq!(lag.source_failures[0].source, QuerySource::ConsumerStatistics);
+
+        let broker = facade
+            .describe_broker(DescribeBrokerArgs {
+                cluster: "local-dev".to_string(),
+                broker_name: "broker-a".to_string(),
+            })
+            .await
+            .unwrap();
+        assert!(broker.partial);
+        assert_eq!(broker.source_failures[0].logical_target, "broker-b");
+
+        let diagnosis = facade.diagnose_consumer_lag(diagnosis_request()).await.unwrap();
+        assert!(diagnosis.partial);
+        assert!(diagnosis
+            .warnings
+            .iter()
+            .any(|warning| warning == "source_failures_present"));
+        assert!(diagnosis.source_failures.len() >= 2);
+    }
+
+    #[tokio::test]
+    async fn failed_selected_broker_is_not_reported_as_not_found() {
+        let facade = QueryFacade::with_factory(
+            example_config(),
+            FakeSessionFactory {
+                failed_selected_broker: true,
+                ..Default::default()
+            },
+        );
+
+        let error = facade
+            .describe_broker(DescribeBrokerArgs {
+                cluster: "local-dev".to_string(),
+                broker_name: "broker-a".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ToolExecutionError::Backend(_)));
+        assert!(!error.to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn selected_broker_beyond_public_failure_cap_is_unavailable_for_tool_and_resource() {
+        let facade = QueryFacade::with_factory(
+            example_config(),
+            FakeSessionFactory {
+                overflow_failed_selected_broker: true,
+                ..Default::default()
+            },
+        );
+
+        let public = facade
+            .cluster_overview(ClusterOverviewArgs {
+                cluster: "local-dev".to_string(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            public.source_failures.len(),
+            crate::model::contract::MAX_SOURCE_FAILURES
+        );
+        assert!(public
+            .warnings
+            .iter()
+            .any(|warning| warning == "source_failures_truncated"));
+        assert!(!public
+            .source_failures
+            .iter()
+            .any(|failure| failure.logical_target == "broker-z"));
+
+        let tool_error = ReadOnlyQuery::describe_broker(
+            &facade,
+            DescribeBrokerArgs {
+                cluster: "local-dev".to_string(),
+                broker_name: "broker-z".to_string(),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(tool_error, ToolExecutionError::Backend(_)));
+        assert!(!tool_error.to_string().contains("not found"));
+
+        let resource_error =
+            resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/brokers/broker-z")
+                .await
+                .unwrap_err();
+        assert_ne!(resource_error.code, rmcp::model::ErrorCode::RESOURCE_NOT_FOUND);
+        assert_eq!(resource_error.data.unwrap()["code"], "source_unavailable");
     }
 
     #[tokio::test]

--- a/rocketmq-ai/rocketmq-mcp/src/infrastructure/cache.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/infrastructure/cache.rs
@@ -30,6 +30,7 @@ use rocketmq_observability::metrics::mcp::McpCacheEvent;
 
 use crate::model::contract::observed_at;
 use crate::model::contract::CacheStatus;
+use crate::model::contract::QueryPayload;
 use crate::model::contract::QueryResult;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -106,8 +107,14 @@ impl QueryCache {
         LoadFuture: Future<Output = Result<T, E>>,
     {
         let cancellation = CancellationToken::new();
-        self.get_or_try_init_cancellable(key, ttl, &cancellation, || unreachable!(), load)
-            .await
+        self.get_or_try_init_cancellable(
+            key,
+            ttl,
+            &cancellation,
+            || unreachable!(),
+            || async { load().await.map(QueryPayload::complete) },
+        )
+        .await
     }
 
     pub(crate) async fn get_or_try_init_cancellable<T, E, Load, LoadFuture, Cancelled>(
@@ -121,18 +128,15 @@ impl QueryCache {
     where
         T: Clone + Send + Sync + 'static,
         Load: FnOnce() -> LoadFuture,
-        LoadFuture: Future<Output = Result<T, E>>,
+        LoadFuture: Future<Output = Result<QueryPayload<T>, E>>,
         Cancelled: FnOnce() -> E,
     {
         if !self.inner.enabled || self.inner.capacity == 0 || ttl.is_zero() {
             self.inner.metrics.bypasses.fetch_add(1, Ordering::Relaxed);
             rocketmq_observability::metrics::mcp::record_cache_event(McpCacheEvent::Bypass);
-            return load().await.map(|data| QueryResult {
-                data,
-                observed_at: observed_at(),
-                freshness_ms: 0,
-                cache_status: CacheStatus::Bypass,
-            });
+            return load()
+                .await
+                .map(|payload| QueryResult::from_payload(payload, observed_at(), 0, CacheStatus::Bypass));
         }
 
         if let Some(result) = self.get(&key).await {
@@ -154,18 +158,13 @@ impl QueryCache {
         }
 
         let generation = self.inner.generation.load(Ordering::Acquire);
-        let data = load().await?;
+        let payload = load().await?;
         let observed_at = observed_at();
-        self.insert_if_current(key, data.clone(), observed_at.clone(), ttl, generation)
+        self.insert_if_current(key, payload.clone(), observed_at.clone(), ttl, generation)
             .await;
         self.inner.metrics.misses.fetch_add(1, Ordering::Relaxed);
         rocketmq_observability::metrics::mcp::record_cache_event(McpCacheEvent::Miss);
-        Ok(QueryResult {
-            data,
-            observed_at,
-            freshness_ms: 0,
-            cache_status: CacheStatus::Miss,
-        })
+        Ok(QueryResult::from_payload(payload, observed_at, 0, CacheStatus::Miss))
     }
 
     pub(crate) fn metrics(&self) -> CacheMetricsSnapshot {
@@ -202,18 +201,13 @@ impl QueryCache {
             return None;
         }
         let entry = state.entries.get(key)?;
-        let data = entry.value.downcast_ref::<T>()?.clone();
+        let payload = entry.value.downcast_ref::<QueryPayload<T>>()?.clone();
         let freshness_ms = now
             .saturating_duration_since(entry.inserted_at)
             .as_millis()
             .try_into()
             .unwrap_or(u64::MAX);
-        let result = QueryResult {
-            data,
-            observed_at: entry.observed_at.clone(),
-            freshness_ms,
-            cache_status: CacheStatus::Hit,
-        };
+        let result = QueryResult::from_payload(payload, entry.observed_at.clone(), freshness_ms, CacheStatus::Hit);
         self.inner.metrics.hits.fetch_add(1, Ordering::Relaxed);
         rocketmq_observability::metrics::mcp::record_cache_event(McpCacheEvent::Hit);
         Some(result)
@@ -283,6 +277,9 @@ mod tests {
     use tokio::sync::Notify;
 
     use crate::model::contract::CacheStatus;
+    use crate::model::contract::QuerySource;
+    use crate::model::contract::SourceFailure;
+    use crate::model::contract::SourceFailureCode;
 
     use super::*;
 
@@ -298,6 +295,51 @@ mod tests {
         assert_eq!(second.cache_status, CacheStatus::Hit);
         assert_eq!(first.data, second.data);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_hit_preserves_partial_evidence_exactly() {
+        let cache = QueryCache::new(true, 8);
+        let cancellation = CancellationToken::new();
+        let payload = QueryPayload::new(
+            "usable".to_string(),
+            true,
+            vec!["enrichment_incomplete".to_string()],
+            vec![SourceFailure::new(
+                QuerySource::ConsumerStatistics,
+                SourceFailureCode::Timeout,
+                true,
+                "broker-b",
+            )],
+        );
+        let first = cache
+            .get_or_try_init_cancellable(
+                "group:orders".to_string(),
+                Duration::from_secs(1),
+                &cancellation,
+                || (),
+                || async { Ok::<_, ()>(payload) },
+            )
+            .await
+            .unwrap();
+        let second: QueryResult<String> = cache
+            .get_or_try_init_cancellable(
+                "group:orders".to_string(),
+                Duration::from_secs(1),
+                &cancellation,
+                || (),
+                || async { panic!("cache hit must not reload") },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(second.cache_status, CacheStatus::Hit);
+        assert_eq!(first.data, second.data);
+        assert_eq!(first.partial, second.partial);
+        assert_eq!(first.warnings, second.warnings);
+        assert_eq!(first.source_failures, second.source_failures);
+        assert_eq!(first.observed_at, second.observed_at);
     }
 
     #[tokio::test]

--- a/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
@@ -23,6 +23,193 @@ use serde::Serialize;
 pub const SCHEMA_VERSION: &str = "rocketmq-mcp.v2";
 pub const DEFAULT_PAGE_LIMIT: u32 = 50;
 pub const MAX_PAGE_LIMIT: u32 = 200;
+pub const MAX_SOURCE_FAILURES: usize = 16;
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum QuerySource {
+    BrokerRuntime,
+    ConsumerStatistics,
+    ConsumerConnection,
+    ProducerConnection,
+    SubscriptionGroups,
+    TopicRoute,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceFailureCode {
+    SourceUnavailable,
+    Timeout,
+    PermissionDenied,
+    NotFound,
+    RateLimited,
+    InvalidResponse,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(deny_unknown_fields)]
+pub struct SourceFailure {
+    pub source: QuerySource,
+    pub code: SourceFailureCode,
+    pub retryable: bool,
+    pub logical_target: String,
+}
+
+impl<'de> Deserialize<'de> for SourceFailure {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct WireFailure {
+            source: QuerySource,
+            code: SourceFailureCode,
+            retryable: bool,
+            logical_target: String,
+        }
+
+        let failure = WireFailure::deserialize(deserializer)?;
+        Ok(Self::new(
+            failure.source,
+            failure.code,
+            failure.retryable,
+            failure.logical_target,
+        ))
+    }
+}
+
+impl SourceFailure {
+    pub(crate) fn new(
+        source: QuerySource,
+        code: SourceFailureCode,
+        retryable: bool,
+        logical_target: impl AsRef<str>,
+    ) -> Self {
+        Self {
+            source,
+            code,
+            retryable,
+            logical_target: safe_logical_target(logical_target.as_ref()),
+        }
+    }
+
+    pub(crate) fn from_admin(failure: &rocketmq_admin_core::core::query::AdminSourceFailure) -> Self {
+        use rocketmq_admin_core::core::query::AdminQueryFailureCode as AdminCode;
+        use rocketmq_admin_core::core::query::AdminQuerySource as AdminSource;
+
+        let source = match failure.source() {
+            AdminSource::BrokerRuntime => QuerySource::BrokerRuntime,
+            AdminSource::ConsumerStatistics => QuerySource::ConsumerStatistics,
+            AdminSource::ConsumerConnection => QuerySource::ConsumerConnection,
+            AdminSource::ProducerConnection => QuerySource::ProducerConnection,
+            AdminSource::SubscriptionGroups => QuerySource::SubscriptionGroups,
+        };
+        let code = match failure.code() {
+            AdminCode::SourceUnavailable => SourceFailureCode::SourceUnavailable,
+            AdminCode::Timeout => SourceFailureCode::Timeout,
+            AdminCode::PermissionDenied => SourceFailureCode::PermissionDenied,
+            AdminCode::NotFound => SourceFailureCode::NotFound,
+            AdminCode::RateLimited => SourceFailureCode::RateLimited,
+            AdminCode::InvalidResponse => SourceFailureCode::InvalidResponse,
+        };
+        Self::new(source, code, failure.retryable(), failure.logical_target())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct QueryPayload<T> {
+    pub data: T,
+    pub partial: bool,
+    pub warnings: Vec<String>,
+    pub source_failures: Vec<SourceFailure>,
+}
+
+impl<T> QueryPayload<T> {
+    pub(crate) fn complete(data: T) -> Self {
+        Self {
+            data,
+            partial: false,
+            warnings: Vec::new(),
+            source_failures: Vec::new(),
+        }
+    }
+
+    pub(crate) fn new(
+        data: T,
+        partial: bool,
+        mut warnings: Vec<String>,
+        mut source_failures: Vec<SourceFailure>,
+    ) -> Self {
+        source_failures.iter_mut().for_each(|failure| {
+            failure.logical_target = safe_logical_target(&failure.logical_target);
+        });
+        source_failures.sort();
+        source_failures.dedup();
+        let overflow = source_failures.len() > MAX_SOURCE_FAILURES;
+        source_failures.truncate(MAX_SOURCE_FAILURES);
+        if !source_failures.is_empty() && !warnings.iter().any(|warning| warning == "source_failures_present") {
+            warnings.push("source_failures_present".to_string());
+        }
+        if overflow && !warnings.iter().any(|warning| warning == "source_failures_truncated") {
+            warnings.push("source_failures_truncated".to_string());
+        }
+        warnings.sort();
+        warnings.dedup();
+        Self {
+            data,
+            partial: partial || !source_failures.is_empty(),
+            warnings,
+            source_failures,
+        }
+    }
+
+    pub(crate) fn from_admin(result: rocketmq_admin_core::core::query::AdminQueryResult<T>) -> Self {
+        Self::new(
+            result.data,
+            result.partial,
+            result.warnings,
+            result.source_failures.iter().map(SourceFailure::from_admin).collect(),
+        )
+    }
+
+    pub(crate) fn map<U>(self, map: impl FnOnce(T) -> U) -> QueryPayload<U> {
+        QueryPayload {
+            data: map(self.data),
+            partial: self.partial,
+            warnings: self.warnings,
+            source_failures: self.source_failures,
+        }
+    }
+
+    pub(crate) fn completeness(&self) -> QueryCompleteness {
+        QueryCompleteness {
+            partial: self.partial,
+            warnings: self.warnings.clone(),
+            source_failures: self.source_failures.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct QueryCompleteness {
+    pub partial: bool,
+    pub warnings: Vec<String>,
+    pub source_failures: Vec<SourceFailure>,
+}
+
+impl QueryCompleteness {
+    pub(crate) fn merge(&mut self, other: QueryCompleteness) {
+        self.partial |= other.partial;
+        self.warnings.extend(other.warnings);
+        self.source_failures.extend(other.source_failures);
+    }
+
+    pub(crate) fn wrap<T>(self, data: T) -> QueryPayload<T> {
+        QueryPayload::new(data, self.partial, self.warnings, self.source_failures)
+    }
+}
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -57,6 +244,9 @@ pub(crate) struct QueryResult<T> {
     pub observed_at: String,
     pub freshness_ms: u64,
     pub cache_status: CacheStatus,
+    pub partial: bool,
+    pub warnings: Vec<String>,
+    pub source_failures: Vec<SourceFailure>,
 }
 
 impl<T> QueryResult<T> {
@@ -67,6 +257,26 @@ impl<T> QueryResult<T> {
             observed_at: observed_at(),
             freshness_ms: 0,
             cache_status: CacheStatus::Bypass,
+            partial: false,
+            warnings: Vec::new(),
+            source_failures: Vec::new(),
+        }
+    }
+
+    pub(crate) fn from_payload(
+        payload: QueryPayload<T>,
+        observed_at: String,
+        freshness_ms: u64,
+        cache_status: CacheStatus,
+    ) -> Self {
+        Self {
+            data: payload.data,
+            observed_at,
+            freshness_ms,
+            cache_status,
+            partial: payload.partial,
+            warnings: payload.warnings,
+            source_failures: payload.source_failures,
         }
     }
 }
@@ -89,6 +299,8 @@ pub struct ToolResponse<T> {
     pub cache_status: CacheStatus,
     pub partial: bool,
     pub warnings: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_failures: Option<Vec<SourceFailure>>,
     pub data: T,
 }
 
@@ -103,6 +315,7 @@ impl<T> ToolResponse<T> {
             cache_status: CacheStatus::Bypass,
             partial: false,
             warnings: Vec::new(),
+            source_failures: None,
             data,
         }
     }
@@ -119,8 +332,9 @@ impl<T> ToolResponse<T> {
             observed_at: result.observed_at,
             freshness_ms: result.freshness_ms,
             cache_status: result.cache_status,
-            partial: false,
-            warnings: Vec::new(),
+            partial: result.partial,
+            warnings: result.warnings,
+            source_failures: (!result.source_failures.is_empty()).then_some(result.source_failures),
             data: result.data,
         }
     }
@@ -187,6 +401,30 @@ fn decode_cursor(cursor: &str) -> Result<usize, PaginationError> {
     usize::from_str_radix(offset, 16).map_err(|_| PaginationError::InvalidCursor)
 }
 
+fn safe_logical_target(target: &str) -> String {
+    const MAX_BYTES: usize = 128;
+    let target = target.trim();
+    if target.is_empty()
+        || target.len() > MAX_BYTES
+        || target.parse::<std::net::IpAddr>().is_ok()
+        || target.parse::<std::net::SocketAddr>().is_ok()
+        || target.contains([':', '/', '\\', '@', '=', '&', '?'])
+        || target.chars().any(char::is_control)
+    {
+        return "unknown".to_string();
+    }
+    target
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,5 +483,95 @@ mod tests {
         let timestamp = observed_at();
         assert!(chrono::DateTime::parse_from_rfc3339(&timestamp).is_ok());
         assert_eq!(observed_at_from_millis(0).as_deref(), Some("1970-01-01T00:00:00.000Z"));
+    }
+
+    #[test]
+    fn complete_tool_response_keeps_the_existing_wire_shape() {
+        let response = ToolResponse::live("request-1", "primary", serde_json::json!({"brokers": []}));
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(value["partial"], false);
+        assert_eq!(value["warnings"], serde_json::json!([]));
+        assert!(value.get("source_failures").is_none());
+    }
+
+    #[test]
+    fn old_complete_tool_response_deserializes_without_source_failures() {
+        let response: ToolResponse<serde_json::Value> = serde_json::from_value(serde_json::json!({
+            "schema_version": "rocketmq-mcp.v2",
+            "request_id": "request-1",
+            "cluster": "primary",
+            "observed_at": "2026-01-01T00:00:00.000Z",
+            "freshness_ms": 0,
+            "cache_status": "bypass",
+            "partial": false,
+            "warnings": [],
+            "data": {"brokers": []}
+        }))
+        .unwrap();
+
+        assert_eq!(response.source_failures, None);
+    }
+
+    #[test]
+    fn tool_response_deserialization_reapplies_source_target_sanitization() {
+        let response: ToolResponse<serde_json::Value> = serde_json::from_value(serde_json::json!({
+            "schema_version": "rocketmq-mcp.v2",
+            "request_id": "request-1",
+            "cluster": "primary",
+            "observed_at": "2026-01-01T00:00:00.000Z",
+            "freshness_ms": 0,
+            "cache_status": "bypass",
+            "partial": true,
+            "warnings": ["source_failures_present"],
+            "source_failures": [{
+                "source": "broker_runtime",
+                "code": "source_unavailable",
+                "retryable": true,
+                "logical_target": "10.0.0.1:10911"
+            }],
+            "data": {"brokers": []}
+        }))
+        .unwrap();
+
+        assert_eq!(response.source_failures.unwrap()[0].logical_target, "unknown");
+    }
+
+    #[test]
+    fn query_payload_normalizes_failure_evidence_deterministically() {
+        let failures = (0..20)
+            .rev()
+            .chain(std::iter::once(0))
+            .map(|index| {
+                SourceFailure::new(
+                    QuerySource::BrokerRuntime,
+                    SourceFailureCode::SourceUnavailable,
+                    true,
+                    format!("broker-{index:02}"),
+                )
+            })
+            .chain(std::iter::once(SourceFailure::new(
+                QuerySource::BrokerRuntime,
+                SourceFailureCode::SourceUnavailable,
+                true,
+                "127.0.0.1:10911",
+            )))
+            .collect();
+        let payload = QueryPayload::new((), false, Vec::new(), failures);
+
+        assert!(payload.partial);
+        assert_eq!(payload.source_failures.len(), MAX_SOURCE_FAILURES);
+        assert_eq!(payload.source_failures[0].logical_target, "broker-00");
+        assert!(payload
+            .warnings
+            .iter()
+            .any(|warning| warning == "source_failures_present"));
+        assert!(payload
+            .warnings
+            .iter()
+            .any(|warning| warning == "source_failures_truncated"));
+        assert!(!serde_json::to_string(&payload.source_failures)
+            .unwrap()
+            .contains("127.0.0.1"));
     }
 }

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -257,6 +257,52 @@ expression: surface
               "generated_at"
             ],
             "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -286,6 +332,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -411,6 +466,52 @@ expression: surface
             ],
             "type": "object"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
           "TopicListEntry": {
             "properties": {
               "cluster": {
@@ -462,6 +563,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -613,6 +723,52 @@ expression: surface
             ],
             "type": "object"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
           "TopicRouteBroker": {
             "properties": {
               "broker_name": {
@@ -702,6 +858,15 @@ expression: surface
           "schema_version": {
             "type": "string"
           },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "warnings": {
             "items": {
               "type": "string"
@@ -778,6 +943,17 @@ expression: surface
             ],
             "type": "string"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
           "QueryTopicRouteOutput": {
             "properties": {
               "brokers": {
@@ -844,6 +1020,41 @@ expression: surface
               "generated_at"
             ],
             "type": "object"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           },
           "TopicRouteBroker": {
             "properties": {
@@ -933,6 +1144,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -1096,6 +1316,52 @@ expression: surface
               "generated_at"
             ],
             "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1125,6 +1391,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -1278,6 +1553,17 @@ expression: surface
             ],
             "type": "object"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
           "QueueLag": {
             "properties": {
               "broker_name": {
@@ -1323,6 +1609,41 @@ expression: surface
               "inflight"
             ],
             "type": "object"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1352,6 +1673,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -1490,6 +1820,52 @@ expression: surface
               "generated_at"
             ],
             "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1519,6 +1895,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -1928,6 +2313,17 @@ expression: surface
             ],
             "type": "object"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
           "Recommendation": {
             "properties": {
               "action": {
@@ -1992,6 +2388,41 @@ expression: surface
               "unknown"
             ],
             "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2021,6 +2452,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -257,6 +257,52 @@ expression: surface
               "generated_at"
             ],
             "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -286,6 +332,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -411,6 +466,52 @@ expression: surface
             ],
             "type": "object"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
           "TopicListEntry": {
             "properties": {
               "cluster": {
@@ -462,6 +563,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -613,6 +723,52 @@ expression: surface
             ],
             "type": "object"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
           "TopicRouteBroker": {
             "properties": {
               "broker_name": {
@@ -702,6 +858,15 @@ expression: surface
           "schema_version": {
             "type": "string"
           },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "warnings": {
             "items": {
               "type": "string"
@@ -778,6 +943,17 @@ expression: surface
             ],
             "type": "string"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
           "QueryTopicRouteOutput": {
             "properties": {
               "brokers": {
@@ -844,6 +1020,41 @@ expression: surface
               "generated_at"
             ],
             "type": "object"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           },
           "TopicRouteBroker": {
             "properties": {
@@ -933,6 +1144,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -1096,6 +1316,52 @@ expression: surface
               "generated_at"
             ],
             "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1125,6 +1391,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -1278,6 +1553,17 @@ expression: surface
             ],
             "type": "object"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
           "QueueLag": {
             "properties": {
               "broker_name": {
@@ -1323,6 +1609,41 @@ expression: surface
               "inflight"
             ],
             "type": "object"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1352,6 +1673,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -1490,6 +1820,52 @@ expression: surface
               "generated_at"
             ],
             "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1519,6 +1895,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -1928,6 +2313,17 @@ expression: surface
             ],
             "type": "object"
           },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
           "Recommendation": {
             "properties": {
               "action": {
@@ -1992,6 +2388,41 @@ expression: surface
               "unknown"
             ],
             "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2021,6 +2452,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -2213,6 +2653,52 @@ expression: surface
               "reset_consumer_offset"
             ],
             "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2242,6 +2728,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -2417,6 +2912,52 @@ expression: surface
               "reset_consumer_offset"
             ],
             "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2446,6 +2987,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -2617,6 +3167,52 @@ expression: surface
               "reset_consumer_offset"
             ],
             "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2646,6 +3242,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -2821,6 +3426,52 @@ expression: surface
               "reset_consumer_offset"
             ],
             "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2850,6 +3501,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {
@@ -3037,6 +3697,52 @@ expression: surface
               "reset_consumer_offset"
             ],
             "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
           }
         },
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -3066,6 +3772,15 @@ expression: surface
           },
           "schema_version": {
             "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "warnings": {
             "items": {

--- a/rocketmq-ai/rocketmq-mcp/src/resources/reader.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/resources/reader.rs
@@ -68,14 +68,7 @@ where
                     cluster: cluster.clone(),
                 })
                 .await?;
-            Ok(live_payload(
-                uri,
-                "overview",
-                output.observed_at,
-                output.freshness_ms,
-                output.cache_status,
-                json!(output.data),
-            ))
+            Ok(live_payload(uri, "overview", output, |data| json!(data)))
         }
         ResourceKind::Topics => {
             let output = query
@@ -85,14 +78,7 @@ where
                     page: PageRequest::default(),
                 })
                 .await?;
-            Ok(live_payload(
-                uri,
-                "topics",
-                output.observed_at,
-                output.freshness_ms,
-                output.cache_status,
-                json!(output.data.page),
-            ))
+            Ok(live_payload(uri, "topics", output, |data| json!(data.page)))
         }
         ResourceKind::Topic(topic) => {
             let output = query
@@ -102,14 +88,7 @@ where
                     page: PageRequest::default(),
                 })
                 .await?;
-            Ok(live_payload(
-                uri,
-                "topic",
-                output.observed_at,
-                output.freshness_ms,
-                output.cache_status,
-                json!(output.data),
-            ))
+            Ok(live_payload(uri, "topic", output, |data| json!(data)))
         }
         ResourceKind::TopicRoute(topic) => {
             let output = query
@@ -119,14 +98,7 @@ where
                     page: PageRequest::default(),
                 })
                 .await?;
-            Ok(live_payload(
-                uri,
-                "route",
-                output.observed_at,
-                output.freshness_ms,
-                output.cache_status,
-                json!(output.data),
-            ))
+            Ok(live_payload(uri, "route", output, |data| json!(data)))
         }
         ResourceKind::Brokers => {
             let output = query
@@ -134,14 +106,7 @@ where
                     cluster: cluster.clone(),
                 })
                 .await?;
-            Ok(live_payload(
-                uri,
-                "brokers",
-                output.observed_at,
-                output.freshness_ms,
-                output.cache_status,
-                json!(output.data.brokers),
-            ))
+            Ok(live_payload(uri, "brokers", output, |data| json!(data.brokers)))
         }
         ResourceKind::Broker(broker) => {
             let output = query
@@ -156,14 +121,7 @@ where
                     cluster
                 )));
             }
-            Ok(live_payload(
-                uri,
-                "broker",
-                output.observed_at,
-                output.freshness_ms,
-                output.cache_status,
-                json!(output.data),
-            ))
+            Ok(live_payload(uri, "broker", output, |data| json!(data)))
         }
         ResourceKind::ConsumerGroups => {
             let output = query
@@ -173,14 +131,7 @@ where
                     page: PageRequest::default(),
                 })
                 .await?;
-            Ok(live_payload(
-                uri,
-                "consumer_groups",
-                output.observed_at,
-                output.freshness_ms,
-                output.cache_status,
-                json!(output.data.page),
-            ))
+            Ok(live_payload(uri, "consumer_groups", output, |data| json!(data.page)))
         }
         ResourceKind::ConsumerGroup(group) => {
             let output = query
@@ -203,14 +154,7 @@ where
                         cluster
                     ))
                 })?;
-            Ok(live_payload(
-                uri,
-                "consumer_group",
-                output.observed_at,
-                output.freshness_ms,
-                output.cache_status,
-                json!(consumer_group),
-            ))
+            Ok(live_payload(uri, "consumer_group", output, |_| json!(consumer_group)))
         }
         ResourceKind::ConsumerLag { group, topic } => {
             let output = query
@@ -221,37 +165,32 @@ where
                     page: PageRequest::default(),
                 })
                 .await?;
-            Ok(live_payload(
-                uri,
-                "consumer_lag",
-                output.observed_at,
-                output.freshness_ms,
-                output.cache_status,
-                json!(output.data),
-            ))
+            Ok(live_payload(uri, "consumer_lag", output, |data| json!(data)))
         }
     }
 }
 
-fn live_payload(
+fn live_payload<T>(
     uri: &RocketmqResourceUri,
     field: &str,
-    observed_at: String,
-    freshness_ms: u64,
-    cache_status: crate::model::contract::CacheStatus,
-    data: Value,
+    output: crate::model::contract::QueryResult<T>,
+    project: impl FnOnce(T) -> Value,
 ) -> Value {
+    let data = project(output.data);
     let mut payload = serde_json::Map::from_iter([
         ("schema_version".to_string(), json!(SCHEMA_VERSION)),
         ("resource".to_string(), json!(uri.as_string())),
         ("cluster".to_string(), json!(uri.cluster())),
-        ("observed_at".to_string(), json!(observed_at)),
-        ("freshness_ms".to_string(), json!(freshness_ms)),
-        ("cache_status".to_string(), json!(cache_status)),
+        ("observed_at".to_string(), json!(output.observed_at)),
+        ("freshness_ms".to_string(), json!(output.freshness_ms)),
+        ("cache_status".to_string(), json!(output.cache_status)),
         ("source".to_string(), json!("live")),
-        ("partial".to_string(), json!(false)),
-        ("warnings".to_string(), json!([])),
+        ("partial".to_string(), json!(output.partial)),
+        ("warnings".to_string(), json!(output.warnings)),
     ]);
+    if !output.source_failures.is_empty() {
+        payload.insert("source_failures".to_string(), json!(output.source_failures));
+    }
     payload.insert(field.to_string(), data);
     Value::Object(payload)
 }
@@ -310,6 +249,9 @@ fn resource_error(uri: &str, error: ToolExecutionError) -> ErrorData {
 mod tests {
     use crate::model::contract::Page;
     use crate::model::contract::QueryResult;
+    use crate::model::contract::QuerySource;
+    use crate::model::contract::SourceFailure;
+    use crate::model::contract::SourceFailureCode;
     use crate::model::diagnosis::DiagnosisReport;
     use crate::tools::broker_tools::DescribeBrokerArgs;
     use crate::tools::broker_tools::DescribeBrokerOutput;
@@ -497,6 +439,27 @@ mod tests {
         assert_eq!(payload["source"], "live");
         assert_eq!(payload["partial"], false);
         assert_eq!(payload["consumer_groups"]["total_count"], 1);
+    }
+
+    #[test]
+    fn query_backed_resource_payload_preserves_partial_evidence() {
+        let uri = RocketmqResourceUri::parse("rocketmq://clusters/local-dev/overview").unwrap();
+        let mut output = QueryResult::bypass(serde_json::json!({"brokers": []}));
+        output.partial = true;
+        output.warnings = vec!["source_failures_present".to_string()];
+        output.source_failures = vec![SourceFailure::new(
+            QuerySource::BrokerRuntime,
+            SourceFailureCode::Timeout,
+            true,
+            "broker-b",
+        )];
+
+        let payload = live_payload(&uri, "overview", output, |data| data);
+
+        assert_eq!(payload["partial"], true);
+        assert_eq!(payload["warnings"], json!(["source_failures_present"]));
+        assert_eq!(payload["source_failures"][0]["source"], "broker_runtime");
+        assert_eq!(payload["source_failures"][0]["logical_target"], "broker-b");
     }
 
     #[tokio::test]

--- a/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
@@ -900,6 +900,7 @@ mod tests {
     #[derive(Clone)]
     struct FakeAdapter {
         fail: bool,
+        partial: bool,
     }
 
     impl ReadOnlyQuery for FakeAdapter {
@@ -912,14 +913,25 @@ mod tests {
                     "nameserver 10.24.7.9:9876 unavailable token=super-secret",
                 ));
             }
-            Ok(QueryResult::bypass(cluster_tools::ClusterOverviewOutput {
+            let mut result = QueryResult::bypass(cluster_tools::ClusterOverviewOutput {
                 cluster: args.cluster,
                 namesrv_addr: "127.0.0.1:9876".to_string(),
                 brokers: vec![broker_summary()],
                 topic_count: 2,
                 consumer_group_count: 1,
                 generated_at: "1".to_string(),
-            }))
+            });
+            if self.partial {
+                result.partial = true;
+                result.warnings = vec!["source_failures_present".to_string()];
+                result.source_failures = vec![crate::model::contract::SourceFailure::new(
+                    crate::model::contract::QuerySource::BrokerRuntime,
+                    crate::model::contract::SourceFailureCode::Timeout,
+                    true,
+                    "broker-b",
+                )];
+            }
+            Ok(result)
         }
 
         async fn list_topics(
@@ -986,19 +998,25 @@ mod tests {
     #[tokio::test]
     async fn call_returns_summary_and_structured_content() {
         let guard = test_guard("diagnose");
-        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
-            .call(
-                CallToolRequestParams::new(ToolId::GetClusterOverview.descriptor().name).with_arguments(
-                    serde_json::json!({
-                        "cluster": "local-dev",
-                    })
-                    .as_object()
-                    .unwrap()
-                    .clone(),
-                ),
-            )
-            .await
-            .unwrap();
+        let result = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            guard.clone(),
+        )
+        .call(
+            CallToolRequestParams::new(ToolId::GetClusterOverview.descriptor().name).with_arguments(
+                serde_json::json!({
+                    "cluster": "local-dev",
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.is_error, Some(false));
         let structured = result.structured_content.as_ref().unwrap();
@@ -1019,21 +1037,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tool_response_propagates_partial_source_failures() {
+        let result = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: true,
+            },
+            test_guard("diagnose"),
+        )
+        .call(
+            CallToolRequestParams::new(ToolId::GetClusterOverview.descriptor().name)
+                .with_arguments(serde_json::json!({"cluster": "local-dev"}).as_object().unwrap().clone()),
+        )
+        .await
+        .unwrap();
+
+        let structured = result.structured_content.unwrap();
+        assert_eq!(structured["partial"], true);
+        assert_eq!(structured["warnings"], serde_json::json!(["source_failures_present"]));
+        assert_eq!(structured["source_failures"][0]["source"], "broker_runtime");
+        assert_eq!(structured["source_failures"][0]["logical_target"], "broker-b");
+    }
+
+    #[tokio::test]
     async fn backend_error_is_returned_as_source_unavailable() {
         let guard = test_guard("diagnose");
-        let result = ToolExecutor::new(FakeAdapter { fail: true }, guard.clone())
-            .call(
-                CallToolRequestParams::new(ToolId::GetClusterOverview.descriptor().name).with_arguments(
-                    serde_json::json!({
-                        "cluster": "local-dev",
-                    })
-                    .as_object()
-                    .unwrap()
-                    .clone(),
-                ),
-            )
-            .await
-            .unwrap();
+        let result = ToolExecutor::new(
+            FakeAdapter {
+                fail: true,
+                partial: false,
+            },
+            guard.clone(),
+        )
+        .call(
+            CallToolRequestParams::new(ToolId::GetClusterOverview.descriptor().name).with_arguments(
+                serde_json::json!({
+                    "cluster": "local-dev",
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.is_error, Some(true));
         assert!(result.structured_content.is_none());
@@ -1052,10 +1099,16 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_arguments_are_actionable_tool_errors() {
-        let result = ToolExecutor::new(FakeAdapter { fail: false }, test_guard("diagnose"))
-            .call(CallToolRequestParams::new(ToolId::GetClusterOverview.descriptor().name))
-            .await
-            .unwrap();
+        let result = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            test_guard("diagnose"),
+        )
+        .call(CallToolRequestParams::new(ToolId::GetClusterOverview.descriptor().name))
+        .await
+        .unwrap();
 
         assert_eq!(result.is_error, Some(true));
         assert!(result.structured_content.is_none());
@@ -1068,10 +1121,16 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_tool_returns_protocol_error() {
-        let err = ToolExecutor::new(FakeAdapter { fail: false }, test_guard("diagnose"))
-            .call(CallToolRequestParams::new("unknown_tool"))
-            .await
-            .unwrap_err();
+        let err = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            test_guard("diagnose"),
+        )
+        .call(CallToolRequestParams::new("unknown_tool"))
+        .await
+        .unwrap_err();
 
         assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
     }
@@ -1079,21 +1138,27 @@ mod tests {
     #[tokio::test]
     async fn read_only_guard_denies_diagnosis_tool() {
         let guard = test_guard("read_only");
-        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
-            .call(
-                CallToolRequestParams::new(ToolId::DiagnoseConsumerLag.descriptor().name).with_arguments(
-                    serde_json::json!({
-                        "cluster": "local-dev",
-                        "topic": "orders",
-                        "consumer_group": "order-service",
-                    })
-                    .as_object()
-                    .unwrap()
-                    .clone(),
-                ),
-            )
-            .await
-            .unwrap();
+        let result = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            guard.clone(),
+        )
+        .call(
+            CallToolRequestParams::new(ToolId::DiagnoseConsumerLag.descriptor().name).with_arguments(
+                serde_json::json!({
+                    "cluster": "local-dev",
+                    "topic": "orders",
+                    "consumer_group": "order-service",
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.is_error, Some(true));
         let error: serde_json::Value = serde_json::from_str(&content_text(&result)).unwrap();
@@ -1109,10 +1174,16 @@ mod tests {
     #[tokio::test]
     async fn runtime_policy_denies_change_planning_by_default() {
         let guard = test_guard_with_policy("operator", false);
-        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
-            .call(plan_create_topic_request())
-            .await
-            .unwrap();
+        let result = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            guard.clone(),
+        )
+        .call(plan_create_topic_request())
+        .await
+        .unwrap();
 
         assert_eq!(result.is_error, Some(true));
         assert!(content_text(&result).contains("change planning disabled"));
@@ -1123,10 +1194,16 @@ mod tests {
     #[tokio::test]
     async fn change_plan_is_non_mutating_and_schema_validated() {
         let guard = test_guard_with_policy("operator", true);
-        let result = ToolExecutor::new(FakeAdapter { fail: false }, guard.clone())
-            .call(plan_create_topic_request())
-            .await
-            .unwrap();
+        let result = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            guard.clone(),
+        )
+        .call(plan_create_topic_request())
+        .await
+        .unwrap();
 
         assert_eq!(result.is_error, Some(false));
         let structured = result.structured_content.as_ref().unwrap();
@@ -1150,6 +1227,9 @@ mod tests {
             observed_at: "first".to_string(),
             freshness_ms: 0,
             cache_status: crate::model::contract::CacheStatus::Bypass,
+            partial: false,
+            warnings: Vec::new(),
+            source_failures: Vec::new(),
         };
         let second = QueryResult {
             data: serde_json::json!({
@@ -1160,6 +1240,9 @@ mod tests {
             observed_at: "second".to_string(),
             freshness_ms: 100,
             cache_status: crate::model::contract::CacheStatus::Hit,
+            partial: false,
+            warnings: Vec::new(),
+            source_failures: Vec::new(),
         };
 
         let first = canonical_current_state(&first).unwrap();

--- a/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
@@ -15,6 +15,7 @@
 use serde_json::Map;
 use serde_json::Value;
 
+use crate::model::contract::MAX_SOURCE_FAILURES;
 use crate::tools::executor::ToolExecutionError;
 
 const MAX_STRUCTURED_OUTPUT_BYTES: usize = 1024 * 1024;
@@ -40,6 +41,17 @@ pub(crate) fn apply(value: Value) -> Result<Value, ToolExecutionError> {
 }
 
 pub(crate) fn apply_with_policy(mut value: Value, policy: OutputPolicy) -> Result<Value, ToolExecutionError> {
+    let source_failures_overflow = value
+        .get("source_failures")
+        .and_then(Value::as_array)
+        .is_some_and(|failures| failures.len() > MAX_SOURCE_FAILURES);
+    let source_metadata_changed = normalize_source_failure_metadata(&mut value);
+    if source_metadata_changed {
+        add_warning(&mut value, "source_failure_metadata_sanitized");
+    }
+    if source_failures_overflow {
+        add_warning(&mut value, "source_failures_truncated");
+    }
     remove_internal_topology(&mut value);
     let truncated = bound_rows(&mut value, policy.max_rows);
     if truncated {
@@ -81,7 +93,14 @@ fn mark_partial(value: &mut Value) {
         return;
     };
     object.insert("partial".to_string(), Value::Bool(true));
-    let warning = Value::String("output_rows_truncated".to_string());
+    add_warning(value, "output_rows_truncated");
+}
+
+fn add_warning(value: &mut Value, warning: &str) {
+    let Value::Object(object) = value else {
+        return;
+    };
+    let warning = Value::String(warning.to_string());
     match object.get_mut("warnings") {
         Some(Value::Array(warnings)) if !warnings.contains(&warning) => warnings.push(warning),
         Some(_) => {
@@ -91,6 +110,102 @@ fn mark_partial(value: &mut Value) {
             object.insert("warnings".to_string(), Value::Array(vec![warning]));
         }
     }
+}
+
+fn normalize_source_failure_metadata(value: &mut Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            let mut changed = object
+                .get_mut("source_failures")
+                .map(normalize_source_failure_array)
+                .unwrap_or(false);
+            for (key, value) in object.iter_mut() {
+                if key != "source_failures" {
+                    changed |= normalize_source_failure_metadata(value);
+                }
+            }
+            changed
+        }
+        Value::Array(values) => values.iter_mut().fold(false, |changed, value| {
+            normalize_source_failure_metadata(value) | changed
+        }),
+        _ => false,
+    }
+}
+
+fn normalize_source_failure_array(value: &mut Value) -> bool {
+    let Value::Array(failures) = value else {
+        *value = Value::Array(Vec::new());
+        return true;
+    };
+    let original = failures.clone();
+    let mut normalized = failures.iter().filter_map(normalize_source_failure).collect::<Vec<_>>();
+    normalized.sort_by_key(source_failure_key);
+    normalized.dedup();
+    normalized.truncate(MAX_SOURCE_FAILURES);
+    let changed = normalized != original;
+    *failures = normalized;
+    changed
+}
+
+fn normalize_source_failure(value: &Value) -> Option<Value> {
+    let object = value.as_object()?;
+    let source = object.get("source")?.as_str()?;
+    let code = object.get("code")?.as_str()?;
+    let retryable = object.get("retryable")?.as_bool()?;
+    let logical_target = safe_logical_target(object.get("logical_target")?.as_str()?);
+    if !matches!(
+        source,
+        "broker_runtime"
+            | "consumer_statistics"
+            | "consumer_connection"
+            | "producer_connection"
+            | "subscription_groups"
+            | "topic_route"
+    ) || !matches!(
+        code,
+        "source_unavailable" | "timeout" | "permission_denied" | "not_found" | "rate_limited" | "invalid_response"
+    ) {
+        return None;
+    }
+    Some(serde_json::json!({
+        "source": source,
+        "code": code,
+        "retryable": retryable,
+        "logical_target": logical_target,
+    }))
+}
+
+fn source_failure_key(value: &Value) -> (String, String, String, bool) {
+    (
+        value["source"].as_str().unwrap_or_default().to_string(),
+        value["code"].as_str().unwrap_or_default().to_string(),
+        value["logical_target"].as_str().unwrap_or_default().to_string(),
+        value["retryable"].as_bool().unwrap_or_default(),
+    )
+}
+
+fn safe_logical_target(target: &str) -> String {
+    let target = target.trim();
+    if target.is_empty()
+        || target.len() > 128
+        || target.parse::<std::net::IpAddr>().is_ok()
+        || target.parse::<std::net::SocketAddr>().is_ok()
+        || target.contains([':', '/', '\\', '@', '=', '&', '?'])
+        || target.chars().any(char::is_control)
+    {
+        return "unknown".to_string();
+    }
+    target
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 fn remove_internal_topology(value: &mut Value) {
@@ -181,6 +296,77 @@ mod tests {
 
         assert_eq!(output["partial"], true);
         assert_eq!(output["warnings"][0], "output_rows_truncated");
+        assert_eq!(output["data"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn source_failure_policy_sanitizes_deduplicates_orders_and_caps_metadata() {
+        let mut failures = (0..20)
+            .rev()
+            .map(|index| {
+                json!({
+                    "source": "broker_runtime",
+                    "code": "source_unavailable",
+                    "retryable": true,
+                    "logical_target": format!("broker-{index:02}"),
+                    "raw_error": "secret backend body"
+                })
+            })
+            .collect::<Vec<_>>();
+        failures.push(failures[19].clone());
+        failures.push(json!({
+            "source": "broker_runtime",
+            "code": "source_unavailable",
+            "retryable": true,
+            "logical_target": "10.0.0.1:10911"
+        }));
+        let output = apply(json!({
+            "partial": true,
+            "warnings": ["source_failures_present"],
+            "source_failures": failures,
+            "data": {}
+        }))
+        .unwrap();
+
+        let normalized = output["source_failures"].as_array().unwrap();
+        assert_eq!(normalized.len(), MAX_SOURCE_FAILURES);
+        assert_eq!(normalized[0]["logical_target"], "broker-00");
+        assert!(output["warnings"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("source_failures_truncated")));
+        let serialized = output.to_string();
+        assert!(!serialized.contains("10.0.0.1"));
+        assert!(!serialized.contains("secret backend body"));
+        assert!(!serialized.contains("raw_error"));
+    }
+
+    #[test]
+    fn row_truncation_composes_with_existing_source_failure_metadata() {
+        let output = apply_with_policy(
+            json!({
+                "partial": true,
+                "warnings": ["source_failures_present"],
+                "source_failures": [{
+                    "source": "consumer_statistics",
+                    "code": "timeout",
+                    "retryable": true,
+                    "logical_target": "broker-a"
+                }],
+                "data": [1, 2, 3]
+            }),
+            OutputPolicy {
+                max_bytes: 1024,
+                max_rows: 2,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(output["partial"], true);
+        let warnings = output["warnings"].as_array().unwrap();
+        assert!(warnings.contains(&json!("source_failures_present")));
+        assert!(warnings.contains(&json!("output_rows_truncated")));
+        assert_eq!(output["source_failures"].as_array().unwrap().len(), 1);
         assert_eq!(output["data"].as_array().unwrap().len(), 2);
     }
 }

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
@@ -122,6 +122,52 @@ expression: contracts
             "generated_at"
           ],
           "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -151,6 +197,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -276,6 +331,52 @@ expression: contracts
           ],
           "type": "object"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
         "TopicListEntry": {
           "properties": {
             "cluster": {
@@ -327,6 +428,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -478,6 +588,52 @@ expression: contracts
           ],
           "type": "object"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
         "TopicRouteBroker": {
           "properties": {
             "broker_name": {
@@ -567,6 +723,15 @@ expression: contracts
         "schema_version": {
           "type": "string"
         },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "warnings": {
           "items": {
             "type": "string"
@@ -643,6 +808,17 @@ expression: contracts
           ],
           "type": "string"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
         "QueryTopicRouteOutput": {
           "properties": {
             "brokers": {
@@ -709,6 +885,41 @@ expression: contracts
             "generated_at"
           ],
           "type": "object"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         },
         "TopicRouteBroker": {
           "properties": {
@@ -798,6 +1009,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -961,6 +1181,52 @@ expression: contracts
             "generated_at"
           ],
           "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -990,6 +1256,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -1143,6 +1418,17 @@ expression: contracts
           ],
           "type": "object"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
         "QueueLag": {
           "properties": {
             "broker_name": {
@@ -1188,6 +1474,41 @@ expression: contracts
             "inflight"
           ],
           "type": "object"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1217,6 +1538,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -1355,6 +1685,52 @@ expression: contracts
             "generated_at"
           ],
           "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1384,6 +1760,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -1793,6 +2178,17 @@ expression: contracts
           ],
           "type": "object"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
         "Recommendation": {
           "properties": {
             "action": {
@@ -1857,6 +2253,41 @@ expression: contracts
             "unknown"
           ],
           "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1886,6 +2317,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
@@ -122,6 +122,52 @@ expression: contracts
             "generated_at"
           ],
           "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -151,6 +197,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -276,6 +331,52 @@ expression: contracts
           ],
           "type": "object"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
         "TopicListEntry": {
           "properties": {
             "cluster": {
@@ -327,6 +428,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -478,6 +588,52 @@ expression: contracts
           ],
           "type": "object"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
         "TopicRouteBroker": {
           "properties": {
             "broker_name": {
@@ -567,6 +723,15 @@ expression: contracts
         "schema_version": {
           "type": "string"
         },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "warnings": {
           "items": {
             "type": "string"
@@ -643,6 +808,17 @@ expression: contracts
           ],
           "type": "string"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
         "QueryTopicRouteOutput": {
           "properties": {
             "brokers": {
@@ -709,6 +885,41 @@ expression: contracts
             "generated_at"
           ],
           "type": "object"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         },
         "TopicRouteBroker": {
           "properties": {
@@ -798,6 +1009,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -961,6 +1181,52 @@ expression: contracts
             "generated_at"
           ],
           "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -990,6 +1256,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -1143,6 +1418,17 @@ expression: contracts
           ],
           "type": "object"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
         "QueueLag": {
           "properties": {
             "broker_name": {
@@ -1188,6 +1474,41 @@ expression: contracts
             "inflight"
           ],
           "type": "object"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1217,6 +1538,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -1355,6 +1685,52 @@ expression: contracts
             "generated_at"
           ],
           "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1384,6 +1760,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -1793,6 +2178,17 @@ expression: contracts
           ],
           "type": "object"
         },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
         "Recommendation": {
           "properties": {
             "action": {
@@ -1857,6 +2253,41 @@ expression: contracts
             "unknown"
           ],
           "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1886,6 +2317,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -2078,6 +2518,52 @@ expression: contracts
             "reset_consumer_offset"
           ],
           "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2107,6 +2593,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -2282,6 +2777,52 @@ expression: contracts
             "reset_consumer_offset"
           ],
           "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2311,6 +2852,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -2482,6 +3032,52 @@ expression: contracts
             "reset_consumer_offset"
           ],
           "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2511,6 +3107,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -2686,6 +3291,52 @@ expression: contracts
             "reset_consumer_offset"
           ],
           "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2715,6 +3366,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {
@@ -2902,6 +3562,52 @@ expression: contracts
             "reset_consumer_offset"
           ],
           "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2931,6 +3637,15 @@ expression: contracts
         },
         "schema_version": {
           "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "warnings": {
           "items": {

--- a/rocketmq-client/src/admin.rs
+++ b/rocketmq-client/src/admin.rs
@@ -58,6 +58,10 @@ pub use mq_admin_mutation_ext::TopicOffsetMutationTargetOutcome;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::BrokerConfigAllowlisted;
 #[cfg(feature = "admin-read")]
+pub use mq_admin_read_ext::BrokerReadFailure;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_read_ext::ConsumeStatsReadResult;
+#[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::MQAdminMessageReadExt;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::MQAdminReadExt;
@@ -65,6 +69,8 @@ pub use mq_admin_read_ext::MQAdminReadExt;
 pub use mq_admin_read_ext::MQAdminTopicInventoryReadExt;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::MessageMetadataRead;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_read_ext::ReadFailureCode;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::SubscriptionGroupConfigVersioned;
 #[cfg(feature = "admin-read")]

--- a/rocketmq-client/src/admin/mq_admin_read_ext.rs
+++ b/rocketmq-client/src/admin/mq_admin_read_ext.rs
@@ -19,6 +19,8 @@
 //! `admin-mutation` capability is enabled.
 
 use std::future::Future;
+use std::net::IpAddr;
+use std::net::SocketAddr;
 
 use cheetah_string::CheetahString;
 use rand::seq::IndexedRandom;
@@ -37,6 +39,7 @@ use rocketmq_protocol::protocol::body::topic::topic_list::TopicList;
 use rocketmq_protocol::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;
 use rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
 use rocketmq_protocol::protocol::header::view_message_request_header::ViewMessageRequestHeader;
+use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::route_facade::BrokerDataExt;
 use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
@@ -67,6 +70,58 @@ pub struct TopicConfigVersioned {
 pub struct SubscriptionGroupConfigVersioned {
     pub version: u64,
     pub config: SubscriptionGroupConfig,
+}
+
+/// Stable failure classification for one exact Broker read.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum ReadFailureCode {
+    SourceUnavailable,
+    Timeout,
+    PermissionDenied,
+    NotFound,
+    RateLimited,
+    InvalidResponse,
+}
+
+/// Address-free evidence for one failed Broker read.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BrokerReadFailure {
+    broker_name: String,
+    code: ReadFailureCode,
+    retryable: bool,
+}
+
+impl BrokerReadFailure {
+    /// Creates failure evidence while reducing the target to a bounded logical
+    /// Broker identifier.
+    pub fn new(broker_name: impl AsRef<str>, code: ReadFailureCode, retryable: bool) -> Self {
+        Self {
+            broker_name: sanitize_broker_logical_target(broker_name.as_ref()),
+            code,
+            retryable,
+        }
+    }
+
+    pub fn broker_name(&self) -> &str {
+        &self.broker_name
+    }
+
+    pub const fn code(&self) -> ReadFailureCode {
+        self.code
+    }
+
+    pub const fn retryable(&self) -> bool {
+        self.retryable
+    }
+}
+
+/// Multi-Broker consumer statistics together with completeness evidence.
+#[derive(Debug)]
+pub struct ConsumeStatsReadResult {
+    pub stats: ConsumeStats,
+    pub attempted_brokers: usize,
+    pub successful_brokers: usize,
+    pub failures: Vec<BrokerReadFailure>,
 }
 
 /// Fixed, body-free metadata returned by the read-only message lookup.
@@ -121,6 +176,27 @@ pub trait MQAdminReadExt: Send {
         broker_addr: Option<CheetahString>,
         timeout_millis: Option<u64>,
     ) -> rocketmq_error::RocketMQResult<ConsumeStats>;
+
+    /// Reads consumer statistics without discarding an individual Broker
+    /// failure. Broker addresses and backend error strings never enter the
+    /// returned evidence.
+    async fn examine_consume_stats_with_evidence(
+        &self,
+        consumer_group: CheetahString,
+        topic: Option<CheetahString>,
+        broker_addr: Option<CheetahString>,
+        timeout_millis: Option<u64>,
+    ) -> rocketmq_error::RocketMQResult<ConsumeStatsReadResult> {
+        let stats = self
+            .examine_consume_stats(consumer_group, topic, None, broker_addr, timeout_millis)
+            .await?;
+        Ok(ConsumeStatsReadResult {
+            stats,
+            attempted_brokers: 1,
+            successful_brokers: 1,
+            failures: Vec::new(),
+        })
+    }
 
     async fn examine_broker_cluster_info(&self) -> rocketmq_error::RocketMQResult<ClusterInfo>;
 
@@ -325,6 +401,73 @@ impl MQAdminReadExt for DefaultMQAdminExt {
                 }
             }
         }
+        Ok(result)
+    }
+
+    async fn examine_consume_stats_with_evidence(
+        &self,
+        consumer_group: CheetahString,
+        topic: Option<CheetahString>,
+        broker_addr: Option<CheetahString>,
+        timeout_millis: Option<u64>,
+    ) -> rocketmq_error::RocketMQResult<ConsumeStatsReadResult> {
+        let timeout = timeout_millis.unwrap_or(self.inner().remoting_timeout_millis()?);
+        let topic = topic.unwrap_or_default();
+        let targets = match broker_addr {
+            Some(broker_addr) => vec![ConsumeStatsReadTarget::Ready {
+                broker_name: "selected-broker".to_string(),
+                address: broker_addr,
+            }],
+            None => {
+                let retry_topic: CheetahString = mix_all::get_retry_topic(&consumer_group).into();
+                let route = self
+                    .inner()
+                    .mq_client_api()?
+                    .get_topic_route_info_from_name_server(&retry_topic, timeout)
+                    .await?;
+                consume_stats_read_targets(route.map(|route| route.broker_datas).unwrap_or_default())
+            }
+        };
+        let mut result = ConsumeStatsReadResult {
+            stats: ConsumeStats::new(),
+            attempted_brokers: targets.len(),
+            successful_brokers: 0,
+            failures: Vec::new(),
+        };
+        for target in targets {
+            let (broker_name, address) = match target {
+                ConsumeStatsReadTarget::Ready { broker_name, address } => (broker_name, address),
+                ConsumeStatsReadTarget::Failed(failure) => {
+                    result.failures.push(failure);
+                    continue;
+                }
+            };
+            match self
+                .inner()
+                .mq_client_api()?
+                .get_consume_stats(
+                    &address,
+                    GetConsumeStatsRequestHeader {
+                        consumer_group: consumer_group.clone(),
+                        topic: topic.clone(),
+                        topic_list: None,
+                        topic_request_header: None,
+                    },
+                    timeout,
+                )
+                .await
+            {
+                Ok(stats) => {
+                    result.successful_brokers += 1;
+                    result.stats.get_offset_table_mut().extend(stats.offset_table);
+                    result
+                        .stats
+                        .set_consume_tps(result.stats.get_consume_tps() + stats.consume_tps);
+                }
+                Err(error) => result.failures.push(broker_read_failure(broker_name, &error)),
+            }
+        }
+        result.failures.sort();
         Ok(result)
     }
 
@@ -625,6 +768,98 @@ where
         .transpose()
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum ConsumeStatsReadTarget {
+    Ready {
+        broker_name: String,
+        address: CheetahString,
+    },
+    Failed(BrokerReadFailure),
+}
+
+fn consume_stats_read_targets(brokers: Vec<BrokerData>) -> Vec<ConsumeStatsReadTarget> {
+    brokers
+        .into_iter()
+        .map(|broker| {
+            let broker_name = broker.broker_name().to_string();
+            match broker.broker_addrs().get(&mix_all::MASTER_ID).cloned() {
+                Some(address) if !address.as_str().trim().is_empty() => {
+                    ConsumeStatsReadTarget::Ready { broker_name, address }
+                }
+                Some(_) | None => ConsumeStatsReadTarget::Failed(BrokerReadFailure::new(
+                    broker_name,
+                    ReadFailureCode::InvalidResponse,
+                    false,
+                )),
+            }
+        })
+        .collect()
+}
+
+fn broker_read_failure(broker_name: String, error: &rocketmq_error::RocketMQError) -> BrokerReadFailure {
+    let view = error.boundary_view();
+    let status = view.http().status.as_u16();
+    let code = match status {
+        401 | 403 => ReadFailureCode::PermissionDenied,
+        404 => ReadFailureCode::NotFound,
+        408 | 504 => ReadFailureCode::Timeout,
+        429 => ReadFailureCode::RateLimited,
+        400 | 413 | 422 => ReadFailureCode::InvalidResponse,
+        _ => ReadFailureCode::SourceUnavailable,
+    };
+    BrokerReadFailure::new(broker_name, code, view.is_retryable())
+}
+
+fn sanitize_broker_logical_target(target: &str) -> String {
+    const UNKNOWN_TARGET: &str = "unknown";
+    const MAX_TARGET_BYTES: usize = 128;
+    const SENSITIVE_OR_ERROR_MARKERS: &[&str] = &[
+        "access_key",
+        "accesskey",
+        "authorization",
+        "bearer",
+        "credential",
+        "denied",
+        "error",
+        "exception",
+        "failed",
+        "failure",
+        "password",
+        "passwd",
+        "refused",
+        "secret",
+        "signature",
+        "source_unavailable",
+        "timed_out",
+        "timeout",
+        "token",
+    ];
+
+    let raw_target = target;
+    let target = raw_target.trim();
+    let lowercase = target.to_ascii_lowercase();
+    let invalid = target.is_empty()
+        || raw_target.len() > MAX_TARGET_BYTES
+        || !target.is_ascii()
+        || target.parse::<IpAddr>().is_ok()
+        || target.parse::<SocketAddr>().is_ok()
+        || target.contains([':', '/', '\\', '@', '=', '&', '?', '#'])
+        || raw_target.chars().any(char::is_control)
+        || !target
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+        || lowercase.starts_with("akia")
+        || lowercase.starts_with("sk-")
+        || SENSITIVE_OR_ERROR_MARKERS
+            .iter()
+            .any(|marker| lowercase.contains(marker));
+    if invalid {
+        UNKNOWN_TARGET.to_string()
+    } else {
+        target.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -633,10 +868,28 @@ mod tests {
     use std::sync::Arc;
 
     use cheetah_string::CheetahString;
+    use rocketmq_model::common::mix_all;
     use rocketmq_protocol::protocol::body::topic::topic_list::TopicList;
+    use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
 
+    use super::consume_stats_read_targets;
     use super::fetch_topic_inventory_from;
     use super::parse_allowlisted_value;
+    use super::BrokerReadFailure;
+    use super::ConsumeStatsReadTarget;
+    use super::ReadFailureCode;
+
+    fn route_broker(name: &str, master: Option<&str>) -> BrokerData {
+        let broker_addrs = master
+            .map(|address| HashMap::from([(mix_all::MASTER_ID, CheetahString::from_string(address.to_string()))]))
+            .unwrap_or_default();
+        BrokerData::new(
+            CheetahString::from_static_str("cluster-a"),
+            CheetahString::from_string(name.to_string()),
+            broker_addrs,
+            None,
+        )
+    }
 
     #[tokio::test]
     async fn cluster_topic_inventory_selects_exactly_one_cluster_source_call() {
@@ -735,5 +988,80 @@ mod tests {
 
         let error = parse_allowlisted_value::<u64>(&properties, "flushDelayOffsetInterval").unwrap_err();
         assert!(error.to_string().contains("flushDelayOffsetInterval"));
+    }
+
+    #[test]
+    fn consume_stats_targets_preserve_mixed_valid_and_unusable_route_entries() {
+        let targets = consume_stats_read_targets(vec![
+            route_broker("broker-a", Some("127.0.0.1:10911")),
+            route_broker("broker-b", None),
+            route_broker("broker-c", Some("  ")),
+        ]);
+
+        assert_eq!(targets.len(), 3);
+        assert!(matches!(
+            &targets[0],
+            ConsumeStatsReadTarget::Ready { broker_name, .. } if broker_name == "broker-a"
+        ));
+        for target in &targets[1..] {
+            let ConsumeStatsReadTarget::Failed(failure) = target else {
+                panic!("unusable master must remain a failed routed attempt");
+            };
+            assert_eq!(failure.code(), ReadFailureCode::InvalidResponse);
+            assert!(!failure.retryable());
+        }
+    }
+
+    #[test]
+    fn consume_stats_targets_preserve_all_missing_masters_as_failures() {
+        let targets = consume_stats_read_targets(vec![route_broker("broker-a", None), route_broker("broker-b", None)]);
+
+        assert_eq!(targets.len(), 2);
+        assert!(targets.iter().all(|target| matches!(
+            target,
+            ConsumeStatsReadTarget::Failed(failure)
+                if failure.code() == ReadFailureCode::InvalidResponse && !failure.retryable()
+        )));
+    }
+
+    #[test]
+    fn consume_stats_targets_keep_zero_broker_route_authoritatively_empty() {
+        assert!(consume_stats_read_targets(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn broker_read_failure_preserves_valid_logical_targets() {
+        let failure = BrokerReadFailure::new(" broker-a_1.prod ", ReadFailureCode::Timeout, true);
+
+        assert_eq!(failure.broker_name(), "broker-a_1.prod");
+        assert_eq!(failure.code(), ReadFailureCode::Timeout);
+        assert!(failure.retryable());
+    }
+
+    #[test]
+    fn broker_read_failure_replaces_unsafe_targets_with_one_safe_token() {
+        let overlong = "a".repeat(129);
+        let unsafe_targets = [
+            "127.0.0.1",
+            "::1",
+            "127.0.0.1:10911",
+            "[::1]:10911",
+            "https://broker.example.invalid/runtime",
+            "broker\nname",
+            "broker-a\r",
+            overlong.as_str(),
+            "password-secret-value",
+            "AKIAIOSFODNN7EXAMPLE",
+            "connection_error_from_backend",
+        ];
+
+        for target in unsafe_targets {
+            let failure = BrokerReadFailure::new(target, ReadFailureCode::SourceUnavailable, true);
+            assert_eq!(
+                failure.broker_name(),
+                "unknown",
+                "target should be rejected: {target:?}"
+            );
+        }
     }
 }

--- a/rocketmq-client/src/public_api.rs
+++ b/rocketmq-client/src/public_api.rs
@@ -22,6 +22,10 @@ pub use crate::admin::BrokerAdmin;
 pub use crate::admin::BrokerConfigAllowlisted;
 #[cfg(feature = "admin-mutation")]
 pub use crate::admin::BrokerConfigPatchOutcome;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::BrokerReadFailure;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::ConsumeStatsReadResult;
 #[cfg(feature = "admin-full")]
 pub use crate::admin::ConsumerAdmin;
 pub use crate::admin::DefaultMQAdminExt;
@@ -38,6 +42,8 @@ pub use crate::admin::MQAdminTopicInventoryReadExt;
 pub use crate::admin::MessageMetadataRead;
 #[cfg(feature = "admin-full")]
 pub use crate::admin::OffsetAdmin;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::ReadFailureCode;
 #[cfg(feature = "admin-full")]
 pub use crate::admin::RouteAdmin;
 #[cfg(feature = "admin-mutation")]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter.rs
@@ -17,6 +17,8 @@
 #[cfg(feature = "client-adapter")]
 mod broker;
 #[cfg(feature = "client-adapter")]
+mod connection;
+#[cfg(feature = "client-adapter")]
 mod consumer;
 #[cfg(feature = "client-adapter")]
 mod dashboard;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/broker.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/broker.rs
@@ -14,6 +14,7 @@
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::{BrokerAdmin as _, RouteAdmin as _};
+use rocketmq_error::RocketMQError;
 use rocketmq_protocol::protocol::body::kv_table::KVTable;
 
 use crate::client_adapter::lifecycle::AdminSession;
@@ -22,15 +23,21 @@ use crate::core::broker::project_broker_log_filter_state;
 use crate::core::broker::BrokerAdmin;
 use crate::core::broker::BrokerAllowlistedConfig;
 use crate::core::broker::BrokerLogFilterState;
+use crate::core::broker::BrokerRuntimeTargetStatus;
 use crate::core::broker::BrokerSummary;
 use crate::core::broker::ListBrokersRequest;
 use crate::core::broker::ListBrokersResult;
 use crate::core::broker::ProbeBrokerRuntimeRequest;
 use crate::core::broker::ProbeBrokerRuntimeResult;
+use crate::core::broker::ProbeBrokerRuntimeTargetRequest;
 use crate::core::broker::QueryBrokerAllowlistedConfigRequest;
 use crate::core::broker::QueryBrokerDiagnosticsRequest;
 use crate::core::broker::QueryBrokerDiagnosticsResult;
 use crate::core::broker::QueryBrokerLogFilterStateRequest;
+use crate::core::query::AdminQueryFailureCode;
+use crate::core::query::AdminQueryResult;
+use crate::core::query::AdminQuerySource;
+use crate::core::query::AdminSourceFailure;
 use crate::core::AdminError;
 use crate::core::AdminFuture;
 
@@ -77,6 +84,77 @@ impl BrokerAdmin for AdminSession {
         })
     }
 
+    fn list_brokers_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListBrokersRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListBrokersResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let cluster_info = self
+                .inner
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| AdminError::backend("examine_broker_cluster_info", error.to_string()))?;
+            let broker_names = cluster_info
+                .cluster_addr_table
+                .as_ref()
+                .and_then(|table| table.get(request.cluster.as_str()))
+                .cloned()
+                .unwrap_or_default();
+            let broker_table = cluster_info.broker_addr_table.unwrap_or_default();
+            let now_millis = self.clock.now_millis();
+            let mut brokers = Vec::new();
+            let mut successful_sources = 0usize;
+            let mut failures = Vec::new();
+            for broker_name in broker_names {
+                let Some(broker_data) = broker_table.get(&broker_name) else {
+                    failures.push(AdminSourceFailure::new(
+                        AdminQuerySource::BrokerRuntime,
+                        AdminQueryFailureCode::InvalidResponse,
+                        false,
+                        broker_name.as_str(),
+                    ));
+                    continue;
+                };
+                if broker_data.broker_addrs().is_empty() {
+                    failures.push(AdminSourceFailure::new(
+                        AdminQuerySource::BrokerRuntime,
+                        AdminQueryFailureCode::InvalidResponse,
+                        false,
+                        broker_name.as_str(),
+                    ));
+                    continue;
+                }
+                for (broker_id, broker_addr) in broker_data.broker_addrs() {
+                    match self.inner.fetch_broker_runtime_stats(broker_addr.clone()).await {
+                        Ok(runtime) => {
+                            successful_sources += 1;
+                            brokers.push(build_broker_summary(
+                                request.cluster.clone(),
+                                broker_name.to_string(),
+                                *broker_id,
+                                broker_addr.to_string(),
+                                Some(&runtime),
+                                now_millis,
+                            ));
+                        }
+                        Err(error) => failures.push(source_failure(
+                            AdminQuerySource::BrokerRuntime,
+                            broker_name.as_str(),
+                            &error,
+                        )),
+                    }
+                }
+            }
+            brokers.sort_by(|left, right| {
+                left.broker_name
+                    .cmp(&right.broker_name)
+                    .then(left.broker_id.cmp(&right.broker_id))
+            });
+            AdminQueryResult::from_sources(ListBrokersResult { brokers }, successful_sources, failures)
+        })
+    }
+
     fn probe_broker_runtime<'a>(
         &'a mut self,
         request: &'a ProbeBrokerRuntimeRequest,
@@ -108,6 +186,116 @@ impl BrokerAdmin for AdminSession {
                 }
             }
             Ok(result)
+        })
+    }
+
+    fn probe_broker_runtime_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ProbeBrokerRuntimeRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ProbeBrokerRuntimeResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let cluster_info = self
+                .inner
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| AdminError::backend("examine_broker_cluster_info", error.to_string()))?;
+            let broker_names = cluster_info
+                .cluster_addr_table
+                .as_ref()
+                .and_then(|table| table.get(request.cluster.as_str()))
+                .cloned()
+                .unwrap_or_default();
+            let broker_table = cluster_info.broker_addr_table.unwrap_or_default();
+            let mut result = ProbeBrokerRuntimeResult::default();
+            let mut successful_sources = 0usize;
+            let mut failures = Vec::new();
+            for broker_name in broker_names {
+                let Some(broker_data) = broker_table.get(&broker_name) else {
+                    result.attempted += 1;
+                    failures.push(AdminSourceFailure::new(
+                        AdminQuerySource::BrokerRuntime,
+                        AdminQueryFailureCode::InvalidResponse,
+                        false,
+                        broker_name.as_str(),
+                    ));
+                    continue;
+                };
+                if broker_data.broker_addrs().is_empty() {
+                    result.attempted += 1;
+                    failures.push(AdminSourceFailure::new(
+                        AdminQuerySource::BrokerRuntime,
+                        AdminQueryFailureCode::InvalidResponse,
+                        false,
+                        broker_name.as_str(),
+                    ));
+                    continue;
+                }
+                for broker_addr in broker_data.broker_addrs().values() {
+                    result.attempted += 1;
+                    match self.inner.fetch_broker_runtime_stats(broker_addr.clone()).await {
+                        Ok(_) => successful_sources += 1,
+                        Err(error) => failures.push(source_failure(
+                            AdminQuerySource::BrokerRuntime,
+                            broker_name.as_str(),
+                            &error,
+                        )),
+                    }
+                }
+            }
+            result.failures = failures
+                .iter()
+                .map(|failure| {
+                    format!(
+                        "source={:?};code={:?};target={}",
+                        failure.source(),
+                        failure.code(),
+                        failure.logical_target()
+                    )
+                    .to_ascii_lowercase()
+                })
+                .collect();
+            AdminQueryResult::from_sources(result, successful_sources, failures)
+        })
+    }
+
+    fn probe_broker_runtime_target<'a>(
+        &'a mut self,
+        request: &'a ProbeBrokerRuntimeTargetRequest,
+    ) -> AdminFuture<'a, BrokerRuntimeTargetStatus> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let cluster_info = self
+                .inner
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| AdminError::backend("examine_broker_cluster_info", error.to_string()))?;
+            let broker_names = cluster_info
+                .cluster_addr_table
+                .as_ref()
+                .and_then(|table| table.get(request.cluster.as_str()))
+                .cloned()
+                .unwrap_or_default();
+            if !broker_names
+                .iter()
+                .any(|broker_name| broker_name.as_str() == request.broker_name)
+            {
+                return Ok(BrokerRuntimeTargetStatus::NotFound);
+            }
+            let broker_table = cluster_info.broker_addr_table.unwrap_or_default();
+            let Some(broker_data) = broker_table.get(request.broker_name.as_str()) else {
+                return Ok(BrokerRuntimeTargetStatus::SourceUnavailable);
+            };
+            for broker_addr in broker_data
+                .broker_addrs()
+                .values()
+                .filter(|broker_addr| !broker_addr.as_str().trim().is_empty())
+            {
+                if self.inner.fetch_broker_runtime_stats(broker_addr.clone()).await.is_ok() {
+                    return Ok(BrokerRuntimeTargetStatus::Available);
+                }
+            }
+            Ok(BrokerRuntimeTargetStatus::SourceUnavailable)
         })
     }
 
@@ -201,6 +389,19 @@ impl BrokerAdmin for AdminSession {
             Ok(project_broker_log_filter_state(request.logger.clone(), &runtime))
         })
     }
+}
+
+fn source_failure(source: AdminQuerySource, logical_target: &str, error: &RocketMQError) -> AdminSourceFailure {
+    let view = error.boundary_view();
+    let code = match view.http().status.as_u16() {
+        401 | 403 => AdminQueryFailureCode::PermissionDenied,
+        404 => AdminQueryFailureCode::NotFound,
+        408 | 504 => AdminQueryFailureCode::Timeout,
+        429 => AdminQueryFailureCode::RateLimited,
+        400 | 413 | 422 => AdminQueryFailureCode::InvalidResponse,
+        _ => AdminQueryFailureCode::SourceUnavailable,
+    };
+    AdminSourceFailure::new(source, code, view.is_retryable(), logical_target)
 }
 
 fn build_broker_summary(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/connection.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/connection.rs
@@ -1,0 +1,365 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection;
+use rocketmq_protocol::protocol::body::producer_table_info::ProducerTableInfo;
+
+use crate::client_adapter::lifecycle::AdminSession;
+use crate::core::client_connection::ClientConnectionObservation;
+use crate::core::client_connection::ClientConnectionQueryAdmin;
+use crate::core::client_connection::ListProducerConnectionsRequest;
+use crate::core::client_connection::ListProducerConnectionsResult;
+use crate::core::client_connection::ProducerConnectionObservation;
+use crate::core::client_connection::QueryConsumerConnectionsRequest;
+use crate::core::client_connection::QueryConsumerConnectionsResult;
+use crate::core::query::AdminQueryFailureCode;
+use crate::core::query::AdminQueryResult;
+use crate::core::query::AdminQuerySource;
+use crate::core::query::AdminSourceFailure;
+use crate::core::AdminError;
+use crate::core::AdminFuture;
+use crate::core::AdminResult;
+
+impl ClientConnectionQueryAdmin for AdminSession {
+    fn query_consumer_connections<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerConnectionsRequest,
+    ) -> AdminFuture<'a, QueryConsumerConnectionsResult> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            query_consumer_connections(&self.inner, request)
+                .await
+                .map(|outcome| outcome.result)
+        })
+    }
+
+    fn query_consumer_connections_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerConnectionsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerConnectionsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let outcome = query_consumer_connections(&self.inner, request).await?;
+            AdminQueryResult::from_sources(outcome.result, outcome.successful_sources, outcome.failures)
+        })
+    }
+
+    fn list_producer_connections<'a>(
+        &'a mut self,
+        request: &'a ListProducerConnectionsRequest,
+    ) -> AdminFuture<'a, ListProducerConnectionsResult> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            query_producer_connections(&self.inner, request)
+                .await
+                .map(|outcome| outcome.result)
+        })
+    }
+
+    fn list_producer_connections_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListProducerConnectionsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListProducerConnectionsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let outcome = query_producer_connections(&self.inner, request).await?;
+            AdminQueryResult::from_sources(outcome.result, outcome.successful_sources, outcome.failures)
+        })
+    }
+}
+
+struct ConnectionOutcome<T> {
+    result: T,
+    successful_sources: usize,
+    failures: Vec<AdminSourceFailure>,
+}
+
+async fn query_consumer_connections(
+    admin: &rocketmq_client_rust::DefaultMQAdminExt,
+    request: &QueryConsumerConnectionsRequest,
+) -> AdminResult<ConnectionOutcome<QueryConsumerConnectionsResult>> {
+    let (targets, mut failures) =
+        cluster_broker_targets(admin, &request.cluster, AdminQuerySource::ConsumerConnection).await?;
+    failures.retain(|failure| {
+        request
+            .broker_name
+            .as_ref()
+            .is_none_or(|expected| expected == failure.logical_target())
+    });
+    let mut connections = BTreeMap::new();
+    let mut queried_brokers = failures
+        .iter()
+        .map(|failure| failure.logical_target().to_string())
+        .collect::<BTreeSet<_>>();
+    let mut successful_sources = 0usize;
+    let mut truncated = false;
+    for (broker_name, broker_addr) in targets {
+        if request
+            .broker_name
+            .as_ref()
+            .is_some_and(|expected| expected != &broker_name)
+        {
+            continue;
+        }
+        queried_brokers.insert(broker_name.clone());
+        match rocketmq_client_rust::MQAdminReadExt::observe_consumer_connection_at(
+            admin,
+            CheetahString::from(request.consumer_group.as_str()),
+            broker_addr,
+        )
+        .await
+        {
+            Ok(connection) => {
+                successful_sources += 1;
+                for row in consumer_connection_rows(&broker_name, connection) {
+                    connections.entry(connection_identity(&row)).or_insert(row);
+                    if connections.len() > request.max_connections {
+                        truncated = true;
+                        break;
+                    }
+                }
+            }
+            Err(error) => failures.push(source_failure(
+                AdminQuerySource::ConsumerConnection,
+                &broker_name,
+                &error,
+            )),
+        }
+        if truncated {
+            break;
+        }
+    }
+    let failed_brokers = failure_targets(&failures);
+    Ok(ConnectionOutcome {
+        result: QueryConsumerConnectionsResult {
+            consumer_group: request.consumer_group.clone(),
+            connections: connections.into_values().take(request.max_connections).collect(),
+            queried_broker_count: queried_brokers.len(),
+            failed_brokers,
+            truncated,
+        },
+        successful_sources,
+        failures,
+    })
+}
+
+async fn query_producer_connections(
+    admin: &rocketmq_client_rust::DefaultMQAdminExt,
+    request: &ListProducerConnectionsRequest,
+) -> AdminResult<ConnectionOutcome<ListProducerConnectionsResult>> {
+    let (targets, mut failures) =
+        cluster_broker_targets(admin, &request.cluster, AdminQuerySource::ProducerConnection).await?;
+    failures.retain(|failure| {
+        request
+            .broker_name
+            .as_ref()
+            .is_none_or(|expected| expected == failure.logical_target())
+    });
+    let mut connections = BTreeMap::new();
+    let mut queried_brokers = failures
+        .iter()
+        .map(|failure| failure.logical_target().to_string())
+        .collect::<BTreeSet<_>>();
+    let mut successful_sources = 0usize;
+    let mut truncated = false;
+    for (broker_name, broker_addr) in targets {
+        if request
+            .broker_name
+            .as_ref()
+            .is_some_and(|expected| expected != &broker_name)
+        {
+            continue;
+        }
+        queried_brokers.insert(broker_name.clone());
+        match rocketmq_client_rust::MQAdminReadExt::get_all_producer_info(admin, broker_addr).await {
+            Ok(table) => {
+                successful_sources += 1;
+                for row in producer_connection_rows(&broker_name, table, request.producer_group.as_deref()) {
+                    let identity = (row.producer_group.clone(), connection_identity(&row.connection));
+                    connections.entry(identity).or_insert(row);
+                    if connections.len() > request.max_connections {
+                        truncated = true;
+                        break;
+                    }
+                }
+            }
+            Err(error) => failures.push(source_failure(
+                AdminQuerySource::ProducerConnection,
+                &broker_name,
+                &error,
+            )),
+        }
+        if truncated {
+            break;
+        }
+    }
+    let failed_brokers = failure_targets(&failures);
+    Ok(ConnectionOutcome {
+        result: ListProducerConnectionsResult {
+            connections: connections.into_values().take(request.max_connections).collect(),
+            queried_broker_count: queried_brokers.len(),
+            failed_brokers,
+            truncated,
+        },
+        successful_sources,
+        failures,
+    })
+}
+
+async fn cluster_broker_targets(
+    admin: &rocketmq_client_rust::DefaultMQAdminExt,
+    cluster: &str,
+    source: AdminQuerySource,
+) -> AdminResult<(Vec<(String, CheetahString)>, Vec<AdminSourceFailure>)> {
+    let cluster_info = rocketmq_client_rust::MQAdminReadExt::examine_broker_cluster_info(admin)
+        .await
+        .map_err(|error| AdminError::backend("examine_broker_cluster_info", error.to_string()))?;
+    let broker_names = cluster_info
+        .cluster_addr_table
+        .as_ref()
+        .and_then(|table| table.get(cluster))
+        .cloned()
+        .unwrap_or_default();
+    let broker_table = cluster_info.broker_addr_table.unwrap_or_default();
+    let mut targets = Vec::new();
+    let mut failures = Vec::new();
+    for broker_name in broker_names {
+        let Some(broker) = broker_table.get(&broker_name) else {
+            failures.push(AdminSourceFailure::new(
+                source,
+                AdminQueryFailureCode::InvalidResponse,
+                false,
+                broker_name.as_str(),
+            ));
+            continue;
+        };
+        if broker.broker_addrs().is_empty() {
+            failures.push(AdminSourceFailure::new(
+                source,
+                AdminQueryFailureCode::InvalidResponse,
+                false,
+                broker_name.as_str(),
+            ));
+            continue;
+        }
+        targets.extend(
+            broker
+                .broker_addrs()
+                .iter()
+                .map(|(broker_id, address)| (broker_name.to_string(), *broker_id, address.clone())),
+        );
+    }
+    targets.sort_by(|left, right| {
+        left.0
+            .cmp(&right.0)
+            .then(left.1.cmp(&right.1))
+            .then(left.2.cmp(&right.2))
+    });
+    Ok((
+        targets
+            .into_iter()
+            .map(|(broker_name, _, address)| (broker_name, address))
+            .collect(),
+        failures,
+    ))
+}
+
+fn consumer_connection_rows(broker_name: &str, connection: ConsumerConnection) -> Vec<ClientConnectionObservation> {
+    let mut rows = connection
+        .get_connection_set()
+        .iter()
+        .map(|item| ClientConnectionObservation {
+            broker_name: broker_name.to_owned(),
+            client_id: item.get_client_id().to_string(),
+            client_addr: item.get_client_addr().to_string(),
+            language: item.get_language().to_string(),
+            version: item.get_version(),
+            last_update_timestamp: None,
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by_key(connection_identity);
+    rows
+}
+
+fn producer_connection_rows(
+    broker_name: &str,
+    table: ProducerTableInfo,
+    producer_group: Option<&str>,
+) -> Vec<ProducerConnectionObservation> {
+    let mut groups = table.data().iter().collect::<Vec<_>>();
+    groups.sort_by(|left, right| left.0.cmp(right.0));
+    let mut rows = Vec::new();
+    for (group, producers) in groups {
+        if producer_group.is_some_and(|expected| expected != group.as_str()) {
+            continue;
+        }
+        let mut producers = producers.iter().collect::<Vec<_>>();
+        producers.sort_by(|left, right| {
+            left.client_id()
+                .cmp(right.client_id())
+                .then(left.remote_ip().cmp(right.remote_ip()))
+                .then(left.version().cmp(&right.version()))
+                .then(left.last_update_timestamp().cmp(&right.last_update_timestamp()))
+        });
+        rows.extend(producers.into_iter().map(|producer| ProducerConnectionObservation {
+            producer_group: group.clone(),
+            connection: ClientConnectionObservation {
+                broker_name: broker_name.to_owned(),
+                client_id: producer.client_id().to_owned(),
+                client_addr: producer.remote_ip().to_owned(),
+                language: producer.language().to_string(),
+                version: producer.version(),
+                last_update_timestamp: Some(producer.last_update_timestamp()),
+            },
+        }));
+    }
+    rows
+}
+
+fn connection_identity(connection: &ClientConnectionObservation) -> (String, String, String, String, i32) {
+    (
+        connection.broker_name.clone(),
+        connection.client_id.clone(),
+        connection.client_addr.clone(),
+        connection.language.clone(),
+        connection.version,
+    )
+}
+
+fn failure_targets(failures: &[AdminSourceFailure]) -> Vec<String> {
+    failures
+        .iter()
+        .map(|failure| failure.logical_target().to_string())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn source_failure(source: AdminQuerySource, logical_target: &str, error: &RocketMQError) -> AdminSourceFailure {
+    let view = error.boundary_view();
+    let code = match view.http().status.as_u16() {
+        401 | 403 => AdminQueryFailureCode::PermissionDenied,
+        404 => AdminQueryFailureCode::NotFound,
+        408 | 504 => AdminQueryFailureCode::Timeout,
+        429 => AdminQueryFailureCode::RateLimited,
+        400 | 413 | 422 => AdminQueryFailureCode::InvalidResponse,
+        _ => AdminQueryFailureCode::SourceUnavailable,
+    };
+    AdminSourceFailure::new(source, code, view.is_retryable(), logical_target)
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
@@ -17,11 +17,13 @@ use std::collections::HashSet;
 use std::time::SystemTime;
 
 use cheetah_string::CheetahString;
-use rocketmq_client_rust::{ConsumerAdmin as _, RouteAdmin as _, TopicAdmin as _};
+use rocketmq_client_rust::{ConsumerAdmin as _, ReadFailureCode, RouteAdmin as _, TopicAdmin as _};
 use rocketmq_error::RocketMQError;
 use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_model::common::key_builder::KeyBuilder;
 use rocketmq_model::common::message::message_enum::MessageRequestMode;
+use rocketmq_model::common::mix_all;
+use rocketmq_model::message::MessageQueue;
 use rocketmq_model::topic::RETRY_GROUP_TOPIC_PREFIX;
 use rocketmq_protocol::common::wire_constants::MASTER_ID;
 use rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats;
@@ -41,6 +43,10 @@ use crate::core::consumer::ConsumerAdmin;
 use crate::core::consumer::ConsumerBatchMutationOutcome;
 use crate::core::consumer::ConsumerDiagnosticAdmin;
 use crate::core::consumer::DeleteSubscriptionGroupsRequest;
+use crate::core::query::AdminQueryFailureCode;
+use crate::core::query::AdminQueryResult;
+use crate::core::query::AdminQuerySource;
+use crate::core::query::AdminSourceFailure;
 use crate::core::AdminError;
 use crate::core::AdminFuture;
 use crate::core::AdminResult;
@@ -131,6 +137,71 @@ impl ConsumerAdmin for AdminSession {
         })
     }
 
+    fn list_consumer_groups_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a consumer::ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<consumer::ListConsumerGroupsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let topic_list = self
+                .inner
+                .fetch_all_topic_list()
+                .await
+                .map_err(|error| backend_error("fetch_all_topic_list", error))?;
+            let mut groups = Vec::new();
+            let mut failures = Vec::new();
+            let mut successful_sources = 1usize;
+            for retry_topic in topic_list
+                .topic_list
+                .into_iter()
+                .filter(|topic| topic.starts_with(RETRY_GROUP_TOPIC_PREFIX))
+            {
+                let group = KeyBuilder::parse_group(retry_topic.as_str());
+                let mut summary = default_consumer_group_summary(&group);
+                let stats = rocketmq_client_rust::MQAdminReadExt::examine_consume_stats_with_evidence(
+                    &self.inner,
+                    CheetahString::from(group.as_str()),
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+                match stats {
+                    Ok(stats) => {
+                        successful_sources += stats.successful_brokers;
+                        summary.consume_tps = stats.stats.get_consume_tps();
+                        summary.diff_total = stats.stats.compute_total_diff();
+                        failures.extend(stats.failures.into_iter().map(|failure| {
+                            source_failure_from_client(
+                                AdminQuerySource::ConsumerStatistics,
+                                failure.broker_name(),
+                                failure.code(),
+                                failure.retryable(),
+                            )
+                        }));
+                    }
+                    Err(error) => failures.push(source_failure(AdminQuerySource::ConsumerStatistics, &group, &error)),
+                }
+                let connection_evidence = collect_group_connection_evidence(&self.inner, &group).await;
+                successful_sources += connection_evidence.successful_sources;
+                failures.extend(connection_evidence.failures);
+                if let Some(connection) = connection_evidence.summary {
+                    summary.client_count = connection.client_count;
+                    summary.consume_type = connection.consume_type;
+                    summary.message_model = connection.message_model;
+                    summary.version = connection.version;
+                }
+                groups.push(summary);
+            }
+            groups.sort_by(|left, right| left.group.cmp(&right.group));
+            AdminQueryResult::from_sources(
+                consumer::ListConsumerGroupsResult { groups },
+                successful_sources,
+                failures,
+            )
+        })
+    }
+
     fn query_consumer_lag<'a>(
         &'a mut self,
         request: &'a consumer::QueryConsumerLagRequest,
@@ -181,6 +252,56 @@ impl ConsumerAdmin for AdminSession {
                 });
             }
             Ok(result)
+        })
+    }
+
+    fn query_consumer_lag_with_evidence<'a>(
+        &'a mut self,
+        request: &'a consumer::QueryConsumerLagRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<consumer::QueryConsumerLagResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let stats = rocketmq_client_rust::MQAdminReadExt::examine_consume_stats_with_evidence(
+                &self.inner,
+                CheetahString::from(request.consumer_group.as_str()),
+                Some(CheetahString::from(request.topic.as_str())),
+                None,
+                None,
+            )
+            .await;
+            let stats = match stats {
+                Ok(stats) => stats,
+                Err(error) => {
+                    return AdminQueryResult::from_sources(
+                        consumer::QueryConsumerLagResult::default(),
+                        0,
+                        vec![source_failure(
+                            AdminQuerySource::ConsumerStatistics,
+                            &request.consumer_group,
+                            &error,
+                        )],
+                    );
+                }
+            };
+            let failures = stats
+                .failures
+                .into_iter()
+                .map(|failure| {
+                    source_failure_from_client(
+                        AdminQuerySource::ConsumerStatistics,
+                        failure.broker_name(),
+                        failure.code(),
+                        failure.retryable(),
+                    )
+                })
+                .collect();
+            let allocation = if request.include_client_ip {
+                message_queue_allocation(&self.inner, request.consumer_group.as_str()).await
+            } else {
+                HashMap::new()
+            };
+            let result = map_lag_result(stats.stats, &allocation);
+            AdminQueryResult::from_sources(result, stats.successful_brokers, failures)
         })
     }
 
@@ -660,6 +781,172 @@ fn now_timestamp_millis() -> i64 {
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|duration| duration.as_millis() as i64)
         .unwrap_or_default()
+}
+
+fn default_consumer_group_summary(group: &str) -> consumer::ConsumerGroupSummary {
+    consumer::ConsumerGroupSummary {
+        group: group.to_string(),
+        version: 0,
+        client_count: 0,
+        consume_type: format!("{:?}", ConsumeType::ConsumePassively),
+        message_model: format!("{:?}", MessageModel::Clustering),
+        consume_tps: 0.0,
+        diff_total: 0,
+    }
+}
+
+struct GroupConnectionSummary {
+    client_count: i32,
+    consume_type: String,
+    message_model: String,
+    version: i32,
+}
+
+struct GroupConnectionEvidence {
+    successful_sources: usize,
+    failures: Vec<AdminSourceFailure>,
+    summary: Option<GroupConnectionSummary>,
+}
+
+async fn collect_group_connection_evidence(
+    admin: &rocketmq_client_rust::DefaultMQAdminExt,
+    group: &str,
+) -> GroupConnectionEvidence {
+    let retry_topic = CheetahString::from_string(mix_all::get_retry_topic(group));
+    let route = match rocketmq_client_rust::MQAdminReadExt::examine_topic_route_info(admin, retry_topic).await {
+        Ok(route) => route,
+        Err(error) => {
+            return GroupConnectionEvidence {
+                successful_sources: 0,
+                failures: vec![source_failure(AdminQuerySource::ConsumerConnection, group, &error)],
+                summary: None,
+            };
+        }
+    };
+    let Some(route) = route else {
+        return GroupConnectionEvidence {
+            successful_sources: 0,
+            failures: Vec::new(),
+            summary: Some(GroupConnectionSummary {
+                client_count: 0,
+                consume_type: format!("{:?}", ConsumeType::ConsumePassively),
+                message_model: format!("{:?}", MessageModel::Clustering),
+                version: 0,
+            }),
+        };
+    };
+
+    let mut successful_sources = 0usize;
+    let mut failures = Vec::new();
+    let mut clients = std::collections::BTreeSet::new();
+    let mut consume_type = None;
+    let mut message_model = None;
+    let mut version = None;
+    for broker in route.broker_datas {
+        let Some(address) = broker.broker_addrs().get(&mix_all::MASTER_ID).cloned() else {
+            continue;
+        };
+        let broker_name = broker.broker_name().to_string();
+        match rocketmq_client_rust::MQAdminReadExt::observe_consumer_connection_at(
+            admin,
+            CheetahString::from(group),
+            address,
+        )
+        .await
+        {
+            Ok(connection) => {
+                successful_sources += 1;
+                clients.extend(connection.get_connection_set().iter().map(|connection| {
+                    (
+                        connection.get_client_id().to_string(),
+                        connection.get_language().to_string(),
+                        connection.get_version(),
+                    )
+                }));
+                consume_type = consume_type.or_else(|| connection.get_consume_type());
+                message_model = message_model.or_else(|| connection.get_message_model());
+                let candidate = connection.compute_min_version();
+                if candidate != i32::MAX {
+                    version = Some(version.map_or(candidate, |current: i32| current.min(candidate)));
+                }
+            }
+            Err(error) => failures.push(source_failure(
+                AdminQuerySource::ConsumerConnection,
+                &broker_name,
+                &error,
+            )),
+        }
+    }
+    GroupConnectionEvidence {
+        successful_sources,
+        failures,
+        summary: Some(GroupConnectionSummary {
+            client_count: i32::try_from(clients.len()).unwrap_or(i32::MAX),
+            consume_type: format!("{:?}", consume_type.unwrap_or(ConsumeType::ConsumePassively)),
+            message_model: format!("{:?}", message_model.unwrap_or(MessageModel::Clustering)),
+            version: version.unwrap_or_default(),
+        }),
+    }
+}
+
+fn map_lag_result(stats: ConsumeStats, allocation: &HashMap<MessageQueue, String>) -> consumer::QueryConsumerLagResult {
+    let mut queues = stats.get_offset_table().keys().cloned().collect::<Vec<_>>();
+    queues.sort();
+    let mut result = consumer::QueryConsumerLagResult {
+        consume_tps: stats.get_consume_tps(),
+        ..consumer::QueryConsumerLagResult::default()
+    };
+    for queue in queues {
+        let Some(offset) = stats.get_offset_table().get(&queue) else {
+            continue;
+        };
+        let lag = offset.get_broker_offset() - offset.get_consumer_offset();
+        let inflight = offset.get_pull_offset() - offset.get_consumer_offset();
+        result.total_lag += lag;
+        result.inflight_total += inflight;
+        result.rows.push(consumer::ConsumerLagRow {
+            topic: queue.topic().to_string(),
+            broker_name: queue.broker_name().to_string(),
+            queue_id: queue.queue_id(),
+            broker_offset: offset.get_broker_offset(),
+            consumer_offset: offset.get_consumer_offset(),
+            lag,
+            inflight,
+            last_timestamp: offset.get_last_timestamp(),
+            client_ip: allocation.get(&queue).cloned(),
+        });
+    }
+    result
+}
+
+fn source_failure(source: AdminQuerySource, logical_target: &str, error: &RocketMQError) -> AdminSourceFailure {
+    let view = error.boundary_view();
+    let code = match view.http().status.as_u16() {
+        401 | 403 => AdminQueryFailureCode::PermissionDenied,
+        404 => AdminQueryFailureCode::NotFound,
+        408 | 504 => AdminQueryFailureCode::Timeout,
+        429 => AdminQueryFailureCode::RateLimited,
+        400 | 413 | 422 => AdminQueryFailureCode::InvalidResponse,
+        _ => AdminQueryFailureCode::SourceUnavailable,
+    };
+    AdminSourceFailure::new(source, code, view.is_retryable(), logical_target)
+}
+
+fn source_failure_from_client(
+    source: AdminQuerySource,
+    logical_target: &str,
+    code: ReadFailureCode,
+    retryable: bool,
+) -> AdminSourceFailure {
+    let code = match code {
+        ReadFailureCode::SourceUnavailable => AdminQueryFailureCode::SourceUnavailable,
+        ReadFailureCode::Timeout => AdminQueryFailureCode::Timeout,
+        ReadFailureCode::PermissionDenied => AdminQueryFailureCode::PermissionDenied,
+        ReadFailureCode::NotFound => AdminQueryFailureCode::NotFound,
+        ReadFailureCode::RateLimited => AdminQueryFailureCode::RateLimited,
+        ReadFailureCode::InvalidResponse => AdminQueryFailureCode::InvalidResponse,
+    };
+    AdminSourceFailure::new(source, code, retryable, logical_target)
 }
 
 fn backend_error(operation: &'static str, error: RocketMQError) -> AdminError {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
@@ -26,12 +26,15 @@ use rocketmq_client_rust::DefaultMQAdminExt;
 use rocketmq_client_rust::MQAdminMessageReadExt;
 use rocketmq_client_rust::MQAdminReadExt;
 use rocketmq_client_rust::MQAdminTopicInventoryReadExt;
+use rocketmq_client_rust::ReadFailureCode;
 use rocketmq_client_rust::SessionCredentials;
 use rocketmq_client_rust::SigningAlgorithm;
 use rocketmq_error::RocketMQError;
 use rocketmq_model::common::key_builder::KeyBuilder;
+use rocketmq_model::common::mix_all;
 use rocketmq_model::topic::DLQ_GROUP_TOPIC_PREFIX;
 use rocketmq_model::topic::RETRY_GROUP_TOPIC_PREFIX;
+use rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats;
 use rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection;
 use rocketmq_protocol::protocol::body::kv_table::KVTable;
 use rocketmq_protocol::protocol::body::producer_table_info::ProducerTableInfo;
@@ -44,11 +47,13 @@ use crate::core::broker::project_broker_log_filter_state;
 use crate::core::broker::BrokerAllowlistedConfig;
 use crate::core::broker::BrokerLogFilterState;
 use crate::core::broker::BrokerQueryAdmin;
+use crate::core::broker::BrokerRuntimeTargetStatus;
 use crate::core::broker::BrokerSummary;
 use crate::core::broker::ListBrokersRequest;
 use crate::core::broker::ListBrokersResult;
 use crate::core::broker::ProbeBrokerRuntimeRequest;
 use crate::core::broker::ProbeBrokerRuntimeResult;
+use crate::core::broker::ProbeBrokerRuntimeTargetRequest;
 use crate::core::broker::QueryBrokerAllowlistedConfigRequest;
 use crate::core::broker::QueryBrokerDiagnosticsRequest;
 use crate::core::broker::QueryBrokerDiagnosticsResult;
@@ -67,6 +72,10 @@ use crate::core::proxy::ProxyDrainPending;
 use crate::core::proxy::ProxyDrainState;
 use crate::core::proxy::ProxyQueryAdmin;
 use crate::core::proxy::QueryProxyDrainStateRequest;
+use crate::core::query::AdminQueryFailureCode;
+use crate::core::query::AdminQueryResult;
+use crate::core::query::AdminQuerySource;
+use crate::core::query::AdminSourceFailure;
 use crate::core::security::AdminCredentials;
 use crate::core::topic::GetTopicRouteRequest;
 use crate::core::topic::ListTopicsRequest;
@@ -399,6 +408,77 @@ impl BrokerQueryAdmin for ReadAdminSession {
         })
     }
 
+    fn list_brokers_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListBrokersRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListBrokersResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let cluster_info = self
+                .inner
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+            let broker_names = cluster_info
+                .cluster_addr_table
+                .as_ref()
+                .and_then(|table| table.get(request.cluster.as_str()))
+                .cloned()
+                .unwrap_or_default();
+            let broker_table = cluster_info.broker_addr_table.unwrap_or_default();
+            let now_millis = self.clock.now_millis();
+            let mut brokers = Vec::new();
+            let mut successful_sources = 0usize;
+            let mut failures = Vec::new();
+            for broker_name in broker_names {
+                let Some(broker_data) = broker_table.get(&broker_name) else {
+                    failures.push(AdminSourceFailure::new(
+                        AdminQuerySource::BrokerRuntime,
+                        AdminQueryFailureCode::InvalidResponse,
+                        false,
+                        broker_name.as_str(),
+                    ));
+                    continue;
+                };
+                if broker_data.broker_addrs().is_empty() {
+                    failures.push(AdminSourceFailure::new(
+                        AdminQuerySource::BrokerRuntime,
+                        AdminQueryFailureCode::InvalidResponse,
+                        false,
+                        broker_name.as_str(),
+                    ));
+                    continue;
+                }
+                for (broker_id, broker_addr) in broker_data.broker_addrs() {
+                    match self.inner.fetch_broker_runtime_stats(broker_addr.clone()).await {
+                        Ok(runtime) => {
+                            successful_sources += 1;
+                            brokers.push(build_broker_summary(
+                                request.cluster.clone(),
+                                broker_name.to_string(),
+                                *broker_id,
+                                broker_addr.to_string(),
+                                Some(&runtime),
+                                now_millis,
+                            ));
+                        }
+                        Err(error) => failures.push(source_failure_from_error(
+                            AdminQuerySource::BrokerRuntime,
+                            broker_name.as_str(),
+                            &error,
+                        )),
+                    }
+                }
+            }
+            brokers.sort_by(|left, right| {
+                left.broker_name
+                    .cmp(&right.broker_name)
+                    .then(left.broker_id.cmp(&right.broker_id))
+            });
+            AdminQueryResult::from_sources(ListBrokersResult { brokers }, successful_sources, failures)
+        })
+    }
+
     fn probe_broker_runtime<'a>(
         &'a mut self,
         request: &'a ProbeBrokerRuntimeRequest,
@@ -444,6 +524,105 @@ impl BrokerQueryAdmin for ReadAdminSession {
                 result.failures.push(format!("code=other;count={overflow}"));
             }
             Ok(result)
+        })
+    }
+
+    fn probe_broker_runtime_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ProbeBrokerRuntimeRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ProbeBrokerRuntimeResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let cluster_info = self
+                .inner
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+            let broker_names = cluster_info
+                .cluster_addr_table
+                .as_ref()
+                .and_then(|table| table.get(request.cluster.as_str()))
+                .cloned()
+                .unwrap_or_default();
+            let broker_table = cluster_info.broker_addr_table.unwrap_or_default();
+            let mut result = ProbeBrokerRuntimeResult::default();
+            let mut successful_sources = 0usize;
+            let mut failures = Vec::new();
+            for broker_name in broker_names {
+                let Some(broker_data) = broker_table.get(&broker_name) else {
+                    result.attempted += 1;
+                    failures.push(AdminSourceFailure::new(
+                        AdminQuerySource::BrokerRuntime,
+                        AdminQueryFailureCode::InvalidResponse,
+                        false,
+                        broker_name.as_str(),
+                    ));
+                    continue;
+                };
+                if broker_data.broker_addrs().is_empty() {
+                    result.attempted += 1;
+                    failures.push(AdminSourceFailure::new(
+                        AdminQuerySource::BrokerRuntime,
+                        AdminQueryFailureCode::InvalidResponse,
+                        false,
+                        broker_name.as_str(),
+                    ));
+                    continue;
+                }
+                for broker_addr in broker_data.broker_addrs().values() {
+                    result.attempted += 1;
+                    match self.inner.fetch_broker_runtime_stats(broker_addr.clone()).await {
+                        Ok(_) => successful_sources += 1,
+                        Err(error) => failures.push(source_failure_from_error(
+                            AdminQuerySource::BrokerRuntime,
+                            broker_name.as_str(),
+                            &error,
+                        )),
+                    }
+                }
+            }
+            result.failures = stable_legacy_failures(&failures);
+            AdminQueryResult::from_sources(result, successful_sources, failures)
+        })
+    }
+
+    fn probe_broker_runtime_target<'a>(
+        &'a mut self,
+        request: &'a ProbeBrokerRuntimeTargetRequest,
+    ) -> AdminFuture<'a, BrokerRuntimeTargetStatus> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let cluster_info = self
+                .inner
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+            let broker_names = cluster_info
+                .cluster_addr_table
+                .as_ref()
+                .and_then(|table| table.get(request.cluster.as_str()))
+                .cloned()
+                .unwrap_or_default();
+            if !broker_names
+                .iter()
+                .any(|broker_name| broker_name.as_str() == request.broker_name)
+            {
+                return Ok(BrokerRuntimeTargetStatus::NotFound);
+            }
+            let broker_table = cluster_info.broker_addr_table.unwrap_or_default();
+            let Some(broker_data) = broker_table.get(request.broker_name.as_str()) else {
+                return Ok(BrokerRuntimeTargetStatus::SourceUnavailable);
+            };
+            for broker_addr in broker_data
+                .broker_addrs()
+                .values()
+                .filter(|broker_addr| !broker_addr.as_str().trim().is_empty())
+            {
+                if self.inner.fetch_broker_runtime_stats(broker_addr.clone()).await.is_ok() {
+                    return Ok(BrokerRuntimeTargetStatus::Available);
+                }
+            }
+            Ok(BrokerRuntimeTargetStatus::SourceUnavailable)
         })
     }
 
@@ -592,6 +771,90 @@ impl ClientConnectionQueryAdmin for ReadAdminSession {
         })
     }
 
+    fn query_consumer_connections_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerConnectionsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerConnectionsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let (targets, mut failures) = cluster_broker_targets_with_evidence(
+                &self.inner,
+                &request.cluster,
+                AdminQuerySource::ConsumerConnection,
+            )
+            .await?;
+            failures.retain(|failure| {
+                request
+                    .broker_name
+                    .as_ref()
+                    .is_none_or(|expected| expected == failure.logical_target())
+            });
+            let mut connections = BTreeMap::new();
+            let mut queried_brokers = failures
+                .iter()
+                .map(|failure| failure.logical_target().to_string())
+                .collect::<BTreeSet<_>>();
+            let mut successful_sources = 0usize;
+            let mut truncated = false;
+            for (broker_name, broker_addr) in targets {
+                if request
+                    .broker_name
+                    .as_ref()
+                    .is_some_and(|expected| expected != &broker_name)
+                {
+                    continue;
+                }
+                queried_brokers.insert(broker_name.clone());
+                match self
+                    .inner
+                    .observe_consumer_connection_at(CheetahString::from(request.consumer_group.as_str()), broker_addr)
+                    .await
+                {
+                    Ok(connection) => {
+                        successful_sources += 1;
+                        for row in consumer_connection_rows(&broker_name, connection) {
+                            let identity = client_connection_identity(&row);
+                            connections.entry(identity).or_insert(row);
+                            if connections.len() > request.max_connections {
+                                truncated = true;
+                                break;
+                            }
+                        }
+                    }
+                    Err(error) => failures.push(source_failure_from_error(
+                        AdminQuerySource::ConsumerConnection,
+                        &broker_name,
+                        &error,
+                    )),
+                }
+                if truncated {
+                    break;
+                }
+            }
+            let connections = connections
+                .into_values()
+                .take(request.max_connections)
+                .collect::<Vec<_>>();
+            let failed_brokers = failures
+                .iter()
+                .map(|failure| failure.logical_target().to_string())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            AdminQueryResult::from_sources(
+                QueryConsumerConnectionsResult {
+                    consumer_group: request.consumer_group.clone(),
+                    connections,
+                    queried_broker_count: queried_brokers.len(),
+                    failed_brokers,
+                    truncated,
+                },
+                successful_sources,
+                failures,
+            )
+        })
+    }
+
     fn list_producer_connections<'a>(
         &'a mut self,
         request: &'a ListProducerConnectionsRequest,
@@ -641,6 +904,85 @@ impl ClientConnectionQueryAdmin for ReadAdminSession {
                 failed_brokers: failed_brokers.into_iter().collect(),
                 truncated,
             })
+        })
+    }
+
+    fn list_producer_connections_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListProducerConnectionsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListProducerConnectionsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let (targets, mut failures) = cluster_broker_targets_with_evidence(
+                &self.inner,
+                &request.cluster,
+                AdminQuerySource::ProducerConnection,
+            )
+            .await?;
+            failures.retain(|failure| {
+                request
+                    .broker_name
+                    .as_ref()
+                    .is_none_or(|expected| expected == failure.logical_target())
+            });
+            let mut connections = BTreeMap::new();
+            let mut queried_brokers = failures
+                .iter()
+                .map(|failure| failure.logical_target().to_string())
+                .collect::<BTreeSet<_>>();
+            let mut successful_sources = 0usize;
+            let mut truncated = false;
+            for (broker_name, broker_addr) in targets {
+                if request
+                    .broker_name
+                    .as_ref()
+                    .is_some_and(|expected| expected != &broker_name)
+                {
+                    continue;
+                }
+                queried_brokers.insert(broker_name.clone());
+                match self.inner.get_all_producer_info(broker_addr).await {
+                    Ok(table) => {
+                        successful_sources += 1;
+                        for row in producer_connection_rows(&broker_name, table, request.producer_group.as_deref()) {
+                            let identity = (row.producer_group.clone(), client_connection_identity(&row.connection));
+                            connections.entry(identity).or_insert(row);
+                            if connections.len() > request.max_connections {
+                                truncated = true;
+                                break;
+                            }
+                        }
+                    }
+                    Err(error) => failures.push(source_failure_from_error(
+                        AdminQuerySource::ProducerConnection,
+                        &broker_name,
+                        &error,
+                    )),
+                }
+                if truncated {
+                    break;
+                }
+            }
+            let connections = connections
+                .into_values()
+                .take(request.max_connections)
+                .collect::<Vec<_>>();
+            let failed_brokers = failures
+                .iter()
+                .map(|failure| failure.logical_target().to_string())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            AdminQueryResult::from_sources(
+                ListProducerConnectionsResult {
+                    connections,
+                    queried_broker_count: queried_brokers.len(),
+                    failed_brokers,
+                    truncated,
+                },
+                successful_sources,
+                failures,
+            )
         })
     }
 }
@@ -955,6 +1297,75 @@ impl ConsumerQueryAdmin for ReadAdminSession {
         })
     }
 
+    fn list_consumer_groups_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a consumer::ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<consumer::ListConsumerGroupsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let topic_list = self
+                .inner
+                .fetch_all_topic_list()
+                .await
+                .map_err(|error| backend_error("fetch_all_topic_list", error))?;
+            let mut groups = Vec::new();
+            let mut failures = Vec::new();
+            // The inventory is itself a successful required source. It makes
+            // an empty inventory authoritative and keeps enrichment failures
+            // partial rather than converting known group rows into a total error.
+            let mut successful_sources = 1usize;
+            for retry_topic in topic_list
+                .topic_list
+                .into_iter()
+                .filter(|topic| topic.starts_with(RETRY_GROUP_TOPIC_PREFIX))
+            {
+                let group = KeyBuilder::parse_group(retry_topic.as_str());
+                let mut summary = default_consumer_group_summary(&group);
+                let stats = self
+                    .inner
+                    .examine_consume_stats_with_evidence(CheetahString::from(group.as_str()), None, None, None)
+                    .await;
+                match stats {
+                    Ok(stats) => {
+                        successful_sources += stats.successful_brokers;
+                        summary.consume_tps = stats.stats.get_consume_tps();
+                        summary.diff_total = stats.stats.compute_total_diff();
+                        failures.extend(stats.failures.into_iter().map(|failure| {
+                            source_failure_from_client(
+                                AdminQuerySource::ConsumerStatistics,
+                                failure.broker_name(),
+                                failure.code(),
+                                failure.retryable(),
+                            )
+                        }));
+                    }
+                    Err(error) => failures.push(source_failure_from_error(
+                        AdminQuerySource::ConsumerStatistics,
+                        &group,
+                        &error,
+                    )),
+                }
+
+                let connection_evidence = collect_group_connection_summary(&self.inner, &group).await?;
+                successful_sources += connection_evidence.successful_sources;
+                failures.extend(connection_evidence.failures);
+                if let Some(connection) = connection_evidence.summary {
+                    summary.client_count = connection.client_count;
+                    summary.consume_type = connection.consume_type;
+                    summary.message_model = connection.message_model;
+                    summary.version = connection.version;
+                }
+                groups.push(summary);
+            }
+            groups.sort_by(|left, right| left.group.cmp(&right.group));
+            AdminQueryResult::from_sources(
+                consumer::ListConsumerGroupsResult { groups },
+                successful_sources,
+                failures,
+            )
+        })
+    }
+
     fn query_consumer_lag<'a>(
         &'a mut self,
         request: &'a consumer::QueryConsumerLagRequest,
@@ -999,6 +1410,52 @@ impl ConsumerQueryAdmin for ReadAdminSession {
                 });
             }
             Ok(result)
+        })
+    }
+
+    fn query_consumer_lag_with_evidence<'a>(
+        &'a mut self,
+        request: &'a consumer::QueryConsumerLagRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<consumer::QueryConsumerLagResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let stats = self
+                .inner
+                .examine_consume_stats_with_evidence(
+                    CheetahString::from(request.consumer_group.as_str()),
+                    Some(CheetahString::from(request.topic.as_str())),
+                    None,
+                    None,
+                )
+                .await;
+            let stats = match stats {
+                Ok(stats) => stats,
+                Err(error) => {
+                    return AdminQueryResult::from_sources(
+                        consumer::QueryConsumerLagResult::default(),
+                        0,
+                        vec![source_failure_from_error(
+                            AdminQuerySource::ConsumerStatistics,
+                            &request.consumer_group,
+                            &error,
+                        )],
+                    );
+                }
+            };
+            let failures = stats
+                .failures
+                .into_iter()
+                .map(|failure| {
+                    source_failure_from_client(
+                        AdminQuerySource::ConsumerStatistics,
+                        failure.broker_name(),
+                        failure.code(),
+                        failure.retryable(),
+                    )
+                })
+                .collect();
+            let result = map_consumer_lag_result(stats.stats);
+            AdminQueryResult::from_sources(result, stats.successful_brokers, failures)
         })
     }
 
@@ -1119,6 +1576,65 @@ async fn cluster_broker_targets(admin: &DefaultMQAdminExt, cluster: &str) -> Adm
         .collect())
 }
 
+async fn cluster_broker_targets_with_evidence(
+    admin: &DefaultMQAdminExt,
+    cluster: &str,
+    source: AdminQuerySource,
+) -> AdminResult<(Vec<(String, CheetahString)>, Vec<AdminSourceFailure>)> {
+    let cluster_info = admin
+        .examine_broker_cluster_info()
+        .await
+        .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+    let broker_names = cluster_info
+        .cluster_addr_table
+        .as_ref()
+        .and_then(|table| table.get(cluster))
+        .cloned()
+        .unwrap_or_default();
+    let broker_table = cluster_info.broker_addr_table.unwrap_or_default();
+    let mut targets = Vec::new();
+    let mut failures = Vec::new();
+    for broker_name in broker_names {
+        let Some(broker) = broker_table.get(&broker_name) else {
+            failures.push(AdminSourceFailure::new(
+                source,
+                AdminQueryFailureCode::InvalidResponse,
+                false,
+                broker_name.as_str(),
+            ));
+            continue;
+        };
+        if broker.broker_addrs().is_empty() {
+            failures.push(AdminSourceFailure::new(
+                source,
+                AdminQueryFailureCode::InvalidResponse,
+                false,
+                broker_name.as_str(),
+            ));
+            continue;
+        }
+        targets.extend(
+            broker
+                .broker_addrs()
+                .iter()
+                .map(|(broker_id, address)| (broker_name.to_string(), *broker_id, address.clone())),
+        );
+    }
+    targets.sort_by(|left, right| {
+        left.0
+            .cmp(&right.0)
+            .then(left.1.cmp(&right.1))
+            .then(left.2.cmp(&right.2))
+    });
+    Ok((
+        targets
+            .into_iter()
+            .map(|(broker_name, _, address)| (broker_name, address))
+            .collect(),
+        failures,
+    ))
+}
+
 fn producer_connection_rows(
     broker_name: &str,
     table: ProducerTableInfo,
@@ -1223,6 +1739,144 @@ fn build_broker_summary(
     }
 }
 
+fn default_consumer_group_summary(group: &str) -> consumer::ConsumerGroupSummary {
+    consumer::ConsumerGroupSummary {
+        group: group.to_string(),
+        version: 0,
+        client_count: 0,
+        consume_type: format!("{:?}", ConsumeType::ConsumePassively),
+        message_model: format!("{:?}", MessageModel::Clustering),
+        consume_tps: 0.0,
+        diff_total: 0,
+    }
+}
+
+struct ConsumerConnectionSummary {
+    client_count: i32,
+    consume_type: String,
+    message_model: String,
+    version: i32,
+}
+
+struct ConsumerConnectionEvidence {
+    successful_sources: usize,
+    failures: Vec<AdminSourceFailure>,
+    summary: Option<ConsumerConnectionSummary>,
+}
+
+async fn collect_group_connection_summary(
+    admin: &DefaultMQAdminExt,
+    group: &str,
+) -> AdminResult<ConsumerConnectionEvidence> {
+    let retry_topic = CheetahString::from_string(mix_all::get_retry_topic(group));
+    let route = match admin.examine_topic_route_info(retry_topic).await {
+        Ok(route) => route,
+        Err(error) => {
+            return Ok(ConsumerConnectionEvidence {
+                successful_sources: 0,
+                failures: vec![source_failure_from_error(
+                    AdminQuerySource::ConsumerConnection,
+                    group,
+                    &error,
+                )],
+                summary: None,
+            });
+        }
+    };
+    let Some(route) = route else {
+        return Ok(ConsumerConnectionEvidence {
+            successful_sources: 0,
+            failures: Vec::new(),
+            summary: Some(ConsumerConnectionSummary {
+                client_count: 0,
+                consume_type: format!("{:?}", ConsumeType::ConsumePassively),
+                message_model: format!("{:?}", MessageModel::Clustering),
+                version: 0,
+            }),
+        });
+    };
+
+    let mut successful_sources = 0usize;
+    let mut failures = Vec::new();
+    let mut clients = BTreeSet::new();
+    let mut consume_type = None;
+    let mut message_model = None;
+    let mut version = None;
+    for broker in route.broker_datas {
+        let Some(address) = broker.broker_addrs().get(&mix_all::MASTER_ID).cloned() else {
+            continue;
+        };
+        let broker_name = broker.broker_name().to_string();
+        match admin
+            .observe_consumer_connection_at(CheetahString::from(group), address)
+            .await
+        {
+            Ok(connection) => {
+                successful_sources += 1;
+                clients.extend(connection.get_connection_set().iter().map(|connection| {
+                    (
+                        connection.get_client_id().to_string(),
+                        connection.get_language().to_string(),
+                        connection.get_version(),
+                    )
+                }));
+                consume_type = consume_type.or_else(|| connection.get_consume_type());
+                message_model = message_model.or_else(|| connection.get_message_model());
+                let candidate = connection.compute_min_version();
+                if candidate != i32::MAX {
+                    version = Some(version.map_or(candidate, |current: i32| current.min(candidate)));
+                }
+            }
+            Err(error) => failures.push(source_failure_from_error(
+                AdminQuerySource::ConsumerConnection,
+                &broker_name,
+                &error,
+            )),
+        }
+    }
+    let client_count = i32::try_from(clients.len()).unwrap_or(i32::MAX);
+    Ok(ConsumerConnectionEvidence {
+        successful_sources,
+        failures,
+        summary: Some(ConsumerConnectionSummary {
+            client_count,
+            consume_type: format!("{:?}", consume_type.unwrap_or(ConsumeType::ConsumePassively)),
+            message_model: format!("{:?}", message_model.unwrap_or(MessageModel::Clustering)),
+            version: version.unwrap_or_default(),
+        }),
+    })
+}
+
+fn map_consumer_lag_result(stats: ConsumeStats) -> consumer::QueryConsumerLagResult {
+    let mut queues = stats.get_offset_table().keys().cloned().collect::<Vec<_>>();
+    queues.sort();
+    let mut result = consumer::QueryConsumerLagResult {
+        consume_tps: stats.get_consume_tps(),
+        ..consumer::QueryConsumerLagResult::default()
+    };
+    for queue in queues {
+        let Some(offset) = stats.get_offset_table().get(&queue) else {
+            continue;
+        };
+        let lag = offset.get_broker_offset() - offset.get_consumer_offset();
+        let inflight = offset.get_pull_offset() - offset.get_consumer_offset();
+        result.total_lag += lag;
+        result.inflight_total += inflight;
+        result.rows.push(consumer::ConsumerLagRow {
+            topic: queue.topic().to_string(),
+            broker_name: queue.broker_name().to_string(),
+            queue_id: queue.queue_id(),
+            broker_offset: offset.get_broker_offset(),
+            consumer_offset: offset.get_consumer_offset(),
+            lag,
+            inflight,
+            last_timestamp: offset.get_last_timestamp(),
+            client_ip: None,
+        });
+    }
+    result
+}
+
 fn runtime_value<'a>(runtime: Option<&'a KVTable>, key: &str) -> Option<&'a str> {
     runtime
         .and_then(|runtime| runtime.table.get(&CheetahString::from(key)))
@@ -1253,6 +1907,63 @@ fn backend_error(operation: &'static str, error: RocketMQError) -> AdminError {
         view.http().status.as_u16(),
         view.is_retryable(),
     )
+}
+
+fn source_failure_from_error(
+    source: AdminQuerySource,
+    logical_target: &str,
+    error: &RocketMQError,
+) -> AdminSourceFailure {
+    let view = error.boundary_view();
+    AdminSourceFailure::new(
+        source,
+        query_failure_code(view.http().status.as_u16()),
+        view.is_retryable(),
+        logical_target,
+    )
+}
+
+fn source_failure_from_client(
+    source: AdminQuerySource,
+    logical_target: &str,
+    code: ReadFailureCode,
+    retryable: bool,
+) -> AdminSourceFailure {
+    let code = match code {
+        ReadFailureCode::SourceUnavailable => AdminQueryFailureCode::SourceUnavailable,
+        ReadFailureCode::Timeout => AdminQueryFailureCode::Timeout,
+        ReadFailureCode::PermissionDenied => AdminQueryFailureCode::PermissionDenied,
+        ReadFailureCode::NotFound => AdminQueryFailureCode::NotFound,
+        ReadFailureCode::RateLimited => AdminQueryFailureCode::RateLimited,
+        ReadFailureCode::InvalidResponse => AdminQueryFailureCode::InvalidResponse,
+    };
+    AdminSourceFailure::new(source, code, retryable, logical_target)
+}
+
+fn query_failure_code(http_status: u16) -> AdminQueryFailureCode {
+    match http_status {
+        401 | 403 => AdminQueryFailureCode::PermissionDenied,
+        404 => AdminQueryFailureCode::NotFound,
+        408 | 504 => AdminQueryFailureCode::Timeout,
+        429 => AdminQueryFailureCode::RateLimited,
+        400 | 413 | 422 => AdminQueryFailureCode::InvalidResponse,
+        _ => AdminQueryFailureCode::SourceUnavailable,
+    }
+}
+
+fn stable_legacy_failures(failures: &[AdminSourceFailure]) -> Vec<String> {
+    failures
+        .iter()
+        .map(|failure| {
+            format!(
+                "source={:?};code={:?};target={}",
+                failure.source(),
+                failure.code(),
+                failure.logical_target()
+            )
+            .to_ascii_lowercase()
+        })
+        .collect()
 }
 
 fn bounded_subscription_group_value(field: &'static str, value: i32, maximum: u32) -> AdminResult<u32> {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker.rs
@@ -24,6 +24,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::core::error::required;
+use crate::core::query::AdminQueryResult;
 use crate::core::AdminFuture;
 use crate::core::AdminResult;
 
@@ -83,6 +84,30 @@ impl ProbeBrokerRuntimeRequest {
 pub struct ProbeBrokerRuntimeResult {
     pub attempted: usize,
     pub failures: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProbeBrokerRuntimeTargetRequest {
+    pub cluster: String,
+    pub broker_name: String,
+}
+
+impl ProbeBrokerRuntimeTargetRequest {
+    pub fn try_new(cluster: impl Into<String>, broker_name: impl Into<String>) -> AdminResult<Self> {
+        Ok(Self {
+            cluster: required("cluster", cluster)?,
+            broker_name: required("broker_name", broker_name)?,
+        })
+    }
+}
+
+/// Exact, uncapped status for one logical Broker target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BrokerRuntimeTargetStatus {
+    Available,
+    SourceUnavailable,
+    NotFound,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -410,6 +435,32 @@ pub trait BrokerAdmin: Send {
         request: &'a ProbeBrokerRuntimeRequest,
     ) -> AdminFuture<'a, ProbeBrokerRuntimeResult>;
 
+    fn list_brokers_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListBrokersRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListBrokersResult>> {
+        Box::pin(async move { self.list_brokers(request).await.map(AdminQueryResult::complete) })
+    }
+
+    fn probe_broker_runtime_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ProbeBrokerRuntimeRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ProbeBrokerRuntimeResult>> {
+        Box::pin(async move { self.probe_broker_runtime(request).await.map(AdminQueryResult::complete) })
+    }
+
+    fn probe_broker_runtime_target<'a>(
+        &'a mut self,
+        _request: &'a ProbeBrokerRuntimeTargetRequest,
+    ) -> AdminFuture<'a, BrokerRuntimeTargetStatus> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "probe_broker_runtime_target",
+                "exact Broker target probing is not implemented by this adapter",
+            ))
+        })
+    }
+
     fn query_broker_diagnostics<'a>(
         &'a mut self,
         request: &'a QueryBrokerDiagnosticsRequest,
@@ -441,6 +492,35 @@ pub trait BrokerQueryAdmin: Send {
         &'a mut self,
         request: &'a ProbeBrokerRuntimeRequest,
     ) -> AdminFuture<'a, ProbeBrokerRuntimeResult>;
+
+    /// Evidence-aware sibling of [`Self::list_brokers`].
+    fn list_brokers_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListBrokersRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListBrokersResult>> {
+        Box::pin(async move { self.list_brokers(request).await.map(AdminQueryResult::complete) })
+    }
+
+    /// Evidence-aware sibling of [`Self::probe_broker_runtime`].
+    fn probe_broker_runtime_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ProbeBrokerRuntimeRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ProbeBrokerRuntimeResult>> {
+        Box::pin(async move { self.probe_broker_runtime(request).await.map(AdminQueryResult::complete) })
+    }
+
+    /// Classifies one target independently of bounded public failure evidence.
+    fn probe_broker_runtime_target<'a>(
+        &'a mut self,
+        _request: &'a ProbeBrokerRuntimeTargetRequest,
+    ) -> AdminFuture<'a, BrokerRuntimeTargetStatus> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "probe_broker_runtime_target",
+                "exact Broker target probing is not implemented by this adapter",
+            ))
+        })
+    }
 
     fn query_broker_diagnostics<'a>(
         &'a mut self,
@@ -475,6 +555,27 @@ impl<T: BrokerAdmin + ?Sized> BrokerQueryAdmin for T {
         request: &'a ProbeBrokerRuntimeRequest,
     ) -> AdminFuture<'a, ProbeBrokerRuntimeResult> {
         BrokerAdmin::probe_broker_runtime(self, request)
+    }
+
+    fn list_brokers_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListBrokersRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListBrokersResult>> {
+        BrokerAdmin::list_brokers_with_evidence(self, request)
+    }
+
+    fn probe_broker_runtime_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ProbeBrokerRuntimeRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ProbeBrokerRuntimeResult>> {
+        BrokerAdmin::probe_broker_runtime_with_evidence(self, request)
+    }
+
+    fn probe_broker_runtime_target<'a>(
+        &'a mut self,
+        request: &'a ProbeBrokerRuntimeTargetRequest,
+    ) -> AdminFuture<'a, BrokerRuntimeTargetStatus> {
+        BrokerAdmin::probe_broker_runtime_target(self, request)
     }
 
     fn query_broker_diagnostics<'a>(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/client_connection.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/client_connection.rs
@@ -18,6 +18,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::core::error::required;
+use crate::core::query::AdminQueryResult;
 use crate::core::AdminError;
 use crate::core::AdminFuture;
 use crate::core::AdminResult;
@@ -122,10 +123,34 @@ pub trait ClientConnectionQueryAdmin: Send {
         request: &'a QueryConsumerConnectionsRequest,
     ) -> AdminFuture<'a, QueryConsumerConnectionsResult>;
 
+    /// Evidence-aware sibling of [`Self::query_consumer_connections`].
+    fn query_consumer_connections_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerConnectionsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerConnectionsResult>> {
+        Box::pin(async move {
+            self.query_consumer_connections(request)
+                .await
+                .map(AdminQueryResult::complete)
+        })
+    }
+
     fn list_producer_connections<'a>(
         &'a mut self,
         request: &'a ListProducerConnectionsRequest,
     ) -> AdminFuture<'a, ListProducerConnectionsResult>;
+
+    /// Evidence-aware sibling of [`Self::list_producer_connections`].
+    fn list_producer_connections_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListProducerConnectionsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListProducerConnectionsResult>> {
+        Box::pin(async move {
+            self.list_producer_connections(request)
+                .await
+                .map(AdminQueryResult::complete)
+        })
+    }
 }
 
 fn validated_limit(limit: usize) -> AdminResult<usize> {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
@@ -19,6 +19,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::core::error::required;
+use crate::core::query::AdminQueryResult;
 use crate::core::AdminFuture;
 use crate::core::AdminResult;
 
@@ -1003,6 +1004,20 @@ pub trait ConsumerAdmin: Send {
         request: &'a QueryConsumerLagRequest,
     ) -> AdminFuture<'a, QueryConsumerLagResult>;
 
+    fn list_consumer_groups_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListConsumerGroupsResult>> {
+        Box::pin(async move { self.list_consumer_groups(request).await.map(AdminQueryResult::complete) })
+    }
+
+    fn query_consumer_lag_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerLagRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerLagResult>> {
+        Box::pin(async move { self.query_consumer_lag(request).await.map(AdminQueryResult::complete) })
+    }
+
     fn query_dashboard_consumer_groups<'a>(
         &'a mut self,
         request: &'a DashboardConsumerGroupListRequest,
@@ -1066,6 +1081,20 @@ pub trait ConsumerQueryAdmin: Send {
         &'a mut self,
         request: &'a QueryConsumerLagRequest,
     ) -> AdminFuture<'a, QueryConsumerLagResult>;
+    /// Evidence-aware sibling of [`Self::list_consumer_groups`].
+    fn list_consumer_groups_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListConsumerGroupsResult>> {
+        Box::pin(async move { self.list_consumer_groups(request).await.map(AdminQueryResult::complete) })
+    }
+    /// Evidence-aware sibling of [`Self::query_consumer_lag`].
+    fn query_consumer_lag_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerLagRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerLagResult>> {
+        Box::pin(async move { self.query_consumer_lag(request).await.map(AdminQueryResult::complete) })
+    }
     fn query_dashboard_consumer_groups<'a>(
         &'a mut self,
         request: &'a DashboardConsumerGroupListRequest,
@@ -1168,6 +1197,18 @@ impl<T: ConsumerAdmin + ?Sized> ConsumerQueryAdmin for T {
         request: &'a QueryConsumerLagRequest,
     ) -> AdminFuture<'a, QueryConsumerLagResult> {
         ConsumerAdmin::query_consumer_lag(self, request)
+    }
+    fn list_consumer_groups_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListConsumerGroupsResult>> {
+        ConsumerAdmin::list_consumer_groups_with_evidence(self, request)
+    }
+    fn query_consumer_lag_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerLagRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerLagResult>> {
+        ConsumerAdmin::query_consumer_lag_with_evidence(self, request)
     }
     fn query_dashboard_consumer_groups<'a>(
         &'a mut self,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/mod.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/mod.rs
@@ -33,6 +33,7 @@ pub mod error_view;
 pub mod lite;
 pub mod message;
 pub mod proxy;
+pub mod query;
 pub mod queue;
 pub mod release_checkpoint;
 pub mod security;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/query.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/query.rs
@@ -1,0 +1,281 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded completeness evidence for multi-source admin queries.
+
+use std::net::IpAddr;
+use std::net::SocketAddr;
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+
+use crate::core::AdminError;
+use crate::core::AdminResult;
+
+/// Maximum number of source failures exposed by one admin query.
+pub const MAX_ADMIN_SOURCE_FAILURES: usize = 16;
+/// Stable warning emitted whenever usable data is accompanied by source failures.
+pub const SOURCE_FAILURE_WARNING: &str = "source_failures_present";
+/// Stable warning emitted after source failures have been capped.
+pub const SOURCE_FAILURE_OVERFLOW_WARNING: &str = "source_failures_truncated";
+
+/// Allowlisted backend observation that can fail independently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdminQuerySource {
+    BrokerRuntime,
+    ConsumerStatistics,
+    ConsumerConnection,
+    ProducerConnection,
+    SubscriptionGroups,
+}
+
+/// Stable, backend-independent failure classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdminQueryFailureCode {
+    SourceUnavailable,
+    Timeout,
+    PermissionDenied,
+    NotFound,
+    RateLimited,
+    InvalidResponse,
+}
+
+/// Sanitized evidence for one independently failed source.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct AdminSourceFailure {
+    source: AdminQuerySource,
+    code: AdminQueryFailureCode,
+    retryable: bool,
+    logical_target: String,
+}
+
+impl AdminSourceFailure {
+    /// Creates a failure while reducing the target to a bounded logical identifier.
+    pub fn new(
+        source: AdminQuerySource,
+        code: AdminQueryFailureCode,
+        retryable: bool,
+        logical_target: impl AsRef<str>,
+    ) -> Self {
+        Self {
+            source,
+            code,
+            retryable,
+            logical_target: sanitize_logical_target(logical_target.as_ref()),
+        }
+    }
+
+    pub const fn source(&self) -> AdminQuerySource {
+        self.source
+    }
+
+    pub const fn code(&self) -> AdminQueryFailureCode {
+        self.code
+    }
+
+    pub const fn retryable(&self) -> bool {
+        self.retryable
+    }
+
+    pub fn logical_target(&self) -> &str {
+        &self.logical_target
+    }
+}
+
+impl<'de> Deserialize<'de> for AdminSourceFailure {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireFailure {
+            source: AdminQuerySource,
+            code: AdminQueryFailureCode,
+            retryable: bool,
+            logical_target: String,
+        }
+
+        let wire = WireFailure::deserialize(deserializer)?;
+        Ok(Self::new(wire.source, wire.code, wire.retryable, wire.logical_target))
+    }
+}
+
+/// Additive result returned by evidence-aware sibling query APIs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdminQueryResult<T> {
+    pub data: T,
+    pub partial: bool,
+    pub warnings: Vec<String>,
+    pub source_failures: Vec<AdminSourceFailure>,
+}
+
+impl<T> AdminQueryResult<T> {
+    /// Wraps an authoritative complete result, including an empty result.
+    pub fn complete(data: T) -> Self {
+        Self {
+            data,
+            partial: false,
+            warnings: Vec::new(),
+            source_failures: Vec::new(),
+        }
+    }
+
+    /// Builds a result from independently attempted required sources.
+    ///
+    /// A zero-source inventory is an authoritative empty result. If sources
+    /// were attempted but none succeeded, the query returns a stable total
+    /// error instead of a successful empty or zero-valued DTO.
+    pub fn from_sources(
+        data: T,
+        successful_sources: usize,
+        source_failures: Vec<AdminSourceFailure>,
+    ) -> AdminResult<Self> {
+        if successful_sources == 0 && !source_failures.is_empty() {
+            let retryable = source_failures.iter().all(AdminSourceFailure::retryable);
+            return Err(AdminError::backend_view(
+                "admin_query_sources",
+                "ADMIN_QUERY_ALL_SOURCES_FAILED",
+                "All required admin query sources failed",
+                None,
+                503,
+                retryable,
+            ));
+        }
+
+        Ok(Self::from_partial_sources(data, source_failures))
+    }
+
+    /// Maps the data while preserving completeness evidence.
+    pub fn map<U>(self, map: impl FnOnce(T) -> U) -> AdminQueryResult<U> {
+        AdminQueryResult {
+            data: map(self.data),
+            partial: self.partial,
+            warnings: self.warnings,
+            source_failures: self.source_failures,
+        }
+    }
+
+    fn from_partial_sources(data: T, mut source_failures: Vec<AdminSourceFailure>) -> Self {
+        source_failures.sort();
+        source_failures.dedup();
+        let overflow = source_failures.len() > MAX_ADMIN_SOURCE_FAILURES;
+        source_failures.truncate(MAX_ADMIN_SOURCE_FAILURES);
+        let partial = !source_failures.is_empty();
+        let mut warnings = Vec::new();
+        if partial {
+            warnings.push(SOURCE_FAILURE_WARNING.to_string());
+        }
+        if overflow {
+            warnings.push(SOURCE_FAILURE_OVERFLOW_WARNING.to_string());
+        }
+        Self {
+            data,
+            partial,
+            warnings,
+            source_failures,
+        }
+    }
+}
+
+fn sanitize_logical_target(target: &str) -> String {
+    const UNKNOWN_TARGET: &str = "unknown";
+    const MAX_TARGET_BYTES: usize = 128;
+
+    let target = target.trim();
+    if target.is_empty()
+        || target.len() > MAX_TARGET_BYTES
+        || target.parse::<IpAddr>().is_ok()
+        || target.parse::<SocketAddr>().is_ok()
+        || target.contains([':', '/', '\\', '@', '=', '&', '?'])
+        || target.chars().any(char::is_control)
+    {
+        return UNKNOWN_TARGET.to_string();
+    }
+
+    let sanitized = target
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        UNKNOWN_TARGET.to_string()
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn failure(target: &str) -> AdminSourceFailure {
+        AdminSourceFailure::new(
+            AdminQuerySource::BrokerRuntime,
+            AdminQueryFailureCode::SourceUnavailable,
+            true,
+            target,
+        )
+    }
+
+    #[test]
+    fn authoritative_empty_is_complete_and_failed_zero_is_an_error() {
+        let empty = AdminQueryResult::from_sources(Vec::<u8>::new(), 0, Vec::new()).unwrap();
+        assert!(!empty.partial);
+        assert!(empty.source_failures.is_empty());
+
+        let error = AdminQueryResult::from_sources(Vec::<u8>::new(), 0, vec![failure("broker-a")]).unwrap_err();
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn failures_are_sanitized_sorted_deduplicated_and_bounded() {
+        let mut failures = (0..20)
+            .rev()
+            .map(|index| failure(&format!("broker-{index:02}")))
+            .collect::<Vec<_>>();
+        failures.push(failure("broker-00"));
+        failures.push(failure("127.0.0.1:10911"));
+        let result = AdminQueryResult::from_sources((), 1, failures).unwrap();
+
+        assert!(result.partial);
+        assert_eq!(result.source_failures.len(), MAX_ADMIN_SOURCE_FAILURES);
+        assert_eq!(result.source_failures[0].logical_target(), "broker-00");
+        assert!(result
+            .warnings
+            .iter()
+            .any(|warning| warning == SOURCE_FAILURE_OVERFLOW_WARNING));
+        assert!(!serde_json::to_string(&result).unwrap().contains("127.0.0.1"));
+    }
+
+    #[test]
+    fn deserialization_reapplies_logical_target_sanitization() {
+        let failure: AdminSourceFailure = serde_json::from_value(serde_json::json!({
+            "source": "consumer_connection",
+            "code": "timeout",
+            "retryable": true,
+            "logical_target": "10.0.0.1:10911"
+        }))
+        .unwrap();
+        assert_eq!(failure.logical_target(), "unknown");
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9905
- Fixes #9905

### Brief Description

- Add evidence-aware Admin Core query results and compatible sibling APIs for broker, consumer, lag, and connection reads.
- Preserve authoritative empty, partial success, and total source failure semantics across both client adapters.
- Cache and propagate bounded, sanitized source failures through MCP tools, query-backed resources, diagnosis, and output truncation while preserving `rocketmq-mcp.v2` and the default eight-tool surface.
- Harden routed consume-stat accounting and selected-broker classification so unusable masters and capped failure evidence cannot produce false complete or not-found results.

#### Completion Checklist

- [x] Existing Admin Core DTOs and legacy methods remain compatible.
- [x] Complete responses continue to omit `source_failures`.
- [x] Cache hits preserve completeness evidence.
- [x] Source failures are sorted, deduplicated, capped, sanitized, and composed with truncation.
- [x] Tool, Resource, diagnosis, lifecycle, overflow, and compatibility regressions are covered.
- [x] Four expected additive schema snapshots were manually reviewed.
- [x] Pagination, visibility wiring, catalogs, manifests, and writes remain out of scope.

### How Did You Test This Change?

Passed locally:

- `cargo fmt -p rocketmq-client-rust -- --check`
- `cargo fmt -p rocketmq-admin-core -- --check`
- `cargo test -p rocketmq-client-rust --features admin-read --lib` (1,076 passed)
- `cargo test -p rocketmq-admin-core --features read-client-adapter`
- `cargo test -p rocketmq-admin-core --features client-adapter`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- From `rocketmq-ai/rocketmq-mcp`: `cargo fmt -p rocketmq-mcp -- --check`, `cargo check --locked`, `python scripts/check_read_only_boundary.py`, `cargo test --locked` (121 library tests), `cargo test --locked --all-features` (145 library tests), `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`, and `cargo doc --locked --no-deps`
- `git diff --check`
- Four additive schema snapshot changes reviewed; snapshot tests passed without updates and no `.snap.new` artifacts remain.

Known clean-main/environment baseline failures, unchanged by this PR:

- MCP `cargo fmt --all -- --check` fails on Windows with OS error 206; package-scoped formatting passes.
- `python scripts/error_architecture_guard.py` reports the existing notification-processor, source-stringification, and transport-redaction findings outside this diff.
- The SRE semantic-registry validation retains its existing clean-main failure.
- The web validation retains its existing clean-main recursion failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query results now indicate when data is partial and identify affected sources with sanitized failure details.
  * Added evidence-aware broker, consumer, producer, and connection queries.
  * Broker runtime checks can target a specific broker and report whether it is available, unavailable, or not found.
  * Partial-result metadata and warnings are preserved through cached results and resource responses.
* **Bug Fixes**
  * Improved handling of mixed-success queries so available data remains accessible when some sources fail.
  * Added safeguards to normalize, deduplicate, and limit failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->