### PR TITLE
[ISSUE #9907]🐛Bound upstream cost for paginated RocketMQ MCP queries

### DIFF
--- a/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml
+++ b/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml
@@ -88,6 +88,8 @@ queue_max_bytes = 1048576
 [cache]
 enabled = true
 max_entries = 256
+cursor_snapshot_max_entries = 256
+cursor_snapshot_ttl_ms = 60000
 cluster_overview_ttl_ms = 3000
 topic_list_ttl_ms = 5000
 broker_metrics_ttl_ms = 2000

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
@@ -21,6 +21,7 @@ use rocketmq_admin_core::core::broker::BrokerRuntimeTargetStatus;
 use rocketmq_admin_core::core::broker::ListBrokersRequest;
 use rocketmq_admin_core::core::broker::ProbeBrokerRuntimeTargetRequest;
 use rocketmq_admin_core::core::consumer::ConsumerQueryAdmin;
+use rocketmq_admin_core::core::consumer::ExactConsumerGroupEnrichmentRequest;
 use rocketmq_admin_core::core::consumer::ListConsumerGroupsRequest;
 use rocketmq_admin_core::core::consumer::QueryConsumerLagRequest;
 use rocketmq_admin_core::core::security::AdminCredentials;
@@ -31,6 +32,7 @@ use rocketmq_admin_core::core::topic::TopicQueryAdmin;
 use rocketmq_admin_core::read_client_adapter::ClientRuntime;
 use rocketmq_admin_core::read_client_adapter::ReadAdminBuilder;
 use rocketmq_admin_core::read_client_adapter::ReadAdminGuard;
+use serde::Serialize;
 
 use crate::model::contract::observed_at_from_millis;
 use crate::model::contract::QueryPayload;
@@ -49,13 +51,13 @@ pub(crate) struct ResolvedCluster {
     pub credentials: Option<AdminCredentials>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct SessionTopicRoute {
     pub brokers: Vec<TopicRouteBroker>,
     pub queues: Vec<TopicRouteQueue>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct SessionConsumerLag {
     pub queues: Vec<QueueLag>,
     pub total_lag: i64,
@@ -78,6 +80,37 @@ pub(crate) trait AdminSession: Send {
     fn consumer_groups(
         &mut self,
     ) -> impl Future<Output = Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError>> + Send;
+
+    fn consumer_group_inventory(
+        &mut self,
+    ) -> impl Future<Output = Result<QueryPayload<Vec<String>>, ToolExecutionError>> + Send {
+        async {
+            self.consumer_groups().await.map(|groups| {
+                groups.map(|groups| {
+                    let mut names = groups.into_iter().map(|group| group.group).collect::<Vec<_>>();
+                    names.sort();
+                    names.dedup();
+                    names
+                })
+            })
+        }
+    }
+
+    fn consumer_groups_exact(
+        &mut self,
+        groups: &[String],
+    ) -> impl Future<Output = Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError>> + Send {
+        async move {
+            self.consumer_groups().await.map(|result| {
+                result.map(|summaries| {
+                    summaries
+                        .into_iter()
+                        .filter(|summary| groups.binary_search(&summary.group).is_ok())
+                        .collect()
+                })
+            })
+        }
+    }
 
     fn consumer_lag(
         &mut self,
@@ -214,6 +247,43 @@ impl AdminSession for AdminCoreSession {
         let result = self
             .admin_mut()?
             .list_consumer_groups_with_evidence(&ListConsumerGroupsRequest)
+            .await
+            .map_err(ToolExecutionError::backend)?;
+        Ok(QueryPayload::from_admin(result).map(|result| {
+            result
+                .groups
+                .into_iter()
+                .map(|group| ConsumerGroupSummary {
+                    group: group.group,
+                    version: group.version,
+                    client_count: group.client_count,
+                    consume_type: group.consume_type,
+                    message_model: group.message_model,
+                    consume_tps: group.consume_tps,
+                    diff_total: group.diff_total,
+                })
+                .collect()
+        }))
+    }
+
+    async fn consumer_group_inventory(&mut self) -> Result<QueryPayload<Vec<String>>, ToolExecutionError> {
+        let result = self
+            .admin_mut()?
+            .list_consumer_group_inventory_with_evidence(&ListConsumerGroupsRequest)
+            .await
+            .map_err(ToolExecutionError::backend)?;
+        Ok(QueryPayload::from_admin(result).map(|result| result.groups))
+    }
+
+    async fn consumer_groups_exact(
+        &mut self,
+        groups: &[String],
+    ) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
+        let request = ExactConsumerGroupEnrichmentRequest::try_new(groups.iter().cloned())
+            .map_err(ToolExecutionError::backend)?;
+        let result = self
+            .admin_mut()?
+            .enrich_consumer_groups_exact_with_evidence(&request)
             .await
             .map_err(ToolExecutionError::backend)?;
         Ok(QueryPayload::from_admin(result).map(|result| {

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
@@ -29,8 +29,15 @@ use crate::adapter::admin_session::SessionTopicRoute;
 use crate::config::McpConfig;
 use crate::infrastructure::cache::CacheMetricsSnapshot;
 use crate::infrastructure::cache::QueryCache;
+use crate::infrastructure::snapshot::SnapshotKind;
+use crate::infrastructure::snapshot::SnapshotRequest;
+use crate::infrastructure::snapshot::SnapshotSelectionMode;
+use crate::infrastructure::snapshot::SnapshotStore;
+use crate::infrastructure::snapshot::SnapshotView;
+use crate::infrastructure::snapshot::SnapshotWeight;
 use crate::model::contract::observed_at;
 use crate::model::contract::paginate;
+use crate::model::contract::Page;
 use crate::model::contract::PageRequest;
 use crate::model::contract::QueryCompleteness;
 use crate::model::contract::QueryPayload;
@@ -38,7 +45,6 @@ use crate::model::contract::QueryResult;
 use crate::model::contract::QuerySource;
 use crate::model::contract::SourceFailure;
 use crate::model::contract::SourceFailureCode;
-use crate::model::contract::DEFAULT_PAGE_LIMIT;
 use crate::model::contract::SCHEMA_VERSION;
 use crate::model::diagnosis::DiagnosisReport;
 use crate::service::diagnosis_collector::ConsumerLagEvidence;
@@ -106,6 +112,44 @@ pub(crate) trait ReadOnlyQuery: Clone + Send + Sync + 'static {
         args: ListConsumerGroupsArgs,
     ) -> impl Future<Output = Result<QueryResult<ListConsumerGroupsOutput>, ToolExecutionError>> + Send;
 
+    fn describe_consumer_group(
+        &self,
+        cluster: String,
+        group: String,
+    ) -> impl Future<Output = Result<QueryResult<crate::tools::consumer_tools::ConsumerGroupSummary>, ToolExecutionError>>
+           + Send {
+        async move {
+            let result = self
+                .list_consumer_groups(ListConsumerGroupsArgs {
+                    cluster: Some(cluster.clone()),
+                    filter: Some(group.clone()),
+                    page: PageRequest {
+                        limit: Some(crate::model::contract::MAX_PAGE_LIMIT),
+                        cursor: None,
+                    },
+                })
+                .await?;
+            let summary = result
+                .data
+                .page
+                .items
+                .iter()
+                .find(|summary| summary.group == group)
+                .cloned()
+                .ok_or_else(|| {
+                    ToolExecutionError::InvalidArguments(format!(
+                        "consumer group not found in cluster {cluster}: {group}"
+                    ))
+                })?;
+            Ok(QueryResult::from_payload(
+                QueryPayload::new(summary, result.partial, result.warnings, result.source_failures),
+                result.observed_at,
+                result.freshness_ms,
+                result.cache_status,
+            ))
+        }
+    }
+
     fn query_consumer_lag(
         &self,
         args: QueryConsumerLagArgs,
@@ -128,6 +172,7 @@ pub(crate) struct QueryFacade<F> {
     factory: F,
     control: WorkflowControl,
     cache: QueryCache,
+    snapshots: SnapshotStore,
     visibility_class: String,
 }
 
@@ -157,6 +202,7 @@ where
     pub(crate) fn with_factory_and_control(config: McpConfig, factory: F, control: WorkflowControl) -> Self {
         Self {
             cache: QueryCache::new(config.cache.enabled, config.cache.max_entries),
+            snapshots: SnapshotStore::new(config.cache.cursor_snapshot_max_entries),
             config,
             factory,
             control,
@@ -175,11 +221,11 @@ where
     }
 
     pub(crate) fn cache_metrics(&self) -> CacheMetricsSnapshot {
-        self.cache.metrics()
+        self.cache.metrics().merge(self.snapshots.metrics())
     }
 
     pub(crate) async fn invalidate_cache(&self) -> usize {
-        self.cache.clear().await
+        self.cache.clear().await.saturating_add(self.snapshots.clear().await)
     }
 
     pub(crate) async fn cluster_overview(
@@ -196,19 +242,23 @@ where
                 &self.control.cancellation,
                 || ToolExecutionError::Cancelled,
                 || async {
-                    self.run_workflow(cluster, |session, cluster| {
+                    let page = PageRequest::default();
+                    let topic_snapshot = self.topic_inventory_snapshot(cluster.clone(), None, &page).await?;
+                    let consumer_snapshot = self
+                        .consumer_group_inventory_snapshot(cluster.clone(), None, false, &page)
+                        .await?;
+                    self.run_workflow(cluster, move |session, cluster| {
                         Box::pin(async move {
                             let brokers = session.broker_rows().await?;
                             let mut completeness = brokers.completeness();
-                            let topics = sorted_unique_topic_names(session.topic_inventory().await?);
-                            let consumer_groups = session.consumer_groups().await?;
-                            completeness.merge(consumer_groups.completeness());
+                            completeness.merge(topic_snapshot.payload.completeness());
+                            completeness.merge(consumer_snapshot.payload.completeness());
                             Ok(completeness.wrap(ClusterOverviewOutput {
                                 cluster: cluster.name.clone(),
                                 namesrv_addr: cluster.namesrv_addr.clone(),
                                 brokers: brokers.data,
-                                topic_count: topics.len(),
-                                consumer_group_count: consumer_groups.data.len(),
+                                topic_count: topic_snapshot.payload.data.len(),
+                                consumer_group_count: consumer_snapshot.payload.data.len(),
                                 generated_at: observed_at(),
                             }))
                         })
@@ -224,46 +274,30 @@ where
         args: ListTopicsArgs,
     ) -> Result<QueryResult<ListTopicsOutput>, ToolExecutionError> {
         let cluster = self.resolve_cluster(args.cluster.as_deref())?;
-        let key = self.cache_key(
-            "list_topics",
-            &cluster.name,
-            &list_key(args.filter.as_deref(), &args.page),
-        );
-        let ttl = Duration::from_millis(self.config.cache.topic_list_ttl_ms);
-        self.cache
-            .get_or_try_init_cancellable(
-                key,
-                ttl,
-                &self.control.cancellation,
-                || ToolExecutionError::Cancelled,
-                || async {
-                    self.run_workflow(cluster, move |session, cluster| {
-                        Box::pin(async move {
-                            let mut topics = sorted_unique_topic_names(session.topic_inventory().await?)
-                                .into_iter()
-                                .map(|topic| crate::tools::topic_tools::TopicListEntry {
-                                    topic,
-                                    cluster: Some(cluster.rocketmq_cluster_name.clone()),
-                                    consumer_group: None,
-                                })
-                                .collect::<Vec<_>>();
-                            if let Some(filter) = normalized_filter(args.filter.as_deref()) {
-                                topics.retain(|entry| entry.topic.to_ascii_lowercase().contains(&filter));
-                            }
-                            let page = paginate(topics, &args.page)
-                                .map_err(|error| ToolExecutionError::InvalidArguments(error.to_string()))?;
-                            Ok(QueryPayload::complete(ListTopicsOutput {
-                                cluster: cluster.name.clone(),
-                                namesrv_addr: cluster.namesrv_addr.clone(),
-                                page,
-                                generated_at: observed_at(),
-                            }))
-                        })
-                    })
-                    .await
-                },
-            )
-            .await
+        let snapshot = self
+            .topic_inventory_snapshot(cluster.clone(), args.filter.as_deref(), &args.page)
+            .await?;
+        let entries = snapshot
+            .payload
+            .data
+            .iter()
+            .cloned()
+            .map(|topic| crate::tools::topic_tools::TopicListEntry {
+                topic,
+                cluster: Some(cluster.rocketmq_cluster_name.clone()),
+                consumer_group: None,
+            })
+            .collect::<Vec<_>>();
+        let page = self.snapshots.page(&snapshot, &entries)?;
+        Ok(query_result_from_snapshot(
+            &snapshot,
+            snapshot.payload.completeness().wrap(ListTopicsOutput {
+                cluster: cluster.name,
+                namesrv_addr: cluster.namesrv_addr,
+                page,
+                generated_at: observed_at(),
+            }),
+        ))
     }
 
     pub(crate) async fn describe_topic(
@@ -272,30 +306,14 @@ where
     ) -> Result<QueryResult<DescribeTopicOutput>, ToolExecutionError> {
         args.topic = normalized_identifier("topic", &args.topic)?;
         let cluster = self.resolve_cluster(Some(&args.cluster))?;
-        let key = self.cache_key(
-            "describe_topic",
-            &cluster.name,
-            &format!("topic={}|{}", args.topic, page_key(&args.page)),
-        );
-        let ttl = Duration::from_millis(self.config.cache.topic_list_ttl_ms);
-        self.cache
-            .get_or_try_init_cancellable(
-                key,
-                ttl,
-                &self.control.cancellation,
-                || ToolExecutionError::Cancelled,
-                || async {
-                    self.run_workflow(cluster, move |session, cluster| {
-                        Box::pin(async move {
-                            let route = session.topic_route(&args.topic).await?;
-                            let route = topic_route_output(cluster, &args.topic, route, &args.page)?;
-                            Ok(QueryPayload::complete(describe_topic_output(&route)))
-                        })
-                    })
-                    .await
-                },
-            )
-            .await
+        let snapshot = self
+            .topic_route_snapshot(cluster.clone(), args.topic.clone(), &args.page)
+            .await?;
+        let route = topic_route_output_from_snapshot(&self.snapshots, &snapshot, &cluster, &args.topic)?;
+        Ok(query_result_from_snapshot(
+            &snapshot,
+            snapshot.payload.completeness().wrap(describe_topic_output(&route)),
+        ))
     }
 
     pub(crate) async fn query_topic_route(
@@ -304,29 +322,14 @@ where
     ) -> Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError> {
         args.topic = normalized_identifier("topic", &args.topic)?;
         let cluster = self.resolve_cluster(Some(&args.cluster))?;
-        let key = self.cache_key(
-            "topic_route",
-            &cluster.name,
-            &format!("topic={}|{}", args.topic, page_key(&args.page)),
-        );
-        let ttl = Duration::from_millis(self.config.cache.topic_list_ttl_ms);
-        self.cache
-            .get_or_try_init_cancellable(
-                key,
-                ttl,
-                &self.control.cancellation,
-                || ToolExecutionError::Cancelled,
-                || async {
-                    self.run_workflow(cluster, move |session, cluster| {
-                        Box::pin(async move {
-                            let route = session.topic_route(&args.topic).await?;
-                            topic_route_output(cluster, &args.topic, route, &args.page).map(QueryPayload::complete)
-                        })
-                    })
-                    .await
-                },
-            )
-            .await
+        let snapshot = self
+            .topic_route_snapshot(cluster.clone(), args.topic.clone(), &args.page)
+            .await?;
+        let output = topic_route_output_from_snapshot(&self.snapshots, &snapshot, &cluster, &args.topic)?;
+        Ok(query_result_from_snapshot(
+            &snapshot,
+            snapshot.payload.completeness().wrap(output),
+        ))
     }
 
     pub(crate) async fn list_consumer_groups(
@@ -334,34 +337,64 @@ where
         args: ListConsumerGroupsArgs,
     ) -> Result<QueryResult<ListConsumerGroupsOutput>, ToolExecutionError> {
         let cluster = self.resolve_cluster(args.cluster.as_deref())?;
+        let snapshot = self
+            .consumer_group_inventory_snapshot(cluster.clone(), args.filter.as_deref(), false, &args.page)
+            .await?;
+        let names_page = self.snapshots.page(&snapshot, &snapshot.payload.data)?;
+        let selected_names = names_page.items.clone();
+        if selected_names.is_empty() {
+            return Ok(query_result_from_snapshot(
+                &snapshot,
+                snapshot.payload.completeness().wrap(ListConsumerGroupsOutput {
+                    cluster: cluster.name,
+                    namesrv_addr: cluster.namesrv_addr,
+                    page: Page {
+                        items: Vec::new(),
+                        count: 0,
+                        total_count: names_page.total_count,
+                        has_more: names_page.has_more,
+                        next_cursor: names_page.next_cursor,
+                    },
+                    generated_at: observed_at(),
+                }),
+            ));
+        }
         let key = self.cache_key(
-            "list_consumer_groups",
+            "consumer_group_page_enrichment",
             &cluster.name,
-            &list_key(args.filter.as_deref(), &args.page),
+            &format!(
+                "snapshot={}|cursor={}",
+                snapshot.identity(),
+                args.page.cursor.as_deref().unwrap_or("first")
+            ),
         );
         let ttl = Duration::from_millis(self.config.cache.consumer_lag_ttl_ms);
-        self.cache
+        let enrichment_snapshot = snapshot.clone();
+        let enriched = self
+            .cache
             .get_or_try_init_cancellable(
                 key,
                 ttl,
                 &self.control.cancellation,
                 || ToolExecutionError::Cancelled,
-                move || async {
-                    self.run_workflow(cluster, move |session, cluster| {
+                move || async move {
+                    self.run_workflow(cluster.clone(), move |session, cluster| {
                         Box::pin(async move {
-                            let groups = session.consumer_groups().await?;
-                            let completeness = groups.completeness();
+                            let groups = session.consumer_groups_exact(&selected_names).await?;
+                            let mut completeness = enrichment_snapshot.payload.completeness();
+                            completeness.merge(groups.completeness());
                             let mut groups = groups.data;
                             groups.sort_by(|left, right| left.group.cmp(&right.group));
-                            if let Some(filter) = normalized_filter(args.filter.as_deref()) {
-                                groups.retain(|entry| entry.group.to_ascii_lowercase().contains(&filter));
-                            }
-                            let page = paginate(groups, &args.page)
-                                .map_err(|error| ToolExecutionError::InvalidArguments(error.to_string()))?;
                             Ok(completeness.wrap(ListConsumerGroupsOutput {
                                 cluster: cluster.name.clone(),
                                 namesrv_addr: cluster.namesrv_addr.clone(),
-                                page,
+                                page: Page {
+                                    count: groups.len(),
+                                    items: groups,
+                                    total_count: names_page.total_count,
+                                    has_more: names_page.has_more,
+                                    next_cursor: names_page.next_cursor,
+                                },
                                 generated_at: observed_at(),
                             }))
                         })
@@ -369,7 +402,18 @@ where
                     .await
                 },
             )
-            .await
+            .await?;
+        Ok(QueryResult::from_payload(
+            QueryPayload::new(
+                enriched.data,
+                enriched.partial,
+                enriched.warnings,
+                enriched.source_failures,
+            ),
+            snapshot.observed_at,
+            snapshot.freshness_ms,
+            enriched.cache_status,
+        ))
     }
 
     pub(crate) async fn query_consumer_lag(
@@ -379,36 +423,90 @@ where
         args.topic = normalized_identifier("topic", &args.topic)?;
         args.consumer_group = normalized_identifier("consumer_group", &args.consumer_group)?;
         let cluster = self.resolve_cluster(Some(&args.cluster))?;
+        let snapshot = self
+            .consumer_lag_snapshot(
+                cluster.clone(),
+                args.topic.clone(),
+                args.consumer_group.clone(),
+                &args.page,
+            )
+            .await?;
+        let output =
+            consumer_lag_output_from_snapshot(&self.snapshots, &snapshot, &cluster, args.topic, args.consumer_group)?;
+        Ok(query_result_from_snapshot(
+            &snapshot,
+            snapshot.payload.completeness().wrap(output),
+        ))
+    }
+
+    pub(crate) async fn describe_consumer_group(
+        &self,
+        cluster_name: String,
+        group: String,
+    ) -> Result<QueryResult<crate::tools::consumer_tools::ConsumerGroupSummary>, ToolExecutionError> {
+        let group = normalized_identifier("consumer_group", &group)?;
+        let cluster = self.resolve_cluster(Some(&cluster_name))?;
+        let page = PageRequest {
+            limit: Some(1),
+            cursor: None,
+        };
+        let snapshot = self
+            .consumer_group_inventory_snapshot(cluster.clone(), Some(&group), true, &page)
+            .await?;
+        if snapshot.payload.data.is_empty() {
+            return Err(ToolExecutionError::InvalidArguments(format!(
+                "consumer group not found in cluster {}: {group}",
+                cluster.name
+            )));
+        }
+        let selected = snapshot.payload.data.clone();
         let key = self.cache_key(
-            "consumer_lag",
+            "consumer_group_exact_enrichment",
             &cluster.name,
-            &format!(
-                "topic={}|group={}|{}",
-                args.topic,
-                args.consumer_group,
-                page_key(&args.page)
-            ),
+            &format!("snapshot={}", snapshot.identity()),
         );
         let ttl = Duration::from_millis(self.config.cache.consumer_lag_ttl_ms);
-        self.cache
+        let inventory_completeness = snapshot.payload.completeness();
+        let enriched = self
+            .cache
             .get_or_try_init_cancellable(
                 key,
                 ttl,
                 &self.control.cancellation,
                 || ToolExecutionError::Cancelled,
-                move || async {
-                    self.run_workflow(cluster, move |session, cluster| {
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
                         Box::pin(async move {
-                            let lag = session.consumer_lag(&args.topic, &args.consumer_group).await?;
-                            let completeness = lag.completeness();
-                            consumer_lag_output(cluster, args.topic, args.consumer_group, &args.page, lag.data)
-                                .map(|output| completeness.wrap(output))
+                            let groups = session.consumer_groups_exact(&selected).await?;
+                            let mut completeness = inventory_completeness;
+                            completeness.merge(groups.completeness());
+                            let summary = groups
+                                .data
+                                .into_iter()
+                                .find(|summary| summary.group == group)
+                                .ok_or_else(|| {
+                                    ToolExecutionError::Backend(
+                                        "selected consumer group enrichment was unavailable".to_string(),
+                                    )
+                                })?;
+                            Ok(completeness.wrap(summary))
                         })
                     })
                     .await
                 },
             )
-            .await
+            .await?;
+        Ok(QueryResult::from_payload(
+            QueryPayload::new(
+                enriched.data,
+                enriched.partial,
+                enriched.warnings,
+                enriched.source_failures,
+            ),
+            snapshot.observed_at,
+            snapshot.freshness_ms,
+            enriched.cache_status,
+        ))
     }
 
     pub(crate) async fn describe_broker(
@@ -546,6 +644,169 @@ where
             .await
     }
 
+    async fn topic_inventory_snapshot(
+        &self,
+        cluster: ResolvedCluster,
+        filter: Option<&str>,
+        page: &PageRequest,
+    ) -> Result<SnapshotView<Vec<String>>, ToolExecutionError> {
+        let filter = normalized_filter(filter).unwrap_or_default();
+        let request = SnapshotRequest::try_new(
+            SnapshotKind::TopicInventory,
+            cluster.name.clone(),
+            filter.clone(),
+            page,
+            self.visibility_class.clone(),
+        )?;
+        self.snapshots
+            .get_or_load(
+                request,
+                page.cursor.as_deref(),
+                self.cursor_snapshot_ttl(),
+                self.snapshot_response_ttl(self.config.cache.topic_list_ttl_ms),
+                |topics: &Vec<String>| SnapshotWeight::inventory(topics.len()),
+                &self.control.cancellation,
+                || {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move {
+                            let mut topics = sorted_unique_topic_names(session.topic_inventory().await?);
+                            if !filter.is_empty() {
+                                topics.retain(|topic| topic.to_ascii_lowercase().contains(&filter));
+                            }
+                            Ok(QueryPayload::complete(topics))
+                        })
+                    })
+                },
+            )
+            .await
+    }
+
+    async fn consumer_group_inventory_snapshot(
+        &self,
+        cluster: ResolvedCluster,
+        filter: Option<&str>,
+        exact: bool,
+        page: &PageRequest,
+    ) -> Result<SnapshotView<Vec<String>>, ToolExecutionError> {
+        let filter = if exact {
+            filter.map(str::trim).unwrap_or_default().to_string()
+        } else {
+            normalized_filter(filter).unwrap_or_default()
+        };
+        let selection_mode = if exact {
+            SnapshotSelectionMode::ExactIdentifier
+        } else {
+            SnapshotSelectionMode::LiteralFilter
+        };
+        let request = SnapshotRequest::try_new_with_selection(
+            SnapshotKind::ConsumerGroupInventory,
+            cluster.name.clone(),
+            filter.clone(),
+            selection_mode,
+            page,
+            self.visibility_class.clone(),
+        )?;
+        self.snapshots
+            .get_or_load(
+                request,
+                page.cursor.as_deref(),
+                self.cursor_snapshot_ttl(),
+                self.snapshot_response_ttl(self.config.cache.consumer_lag_ttl_ms),
+                |groups: &Vec<String>| SnapshotWeight::inventory(groups.len()),
+                &self.control.cancellation,
+                || {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move {
+                            let groups = session.consumer_group_inventory().await?;
+                            Ok(groups.map(|mut groups| {
+                                groups.sort();
+                                groups.dedup();
+                                if !filter.is_empty() {
+                                    if exact {
+                                        groups.retain(|group| group == &filter);
+                                    } else {
+                                        groups.retain(|group| group.to_ascii_lowercase().contains(&filter));
+                                    }
+                                }
+                                groups
+                            }))
+                        })
+                    })
+                },
+            )
+            .await
+    }
+
+    async fn topic_route_snapshot(
+        &self,
+        cluster: ResolvedCluster,
+        topic: String,
+        page: &PageRequest,
+    ) -> Result<SnapshotView<SessionTopicRoute>, ToolExecutionError> {
+        let request = SnapshotRequest::try_new(
+            SnapshotKind::TopicRoute,
+            cluster.name.clone(),
+            format!("topic={topic}"),
+            page,
+            self.visibility_class.clone(),
+        )?;
+        self.snapshots
+            .get_or_load(
+                request,
+                page.cursor.as_deref(),
+                self.cursor_snapshot_ttl(),
+                self.snapshot_response_ttl(self.config.cache.topic_list_ttl_ms),
+                |route: &SessionTopicRoute| SnapshotWeight::detail(route.queues.len()),
+                &self.control.cancellation,
+                || {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.topic_route(&topic).await.map(QueryPayload::complete) })
+                    })
+                },
+            )
+            .await
+    }
+
+    async fn consumer_lag_snapshot(
+        &self,
+        cluster: ResolvedCluster,
+        topic: String,
+        consumer_group: String,
+        page: &PageRequest,
+    ) -> Result<SnapshotView<SessionConsumerLag>, ToolExecutionError> {
+        let request = SnapshotRequest::try_new(
+            SnapshotKind::ConsumerLag,
+            cluster.name.clone(),
+            format!("topic={topic}|group={consumer_group}"),
+            page,
+            self.visibility_class.clone(),
+        )?;
+        self.snapshots
+            .get_or_load(
+                request,
+                page.cursor.as_deref(),
+                self.cursor_snapshot_ttl(),
+                self.snapshot_response_ttl(self.config.cache.consumer_lag_ttl_ms),
+                |lag: &SessionConsumerLag| SnapshotWeight::detail(lag.queues.len()),
+                &self.control.cancellation,
+                || {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.consumer_lag(&topic, &consumer_group).await })
+                    })
+                },
+            )
+            .await
+    }
+
+    fn cursor_snapshot_ttl(&self) -> Duration {
+        Duration::from_millis(self.config.cache.cursor_snapshot_ttl_ms)
+    }
+
+    fn snapshot_response_ttl(&self, ttl_ms: u64) -> Option<Duration> {
+        (self.config.cache.enabled && self.config.cache.max_entries > 0 && ttl_ms > 0)
+            .then(|| Duration::from_millis(ttl_ms))
+    }
+
     async fn run_workflow<T, O>(&self, cluster: ResolvedCluster, operation: O) -> Result<T, ToolExecutionError>
     where
         T: Send,
@@ -669,6 +930,14 @@ where
         QueryFacade::list_consumer_groups(self, args).await
     }
 
+    async fn describe_consumer_group(
+        &self,
+        cluster: String,
+        group: String,
+    ) -> Result<QueryResult<crate::tools::consumer_tools::ConsumerGroupSummary>, ToolExecutionError> {
+        QueryFacade::describe_consumer_group(self, cluster, group).await
+    }
+
     async fn query_consumer_lag(
         &self,
         args: QueryConsumerLagArgs,
@@ -689,6 +958,61 @@ where
     ) -> Result<QueryResult<DiagnosisReport>, ToolExecutionError> {
         QueryFacade::diagnose_consumer_lag(self, args).await
     }
+}
+
+fn query_result_from_snapshot<S, T>(snapshot: &SnapshotView<S>, payload: QueryPayload<T>) -> QueryResult<T> {
+    QueryResult::from_payload(
+        payload,
+        snapshot.observed_at.clone(),
+        snapshot.freshness_ms,
+        snapshot.cache_status,
+    )
+}
+
+fn consumer_lag_output_from_snapshot(
+    store: &SnapshotStore,
+    snapshot: &SnapshotView<SessionConsumerLag>,
+    cluster: &ResolvedCluster,
+    topic: String,
+    consumer_group: String,
+) -> Result<QueryConsumerLagOutput, ToolExecutionError> {
+    let lag = &snapshot.payload.data;
+    let max_queue_lag = lag.queues.iter().map(|queue| queue.lag).max().unwrap_or_default();
+    let page = store.page(snapshot, &lag.queues)?;
+    Ok(QueryConsumerLagOutput {
+        cluster: cluster.name.clone(),
+        namesrv_addr: cluster.namesrv_addr.clone(),
+        topic,
+        consumer_group,
+        total_lag: lag.total_lag,
+        max_queue_lag,
+        consume_tps: lag.consume_tps,
+        inflight_total: lag.inflight_total,
+        page,
+        generated_at: observed_at(),
+    })
+}
+
+fn topic_route_output_from_snapshot(
+    store: &SnapshotStore,
+    snapshot: &SnapshotView<SessionTopicRoute>,
+    cluster: &ResolvedCluster,
+    topic: &str,
+) -> Result<QueryTopicRouteOutput, ToolExecutionError> {
+    let route = &snapshot.payload.data;
+    let read_queue_count = route.queues.iter().map(|queue| queue.read_queue_nums).sum();
+    let write_queue_count = route.queues.iter().map(|queue| queue.write_queue_nums).sum();
+    let page = store.page(snapshot, &route.queues)?;
+    Ok(QueryTopicRouteOutput {
+        cluster: cluster.name.clone(),
+        namesrv_addr: cluster.namesrv_addr.clone(),
+        topic: topic.to_string(),
+        brokers: route.brokers.clone(),
+        read_queue_count,
+        write_queue_count,
+        page,
+        generated_at: observed_at(),
+    })
 }
 
 fn consumer_lag_output(
@@ -841,38 +1165,30 @@ fn sorted_unique_topic_names(mut topics: Vec<String>) -> Vec<String> {
 }
 
 fn normalized_identifier(field: &str, value: &str) -> Result<String, ToolExecutionError> {
+    const MAX_IDENTIFIER_BYTES: usize = 255;
     let value = value.trim();
     if value.is_empty() {
         return Err(ToolExecutionError::InvalidArguments(format!(
             "{field} must not be empty"
         )));
     }
+    if value.len() > MAX_IDENTIFIER_BYTES {
+        return Err(ToolExecutionError::InvalidArguments(format!(
+            "{field} must not exceed {MAX_IDENTIFIER_BYTES} bytes"
+        )));
+    }
     Ok(value.to_string())
-}
-
-fn list_key(filter: Option<&str>, page: &PageRequest) -> String {
-    format!(
-        "filter={}|{}",
-        normalized_filter(filter).unwrap_or_default(),
-        page_key(page)
-    )
-}
-
-fn page_key(page: &PageRequest) -> String {
-    format!(
-        "limit={}|cursor={}",
-        page.limit.unwrap_or(DEFAULT_PAGE_LIMIT),
-        page.cursor.as_deref().unwrap_or_default()
-    )
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
     use std::time::Duration;
 
+    use tokio::sync::Barrier;
     use tokio_util::sync::CancellationToken;
 
     use crate::config::McpConfig;
@@ -895,9 +1211,56 @@ mod tests {
         broker_queries: AtomicUsize,
         topic_inventory_queries: AtomicUsize,
         consumer_group_queries: AtomicUsize,
+        consumer_group_inventory_queries: AtomicUsize,
+        consumer_group_enrichment_queries: AtomicUsize,
+        consumer_group_enriched_targets: AtomicUsize,
         route_queries: AtomicUsize,
         consumer_lag_queries: AtomicUsize,
         runtime_probes: AtomicUsize,
+    }
+
+    #[derive(Debug)]
+    struct TopicInventoryGate {
+        armed: AtomicBool,
+        entered: AtomicUsize,
+        release: Barrier,
+    }
+
+    impl TopicInventoryGate {
+        fn new(expected_loaders: usize) -> Self {
+            Self {
+                armed: AtomicBool::new(false),
+                entered: AtomicUsize::new(0),
+                release: Barrier::new(expected_loaders + 1),
+            }
+        }
+
+        fn arm(&self) {
+            self.entered.store(0, Ordering::SeqCst);
+            self.armed.store(true, Ordering::SeqCst);
+        }
+
+        async fn wait_if_armed(&self) {
+            if self.armed.load(Ordering::SeqCst) {
+                self.entered.fetch_add(1, Ordering::SeqCst);
+                self.release.wait().await;
+            }
+        }
+
+        async fn release(&self) {
+            self.armed.store(false, Ordering::SeqCst);
+            self.release.wait().await;
+        }
+    }
+
+    async fn wait_for_atomic_count(counter: &AtomicUsize, expected: usize) {
+        for _ in 0..10_000 {
+            if counter.load(Ordering::SeqCst) == expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), expected);
     }
 
     #[derive(Clone, Default)]
@@ -909,8 +1272,16 @@ mod tests {
         partial_sources: bool,
         hang_broker_query: bool,
         hang_topic_inventory: bool,
-        delay_topic_inventory: bool,
+        topic_inventory_gate: Option<Arc<TopicInventoryGate>>,
         fail_topic_inventory: bool,
+        many_groups: bool,
+        case_colliding_groups: bool,
+        empty_groups: bool,
+        mutating_group_inventory: bool,
+        many_route_rows: bool,
+        many_lag_rows: bool,
+        fail_group_enrichment: bool,
+        yield_snapshot_queries: bool,
     }
 
     impl AdminSessionFactory for FakeSessionFactory {
@@ -927,8 +1298,16 @@ mod tests {
                 partial_sources: self.partial_sources,
                 hang_broker_query: self.hang_broker_query,
                 hang_topic_inventory: self.hang_topic_inventory,
-                delay_topic_inventory: self.delay_topic_inventory,
+                topic_inventory_gate: self.topic_inventory_gate.clone(),
                 fail_topic_inventory: self.fail_topic_inventory,
+                many_groups: self.many_groups,
+                case_colliding_groups: self.case_colliding_groups,
+                empty_groups: self.empty_groups,
+                mutating_group_inventory: self.mutating_group_inventory,
+                many_route_rows: self.many_route_rows,
+                many_lag_rows: self.many_lag_rows,
+                fail_group_enrichment: self.fail_group_enrichment,
+                yield_snapshot_queries: self.yield_snapshot_queries,
             })
         }
     }
@@ -942,8 +1321,16 @@ mod tests {
         partial_sources: bool,
         hang_broker_query: bool,
         hang_topic_inventory: bool,
-        delay_topic_inventory: bool,
+        topic_inventory_gate: Option<Arc<TopicInventoryGate>>,
         fail_topic_inventory: bool,
+        many_groups: bool,
+        case_colliding_groups: bool,
+        empty_groups: bool,
+        mutating_group_inventory: bool,
+        many_route_rows: bool,
+        many_lag_rows: bool,
+        fail_group_enrichment: bool,
+        yield_snapshot_queries: bool,
     }
 
     impl AdminSession for FakeSession {
@@ -992,8 +1379,8 @@ mod tests {
             if self.hang_topic_inventory {
                 std::future::pending::<()>().await;
             }
-            if self.delay_topic_inventory {
-                tokio::time::sleep(Duration::from_millis(20)).await;
+            if let Some(gate) = &self.topic_inventory_gate {
+                gate.wait_if_armed().await;
             }
             if self.fail_topic_inventory {
                 return Err(ToolExecutionError::backend("topic query failed"));
@@ -1003,9 +1390,17 @@ mod tests {
 
         async fn topic_route(&mut self, _topic: &str) -> Result<SessionTopicRoute, ToolExecutionError> {
             self.counters.route_queries.fetch_add(1, Ordering::SeqCst);
+            if self.yield_snapshot_queries {
+                tokio::task::yield_now().await;
+            }
+            let queues = if self.many_route_rows {
+                (0..5).map(|index| route_queue(&format!("broker-{index}"))).collect()
+            } else {
+                vec![route_queue("broker-a")]
+            };
             Ok(SessionTopicRoute {
                 brokers: vec![route_broker(&self.cluster.name, "broker-a")],
-                queues: vec![route_queue("broker-a")],
+                queues,
             })
         }
 
@@ -1019,14 +1414,78 @@ mod tests {
             })
         }
 
+        async fn consumer_group_inventory(&mut self) -> Result<QueryPayload<Vec<String>>, ToolExecutionError> {
+            let query_index = self
+                .counters
+                .consumer_group_inventory_queries
+                .fetch_add(1, Ordering::SeqCst);
+            if self.yield_snapshot_queries {
+                tokio::task::yield_now().await;
+            }
+            let groups = if self.empty_groups {
+                Vec::new()
+            } else if self.case_colliding_groups {
+                vec!["OrderGroup".to_string(), "ordergroup".to_string()]
+            } else if self.mutating_group_inventory && query_index > 0 {
+                vec![
+                    "group-inserted".to_string(),
+                    "group-4".to_string(),
+                    "group-0".to_string(),
+                ]
+            } else if self.many_groups || self.mutating_group_inventory {
+                (0..5).map(|index| format!("group-{index}")).collect()
+            } else {
+                vec!["order-service".to_string()]
+            };
+            Ok(QueryPayload::complete(groups))
+        }
+
+        async fn consumer_groups_exact(
+            &mut self,
+            groups: &[String],
+        ) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
+            self.counters
+                .consumer_group_enrichment_queries
+                .fetch_add(1, Ordering::SeqCst);
+            self.counters
+                .consumer_group_enriched_targets
+                .fetch_add(groups.len(), Ordering::SeqCst);
+            if self.yield_snapshot_queries {
+                tokio::task::yield_now().await;
+            }
+            if self.fail_group_enrichment {
+                return Err(ToolExecutionError::backend("all group enrichment sources failed"));
+            }
+            let groups = groups.iter().map(|group| consumer_group(group)).collect::<Vec<_>>();
+            Ok(if self.partial_sources {
+                partial_payload(groups, QuerySource::ConsumerConnection, "broker-b")
+            } else {
+                QueryPayload::complete(groups)
+            })
+        }
+
         async fn consumer_lag(
             &mut self,
             _topic: &str,
             _consumer_group: &str,
         ) -> Result<QueryPayload<SessionConsumerLag>, ToolExecutionError> {
             self.counters.consumer_lag_queries.fetch_add(1, Ordering::SeqCst);
+            if self.yield_snapshot_queries {
+                tokio::task::yield_now().await;
+            }
+            let queues = if self.many_lag_rows {
+                (0..5)
+                    .map(|index| {
+                        let mut row = queue_lag("broker-a");
+                        row.queue_id = index;
+                        row
+                    })
+                    .collect()
+            } else {
+                vec![queue_lag("broker-a")]
+            };
             let lag = SessionConsumerLag {
-                queues: vec![queue_lag("broker-a")],
+                queues,
                 total_lag: 10_000,
                 consume_tps: 0.5,
                 inflight_total: 5,
@@ -1149,11 +1608,13 @@ mod tests {
 
         assert_eq!(result.topic_count, 2);
         assert_eq!(result.consumer_group_count, 1);
-        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
-        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 3);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 3);
         assert_eq!(counters.broker_queries.load(Ordering::SeqCst), 1);
         assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
-        assert_eq!(counters.consumer_group_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 0);
+        assert_eq!(counters.consumer_group_queries.load(Ordering::SeqCst), 0);
         assert_eq!(counters.route_queries.load(Ordering::SeqCst), 0);
     }
 
@@ -1174,7 +1635,7 @@ mod tests {
             .await
             .unwrap();
         assert!(overview.partial);
-        assert_eq!(overview.source_failures.len(), 2);
+        assert_eq!(overview.source_failures.len(), 1);
 
         let groups = facade
             .list_consumer_groups(ListConsumerGroupsArgs {
@@ -1380,7 +1841,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn query_facade_timeout_shuts_down_the_started_session_once() {
+    async fn query_facade_timeout_shuts_down_every_started_session_once() {
         let factory = FakeSessionFactory {
             hang_broker_query: true,
             ..Default::default()
@@ -1397,12 +1858,13 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, ToolExecutionError::TimedOut { .. }));
-        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
-        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+        let starts = counters.starts.load(Ordering::SeqCst);
+        assert!(starts > 0);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), starts);
     }
 
     #[tokio::test]
-    async fn query_facade_cancellation_shuts_down_the_started_session_once() {
+    async fn query_facade_cancellation_shuts_down_every_started_session_once() {
         let factory = FakeSessionFactory {
             hang_broker_query: true,
             ..Default::default()
@@ -1424,8 +1886,9 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, ToolExecutionError::Cancelled));
-        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
-        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+        let starts = counters.starts.load(Ordering::SeqCst);
+        assert!(starts > 0);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), starts);
     }
 
     #[tokio::test]
@@ -1533,16 +1996,21 @@ mod tests {
 
     #[tokio::test]
     async fn query_facade_singleflight_coalesces_concurrent_identical_misses() {
+        let gate = Arc::new(TopicInventoryGate::new(1));
+        gate.arm();
         let factory = FakeSessionFactory {
-            delay_topic_inventory: true,
+            topic_inventory_gate: Some(gate.clone()),
             ..Default::default()
         };
         let counters = factory.counters.clone();
         let facade = QueryFacade::with_factory(example_config(), factory);
+        let start = Arc::new(Barrier::new(9));
         let mut tasks = tokio::task::JoinSet::new();
         for _ in 0..8 {
             let facade = facade.clone();
+            let start = start.clone();
             tasks.spawn(async move {
+                start.wait().await;
                 facade
                     .list_topics(ListTopicsArgs {
                         cluster: Some("local-dev".to_string()),
@@ -1554,6 +2022,18 @@ mod tests {
                     .cache_status
             });
         }
+
+        start.wait().await;
+        wait_for_atomic_count(&gate.entered, 1).await;
+        for _ in 0..10_000 {
+            if facade.cache_metrics().coalesced_waiters == 7 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(gate.entered.load(Ordering::SeqCst), 1);
+        assert_eq!(facade.cache_metrics().coalesced_waiters, 7);
+        gate.release().await;
 
         let mut statuses = Vec::new();
         while let Some(status) = tasks.join_next().await {
@@ -1654,6 +2134,825 @@ mod tests {
         assert_eq!(counters.route_queries.load(Ordering::SeqCst), 1);
     }
 
+    #[tokio::test]
+    async fn consumer_group_walk_is_stable_when_upstream_reorders_removes_and_inserts() {
+        let factory = FakeSessionFactory {
+            mutating_group_inventory: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let mut cursor = None;
+        let mut second_cursor = None;
+        let mut observed = Vec::new();
+        loop {
+            let result = facade
+                .list_consumer_groups(ListConsumerGroupsArgs {
+                    cluster: Some("local-dev".to_string()),
+                    filter: None,
+                    page: PageRequest {
+                        limit: Some(2),
+                        cursor: cursor.clone(),
+                    },
+                })
+                .await
+                .unwrap();
+            observed.extend(result.page.items.iter().map(|group| group.group.clone()));
+            if second_cursor.is_none() {
+                second_cursor = result.page.next_cursor.clone();
+            }
+            cursor = result.page.next_cursor.clone();
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        assert_eq!(observed, ["group-0", "group-1", "group-2", "group-3", "group-4"]);
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 3);
+        assert_eq!(counters.consumer_group_enriched_targets.load(Ordering::SeqCst), 5);
+        let sessions_before_replay = counters.starts.load(Ordering::SeqCst);
+        let replay = facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: None,
+                page: PageRequest {
+                    limit: Some(2),
+                    cursor: second_cursor,
+                },
+            })
+            .await
+            .unwrap();
+        assert_eq!(replay.cache_status, CacheStatus::Hit);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), sessions_before_replay);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), sessions_before_replay);
+    }
+
+    #[tokio::test]
+    async fn empty_consumer_group_inventory_needs_no_enrichment_session() {
+        let factory = FakeSessionFactory {
+            empty_groups: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let result = facade
+            .list_consumer_groups(ListConsumerGroupsArgs::default())
+            .await
+            .unwrap();
+
+        assert!(result.page.items.is_empty());
+        assert_eq!(result.page.total_count, 0);
+        assert!(!result.page.has_more);
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 0);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn total_selected_page_enrichment_failure_is_not_cached_and_shuts_down() {
+        let factory = FakeSessionFactory {
+            fail_group_enrichment: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let error = facade
+            .list_consumer_groups(ListConsumerGroupsArgs::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ToolExecutionError::Backend(_)));
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn route_snapshot_is_shared_by_tool_description_and_query_resource_pages() {
+        let factory = FakeSessionFactory {
+            many_route_rows: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let first = facade
+            .query_topic_route(QueryTopicRouteArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                page: PageRequest {
+                    limit: Some(2),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        let cursor = first.page.next_cursor.clone().unwrap();
+        let described = facade
+            .describe_topic(DescribeTopicArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                page: PageRequest {
+                    limit: Some(2),
+                    cursor: Some(cursor.clone()),
+                },
+            })
+            .await
+            .unwrap();
+        assert_eq!(described.page.items.len(), 2);
+        let uri = format!("rocketmq://clusters/local-dev/topics/orders/route?limit=2&cursor={cursor}");
+        resources::reader::read_resource(&facade, &uri).await.unwrap();
+
+        assert_eq!(counters.route_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn consumer_lag_resource_page_reuses_tool_detail_snapshot_without_a_session() {
+        let factory = FakeSessionFactory {
+            many_lag_rows: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let first = facade
+            .query_consumer_lag(QueryConsumerLagArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                consumer_group: "order-service".to_string(),
+                page: PageRequest {
+                    limit: Some(2),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        let cursor = first.page.next_cursor.clone().unwrap();
+        let uri = format!(
+            "rocketmq://clusters/local-dev/consumer-groups/order-service/lag?topic=orders&limit=2&cursor={cursor}"
+        );
+        resources::reader::read_resource(&facade, &uri).await.unwrap();
+
+        assert_eq!(counters.consumer_lag_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn exact_consumer_group_resource_enriches_only_the_requested_group() {
+        let factory = FakeSessionFactory {
+            many_groups: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let result = resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/consumer-groups/group-4")
+            .await
+            .unwrap();
+        let payload = match &result.contents[0] {
+            rmcp::model::ResourceContents::TextResourceContents { text, .. } => {
+                serde_json::from_str::<serde_json::Value>(text).unwrap()
+            }
+            _ => panic!("resource should contain JSON text"),
+        };
+        assert_eq!(payload["consumer_group"]["group"], "group-4");
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_group_enriched_targets.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn literal_filter_then_exact_resource_use_distinct_structured_snapshot_selections() {
+        let factory = FakeSessionFactory {
+            many_groups: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+
+        let listed = facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: Some("exact=group-4".to_string()),
+                page: PageRequest {
+                    limit: Some(1),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        assert!(listed.page.items.is_empty());
+        let same_text_filter = facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: Some("group-4".to_string()),
+                page: PageRequest {
+                    limit: Some(1),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        assert_eq!(same_text_filter.page.items[0].group, "group-4");
+
+        let resource =
+            resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/consumer-groups/group-4")
+                .await
+                .unwrap();
+        let payload = match &resource.contents[0] {
+            rmcp::model::ResourceContents::TextResourceContents { text, .. } => {
+                serde_json::from_str::<serde_json::Value>(text).unwrap()
+            }
+            _ => panic!("resource should contain JSON text"),
+        };
+        assert_eq!(payload["consumer_group"]["group"], "group-4");
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 3);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn exact_resource_then_literal_filter_use_distinct_structured_snapshot_selections() {
+        let factory = FakeSessionFactory {
+            many_groups: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+
+        resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/consumer-groups/group-4")
+            .await
+            .unwrap();
+        let same_text_filter = facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: Some("group-4".to_string()),
+                page: PageRequest {
+                    limit: Some(1),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        assert_eq!(same_text_filter.page.items[0].group, "group-4");
+        let listed = facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: Some("exact=group-4".to_string()),
+                page: PageRequest {
+                    limit: Some(1),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+
+        assert!(listed.page.items.is_empty());
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 3);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn case_colliding_group_list_then_exact_resources_preserve_identity() {
+        let factory = FakeSessionFactory {
+            case_colliding_groups: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+
+        let listed = facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: Some("ordergroup".to_string()),
+                page: PageRequest {
+                    limit: Some(10),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            listed
+                .page
+                .items
+                .iter()
+                .map(|item| item.group.as_str())
+                .collect::<Vec<_>>(),
+            ["OrderGroup", "ordergroup"]
+        );
+        for group in ["OrderGroup", "ordergroup"] {
+            let resource = resources::reader::read_resource(
+                &facade,
+                &format!("rocketmq://clusters/local-dev/consumer-groups/{group}"),
+            )
+            .await
+            .unwrap();
+            assert_eq!(resource_json(resource)["consumer_group"]["group"], group);
+        }
+        let error =
+            resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/consumer-groups/ORDERGROUP")
+                .await
+                .unwrap_err();
+        assert!(error.to_string().contains("not found"));
+        assert!(!error.to_string().contains("unavailable"));
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 4);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 3);
+        assert_eq!(counters.consumer_group_enriched_targets.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn case_colliding_exact_resources_then_list_preserve_identity() {
+        let factory = FakeSessionFactory {
+            case_colliding_groups: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+
+        for group in ["OrderGroup", "ordergroup"] {
+            let resource = resources::reader::read_resource(
+                &facade,
+                &format!("rocketmq://clusters/local-dev/consumer-groups/{group}"),
+            )
+            .await
+            .unwrap();
+            assert_eq!(resource_json(resource)["consumer_group"]["group"], group);
+        }
+        let error =
+            resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/consumer-groups/ORDERGROUP")
+                .await
+                .unwrap_err();
+        assert!(error.to_string().contains("not found"));
+        assert!(!error.to_string().contains("unavailable"));
+        let listed = facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: Some("ordergroup".to_string()),
+                page: PageRequest {
+                    limit: Some(10),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            listed
+                .page
+                .items
+                .iter()
+                .map(|item| item.group.as_str())
+                .collect::<Vec<_>>(),
+            ["OrderGroup", "ordergroup"]
+        );
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 4);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 3);
+        assert_eq!(counters.consumer_group_enriched_targets.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn cursor_mismatch_fails_without_rebuilding_or_starting_a_session() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let first = facade
+            .list_topics(ListTopicsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: None,
+                page: PageRequest {
+                    limit: Some(1),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        let starts = counters.starts.load(Ordering::SeqCst);
+        let error = facade
+            .list_topics(ListTopicsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: Some("orders".to_string()),
+                page: PageRequest {
+                    limit: Some(1),
+                    cursor: first.page.next_cursor.clone(),
+                },
+            })
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("context"));
+        assert_eq!(counters.starts.load(Ordering::SeqCst), starts);
+    }
+
+    #[tokio::test]
+    async fn topic_snapshot_bypass_reloads_first_pages_without_losing_cursor_replay() {
+        let mut config = example_config();
+        config.cache.enabled = false;
+        let gate = Arc::new(TopicInventoryGate::new(2));
+        let factory = FakeSessionFactory {
+            topic_inventory_gate: Some(gate.clone()),
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config, factory);
+        let args = || ListTopicsArgs {
+            cluster: Some("local-dev".to_string()),
+            filter: None,
+            page: PageRequest {
+                limit: Some(1),
+                cursor: None,
+            },
+        };
+
+        assert_eq!(
+            facade.list_topics(args()).await.unwrap().cache_status,
+            CacheStatus::Bypass
+        );
+        assert_eq!(
+            facade.list_topics(args()).await.unwrap().cache_status,
+            CacheStatus::Bypass
+        );
+        gate.arm();
+        let start = Arc::new(Barrier::new(3));
+        let left_start = start.clone();
+        let left_facade = facade.clone();
+        let left = tokio::spawn(async move {
+            left_start.wait().await;
+            left_facade.list_topics(args()).await
+        });
+        let right_start = start.clone();
+        let right_facade = facade.clone();
+        let right = tokio::spawn(async move {
+            right_start.wait().await;
+            right_facade.list_topics(args()).await
+        });
+        start.wait().await;
+        wait_for_atomic_count(&gate.entered, 2).await;
+        assert_eq!(facade.cache_metrics().coalesced_waiters, 0);
+        gate.release().await;
+        let left = left.await.unwrap();
+        let right = right.await.unwrap();
+        assert_eq!(left.unwrap().cache_status, CacheStatus::Bypass);
+        assert_eq!(right.unwrap().cache_status, CacheStatus::Bypass);
+        let first = facade.list_topics(args()).await.unwrap();
+        let continuation = ListTopicsArgs {
+            page: PageRequest {
+                limit: Some(1),
+                cursor: first.page.next_cursor.clone(),
+            },
+            ..args()
+        };
+        assert_eq!(
+            facade.list_topics(continuation.clone()).await.unwrap().cache_status,
+            CacheStatus::Hit
+        );
+        assert_eq!(
+            facade.list_topics(continuation).await.unwrap().cache_status,
+            CacheStatus::Hit
+        );
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 5);
+        assert_eq!(facade.cache_metrics().coalesced_waiters, 0);
+    }
+
+    #[tokio::test]
+    async fn route_snapshot_zero_ttl_reloads_first_pages_without_losing_cursor_replay() {
+        let mut config = example_config();
+        config.cache.topic_list_ttl_ms = 0;
+        let factory = FakeSessionFactory {
+            many_route_rows: true,
+            yield_snapshot_queries: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config, factory);
+        let args = || QueryTopicRouteArgs {
+            cluster: "local-dev".to_string(),
+            topic: "orders".to_string(),
+            page: PageRequest {
+                limit: Some(2),
+                cursor: None,
+            },
+        };
+
+        assert_eq!(
+            facade.query_topic_route(args()).await.unwrap().cache_status,
+            CacheStatus::Bypass
+        );
+        assert_eq!(
+            facade.query_topic_route(args()).await.unwrap().cache_status,
+            CacheStatus::Bypass
+        );
+        let (left, right) = tokio::join!(facade.query_topic_route(args()), facade.query_topic_route(args()));
+        assert_eq!(left.unwrap().cache_status, CacheStatus::Bypass);
+        assert_eq!(right.unwrap().cache_status, CacheStatus::Bypass);
+        let first = facade.query_topic_route(args()).await.unwrap();
+        let continuation = QueryTopicRouteArgs {
+            page: PageRequest {
+                limit: Some(2),
+                cursor: first.page.next_cursor.clone(),
+            },
+            ..args()
+        };
+        assert_eq!(
+            facade
+                .query_topic_route(continuation.clone())
+                .await
+                .unwrap()
+                .cache_status,
+            CacheStatus::Hit
+        );
+        assert_eq!(
+            facade.query_topic_route(continuation).await.unwrap().cache_status,
+            CacheStatus::Hit
+        );
+        assert_eq!(counters.route_queries.load(Ordering::SeqCst), 5);
+        assert_eq!(facade.cache_metrics().coalesced_waiters, 0);
+    }
+
+    #[tokio::test]
+    async fn lag_snapshot_zero_ttl_reloads_first_pages_without_losing_cursor_replay() {
+        let mut config = example_config();
+        config.cache.consumer_lag_ttl_ms = 0;
+        let factory = FakeSessionFactory {
+            many_lag_rows: true,
+            yield_snapshot_queries: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config, factory);
+        let args = || QueryConsumerLagArgs {
+            cluster: "local-dev".to_string(),
+            topic: "orders".to_string(),
+            consumer_group: "order-service".to_string(),
+            page: PageRequest {
+                limit: Some(2),
+                cursor: None,
+            },
+        };
+
+        assert_eq!(
+            facade.query_consumer_lag(args()).await.unwrap().cache_status,
+            CacheStatus::Bypass
+        );
+        assert_eq!(
+            facade.query_consumer_lag(args()).await.unwrap().cache_status,
+            CacheStatus::Bypass
+        );
+        let (left, right) = tokio::join!(facade.query_consumer_lag(args()), facade.query_consumer_lag(args()));
+        assert_eq!(left.unwrap().cache_status, CacheStatus::Bypass);
+        assert_eq!(right.unwrap().cache_status, CacheStatus::Bypass);
+        let first = facade.query_consumer_lag(args()).await.unwrap();
+        let continuation = QueryConsumerLagArgs {
+            page: PageRequest {
+                limit: Some(2),
+                cursor: first.page.next_cursor.clone(),
+            },
+            ..args()
+        };
+        assert_eq!(
+            facade
+                .query_consumer_lag(continuation.clone())
+                .await
+                .unwrap()
+                .cache_status,
+            CacheStatus::Hit
+        );
+        assert_eq!(
+            facade.query_consumer_lag(continuation).await.unwrap().cache_status,
+            CacheStatus::Hit
+        );
+        assert_eq!(counters.consumer_lag_queries.load(Ordering::SeqCst), 5);
+        assert_eq!(facade.cache_metrics().coalesced_waiters, 0);
+    }
+
+    #[tokio::test]
+    async fn group_snapshot_bypass_reloads_first_pages_but_reuses_cursor_inventory() {
+        let mut config = example_config();
+        config.cache.enabled = false;
+        let factory = FakeSessionFactory {
+            many_groups: true,
+            yield_snapshot_queries: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config, factory);
+        let args = || ListConsumerGroupsArgs {
+            cluster: Some("local-dev".to_string()),
+            filter: None,
+            page: PageRequest {
+                limit: Some(2),
+                cursor: None,
+            },
+        };
+
+        assert_eq!(
+            facade.list_consumer_groups(args()).await.unwrap().cache_status,
+            CacheStatus::Bypass
+        );
+        assert_eq!(
+            facade.list_consumer_groups(args()).await.unwrap().cache_status,
+            CacheStatus::Bypass
+        );
+        let (left, right) = tokio::join!(facade.list_consumer_groups(args()), facade.list_consumer_groups(args()));
+        assert_eq!(left.unwrap().cache_status, CacheStatus::Bypass);
+        assert_eq!(right.unwrap().cache_status, CacheStatus::Bypass);
+        let first = facade.list_consumer_groups(args()).await.unwrap();
+        let continuation = ListConsumerGroupsArgs {
+            page: PageRequest {
+                limit: Some(2),
+                cursor: first.page.next_cursor.clone(),
+            },
+            ..args()
+        };
+        assert_eq!(
+            facade
+                .list_consumer_groups(continuation.clone())
+                .await
+                .unwrap()
+                .cache_status,
+            CacheStatus::Bypass
+        );
+        assert_eq!(
+            facade.list_consumer_groups(continuation).await.unwrap().cache_status,
+            CacheStatus::Bypass
+        );
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 5);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 7);
+        assert_eq!(facade.cache_metrics().coalesced_waiters, 0);
+    }
+
+    #[tokio::test]
+    async fn topic_route_and_lag_full_page_walks_use_one_base_rpc_each() {
+        let factory = FakeSessionFactory {
+            many_route_rows: true,
+            many_lag_rows: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+
+        let mut cursor = None;
+        let mut topics = Vec::new();
+        loop {
+            let result = facade
+                .list_topics(ListTopicsArgs {
+                    cluster: Some("local-dev".to_string()),
+                    filter: None,
+                    page: PageRequest { limit: Some(1), cursor },
+                })
+                .await
+                .unwrap();
+            topics.extend(result.page.items.iter().map(|topic| topic.topic.clone()));
+            cursor = result.page.next_cursor.clone();
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        let mut cursor = None;
+        let mut route_rows = 0;
+        loop {
+            let result = facade
+                .query_topic_route(QueryTopicRouteArgs {
+                    cluster: "local-dev".to_string(),
+                    topic: "orders".to_string(),
+                    page: PageRequest { limit: Some(2), cursor },
+                })
+                .await
+                .unwrap();
+            route_rows += result.page.items.len();
+            cursor = result.page.next_cursor.clone();
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        let mut cursor = None;
+        let mut lag_rows = 0;
+        loop {
+            let result = facade
+                .query_consumer_lag(QueryConsumerLagArgs {
+                    cluster: "local-dev".to_string(),
+                    topic: "orders".to_string(),
+                    consumer_group: "order-service".to_string(),
+                    page: PageRequest { limit: Some(2), cursor },
+                })
+                .await
+                .unwrap();
+            lag_rows += result.page.items.len();
+            cursor = result.page.next_cursor.clone();
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        assert_eq!(topics, ["orders", "payments"]);
+        assert_eq!(route_rows, 5);
+        assert_eq!(lag_rows, 5);
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.route_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_lag_queries.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn consumer_group_pages_share_inventory_and_enrichment_in_both_surface_orders() {
+        let factory = FakeSessionFactory {
+            many_groups: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: None,
+                page: PageRequest {
+                    limit: Some(2),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/consumer-groups?limit=2")
+            .await
+            .unwrap();
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 1);
+
+        let factory = FakeSessionFactory {
+            many_groups: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/consumer-groups?limit=2")
+            .await
+            .unwrap();
+        facade
+            .list_consumer_groups(ListConsumerGroupsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: None,
+                page: PageRequest {
+                    limit: Some(2),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        assert_eq!(counters.consumer_group_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.consumer_group_enrichment_queries.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn detail_snapshot_preserves_observation_and_full_evidence_across_surfaces() {
+        let factory = FakeSessionFactory {
+            many_lag_rows: true,
+            partial_sources: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let first = facade
+            .query_consumer_lag(QueryConsumerLagArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                consumer_group: "order-service".to_string(),
+                page: PageRequest {
+                    limit: Some(2),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+        let cursor = first.page.next_cursor.clone().unwrap();
+        let uri = format!(
+            "rocketmq://clusters/local-dev/consumer-groups/order-service/lag?topic=orders&limit=2&cursor={cursor}"
+        );
+        let resource = resource_json(resources::reader::read_resource(&facade, &uri).await.unwrap());
+        assert_eq!(resource["observed_at"], first.observed_at);
+        assert_eq!(resource["partial"], first.partial);
+        assert_eq!(resource["warnings"], serde_json::json!(first.warnings));
+        assert_eq!(resource["source_failures"], serde_json::json!(first.source_failures));
+
+        let replay = facade
+            .query_consumer_lag(QueryConsumerLagArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                consumer_group: "order-service".to_string(),
+                page: PageRequest {
+                    limit: Some(2),
+                    cursor: Some(cursor),
+                },
+            })
+            .await
+            .unwrap();
+        assert_eq!(replay.observed_at, first.observed_at);
+        assert_eq!(replay.partial, first.partial);
+        assert_eq!(replay.warnings, first.warnings);
+        assert_eq!(replay.source_failures, first.source_failures);
+        assert_eq!(replay.cache_status, CacheStatus::Hit);
+        assert_eq!(counters.consumer_lag_queries.load(Ordering::SeqCst), 1);
+    }
+
     fn example_config() -> McpConfig {
         McpConfig::load(
             std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -1661,6 +2960,13 @@ mod tests {
                 .join("mcp.example.toml"),
         )
         .unwrap()
+    }
+
+    fn resource_json(result: rmcp::model::ReadResourceResult) -> serde_json::Value {
+        match &result.contents[0] {
+            rmcp::model::ResourceContents::TextResourceContents { text, .. } => serde_json::from_str(text).unwrap(),
+            _ => panic!("resource should contain JSON text"),
+        }
     }
 
     fn example_config_with_physical_cluster() -> McpConfig {

--- a/rocketmq-ai/rocketmq-mcp/src/config.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/config.rs
@@ -267,6 +267,16 @@ impl McpConfig {
                 "cache.max_entries must be greater than zero when cache is enabled".to_string(),
             ));
         }
+        if self.cache.cursor_snapshot_ttl_ms == 0 || self.cache.cursor_snapshot_ttl_ms > 5 * 60 * 1_000 {
+            return Err(McpError::InvalidConfig(
+                "cache.cursor_snapshot_ttl_ms must be between 1 and 300000".to_string(),
+            ));
+        }
+        if !(1..=10_000).contains(&self.cache.cursor_snapshot_max_entries) {
+            return Err(McpError::InvalidConfig(
+                "cache.cursor_snapshot_max_entries must be between 1 and 10000".to_string(),
+            ));
+        }
         validate_non_empty(
             "diagnosis.consumer_lag_policy_profile",
             &self.diagnosis.consumer_lag_policy_profile,
@@ -842,10 +852,22 @@ const fn default_audit_queue_max_bytes() -> usize {
 pub struct CacheConfig {
     pub enabled: bool,
     pub max_entries: usize,
+    #[serde(default = "default_cursor_snapshot_max_entries")]
+    pub cursor_snapshot_max_entries: usize,
+    #[serde(default = "default_cursor_snapshot_ttl_ms")]
+    pub cursor_snapshot_ttl_ms: u64,
     pub cluster_overview_ttl_ms: u64,
     pub topic_list_ttl_ms: u64,
     pub broker_metrics_ttl_ms: u64,
     pub consumer_lag_ttl_ms: u64,
+}
+
+const fn default_cursor_snapshot_max_entries() -> usize {
+    256
+}
+
+const fn default_cursor_snapshot_ttl_ms() -> u64 {
+    60_000
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -1315,6 +1337,43 @@ headers = {{ "{HEADER_KEY_SENTINEL}" = ["{INVALID_VALUE_SENTINEL}"] }}
         let error = config.validate().unwrap_err();
 
         assert!(error.to_string().contains("cache.max_entries"));
+    }
+
+    #[test]
+    fn cursor_snapshot_policy_defaults_and_requires_positive_bounds() {
+        let source = std::fs::read_to_string(example_config_path()).unwrap();
+        let source = source
+            .lines()
+            .filter(|line| {
+                !line.starts_with("cursor_snapshot_max_entries") && !line.starts_with("cursor_snapshot_ttl_ms")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let parsed = config::Config::builder()
+            .add_source(config::File::from_str(&source, config::FileFormat::Toml))
+            .build()
+            .unwrap()
+            .try_deserialize::<McpConfig>()
+            .unwrap();
+        assert_eq!(parsed.cache.cursor_snapshot_max_entries, 256);
+        assert_eq!(parsed.cache.cursor_snapshot_ttl_ms, 60_000);
+
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.cache.enabled = false;
+        config.cache.cursor_snapshot_ttl_ms = 0;
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("cursor_snapshot_ttl_ms"));
+
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.cache.cursor_snapshot_max_entries = 0;
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("cursor_snapshot_max_entries"));
     }
 
     #[test]

--- a/rocketmq-ai/rocketmq-mcp/src/infrastructure.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/infrastructure.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 pub(crate) mod cache;
+pub(crate) mod snapshot;

--- a/rocketmq-ai/rocketmq-mcp/src/infrastructure/cache.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/infrastructure/cache.rs
@@ -43,6 +43,19 @@ pub(crate) struct CacheMetricsSnapshot {
     pub coalesced_waiters: u64,
 }
 
+impl CacheMetricsSnapshot {
+    pub(crate) fn merge(self, other: Self) -> Self {
+        Self {
+            hits: self.hits.saturating_add(other.hits),
+            misses: self.misses.saturating_add(other.misses),
+            bypasses: self.bypasses.saturating_add(other.bypasses),
+            evictions: self.evictions.saturating_add(other.evictions),
+            invalidations: self.invalidations.saturating_add(other.invalidations),
+            coalesced_waiters: self.coalesced_waiters.saturating_add(other.coalesced_waiters),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 struct CacheMetrics {
     hits: AtomicU64,

--- a/rocketmq-ai/rocketmq-mcp/src/infrastructure/snapshot.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/infrastructure/snapshot.rs
@@ -1,0 +1,3182 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::collections::hash_map::RandomState;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::hash::BuildHasher;
+use std::hash::Hasher;
+use std::mem::size_of;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::MutexGuard;
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+use crate::adapter::admin_session::SessionConsumerLag;
+use crate::adapter::admin_session::SessionTopicRoute;
+use crate::infrastructure::cache::CacheMetricsSnapshot;
+use crate::model::contract::observed_at;
+use crate::model::contract::CacheStatus;
+use crate::model::contract::Page;
+use crate::model::contract::PageRequest;
+use crate::model::contract::QueryPayload;
+use crate::model::contract::SourceFailure;
+use crate::model::contract::DEFAULT_PAGE_LIMIT;
+use crate::model::contract::MAX_PAGE_LIMIT;
+use crate::model::contract::SCHEMA_VERSION;
+use crate::tools::consumer_tools::QueueLag;
+use crate::tools::executor::ToolExecutionError;
+use crate::tools::topic_tools::TopicRouteBroker;
+use crate::tools::topic_tools::TopicRouteQueue;
+
+const CURSOR_PREFIX: &str = "rmq-s2-";
+const MAX_SNAPSHOT_ENTRIES: usize = 10_000;
+const MAX_SNAPSHOT_ROWS: usize = 10_000;
+const MAX_SNAPSHOT_BYTES: usize = 4 * 1024 * 1024;
+const MAX_TOTAL_BYTES: usize = 32 * 1024 * 1024;
+const MAX_SCOPE_BYTES: usize = MAX_TOTAL_BYTES / 4;
+const MAX_LIFETIME: Duration = Duration::from_secs(5 * 60);
+const MAX_CLUSTER_BYTES: usize = 255;
+const MAX_FILTER_BYTES: usize = 1_024;
+const MAX_VISIBILITY_BYTES: usize = 128;
+const MAX_CURSOR_BYTES: usize = 256;
+// These per-record envelopes deliberately exceed the smallest HashMap/BTreeMap
+// allocations and VecDeque growth blocks. Containers are compacted after removals,
+// so charging the full envelope to every live record remains conservative.
+const RETAINED_ENTRY_BOOKKEEPING_OVERHEAD: usize = 2 * 1024;
+const RETAINED_TOMBSTONE_OVERHEAD: usize = 1024;
+const RETAINED_FLIGHT_BOOKKEEPING_OVERHEAD: usize = 2 * 1024;
+const BTREE_MAP_ENTRY_ALLOCATION_OVERHEAD: usize = 1024;
+const ARC_ALLOCATION_OVERHEAD: usize = 2 * size_of::<usize>();
+
+pub(crate) trait RetainedSize {
+    fn retained_heap_size(&self) -> usize;
+
+    fn retained_size(&self) -> usize
+    where
+        Self: Sized,
+    {
+        size_of::<Self>().saturating_add(self.retained_heap_size())
+    }
+}
+
+impl RetainedSize for u8 {
+    fn retained_heap_size(&self) -> usize {
+        0
+    }
+}
+
+impl RetainedSize for String {
+    fn retained_heap_size(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl<T: RetainedSize> RetainedSize for Vec<T> {
+    fn retained_heap_size(&self) -> usize {
+        self.capacity().saturating_mul(size_of::<T>()).saturating_add(
+            self.iter()
+                .fold(0usize, |total, item| total.saturating_add(item.retained_heap_size())),
+        )
+    }
+}
+
+impl<T: RetainedSize> RetainedSize for Option<T> {
+    fn retained_heap_size(&self) -> usize {
+        self.as_ref().map_or(0, RetainedSize::retained_heap_size)
+    }
+}
+
+impl RetainedSize for BTreeMap<String, String> {
+    fn retained_heap_size(&self) -> usize {
+        self.iter().fold(0usize, |total, (key, value)| {
+            total
+                .saturating_add(size_of::<(String, String)>())
+                .saturating_add(BTREE_MAP_ENTRY_ALLOCATION_OVERHEAD)
+                .saturating_add(key.retained_heap_size())
+                .saturating_add(value.retained_heap_size())
+        })
+    }
+}
+
+impl RetainedSize for SourceFailure {
+    fn retained_heap_size(&self) -> usize {
+        self.logical_target.retained_heap_size()
+    }
+}
+
+impl RetainedSize for TopicRouteBroker {
+    fn retained_heap_size(&self) -> usize {
+        self.cluster
+            .retained_heap_size()
+            .saturating_add(self.broker_name.retained_heap_size())
+            .saturating_add(self.broker_addrs.retained_heap_size())
+            .saturating_add(self.zone_name.retained_heap_size())
+    }
+}
+
+impl RetainedSize for TopicRouteQueue {
+    fn retained_heap_size(&self) -> usize {
+        self.broker_name.retained_heap_size()
+    }
+}
+
+impl RetainedSize for QueueLag {
+    fn retained_heap_size(&self) -> usize {
+        self.topic
+            .retained_heap_size()
+            .saturating_add(self.broker_name.retained_heap_size())
+            .saturating_add(self.last_observed_at.retained_heap_size())
+            .saturating_add(self.client_ip.retained_heap_size())
+    }
+}
+
+impl RetainedSize for SessionTopicRoute {
+    fn retained_heap_size(&self) -> usize {
+        self.brokers
+            .retained_heap_size()
+            .saturating_add(self.queues.retained_heap_size())
+    }
+}
+
+impl RetainedSize for SessionConsumerLag {
+    fn retained_heap_size(&self) -> usize {
+        self.queues.retained_heap_size()
+    }
+}
+
+impl<T: RetainedSize> RetainedSize for QueryPayload<T> {
+    fn retained_heap_size(&self) -> usize {
+        self.data
+            .retained_heap_size()
+            .saturating_add(self.warnings.retained_heap_size())
+            .saturating_add(self.source_failures.retained_heap_size())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SnapshotLimits {
+    max_entries: usize,
+    max_rows: usize,
+    max_snapshot_bytes: usize,
+    max_total_bytes: usize,
+    max_scope_bytes: usize,
+    max_lifetime: Duration,
+}
+
+impl Default for SnapshotLimits {
+    fn default() -> Self {
+        Self {
+            max_entries: MAX_SNAPSHOT_ENTRIES,
+            max_rows: MAX_SNAPSHOT_ROWS,
+            max_snapshot_bytes: MAX_SNAPSHOT_BYTES,
+            max_total_bytes: MAX_TOTAL_BYTES,
+            max_scope_bytes: MAX_SCOPE_BYTES,
+            max_lifetime: MAX_LIFETIME,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SnapshotKind {
+    TopicInventory,
+    ConsumerGroupInventory,
+    TopicRoute,
+    ConsumerLag,
+}
+
+impl SnapshotKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::TopicInventory => "topic_inventory",
+            Self::ConsumerGroupInventory => "consumer_group_inventory",
+            Self::TopicRoute => "topic_route",
+            Self::ConsumerLag => "consumer_lag",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SnapshotSelectionMode {
+    LiteralFilter,
+    ExactIdentifier,
+}
+
+impl SnapshotSelectionMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::LiteralFilter => "literal_filter",
+            Self::ExactIdentifier => "exact_identifier",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SnapshotRequest {
+    kind: SnapshotKind,
+    cluster: String,
+    normalized_filter: String,
+    selection_mode: SnapshotSelectionMode,
+    page_limit: u32,
+    schema_version: &'static str,
+    visibility: String,
+}
+
+impl SnapshotRequest {
+    pub(crate) fn try_new(
+        kind: SnapshotKind,
+        cluster: impl Into<String>,
+        normalized_filter: impl Into<String>,
+        page: &PageRequest,
+        visibility: impl Into<String>,
+    ) -> Result<Self, SnapshotError> {
+        Self::try_new_with_selection(
+            kind,
+            cluster,
+            normalized_filter,
+            SnapshotSelectionMode::LiteralFilter,
+            page,
+            visibility,
+        )
+    }
+
+    pub(crate) fn try_new_with_selection(
+        kind: SnapshotKind,
+        cluster: impl Into<String>,
+        normalized_filter: impl Into<String>,
+        selection_mode: SnapshotSelectionMode,
+        page: &PageRequest,
+        visibility: impl Into<String>,
+    ) -> Result<Self, SnapshotError> {
+        let page_limit = page.limit.unwrap_or(DEFAULT_PAGE_LIMIT);
+        if !(1..=MAX_PAGE_LIMIT).contains(&page_limit) {
+            return Err(SnapshotError::InvalidLimit);
+        }
+        let cluster = cluster.into();
+        let normalized_filter = normalized_filter.into();
+        let visibility = visibility.into();
+        if cluster.trim().is_empty()
+            || cluster.len() > MAX_CLUSTER_BYTES
+            || normalized_filter.len() > MAX_FILTER_BYTES
+            || visibility.trim().is_empty()
+            || visibility.len() > MAX_VISIBILITY_BYTES
+        {
+            return Err(SnapshotError::ContextTooLarge);
+        }
+        Ok(Self {
+            kind,
+            cluster,
+            normalized_filter,
+            selection_mode,
+            page_limit,
+            schema_version: SCHEMA_VERSION,
+            visibility,
+        })
+    }
+
+    fn scope(&self) -> (&str, &str) {
+        (&self.cluster, &self.visibility)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SnapshotWeight {
+    entries: usize,
+    rows: usize,
+}
+
+impl SnapshotWeight {
+    pub(crate) const fn inventory(entries: usize) -> Self {
+        Self { entries, rows: 0 }
+    }
+
+    pub(crate) const fn detail(rows: usize) -> Self {
+        Self { entries: 1, rows }
+    }
+}
+
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapshotError {
+    #[error("limit must be between 1 and {MAX_PAGE_LIMIT}")]
+    InvalidLimit,
+    #[error("snapshot query context is blank or exceeds its bounded size")]
+    ContextTooLarge,
+    #[error("cursor is invalid or has been tampered with")]
+    InvalidCursor,
+    #[error("cursor snapshot has expired")]
+    Expired,
+    #[error("cursor snapshot was evicted")]
+    Evicted,
+    #[error("cursor snapshot was invalidated")]
+    Invalidated,
+    #[error("cursor does not match the requested query context")]
+    ContextMismatch,
+    #[error("cursor does not match the requested page contract")]
+    PageContractMismatch,
+    #[error("snapshot exceeds the bounded entry budget")]
+    EntryBudgetExceeded,
+    #[error("snapshot exceeds the bounded row budget")]
+    RowBudgetExceeded,
+    #[error("snapshot exceeds the bounded byte budget")]
+    ByteBudgetExceeded,
+}
+
+impl From<SnapshotError> for ToolExecutionError {
+    fn from(error: SnapshotError) -> Self {
+        ToolExecutionError::InvalidArguments(error.to_string())
+    }
+}
+
+#[derive(Debug, Default)]
+struct SnapshotMetrics {
+    hits: AtomicU64,
+    misses: AtomicU64,
+    bypasses: AtomicU64,
+    evictions: AtomicU64,
+    invalidations: AtomicU64,
+    coalesced_waiters: AtomicU64,
+}
+
+#[derive(Clone)]
+pub(crate) struct SnapshotStore {
+    inner: Arc<SnapshotStoreInner>,
+}
+
+struct SnapshotStoreInner {
+    capacity: usize,
+    per_scope_capacity: usize,
+    limits: SnapshotLimits,
+    generation: AtomicU64,
+    sequence: AtomicU64,
+    flight_sequence: AtomicU64,
+    primary_key: RandomState,
+    secondary_key: RandomState,
+    state: StdMutex<StoreState>,
+    metrics: SnapshotMetrics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SnapshotKey {
+    request: SnapshotRequest,
+    generation: u64,
+}
+
+#[derive(Default)]
+struct StoreState {
+    snapshots: SnapshotState,
+    flights: FlightState,
+}
+
+#[derive(Default)]
+struct SnapshotState {
+    entries: HashMap<Arc<str>, SnapshotEntry>,
+    insertion_order: VecDeque<Arc<str>>,
+    tombstones: HashMap<Arc<str>, TombstoneReason>,
+    tombstone_order: VecDeque<Arc<str>>,
+    total_bytes: usize,
+}
+
+#[derive(Default)]
+struct FlightState {
+    joinable: HashMap<SnapshotKey, u64>,
+    records: HashMap<u64, FlightRecord>,
+    total_bytes: usize,
+}
+
+struct FlightRecord {
+    key: SnapshotKey,
+    cell: Arc<FlightCell>,
+    bytes: usize,
+    phase: FlightPhase,
+    outcome: FlightOutcome,
+}
+
+enum FlightPhase {
+    Loading { participants: usize },
+    Completed { remaining: usize },
+}
+
+struct FlightCell {
+    completed: Notify,
+}
+
+enum FlightOutcome {
+    Loading,
+    Success(Arc<str>),
+    Failure(SharedFlightFailure),
+}
+
+struct FlightTicket {
+    inner: Arc<SnapshotStoreInner>,
+    id: u64,
+    cell: Arc<FlightCell>,
+    leader: bool,
+}
+
+impl std::fmt::Debug for FlightTicket {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FlightTicket")
+            .field("id", &self.id)
+            .field("leader", &self.leader)
+            .finish_non_exhaustive()
+    }
+}
+
+enum BeginFlight<T> {
+    Cached(SnapshotView<T>),
+    Leader(FlightTicket),
+    Waiter(FlightTicket),
+}
+
+#[derive(Clone, Copy)]
+enum SharedFlightFailure {
+    InvalidArguments,
+    Backend,
+    PermissionDenied,
+    UnauthorizedScope,
+    TenantMismatch,
+    ClusterNotAllowed,
+    RateLimited,
+    ChangePlanningDisabled,
+    Internal,
+    OutputTooLarge { actual_bytes: usize, max_bytes: usize },
+    TimedOut { timeout_ms: u64 },
+    Cancelled,
+}
+
+impl SharedFlightFailure {
+    fn from_error(error: &ToolExecutionError) -> Self {
+        match error {
+            ToolExecutionError::InvalidArguments(_) => Self::InvalidArguments,
+            ToolExecutionError::Backend(_) => Self::Backend,
+            ToolExecutionError::PermissionDenied(_) => Self::PermissionDenied,
+            ToolExecutionError::UnauthorizedScope(_) => Self::UnauthorizedScope,
+            ToolExecutionError::TenantMismatch(_) => Self::TenantMismatch,
+            ToolExecutionError::ClusterNotAllowed(_) => Self::ClusterNotAllowed,
+            ToolExecutionError::RateLimited(_) => Self::RateLimited,
+            ToolExecutionError::ChangePlanningDisabled(_) => Self::ChangePlanningDisabled,
+            ToolExecutionError::Internal(_) => Self::Internal,
+            ToolExecutionError::OutputTooLarge {
+                actual_bytes,
+                max_bytes,
+            } => Self::OutputTooLarge {
+                actual_bytes: *actual_bytes,
+                max_bytes: *max_bytes,
+            },
+            ToolExecutionError::TimedOut { timeout_ms } => Self::TimedOut {
+                timeout_ms: *timeout_ms,
+            },
+            ToolExecutionError::Cancelled => Self::Cancelled,
+        }
+    }
+
+    fn into_error(self) -> ToolExecutionError {
+        const MESSAGE: &str = "coalesced upstream load failed";
+        match self {
+            Self::InvalidArguments => ToolExecutionError::InvalidArguments(MESSAGE.to_string()),
+            Self::Backend => ToolExecutionError::Backend(MESSAGE.to_string()),
+            Self::PermissionDenied => ToolExecutionError::PermissionDenied(MESSAGE.to_string()),
+            Self::UnauthorizedScope => ToolExecutionError::UnauthorizedScope(MESSAGE.to_string()),
+            Self::TenantMismatch => ToolExecutionError::TenantMismatch(MESSAGE.to_string()),
+            Self::ClusterNotAllowed => ToolExecutionError::ClusterNotAllowed(MESSAGE.to_string()),
+            Self::RateLimited => ToolExecutionError::RateLimited(MESSAGE.to_string()),
+            Self::ChangePlanningDisabled => ToolExecutionError::ChangePlanningDisabled(MESSAGE.to_string()),
+            Self::Internal => ToolExecutionError::Internal(MESSAGE.to_string()),
+            Self::OutputTooLarge {
+                actual_bytes,
+                max_bytes,
+            } => ToolExecutionError::OutputTooLarge {
+                actual_bytes,
+                max_bytes,
+            },
+            Self::TimedOut { timeout_ms } => ToolExecutionError::TimedOut { timeout_ms },
+            Self::Cancelled => ToolExecutionError::Cancelled,
+        }
+    }
+}
+
+struct SnapshotEntry {
+    key: SnapshotKey,
+    value: Arc<dyn Any + Send + Sync>,
+    observed_at: String,
+    inserted_at: Instant,
+    reusable_until: Option<Instant>,
+    expires_at: Instant,
+    bytes: usize,
+    pinned_by_flight: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TombstoneReason {
+    Expired,
+    Evicted,
+    Invalidated,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SnapshotView<T> {
+    id: Arc<str>,
+    request: SnapshotRequest,
+    generation: u64,
+    position: usize,
+    pub(crate) payload: QueryPayload<T>,
+    pub(crate) observed_at: String,
+    pub(crate) freshness_ms: u64,
+    pub(crate) cache_status: CacheStatus,
+}
+
+impl<T> SnapshotView<T> {
+    pub(crate) fn identity(&self) -> &str {
+        &self.id
+    }
+}
+
+impl SnapshotStore {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self::with_limits(capacity, SnapshotLimits::default())
+    }
+
+    fn with_limits(capacity: usize, limits: SnapshotLimits) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            inner: Arc::new(SnapshotStoreInner {
+                capacity,
+                per_scope_capacity: (capacity / 4).max(1),
+                limits,
+                generation: AtomicU64::new(0),
+                sequence: AtomicU64::new(0),
+                flight_sequence: AtomicU64::new(0),
+                primary_key: RandomState::new(),
+                secondary_key: RandomState::new(),
+                state: StdMutex::new(StoreState::default()),
+                metrics: SnapshotMetrics::default(),
+            }),
+        }
+    }
+
+    pub(crate) async fn get_or_load<T, Load, LoadFuture>(
+        &self,
+        request: SnapshotRequest,
+        cursor: Option<&str>,
+        cursor_ttl: Duration,
+        response_cache_ttl: Option<Duration>,
+        weight: impl FnOnce(&T) -> SnapshotWeight,
+        cancellation: &CancellationToken,
+        load: Load,
+    ) -> Result<SnapshotView<T>, ToolExecutionError>
+    where
+        T: Clone + RetainedSize + Send + Sync + 'static,
+        Load: FnOnce() -> LoadFuture,
+        LoadFuture: Future<Output = Result<QueryPayload<T>, ToolExecutionError>>,
+    {
+        if let Some(cursor) = cursor {
+            return self.resolve_cursor(&request, cursor).map_err(Into::into);
+        }
+
+        let cursor_ttl = cursor_ttl.min(self.inner.limits.max_lifetime);
+        if cursor_ttl.is_zero() {
+            return Err(SnapshotError::Expired.into());
+        }
+        let response_cache_ttl = response_cache_ttl
+            .filter(|ttl| !ttl.is_zero())
+            .map(|ttl| ttl.min(cursor_ttl));
+        let generation = self.inner.generation.load(Ordering::Acquire);
+        let key = SnapshotKey {
+            request: request.clone(),
+            generation,
+        };
+        let ticket = if response_cache_ttl.is_some() {
+            match self.begin_flight::<T>(&key)? {
+                BeginFlight::Cached(view) => return Ok(view),
+                BeginFlight::Leader(ticket) => Some(ticket),
+                BeginFlight::Waiter(ticket) => {
+                    self.inner.metrics.coalesced_waiters.fetch_add(1, Ordering::Relaxed);
+                    return ticket.wait::<T>(&key, cancellation).await;
+                }
+            }
+        } else {
+            None
+        };
+
+        if cancellation.is_cancelled() {
+            return Err(ToolExecutionError::Cancelled);
+        }
+
+        let payload = match load().await {
+            Ok(payload) => payload,
+            Err(error) => {
+                if let Some(ticket) = ticket.as_ref() {
+                    self.finish_failure(ticket, SharedFlightFailure::from_error(&error));
+                }
+                return Err(error);
+            }
+        };
+        let snapshot_weight = weight(&payload.data);
+        let budget_error = if snapshot_weight.entries > self.inner.limits.max_entries {
+            Some(SnapshotError::EntryBudgetExceeded)
+        } else if snapshot_weight.rows > self.inner.limits.max_rows {
+            Some(SnapshotError::RowBudgetExceeded)
+        } else {
+            None
+        };
+        if let Some(error) = budget_error {
+            let tool_error: ToolExecutionError = error.into();
+            if let Some(ticket) = ticket.as_ref() {
+                self.finish_failure(ticket, SharedFlightFailure::from_error(&tool_error));
+            }
+            return Err(tool_error);
+        }
+        let observed_at = observed_at();
+        let id = self.snapshot_id(&key);
+        let bytes = retained_entry_bytes(&payload, &key, &id, &observed_at);
+        if bytes > self.inner.limits.max_snapshot_bytes
+            || bytes > self.inner.limits.max_scope_bytes
+            || bytes > self.inner.limits.max_total_bytes
+        {
+            let error: ToolExecutionError = SnapshotError::ByteBudgetExceeded.into();
+            if let Some(ticket) = ticket.as_ref() {
+                self.finish_failure(ticket, SharedFlightFailure::from_error(&error));
+            }
+            return Err(error);
+        }
+        let inserted_at = Instant::now();
+        if let Some(ticket) = ticket.as_ref() {
+            if let Err(error) = self.finish_success(
+                ticket,
+                id.clone(),
+                Arc::new(payload.clone()),
+                observed_at.clone(),
+                inserted_at,
+                cursor_ttl,
+                response_cache_ttl,
+                bytes,
+            ) {
+                return Err(error.into());
+            }
+            self.inner.metrics.misses.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.insert(
+                id.clone(),
+                key.clone(),
+                Arc::new(payload.clone()),
+                observed_at.clone(),
+                inserted_at,
+                cursor_ttl,
+                response_cache_ttl,
+                bytes,
+                generation,
+            )?;
+            self.inner.metrics.bypasses.fetch_add(1, Ordering::Relaxed);
+        }
+        let cache_status = if response_cache_ttl.is_some() {
+            CacheStatus::Miss
+        } else {
+            CacheStatus::Bypass
+        };
+        Ok(SnapshotView {
+            id,
+            request,
+            generation,
+            position: 0,
+            payload,
+            observed_at,
+            freshness_ms: 0,
+            cache_status,
+        })
+    }
+
+    pub(crate) fn page<T: Clone>(
+        &self,
+        view: &SnapshotView<impl Clone>,
+        items: &[T],
+    ) -> Result<Page<T>, SnapshotError> {
+        let total_count = items.len();
+        if view.position > total_count {
+            return Err(SnapshotError::InvalidCursor);
+        }
+        let end = view
+            .position
+            .saturating_add(view.request.page_limit as usize)
+            .min(total_count);
+        let page_items = items[view.position..end].to_vec();
+        let count = page_items.len();
+        let has_more = end < total_count;
+        let next_cursor = has_more.then(|| self.encode_cursor(&view.id, end, view.generation));
+        Ok(Page {
+            items: page_items,
+            count,
+            total_count,
+            has_more,
+            next_cursor,
+        })
+    }
+
+    pub(crate) fn metrics(&self) -> CacheMetricsSnapshot {
+        CacheMetricsSnapshot {
+            hits: self.inner.metrics.hits.load(Ordering::Relaxed),
+            misses: self.inner.metrics.misses.load(Ordering::Relaxed),
+            bypasses: self.inner.metrics.bypasses.load(Ordering::Relaxed),
+            evictions: self.inner.metrics.evictions.load(Ordering::Relaxed),
+            invalidations: self.inner.metrics.invalidations.load(Ordering::Relaxed),
+            coalesced_waiters: self.inner.metrics.coalesced_waiters.load(Ordering::Relaxed),
+        }
+    }
+
+    pub(crate) async fn clear(&self) -> usize {
+        let mut store = self.lock_state();
+        // The store lock is the invalidation linearization point shared with
+        // flight admission and completion.
+        self.inner.generation.fetch_add(1, Ordering::AcqRel);
+        let completed_cells = store
+            .flights
+            .records
+            .values_mut()
+            .filter_map(|record| match record.phase {
+                FlightPhase::Completed { .. } => {
+                    if matches!(record.outcome, FlightOutcome::Success(_)) {
+                        record.outcome = FlightOutcome::Failure(SharedFlightFailure::InvalidArguments);
+                    }
+                    Some(record.cell.clone())
+                }
+                FlightPhase::Loading { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        let state = &mut store.snapshots;
+        let ids = state.entries.keys().cloned().collect::<Vec<_>>();
+        let removed = ids.len();
+        for id in ids {
+            remove_entry(
+                state,
+                &id,
+                Some(TombstoneReason::Invalidated),
+                self.tombstone_capacity(),
+            );
+        }
+        compact_state_containers(state);
+        self.inner.metrics.invalidations.fetch_add(1, Ordering::Relaxed);
+        drop(store);
+        for cell in completed_cells {
+            cell.completed.notify_waiters();
+        }
+        removed
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, StoreState> {
+        self.inner.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn get_by_key_locked<T>(&self, state: &mut SnapshotState, key: &SnapshotKey) -> Option<SnapshotView<T>>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        purge_expired(state, self.tombstone_capacity());
+        let now = Instant::now();
+        let id = state.insertion_order.iter().rev().find_map(|id| {
+            state
+                .entries
+                .get(id)
+                .filter(|entry| entry.key == *key && entry.reusable_until.is_some_and(|until| until > now))
+                .map(|_| id.clone())
+        })?;
+        let entry = state.entries.get(&id)?;
+        let payload = entry.value.downcast_ref::<QueryPayload<T>>()?.clone();
+        let freshness_ms = Instant::now()
+            .saturating_duration_since(entry.inserted_at)
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        self.inner.metrics.hits.fetch_add(1, Ordering::Relaxed);
+        Some(SnapshotView {
+            id,
+            request: key.request.clone(),
+            generation: key.generation,
+            position: 0,
+            payload,
+            observed_at: entry.observed_at.clone(),
+            freshness_ms,
+            cache_status: CacheStatus::Hit,
+        })
+    }
+
+    fn resolve_cursor<T>(&self, request: &SnapshotRequest, cursor: &str) -> Result<SnapshotView<T>, SnapshotError>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        let claims = self.decode_cursor(cursor)?;
+        let mut store = self.lock_state();
+        let state = &mut store.snapshots;
+        purge_expired(state, self.tombstone_capacity());
+        if let Some(entry) = state.entries.get(claims.id.as_str()) {
+            return self.view_from_entry(request, &claims, entry);
+        }
+        Err(match state.tombstones.get(claims.id.as_str()) {
+            Some(TombstoneReason::Expired) => SnapshotError::Expired,
+            Some(TombstoneReason::Evicted) => SnapshotError::Evicted,
+            Some(TombstoneReason::Invalidated) => SnapshotError::Invalidated,
+            None => SnapshotError::InvalidCursor,
+        })
+    }
+
+    fn view_from_entry<T>(
+        &self,
+        request: &SnapshotRequest,
+        claims: &CursorClaims,
+        entry: &SnapshotEntry,
+    ) -> Result<SnapshotView<T>, SnapshotError>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        if claims.generation != entry.key.generation {
+            return Err(SnapshotError::InvalidCursor);
+        }
+        validate_request(request, &entry.key.request)?;
+        let payload = entry
+            .value
+            .downcast_ref::<QueryPayload<T>>()
+            .ok_or(SnapshotError::ContextMismatch)?
+            .clone();
+        let freshness_ms = Instant::now()
+            .saturating_duration_since(entry.inserted_at)
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        self.inner.metrics.hits.fetch_add(1, Ordering::Relaxed);
+        Ok(SnapshotView {
+            id: Arc::from(claims.id.as_str()),
+            request: request.clone(),
+            generation: claims.generation,
+            position: claims.position,
+            payload,
+            observed_at: entry.observed_at.clone(),
+            freshness_ms,
+            cache_status: CacheStatus::Hit,
+        })
+    }
+
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "snapshot retention metadata is validated together"
+    )]
+    fn insert(
+        &self,
+        id: Arc<str>,
+        key: SnapshotKey,
+        value: Arc<dyn Any + Send + Sync>,
+        observed_at: String,
+        inserted_at: Instant,
+        cursor_ttl: Duration,
+        response_cache_ttl: Option<Duration>,
+        bytes: usize,
+        generation: u64,
+    ) -> Result<(), SnapshotError> {
+        let mut store = self.lock_state();
+        if self.inner.generation.load(Ordering::Acquire) != generation {
+            return Err(SnapshotError::Invalidated);
+        }
+        let StoreState { snapshots, flights } = &mut *store;
+        purge_expired(snapshots, self.tombstone_capacity());
+        let scope = key.request.scope();
+        let mut evicted_any = false;
+        while scope_entry_count(snapshots, scope).saturating_add(flight_scope_count(flights, scope))
+            >= self.inner.per_scope_capacity
+            || scope_bytes(snapshots, scope)
+                .saturating_add(flight_scope_bytes(flights, scope))
+                .saturating_add(bytes)
+                > self.inner.limits.max_scope_bytes
+        {
+            let Some(oldest) = oldest_in_scope(snapshots, scope) else {
+                break;
+            };
+            remove_entry(
+                snapshots,
+                &oldest,
+                Some(TombstoneReason::Evicted),
+                self.tombstone_capacity(),
+            );
+            self.inner.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+            evicted_any = true;
+        }
+        if scope_entry_count(snapshots, scope).saturating_add(flight_scope_count(flights, scope))
+            >= self.inner.per_scope_capacity
+        {
+            return Err(SnapshotError::EntryBudgetExceeded);
+        }
+        if scope_bytes(snapshots, scope)
+            .saturating_add(flight_scope_bytes(flights, scope))
+            .saturating_add(bytes)
+            > self.inner.limits.max_scope_bytes
+        {
+            return Err(SnapshotError::ByteBudgetExceeded);
+        }
+        while snapshots.entries.len().saturating_add(flights.records.len()) >= self.inner.capacity
+            || snapshots
+                .total_bytes
+                .saturating_add(flights.total_bytes)
+                .saturating_add(bytes)
+                > self.inner.limits.max_total_bytes
+        {
+            let Some(oldest) = oldest_evictable(snapshots) else {
+                break;
+            };
+            remove_entry(
+                snapshots,
+                &oldest,
+                Some(TombstoneReason::Evicted),
+                self.tombstone_capacity(),
+            );
+            self.inner.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+            evicted_any = true;
+        }
+        if evicted_any {
+            compact_state_containers(snapshots);
+        }
+        trim_tombstones_for_bytes(
+            snapshots,
+            flights.total_bytes.saturating_add(bytes),
+            self.inner.limits.max_total_bytes,
+        );
+        if snapshots.entries.len().saturating_add(flights.records.len()) >= self.inner.capacity {
+            return Err(SnapshotError::EntryBudgetExceeded);
+        }
+        if snapshots
+            .total_bytes
+            .saturating_add(flights.total_bytes)
+            .saturating_add(bytes)
+            > self.inner.limits.max_total_bytes
+        {
+            return Err(SnapshotError::ByteBudgetExceeded);
+        }
+        snapshots.insertion_order.push_back(id.clone());
+        snapshots.total_bytes = snapshots.total_bytes.saturating_add(bytes);
+        snapshots.entries.insert(
+            id,
+            SnapshotEntry {
+                key,
+                value,
+                observed_at,
+                inserted_at,
+                reusable_until: response_cache_ttl.map(|ttl| inserted_at + ttl),
+                expires_at: inserted_at + cursor_ttl,
+                bytes,
+                pinned_by_flight: false,
+            },
+        );
+        Ok(())
+    }
+
+    fn begin_flight<T>(&self, key: &SnapshotKey) -> Result<BeginFlight<T>, SnapshotError>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        let mut store = self.lock_state();
+        if self.inner.generation.load(Ordering::Acquire) != key.generation {
+            return Err(SnapshotError::Invalidated);
+        }
+        let StoreState { snapshots, flights } = &mut *store;
+        purge_expired(snapshots, self.tombstone_capacity());
+        if let Some(view) = self.get_by_key_locked(snapshots, key) {
+            return Ok(BeginFlight::Cached(view));
+        }
+        if let Some(id) = flights.joinable.get(key).copied() {
+            if let Some(record) = flights.records.get_mut(&id) {
+                if let FlightPhase::Loading { participants } = &mut record.phase {
+                    *participants = participants.saturating_add(1);
+                    return Ok(BeginFlight::Waiter(FlightTicket {
+                        inner: self.inner.clone(),
+                        id,
+                        cell: record.cell.clone(),
+                        leader: false,
+                    }));
+                }
+            }
+            flights.joinable.remove(key);
+        }
+
+        let bytes = retained_flight_bytes(key);
+        if bytes > self.inner.limits.max_scope_bytes || bytes > self.inner.limits.max_total_bytes {
+            return Err(SnapshotError::ByteBudgetExceeded);
+        }
+        let scope = key.request.scope();
+        // Every flight record owns an active loading or completed cohort and is
+        // therefore non-evictable. Only retained snapshots can make room.
+        let mut evicted_any = false;
+        while scope_entry_count(snapshots, scope).saturating_add(flight_scope_count(flights, scope))
+            >= self.inner.per_scope_capacity
+            || scope_bytes(snapshots, scope)
+                .saturating_add(flight_scope_bytes(flights, scope))
+                .saturating_add(bytes)
+                > self.inner.limits.max_scope_bytes
+        {
+            let Some(oldest) = oldest_in_scope(snapshots, scope) else {
+                break;
+            };
+            remove_entry(
+                snapshots,
+                &oldest,
+                Some(TombstoneReason::Evicted),
+                self.tombstone_capacity(),
+            );
+            self.inner.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+            evicted_any = true;
+        }
+        while snapshots.entries.len().saturating_add(flights.records.len()) >= self.inner.capacity
+            || snapshots
+                .total_bytes
+                .saturating_add(flights.total_bytes)
+                .saturating_add(bytes)
+                > self.inner.limits.max_total_bytes
+        {
+            let Some(oldest) = oldest_evictable(snapshots) else {
+                break;
+            };
+            remove_entry(
+                snapshots,
+                &oldest,
+                Some(TombstoneReason::Evicted),
+                self.tombstone_capacity(),
+            );
+            self.inner.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+            evicted_any = true;
+        }
+        if evicted_any {
+            compact_state_containers(snapshots);
+        }
+        trim_tombstones_for_bytes(
+            snapshots,
+            flights.total_bytes.saturating_add(bytes),
+            self.inner.limits.max_total_bytes,
+        );
+        if scope_entry_count(snapshots, scope).saturating_add(flight_scope_count(flights, scope))
+            >= self.inner.per_scope_capacity
+            || flights.records.len() >= self.inner.capacity
+            || snapshots.entries.len().saturating_add(flights.records.len()) >= self.inner.capacity
+        {
+            return Err(SnapshotError::EntryBudgetExceeded);
+        }
+        if scope_bytes(snapshots, scope)
+            .saturating_add(flight_scope_bytes(flights, scope))
+            .saturating_add(bytes)
+            > self.inner.limits.max_scope_bytes
+            || snapshots
+                .total_bytes
+                .saturating_add(flights.total_bytes)
+                .saturating_add(bytes)
+                > self.inner.limits.max_total_bytes
+        {
+            return Err(SnapshotError::ByteBudgetExceeded);
+        }
+
+        let id = self.inner.flight_sequence.fetch_add(1, Ordering::Relaxed);
+        let cell = Arc::new(FlightCell {
+            completed: Notify::new(),
+        });
+        flights.joinable.insert(key.clone(), id);
+        flights.records.insert(
+            id,
+            FlightRecord {
+                key: key.clone(),
+                cell: cell.clone(),
+                bytes,
+                phase: FlightPhase::Loading { participants: 1 },
+                outcome: FlightOutcome::Loading,
+            },
+        );
+        flights.total_bytes = flights.total_bytes.saturating_add(bytes);
+        Ok(BeginFlight::Leader(FlightTicket {
+            inner: self.inner.clone(),
+            id,
+            cell,
+            leader: true,
+        }))
+    }
+
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "flight completion transfers validated snapshot metadata atomically"
+    )]
+    fn finish_success(
+        &self,
+        ticket: &FlightTicket,
+        id: Arc<str>,
+        value: Arc<dyn Any + Send + Sync>,
+        observed_at: String,
+        inserted_at: Instant,
+        cursor_ttl: Duration,
+        response_cache_ttl: Option<Duration>,
+        entry_bytes: usize,
+    ) -> Result<(), SnapshotError> {
+        let mut store = self.lock_state();
+        let StoreState { snapshots, flights } = &mut *store;
+        let Some(record) = flights.records.get(&ticket.id) else {
+            return Err(SnapshotError::Invalidated);
+        };
+        let FlightPhase::Loading { participants } = record.phase else {
+            return Err(SnapshotError::Invalidated);
+        };
+        if !ticket.leader || !Arc::ptr_eq(&ticket.cell, &record.cell) {
+            return Err(SnapshotError::Invalidated);
+        }
+        let key = record.key.clone();
+        let old_bytes = record.bytes;
+        let keeps_terminal_flight = participants > 1;
+        let terminal_bytes = keeps_terminal_flight.then(|| retained_terminal_flight_bytes(&key, &id));
+        let incoming_bytes = entry_bytes.saturating_add(terminal_bytes.unwrap_or(0));
+        let error = if self.inner.generation.load(Ordering::Acquire) != key.generation {
+            Some(SnapshotError::Invalidated)
+        } else if incoming_bytes > self.inner.limits.max_scope_bytes
+            || incoming_bytes > self.inner.limits.max_total_bytes
+        {
+            Some(SnapshotError::ByteBudgetExceeded)
+        } else {
+            purge_expired(snapshots, self.tombstone_capacity());
+            let scope = key.request.scope();
+            let mut evicted_any = false;
+            while scope_entry_count(snapshots, scope)
+                .saturating_add(flight_scope_count(flights, scope))
+                .saturating_add(usize::from(keeps_terminal_flight))
+                > self.inner.per_scope_capacity
+                || scope_bytes(snapshots, scope)
+                    .saturating_add(flight_scope_bytes(flights, scope))
+                    .saturating_sub(old_bytes)
+                    .saturating_add(incoming_bytes)
+                    > self.inner.limits.max_scope_bytes
+            {
+                let Some(oldest) = oldest_in_scope(snapshots, scope) else {
+                    break;
+                };
+                remove_entry(
+                    snapshots,
+                    &oldest,
+                    Some(TombstoneReason::Evicted),
+                    self.tombstone_capacity(),
+                );
+                self.inner.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+                evicted_any = true;
+            }
+            while snapshots
+                .entries
+                .len()
+                .saturating_add(flights.records.len())
+                .saturating_add(usize::from(keeps_terminal_flight))
+                > self.inner.capacity
+                || snapshots
+                    .total_bytes
+                    .saturating_add(flights.total_bytes)
+                    .saturating_sub(old_bytes)
+                    .saturating_add(incoming_bytes)
+                    > self.inner.limits.max_total_bytes
+            {
+                let Some(oldest) = oldest_evictable(snapshots) else {
+                    break;
+                };
+                remove_entry(
+                    snapshots,
+                    &oldest,
+                    Some(TombstoneReason::Evicted),
+                    self.tombstone_capacity(),
+                );
+                self.inner.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+                evicted_any = true;
+            }
+            if evicted_any {
+                compact_state_containers(snapshots);
+            }
+            trim_tombstones_for_bytes(
+                snapshots,
+                flights
+                    .total_bytes
+                    .saturating_sub(old_bytes)
+                    .saturating_add(incoming_bytes),
+                self.inner.limits.max_total_bytes,
+            );
+            if scope_entry_count(snapshots, scope)
+                .saturating_add(flight_scope_count(flights, scope))
+                .saturating_add(usize::from(keeps_terminal_flight))
+                > self.inner.per_scope_capacity
+                || snapshots
+                    .entries
+                    .len()
+                    .saturating_add(flights.records.len())
+                    .saturating_add(usize::from(keeps_terminal_flight))
+                    > self.inner.capacity
+            {
+                Some(SnapshotError::EntryBudgetExceeded)
+            } else if scope_bytes(snapshots, scope)
+                .saturating_add(flight_scope_bytes(flights, scope))
+                .saturating_sub(old_bytes)
+                .saturating_add(incoming_bytes)
+                > self.inner.limits.max_scope_bytes
+                || snapshots
+                    .total_bytes
+                    .saturating_add(flights.total_bytes)
+                    .saturating_sub(old_bytes)
+                    .saturating_add(incoming_bytes)
+                    > self.inner.limits.max_total_bytes
+            {
+                Some(SnapshotError::ByteBudgetExceeded)
+            } else {
+                None
+            }
+        };
+        if let Some(error) = error {
+            let shared = SharedFlightFailure::from_error(&ToolExecutionError::from(error));
+            let notify = transition_failure(flights, ticket.id, shared);
+            drop(store);
+            if let Some(cell) = notify {
+                cell.completed.notify_waiters();
+            }
+            return Err(error);
+        }
+        if flights.joinable.get(&key) == Some(&ticket.id) {
+            flights.joinable.remove(&key);
+        }
+        let mut notify = None;
+        if let Some(terminal_bytes) = terminal_bytes {
+            let record = flights.records.get_mut(&ticket.id).ok_or(SnapshotError::Invalidated)?;
+            record.bytes = terminal_bytes;
+            record.phase = FlightPhase::Completed {
+                remaining: participants,
+            };
+            flights.total_bytes = flights
+                .total_bytes
+                .saturating_sub(old_bytes)
+                .saturating_add(terminal_bytes);
+            record.outcome = FlightOutcome::Success(id.clone());
+            notify = Some(record.cell.clone());
+        } else {
+            remove_flight_record(flights, ticket.id);
+        }
+        snapshots.insertion_order.push_back(id.clone());
+        snapshots.total_bytes = snapshots.total_bytes.saturating_add(entry_bytes);
+        snapshots.entries.insert(
+            id,
+            SnapshotEntry {
+                key,
+                value,
+                observed_at,
+                inserted_at,
+                reusable_until: response_cache_ttl.map(|ttl| inserted_at + ttl),
+                expires_at: inserted_at + cursor_ttl,
+                bytes: entry_bytes,
+                pinned_by_flight: keeps_terminal_flight,
+            },
+        );
+        drop(store);
+        if let Some(cell) = notify {
+            cell.completed.notify_waiters();
+        }
+        Ok(())
+    }
+
+    fn finish_failure(&self, ticket: &FlightTicket, error: SharedFlightFailure) {
+        let mut store = self.lock_state();
+        let notify = transition_failure(&mut store.flights, ticket.id, error);
+        drop(store);
+        if let Some(cell) = notify {
+            cell.completed.notify_waiters();
+        }
+    }
+
+    #[cfg(test)]
+    async fn flight_lock(&self, key: &SnapshotKey) -> Result<(FlightTicket, bool), SnapshotError> {
+        match self.begin_flight::<Vec<u8>>(key)? {
+            BeginFlight::Leader(ticket) => Ok((ticket, false)),
+            BeginFlight::Waiter(ticket) => Ok((ticket, true)),
+            BeginFlight::Cached(_) => Err(SnapshotError::Invalidated),
+        }
+    }
+
+    #[cfg(test)]
+    async fn prune_flights(&self) {}
+
+    fn snapshot_id(&self, key: &SnapshotKey) -> Arc<str> {
+        let sequence = self.inner.sequence.fetch_add(1, Ordering::Relaxed);
+        let sequence = sequence.to_le_bytes();
+        let generation = key.generation.to_le_bytes();
+        let page_limit = key.request.page_limit.to_le_bytes();
+        let parts = [
+            sequence.as_slice(),
+            generation.as_slice(),
+            key.request.kind.as_str().as_bytes(),
+            key.request.cluster.as_bytes(),
+            key.request.normalized_filter.as_bytes(),
+            key.request.selection_mode.as_str().as_bytes(),
+            page_limit.as_slice(),
+            key.request.schema_version.as_bytes(),
+            key.request.visibility.as_bytes(),
+        ];
+        Arc::from(hex_encode(&self.authentication_tag(0x51, &parts)))
+    }
+
+    fn encode_cursor(&self, id: &str, position: usize, generation: u64) -> String {
+        let claims = format!("{id}:{position}:{generation}");
+        let tag = hex_encode(&self.authentication_tag(0x72, &[claims.as_bytes()]));
+        format!("{CURSOR_PREFIX}{}.{}", hex_encode(claims.as_bytes()), tag)
+    }
+
+    fn decode_cursor(&self, cursor: &str) -> Result<CursorClaims, SnapshotError> {
+        if cursor.len() > MAX_CURSOR_BYTES {
+            return Err(SnapshotError::InvalidCursor);
+        }
+        let encoded = cursor.strip_prefix(CURSOR_PREFIX).ok_or(SnapshotError::InvalidCursor)?;
+        let (claims_hex, tag) = encoded.split_once('.').ok_or(SnapshotError::InvalidCursor)?;
+        let claims_bytes = hex_decode(claims_hex).ok_or(SnapshotError::InvalidCursor)?;
+        let claims = std::str::from_utf8(&claims_bytes).map_err(|_| SnapshotError::InvalidCursor)?;
+        let supplied_tag = hex_decode(tag)
+            .filter(|tag| tag.len() == 16)
+            .ok_or(SnapshotError::InvalidCursor)?;
+        let expected = self.authentication_tag(0x72, &[claims.as_bytes()]);
+        if !constant_time_eq(&supplied_tag, &expected) {
+            return Err(SnapshotError::InvalidCursor);
+        }
+        let mut fields = claims.split(':');
+        let id = fields
+            .next()
+            .filter(|id| id.len() == 32)
+            .ok_or(SnapshotError::InvalidCursor)?;
+        let position = fields
+            .next()
+            .ok_or(SnapshotError::InvalidCursor)?
+            .parse()
+            .map_err(|_| SnapshotError::InvalidCursor)?;
+        let generation = fields
+            .next()
+            .ok_or(SnapshotError::InvalidCursor)?
+            .parse()
+            .map_err(|_| SnapshotError::InvalidCursor)?;
+        if fields.next().is_some() || !id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(SnapshotError::InvalidCursor);
+        }
+        Ok(CursorClaims {
+            id: id.to_string(),
+            position,
+            generation,
+        })
+    }
+
+    fn tombstone_capacity(&self) -> usize {
+        self.inner.capacity.saturating_mul(4).clamp(32, 4_096)
+    }
+
+    fn authentication_tag(&self, domain: u8, parts: &[&[u8]]) -> [u8; 16] {
+        let primary = keyed_hash(&self.inner.primary_key, domain, parts);
+        let secondary = keyed_hash(&self.inner.secondary_key, domain ^ 0xa5, parts);
+        let mut tag = [0u8; 16];
+        tag[..8].copy_from_slice(&primary.to_le_bytes());
+        tag[8..].copy_from_slice(&secondary.to_le_bytes());
+        tag
+    }
+}
+
+impl FlightTicket {
+    async fn wait<T>(
+        &self,
+        key: &SnapshotKey,
+        cancellation: &CancellationToken,
+    ) -> Result<SnapshotView<T>, ToolExecutionError>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        loop {
+            let notified = self.cell.completed.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            let outcome = {
+                let store = self.inner.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+                let Some(record) = store.flights.records.get(&self.id) else {
+                    return Err(ToolExecutionError::Cancelled);
+                };
+                if !Arc::ptr_eq(&self.cell, &record.cell) {
+                    return Err(ToolExecutionError::Cancelled);
+                }
+                match &record.outcome {
+                    FlightOutcome::Loading => None,
+                    FlightOutcome::Failure(error) => Some(Err(error.into_error())),
+                    FlightOutcome::Success(id) => {
+                        let entry =
+                            store.snapshots.entries.get(id).ok_or_else(|| {
+                                ToolExecutionError::internal("pinned coalesced snapshot is unavailable")
+                            })?;
+                        let payload = entry
+                            .value
+                            .downcast_ref::<QueryPayload<T>>()
+                            .ok_or_else(|| ToolExecutionError::internal("coalesced snapshot type mismatch"))?
+                            .clone();
+                        let freshness_ms = Instant::now()
+                            .saturating_duration_since(entry.inserted_at)
+                            .as_millis()
+                            .try_into()
+                            .unwrap_or(u64::MAX);
+                        self.inner.metrics.hits.fetch_add(1, Ordering::Relaxed);
+                        Some(Ok(SnapshotView {
+                            id: id.clone(),
+                            request: key.request.clone(),
+                            generation: key.generation,
+                            position: 0,
+                            payload,
+                            observed_at: entry.observed_at.clone(),
+                            freshness_ms,
+                            cache_status: CacheStatus::Hit,
+                        }))
+                    }
+                }
+            };
+            if let Some(outcome) = outcome {
+                return outcome;
+            }
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => return Err(ToolExecutionError::Cancelled),
+                _ = &mut notified => {}
+            }
+        }
+    }
+}
+
+impl Drop for FlightTicket {
+    fn drop(&mut self) {
+        let mut store = self.inner.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let flights = &mut store.flights;
+        let Some(record) = flights.records.get(&self.id) else {
+            return;
+        };
+        if !Arc::ptr_eq(&self.cell, &record.cell) {
+            return;
+        }
+
+        let mut notify = None;
+        let loading = matches!(record.phase, FlightPhase::Loading { .. });
+        if loading && self.leader {
+            notify = transition_failure(flights, self.id, SharedFlightFailure::Cancelled);
+        }
+        let remove = if let Some(record) = flights.records.get_mut(&self.id) {
+            match &mut record.phase {
+                FlightPhase::Loading { participants } => {
+                    *participants = participants.saturating_sub(1);
+                    false
+                }
+                FlightPhase::Completed { remaining } => {
+                    *remaining = remaining.saturating_sub(1);
+                    *remaining == 0
+                }
+            }
+        } else {
+            false
+        };
+
+        if remove {
+            release_flight_record(&self.inner, &mut store, self.id);
+        }
+        drop(store);
+        if let Some(cell) = notify {
+            cell.completed.notify_waiters();
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CursorClaims {
+    id: String,
+    position: usize,
+    generation: u64,
+}
+
+fn validate_request(request: &SnapshotRequest, retained: &SnapshotRequest) -> Result<(), SnapshotError> {
+    if request.page_limit != retained.page_limit {
+        return Err(SnapshotError::PageContractMismatch);
+    }
+    if request.kind != retained.kind
+        || request.cluster != retained.cluster
+        || request.normalized_filter != retained.normalized_filter
+        || request.selection_mode != retained.selection_mode
+        || request.schema_version != retained.schema_version
+        || request.visibility != retained.visibility
+    {
+        return Err(SnapshotError::ContextMismatch);
+    }
+    Ok(())
+}
+
+fn scope_entry_count(state: &SnapshotState, scope: (&str, &str)) -> usize {
+    state
+        .entries
+        .values()
+        .filter(|entry| entry.key.request.scope() == scope)
+        .count()
+}
+
+fn flight_scope_count(state: &FlightState, scope: (&str, &str)) -> usize {
+    state
+        .records
+        .values()
+        .filter(|record| record.key.request.scope() == scope)
+        .count()
+}
+
+#[cfg(test)]
+fn flight_entry_reservation_count(state: &FlightState) -> usize {
+    state.records.len()
+}
+
+fn flight_scope_bytes(state: &FlightState, scope: (&str, &str)) -> usize {
+    state
+        .records
+        .values()
+        .filter(|record| record.key.request.scope() == scope)
+        .fold(0usize, |total, record| total.saturating_add(record.bytes))
+}
+
+fn transition_failure(state: &mut FlightState, id: u64, error: SharedFlightFailure) -> Option<Arc<FlightCell>> {
+    let record = state.records.get_mut(&id)?;
+    let FlightPhase::Loading { participants } = record.phase else {
+        return None;
+    };
+    let key = record.key.clone();
+    record.phase = FlightPhase::Completed {
+        remaining: participants,
+    };
+    record.outcome = FlightOutcome::Failure(error);
+    let cell = record.cell.clone();
+    if state.joinable.get(&key) == Some(&id) {
+        state.joinable.remove(&key);
+    }
+    Some(cell)
+}
+
+fn remove_flight_record(state: &mut FlightState, id: u64) -> Option<FlightRecord> {
+    let record = state.records.remove(&id)?;
+    if state.joinable.get(&record.key) == Some(&id) {
+        state.joinable.remove(&record.key);
+    }
+    state.total_bytes = state.total_bytes.saturating_sub(record.bytes);
+    state.records.shrink_to_fit();
+    state.joinable.shrink_to_fit();
+    Some(record)
+}
+
+fn release_flight_record(inner: &SnapshotStoreInner, store: &mut StoreState, id: u64) {
+    let snapshot_id = store.flights.records.get(&id).and_then(|record| match &record.outcome {
+        FlightOutcome::Success(id) => Some(id.clone()),
+        FlightOutcome::Loading | FlightOutcome::Failure(_) => None,
+    });
+    remove_flight_record(&mut store.flights, id);
+    if let Some(id) = snapshot_id {
+        if let Some(entry) = store.snapshots.entries.get_mut(&id) {
+            entry.pinned_by_flight = false;
+        }
+        purge_expired(&mut store.snapshots, inner.capacity.saturating_mul(4).clamp(32, 4_096));
+    }
+}
+
+fn scope_bytes(state: &SnapshotState, scope: (&str, &str)) -> usize {
+    state
+        .entries
+        .values()
+        .filter(|entry| entry.key.request.scope() == scope)
+        .fold(0usize, |total, entry| total.saturating_add(entry.bytes))
+}
+
+fn oldest_in_scope(state: &SnapshotState, scope: (&str, &str)) -> Option<Arc<str>> {
+    state.insertion_order.iter().find_map(|id| {
+        state
+            .entries
+            .get(id)
+            .filter(|entry| !entry.pinned_by_flight && entry.key.request.scope() == scope)
+            .map(|_| id.clone())
+    })
+}
+
+fn oldest_evictable(state: &SnapshotState) -> Option<Arc<str>> {
+    state.insertion_order.iter().find_map(|id| {
+        state
+            .entries
+            .get(id)
+            .filter(|entry| !entry.pinned_by_flight)
+            .map(|_| id.clone())
+    })
+}
+
+fn purge_expired(state: &mut SnapshotState, tombstone_capacity: usize) {
+    let now = Instant::now();
+    let expired = state
+        .entries
+        .iter()
+        .filter(|(_, entry)| !entry.pinned_by_flight && entry.expires_at <= now)
+        .map(|(id, _)| id.clone())
+        .collect::<Vec<_>>();
+    let removed_any = !expired.is_empty();
+    for id in expired {
+        remove_entry(state, &id, Some(TombstoneReason::Expired), tombstone_capacity);
+    }
+    if removed_any {
+        compact_state_containers(state);
+    }
+}
+
+fn remove_entry(state: &mut SnapshotState, id: &str, tombstone: Option<TombstoneReason>, tombstone_capacity: usize) {
+    if let Some(entry) = state.entries.remove(id) {
+        state.insertion_order.retain(|candidate| candidate.as_ref() != id);
+        state.total_bytes = state.total_bytes.saturating_sub(entry.bytes);
+    }
+    if let Some(reason) = tombstone {
+        let id: Arc<str> = Arc::from(id);
+        if state.tombstones.insert(id.clone(), reason).is_none() {
+            state.total_bytes = state
+                .total_bytes
+                .saturating_add(RETAINED_TOMBSTONE_OVERHEAD.saturating_add(id.len()));
+        }
+        state
+            .tombstone_order
+            .retain(|candidate| candidate.as_ref() != id.as_ref());
+        state.tombstone_order.push_back(id);
+        while state.tombstone_order.len() > tombstone_capacity {
+            if let Some(oldest) = state.tombstone_order.pop_front() {
+                if state.tombstones.remove(&oldest).is_some() {
+                    state.total_bytes = state
+                        .total_bytes
+                        .saturating_sub(RETAINED_TOMBSTONE_OVERHEAD.saturating_add(oldest.len()));
+                }
+            }
+        }
+    }
+}
+
+fn trim_tombstones_for_bytes(state: &mut SnapshotState, incoming: usize, max_total_bytes: usize) {
+    let mut removed_any = false;
+    while state.total_bytes.saturating_add(incoming) > max_total_bytes {
+        let Some(oldest) = state.tombstone_order.pop_front() else {
+            break;
+        };
+        if state.tombstones.remove(&oldest).is_some() {
+            removed_any = true;
+            state.total_bytes = state
+                .total_bytes
+                .saturating_sub(RETAINED_TOMBSTONE_OVERHEAD.saturating_add(oldest.len()));
+        }
+    }
+    if removed_any {
+        compact_state_containers(state);
+    }
+}
+
+fn compact_state_containers(state: &mut SnapshotState) {
+    state.entries.shrink_to_fit();
+    state.insertion_order.shrink_to_fit();
+    state.tombstones.shrink_to_fit();
+    state.tombstone_order.shrink_to_fit();
+}
+
+fn retained_entry_bytes<T: RetainedSize>(
+    payload: &QueryPayload<T>,
+    key: &SnapshotKey,
+    id: &str,
+    observed_at: &String,
+) -> usize {
+    payload
+        .retained_size()
+        .saturating_add(key.request.cluster.capacity())
+        .saturating_add(key.request.normalized_filter.capacity())
+        .saturating_add(key.request.visibility.capacity())
+        .saturating_add(key.request.schema_version.len())
+        .saturating_add(id.len())
+        .saturating_add(ARC_ALLOCATION_OVERHEAD)
+        .saturating_add(observed_at.capacity())
+        .saturating_add(size_of::<SnapshotEntry>())
+        .saturating_add(size_of::<SnapshotKey>())
+        .saturating_add(size_of::<SnapshotRequest>())
+        .saturating_add(size_of::<SnapshotState>())
+        .saturating_add(ARC_ALLOCATION_OVERHEAD)
+        .saturating_add(RETAINED_ENTRY_BOOKKEEPING_OVERHEAD)
+}
+
+fn retained_flight_bytes(key: &SnapshotKey) -> usize {
+    size_of::<SnapshotKey>()
+        .saturating_mul(2)
+        .saturating_add(size_of::<FlightRecord>())
+        .saturating_add(size_of::<FlightCell>())
+        .saturating_add(key.request.cluster.len())
+        .saturating_add(key.request.normalized_filter.len())
+        .saturating_add(key.request.visibility.len())
+        .saturating_add(ARC_ALLOCATION_OVERHEAD)
+        .saturating_add(RETAINED_FLIGHT_BOOKKEEPING_OVERHEAD)
+}
+
+fn retained_terminal_flight_bytes(key: &SnapshotKey, id: &str) -> usize {
+    retained_flight_bytes(key)
+        .saturating_add(id.len())
+        .saturating_add(ARC_ALLOCATION_OVERHEAD)
+}
+
+fn keyed_hash(key: &RandomState, domain: u8, parts: &[&[u8]]) -> u64 {
+    let mut hasher = key.build_hasher();
+    hasher.write_u8(domain);
+    for part in parts {
+        hasher.write_usize(part.len());
+        hasher.write(part);
+    }
+    hasher.finish()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn hex_decode(value: &str) -> Option<Vec<u8>> {
+    if !value.len().is_multiple_of(2) {
+        return None;
+    }
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = (pair[0] as char).to_digit(16)?;
+            let low = (pair[1] as char).to_digit(16)?;
+            Some(((high << 4) | low) as u8)
+        })
+        .collect()
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
+        == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+    use std::sync::atomic::AtomicUsize;
+
+    use super::*;
+    use tokio::sync::Barrier;
+    use tokio::sync::Notify;
+
+    fn request(kind: SnapshotKind, cluster: &str, limit: u32) -> SnapshotRequest {
+        SnapshotRequest::try_new(
+            kind,
+            cluster,
+            "",
+            &PageRequest {
+                limit: Some(limit),
+                cursor: None,
+            },
+            "standard",
+        )
+        .unwrap()
+    }
+
+    fn short_string_with_capacity(capacity: usize) -> String {
+        let mut value = String::with_capacity(capacity);
+        value.push('x');
+        value
+    }
+
+    #[tokio::test]
+    async fn cursor_is_stable_context_bound_and_tamper_evident() {
+        let store = SnapshotStore::new(8);
+        let cancellation = CancellationToken::new();
+        let view = store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 2),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![1u8, 2, 3])) },
+            )
+            .await
+            .unwrap();
+        let first = store.page(&view, &view.payload.data).unwrap();
+        let cursor = first.next_cursor.unwrap();
+        let resumed = store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 2),
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { panic!("cursor hit must not reload") },
+            )
+            .await
+            .unwrap();
+        assert_eq!(store.page(&resumed, &resumed.payload.data).unwrap().items, [3]);
+
+        let mut tampered = cursor.clone().into_bytes();
+        *tampered.last_mut().unwrap() ^= 1;
+        let tampered = String::from_utf8(tampered).unwrap();
+        assert!(store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 2),
+                Some(&tampered),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { panic!("tampered cursor must not reload") },
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("tampered"));
+
+        let claims = store.decode_cursor(&cursor).unwrap();
+        let forged_claims = format!("{}:{}:{}", claims.id, claims.position + 1, claims.generation);
+        let (_, original_tag) = cursor.rsplit_once('.').unwrap();
+        let forged = format!(
+            "{CURSOR_PREFIX}{}.{}",
+            hex_encode(forged_claims.as_bytes()),
+            original_tag
+        );
+        assert_eq!(store.decode_cursor(&forged), Err(SnapshotError::InvalidCursor));
+
+        let (encoded_claims, _) = cursor.rsplit_once('.').unwrap();
+        assert_eq!(
+            store.decode_cursor(&format!("{encoded_claims}.not-hex")),
+            Err(SnapshotError::InvalidCursor)
+        );
+
+        let other_store = SnapshotStore::new(8);
+        assert_eq!(other_store.decode_cursor(&cursor), Err(SnapshotError::InvalidCursor));
+        assert_eq!(
+            store.decode_cursor(&"x".repeat(MAX_CURSOR_BYTES + 1)),
+            Err(SnapshotError::InvalidCursor)
+        );
+        assert!(store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "b", 2),
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { panic!("context mismatch must not reload") },
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("context"));
+
+        assert!(store
+            .get_or_load(
+                request(SnapshotKind::ConsumerGroupInventory, "a", 2),
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { panic!("cross-query cursor must not reload") },
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("context"));
+
+        assert!(store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 1),
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { panic!("page-contract mismatch must not reload") },
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("page contract"));
+
+        let mut visibility_mismatch = request(SnapshotKind::TopicInventory, "a", 2);
+        visibility_mismatch.visibility = "sensitive".to_string();
+        assert!(store
+            .get_or_load(
+                visibility_mismatch,
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { panic!("visibility mismatch must not reload") },
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("context"));
+    }
+
+    #[tokio::test]
+    async fn expiry_eviction_and_invalidation_are_lazy_and_stable() {
+        let cancellation = CancellationToken::new();
+        let store = SnapshotStore::new(4);
+        let view = store
+            .get_or_load(
+                request(SnapshotKind::TopicRoute, "a", 1),
+                None,
+                Duration::from_millis(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::detail(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![1u8, 2])) },
+            )
+            .await
+            .unwrap();
+        let cursor = store.page(&view, &view.payload.data).unwrap().next_cursor.unwrap();
+        store
+            .lock_state()
+            .snapshots
+            .entries
+            .get_mut(view.id.as_ref())
+            .unwrap()
+            .expires_at = Instant::now();
+        let error = store
+            .get_or_load(
+                request(SnapshotKind::TopicRoute, "a", 1),
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::detail(items.len()),
+                &cancellation,
+                || async { panic!("expired cursor must not reload") },
+            )
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("expired"));
+
+        let view = store
+            .get_or_load(
+                request(SnapshotKind::ConsumerLag, "b", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::detail(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![1u8, 2])) },
+            )
+            .await
+            .unwrap();
+        let cursor = store.page(&view, &view.payload.data).unwrap().next_cursor.unwrap();
+        assert_eq!(store.clear().await, 1);
+        let error = store
+            .get_or_load(
+                request(SnapshotKind::ConsumerLag, "b", 1),
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::detail(items.len()),
+                &cancellation,
+                || async { panic!("invalidated cursor must not reload") },
+            )
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("invalidated"));
+    }
+
+    #[tokio::test]
+    async fn deterministic_scope_eviction_rejects_old_cursor_without_reloading() {
+        let store = SnapshotStore::new(4);
+        let cancellation = CancellationToken::new();
+        let first = store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![1u8, 2])) },
+            )
+            .await
+            .unwrap();
+        let cursor = store.page(&first, &first.payload.data).unwrap().next_cursor.unwrap();
+        store
+            .get_or_load(
+                request(SnapshotKind::ConsumerLag, "a", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::detail(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![3u8])) },
+            )
+            .await
+            .unwrap();
+        let error = store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 1),
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { panic!("evicted cursor must not reload") },
+            )
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("evicted"));
+    }
+
+    #[tokio::test]
+    async fn per_snapshot_entry_row_and_byte_budgets_are_enforced() {
+        let cancellation = CancellationToken::new();
+        let store = SnapshotStore::new(8);
+        let entry_error = store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "entries", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |_| SnapshotWeight::inventory(MAX_SNAPSHOT_ENTRIES + 1),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(Vec::<u8>::new())) },
+            )
+            .await
+            .unwrap_err();
+        assert!(entry_error.to_string().contains("entry budget"));
+
+        let row_error = store
+            .get_or_load(
+                request(SnapshotKind::ConsumerLag, "rows", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |_| SnapshotWeight::detail(MAX_SNAPSHOT_ROWS + 1),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(Vec::<u8>::new())) },
+            )
+            .await
+            .unwrap_err();
+        assert!(row_error.to_string().contains("row budget"));
+
+        let byte_error = store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "bytes", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |_| SnapshotWeight::inventory(1),
+                &cancellation,
+                || async { Ok(QueryPayload::complete("x".repeat(MAX_SNAPSHOT_BYTES + 1))) },
+            )
+            .await
+            .unwrap_err();
+        assert!(byte_error.to_string().contains("byte budget"));
+
+        let metadata_store = SnapshotStore::with_limits(
+            8,
+            SnapshotLimits {
+                max_snapshot_bytes: 1_024,
+                ..SnapshotLimits::default()
+            },
+        );
+        let metadata_error = metadata_store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "metadata", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |_| SnapshotWeight::inventory(0),
+                &cancellation,
+                || async {
+                    Ok(QueryPayload::new(
+                        Vec::<u8>::new(),
+                        true,
+                        vec!["w".repeat(2_048)],
+                        vec![crate::model::contract::SourceFailure::new(
+                            crate::model::contract::QuerySource::TopicRoute,
+                            crate::model::contract::SourceFailureCode::SourceUnavailable,
+                            true,
+                            "broker-a",
+                        )],
+                    ))
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(metadata_error.to_string().contains("byte budget"));
+    }
+
+    #[tokio::test]
+    async fn retained_size_rejects_maximum_count_short_strings_with_large_capacities() {
+        let store = SnapshotStore::new(8);
+        let error = store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "short-strings", 1),
+                None,
+                Duration::from_secs(1),
+                None,
+                |items: &Vec<String>| SnapshotWeight::inventory(items.len()),
+                &CancellationToken::new(),
+                || async {
+                    Ok(QueryPayload::complete(
+                        (0..MAX_SNAPSHOT_ENTRIES)
+                            .map(|_| short_string_with_capacity(512))
+                            .collect::<Vec<_>>(),
+                    ))
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("byte budget"));
+    }
+
+    #[tokio::test]
+    async fn retained_size_rejects_metadata_capacity_not_visible_on_the_wire() {
+        let store = SnapshotStore::new(8);
+        let error = store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "metadata-capacity", 1),
+                None,
+                Duration::from_secs(1),
+                None,
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &CancellationToken::new(),
+                || async {
+                    Ok(QueryPayload::new(
+                        Vec::<u8>::new(),
+                        true,
+                        vec![short_string_with_capacity(MAX_SNAPSHOT_BYTES + 1)],
+                        Vec::new(),
+                    ))
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("byte budget"));
+    }
+
+    #[test]
+    fn snapshot_context_components_are_bounded() {
+        let page = PageRequest {
+            limit: Some(1),
+            cursor: None,
+        };
+        assert_eq!(
+            SnapshotRequest::try_new(
+                SnapshotKind::TopicInventory,
+                "c".repeat(MAX_CLUSTER_BYTES + 1),
+                "",
+                &page,
+                "standard",
+            ),
+            Err(SnapshotError::ContextTooLarge)
+        );
+        assert_eq!(
+            SnapshotRequest::try_new(
+                SnapshotKind::TopicInventory,
+                "cluster",
+                "f".repeat(MAX_FILTER_BYTES + 1),
+                &page,
+                "standard",
+            ),
+            Err(SnapshotError::ContextTooLarge)
+        );
+        assert_eq!(
+            SnapshotRequest::try_new(
+                SnapshotKind::TopicInventory,
+                "cluster",
+                "",
+                &page,
+                "v".repeat(MAX_VISIBILITY_BYTES + 1),
+            ),
+            Err(SnapshotError::ContextTooLarge)
+        );
+    }
+
+    #[tokio::test]
+    async fn per_scope_and_global_byte_limits_evict_deterministically() {
+        let cancellation = CancellationToken::new();
+        let payload = QueryPayload::complete(vec![short_string_with_capacity(8 * 1024)]);
+        let sample_key = SnapshotKey {
+            request: request(SnapshotKind::TopicInventory, "a", 1),
+            generation: 0,
+        };
+        let observed_at = "2026-01-01T00:00:00.000Z".to_string();
+        let sample_bytes =
+            retained_entry_bytes(&payload, &sample_key, "00000000000000000000000000000000", &observed_at);
+
+        let scope_store = SnapshotStore::with_limits(
+            16,
+            SnapshotLimits {
+                max_snapshot_bytes: sample_bytes + 256,
+                max_scope_bytes: sample_bytes * 2 - 1,
+                ..SnapshotLimits::default()
+            },
+        );
+        let first = scope_store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 1),
+                None,
+                Duration::from_secs(1),
+                None,
+                |_: &Vec<String>| SnapshotWeight::inventory(2),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![short_string_with_capacity(8 * 1024)])) },
+            )
+            .await
+            .unwrap();
+        let cursor = scope_store.page(&first, &[1u8, 2]).unwrap().next_cursor.unwrap();
+        scope_store
+            .get_or_load(
+                request(SnapshotKind::ConsumerGroupInventory, "a", 1),
+                None,
+                Duration::from_secs(1),
+                None,
+                |_: &Vec<String>| SnapshotWeight::inventory(1),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![short_string_with_capacity(8 * 1024)])) },
+            )
+            .await
+            .unwrap();
+        assert!(scope_store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 1),
+                Some(&cursor),
+                Duration::from_secs(1),
+                None,
+                |_: &Vec<String>| SnapshotWeight::inventory(2),
+                &cancellation,
+                || async { panic!("evicted cursor must not reload") },
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("evicted"));
+
+        let too_large_for_scope = SnapshotStore::with_limits(
+            16,
+            SnapshotLimits {
+                max_snapshot_bytes: sample_bytes + 256,
+                max_scope_bytes: sample_bytes - 1,
+                ..SnapshotLimits::default()
+            },
+        );
+        assert!(too_large_for_scope
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 1),
+                None,
+                Duration::from_secs(1),
+                None,
+                |_: &Vec<String>| SnapshotWeight::inventory(1),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![short_string_with_capacity(8 * 1024)])) },
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("byte budget"));
+
+        let global_store = SnapshotStore::with_limits(
+            16,
+            SnapshotLimits {
+                max_snapshot_bytes: sample_bytes + 256,
+                max_total_bytes: sample_bytes * 2 - 1,
+                max_scope_bytes: sample_bytes * 2,
+                ..SnapshotLimits::default()
+            },
+        );
+        let first = global_store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 1),
+                None,
+                Duration::from_secs(1),
+                None,
+                |_: &Vec<String>| SnapshotWeight::inventory(2),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![short_string_with_capacity(8 * 1024)])) },
+            )
+            .await
+            .unwrap();
+        let cursor = global_store.page(&first, &[1u8, 2]).unwrap().next_cursor.unwrap();
+        global_store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "b", 1),
+                None,
+                Duration::from_secs(1),
+                None,
+                |_: &Vec<String>| SnapshotWeight::inventory(1),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![short_string_with_capacity(8 * 1024)])) },
+            )
+            .await
+            .unwrap();
+        assert!(global_store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "a", 1),
+                Some(&cursor),
+                Duration::from_secs(1),
+                None,
+                |_: &Vec<String>| SnapshotWeight::inventory(2),
+                &cancellation,
+                || async { panic!("globally evicted cursor must not reload") },
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("evicted"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_initial_load_is_singleflight_and_budgeted() {
+        let store = SnapshotStore::new(8);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(9));
+        let release_loader = Arc::new(Notify::new());
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let store = store.clone();
+            let calls = calls.clone();
+            let start = start.clone();
+            let release_loader = release_loader.clone();
+            tasks.push(tokio::spawn(async move {
+                start.wait().await;
+                store
+                    .get_or_load(
+                        request(SnapshotKind::ConsumerGroupInventory, "a", 2),
+                        None,
+                        Duration::from_secs(1),
+                        Some(Duration::from_secs(1)),
+                        |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                        &CancellationToken::new(),
+                        || async move {
+                            calls.fetch_add(1, Ordering::SeqCst);
+                            release_loader.notified().await;
+                            Ok(QueryPayload::complete(vec![1u8, 2, 3]))
+                        },
+                    )
+                    .await
+                    .unwrap()
+                    .cache_status
+            }));
+        }
+        start.wait().await;
+        for _ in 0..1_000 {
+            if store.metrics().coalesced_waiters == 7 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(store.metrics().coalesced_waiters, 7);
+        release_loader.notify_one();
+        for task in tasks {
+            task.await.unwrap();
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(store.metrics().coalesced_waiters, 7);
+        assert!(store.lock_state().flights.records.is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_failed_load_is_shared_without_duplicate_upstream_work() {
+        let store = SnapshotStore::new(8);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(9));
+        let release_loader = Arc::new(Notify::new());
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let store = store.clone();
+            let calls = calls.clone();
+            let start = start.clone();
+            let release_loader = release_loader.clone();
+            tasks.push(tokio::spawn(async move {
+                start.wait().await;
+                store
+                    .get_or_load(
+                        request(SnapshotKind::ConsumerGroupInventory, "failed", 2),
+                        None,
+                        Duration::from_secs(1),
+                        Some(Duration::from_secs(1)),
+                        |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                        &CancellationToken::new(),
+                        || async move {
+                            calls.fetch_add(1, Ordering::SeqCst);
+                            release_loader.notified().await;
+                            Err(ToolExecutionError::backend("shared failure"))
+                        },
+                    )
+                    .await
+                    .unwrap_err()
+                    .to_string()
+            }));
+        }
+        start.wait().await;
+        for _ in 0..1_000 {
+            if store.metrics().coalesced_waiters == 7 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(store.metrics().coalesced_waiters, 7);
+        release_loader.notify_one();
+        for task in tasks {
+            assert!(task.await.unwrap().contains("backend error"));
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        let state = store.lock_state();
+        assert!(state.flights.records.is_empty());
+        assert_eq!(state.flights.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn active_flights_are_rejected_at_scope_and_global_count_boundaries() {
+        let scope_store = SnapshotStore::new(4);
+        let first_key = SnapshotKey {
+            request: request(SnapshotKind::TopicInventory, "scope-a", 1),
+            generation: 0,
+        };
+        let (first, coalesced) = scope_store.flight_lock(&first_key).await.unwrap();
+        assert!(!coalesced);
+        let (same, coalesced) = scope_store.flight_lock(&first_key).await.unwrap();
+        assert!(coalesced);
+
+        let same_scope_key = SnapshotKey {
+            request: request(SnapshotKind::ConsumerGroupInventory, "scope-a", 1),
+            generation: 0,
+        };
+        assert_eq!(
+            scope_store.flight_lock(&same_scope_key).await.unwrap_err(),
+            SnapshotError::EntryBudgetExceeded
+        );
+
+        drop(first);
+        drop(same);
+        scope_store.prune_flights().await;
+
+        let global_store = SnapshotStore::new(1);
+        let (active, coalesced) = global_store.flight_lock(&first_key).await.unwrap();
+        assert!(!coalesced);
+        let other_scope_key = SnapshotKey {
+            request: request(SnapshotKind::TopicInventory, "scope-b", 1),
+            generation: 0,
+        };
+        assert_eq!(
+            global_store.flight_lock(&other_scope_key).await.unwrap_err(),
+            SnapshotError::EntryBudgetExceeded
+        );
+        drop(active);
+        global_store.prune_flights().await;
+    }
+
+    #[tokio::test]
+    async fn active_flight_bytes_are_rejected_before_insertion() {
+        let key = SnapshotKey {
+            request: request(SnapshotKind::TopicInventory, "scope-a", 1),
+            generation: 0,
+        };
+        let bytes = retained_flight_bytes(&key);
+        let total_store = SnapshotStore::with_limits(
+            4,
+            SnapshotLimits {
+                max_total_bytes: bytes - 1,
+                max_scope_bytes: bytes,
+                ..SnapshotLimits::default()
+            },
+        );
+        assert_eq!(
+            total_store.flight_lock(&key).await.unwrap_err(),
+            SnapshotError::ByteBudgetExceeded
+        );
+        {
+            let store = total_store.lock_state();
+            let flights = &store.flights;
+            assert!(flights.records.is_empty());
+            assert_eq!(flights.total_bytes, 0);
+        }
+
+        let scope_store = SnapshotStore::with_limits(
+            4,
+            SnapshotLimits {
+                max_total_bytes: bytes,
+                max_scope_bytes: bytes - 1,
+                ..SnapshotLimits::default()
+            },
+        );
+        assert_eq!(
+            scope_store.flight_lock(&key).await.unwrap_err(),
+            SnapshotError::ByteBudgetExceeded
+        );
+        let store = scope_store.lock_state();
+        let flights = &store.flights;
+        assert!(flights.records.is_empty());
+        assert_eq!(flights.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn pruning_dead_flights_releases_accounting_and_bucket_high_water() {
+        let store = SnapshotStore::new(64);
+        let mut active = Vec::new();
+        for index in 0..32 {
+            let key = SnapshotKey {
+                request: request(SnapshotKind::TopicInventory, &format!("scope-{index}"), 1),
+                generation: 0,
+            };
+            let (flight, coalesced) = store.flight_lock(&key).await.unwrap();
+            assert!(!coalesced);
+            active.push(flight);
+        }
+        {
+            let state = store.lock_state();
+            let flights = &state.flights;
+            assert_eq!(flights.records.len(), 32);
+            assert!(flights.records.capacity() >= 32);
+            assert!(flights.total_bytes > 0);
+        }
+
+        drop(active);
+        store.prune_flights().await;
+        let state = store.lock_state();
+        let flights = &state.flights;
+        assert!(flights.records.is_empty());
+        assert_eq!(flights.records.capacity(), 0);
+        assert_eq!(flights.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn cancellation_before_flight_acquisition_releases_the_flight_record() {
+        let store = SnapshotStore::new(8);
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let error = store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "scope-a", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { panic!("cancelled request must not load") },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ToolExecutionError::Cancelled));
+
+        let state = store.lock_state();
+        let flights = &state.flights;
+        assert!(flights.records.is_empty());
+        assert_eq!(flights.records.capacity(), 0);
+        assert_eq!(flights.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn existing_snapshots_and_new_flights_share_scope_and_global_count_reservations() {
+        let cancellation = CancellationToken::new();
+        let scope_store = SnapshotStore::new(4);
+        scope_store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "scope-a", 1),
+                None,
+                Duration::from_secs(1),
+                None,
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![1u8])) },
+            )
+            .await
+            .unwrap();
+        let scope_key = SnapshotKey {
+            request: request(SnapshotKind::ConsumerGroupInventory, "scope-a", 1),
+            generation: 0,
+        };
+        let (scope_flight, coalesced) = scope_store.flight_lock(&scope_key).await.unwrap();
+        assert!(!coalesced);
+        {
+            let state = scope_store.lock_state();
+            assert_eq!(state.snapshots.entries.len(), 0);
+            assert_eq!(flight_entry_reservation_count(&state.flights), 1);
+        }
+        drop(scope_flight);
+        scope_store.prune_flights().await;
+
+        let global_store = SnapshotStore::new(1);
+        global_store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "scope-a", 1),
+                None,
+                Duration::from_secs(1),
+                None,
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![1u8])) },
+            )
+            .await
+            .unwrap();
+        let global_key = SnapshotKey {
+            request: request(SnapshotKind::ConsumerGroupInventory, "scope-b", 1),
+            generation: 0,
+        };
+        let (global_flight, coalesced) = global_store.flight_lock(&global_key).await.unwrap();
+        assert!(!coalesced);
+        {
+            let state = global_store.lock_state();
+            assert_eq!(state.snapshots.entries.len(), 0);
+            assert_eq!(flight_entry_reservation_count(&state.flights), 1);
+        }
+        drop(global_flight);
+        global_store.prune_flights().await;
+    }
+
+    #[tokio::test]
+    async fn existing_snapshots_and_new_flights_share_scope_and_global_byte_reservations() {
+        let cancellation = CancellationToken::new();
+        let payload = QueryPayload::complete(vec![short_string_with_capacity(8 * 1024)]);
+        let snapshot_key = SnapshotKey {
+            request: request(SnapshotKind::TopicInventory, "scope-a", 1),
+            generation: 0,
+        };
+        let observed_at = "2026-01-01T00:00:00.000Z".to_string();
+        let snapshot_bytes = retained_entry_bytes(
+            &payload,
+            &snapshot_key,
+            "00000000000000000000000000000000",
+            &observed_at,
+        );
+        let scope_key = SnapshotKey {
+            request: request(SnapshotKind::ConsumerGroupInventory, "scope-a", 1),
+            generation: 0,
+        };
+        let scope_flight_bytes = retained_flight_bytes(&scope_key);
+        let scope_store = SnapshotStore::with_limits(
+            8,
+            SnapshotLimits {
+                max_snapshot_bytes: snapshot_bytes + 256,
+                max_scope_bytes: snapshot_bytes + scope_flight_bytes - 1,
+                ..SnapshotLimits::default()
+            },
+        );
+        scope_store
+            .get_or_load(
+                snapshot_key.request.clone(),
+                None,
+                Duration::from_secs(1),
+                None,
+                |items: &Vec<String>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![short_string_with_capacity(8 * 1024)])) },
+            )
+            .await
+            .unwrap();
+        let (scope_flight, _) = scope_store.flight_lock(&scope_key).await.unwrap();
+        {
+            let state = scope_store.lock_state();
+            assert!(state.snapshots.entries.is_empty());
+            assert!(
+                state.snapshots.total_bytes.saturating_add(state.flights.total_bytes)
+                    <= scope_store.inner.limits.max_total_bytes
+            );
+            assert!(
+                flight_scope_bytes(&state.flights, scope_key.request.scope())
+                    <= scope_store.inner.limits.max_scope_bytes
+            );
+        }
+        drop(scope_flight);
+        scope_store.prune_flights().await;
+
+        let global_key = SnapshotKey {
+            request: request(SnapshotKind::ConsumerGroupInventory, "scope-b", 1),
+            generation: 0,
+        };
+        let global_flight_bytes = retained_flight_bytes(&global_key);
+        let global_store = SnapshotStore::with_limits(
+            8,
+            SnapshotLimits {
+                max_snapshot_bytes: snapshot_bytes + 256,
+                max_scope_bytes: snapshot_bytes + 256,
+                max_total_bytes: snapshot_bytes + global_flight_bytes - 1,
+                ..SnapshotLimits::default()
+            },
+        );
+        global_store
+            .get_or_load(
+                snapshot_key.request,
+                None,
+                Duration::from_secs(1),
+                None,
+                |items: &Vec<String>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![short_string_with_capacity(8 * 1024)])) },
+            )
+            .await
+            .unwrap();
+        let (global_flight, _) = global_store.flight_lock(&global_key).await.unwrap();
+        {
+            let state = global_store.lock_state();
+            assert!(state.snapshots.entries.is_empty());
+            assert!(
+                state.snapshots.total_bytes.saturating_add(state.flights.total_bytes)
+                    <= global_store.inner.limits.max_total_bytes
+            );
+        }
+        drop(global_flight);
+        global_store.prune_flights().await;
+    }
+
+    #[tokio::test]
+    async fn successful_transfer_and_failed_load_release_shared_flight_reservations() {
+        let cancellation = CancellationToken::new();
+        let store = SnapshotStore::new(1);
+        store
+            .get_or_load(
+                request(SnapshotKind::TopicInventory, "scope-a", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { Ok(QueryPayload::complete(vec![1u8])) },
+            )
+            .await
+            .unwrap();
+        {
+            let state = store.lock_state();
+            assert_eq!(state.snapshots.entries.len(), 1);
+            assert!(state.flights.records.is_empty());
+            assert_eq!(state.flights.total_bytes, 0);
+        }
+
+        store.clear().await;
+        let error = store
+            .get_or_load(
+                request(SnapshotKind::ConsumerGroupInventory, "scope-a", 1),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &cancellation,
+                || async { Err(ToolExecutionError::backend("load failed")) },
+            )
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("load failed"));
+        let state = store.lock_state();
+        assert!(state.flights.records.is_empty());
+        assert_eq!(state.flights.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn registered_cohort_consumes_one_nanosecond_success_and_immediate_cursor() {
+        let store = SnapshotStore::new(8);
+        let key = SnapshotKey {
+            request: request(SnapshotKind::TopicInventory, "one-nanosecond", 1),
+            generation: 0,
+        };
+        let (leader, coalesced) = store.flight_lock(&key).await.unwrap();
+        assert!(!coalesced);
+        let (waiter, coalesced) = store.flight_lock(&key).await.unwrap();
+        assert!(coalesced);
+
+        let upstream_calls = AtomicUsize::new(0);
+        upstream_calls.fetch_add(1, Ordering::SeqCst);
+        let payload = QueryPayload::complete(vec![1u8, 2]);
+        let observed_at = observed_at();
+        let id = store.snapshot_id(&key);
+        let bytes = retained_entry_bytes(&payload, &key, &id, &observed_at);
+        let inserted_at = Instant::now();
+        store
+            .finish_success(
+                &leader,
+                id.clone(),
+                Arc::new(payload.clone()),
+                observed_at.clone(),
+                inserted_at,
+                Duration::from_nanos(1),
+                Some(Duration::from_nanos(1)),
+                bytes,
+            )
+            .unwrap();
+        drop(leader);
+
+        let leader_view = SnapshotView {
+            id: id.clone(),
+            request: key.request.clone(),
+            generation: key.generation,
+            position: 0,
+            payload: payload.clone(),
+            observed_at,
+            freshness_ms: 0,
+            cache_status: CacheStatus::Miss,
+        };
+        let cursor = store
+            .page(&leader_view, &leader_view.payload.data)
+            .unwrap()
+            .next_cursor
+            .unwrap();
+        let resumed = store
+            .get_or_load(
+                key.request.clone(),
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &CancellationToken::new(),
+                || async { panic!("pinned cursor continuation must not reload") },
+            )
+            .await
+            .unwrap();
+        assert_eq!(resumed.payload.data, [1, 2]);
+
+        let waiter_view = waiter.wait::<Vec<u8>>(&key, &CancellationToken::new()).await.unwrap();
+        assert_eq!(waiter_view.payload.data, [1, 2]);
+        assert_eq!(upstream_calls.load(Ordering::SeqCst), 1);
+        drop(waiter);
+        let state = store.lock_state();
+        assert!(state.flights.records.is_empty());
+        assert!(state.snapshots.entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn completed_failure_is_closed_to_new_requests_and_recovery_uses_a_new_cohort() {
+        let store = SnapshotStore::new(8);
+        let key = SnapshotKey {
+            request: request(SnapshotKind::ConsumerGroupInventory, "recover", 1),
+            generation: 0,
+        };
+        let (leader, _) = store.flight_lock(&key).await.unwrap();
+        let (old_waiter, coalesced) = store.flight_lock(&key).await.unwrap();
+        assert!(coalesced);
+        store.finish_failure(&leader, SharedFlightFailure::Backend);
+        let old_cohort = leader.id;
+        drop(leader);
+
+        let new_calls = Arc::new(AtomicUsize::new(0));
+        let calls = new_calls.clone();
+        let recovered = store
+            .get_or_load(
+                key.request.clone(),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &CancellationToken::new(),
+                || async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(QueryPayload::complete(vec![7u8]))
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(recovered.payload.data, [7]);
+        assert_eq!(new_calls.load(Ordering::SeqCst), 1);
+        assert_ne!(store.inner.flight_sequence.load(Ordering::Relaxed) - 1, old_cohort);
+
+        let old_error = old_waiter
+            .wait::<Vec<u8>>(&key, &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(matches!(old_error, ToolExecutionError::Backend(_)));
+        drop(old_waiter);
+        assert!(store.lock_state().flights.records.is_empty());
+    }
+
+    #[tokio::test]
+    async fn completed_flights_remain_inside_scope_global_and_byte_budgets() {
+        let key = SnapshotKey {
+            request: request(SnapshotKind::TopicInventory, "bounded", 1),
+            generation: 0,
+        };
+        let other_scope = SnapshotKey {
+            request: request(SnapshotKind::ConsumerGroupInventory, "other", 1),
+            generation: 0,
+        };
+        let global = SnapshotStore::new(1);
+        let (leader, _) = global.flight_lock(&key).await.unwrap();
+        let (waiter, _) = global.flight_lock(&key).await.unwrap();
+        global.finish_failure(&leader, SharedFlightFailure::Backend);
+        drop(leader);
+        assert_eq!(
+            global.flight_lock(&other_scope).await.unwrap_err(),
+            SnapshotError::EntryBudgetExceeded
+        );
+        drop(waiter);
+
+        let scope = SnapshotStore::new(4);
+        let same_scope = SnapshotKey {
+            request: request(SnapshotKind::ConsumerGroupInventory, "bounded", 1),
+            generation: 0,
+        };
+        let (leader, _) = scope.flight_lock(&key).await.unwrap();
+        let (waiter, _) = scope.flight_lock(&key).await.unwrap();
+        scope.finish_failure(&leader, SharedFlightFailure::Backend);
+        drop(leader);
+        assert_eq!(
+            scope.flight_lock(&same_scope).await.unwrap_err(),
+            SnapshotError::EntryBudgetExceeded
+        );
+        drop(waiter);
+
+        let first_bytes = retained_flight_bytes(&key);
+        let second_bytes = retained_flight_bytes(&other_scope);
+        let bytes = SnapshotStore::with_limits(
+            4,
+            SnapshotLimits {
+                max_total_bytes: first_bytes + second_bytes - 1,
+                max_scope_bytes: first_bytes + second_bytes,
+                ..SnapshotLimits::default()
+            },
+        );
+        let (leader, _) = bytes.flight_lock(&key).await.unwrap();
+        let (waiter, _) = bytes.flight_lock(&key).await.unwrap();
+        bytes.finish_failure(&leader, SharedFlightFailure::Backend);
+        drop(leader);
+        assert_eq!(
+            bytes.flight_lock(&other_scope).await.unwrap_err(),
+            SnapshotError::ByteBudgetExceeded
+        );
+        drop(waiter);
+        let state = bytes.lock_state();
+        assert!(state.flights.records.is_empty());
+        assert_eq!(state.flights.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn dropping_leader_future_without_waiters_releases_container_high_water() {
+        let store = SnapshotStore::new(8);
+        let entered = Arc::new(Notify::new());
+        let task_store = store.clone();
+        let task_entered = entered.clone();
+        let handle = tokio::spawn(async move {
+            task_store
+                .get_or_load(
+                    request(SnapshotKind::TopicInventory, "abort-alone", 1),
+                    None,
+                    Duration::from_secs(1),
+                    Some(Duration::from_secs(1)),
+                    |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                    &CancellationToken::new(),
+                    || async move {
+                        task_entered.notify_one();
+                        pending::<Result<QueryPayload<Vec<u8>>, ToolExecutionError>>().await
+                    },
+                )
+                .await
+        });
+        entered.notified().await;
+        handle.abort();
+        assert!(handle.await.unwrap_err().is_cancelled());
+        let state = store.lock_state();
+        assert!(state.flights.records.is_empty());
+        assert_eq!(state.flights.records.capacity(), 0);
+        assert_eq!(state.flights.joinable.capacity(), 0);
+        assert_eq!(state.flights.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn dropping_leader_future_wakes_registered_waiter_and_releases_container() {
+        let store = SnapshotStore::new(8);
+        let entered = Arc::new(Notify::new());
+        let leader_store = store.clone();
+        let leader_entered = entered.clone();
+        let leader = tokio::spawn(async move {
+            leader_store
+                .get_or_load(
+                    request(SnapshotKind::TopicInventory, "abort-shared", 1),
+                    None,
+                    Duration::from_secs(1),
+                    Some(Duration::from_secs(1)),
+                    |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                    &CancellationToken::new(),
+                    || async move {
+                        leader_entered.notify_one();
+                        pending::<Result<QueryPayload<Vec<u8>>, ToolExecutionError>>().await
+                    },
+                )
+                .await
+        });
+        entered.notified().await;
+        let waiter_store = store.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_store
+                .get_or_load(
+                    request(SnapshotKind::TopicInventory, "abort-shared", 1),
+                    None,
+                    Duration::from_secs(1),
+                    Some(Duration::from_secs(1)),
+                    |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                    &CancellationToken::new(),
+                    || async { panic!("registered waiter must not load") },
+                )
+                .await
+        });
+        for _ in 0..1_000 {
+            if store.metrics().coalesced_waiters == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(store.metrics().coalesced_waiters, 1);
+        leader.abort();
+        assert!(leader.await.unwrap_err().is_cancelled());
+        let waiter_error = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter must be woken")
+            .unwrap()
+            .unwrap_err();
+        assert!(matches!(waiter_error, ToolExecutionError::Cancelled));
+        let state = store.lock_state();
+        assert!(state.flights.records.is_empty());
+        assert_eq!(state.flights.records.capacity(), 0);
+        assert_eq!(state.flights.joinable.capacity(), 0);
+        assert_eq!(state.flights.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn clear_atomically_invalidates_terminal_success_before_waiter_consumes_it() {
+        let store = SnapshotStore::new(8);
+        let key = SnapshotKey {
+            request: request(SnapshotKind::TopicInventory, "clear-terminal", 1),
+            generation: 0,
+        };
+        let (leader, _) = store.flight_lock(&key).await.unwrap();
+        let (waiter, _) = store.flight_lock(&key).await.unwrap();
+        let payload = QueryPayload::complete(vec![1u8, 2]);
+        let observed_at = observed_at();
+        let id = store.snapshot_id(&key);
+        let bytes = retained_entry_bytes(&payload, &key, &id, &observed_at);
+        store
+            .finish_success(
+                &leader,
+                id.clone(),
+                Arc::new(payload.clone()),
+                observed_at.clone(),
+                Instant::now(),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                bytes,
+            )
+            .unwrap();
+        drop(leader);
+        let leader_view = SnapshotView {
+            id,
+            request: key.request.clone(),
+            generation: key.generation,
+            position: 0,
+            payload,
+            observed_at,
+            freshness_ms: 0,
+            cache_status: CacheStatus::Miss,
+        };
+        let cursor = store
+            .page(&leader_view, &leader_view.payload.data)
+            .unwrap()
+            .next_cursor
+            .unwrap();
+
+        assert_eq!(store.clear().await, 1);
+        let waiter_error = waiter
+            .wait::<Vec<u8>>(&key, &CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(matches!(waiter_error, ToolExecutionError::InvalidArguments(_)));
+        drop(waiter);
+        let cursor_error = store
+            .get_or_load(
+                key.request,
+                Some(&cursor),
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &CancellationToken::new(),
+                || async { panic!("invalidated cursor must not reload") },
+            )
+            .await
+            .unwrap_err();
+        assert!(cursor_error.to_string().contains("invalidated"));
+        assert!(store.lock_state().flights.records.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stale_admission_and_late_leader_cannot_pollute_new_clear_generation() {
+        let store = SnapshotStore::new(8);
+        let stale_key = SnapshotKey {
+            request: request(SnapshotKind::TopicInventory, "clear-generation", 1),
+            generation: 0,
+        };
+        let (stale_leader, _) = store.flight_lock(&stale_key).await.unwrap();
+        let (stale_waiter, _) = store.flight_lock(&stale_key).await.unwrap();
+        store.clear().await;
+        assert_eq!(
+            store.flight_lock(&stale_key).await.unwrap_err(),
+            SnapshotError::Invalidated
+        );
+
+        let current = store
+            .get_or_load(
+                stale_key.request.clone(),
+                None,
+                Duration::from_secs(1),
+                Some(Duration::from_secs(1)),
+                |items: &Vec<u8>| SnapshotWeight::inventory(items.len()),
+                &CancellationToken::new(),
+                || async { Ok(QueryPayload::complete(vec![9u8])) },
+            )
+            .await
+            .unwrap();
+        assert_eq!(current.generation, 1);
+
+        let stale_payload = QueryPayload::complete(vec![1u8]);
+        let stale_observed_at = observed_at();
+        let stale_id = store.snapshot_id(&stale_key);
+        let stale_bytes = retained_entry_bytes(&stale_payload, &stale_key, &stale_id, &stale_observed_at);
+        assert_eq!(
+            store
+                .finish_success(
+                    &stale_leader,
+                    stale_id,
+                    Arc::new(stale_payload),
+                    stale_observed_at,
+                    Instant::now(),
+                    Duration::from_secs(1),
+                    Some(Duration::from_secs(1)),
+                    stale_bytes,
+                )
+                .unwrap_err(),
+            SnapshotError::Invalidated
+        );
+        drop(stale_leader);
+        assert!(matches!(
+            stale_waiter
+                .wait::<Vec<u8>>(&stale_key, &CancellationToken::new())
+                .await
+                .unwrap_err(),
+            ToolExecutionError::InvalidArguments(_)
+        ));
+        drop(stale_waiter);
+        let state = store.lock_state();
+        assert_eq!(state.snapshots.entries.len(), 1);
+        assert!(state.snapshots.entries.values().all(|entry| entry.key.generation == 1));
+        assert!(state.flights.records.is_empty());
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
@@ -118,7 +118,7 @@ impl SourceFailure {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) struct QueryPayload<T> {
     pub data: T,
     pub partial: bool,

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -84,6 +84,41 @@ expression: surface
       "name": "rocketmq_broker",
       "title": "RocketMQ broker",
       "uriTemplate": "rocketmq://clusters/{cluster}/brokers/{broker}"
+    },
+    {
+      "description": "Read a filtered page from one stable topic inventory snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topics_page",
+      "title": "RocketMQ topic page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics{?filter,limit,cursor}"
+    },
+    {
+      "description": "Read a bounded page from one stable topic detail snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topic_page",
+      "title": "RocketMQ topic detail page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics/{topic}{?limit,cursor}"
+    },
+    {
+      "description": "Read a bounded page from one stable topic route snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topic_route_page",
+      "title": "RocketMQ topic route page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics/{topic}/route{?limit,cursor}"
+    },
+    {
+      "description": "Read and enrich one filtered page from a stable consumer-group inventory snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_consumer_groups_page",
+      "title": "RocketMQ consumer group page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/consumer-groups{?filter,limit,cursor}"
+    },
+    {
+      "description": "Read a bounded page from one stable consumer-lag snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_consumer_lag_page",
+      "title": "RocketMQ consumer lag page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic,limit,cursor}"
     }
   ],
   "resources": [

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -84,6 +84,41 @@ expression: surface
       "name": "rocketmq_broker",
       "title": "RocketMQ broker",
       "uriTemplate": "rocketmq://clusters/{cluster}/brokers/{broker}"
+    },
+    {
+      "description": "Read a filtered page from one stable topic inventory snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topics_page",
+      "title": "RocketMQ topic page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics{?filter,limit,cursor}"
+    },
+    {
+      "description": "Read a bounded page from one stable topic detail snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topic_page",
+      "title": "RocketMQ topic detail page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics/{topic}{?limit,cursor}"
+    },
+    {
+      "description": "Read a bounded page from one stable topic route snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_topic_route_page",
+      "title": "RocketMQ topic route page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/topics/{topic}/route{?limit,cursor}"
+    },
+    {
+      "description": "Read and enrich one filtered page from a stable consumer-group inventory snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_consumer_groups_page",
+      "title": "RocketMQ consumer group page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/consumer-groups{?filter,limit,cursor}"
+    },
+    {
+      "description": "Read a bounded page from one stable consumer-lag snapshot.",
+      "mimeType": "application/json",
+      "name": "rocketmq_consumer_lag_page",
+      "title": "RocketMQ consumer lag page",
+      "uriTemplate": "rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic,limit,cursor}"
     }
   ],
   "resources": [

--- a/rocketmq-ai/rocketmq-mcp/src/resources/reader.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/resources/reader.rs
@@ -19,7 +19,6 @@ use serde_json::json;
 use serde_json::Value;
 
 use crate::adapter::query_facade::ReadOnlyQuery;
-use crate::model::contract::PageRequest;
 use crate::model::contract::SCHEMA_VERSION;
 use crate::resources::uri::ResourceKind;
 use crate::resources::uri::RocketmqResourceUri;
@@ -74,8 +73,8 @@ where
             let output = query
                 .list_topics(ListTopicsArgs {
                     cluster: Some(cluster.clone()),
-                    filter: None,
-                    page: PageRequest::default(),
+                    filter: uri.query().filter.clone(),
+                    page: uri.query().page.clone(),
                 })
                 .await?;
             Ok(live_payload(uri, "topics", output, |data| json!(data.page)))
@@ -85,7 +84,7 @@ where
                 .describe_topic(DescribeTopicArgs {
                     cluster: cluster.clone(),
                     topic: topic.clone(),
-                    page: PageRequest::default(),
+                    page: uri.query().page.clone(),
                 })
                 .await?;
             Ok(live_payload(uri, "topic", output, |data| json!(data)))
@@ -95,7 +94,7 @@ where
                 .query_topic_route(QueryTopicRouteArgs {
                     cluster: cluster.clone(),
                     topic: topic.clone(),
-                    page: PageRequest::default(),
+                    page: uri.query().page.clone(),
                 })
                 .await?;
             Ok(live_payload(uri, "route", output, |data| json!(data)))
@@ -127,34 +126,15 @@ where
             let output = query
                 .list_consumer_groups(ListConsumerGroupsArgs {
                     cluster: Some(cluster.clone()),
-                    filter: None,
-                    page: PageRequest::default(),
+                    filter: uri.query().filter.clone(),
+                    page: uri.query().page.clone(),
                 })
                 .await?;
             Ok(live_payload(uri, "consumer_groups", output, |data| json!(data.page)))
         }
         ResourceKind::ConsumerGroup(group) => {
-            let output = query
-                .list_consumer_groups(ListConsumerGroupsArgs {
-                    cluster: Some(cluster.clone()),
-                    filter: Some(group.clone()),
-                    page: PageRequest::default(),
-                })
-                .await?;
-            let consumer_group = output
-                .data
-                .page
-                .items
-                .iter()
-                .find(|item| item.group == *group)
-                .cloned()
-                .ok_or_else(|| {
-                    ToolExecutionError::InvalidArguments(format!(
-                        "consumer group not found in cluster {}: {group}",
-                        cluster
-                    ))
-                })?;
-            Ok(live_payload(uri, "consumer_group", output, |_| json!(consumer_group)))
+            let output = query.describe_consumer_group(cluster.clone(), group.clone()).await?;
+            Ok(live_payload(uri, "consumer_group", output, |data| json!(data)))
         }
         ResourceKind::ConsumerLag { group, topic } => {
             let output = query
@@ -162,7 +142,7 @@ where
                     cluster: cluster.clone(),
                     topic: topic.clone(),
                     consumer_group: group.clone(),
-                    page: PageRequest::default(),
+                    page: uri.query().page.clone(),
                 })
                 .await?;
             Ok(live_payload(uri, "consumer_lag", output, |data| json!(data)))

--- a/rocketmq-ai/rocketmq-mcp/src/resources/registry.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/resources/registry.rs
@@ -100,6 +100,36 @@ pub fn list_resource_templates(
             "RocketMQ broker",
             "Read-only details for one RocketMQ broker.",
         ),
+        resource_template(
+            "rocketmq://clusters/{cluster}/topics{?filter,limit,cursor}",
+            "rocketmq_topics_page",
+            "RocketMQ topic page",
+            "Read a filtered page from one stable topic inventory snapshot.",
+        ),
+        resource_template(
+            "rocketmq://clusters/{cluster}/topics/{topic}{?limit,cursor}",
+            "rocketmq_topic_page",
+            "RocketMQ topic detail page",
+            "Read a bounded page from one stable topic detail snapshot.",
+        ),
+        resource_template(
+            "rocketmq://clusters/{cluster}/topics/{topic}/route{?limit,cursor}",
+            "rocketmq_topic_route_page",
+            "RocketMQ topic route page",
+            "Read a bounded page from one stable topic route snapshot.",
+        ),
+        resource_template(
+            "rocketmq://clusters/{cluster}/consumer-groups{?filter,limit,cursor}",
+            "rocketmq_consumer_groups_page",
+            "RocketMQ consumer group page",
+            "Read and enrich one filtered page from a stable consumer-group inventory snapshot.",
+        ),
+        resource_template(
+            "rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic,limit,cursor}",
+            "rocketmq_consumer_lag_page",
+            "RocketMQ consumer lag page",
+            "Read a bounded page from one stable consumer-lag snapshot.",
+        ),
     ];
     let page = discovery_page(templates, request)?;
     let mut result = ListResourceTemplatesResult::with_all_items(page.items);
@@ -181,6 +211,11 @@ mod tests {
                 "rocketmq://clusters/{cluster}/consumer-groups/{group}",
                 "rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic}",
                 "rocketmq://clusters/{cluster}/brokers/{broker}",
+                "rocketmq://clusters/{cluster}/topics{?filter,limit,cursor}",
+                "rocketmq://clusters/{cluster}/topics/{topic}{?limit,cursor}",
+                "rocketmq://clusters/{cluster}/topics/{topic}/route{?limit,cursor}",
+                "rocketmq://clusters/{cluster}/consumer-groups{?filter,limit,cursor}",
+                "rocketmq://clusters/{cluster}/consumer-groups/{group}/lag{?topic,limit,cursor}",
             ]
         );
     }

--- a/rocketmq-ai/rocketmq-mcp/src/resources/uri.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/resources/uri.rs
@@ -17,6 +17,9 @@ use percent_encoding::utf8_percent_encode;
 use percent_encoding::AsciiSet;
 use percent_encoding::CONTROLS;
 
+use crate::model::contract::PageRequest;
+use crate::model::contract::MAX_PAGE_LIMIT;
+
 pub const JSON_MIME_TYPE: &str = "application/json";
 const CLUSTER_URI_PREFIX: &str = "rocketmq://clusters/";
 const SYSTEM_URI_PREFIX: &str = "rocketmq://system/";
@@ -89,11 +92,7 @@ impl ResourceKind {
             Self::Broker(broker) => format!("brokers/{}", encode_segment(broker)),
             Self::ConsumerGroups => "consumer-groups".to_string(),
             Self::ConsumerGroup(group) => format!("consumer-groups/{}", encode_segment(group)),
-            Self::ConsumerLag { group, topic } => format!(
-                "consumer-groups/{}/lag?topic={}",
-                encode_segment(group),
-                encode_segment(topic)
-            ),
+            Self::ConsumerLag { group, .. } => format!("consumer-groups/{}/lag", encode_segment(group)),
         }
     }
 
@@ -136,6 +135,13 @@ impl ResourceKind {
 pub struct RocketmqResourceUri {
     cluster: Option<String>,
     pub kind: ResourceKind,
+    query: ResourceQuery,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResourceQuery {
+    pub filter: Option<String>,
+    pub page: PageRequest,
 }
 
 impl RocketmqResourceUri {
@@ -143,6 +149,7 @@ impl RocketmqResourceUri {
         Self {
             cluster: Some(cluster.into()),
             kind,
+            query: ResourceQuery::default(),
         }
     }
 
@@ -151,7 +158,11 @@ impl RocketmqResourceUri {
             kind,
             ResourceKind::SystemRuntimeV1 | ResourceKind::SystemObservabilityV1
         )
-        .then_some(Self { cluster: None, kind })
+        .then_some(Self {
+            cluster: None,
+            kind,
+            query: ResourceQuery::default(),
+        })
     }
 
     pub fn cluster(&self) -> Option<&str> {
@@ -160,6 +171,10 @@ impl RocketmqResourceUri {
 
     pub fn is_system(&self) -> bool {
         self.cluster.is_none()
+    }
+
+    pub fn query(&self) -> &ResourceQuery {
+        &self.query
     }
 
     pub fn parse(uri: &str) -> Option<Self> {
@@ -187,33 +202,65 @@ impl RocketmqResourceUri {
         if segments.iter().any(|segment| segment.is_empty()) {
             return None;
         }
-        let kind = match (segments.as_slice(), query) {
-            (["capabilities"], None) => ResourceKind::Capabilities,
-            (["overview"], None) => ResourceKind::Overview,
-            (["topics"], None) => ResourceKind::Topics,
-            (["topics", topic], None) => ResourceKind::Topic(decode_segment(topic)?),
-            (["topics", topic, "route"], None) => ResourceKind::TopicRoute(decode_segment(topic)?),
-            (["brokers"], None) => ResourceKind::Brokers,
-            (["brokers", broker], None) => ResourceKind::Broker(decode_segment(broker)?),
-            (["consumer-groups"], None) => ResourceKind::ConsumerGroups,
-            (["consumer-groups", group], None) => ResourceKind::ConsumerGroup(decode_segment(group)?),
-            (["consumer-groups", group, "lag"], Some(query)) => {
-                let topic = query
-                    .strip_prefix("topic=")
-                    .filter(|topic| !topic.is_empty() && !topic.contains('&'))?;
-                ResourceKind::ConsumerLag {
-                    group: decode_segment(group)?,
-                    topic: decode_segment(topic)?,
+        let parameters = parse_query(query)?;
+        let (kind, query) = match segments.as_slice() {
+            ["capabilities"] if parameters.is_empty() => (ResourceKind::Capabilities, ResourceQuery::default()),
+            ["overview"] if parameters.is_empty() => (ResourceKind::Overview, ResourceQuery::default()),
+            ["topics"] => (
+                ResourceKind::Topics,
+                resource_query(&parameters, &["filter", "limit", "cursor"])?,
+            ),
+            ["topics", topic] => (
+                ResourceKind::Topic(decode_segment(topic)?),
+                resource_query(&parameters, &["limit", "cursor"])?,
+            ),
+            ["topics", topic, "route"] => (
+                ResourceKind::TopicRoute(decode_segment(topic)?),
+                resource_query(&parameters, &["limit", "cursor"])?,
+            ),
+            ["brokers"] if parameters.is_empty() => (ResourceKind::Brokers, ResourceQuery::default()),
+            ["brokers", broker] if parameters.is_empty() => {
+                (ResourceKind::Broker(decode_segment(broker)?), ResourceQuery::default())
+            }
+            ["consumer-groups"] => (
+                ResourceKind::ConsumerGroups,
+                resource_query(&parameters, &["filter", "limit", "cursor"])?,
+            ),
+            ["consumer-groups", group] if parameters.is_empty() => (
+                ResourceKind::ConsumerGroup(decode_segment(group)?),
+                ResourceQuery::default(),
+            ),
+            ["consumer-groups", group, "lag"] => {
+                if parameters
+                    .keys()
+                    .any(|key| !["topic", "limit", "cursor"].contains(&key.as_str()))
+                {
+                    return None;
                 }
+                let topic = parameters.get("topic").filter(|topic| !topic.is_empty())?.clone();
+                (
+                    ResourceKind::ConsumerLag {
+                        group: decode_segment(group)?,
+                        topic,
+                    },
+                    resource_query(&parameters, &["topic", "limit", "cursor"])?,
+                )
             }
             _ => return None,
         };
-        Some(Self::new(cluster, kind))
+        Some(Self {
+            cluster: Some(cluster),
+            kind,
+            query,
+        })
     }
 
     pub fn as_string(&self) -> String {
         match &self.cluster {
-            Some(cluster) => format!("{CLUSTER_URI_PREFIX}{}/{}", encode_segment(cluster), self.kind.path()),
+            Some(cluster) => {
+                let base = format!("{CLUSTER_URI_PREFIX}{}/{}", encode_segment(cluster), self.kind.path());
+                append_query(base, &self.kind, &self.query)
+            }
             None => format!("{SYSTEM_URI_PREFIX}{}", self.kind.path()),
         }
     }
@@ -224,6 +271,65 @@ impl RocketmqResourceUri {
             Some(cluster) => format!("{cluster}_{path}"),
             None => format!("system_{path}"),
         }
+    }
+}
+
+fn parse_query(query: Option<&str>) -> Option<std::collections::BTreeMap<String, String>> {
+    let Some(query) = query else {
+        return Some(std::collections::BTreeMap::new());
+    };
+    let mut parameters = std::collections::BTreeMap::new();
+    for parameter in query.split('&') {
+        let (key, value) = parameter.split_once('=')?;
+        if key.is_empty() || value.is_empty() || parameters.contains_key(key) {
+            return None;
+        }
+        parameters.insert(key.to_string(), decode_segment(value)?);
+    }
+    Some(parameters)
+}
+
+fn resource_query(parameters: &std::collections::BTreeMap<String, String>, allowed: &[&str]) -> Option<ResourceQuery> {
+    if parameters.keys().any(|key| !allowed.contains(&key.as_str())) {
+        return None;
+    }
+    let limit = match parameters.get("limit") {
+        Some(limit) => {
+            let limit = limit.parse::<u32>().ok()?;
+            if !(1..=MAX_PAGE_LIMIT).contains(&limit) {
+                return None;
+            }
+            Some(limit)
+        }
+        None => None,
+    };
+    Some(ResourceQuery {
+        filter: parameters.get("filter").cloned(),
+        page: PageRequest {
+            limit,
+            cursor: parameters.get("cursor").cloned(),
+        },
+    })
+}
+
+fn append_query(base: String, kind: &ResourceKind, query: &ResourceQuery) -> String {
+    let mut parameters = Vec::new();
+    if let ResourceKind::ConsumerLag { topic, .. } = kind {
+        parameters.push(format!("topic={}", encode_segment(topic)));
+    }
+    if let Some(filter) = query.filter.as_deref() {
+        parameters.push(format!("filter={}", encode_segment(filter)));
+    }
+    if let Some(limit) = query.page.limit {
+        parameters.push(format!("limit={limit}"));
+    }
+    if let Some(cursor) = query.page.cursor.as_deref() {
+        parameters.push(format!("cursor={}", encode_segment(cursor)));
+    }
+    if parameters.is_empty() {
+        base
+    } else {
+        format!("{base}?{}", parameters.join("&"))
     }
 }
 
@@ -329,5 +435,27 @@ mod tests {
              3Dhigh"
         );
         assert_eq!(decoded, uri);
+    }
+
+    #[test]
+    fn query_bearing_resource_uris_round_trip_bounded_pagination() {
+        let uri = RocketmqResourceUri::parse(
+            "rocketmq://clusters/local-dev/topics?filter=order%2Fpriority&limit=2&cursor=rmq-s2-ab.cd",
+        )
+        .unwrap();
+        assert_eq!(uri.query().filter.as_deref(), Some("order/priority"));
+        assert_eq!(uri.query().page.limit, Some(2));
+        assert_eq!(uri.query().page.cursor.as_deref(), Some("rmq-s2-ab.cd"));
+        assert_eq!(
+            uri.as_string(),
+            "rocketmq://clusters/local-dev/topics?filter=order%2Fpriority&limit=2&cursor=rmq-s2-ab.cd"
+        );
+
+        assert!(RocketmqResourceUri::parse("rocketmq://clusters/local-dev/topics?limit=0").is_none());
+        assert!(RocketmqResourceUri::parse("rocketmq://clusters/local-dev/topics?unknown=x").is_none());
+        assert!(RocketmqResourceUri::parse(
+            "rocketmq://clusters/local-dev/consumer-groups/group/lag?topic=orders&topic=payments"
+        )
+        .is_none());
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
@@ -202,6 +202,26 @@ impl ConsumerAdmin for AdminSession {
         })
     }
 
+    fn list_consumer_group_inventory_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a consumer::ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<consumer::ConsumerGroupInventoryResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            consumer_group_inventory(&mut self.inner).await
+        })
+    }
+
+    fn enrich_consumer_groups_exact_with_evidence<'a>(
+        &'a mut self,
+        request: &'a consumer::ExactConsumerGroupEnrichmentRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<consumer::ListConsumerGroupsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            enrich_consumer_groups_exact(&mut self.inner, request).await
+        })
+    }
+
     fn query_consumer_lag<'a>(
         &'a mut self,
         request: &'a consumer::QueryConsumerLagRequest,
@@ -795,6 +815,125 @@ fn default_consumer_group_summary(group: &str) -> consumer::ConsumerGroupSummary
     }
 }
 
+#[derive(Clone)]
+struct ExactGroupObservation {
+    summary: consumer::ConsumerGroupSummary,
+    successful_sources: usize,
+    failures: Vec<AdminSourceFailure>,
+}
+
+trait ConsumerGroupSnapshotSource {
+    fn fetch_retry_topics(&mut self) -> AdminFuture<'_, Vec<CheetahString>>;
+
+    fn observe_exact_group<'a>(&'a mut self, group: &'a str) -> AdminFuture<'a, ExactGroupObservation>;
+}
+
+impl ConsumerGroupSnapshotSource for rocketmq_client_rust::DefaultMQAdminExt {
+    fn fetch_retry_topics(&mut self) -> AdminFuture<'_, Vec<CheetahString>> {
+        Box::pin(async move {
+            self.fetch_all_topic_list()
+                .await
+                .map(|topics| topics.topic_list)
+                .map_err(|error| backend_error("fetch_all_topic_list", error))
+        })
+    }
+
+    fn observe_exact_group<'a>(&'a mut self, group: &'a str) -> AdminFuture<'a, ExactGroupObservation> {
+        Box::pin(async move {
+            let mut summary = default_consumer_group_summary(group);
+            let mut successful_sources = 0usize;
+            let mut failures = Vec::new();
+            match rocketmq_client_rust::MQAdminReadExt::examine_consume_stats_with_evidence(
+                &*self,
+                CheetahString::from(group),
+                None,
+                None,
+                None,
+            )
+            .await
+            {
+                Ok(stats) => {
+                    successful_sources += stats.successful_brokers;
+                    summary.consume_tps = stats.stats.get_consume_tps();
+                    summary.diff_total = stats.stats.compute_total_diff();
+                    failures.extend(stats.failures.into_iter().map(|failure| {
+                        source_failure_from_client(
+                            AdminQuerySource::ConsumerStatistics,
+                            failure.broker_name(),
+                            failure.code(),
+                            failure.retryable(),
+                        )
+                    }));
+                }
+                Err(error) => failures.push(source_failure(AdminQuerySource::ConsumerStatistics, group, &error)),
+            }
+            let connection_evidence = collect_group_connection_evidence(self, group).await;
+            successful_sources += connection_evidence.successful_sources;
+            if connection_evidence.successful_sources == 0
+                && connection_evidence.failures.is_empty()
+                && connection_evidence.summary.is_some()
+            {
+                successful_sources += 1;
+            }
+            failures.extend(connection_evidence.failures);
+            if let Some(connection) = connection_evidence.summary {
+                summary.client_count = connection.client_count;
+                summary.consume_type = connection.consume_type;
+                summary.message_model = connection.message_model;
+                summary.version = connection.version;
+            }
+            Ok(ExactGroupObservation {
+                summary,
+                successful_sources,
+                failures,
+            })
+        })
+    }
+}
+
+async fn consumer_group_inventory(
+    source: &mut impl ConsumerGroupSnapshotSource,
+) -> AdminResult<AdminQueryResult<consumer::ConsumerGroupInventoryResult>> {
+    let topics = source.fetch_retry_topics().await?;
+    Ok(AdminQueryResult::complete(consumer::ConsumerGroupInventoryResult {
+        groups: retry_consumer_groups(topics),
+    }))
+}
+
+async fn enrich_consumer_groups_exact(
+    source: &mut impl ConsumerGroupSnapshotSource,
+    request: &consumer::ExactConsumerGroupEnrichmentRequest,
+) -> AdminResult<AdminQueryResult<consumer::ListConsumerGroupsResult>> {
+    if request.groups().is_empty() {
+        return Ok(AdminQueryResult::complete(consumer::ListConsumerGroupsResult::default()));
+    }
+    let mut groups = Vec::with_capacity(request.groups().len());
+    let mut failures = Vec::new();
+    let mut successful_sources = 0usize;
+    for group in request.groups() {
+        let observation = source.observe_exact_group(group).await?;
+        successful_sources += observation.successful_sources;
+        failures.extend(observation.failures);
+        groups.push(observation.summary);
+    }
+    AdminQueryResult::from_sources(
+        consumer::ListConsumerGroupsResult { groups },
+        successful_sources,
+        failures,
+    )
+}
+
+fn retry_consumer_groups(topics: impl IntoIterator<Item = CheetahString>) -> Vec<String> {
+    let mut groups = topics
+        .into_iter()
+        .filter(|topic| topic.starts_with(RETRY_GROUP_TOPIC_PREFIX))
+        .map(|topic| KeyBuilder::parse_group(topic.as_str()))
+        .collect::<Vec<_>>();
+    groups.sort();
+    groups.dedup();
+    groups
+}
+
 struct GroupConnectionSummary {
     client_count: i32,
     consume_type: String,
@@ -965,6 +1104,119 @@ fn backend_error(operation: &'static str, error: RocketMQError) -> AdminError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    mod consumer_snapshot_tests {
+        use super::*;
+
+        #[derive(Default)]
+        struct FakeSource {
+            inventory_calls: usize,
+            observed_groups: Vec<String>,
+            topics: Vec<CheetahString>,
+            partial_groups: HashSet<String>,
+            failed_groups: HashSet<String>,
+        }
+
+        impl ConsumerGroupSnapshotSource for FakeSource {
+            fn fetch_retry_topics(&mut self) -> AdminFuture<'_, Vec<CheetahString>> {
+                Box::pin(async move {
+                    self.inventory_calls += 1;
+                    Ok(self.topics.clone())
+                })
+            }
+
+            fn observe_exact_group<'a>(&'a mut self, group: &'a str) -> AdminFuture<'a, ExactGroupObservation> {
+                Box::pin(async move {
+                    self.observed_groups.push(group.to_string());
+                    let failed = self.failed_groups.contains(group);
+                    let partial = self.partial_groups.contains(group);
+                    let failures = (failed || partial)
+                        .then(|| {
+                            AdminSourceFailure::new(
+                                AdminQuerySource::ConsumerStatistics,
+                                AdminQueryFailureCode::SourceUnavailable,
+                                true,
+                                "10.0.0.1:10911",
+                            )
+                        })
+                        .into_iter()
+                        .collect();
+                    Ok(ExactGroupObservation {
+                        summary: default_consumer_group_summary(group),
+                        successful_sources: usize::from(!failed),
+                        failures,
+                    })
+                })
+            }
+        }
+
+        #[tokio::test]
+        async fn inventory_is_one_rpc_and_never_enriches() {
+            let mut source = FakeSource {
+                topics: vec![
+                    "%RETRY%group-b".into(),
+                    "orders".into(),
+                    "%RETRY%group-a".into(),
+                    "%RETRY%group-b".into(),
+                ],
+                ..Default::default()
+            };
+            let result = consumer_group_inventory(&mut source).await.unwrap();
+            assert_eq!(result.data.groups, ["group-a", "group-b"]);
+            assert_eq!(source.inventory_calls, 1);
+            assert!(source.observed_groups.is_empty());
+        }
+
+        #[tokio::test]
+        async fn exact_enrichment_is_bounded_sorted_and_skips_inventory() {
+            let request =
+                consumer::ExactConsumerGroupEnrichmentRequest::try_new(["group-b", "group-a", "group-b"]).unwrap();
+            let mut source = FakeSource::default();
+            let result = enrich_consumer_groups_exact(&mut source, &request).await.unwrap();
+            assert_eq!(source.inventory_calls, 0);
+            assert_eq!(source.observed_groups, ["group-a", "group-b"]);
+            assert_eq!(
+                result
+                    .data
+                    .groups
+                    .iter()
+                    .map(|group| group.group.as_str())
+                    .collect::<Vec<_>>(),
+                ["group-a", "group-b"]
+            );
+
+            let empty = consumer::ExactConsumerGroupEnrichmentRequest::try_new(Vec::<String>::new()).unwrap();
+            enrich_consumer_groups_exact(&mut source, &empty).await.unwrap();
+            assert_eq!(source.observed_groups, ["group-a", "group-b"]);
+            assert!(consumer::ExactConsumerGroupEnrichmentRequest::try_new(["invalid.group"]).is_err());
+            assert!(consumer::ExactConsumerGroupEnrichmentRequest::try_new(
+                (0..consumer::ExactConsumerGroupEnrichmentRequest::MAX_GROUPS).map(|index| format!("group-{index}"))
+            )
+            .is_ok());
+            assert!(consumer::ExactConsumerGroupEnrichmentRequest::try_new(
+                (0..=consumer::ExactConsumerGroupEnrichmentRequest::MAX_GROUPS).map(|index| format!("group-{index}"))
+            )
+            .is_err());
+        }
+
+        #[tokio::test]
+        async fn exact_enrichment_preserves_partial_total_and_safe_evidence() {
+            let request = consumer::ExactConsumerGroupEnrichmentRequest::try_new(["group-a"]).unwrap();
+            let mut partial = FakeSource {
+                partial_groups: HashSet::from(["group-a".to_string()]),
+                ..Default::default()
+            };
+            let result = enrich_consumer_groups_exact(&mut partial, &request).await.unwrap();
+            assert!(result.partial);
+            assert_eq!(result.source_failures[0].logical_target(), "unknown");
+
+            let mut failed = FakeSource {
+                failed_groups: HashSet::from(["group-a".to_string()]),
+                ..Default::default()
+            };
+            assert!(enrich_consumer_groups_exact(&mut failed, &request).await.is_err());
+        }
+    }
 
     #[test]
     fn admin_session_exposes_independent_consumer_diagnostics() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
@@ -1366,6 +1366,26 @@ impl ConsumerQueryAdmin for ReadAdminSession {
         })
     }
 
+    fn list_consumer_group_inventory_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a consumer::ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<consumer::ConsumerGroupInventoryResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            consumer_group_inventory(&mut self.inner).await
+        })
+    }
+
+    fn enrich_consumer_groups_exact_with_evidence<'a>(
+        &'a mut self,
+        request: &'a consumer::ExactConsumerGroupEnrichmentRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<consumer::ListConsumerGroupsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            enrich_consumer_groups_exact(&mut self.inner, request).await
+        })
+    }
+
     fn query_consumer_lag<'a>(
         &'a mut self,
         request: &'a consumer::QueryConsumerLagRequest,
