### PR TITLE
[ISSUE #9908]♻️Define the opaque canonical error architecture

### DIFF
--- a/rocketmq-doc/en/07-error-architecture-adr.md
+++ b/rocketmq-doc/en/07-error-architecture-adr.md
@@ -2,7 +2,7 @@
 title: "Error Architecture Redesign ADR"
 permalink: /docs/error-architecture-adr/
 excerpt: "Accepted direction for the RocketMQ Rust error architecture redesign."
-last_modified_at: 2026-07-04T00:00:00+08:00
+last_modified_at: 2026-08-31T00:00:00+08:00
 toc: true
 classes: wide
 ---
@@ -11,139 +11,218 @@ classes: wide
 
 ## Status
 
-Accepted.
+Accepted. This decision supersedes the previously accepted transitional
+public `RocketMQError` enum/`ErrorKind`/`ErrorSpec` architecture. The target
+implementation remains pending; this document must not be read as evidence
+that every target type or classification already exists.
 
-## Context
+## Context and current state
 
-RocketMQ Rust already has a central `rocketmq-error` crate and a widely used
-`RocketMQError` type. The current design is still transitional:
+At the pinned inventory baseline,
+`e016a878703767924529911240808c649ed4a801`, the repository has one large
+public `RocketMQError` enum and a partially centralized error vocabulary. The
+current implementation includes:
 
-- `RocketmqError`, `LegacyRocketMQResult`, `LegacyResult`, and legacy macros are
-  still public.
-- `rocketmq-error::Result<T>` is an alias for `anyhow::Result<T>`.
-- Remoting, proxy gRPC, dashboard HTTP, admin tools, broker processors, and
-  NameServer processors map errors locally.
-- Some domain errors still collapse into string-only variants such as
-  `Internal(String)` or `General(String)`.
-- Client callbacks and request futures still expose dynamic error values.
-- Credential formatting previously printed secret material in
-  `SessionCredentials::Display`.
+- `ErrorKind`, `ErrorSpec`, and `ALL_ERROR_SPECS` in `rocketmq-error`;
+- a `DomainError` override path, free-string `ErrorContext`,
+  `BoundaryErrorView`, and shared `Sensitive` support;
+- typed client callback errors and an opaque `StoreError` facade;
+- arbitrary boundary remarks and source `Display` output that are still
+  observable but are not stable semantic contracts; and
+- `anyhow`, configuration, and `serde_json` dependencies in `rocketmq-error`.
 
-Compatibility with the legacy error API is not a goal for this redesign. The
-project should converge on the latest error architecture instead of preserving
-old aliases or adapters.
+The baseline has no `RocketmqError` or `Legacy*` aliases, no public
+`anyhow::Result` alias or callers, no dynamic client callback error, and no
+`StoreError::General`. `AdminErrorCode::RocketMqError` in dashboard code is a
+dashboard response-code name, not evidence of a legacy `rocketmq-error` type.
+
+This distinction matters: the current mega-enum and existing support types are
+effective repository APIs today, while the opaque canonical contract below is
+the migration target.
 
 ## Decision
 
-Use a single error architecture:
+Adopt an opaque canonical `Error` contract with five layers. The layers are
+ordered by responsibility; `ErrorCatalog`, boundary adapters, and presentation
+are supporting mechanisms, not additional error layers.
 
-**Typed Error Kernel + ErrorSpec Registry + Boundary Adapter +
-Redaction/Observability Contract**.
+This accepted decision replaces the transitional public enum architecture
+described in the current-state section; migration is still required before the
+target implementation is effective in each consumer.
 
-The central contract is:
+### Target five-layer model
 
-- `rocketmq-error` owns the public error kernel:
-  `RocketMQError`, `RocketMQResult<T>`, `ErrorKind`, `ErrorCode`,
-  `ErrorCategory`, `ErrorScope`, `RetryClass`, `ErrorSeverity`,
-  `ErrorSpec`, `ErrorContext`, and `Sensitive<T>`.
-- Public library APIs return typed errors. Application entry points, tests,
-  and one-shot tools may use `anyhow` only at their outermost boundary.
-- Every cross-boundary error has stable metadata for protocol mapping, retry,
-  severity, redaction, metrics, logs, traces, and runbook routing.
-- External exits use boundary adapters. `rocketmq-error` can define primitive
-  specs, but it must not depend on remoting, proxy, dashboard, or frontend
-  crates.
-- Sensitive fields are redacted by default in `Display`, `Debug`, structured
-  logs, and exported error reports.
-- Legacy error types, legacy result aliases, and legacy macro output are removed
-  after callers are migrated.
+1. **Outcome/Decision/Rejection.** Public control-flow outcomes express a
+   successful outcome, a decision, or a rejection without exposing leaf error
+   representation. Retry is not inferred from a rejection's rendered text.
+2. **ContractViolation.** Caller, protocol, and invariant violations have a
+   distinct contract-violation shape. They are not mixed into operational leaf
+   errors merely because both cross a boundary.
+3. **Private leaf `Error`.** Domain implementation errors retain typed source
+   chains for I/O, serde, storage, raft, transport, and runtime failures. Leaf
+   representation and matching remain private to the owning implementation.
+4. **Domain operational facade.** A domain such as storage exposes a narrow
+   operational facade (for example, the existing opaque `StoreError` facade)
+   instead of leaking its private leaf set. The facade preserves source and
+   policy information needed by the canonical conversion.
+5. **Opaque canonical `Error` with safe projections.** `rocketmq-error` owns
+   one canonical value with private representation. Consumers use safe
+   projections such as `PublicErrorView` or `DiagnosticView`; they do not match
+   a public mega-enum to classify failures.
 
-## Dependency Direction
+The declarative `ErrorCatalog` is a supporting mechanism and the sole owner of
+stable dotted codes, `CanonicalCondition`, fixed public messages, severity,
+`RecoveryHint`, and projection metadata. Boundary adapters project catalog
+metadata into remoting, gRPC, HTTP, CLI, and other local primitives.
+Presentation and observability render the approved views with redaction; they
+do not create a second semantic catalog.
 
-`rocketmq-error` stays below all protocol and application crates.
+### Canonical metadata and views
+
+Each catalog entry owns a stable dotted code and its
+`CanonicalCondition`, fixed public message, severity, `RecoveryHint`, and
+projection metadata. A free-form remark or a source display string is not an
+entry key, policy, or compatibility value.
+
+Catalog codes use lowercase dotted stable domain semantics, for example
+`storage.commit_log.corrupt_record`. A code must never contain a dynamic topic,
+group, path, broker address, or other runtime value. `CanonicalCondition` is
+protocol-independent. Domain facades and private leaf errors cannot override
+the catalog code, condition, severity, `RecoveryHint`, or projection metadata.
+
+Context has an explicit visibility class:
+
+- `Public`: safe for the public error view and external protocol response;
+- `Diagnostic`: available only to controlled diagnostics and operational
+  telemetry; and
+- `SecretPresenceOnly`: records only that a secret-bearing value was present,
+  never the value itself.
+
+`PublicErrorView` contains only catalog-approved identity, fixed public message,
+safe public context, and boundary-safe projection fields. `DiagnosticView` may
+add redacted diagnostic context and typed source information subject to its
+visibility policy. Neither view treats arbitrary remarks or source
+stringification as stable input.
+
+`RetryDecision` is a separate decision, not a catalog field copied into an
+error. It considers operation idempotency, operation stage, and remaining
+budget together with the catalog's `RecoveryHint`; a response message or
+source string cannot decide retry on its own.
+
+### Public-surface freezes
+
+The migration freezes three accidental contracts now:
+
+- **Public leaf errors:** do not add consumer-facing enum variants,
+  constructors, or exhaustive matching surfaces merely to represent a new
+  boundary condition. Keep leaf representation private behind the domain
+  facade and canonical conversion.
+- **Arbitrary remarks:** remarks are bounded presentation text only. They are
+  not stable codes, public messages, retry signals, or catalog entries. A
+  boundary adapter must use the catalog and safe context rather than treating
+  caller-supplied text as authoritative.
+- **Source stringification:** `Display`, `Debug`, and
+  `source().to_string()` output is diagnostic presentation, not stable data.
+  Preserve typed sources where useful, but never classify, map, retry, persist,
+  or compare an error by rendered source text.
+
+## Current versus target
+
+| Concern | Effective current repository | Target after migration |
+| --- | --- | --- |
+| Public error value | Large public `RocketMQError` enum | Opaque canonical `Error` with safe projections |
+| Outcome/control flow | Existing APIs mix error and operation-specific outcomes | `Outcome`/`Decision`/`Rejection` are explicit public control-flow concepts |
+| Contract failures | Not uniformly separated from operational errors | `ContractViolation` is a distinct layer |
+| Leaf errors | Domain-specific leaves plus a domain override path | Private leaf `Error` retained behind each domain facade |
+| Domain facades | Opaque `StoreError` exists; other domains vary | Narrow operational facades preserve source and policy information |
+| Catalog | `ErrorKind`, `ErrorSpec`, and `ALL_ERROR_SPECS` exist, but the target declarative ownership is incomplete | `ErrorCatalog` solely owns dotted code, condition, fixed public message, severity, recovery hint, and projections |
+| Context/views | Free-string `ErrorContext` and `BoundaryErrorView` exist | Visibility-tagged context feeds `PublicErrorView` and `DiagnosticView` |
+| Retry | Decisions remain distributed | Separate `RetryDecision` uses idempotency, stage, and budget |
+| Boundaries | Local adapters can emit arbitrary remarks and inspect display text | Adapters project catalog metadata and safe views |
+| Dependencies | `rocketmq-error` still depends on anyhow/config/serde_json | Dependencies are reduced or isolated without widening the public contract |
+| Sensitive data | Shared `Sensitive` support exists | Public, diagnostic, and secret-presence-only views enforce default redaction |
+
+## Compatibility and dependency direction
+
+The Rust API is allowed to break as this redesign lands. There will be no V1 or
+V2 public compatibility layer, deprecated compatibility shim, compatibility
+feature, or long-lived dual API. A private migration bridge may exist only
+inside the wave that needs it and must be removed in that wave after its
+producer and every consumer have migrated.
+
+The redesign nevertheless preserves externally observable compatibility where
+it is a protocol or storage contract: remoting numeric response codes and
+headers, gRPC and HTTP external contracts, wire semantics, and persisted record
+layouts. Each affected migration supplies focused regression evidence for
+those surfaces; preserving a wire contract does not require preserving a Rust
+error enum or rendered message.
+
+`rocketmq-error` stays below all protocol and application crates:
 
 ```text
-rocketmq-error
-  -> rocketmq-common
-  -> rocketmq-remoting
-  -> rocketmq-client
-  -> rocketmq-broker / rocketmq-namesrv / rocketmq-controller / rocketmq-store
-  -> rocketmq-proxy / dashboard backends / tools
+leaf Error / ContractViolation / domain facade
+  -> rocketmq-error (opaque canonical Error + declarative ErrorCatalog)
+  -> remoting / client / broker / namesrv / controller / store
+  -> proxy / dashboard / tools boundary adapters
 ```
 
-Boundary crates convert primitive specs into their local protocol types:
+The central crate may define catalog primitives, canonical views, and redaction
+rules, but it must not depend on remoting, proxy, dashboard, or frontend
+crates.
 
-| Boundary | Local adapter output |
+| Boundary | Target projection |
 | --- | --- |
-| Remoting | `ResponseCode` and response remark |
-| Proxy gRPC | `v2::Code` and `tonic::Code` |
-| Dashboard HTTP | HTTP status, API code, and public message |
-| CLI/tools | exit category and concise user message |
-| Observability | low-cardinality labels and redacted fields |
+| Remoting | Preserved numeric `ResponseCode`, headers, and safe response remark |
+| Proxy gRPC | Preserved external payload/status contract and local gRPC codes |
+| Dashboard HTTP | Preserved HTTP/API contract and public message |
+| CLI/tools | Exit category and concise public message |
+| Observability | Redacted `DiagnosticView` fields and low-cardinality labels |
 
-## Delivery Sequence
+## Dependency-driven delivery waves
 
-Each PR must keep the affected Cargo project buildable. The legacy API is
-deleted only after macro, remoting, client, and public alias callers are moved.
+The migration follows producer and consumer dependencies, not a fixed list of
+PR numbers. A wave closes only after its producer changes and every known
+consumer is migrated, focused tests and compatibility regression evidence pass,
+and any private bridge introduced for that wave is removed. Bridges never
+become public, deprecated, feature-gated, or long-lived APIs.
 
-| PR | Scope | Goal |
+| Wave | Producer/consumer scope | Bridge removal condition |
 | --- | --- | --- |
-| 01 | docs | Accept the no-compatibility error redesign ADR |
-| 02 | docs + scan evidence | Add error inventory and ownership matrix |
-| 03 | `rocketmq-client` | Redact credential formatting |
-| 04 | `rocketmq-error` | Introduce `ErrorKind`, `ErrorCode`, and `ErrorScope` |
-| 05 | `rocketmq-error` | Introduce the `ErrorSpec` registry |
-| 06 | `rocketmq-error` | Add redacted `ErrorContext` and `Sensitive<T>` |
-| 07 | `rocketmq-error` | Add protocol primitive specs |
-| 08 | `rocketmq-error` | Add recovery and observability policies |
-| 09 | broker, controller, namesrv, examples | Replace `rocketmq_error::Result` callers |
-| 10 | `rocketmq-error` | Remove public `anyhow` aliases |
-| 11 | `rocketmq-macros` | Generate typed `RocketMQError` values |
-| 12 | `rocketmq-remoting` | Migrate codec and serialization errors |
-| 13 | `rocketmq-remoting` | Add the remoting boundary adapter |
-| 14 | broker and namesrv | Route processor failures through the adapter |
-| 15 | `rocketmq-client` | Replace callback dynamic error downcasts |
-| 16 | `rocketmq-client` | Centralize retry decisions |
-| 17 | `rocketmq-store` | Replace `StoreError::General` with typed variants |
-| 18 | `rocketmq-controller` | Preserve raft, storage, and serde sources |
-| 19 | `rocketmq-auth` | Split authentication, authorization, config, and storage errors |
-| 20 | common and tools | Remove public `anyhow` and unclassified internals |
-| 21 | `rocketmq-proxy` | Use the gRPC boundary adapter |
-| 22 | dashboard web backend | Use a typed `RocketMQError` wrapper |
-| 23 | standalone projects | Align examples and dashboard apps with typed errors |
-| 24 | `rocketmq-error` | Delete the legacy `RocketmqError` API |
-| 25 | scripts/CI | Add legacy, public-anyhow, mapping, and redaction guards |
-| 26 | docs | Publish contribution guide and runbooks |
+| 0 | Pin the inventory baseline; freeze leaf, remark, and source-string contracts; record protocol and persistence invariants | No bridge; baseline and evidence rules are established |
+| 0B | Revalidate every inventory row and every current consumer against the pinned lexical baseline before changing ownership or status | No bridge; row-level and consumer-level evidence is required |
+| 1 | Define Outcome/Decision/Rejection, ContractViolation, context visibility, views, and declarative catalog primitives | Remove temporary representations once all primitive producers and readers use the new schema |
+| 2 | Convert domain leaf producers and operational facades, beginning with storage and other high-fan-out domains | Remove each private facade bridge after its leaf producers and all domain consumers migrate |
+| 3 | Wrap migrated leaves and facades in opaque canonical `Error`; update central constructors and conversions | Remove enum-to-canonical bridges after all error producers and canonical consumers migrate |
+| 4 | Migrate remoting, gRPC, HTTP, CLI, and observability consumers to safe projections | Remove each boundary bridge after its producer path and every boundary consumer have regression evidence |
+| 5 | Migrate client retry decisions and remaining broker, namesrv, controller, auth, common, proxy, dashboard, tools, and standalone consumers | Remove per-domain private bridges only after producer plus consumer coverage is complete |
+| 6 | Remove obsolete internal aliases, local semantic tables, display-text mapping, and transitional adapters | Remove the private bridge in the same wave; no compatibility shim survives as public API |
+| 7 | Run focused tests, applicable guards, targeted scans, link checks, and protocol/persistence regression evidence | No bridge remains; inventory status changes only with evidence |
 
-## Acceptance Gates
+## Lightweight governance and non-goals
 
-Root workspace Rust changes must finish with:
+Governance is intentionally lightweight: each implementation change gets
+focused tests, the current error guard when applicable, targeted `rg` scans,
+`git diff --check`, and relative Markdown link checks. Rust changes follow the
+repository profile of package-scoped `cargo fmt -p <package> -- --check` plus
+workspace Clippy; documentation-only changes do not require Cargo validation.
 
-```powershell
-cargo fmt --all
-cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
-```
+This effort does not add content fingerprints, file hashes, complex AST gates,
+custom Clippy policy, or a heavy platform. The pinned Git commit identifies the
+inventory snapshot; it is not a content-fingerprint mechanism.
 
-Focused tests should also run for the modified crate, for example:
+## Acceptance gates
 
-```powershell
-cargo test -p rocketmq-client-rust --lib session_credentials_display
-```
-
-Static checks must eventually reject unapproved occurrences of:
-
-```powershell
-rg -n "RocketmqError|LegacyRocketMQResult|LegacyResult" --glob "*.rs"
-rg -n "type Result<T> = anyhow::Result|pub type Result<T> = anyhow::Result" --glob "*.rs"
-rg -n "Internal\\(String\\)|General\\(String\\)|to_string\\(\\)" --glob "*.rs"
-rg -n "secretKey|SecurityToken|signature" rocketmq-client rocketmq-auth --glob "*.rs"
-```
+The target is reached only when implementation and evidence show that each
+migrated producer and consumer uses the opaque canonical identity, declarative
+catalog, and safe projections; that retry remains a separate decision; and
+that public leaf matching, arbitrary remarks, and source stringification are
+not semantic contracts. The inventory records pending classification and
+evidence rather than asserting completion.
 
 ## Consequences
 
-This is a breaking redesign. The short-term cost is a coordinated migration
-across the error kernel, macros, remoting, client, store, controller, auth,
-proxy, dashboard, tools, and standalone projects.
-
-The long-term result is a single machine-readable error contract for protocol
-mapping, retry behavior, operations, security redaction, and debugging.
+This is a deliberate Rust API break with a narrow compatibility promise for
+remoting, gRPC, HTTP, wire, and persistence contracts. Stable semantic meaning
+lives in the declarative catalog, typed causes remain available to controlled
+diagnostics, and safe public views prevent accidental leakage or coupling to
+the mega-enum.

--- a/rocketmq-doc/en/07-error-inventory.md
+++ b/rocketmq-doc/en/07-error-inventory.md
@@ -2,79 +2,217 @@
 title: "Error Architecture Inventory"
 permalink: /docs/error-inventory/
 excerpt: "Current RocketMQ Rust error ownership and migration inventory."
-last_modified_at: 2026-07-04T00:00:00+08:00
+last_modified_at: 2026-08-31T00:00:00+08:00
 toc: true
 classes: wide
 ---
 
 # Error Architecture Inventory
 
-Snapshot date: 2026-07-04.
+Snapshot date: 2026-08-31.
 
-This inventory records the current error architecture baseline for the
-no-compatibility redesign. It is not a completion claim; it identifies the
-remaining migration surface and assigns ownership by crate boundary.
+Inventory baseline commit: `e016a878703767924529911240808c649ed4a801`.
 
-## Current Signals
+This is a pinned current-state inventory, not a completion claim. At this
+baseline, `rocketmq-error` has a public mega `RocketMQError` enum together with
+`ErrorKind`, `ErrorSpec`, and `ALL_ERROR_SPECS`. It also has a `DomainError`
+override path, free-string `ErrorContext`, `BoundaryErrorView`, and shared
+`Sensitive` support. Client callback errors are typed, and `StoreError` is an
+opaque domain facade.
 
-Recent repository scans show these open items:
+The baseline has no `RocketmqError` or `Legacy*` aliases, no public `anyhow`
+`Result` alias or callers, no dynamic client callback error, and no
+`StoreError::General`. Dashboard `AdminErrorCode::RocketMqError` is an
+unrelated dashboard response-code name. The `rocketmq-error` crate still has
+`anyhow`, configuration, and `serde_json` dependencies. Boundary remarks remain
+arbitrary, and source `Display` output remains observable; neither is stable
+semantic data.
 
-| Signal | Current evidence |
+The target vocabulary is the exact five-layer model in the [Error Architecture
+Redesign ADR](07-error-architecture-adr.md). Itemized classification is pending
+follow-up; the presence of a target schema or a migration wave does not assert
+that any row is complete.
+
+## Counting scope and methodology
+
+The baseline counts below are lexical candidates from the implementation-plan
+scan, not Rustdoc reachability, semantic ownership, or completion results. Run
+the following read-only commands from the repository root in PowerShell. The
+all-tree scope excludes `rocketmq-error`, `target`, and tests using the exact
+globs shown. The explicit standalone scopes are `rocketmq-ai/rocketmq-mcp`,
+`rocketmq-ai/rocketmq-sre`,
+`rocketmq-dashboard/rocketmq-dashboard-gpui`,
+`rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri`, and
+`rocketmq-dashboard/rocketmq-dashboard-web/backend`. Root-workspace counts
+mean Cargo metadata workspace members excluding `rocketmq-error`; equivalently,
+at this baseline they are the all-tree counts minus those explicit standalone
+scope counts.
+
+```powershell
+$errorPattern = '^\s*(?:pub(?:\([^)]*\))?\s+)?(?:enum|struct)\s+\w*Error\b'
+$plainErrorPattern = '^\s*pub\s+(?:enum|struct)\s+\w*Error\b'
+$errorKindPattern = '^\s*(?:pub(?:\([^)]*\))?\s+)?(?:enum|struct)\s+\w*ErrorKind\b'
+$plainErrorKindPattern = '^\s*pub\s+(?:enum|struct)\s+\w*ErrorKind\b'
+$standaloneScopes = @(
+  'rocketmq-ai/rocketmq-mcp',
+  'rocketmq-ai/rocketmq-sre',
+  'rocketmq-dashboard/rocketmq-dashboard-gpui',
+  'rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri',
+  'rocketmq-dashboard/rocketmq-dashboard-web/backend'
+)
+
+$all = @(rg -n --glob '*.rs' --glob '!target/**' --glob '!**/tests/**' --glob '!rocketmq-error/**' $errorPattern .)
+$plainAll = @(rg -n --glob '*.rs' --glob '!target/**' --glob '!**/tests/**' --glob '!rocketmq-error/**' $plainErrorPattern .)
+$kindAll = @(rg -n --glob '*.rs' --glob '!target/**' --glob '!**/tests/**' --glob '!rocketmq-error/**' $errorKindPattern .)
+$plainKindAll = @(rg -n --glob '*.rs' --glob '!target/**' --glob '!**/tests/**' --glob '!rocketmq-error/**' $plainErrorKindPattern .)
+$standalone = @($standaloneScopes | ForEach-Object { rg -n --glob '*.rs' --glob '!target/**' --glob '!**/tests/**' $errorPattern $_ })
+$plainStandalone = @($standaloneScopes | ForEach-Object { rg -n --glob '*.rs' --glob '!target/**' --glob '!**/tests/**' $plainErrorPattern $_ })
+
+[pscustomobject]@{
+  All = $all.Count
+  RootWorkspace = $all.Count - $standalone.Count
+  Standalone = $standalone.Count
+  PlainPubAll = $plainAll.Count
+  PlainPubRootWorkspace = $plainAll.Count - $plainStandalone.Count
+  PlainPubStandalone = $plainStandalone.Count
+  ErrorKind = $kindAll.Count
+  PlainPubErrorKind = $plainKindAll.Count
+}
+```
+
+This produces 301 enum/struct names ending in `Error`: 238 in the root
+workspace (129 plain `pub`) and 63 in standalone projects (49 plain `pub`). It
+also produces 47 `ErrorKind` declarations, of which 25 are plain `pub`. These
+figures are repeatable lexical candidates for triage, not proof that a name is
+reachable in Rustdoc or that a migration is complete. Wave 0B must revalidate
+every inventory row and every current consumer before its status or ownership
+is changed.
+
+## Baseline signals
+
+| Current signal | Baseline truth |
 | --- | --- |
-| Legacy error API | `RocketmqError`, `LegacyRocketMQResult`, and `LegacyResult` still appear in `rocketmq-error`, `rocketmq-macros`, `rocketmq-remoting`, `rocketmq-client`, and dashboard common code |
-| Public `anyhow` alias | `rocketmq-error/src/unified.rs` exposes `pub type Result<T> = anyhow::Result<T>` |
-| Public alias callers | `rocketmq-broker`, `rocketmq-controller`, `rocketmq-namesrv`, and a controller example import `rocketmq_error::Result` |
-| Dynamic callback errors | client callback and request future paths still use `dyn Error` |
-| Distributed protocol mapping | proxy maps `RocketMQError` to gRPC locally; remoting and proxy remoting paths also map directly to `ResponseCode` |
-| Generic string variants | store, controller, dashboard backend, and unified errors still contain string-only internal or general variants |
-| Credential formatting | `SessionCredentials::Display` now redacts secret key, signature, and security token; broader `Sensitive<T>` infrastructure is still pending |
+| Public central error | A large public `RocketMQError` enum is the central error value |
+| Existing metadata | `ErrorKind`, `ErrorSpec`, and `ALL_ERROR_SPECS` exist, but declarative sole ownership is not yet established |
+| Domain override/context | `DomainError` override and free-string `ErrorContext` exist |
+| Boundary view | `BoundaryErrorView` exists; boundary remarks can still be arbitrary |
+| Client callback | Callback error paths are typed rather than dynamic |
+| Storage facade | `StoreError` is opaque; `StoreError::General` is absent |
+| Redaction | Shared `Sensitive` support exists |
+| Source presentation | Source `Display` output remains observable and is not a stable contract |
+| `rocketmq-error` dependencies | `anyhow`, configuration, and `serde_json` dependencies remain |
+| Legacy aliases | No `RocketmqError` or `Legacy*` aliases are present at the baseline |
 
-## Ownership Matrix
+## Exact target five-layer model
 
-| Area | Error owner | Current role | Target role |
-| --- | --- | --- | --- |
-| `rocketmq-error` | Error kernel | Central enum plus legacy API and public `anyhow` alias | Own typed error kernel, spec registry, context, redaction, recovery, and observability metadata |
-| `rocketmq-macros` | Macro output | Generates legacy `RocketmqError` in request header code | Generate typed `RocketMQError` variants only |
-| `rocketmq-remoting` | Protocol boundary | Codec and serialization paths still carry legacy errors and direct response mapping | Convert `ErrorSpec` remoting primitives into `ResponseCode` and remarks |
-| `rocketmq-client` | Client boundary | Uses `RocketMQError`, dynamic callback errors, and local retry decisions | Use typed callback errors, `RetryClass`, and redacted context |
-| `rocketmq-broker` | Broker boundary | Uses typed errors in many areas and direct processor response mapping | Route externally visible processor failures through remoting adapter |
-| `rocketmq-namesrv` | NameServer boundary | Uses typed errors and direct response mapping | Route externally visible failures through remoting adapter |
-| `rocketmq-store` | Storage domain | Uses local `StoreError` and `StoreError::General` | Keep private domain errors but expose typed storage variants and sources |
-| `rocketmq-controller` | Controller domain | Re-exports central controller errors but still has internal string paths and public alias callers | Preserve raft, storage, serde, and network sources in typed variants |
-| `rocketmq-auth` | Auth domain | Uses central errors but mixes authentication, authorization, config, and storage semantics | Split authn, authz, config, and storage categories |
-| `rocketmq-common` | Shared utilities | Contains shared helpers that can spread string conversion patterns | Keep shared helpers typed and avoid public `anyhow` contracts |
-| `rocketmq-tools` | CLI/tools | Uses app-style error handling and string conversion in admin/storage tools | Keep `anyhow` at binary boundary and map typed errors to CLI categories |
-| `rocketmq-proxy` | gRPC and remoting proxy boundary | Owns `ProxyError` and local status mapper | Convert central gRPC primitives to `v2::Code` and `tonic::Code` |
-| dashboard web backend | HTTP boundary | Uses `DashboardError` and string-based RocketMQ wrappers | Wrap typed `RocketMQError` and map through HTTP adapter |
-| standalone projects | App boundaries | Examples and dashboard apps may lag behind root workspace changes | Follow typed public API after root workspace migration |
+| Layer | Target responsibility | Current position |
+| --- | --- | --- |
+| Outcome/Decision/Rejection | Public control-flow outcomes; retry is not inferred from rendered text | Not yet a uniformly separated public model |
+| ContractViolation | Caller, protocol, and invariant violations distinct from operational failures | Not yet uniformly separated |
+| Private leaf `Error` | Domain implementation errors retain typed sources behind private representation | Current domain errors vary; public mega-enum remains central |
+| Domain operational facade | Narrow domain facade hides private leaves while retaining source and policy information | Opaque `StoreError` exists; other domains vary |
+| Opaque canonical `Error` with safe projections | One canonical value with private representation projected through `PublicErrorView` and `DiagnosticView` | Target migration from public mega-enum is pending |
 
-## Migration Order
+`ErrorCatalog`, boundary adapters, and presentation/observability are supporting
+mechanisms for these five layers, not extra layers. The declarative catalog is
+the sole owner of stable dotted code, `CanonicalCondition`, fixed public
+message, severity, `RecoveryHint`, and projection metadata.
 
-The migration must keep deletion after caller movement:
+## Catalog, context, and decision contract
 
-1. Add kernel metadata and redaction primitives.
-2. Add protocol primitive specs and adapter contracts.
-3. Replace public alias callers.
-4. Remove public `anyhow` aliases.
-5. Move macros, remoting codecs, client callbacks, and retry decisions.
-6. Split store, controller, auth, common, and tools string-only errors.
-7. Move proxy, dashboard, and standalone boundaries.
-8. Delete legacy `RocketmqError` and add static guards.
+Every catalog entry must declaratively own:
 
-## Done Criteria
+- one stable dotted code;
+- one `CanonicalCondition`;
+- one fixed public message;
+- severity and `RecoveryHint`; and
+- projection metadata for remoting, gRPC, HTTP, CLI, and observability.
 
-The redesign is complete only when all of these are true:
+Catalog codes use lowercase dotted stable domain semantics, for example
+`storage.commit_log.corrupt_record`. A code must never contain a dynamic topic,
+group, path, broker address, or other runtime value. `CanonicalCondition` is
+protocol-independent. Domain facades and private leaf errors cannot override
+the catalog code, condition, severity, `RecoveryHint`, or projection metadata.
 
-- `rocketmq-error` no longer exposes `RocketmqError`,
-  `LegacyRocketMQResult`, or `LegacyResult`.
-- Library APIs do not expose `anyhow::Result` as the business error contract.
-- Every cross-boundary error has `ErrorKind`, stable code, `ErrorSpec`, retry,
-  severity, redaction, and observability metadata.
-- Remoting, gRPC, HTTP, CLI, and observability exits read from the central
-  metadata instead of interpreting display text.
-- Credentials, tokens, signatures, and authorization values are redacted by
-  default.
-- Source chains are preserved for I/O, serde, storage, raft, transport, and
-  runtime failures.
-- CI rejects unapproved legacy, public `anyhow`, unmapped error metadata, and
-  sensitive formatting regressions.
+Context visibility is explicit:
+
+- `Public` may appear in `PublicErrorView` and external responses;
+- `Diagnostic` is restricted to controlled diagnostics and operational
+  telemetry; and
+- `SecretPresenceOnly` records only the presence of secret-bearing data, never
+  its value.
+
+`PublicErrorView` contains catalog-approved identity, fixed public message,
+safe public context, and boundary-safe projection fields. `DiagnosticView` may
+add redacted diagnostic context and typed source information according to
+visibility policy. Free-form remarks and source `Display` text are not fields
+that define either view.
+
+`RetryDecision` is separate from catalog identity and error rendering. It uses
+operation idempotency, operation stage, and remaining budget together with the
+catalog's `RecoveryHint`; no response message or source string decides retry by
+itself.
+
+## Per-type inventory schema
+
+Itemized classification is a pending follow-up. When rows are added, the
+inventory must use these exact fields (extra evidence columns are allowed):
+
+| Type | Crate/Path | Visibility | Current Consumers | Category | Target Type | Catalog Code | Source Preserved | Owner | Wave | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| _pending follow-up_ | _pending follow-up_ | _pending follow-up_ | _pending follow-up_ | _one of Outcome/Contract/PrivateLeaf/Facade/Delete_ | _pending follow-up_ | _pending follow-up_ | _pending follow-up_ | _pending follow-up_ | _pending follow-up_ | _pending; no completion implied_ |
+
+`Category` is deliberately limited to `Outcome`, `Contract`, `PrivateLeaf`,
+`Facade`, or `Delete`. `Source Preserved` records the typed source-chain
+decision and rationale; it must never be inferred from source stringification.
+`Status` needs implementation and evidence before it can be changed from
+pending.
+
+## Compatibility constraints
+
+The Rust API is allowed to break. There will be no V1/V2 public compatibility
+API, deprecated compatibility shim, compatibility feature, or long-lived dual
+API. A private migration bridge may exist only inside its dependency-driven
+wave and must be removed in that wave after its producer and every consumer
+have migrated.
+
+The inventory preserves external contracts separately from Rust API shape:
+remoting numeric response codes and headers, gRPC and HTTP external contracts,
+wire semantics, and persisted record layouts require regression evidence when
+affected. Preserving those contracts does not preserve an enum, arbitrary
+remark, or source `Display` string.
+
+## Dependency-driven waves
+
+| Wave | Producer and consumer scope | Required evidence and bridge rule |
+| --- | --- | --- |
+| 0 | Pin baseline; freeze public leaves, arbitrary remarks, and source stringification; record wire/persistence invariants | Establish evidence; no bridge |
+| 0B | Revalidate every inventory row and every current consumer against the pinned lexical baseline | Row-level and consumer-level evidence is required before changing ownership or status; no bridge |
+| 1 | Define Outcome/Decision/Rejection, ContractViolation, context visibility, views, and catalog primitives | Primitive producer and all initial readers migrate before temporary representation is removed |
+| 2 | Migrate domain leaf producers and operational facades | Remove each private facade bridge after its producer set and every domain consumer migrate |
+| 3 | Wrap migrated leaves/facades in opaque canonical `Error` | Remove enum-to-canonical bridge after all affected producers and canonical consumers migrate |
+| 4 | Migrate boundary adapters and safe projections for remoting, gRPC, HTTP, CLI, and observability | Remove each boundary bridge only after producer paths and all consumers have regression evidence |
+| 5 | Migrate client retry decisions and remaining broker, namesrv, controller, auth, common, proxy, dashboard, tool, and standalone consumers | Remove each domain bridge after producer plus consumer coverage is complete |
+| 6 | Remove local semantic tables, display-text mapping, and transitional internal adapters | Private bridge is removed in the same wave; nothing becomes a public/deprecated API |
+| 7 | Run focused tests, applicable guards, targeted scans, link checks, and protocol/persistence regression evidence | No bridge remains; inventory status changes only with evidence |
+
+## Target acceptance criteria
+
+These are future acceptance criteria, not statements that the pinned baseline
+passes:
+
+- The five layers are separated, with `ErrorCatalog` as the sole owner of
+  stable semantic metadata and adapters/presentation as supporting mechanisms.
+- Public boundaries use opaque canonical `Error` and safe projections rather
+  than exhaustive mega-enum matching.
+- `PublicErrorView` and `DiagnosticView` enforce context visibility and default
+  redaction; source chains remain typed where useful.
+- `RetryDecision` uses idempotency, stage, and budget separately from error
+  identity and rendered text.
+- Remoting numeric codes/headers, gRPC/HTTP contracts, wire semantics, and
+  persisted layouts retain regression evidence.
+- Legacy aliases, public anyhow contracts, and private bridges are absent when
+  their owning waves complete; no compatibility shim survives as public API.
+
+No itemized row should be marked complete solely because this target design is
+documented. The pinned commit and follow-up evidence are the audit trail.

--- a/rocketmq-doc/en/19-error-contribution-guide.md
+++ b/rocketmq-doc/en/19-error-contribution-guide.md
@@ -2,112 +2,197 @@
 title: "Error Architecture Contribution Guide"
 permalink: /docs/error-contribution-guide/
 excerpt: "How to add, map, test, and review typed RocketMQ Rust errors."
-last_modified_at: 2026-07-04T00:00:00+08:00
+last_modified_at: 2026-08-31T00:00:00+08:00
 toc: true
 classes: wide
 ---
 
 # Error Architecture Contribution Guide
 
-This guide is the contribution contract for RocketMQ Rust error changes. The
-current direction is no-compatibility typed errors: new code must use the
-central `RocketMQError` architecture instead of adding legacy aliases or local
-string-only mappings.
+This guide separates rules effective in the current repository from the target
+opaque canonical architecture. The [Error Architecture Redesign
+ADR](07-error-architecture-adr.md) defines the target, and the [Error
+Architecture Inventory](07-error-inventory.md) pins the baseline and records
+pending migration evidence. Naming a target type here does not make a future
+API available to current callers.
 
-## Core Rules
+## Effective-now rules
 
-1. Use `rocketmq_error::RocketMQError` and `RocketMQResult<T>` for library
-   error contracts.
-2. Do not reintroduce `RocketmqError`, `RocketMqError`,
-   `LegacyRocketMQResult`, `LegacyResult`, or `rocketmq_error::Result`.
-3. Keep `anyhow` at application, binary, test, and one-shot tool boundaries.
-   Core library crates such as `rocketmq-error` and `rocketmq-common` must not
-   expose public `anyhow::Result` contracts.
-4. Add or reuse an `ErrorKind` and `ErrorSpec` entry before exposing a new
-   cross-boundary error.
-5. Boundary crates must map from `ErrorSpec` primitives instead of parsing
-   display text.
-6. Sensitive fields such as secret keys, tokens, signatures, and passwords must
-   be redacted in `Display`, `Debug`, logs, and exported diagnostics.
+At the pinned baseline, the effective central API is the public mega
+`RocketMQError` enum and the existing `ErrorKind`, `ErrorSpec`,
+`ALL_ERROR_SPECS`, `DomainError`, `ErrorContext`, `BoundaryErrorView`, and
+shared `Sensitive` support. Client callback errors are typed and `StoreError`
+is an opaque domain facade. Work in a crate must follow that crate's existing
+public API until its migration wave lands.
 
-## Where Changes Belong
+1. Preserve typed sources for I/O, serde, storage, raft, transport, and runtime
+   failures. Do not replace a source with rendered text.
+2. Keep public leaf error shapes frozen. Do not add consumer-facing enum
+   variants, constructors, or exhaustive matching surfaces merely to represent
+   a boundary condition.
+3. Treat arbitrary boundary remarks as bounded presentation text only. They
+   are not stable codes, public messages, retry signals, or catalog entries;
+   caller-provided strings must not become authoritative protocol meaning.
+4. Treat `Display`, `Debug`, and `source().to_string()` output as diagnostic
+   presentation, never as data for classification, mapping, retry, persistence,
+   or comparison.
+5. Use the existing typed error contracts and local boundary mappings without
+   widening public `anyhow` contracts. The baseline has no legacy
+   `RocketmqError`/`Legacy*` aliases and no public anyhow `Result` alias or
+   callers; do not reintroduce either.
+6. Redact secret keys, tokens, signatures, passwords, authorization values,
+   and equivalent sensitive data in public output, diagnostics, logs, traces,
+   and exported reports. Use the repository's existing shared redaction
+   support where available.
+
+These rules apply now, including while a private migration bridge is present.
+A bridge must remain private and temporary; it must not become a public,
+deprecated, feature-gated, or long-lived dual API.
+
+## Future target, not current imports
+
+When an owning migration lands, it follows these five layers exactly:
+
+1. **Outcome/Decision/Rejection:** public control-flow outcomes without leaf
+   representation; retry is not inferred from rendered text.
+2. **ContractViolation:** caller, protocol, and invariant violations kept
+   distinct from operational failures.
+3. **Private leaf `Error`:** domain implementation errors with typed source
+   chains and private representation.
+4. **Domain operational facade:** a narrow domain facade that hides private
+   leaves while retaining source and policy information.
+5. **Opaque canonical `Error` with safe projections:** one canonical value with
+   private representation, projected through `PublicErrorView` and
+   `DiagnosticView`.
+
+`ErrorCatalog`, boundary adapters, and presentation/observability are
+supporting mechanisms, not additional layers. The declarative catalog is the
+sole owner of stable dotted code, `CanonicalCondition`, fixed public message,
+severity, `RecoveryHint`, and projection metadata.
+
+Catalog codes use lowercase dotted stable domain semantics, for example
+`storage.commit_log.corrupt_record`. Never include a dynamic topic, group, path,
+broker address, or other runtime value in a code. `CanonicalCondition` is
+protocol-independent. Domain facades and private leaf errors cannot override
+the catalog code, condition, severity, `RecoveryHint`, or projection metadata.
+
+Context visibility is explicit: `Public` is safe for the public view,
+`Diagnostic` is restricted to controlled diagnostics and operational telemetry,
+and `SecretPresenceOnly` records only that secret-bearing data was present.
+`PublicErrorView` contains only catalog-approved identity, fixed public message,
+safe public context, and boundary-safe projection fields. `DiagnosticView` may
+add redacted context and typed source information according to its visibility
+policy.
+
+`RetryDecision` remains separate from canonical error identity. It uses
+operation idempotency, operation stage, and remaining budget together with the
+catalog's `RecoveryHint`; it never uses a response message or source string as
+the decision.
+
+These are target concepts, not instructions to add future imports to an
+unmigrated crate. A target API becomes usable only in the owning migration,
+with its inventory evidence and focused tests.
+
+## Where changes belong
 
 | Change type | Owner |
 | --- | --- |
-| New stable kind, code, severity, retry class, or redaction contract | `rocketmq-error` |
-| Remoting response code and remark conversion | `rocketmq-remoting::error_response` |
-| gRPC payload/status conversion | `rocketmq-proxy::status` |
-| Broker or NameServer external response conversion | Processor code using `rocketmq_remoting::error_response` |
+| Current leaf/source type and source preservation | Owning domain crate |
+| Future canonical identity, catalog policy, redaction, or recovery contract | `rocketmq-error` |
+| Remoting response code and safe remark conversion | Remoting boundary adapter |
+| gRPC payload/status conversion | Proxy gRPC boundary adapter |
+| Broker or NameServer external response conversion | Processor code using the remoting adapter |
 | Dashboard or HTTP conversion | Dashboard boundary error wrapper |
 | CLI display and exit behavior | CLI/tool boundary |
-| Domain-local storage, auth, controller, or client source preservation | Owning crate, then convert to `RocketMQError` at the boundary |
+| Domain-local storage, auth, controller, or client source preservation | Owning crate, then canonical conversion during migration |
 
-## Adding A New Error
+Do not create a second semantic catalog in a boundary crate. During migration,
+keep an existing local mapper buildable while removing new display-text and
+arbitrary-remark decisions. Preserve remoting numeric codes and headers,
+gRPC/HTTP external contracts, wire semantics, and persisted layouts with
+focused regression evidence when affected.
 
-Use this sequence for any new cross-boundary error:
+## Adding a new error
 
-1. Add or reuse an `ErrorKind`.
-2. Add a stable `ErrorCode` and `ErrorSpec` entry.
-3. Define retry, severity, observability, remoting, gRPC, HTTP, and CLI
-   primitive metadata.
-4. Add a typed `RocketMQError` variant or domain error conversion.
-5. Update the relevant boundary adapter if the default metadata is not enough.
-6. Add focused tests for the new kind and the affected boundary.
-7. Run the error guard and the relevant Cargo validation.
+For a current API change:
 
-```powershell
-python scripts/error_architecture_guard.py
-cargo fmt --all
-cargo test -p rocketmq-error
-cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
-```
+1. Reuse the owning crate's existing typed shape where possible.
+2. Preserve the typed source and record deliberate redaction.
+3. Keep boundary status and remark handling local until the canonical adapter
+   migration lands; do not add a new semantic mapping table.
+4. Add focused tests for source preservation, redaction, and boundary output.
+5. Add or update the inventory row. Mark target fields pending when catalog
+   migration has not happened; itemized classification remains a follow-up.
 
-## Boundary Mapping Pattern
+For a target migration, the owning change assigns the catalog's stable dotted
+code, `CanonicalCondition`, fixed public message, severity, `RecoveryHint`,
+projection metadata, context visibility, and source policy. It also migrates
+both producers and consumers before removing its private bridge. These are
+implementation requirements for that wave, not current API imports.
 
-Boundary code should look up the spec and convert primitive metadata into local
-wire types.
+## Boundary and redaction rules
 
-```rust
-use rocketmq_error::RocketMQError;
-use rocketmq_remoting::error_response;
+Future boundary adapters project catalog metadata into local protocol
+primitives and safe views. Until the adapter exists, preserve the current
+mapper without parsing display text or making an arbitrary remark authoritative.
 
-fn to_response(error: &RocketMQError, opaque: i32) -> RemotingCommand {
-    error_response::command_from_error_with_opaque(error, opaque)
-}
-```
+Public output uses only `PublicErrorView`; controlled diagnostics may use
+`DiagnosticView` with visibility checks and redaction. `SecretPresenceOnly`
+never carries a secret value. Typed source chains may be retained for
+diagnostics, but their rendered strings are not copied into stable fields.
 
-Do not add new mapping tables beside the boundary adapters unless the adapter
-itself is being extended.
+## Dependency-driven wave rule
 
-## Redaction Pattern
+The work is organized by producer/consumer dependency, not by a fixed PR list.
+A wave closes only after its producer and every known consumer migrate, focused
+tests and compatibility regression evidence pass, and the private bridge for
+that wave is removed. No bridge may become a V1/V2 API, deprecated shim,
+compatibility feature, or long-lived dual path.
 
-Prefer `Sensitive<T>` or a small local redaction helper. Never format secret
-material directly.
+The dependency order is: baseline and freezes; primitive layers, views, and
+catalog; domain leaf producers and facades; opaque canonical conversion;
+boundary projections and client retry decisions; remaining application
+consumers; bridge and local-table removal; then evidence and inventory update.
+Wave 0B specifically revalidates every inventory row and every current consumer
+before a row's ownership or status changes.
 
-```rust
-use rocketmq_error::Sensitive;
+## Lightweight governance and validation
 
-let secret = Sensitive::new(secret_key);
-tracing::warn!(secret = %secret, "authentication failed");
-```
+For implementation changes, run focused tests, the current error guard when
+applicable, targeted `rg` scans, `git diff --check`, relative Markdown link
+checks, and protocol/persistence regression checks when those contracts are
+affected. Rust changes use the root repository profile: package-scoped
+`cargo fmt -p <package> -- --check` and workspace Clippy with warnings denied.
+Documentation-only changes do not require Cargo validation.
 
-For custom `Debug` implementations, sensitive fields must render as
-`<redacted>` or route through an equivalent helper.
+This guide intentionally does not require content fingerprints, file hashes,
+complex AST gates, custom Clippy policy, or a heavy platform. The inventory's
+pinned Git commit identifies its source snapshot; it is not a content
+fingerprint requirement.
 
-## Review Checklist
+## Review checklist
 
-- Does the change add a typed error instead of a string-only internal error?
-- Does the new error have a stable `ErrorKind` and `ErrorSpec`?
-- Do remoting, gRPC, HTTP, CLI, retry, severity, and observability mappings
-  come from the central spec?
-- Are source errors preserved where they help debugging?
-- Are credentials, tokens, signatures, passwords, and authorization values
-  redacted?
-- Does the change avoid public `anyhow` in library APIs?
-- Did `python scripts/error_architecture_guard.py` pass?
-- Did the affected crate tests and required clippy command pass?
+- Is the change following the current crate API rather than assuming a future
+  canonical type is importable?
+- Are Outcome/Decision/Rejection, ContractViolation, private leaf `Error`,
+  domain facade, and opaque canonical `Error` kept distinct where migrated?
+- Are public leaf errors, arbitrary remarks, and source stringification kept
+  out of stable semantic contracts?
+- Does the declarative catalog remain the sole owner of dotted code,
+  `CanonicalCondition`, fixed public message, severity, `RecoveryHint`, and
+  projection metadata?
+- Do `PublicErrorView`, `DiagnosticView`, and context visibility prevent
+  sensitive data from crossing the wrong boundary?
+- Is `RetryDecision` based on idempotency, stage, and budget separately from
+  error identity?
+- Are remoting, gRPC, HTTP, wire, and persistence contracts backed by
+  regression evidence when affected?
+- Are producer and consumer migrations complete before removing the private
+  bridge?
+- Were focused tests, applicable guard, targeted scans, diff checks, and link
+  checks run according to the change scope?
 
-## Useful References
+## Useful references
 
 - [Error Architecture Redesign ADR](07-error-architecture-adr.md)
 - [Error Architecture Inventory](07-error-inventory.md)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9908
- Fixes #9908

### Brief Description

This documentation-only change supersedes the transitional public-enum error design with the accepted target architecture while keeping current repository state distinct from future APIs.

- [x] Defines Outcome/Decision/Rejection, ContractViolation, private leaf errors, domain operational facades, and an opaque canonical error as the five layers.
- [x] Makes the declarative catalog the sole owner of stable dotted codes, protocol-independent conditions, public messages, recovery hints, severity, and projection metadata.
- [x] Defines public, diagnostic, and secret-presence-only context visibility plus safe public and diagnostic views.
- [x] Separates retry hints from operation-aware retry decisions.
- [x] Preserves wire, header, external protocol, and persisted-layout compatibility without adding a V1/V2 Rust API compatibility layer.
- [x] Pins a reproducible repository error-surface baseline and the schema for the follow-up itemized inventory.
- [x] Freezes new public leaf errors, arbitrary boundary remarks, and source-string semantics with lightweight governance.

### How Did You Test This Change?

- `git diff --check`
- Reproduced the documented lexical inventory counts: 301 total non-central errors, 238 root-workspace errors, 63 standalone errors, 178 plain-public errors, and 47 error-kind declarations.
- Verified stale enum-extension guidance and the obsolete fixed PR sequence are absent with targeted `rg` scans.
- Verified every relative Markdown link in the three changed documents resolves.
- Independent architecture review approved the corrected diff.
- Cargo validation was not run because the change is documentation-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked the error architecture documentation around a canonical, layered error model.
  * Added guidance for stable error codes, severity, recovery hints, context visibility, redaction, and boundary projections.
  * Updated the error inventory with reproducible baseline measurements and migration criteria.
  * Replaced the contribution guide with current-state guidance, migration practices, and validation requirements.
  * Updated the architecture document’s modification date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->