@@ -1751,6 +1771,124 @@ fn default_consumer_group_summary(group: &str) -> consumer::ConsumerGroupSummary
     }
 }
 
+#[derive(Clone)]
+struct ExactGroupObservation {
+    summary: consumer::ConsumerGroupSummary,
+    successful_sources: usize,
+    failures: Vec<AdminSourceFailure>,
+}
+
+trait ConsumerGroupSnapshotSource {
+    fn fetch_retry_topics(&mut self) -> AdminFuture<'_, Vec<CheetahString>>;
+
+    fn observe_exact_group<'a>(&'a mut self, group: &'a str) -> AdminFuture<'a, ExactGroupObservation>;
+}
+
+impl ConsumerGroupSnapshotSource for DefaultMQAdminExt {
+    fn fetch_retry_topics(&mut self) -> AdminFuture<'_, Vec<CheetahString>> {
+        Box::pin(async move {
+            self.fetch_all_topic_list()
+                .await
+                .map(|topics| topics.topic_list)
+                .map_err(|error| backend_error("fetch_all_topic_list", error))
+        })
+    }
+
+    fn observe_exact_group<'a>(&'a mut self, group: &'a str) -> AdminFuture<'a, ExactGroupObservation> {
+        Box::pin(async move {
+            let mut summary = default_consumer_group_summary(group);
+            let mut successful_sources = 0usize;
+            let mut failures = Vec::new();
+            match self
+                .examine_consume_stats_with_evidence(CheetahString::from(group), None, None, None)
+                .await
+            {
+                Ok(stats) => {
+                    successful_sources += stats.successful_brokers;
+                    summary.consume_tps = stats.stats.get_consume_tps();
+                    summary.diff_total = stats.stats.compute_total_diff();
+                    failures.extend(stats.failures.into_iter().map(|failure| {
+                        source_failure_from_client(
+                            AdminQuerySource::ConsumerStatistics,
+                            failure.broker_name(),
+                            failure.code(),
+                            failure.retryable(),
+                        )
+                    }));
+                }
+                Err(error) => failures.push(source_failure_from_error(
+                    AdminQuerySource::ConsumerStatistics,
+                    group,
+                    &error,
+                )),
+            }
+            let connection_evidence = collect_group_connection_summary(self, group).await?;
+            successful_sources += connection_evidence.successful_sources;
+            if connection_evidence.successful_sources == 0
+                && connection_evidence.failures.is_empty()
+                && connection_evidence.summary.is_some()
+            {
+                successful_sources += 1;
+            }
+            failures.extend(connection_evidence.failures);
+            if let Some(connection) = connection_evidence.summary {
+                summary.client_count = connection.client_count;
+                summary.consume_type = connection.consume_type;
+                summary.message_model = connection.message_model;
+                summary.version = connection.version;
+            }
+            Ok(ExactGroupObservation {
+                summary,
+                successful_sources,
+                failures,
+            })
+        })
+    }
+}
+
+async fn consumer_group_inventory(
+    source: &mut impl ConsumerGroupSnapshotSource,
+) -> AdminResult<AdminQueryResult<consumer::ConsumerGroupInventoryResult>> {
+    let topics = source.fetch_retry_topics().await?;
+    Ok(AdminQueryResult::complete(consumer::ConsumerGroupInventoryResult {
+        groups: retry_consumer_groups(topics),
+    }))
+}
+
+async fn enrich_consumer_groups_exact(
+    source: &mut impl ConsumerGroupSnapshotSource,
+    request: &consumer::ExactConsumerGroupEnrichmentRequest,
+) -> AdminResult<AdminQueryResult<consumer::ListConsumerGroupsResult>> {
+    if request.groups().is_empty() {
+        return Ok(AdminQueryResult::complete(consumer::ListConsumerGroupsResult::default()));
+    }
+    let mut groups = Vec::with_capacity(request.groups().len());
+    let mut failures = Vec::new();
+    let mut successful_sources = 0usize;
+    for group in request.groups() {
+        let observation = source.observe_exact_group(group).await?;
+        successful_sources += observation.successful_sources;
+        failures.extend(observation.failures);
+        groups.push(observation.summary);
+    }
+    AdminQueryResult::from_sources(
+        consumer::ListConsumerGroupsResult { groups },
+        successful_sources,
+        failures,
+    )
+}
+
+fn retry_consumer_groups(topics: impl IntoIterator<Item = CheetahString>) -> Vec<String> {
+    let mut groups = topics
+        .into_iter()
+        .filter(|topic| topic.starts_with(RETRY_GROUP_TOPIC_PREFIX))
+        .map(|topic| KeyBuilder::parse_group(topic.as_str()))
+        .collect::<Vec<_>>();
+    groups.sort();
+    groups.dedup();
+    groups
+}
+
 struct ConsumerConnectionSummary {
     client_count: i32,
     consume_type: String,
@@ -2025,6 +2163,121 @@ mod tests {
     use rocketmq_protocol::protocol::LanguageCode;
 
     use super::*;
+
+    mod consumer_snapshot_tests {
+        use std::collections::HashSet;
+
+        use super::*;
+
+        #[derive(Default)]
+        struct FakeSource {
+            inventory_calls: usize,
+            observed_groups: Vec<String>,
+            topics: Vec<CheetahString>,
+            partial_groups: HashSet<String>,
+            failed_groups: HashSet<String>,
+        }
+
+        impl ConsumerGroupSnapshotSource for FakeSource {
+            fn fetch_retry_topics(&mut self) -> AdminFuture<'_, Vec<CheetahString>> {
+                Box::pin(async move {
+                    self.inventory_calls += 1;
+                    Ok(self.topics.clone())
+                })
+            }
+
+            fn observe_exact_group<'a>(&'a mut self, group: &'a str) -> AdminFuture<'a, ExactGroupObservation> {
+                Box::pin(async move {
+                    self.observed_groups.push(group.to_string());
+                    let failed = self.failed_groups.contains(group);
+                    let partial = self.partial_groups.contains(group);
+                    let failures = (failed || partial)
+                        .then(|| {
+                            AdminSourceFailure::new(
+                                AdminQuerySource::ConsumerStatistics,
+                                AdminQueryFailureCode::SourceUnavailable,
+                                true,
+                                "10.0.0.1:10911",
+                            )
+                        })
+                        .into_iter()
+                        .collect();
+                    Ok(ExactGroupObservation {
+                        summary: default_consumer_group_summary(group),
+                        successful_sources: usize::from(!failed),
+                        failures,
+                    })
+                })
+            }
+        }
+
+        #[tokio::test]
+        async fn inventory_is_one_rpc_and_never_enriches() {
+            let mut source = FakeSource {
+                topics: vec![
+                    "%RETRY%group-b".into(),
+                    "orders".into(),
+                    "%RETRY%group-a".into(),
+                    "%RETRY%group-b".into(),
+                ],
+                ..Default::default()
+            };
+            let result = consumer_group_inventory(&mut source).await.unwrap();
+            assert_eq!(result.data.groups, ["group-a", "group-b"]);
+            assert_eq!(source.inventory_calls, 1);
+            assert!(source.observed_groups.is_empty());
+        }
+
+        #[tokio::test]
+        async fn exact_enrichment_is_bounded_sorted_and_skips_inventory() {
+            let request =
+                consumer::ExactConsumerGroupEnrichmentRequest::try_new(["group-b", "group-a", "group-b"]).unwrap();
+            let mut source = FakeSource::default();
+            let result = enrich_consumer_groups_exact(&mut source, &request).await.unwrap();
+            assert_eq!(source.inventory_calls, 0);
+            assert_eq!(source.observed_groups, ["group-a", "group-b"]);
+            assert_eq!(
+                result
+                    .data
+                    .groups
+                    .iter()
+                    .map(|group| group.group.as_str())
+                    .collect::<Vec<_>>(),
+                ["group-a", "group-b"]
+            );
+
+            let empty = consumer::ExactConsumerGroupEnrichmentRequest::try_new(Vec::<String>::new()).unwrap();
+            enrich_consumer_groups_exact(&mut source, &empty).await.unwrap();
+            assert_eq!(source.observed_groups, ["group-a", "group-b"]);
+            assert!(consumer::ExactConsumerGroupEnrichmentRequest::try_new(["invalid.group"]).is_err());
+            assert!(consumer::ExactConsumerGroupEnrichmentRequest::try_new(
+                (0..consumer::ExactConsumerGroupEnrichmentRequest::MAX_GROUPS).map(|index| format!("group-{index}"))
+            )
+            .is_ok());
+            assert!(consumer::ExactConsumerGroupEnrichmentRequest::try_new(
+                (0..=consumer::ExactConsumerGroupEnrichmentRequest::MAX_GROUPS).map(|index| format!("group-{index}"))
+            )
+            .is_err());
+        }
+
+        #[tokio::test]
+        async fn exact_enrichment_preserves_partial_total_and_safe_evidence() {
+            let request = consumer::ExactConsumerGroupEnrichmentRequest::try_new(["group-a"]).unwrap();
+            let mut partial = FakeSource {
+                partial_groups: HashSet::from(["group-a".to_string()]),
+                ..Default::default()
+            };
+            let result = enrich_consumer_groups_exact(&mut partial, &request).await.unwrap();
+            assert!(result.partial);
+            assert_eq!(result.source_failures[0].logical_target(), "unknown");
+
+            let mut failed = FakeSource {
+                failed_groups: HashSet::from(["group-a".to_string()]),
+                ..Default::default()
+            };
+            assert!(enrich_consumer_groups_exact(&mut failed, &request).await.is_err());
+        }
+    }
 
     #[test]
     fn cluster_topic_inventory_filters_retry_and_dlq_then_sorts_and_deduplicates() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
@@ -42,6 +42,74 @@ pub struct ListConsumerGroupsResult {
     pub groups: Vec<ConsumerGroupSummary>,
 }
 
+/// Cheap, ordered consumer-group inventory without per-group enrichment.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsumerGroupInventoryResult {
+    pub groups: Vec<String>,
+}
+
+/// Validated logical groups selected for bounded exact enrichment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ExactConsumerGroupEnrichmentRequest {
+    groups: Vec<String>,
+}
+
+impl<'de> Deserialize<'de> for ExactConsumerGroupEnrichmentRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireRequest {
+            groups: Vec<String>,
+        }
+
+        let request = WireRequest::deserialize(deserializer)?;
+        Self::try_new(request.groups).map_err(serde::de::Error::custom)
+    }
+}
+
+impl ExactConsumerGroupEnrichmentRequest {
+    /// Maximum number of logical groups accepted by one enrichment request.
+    pub const MAX_GROUPS: usize = 200;
+
+    /// Normalizes, sorts, deduplicates, and bounds exact logical group names.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-argument error when a name is blank or the unique
+    /// group count exceeds [`Self::MAX_GROUPS`].
+    pub fn try_new<I, S>(groups: I) -> AdminResult<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut groups = groups
+            .into_iter()
+            .map(|group| {
+                let group = required("consumerGroup", group)?;
+                validate_subscription_group_name(&group)
+                    .map_err(|error| crate::core::AdminError::invalid_argument("consumerGroup", error.to_string()))?;
+                Ok(group)
+            })
+            .collect::<AdminResult<Vec<_>>>()?;
+        groups.sort();
+        groups.dedup();
+        if groups.len() > Self::MAX_GROUPS {
+            return Err(crate::core::AdminError::invalid_argument(
+                "consumerGroups",
+                format!("must contain at most {} unique groups", Self::MAX_GROUPS),
+            ));
+        }
+        Ok(Self { groups })
+    }
+
+    #[must_use]
+    pub fn groups(&self) -> &[String] {
+        &self.groups
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueryConsumerLagRequest {
     pub topic: String,
@@ -1011,6 +1079,40 @@ pub trait ConsumerAdmin: Send {
         Box::pin(async move { self.list_consumer_groups(request).await.map(AdminQueryResult::complete) })
     }
 
+    /// Evidence-aware cheap inventory sibling of [`Self::list_consumer_groups`].
+    ///
+    /// Implementations must use a single inventory source and perform no
+    /// per-group enrichment. The default fails closed when that capability is
+    /// unavailable.
+    fn list_consumer_group_inventory_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ConsumerGroupInventoryResult>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "list_consumer_group_inventory_with_evidence",
+                "cheap consumer group inventory is not implemented by this adapter",
+            ))
+        })
+    }
+
+    /// Evidence-aware bounded enrichment for an exact logical group set.
+    ///
+    /// Implementations must contact only the selected groups and must not
+    /// obtain an unbounded consumer-group inventory. The default fails closed
+    /// when bounded enrichment is unavailable.
+    fn enrich_consumer_groups_exact_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a ExactConsumerGroupEnrichmentRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListConsumerGroupsResult>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "enrich_consumer_groups_exact_with_evidence",
+                "bounded exact consumer group enrichment is not implemented by this adapter",
+            ))
+        })
+    }
+
     fn query_consumer_lag_with_evidence<'a>(
         &'a mut self,
         request: &'a QueryConsumerLagRequest,
@@ -1087,6 +1189,38 @@ pub trait ConsumerQueryAdmin: Send {
         request: &'a ListConsumerGroupsRequest,
     ) -> AdminFuture<'a, AdminQueryResult<ListConsumerGroupsResult>> {
         Box::pin(async move { self.list_consumer_groups(request).await.map(AdminQueryResult::complete) })
+    }
+    /// Evidence-aware cheap inventory sibling of [`Self::list_consumer_groups`].
+    ///
+    /// Implementations must use a single inventory source and perform no
+    /// per-group enrichment. The default fails closed when that capability is
+    /// unavailable.
+    fn list_consumer_group_inventory_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ConsumerGroupInventoryResult>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "list_consumer_group_inventory_with_evidence",
+                "cheap consumer group inventory is not implemented by this adapter",
+            ))
+        })
+    }
+    /// Evidence-aware bounded enrichment for an exact logical group set.
+    ///
+    /// Implementations must contact only the selected groups and must not
+    /// obtain an unbounded consumer-group inventory. The default fails closed
+    /// when bounded enrichment is unavailable.
+    fn enrich_consumer_groups_exact_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a ExactConsumerGroupEnrichmentRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListConsumerGroupsResult>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "enrich_consumer_groups_exact_with_evidence",
+                "bounded exact consumer group enrichment is not implemented by this adapter",
+            ))
+        })
     }
     /// Evidence-aware sibling of [`Self::query_consumer_lag`].
     fn query_consumer_lag_with_evidence<'a>(
@@ -1203,6 +1337,18 @@ impl<T: ConsumerAdmin + ?Sized> ConsumerQueryAdmin for T {
         request: &'a ListConsumerGroupsRequest,
     ) -> AdminFuture<'a, AdminQueryResult<ListConsumerGroupsResult>> {
         ConsumerAdmin::list_consumer_groups_with_evidence(self, request)
+    }
+    fn list_consumer_group_inventory_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ListConsumerGroupsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ConsumerGroupInventoryResult>> {
+        ConsumerAdmin::list_consumer_group_inventory_with_evidence(self, request)
+    }
+    fn enrich_consumer_groups_exact_with_evidence<'a>(
+        &'a mut self,
+        request: &'a ExactConsumerGroupEnrichmentRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<ListConsumerGroupsResult>> {
+        ConsumerAdmin::enrich_consumer_groups_exact_with_evidence(self, request)
     }
     fn query_consumer_lag_with_evidence<'a>(
         &'a mut self,
@@ -1359,9 +1505,57 @@ mod tests {
     }
 
     #[test]
+    fn exact_consumer_group_enrichment_request_is_sorted_unique_and_bounded() {
+        let request = ExactConsumerGroupEnrichmentRequest::try_new([" group-b ", "group-a", "group-b"]).unwrap();
+        assert_eq!(request.groups(), ["group-a", "group-b"]);
+        assert!(ExactConsumerGroupEnrichmentRequest::try_new([" "]).is_err());
+        assert!(ExactConsumerGroupEnrichmentRequest::try_new(["group.with.dot"]).is_err());
+        assert!(ExactConsumerGroupEnrichmentRequest::try_new(["g".repeat(256)]).is_err());
+        assert!(ExactConsumerGroupEnrichmentRequest::try_new(["g".repeat(255)]).is_ok());
+        assert!(ExactConsumerGroupEnrichmentRequest::try_new(
+            (0..=ExactConsumerGroupEnrichmentRequest::MAX_GROUPS).map(|index| format!("group-{index}"))
+        )
+        .is_err());
+        assert!(
+            serde_json::from_value::<ExactConsumerGroupEnrichmentRequest>(serde_json::json!({
+                "groups": [" "]
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
     fn existing_consumer_admin_implementation_does_not_require_diagnostics() {
         let mut admin = ExistingConsumerAdmin;
         let _: &mut dyn ConsumerAdmin = &mut admin;
+    }
+
+    #[tokio::test]
+    async fn cheap_inventory_defaults_fail_closed_without_full_enrichment() {
+        let mut admin = ExistingConsumerAdmin;
+        let inventory =
+            ConsumerAdmin::list_consumer_group_inventory_with_evidence(&mut admin, &ListConsumerGroupsRequest)
+                .await
+                .unwrap_err();
+        assert!(matches!(
+            inventory,
+            crate::core::AdminError::Backend {
+                operation: "list_consumer_group_inventory_with_evidence",
+                ..
+            }
+        ));
+
+        let exact = ExactConsumerGroupEnrichmentRequest::try_new(["orders"]).unwrap();
+        let enrichment = ConsumerQueryAdmin::enrich_consumer_groups_exact_with_evidence(&mut admin, &exact)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            enrichment,
+            crate::core::AdminError::Backend {
+                operation: "enrich_consumer_groups_exact_with_evidence",
+                ..
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9907

- Fixes #9907

### Brief Description

This change bounds the upstream cost of RocketMQ MCP pagination while preserving the existing read-only contracts and Q1b partial-result evidence.

- Add cheap, sorted, deduplicated consumer-group inventory APIs and bounded exact enrichment in Admin Core.
- Page consumer-group inventories before enrichment and use the inventory directly for overview counts.
- Add bounded server-side snapshots with opaque context-bound cursors, lazy expiry, deterministic eviction, invalidation, and singleflight loading.
- Reuse topic inventory, route, lag, and consumer-group snapshots across Tool and Resource page walks.
- Add query-bearing Resource templates without changing existing Resource URIs, Tool schemas, or business schema versions.
- Preserve output sanitization, source-failure metadata, cache visibility isolation, and owned admin-session shutdown behavior.

### How Did You Test This Change?

Passed:

- `cargo fmt -p rocketmq-mcp -- --check`
- `cargo fmt -p rocketmq-admin-core -- --check`
- `git diff --check origin/main...HEAD`
- Focused MCP snapshot, query-facade, Resource, and protocol tests: 24, 36, 16, and 3 tests passed respectively.
- Focused Admin Core contract, read-adapter, and full-adapter tests: 6, 8, and 17 tests passed respectively.
- From `rocketmq-ai/rocketmq-mcp`: `cargo check --locked`
- From `rocketmq-ai/rocketmq-mcp`: `python scripts/check_read_only_boundary.py`
- From `rocketmq-ai/rocketmq-mcp`: `cargo test --locked` (165 library tests, 5 binary tests, 1 compatibility test, and 3 integration tests passed; 1 external-cluster test was ignored because its required environment was not configured)
- From `rocketmq-ai/rocketmq-mcp`: `cargo test --locked --all-features` (189 library tests, 5 binary tests, 1 compatibility test, and 3 integration tests passed; 1 external-cluster test was ignored because its required environment was not configured)
- From `rocketmq-ai/rocketmq-mcp`: `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`
- From `rocketmq-ai/rocketmq-mcp`: `cargo doc --locked --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- No `.snap.new` artifacts were present.

Attempted baseline exception:

- From `rocketmq-ai/rocketmq-mcp`, `cargo fmt --all -- --check` still fails on Windows with operating-system error 206 (`The filename or extension is too long`). Both affected packages pass their package-scoped format checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated resource views for topic inventories, topic details, routes, consumer-group inventories, and consumer lag.
  * Added direct consumer-group detail queries with improved exact-group matching.
  * Added filtering and pagination parameters to resource URLs, including cursor support.
* **Improvements**
  * Improved consistency and efficiency when browsing topics, consumer groups, routes, and lag data through snapshot-based results.
  * Added configurable snapshot cache limits and expiration settings.
* **Bug Fixes**
  * Resource requests now correctly honor URL-supplied filters and pagination.
  * Invalid or oversized query parameters are rejected with clearer validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->