### PR TITLE
[ISSUE #9912]🐛Isolate RocketMQ MCP query state by principal visibility

### DIFF
--- a/rocketmq-ai/rocketmq-mcp/README.md
+++ b/rocketmq-ai/rocketmq-mcp/README.md
@@ -52,7 +52,7 @@ The server targets MCP protocol version `2025-11-25`. Clients requesting another
 
 Successful Tool calls return a `rocketmq-mcp.v2` envelope with `request_id`, cluster, RFC 3339 observation time, freshness, cache status, partial status, warnings, and typed data. Correctable input and backend failures return Tool execution errors with a stable code, retryability, suggestions, and the request identifier.
 
-Read-only Tool calls also return a ResourceLink for the corresponding live Resource. Tool and Resource requests share the application-level `QueryFacade`, bounded TTL cache, and singleflight coordination, so an identical query can be replayed without starting a second admin session while its entry is fresh.
+Read-only Tool calls also return a ResourceLink for the corresponding live Resource. Tool and Resource requests share the application-level `QueryFacade`, bounded TTL cache, and singleflight coordination, so an identical query can be replayed without starting a second admin session while its entry is fresh. Each verified request selects one of two closed query visibility classes: read-only HTTP principals and local read-only stdio profiles use `standard`, while principals or local profiles with diagnosis or planning access use `sensitive`. Requests share query state within a class, but ordinary cache entries, snapshots, singleflight work, and continuation cursors never cross classes.
 Both surfaces pass through the same authorization, audit, redaction, row-bound, byte-bound, and stable-error pipeline. Arrays are bounded to 1,000 rows, structured output to 1 MiB, and truncation is reported with `partial = true` and the stable `output_rows_truncated` warning.
 
 ## Build
@@ -142,7 +142,7 @@ headers or tokens in a broadly readable ConfigMap; use an access-restricted,
 secret-mounted configuration file when headers are required. Raw headers,
 resource attributes, and collector endpoints are not written to startup logs.
 
-Cache keys include the schema version, visibility class, query kind, resolved cluster, and normalized query parameters. Failures are not cached. Concurrent misses for the same key are coalesced, and `cache_status` reports `miss`, `hit`, or `bypass`. Embedders can call `McpApp::invalidate_cache()` to clear all entries explicitly. Cumulative hit, miss, bypass, eviction, invalidation, and coalesced-waiter counters are emitted at trace level after Tool and Resource requests.
+Cache keys include the schema version, the stable `standard` or `sensitive` visibility name, query kind, resolved cluster, and normalized query parameters. The shared query state never retains a principal identifier, tenant, role, scope, client identifier, or bearer token. Failures are not cached. Concurrent misses for the same class and key are coalesced, and `cache_status` reports `miss`, `hit`, or `bypass`. Embedders can call `McpApp::invalidate_cache()` to clear all entries explicitly. Cumulative hit, miss, bypass, eviction, invalidation, and coalesced-waiter counters are emitted at trace level after Tool and Resource requests.
 
 Audit records use `schema_version = 1`, redact sensitive assignments and control characters before admission, and
 bound every variable-length field. Shutdown closes admission, drains accepted records in FIFO order, flushes the sink,

--- a/rocketmq-ai/rocketmq-mcp/docs/production-validation.md
+++ b/rocketmq-ai/rocketmq-mcp/docs/production-validation.md
@@ -71,7 +71,7 @@ Confirm each control in the deployed configuration before exposing the endpoint:
 | Redaction | `security.sanitize_output = true` in production. Internal addresses, credentials, bearer tokens, and sensitive assignments do not leave through tool/resource output or audit records; audit records may contain bounded principal and client identifiers for accountability. | Sanitized sample output and audit record review. |
 | Row and byte bounds | Arrays are capped at 1,000 rows and structured output at 1 MiB. Row truncation reports `partial = true` and `output_rows_truncated`; oversized output returns `output_too_large`. HTTP request bodies are also capped at 1 MiB. | Boundary probes that verify the stable warning/error without retaining sensitive payloads. |
 | Audit | Keep `audit.enabled = true`; choose `file` or `tracing` for durable operations evidence and size the count and byte queues deliberately. Records are redacted, bounded, and drained FIFO during shutdown. | Sink-health, accepted/written/drop, pending-record, and flush evidence. |
-| Cache | Cache keys include schema version, visibility class, query kind, resolved cluster, and normalized parameters. Failures are not cached; misses are coalesced; TTLs and capacity are reviewed for the workload. | Hit/miss/bypass and invalidation observations, with no secret query values. |
+| Cache and visibility | Every verified request maps to the closed `standard` or `sensitive` visibility class. Read-only HTTP principals and local read-only stdio profiles use `standard`; diagnosis/planning principals and local diagnose/operator profiles use `sensitive`. Cache keys include only the stable class name, schema version, query kind, resolved cluster, and normalized parameters. Ordinary entries, snapshots, cursors, and singleflight work are shared within a class and isolated across classes. Principal, tenant, role, scope, client, and bearer-token values are not retained in query state. Failures are not cached; TTLs and capacity are reviewed for the workload. | Allowed Tool and live Resource probes for both classes; same-class hit/coalescing evidence; cross-class miss and cursor-context rejection without a backend reload; query-state review with identity and credential values omitted. |
 | Mutation boundary | Keep the RocketMQ user least-privileged and retain the `read-client-adapter` dependency boundary. No Apply path, mutation feature, or mutation admin API is part of the MCP binary. | Read-only boundary check and dependency review. |
 
 ## Validation stages
@@ -94,6 +94,7 @@ Check that:
 4. The permission file allows only the intended tools and clusters, and planning remains disabled unless the
    feature, runtime opt-in, policy, and principal scope are all intentionally enabled.
 5. Audit and cache capacities, TTLs, and diagnosis thresholds are explicit and reviewed.
+6. The same verified principal maps to the same visibility class for Tool and live Resource requests; a `standard` cursor is rejected in `sensitive` context, and conversely, without a RocketMQ query.
 
 ### 3. Startup checks
 

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
@@ -136,20 +136,33 @@ pub(crate) trait AdminSessionFactory: Clone + Send + Sync + 'static {
 #[derive(Clone)]
 pub(crate) struct AdminCoreSessionFactory {
     client_runtime: Arc<ClientRuntime>,
+    #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+    test_session_factory: Option<ProtocolTestSessionFactory>,
 }
 
 impl std::fmt::Debug for AdminCoreSessionFactory {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("AdminCoreSessionFactory")
-            .field("client_runtime", &"explicit")
-            .finish()
+        let mut debug = formatter.debug_struct("AdminCoreSessionFactory");
+        debug.field("client_runtime", &"explicit");
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        debug.field("test_session_factory", &self.test_session_factory.is_some());
+        debug.finish()
     }
 }
 
 impl AdminCoreSessionFactory {
     pub(crate) fn new(client_runtime: Arc<ClientRuntime>) -> Self {
-        Self { client_runtime }
+        Self {
+            client_runtime,
+            #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+            test_session_factory: None,
+        }
+    }
+
+    #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+    pub(crate) fn with_test_session_factory(mut self, factory: ProtocolTestSessionFactory) -> Self {
+        self.test_session_factory = Some(factory);
+        self
     }
 }
 
@@ -157,6 +170,14 @@ impl AdminSessionFactory for AdminCoreSessionFactory {
     type Session = AdminCoreSession;
 
     async fn start(&self, cluster: ResolvedCluster) -> Result<Self::Session, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(factory) = &self.test_session_factory {
+            return Ok(AdminCoreSession {
+                cluster,
+                admin: None,
+                test_session: Some(factory.start()),
+            });
+        }
         let mut builder = ReadAdminBuilder::new(self.client_runtime.clone()).namesrv_addr(cluster.namesrv_addr.clone());
         if let Some(credentials) = cluster.credentials.clone() {
             builder = builder.credentials(credentials);
@@ -165,6 +186,8 @@ impl AdminSessionFactory for AdminCoreSessionFactory {
         Ok(AdminCoreSession {
             cluster,
             admin: Some(admin),
+            #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+            test_session: None,
         })
     }
 }
@@ -172,6 +195,8 @@ impl AdminSessionFactory for AdminCoreSessionFactory {
 pub(crate) struct AdminCoreSession {
     cluster: ResolvedCluster,
     admin: Option<ReadAdminGuard>,
+    #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+    test_session: Option<ProtocolTestSession>,
 }
 
 impl AdminCoreSession {
@@ -184,6 +209,10 @@ impl AdminCoreSession {
 
 impl AdminSession for AdminCoreSession {
     async fn broker_rows(&mut self) -> Result<QueryPayload<Vec<BrokerSummary>>, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.broker_rows().await;
+        }
         let request = ListBrokersRequest::try_new(self.cluster.rocketmq_cluster_name.clone())
             .map_err(ToolExecutionError::backend)?;
         let result = self
@@ -195,6 +224,10 @@ impl AdminSession for AdminCoreSession {
     }
 
     async fn topic_inventory(&mut self) -> Result<Vec<String>, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.topic_inventory().await;
+        }
         let request = TopicInventoryRequest::new(Some(self.cluster.rocketmq_cluster_name.clone()));
         let result = self
             .admin_mut()?
@@ -205,6 +238,10 @@ impl AdminSession for AdminCoreSession {
     }
 
     async fn topic_route(&mut self, topic: &str) -> Result<SessionTopicRoute, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.topic_route(topic).await;
+        }
         let request = GetTopicRouteRequest::try_new(topic).map_err(ToolExecutionError::backend)?;
         let route = self
             .admin_mut()?
@@ -244,6 +281,10 @@ impl AdminSession for AdminCoreSession {
     }
 
     async fn consumer_groups(&mut self) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.consumer_groups().await;
+        }
         let result = self
             .admin_mut()?
             .list_consumer_groups_with_evidence(&ListConsumerGroupsRequest)
@@ -267,6 +308,10 @@ impl AdminSession for AdminCoreSession {
     }
 
     async fn consumer_group_inventory(&mut self) -> Result<QueryPayload<Vec<String>>, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.consumer_group_inventory().await;
+        }
         let result = self
             .admin_mut()?
             .list_consumer_group_inventory_with_evidence(&ListConsumerGroupsRequest)
@@ -279,6 +324,10 @@ impl AdminSession for AdminCoreSession {
         &mut self,
         groups: &[String],
     ) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.consumer_groups_exact(groups).await;
+        }
         let request = ExactConsumerGroupEnrichmentRequest::try_new(groups.iter().cloned())
             .map_err(ToolExecutionError::backend)?;
         let result = self
@@ -308,6 +357,10 @@ impl AdminSession for AdminCoreSession {
         topic: &str,
         consumer_group: &str,
     ) -> Result<QueryPayload<SessionConsumerLag>, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.consumer_lag(topic, consumer_group).await;
+        }
         let request =
             QueryConsumerLagRequest::try_new(topic, consumer_group, false).map_err(ToolExecutionError::backend)?;
         let result = self
@@ -349,6 +402,10 @@ impl AdminSession for AdminCoreSession {
         &mut self,
         broker_name: &str,
     ) -> Result<BrokerRuntimeTargetStatus, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.probe_broker_runtime_target(broker_name).await;
+        }
         let request = ProbeBrokerRuntimeTargetRequest::try_new(
             self.cluster.rocketmq_cluster_name.clone(),
             broker_name.to_string(),
@@ -361,12 +418,157 @@ impl AdminSession for AdminCoreSession {
     }
 
     async fn shutdown(mut self) -> Result<(), ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = self.test_session.take() {
+            return session.shutdown().await;
+        }
         if let Some(admin) = self.admin.take() {
             admin.shutdown().await;
         }
         Ok(())
     }
 }
+
+#[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+mod protocol_test_support {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use tokio::sync::Barrier;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    pub(crate) struct ProtocolTestCounters {
+        pub(crate) starts: AtomicUsize,
+        pub(crate) shutdowns: AtomicUsize,
+        pub(crate) broker_queries: AtomicUsize,
+        pub(crate) topic_inventory_queries: AtomicUsize,
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct ProtocolTestGate {
+        entered: AtomicUsize,
+        release: Barrier,
+    }
+
+    impl ProtocolTestGate {
+        pub(crate) fn new(expected_loaders: usize) -> Self {
+            Self {
+                entered: AtomicUsize::new(0),
+                release: Barrier::new(expected_loaders + 1),
+            }
+        }
+
+        async fn wait(&self) {
+            self.entered.fetch_add(1, Ordering::SeqCst);
+            self.release.wait().await;
+        }
+
+        pub(crate) async fn wait_until_entered(&self, expected: usize) {
+            for _ in 0..10_000 {
+                if self.entered.load(Ordering::SeqCst) == expected {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(self.entered.load(Ordering::SeqCst), expected);
+        }
+
+        pub(crate) async fn release(&self) {
+            self.release.wait().await;
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub(crate) struct ProtocolTestSessionFactory {
+        pub(crate) counters: Arc<ProtocolTestCounters>,
+        gate: Option<Arc<ProtocolTestGate>>,
+    }
+
+    impl ProtocolTestSessionFactory {
+        pub(crate) fn new(gate: Option<Arc<ProtocolTestGate>>) -> Self {
+            Self {
+                counters: Arc::new(ProtocolTestCounters::default()),
+                gate,
+            }
+        }
+
+        pub(super) fn start(&self) -> ProtocolTestSession {
+            self.counters.starts.fetch_add(1, Ordering::SeqCst);
+            ProtocolTestSession {
+                counters: self.counters.clone(),
+                gate: self.gate.clone(),
+            }
+        }
+    }
+
+    pub(crate) struct ProtocolTestSession {
+        counters: Arc<ProtocolTestCounters>,
+        gate: Option<Arc<ProtocolTestGate>>,
+    }
+
+    impl AdminSession for ProtocolTestSession {
+        async fn broker_rows(&mut self) -> Result<QueryPayload<Vec<BrokerSummary>>, ToolExecutionError> {
+            self.counters.broker_queries.fetch_add(1, Ordering::SeqCst);
+            Ok(QueryPayload::complete(Vec::new()))
+        }
+
+        async fn topic_inventory(&mut self) -> Result<Vec<String>, ToolExecutionError> {
+            self.counters.topic_inventory_queries.fetch_add(1, Ordering::SeqCst);
+            if let Some(gate) = &self.gate {
+                gate.wait().await;
+            }
+            Ok(vec!["payments".to_string(), "orders".to_string()])
+        }
+
+        async fn topic_route(&mut self, _topic: &str) -> Result<SessionTopicRoute, ToolExecutionError> {
+            Ok(SessionTopicRoute {
+                brokers: Vec::new(),
+                queues: Vec::new(),
+            })
+        }
+
+        async fn consumer_groups(&mut self) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
+            Ok(QueryPayload::complete(Vec::new()))
+        }
+
+        async fn consumer_lag(
+            &mut self,
+            _topic: &str,
+            _consumer_group: &str,
+        ) -> Result<QueryPayload<SessionConsumerLag>, ToolExecutionError> {
+            Ok(QueryPayload::complete(SessionConsumerLag {
+                queues: Vec::new(),
+                total_lag: 0,
+                consume_tps: 0.0,
+                inflight_total: 0,
+            }))
+        }
+
+        async fn probe_broker_runtime_target(
+            &mut self,
+            _broker_name: &str,
+        ) -> Result<BrokerRuntimeTargetStatus, ToolExecutionError> {
+            Ok(BrokerRuntimeTargetStatus::NotFound)
+        }
+
+        async fn shutdown(self) -> Result<(), ToolExecutionError> {
+            self.counters.shutdowns.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+pub(crate) use protocol_test_support::ProtocolTestCounters;
+#[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+pub(crate) use protocol_test_support::ProtocolTestGate;
+#[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+pub(crate) use protocol_test_support::ProtocolTestSession;
+#[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+pub(crate) use protocol_test_support::ProtocolTestSessionFactory;
 
 fn map_broker_summary(row: &rocketmq_admin_core::core::broker::BrokerSummary) -> BrokerSummary {
     BrokerSummary {

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
@@ -27,6 +27,7 @@ use crate::adapter::admin_session::ResolvedCluster;
 use crate::adapter::admin_session::SessionConsumerLag;
 use crate::adapter::admin_session::SessionTopicRoute;
 use crate::config::McpConfig;
+use crate::guard::context::VisibilityClass;
 use crate::infrastructure::cache::CacheMetricsSnapshot;
 use crate::infrastructure::cache::QueryCache;
 use crate::infrastructure::snapshot::SnapshotKind;
@@ -173,7 +174,7 @@ pub(crate) struct QueryFacade<F> {
     control: WorkflowControl,
     cache: QueryCache,
     snapshots: SnapshotStore,
-    visibility_class: String,
+    visibility_class: VisibilityClass,
 }
 
 impl<F> fmt::Debug for QueryFacade<F>
@@ -206,7 +207,7 @@ where
             config,
             factory,
             control,
-            visibility_class: "local".to_string(),
+            visibility_class: VisibilityClass::default(),
         }
     }
 
@@ -215,9 +216,14 @@ where
         self
     }
 
-    pub(crate) fn with_visibility_class(mut self, visibility_class: impl Into<String>) -> Self {
-        self.visibility_class = visibility_class.into();
+    pub(crate) fn with_visibility_class(mut self, visibility_class: VisibilityClass) -> Self {
+        self.visibility_class = visibility_class;
         self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn visibility_class(&self) -> VisibilityClass {
+        self.visibility_class
     }
 
     pub(crate) fn cache_metrics(&self) -> CacheMetricsSnapshot {
@@ -656,7 +662,7 @@ where
             cluster.name.clone(),
             filter.clone(),
             page,
-            self.visibility_class.clone(),
+            self.visibility_class.as_str(),
         )?;
         self.snapshots
             .get_or_load(
@@ -704,7 +710,7 @@ where
             filter.clone(),
             selection_mode,
             page,
-            self.visibility_class.clone(),
+            self.visibility_class.as_str(),
         )?;
         self.snapshots
             .get_or_load(
@@ -748,7 +754,7 @@ where
             cluster.name.clone(),
             format!("topic={topic}"),
             page,
-            self.visibility_class.clone(),
+            self.visibility_class.as_str(),
         )?;
         self.snapshots
             .get_or_load(
@@ -779,7 +785,7 @@ where
             cluster.name.clone(),
             format!("topic={topic}|group={consumer_group}"),
             page,
-            self.visibility_class.clone(),
+            self.visibility_class.as_str(),
         )?;
         self.snapshots
             .get_or_load(
@@ -879,7 +885,7 @@ where
     fn cache_key(&self, kind: &str, cluster: &str, parameters: &str) -> String {
         format!(
             "{SCHEMA_VERSION}|{}|{kind}|cluster={}|{parameters}",
-            self.visibility_class,
+            self.visibility_class.as_str(),
             cluster.trim()
         )
     }
@@ -1962,14 +1968,16 @@ mod tests {
         let factory = FakeSessionFactory::default();
         let counters = factory.counters.clone();
         let facade = QueryFacade::with_factory(example_config(), factory);
+        let tool_query = facade.clone().with_visibility_class(VisibilityClass::Sensitive);
+        let resource_query = facade.clone().with_visibility_class(VisibilityClass::Sensitive);
         let request = ListTopicsArgs {
             cluster: Some("local-dev".to_string()),
             filter: None,
             page: PageRequest::default(),
         };
 
-        let tool_result = facade.list_topics(request).await.unwrap();
-        let resource_result = resources::reader::read_resource(&facade, "rocketmq://clusters/local-dev/topics")
+        let tool_result = tool_query.list_topics(request).await.unwrap();
+        let resource_result = resources::reader::read_resource(&resource_query, "rocketmq://clusters/local-dev/topics")
             .await
             .unwrap();
         let payload = match &resource_result.contents[0] {
@@ -2095,8 +2103,8 @@ mod tests {
         let factory = FakeSessionFactory::default();
         let counters = factory.counters.clone();
         let facade = QueryFacade::with_factory(example_config(), factory);
-        let reader = facade.clone().with_visibility_class("reader");
-        let topology_reader = facade.with_visibility_class("topology-reader");
+        let reader = facade.clone().with_visibility_class(VisibilityClass::Standard);
+        let topology_reader = facade.with_visibility_class(VisibilityClass::Sensitive);
         let request = || ListTopicsArgs {
             cluster: Some("local-dev".to_string()),
             filter: None,
@@ -2111,6 +2119,178 @@ mod tests {
         assert_eq!(counters.starts.load(Ordering::SeqCst), 2);
         assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 2);
         assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn query_facade_same_class_shares_ordinary_cache_and_snapshot_state() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let first = facade.clone().with_visibility_class(VisibilityClass::Standard);
+        let second = facade.with_visibility_class(VisibilityClass::Standard);
+
+        let topic_args = || ListTopicsArgs {
+            cluster: Some("local-dev".to_string()),
+            filter: None,
+            page: PageRequest::default(),
+        };
+        assert_eq!(
+            first.list_topics(topic_args()).await.unwrap().cache_status,
+            CacheStatus::Miss
+        );
+        assert_eq!(
+            second.list_topics(topic_args()).await.unwrap().cache_status,
+            CacheStatus::Hit
+        );
+
+        let broker_args = || DescribeBrokerArgs {
+            cluster: "local-dev".to_string(),
+            broker_name: "broker-a".to_string(),
+        };
+        assert_eq!(
+            first.describe_broker(broker_args()).await.unwrap().cache_status,
+            CacheStatus::Miss
+        );
+        assert_eq!(
+            second.describe_broker(broker_args()).await.unwrap().cache_status,
+            CacheStatus::Hit
+        );
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.broker_queries.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn query_facade_different_classes_isolate_ordinary_cache_and_snapshot_state() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let standard = facade.clone().with_visibility_class(VisibilityClass::Standard);
+        let sensitive = facade.with_visibility_class(VisibilityClass::Sensitive);
+
+        let topic_args = || ListTopicsArgs {
+            cluster: Some("local-dev".to_string()),
+            filter: None,
+            page: PageRequest::default(),
+        };
+        assert_eq!(
+            standard.list_topics(topic_args()).await.unwrap().cache_status,
+            CacheStatus::Miss
+        );
+        assert_eq!(
+            sensitive.list_topics(topic_args()).await.unwrap().cache_status,
+            CacheStatus::Miss
+        );
+
+        let broker_args = || DescribeBrokerArgs {
+            cluster: "local-dev".to_string(),
+            broker_name: "broker-a".to_string(),
+        };
+        assert_eq!(
+            standard.describe_broker(broker_args()).await.unwrap().cache_status,
+            CacheStatus::Miss
+        );
+        assert_eq!(
+            sensitive.describe_broker(broker_args()).await.unwrap().cache_status,
+            CacheStatus::Miss
+        );
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.broker_queries.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn cross_class_cursor_replay_fails_without_an_upstream_reload() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let standard = facade.clone().with_visibility_class(VisibilityClass::Standard);
+        let sensitive = facade.with_visibility_class(VisibilityClass::Sensitive);
+        let first = standard
+            .list_topics(ListTopicsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: None,
+                page: PageRequest {
+                    limit: Some(1),
+                    cursor: None,
+                },
+            })
+            .await
+            .unwrap();
+
+        let error = sensitive
+            .list_topics(ListTopicsArgs {
+                cluster: Some("local-dev".to_string()),
+                filter: None,
+                page: PageRequest {
+                    limit: Some(1),
+                    cursor: first.page.next_cursor.clone(),
+                },
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ToolExecutionError::InvalidArguments(_)));
+        assert!(error.to_string().contains("requested query context"));
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn singleflight_coalesces_within_class_but_not_across_classes() {
+        let gate = Arc::new(TopicInventoryGate::new(2));
+        gate.arm();
+        let factory = FakeSessionFactory {
+            topic_inventory_gate: Some(gate.clone()),
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let start = Arc::new(Barrier::new(5));
+        let mut tasks = tokio::task::JoinSet::new();
+        for visibility in [
+            VisibilityClass::Standard,
+            VisibilityClass::Standard,
+            VisibilityClass::Sensitive,
+            VisibilityClass::Sensitive,
+        ] {
+            let request_facade = facade.clone().with_visibility_class(visibility);
+            let start = start.clone();
+            tasks.spawn(async move {
+                start.wait().await;
+                request_facade
+                    .list_topics(ListTopicsArgs {
+                        cluster: Some("local-dev".to_string()),
+                        filter: None,
+                        page: PageRequest::default(),
+                    })
+                    .await
+                    .unwrap()
+                    .cache_status
+            });
+        }
+
+        start.wait().await;
+        wait_for_atomic_count(&gate.entered, 2).await;
+        for _ in 0..10_000 {
+            if facade.cache_metrics().coalesced_waiters == 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(facade.cache_metrics().coalesced_waiters, 2);
+        gate.release().await;
+
+        let mut statuses = Vec::new();
+        while let Some(status) = tasks.join_next().await {
+            statuses.push(status.unwrap());
+        }
+        assert_eq!(
+            statuses.iter().filter(|status| **status == CacheStatus::Miss).count(),
+            2
+        );
+        assert_eq!(statuses.iter().filter(|status| **status == CacheStatus::Hit).count(), 2);
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/rocketmq-ai/rocketmq-mcp/src/app.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/app.rs
@@ -141,7 +141,7 @@ impl McpApp {
             telemetry_handle,
         )
         .map_err(|error| crate::error::McpError::infrastructure("initialize MCP client runtime", error))?;
-        let query = Arc::new(QueryFacade::new(config.clone(), client_runtime.clone()).with_visibility_class("local"));
+        let query = Arc::new(QueryFacade::new(config.clone(), client_runtime.clone()));
         Ok(Self {
             config,
             guard,
@@ -151,6 +151,16 @@ impl McpApp {
             service_context,
             telemetry: Arc::new(std::sync::Mutex::new(None)),
         })
+    }
+
+    #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+    pub(crate) fn with_test_session_factory(
+        mut self,
+        factory: crate::adapter::admin_session::ProtocolTestSessionFactory,
+    ) -> Self {
+        let factory = AdminCoreSessionFactory::new(self.client_runtime.clone()).with_test_session_factory(factory);
+        self.query = Arc::new(QueryFacade::with_factory(self.config.clone(), factory));
+        self
     }
 
     /// Initializes telemetry and background work only after the composition root has

--- a/rocketmq-ai/rocketmq-mcp/src/guard/context.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/guard/context.rs
@@ -14,6 +14,30 @@
 
 use std::collections::BTreeSet;
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VisibilityClass {
+    #[default]
+    Standard,
+    Sensitive,
+}
+
+impl VisibilityClass {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Sensitive => "sensitive",
+        }
+    }
+
+    fn from_scopes(scopes: &BTreeSet<String>) -> Self {
+        if scopes.contains("rocketmq:diagnose") || scopes.contains("rocketmq:plan") {
+            Self::Sensitive
+        } else {
+            Self::Standard
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Principal {
     pub id: String,
@@ -26,10 +50,13 @@ pub struct Principal {
 impl Principal {
     pub fn local(profile: &str) -> Self {
         let mut scopes = BTreeSet::from(["rocketmq:read".to_string()]);
-        if profile.eq_ignore_ascii_case("diagnose") || profile.eq_ignore_ascii_case("operator") {
+        if profile.eq_ignore_ascii_case("diagnose")
+            || profile.eq_ignore_ascii_case("diagnostic")
+            || profile.eq_ignore_ascii_case("operator")
+        {
             scopes.insert("rocketmq:diagnose".to_string());
         }
-        if profile.eq_ignore_ascii_case("operator") {
+        if profile.eq_ignore_ascii_case("plan") || profile.eq_ignore_ascii_case("operator") {
             scopes.insert("rocketmq:plan".to_string());
         }
         Self {
@@ -39,6 +66,10 @@ impl Principal {
             scopes,
             allowed_clusters: None,
         }
+    }
+
+    pub(crate) fn visibility_class(&self) -> VisibilityClass {
+        VisibilityClass::from_scopes(&self.scopes)
     }
 }
 
@@ -54,5 +85,59 @@ impl RequestContext {
             principal: Principal::local(profile),
             client: Some("stdio".to_string()),
         }
+    }
+
+    pub(crate) fn visibility_class(&self) -> VisibilityClass {
+        self.principal.visibility_class()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn principal_scope_mapping_is_closed_and_least_privilege() {
+        for (scopes, expected) in [
+            (&[][..], VisibilityClass::Standard),
+            (&["rocketmq:read"][..], VisibilityClass::Standard),
+            (&["unrelated:scope"][..], VisibilityClass::Standard),
+            (&["rocketmq:diagnose"][..], VisibilityClass::Sensitive),
+            (&["rocketmq:plan"][..], VisibilityClass::Sensitive),
+            (
+                &["rocketmq:read", "rocketmq:diagnose", "rocketmq:plan"][..],
+                VisibilityClass::Sensitive,
+            ),
+        ] {
+            let principal = Principal {
+                id: "principal-not-retained-by-query-state".to_string(),
+                tenant: None,
+                roles: BTreeSet::new(),
+                scopes: scopes.iter().map(|scope| (*scope).to_string()).collect(),
+                allowed_clusters: None,
+            };
+            assert_eq!(principal.visibility_class(), expected, "scopes={scopes:?}");
+        }
+    }
+
+    #[test]
+    fn local_profile_mapping_uses_the_same_scope_rule() {
+        for (profile, expected) in [
+            ("read_only", VisibilityClass::Standard),
+            ("readonly", VisibilityClass::Standard),
+            ("read-only", VisibilityClass::Standard),
+            ("diagnose", VisibilityClass::Sensitive),
+            ("diagnostic", VisibilityClass::Sensitive),
+            ("operator", VisibilityClass::Sensitive),
+        ] {
+            let context = RequestContext::local(profile);
+            assert_eq!(context.visibility_class(), expected, "profile={profile}");
+        }
+    }
+
+    #[test]
+    fn visibility_names_are_stable_and_non_sensitive() {
+        assert_eq!(VisibilityClass::Standard.as_str(), "standard");
+        assert_eq!(VisibilityClass::Sensitive.as_str(), "sensitive");
     }
 }

--- a/rocketmq-ai/rocketmq-mcp/src/guard/http_auth.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/guard/http_auth.rs
@@ -363,6 +363,7 @@ mod tests {
     use crate::config::AuditConfig;
     use crate::config::ClusterConfig;
     use crate::config::SecurityConfig;
+    use crate::guard::context::VisibilityClass;
     use crate::guard::jwks::JwksError;
     use crate::guard::jwks::JwksSource;
 
@@ -390,7 +391,32 @@ mod tests {
         assert_eq!(context.principal.id, "sre@example.test");
         assert_eq!(context.client.as_deref(), Some("mcp-test-client"));
         assert!(context.principal.roles.contains("diagnose"));
+        assert_eq!(context.visibility_class(), VisibilityClass::Sensitive);
         assert_eq!(context.principal.allowed_clusters.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn http_auth_visibility_uses_verified_scopes_for_oauth_and_development_mode() {
+        let oauth = oauth_state(["rocketmq:read"]).await;
+        let read_only = oauth
+            .authenticate(&bearer_headers(&signed_token("rocketmq:read", "test-key")))
+            .await
+            .unwrap();
+        assert_eq!(read_only.visibility_class(), VisibilityClass::Standard);
+
+        let development: HttpAuthState<StaticSource> = HttpAuthState {
+            authenticator: HttpAuthenticator::DevelopmentToken {
+                token: Arc::from("local-test-token"),
+                tenant: None,
+            },
+            guard: test_guard(),
+            resource_metadata: None,
+        };
+        let context = development
+            .authenticate(&bearer_headers("local-test-token"))
+            .await
+            .unwrap();
+        assert_eq!(context.visibility_class(), VisibilityClass::Sensitive);
     }
 
     #[tokio::test]

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/server.rs
@@ -39,6 +39,8 @@ use serde_json::json;
 use std::time::Instant;
 use tracing::Instrument;
 
+use crate::adapter::admin_session::AdminCoreSessionFactory;
+use crate::adapter::query_facade::QueryFacade;
 use crate::app::McpApp;
 use crate::guard::context::RequestContext as AccessContext;
 use crate::guard::GuardError;
@@ -251,7 +253,7 @@ impl ServerHandler for RocketmqMcpServer {
                     resources::system::read_result(&request.uri, "observability", self.app.observability_status_view())
                 }
                 _ => {
-                    let query = self.app.query().as_ref().clone().with_cancellation(context.ct);
+                    let query = self.request_query(&access, context.ct);
                     resources::reader::read_resource(&query, &request.uri).await
                 }
             };
@@ -312,8 +314,8 @@ impl ServerHandler for RocketmqMcpServer {
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResponse, ErrorData> {
-        let query = self.app.query().as_ref().clone().with_cancellation(context.ct.clone());
         let access = self.access_context(&context)?;
+        let query = self.request_query(&access, context.ct.clone());
         let result = ToolExecutor::new(query, self.app.guard().clone())
             .with_metrics(self.app.metrics().clone())
             .with_request_context(access)
@@ -329,6 +331,19 @@ impl ServerHandler for RocketmqMcpServer {
 }
 
 impl RocketmqMcpServer {
+    fn request_query(
+        &self,
+        access: &AccessContext,
+        cancellation: tokio_util::sync::CancellationToken,
+    ) -> QueryFacade<AdminCoreSessionFactory> {
+        self.app
+            .query()
+            .as_ref()
+            .clone()
+            .with_visibility_class(access.visibility_class())
+            .with_cancellation(cancellation)
+    }
+
     fn access_context(&self, context: &RequestContext<RoleServer>) -> Result<AccessContext, ErrorData> {
         #[cfg(feature = "streamable-http")]
         if let Some(parts) = context.extensions.get::<axum::http::request::Parts>() {
@@ -419,15 +434,34 @@ fn record_resource_operation(operation: &'static str, outcome: McpOperationOutco
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    use std::sync::atomic::Ordering;
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    use std::sync::Arc;
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    use rmcp::model::NumberOrString;
     use rmcp::ServerHandler;
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    use rmcp::ServiceExt;
     use serde_json::json;
 
     use super::*;
     use crate::app::McpApp;
     use crate::config::McpConfig;
+    use crate::guard::context::Principal;
+    use crate::guard::context::VisibilityClass;
     use crate::prompts;
     use crate::resources;
     use crate::tools;
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    use crate::adapter::admin_session::ProtocolTestCounters;
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    use crate::adapter::admin_session::ProtocolTestGate;
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    use crate::adapter::admin_session::ProtocolTestSessionFactory;
 
     #[test]
     fn server_info_declares_mvp_capabilities() {
@@ -464,6 +498,453 @@ mod tests {
         assert_eq!(data["retryable"], false);
         assert_eq!(data["correlation_id"], "request-7");
         assert!(!error.message.contains("secret tenant details"));
+    }
+
+    #[test]
+    fn request_query_unit_binds_closed_visibility_without_retaining_identity() {
+        let owner =
+            rocketmq_runtime::RuntimeOwner::new(rocketmq_runtime::RuntimeConfig::server_default("mcp-visibility-test"))
+                .unwrap();
+        let app = McpApp::new(
+            McpConfig::load(example_config_path()).unwrap(),
+            owner.root_context().component("mcp-app"),
+            rocketmq_observability::TelemetryHandle::noop(),
+        )
+        .unwrap();
+        let server = RocketmqMcpServer::new(app);
+        let access = |scope: &str| AccessContext {
+            principal: Principal {
+                id: "private-principal-sentinel".to_string(),
+                tenant: Some("private-tenant-sentinel".to_string()),
+                roles: ["private-role-sentinel".to_string()].into_iter().collect(),
+                scopes: [scope.to_string()].into_iter().collect(),
+                allowed_clusters: Some(BTreeSet::from(["local-dev".to_string()])),
+            },
+            client: Some("private-client-sentinel".to_string()),
+        };
+
+        let standard = server.request_query(&access("rocketmq:read"), tokio_util::sync::CancellationToken::new());
+        let sensitive = server.request_query(&access("rocketmq:diagnose"), tokio_util::sync::CancellationToken::new());
+
+        assert_eq!(standard.visibility_class(), VisibilityClass::Standard);
+        assert_eq!(sensitive.visibility_class(), VisibilityClass::Sensitive);
+        for debug in [format!("{standard:?}"), format!("{sensitive:?}")] {
+            assert!(!debug.contains("private-principal-sentinel"));
+            assert!(!debug.contains("private-tenant-sentinel"));
+            assert!(!debug.contains("private-role-sentinel"));
+            assert!(!debug.contains("private-client-sentinel"));
+        }
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn real_handlers_bind_http_and_stdio_visibility_and_isolate_query_state() {
+        let (_owner, server, counters) = test_server("diagnose", None);
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
+
+        let standard = oauth_context(&peer, 1, "oauth-read", ["read_only"], ["rocketmq:read"]);
+        let standard_tool = complete_tool_response(
+            running
+                .service()
+                .call_tool(list_topics_request(Some(1), None), standard)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(standard_tool.is_error, Some(false));
+        let cursor = standard_tool.structured_content.as_ref().unwrap()["data"]["next_cursor"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
+
+        let standard_resource = oauth_context(&peer, 2, "other-oauth-read", ["read_only"], ["rocketmq:read"]);
+        running
+            .service()
+            .read_resource(
+                ReadResourceRequestParams::new("rocketmq://clusters/local-dev/topics?limit=1"),
+                standard_resource,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            counters.topic_inventory_queries.load(Ordering::SeqCst),
+            1,
+            "same-class Tool and Resource must share the retained snapshot"
+        );
+
+        let sensitive = oauth_context(
+            &peer,
+            3,
+            "oauth-diagnose",
+            ["diagnose"],
+            ["rocketmq:read", "rocketmq:diagnose"],
+        );
+        running
+            .service()
+            .read_resource(
+                ReadResourceRequestParams::new("rocketmq://clusters/local-dev/topics?limit=1"),
+                sensitive,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            counters.topic_inventory_queries.load(Ordering::SeqCst),
+            2,
+            "standard and sensitive snapshots must not share"
+        );
+
+        let before_cursor_replay = counters.starts.load(Ordering::SeqCst);
+        let replay = complete_tool_response(
+            running
+                .service()
+                .call_tool(
+                    list_topics_request(Some(1), Some(cursor)),
+                    oauth_context(
+                        &peer,
+                        4,
+                        "oauth-diagnose",
+                        ["diagnose"],
+                        ["rocketmq:read", "rocketmq:diagnose"],
+                    ),
+                )
+                .await
+                .unwrap(),
+        );
+        assert_eq!(replay.is_error, Some(true));
+        assert_eq!(
+            counters.starts.load(Ordering::SeqCst),
+            before_cursor_replay,
+            "cross-class cursor rejection must not start an admin session"
+        );
+
+        let stdio_diagnose = local_context(&peer, 5);
+        running
+            .service()
+            .read_resource(
+                ReadResourceRequestParams::new("rocketmq://clusters/local-dev/topics?limit=1"),
+                stdio_diagnose,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            counters.topic_inventory_queries.load(Ordering::SeqCst),
+            2,
+            "local diagnose must share the sensitive class"
+        );
+
+        let overview = || {
+            CallToolRequestParams::new("rocketmq_get_cluster_overview")
+                .with_arguments(json!({"cluster": "local-dev"}).as_object().unwrap().clone())
+        };
+        running
+            .service()
+            .call_tool(
+                overview(),
+                oauth_context(&peer, 6, "oauth-read", ["read_only"], ["rocketmq:read"]),
+            )
+            .await
+            .unwrap();
+        running
+            .service()
+            .call_tool(
+                overview(),
+                oauth_context(
+                    &peer,
+                    7,
+                    "oauth-diagnose",
+                    ["diagnose"],
+                    ["rocketmq:read", "rocketmq:diagnose"],
+                ),
+            )
+            .await
+            .unwrap();
+        running
+            .service()
+            .call_tool(
+                overview(),
+                oauth_context(&peer, 8, "another-read", ["read_only"], ["rocketmq:read"]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            counters.broker_queries.load(Ordering::SeqCst),
+            2,
+            "ordinary cache entries must share within, but not across, visibility classes"
+        );
+
+        drop(running);
+        drop(client);
+
+        let (_owner, read_only_server, read_only_counters) = test_server("read_only", None);
+        let (read_only_running, read_only_client) = connected_test_server(read_only_server).await;
+        let read_only_peer = read_only_running.peer().clone();
+
+        read_only_running
+            .service()
+            .call_tool(
+                list_topics_request(None, None),
+                oauth_context(&read_only_peer, 9, "oauth-read", ["read_only"], ["rocketmq:read"]),
+            )
+            .await
+            .unwrap();
+        read_only_running
+            .service()
+            .read_resource(
+                ReadResourceRequestParams::new("rocketmq://clusters/local-dev/topics"),
+                local_context(&read_only_peer, 10),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            read_only_counters.topic_inventory_queries.load(Ordering::SeqCst),
+            1,
+            "local read-only must use the standard HTTP read class"
+        );
+
+        drop(read_only_running);
+        drop(read_only_client);
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn real_handlers_map_local_operator_and_reject_unauthorized_before_sessions() {
+        let (_owner, server, counters) = test_server("operator", None);
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
+
+        running
+            .service()
+            .call_tool(
+                list_topics_request(None, None),
+                oauth_context(&peer, 1, "oauth-read", ["read_only"], ["rocketmq:read"]),
+            )
+            .await
+            .unwrap();
+        running
+            .service()
+            .call_tool(list_topics_request(None, None), local_context(&peer, 2))
+            .await
+            .unwrap();
+        assert_eq!(
+            counters.topic_inventory_queries.load(Ordering::SeqCst),
+            2,
+            "local operator must use sensitive rather than the HTTP read class"
+        );
+
+        drop(running);
+        drop(client);
+
+        let (_owner, denied_server, denied_counters) = test_server("read_only", None);
+        let (denied_running, denied_client) = connected_test_server(denied_server).await;
+        let denied_peer = denied_running.peer().clone();
+        let diagnose = CallToolRequestParams::new("rocketmq_diagnose_consumer_lag").with_arguments(
+            json!({"cluster": "local-dev", "topic": "orders", "consumer_group": "orders-service"})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+        let denied = complete_tool_response(
+            denied_running
+                .service()
+                .call_tool(diagnose, local_context(&denied_peer, 3))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(denied.is_error, Some(true));
+        let unknown = denied_running
+            .service()
+            .call_tool(
+                CallToolRequestParams::new("rocketmq_unknown_query"),
+                local_context(&denied_peer, 4),
+            )
+            .await;
+        assert!(unknown.is_err());
+        let no_scope = oauth_context(&denied_peer, 5, "oauth-no-scope", ["diagnose"], []);
+        let denied_tool = complete_tool_response(
+            denied_running
+                .service()
+                .call_tool(list_topics_request(None, None), no_scope)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(denied_tool.is_error, Some(true));
+        let unknown_scope = complete_tool_response(
+            denied_running
+                .service()
+                .call_tool(
+                    list_topics_request(None, None),
+                    oauth_context(
+                        &denied_peer,
+                        6,
+                        "oauth-unknown-scope",
+                        ["diagnose"],
+                        ["rocketmq:unknown"],
+                    ),
+                )
+                .await
+                .unwrap(),
+        );
+        assert_eq!(unknown_scope.is_error, Some(true));
+        let denied_resource = denied_running
+            .service()
+            .read_resource(
+                ReadResourceRequestParams::new("rocketmq://clusters/local-dev/topics"),
+                oauth_context(&denied_peer, 7, "oauth-no-scope", ["diagnose"], []),
+            )
+            .await;
+        assert!(denied_resource.is_err());
+        assert_eq!(
+            denied_counters.starts.load(Ordering::SeqCst),
+            0,
+            "denied and unknown requests must not reach Admin/session work"
+        );
+        assert_eq!(denied_counters.broker_queries.load(Ordering::SeqCst), 0);
+        assert_eq!(denied_counters.topic_inventory_queries.load(Ordering::SeqCst), 0);
+        assert_eq!(denied_counters.shutdowns.load(Ordering::SeqCst), 0);
+
+        drop(denied_running);
+        drop(denied_client);
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn real_handler_singleflight_coalesces_within_but_not_across_classes() {
+        let gate = Arc::new(ProtocolTestGate::new(2));
+        let (_owner, server, counters) = test_server("diagnose", Some(gate.clone()));
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
+        let start = Arc::new(tokio::sync::Barrier::new(5));
+        let mut tasks = tokio::task::JoinSet::new();
+
+        for (id, principal, role, scopes) in [
+            (1, "read-a", "read_only", vec!["rocketmq:read"]),
+            (2, "read-b", "read_only", vec!["rocketmq:read"]),
+            (3, "diagnose-a", "diagnose", vec!["rocketmq:read", "rocketmq:diagnose"]),
+            (4, "diagnose-b", "diagnose", vec!["rocketmq:read", "rocketmq:diagnose"]),
+        ] {
+            let server = running.service().clone();
+            let peer = peer.clone();
+            let start = start.clone();
+            tasks.spawn(async move {
+                start.wait().await;
+                server
+                    .call_tool(
+                        list_topics_request(None, None),
+                        oauth_context(&peer, id, principal, [role], scopes),
+                    )
+                    .await
+                    .unwrap()
+            });
+        }
+
+        start.wait().await;
+        gate.wait_until_entered(2).await;
+        gate.release().await;
+        while let Some(result) = tasks.join_next().await {
+            assert_eq!(complete_tool_response(result.unwrap()).is_error, Some(false));
+        }
+        assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 2);
+
+        drop(running);
+        drop(client);
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    fn test_server(
+        profile: &str,
+        gate: Option<Arc<ProtocolTestGate>>,
+    ) -> (
+        rocketmq_runtime::RuntimeOwner,
+        RocketmqMcpServer,
+        Arc<ProtocolTestCounters>,
+    ) {
+        let owner = rocketmq_runtime::RuntimeOwner::new(rocketmq_runtime::RuntimeConfig::server_default(
+            "mcp-real-handler-test",
+        ))
+        .unwrap();
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.security.profile = profile.to_string();
+        let factory = ProtocolTestSessionFactory::new(gate);
+        let counters = factory.counters.clone();
+        let app = McpApp::new(
+            config,
+            owner.root_context().component("mcp-app"),
+            rocketmq_observability::TelemetryHandle::noop(),
+        )
+        .unwrap()
+        .with_test_session_factory(factory);
+        (owner, RocketmqMcpServer::new(app), counters)
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    async fn connected_test_server(
+        server: RocketmqMcpServer,
+    ) -> (
+        rmcp::service::RunningService<RoleServer, RocketmqMcpServer>,
+        tokio::io::DuplexStream,
+    ) {
+        use tokio::io::AsyncWriteExt;
+
+        const INITIALIZE: &[u8] = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"handler-test\",\"version\":\"1.0.0\"}}}\n";
+        let (server_transport, mut client_transport) = tokio::io::duplex(64 * 1024);
+        let server_task = tokio::spawn(async move { server.serve(server_transport).await });
+        client_transport.write_all(INITIALIZE).await.unwrap();
+        let server = server_task.await.unwrap().unwrap();
+        (server, client_transport)
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    fn oauth_context(
+        peer: &rmcp::service::Peer<RoleServer>,
+        id: i64,
+        principal: &str,
+        roles: impl IntoIterator<Item = &'static str>,
+        scopes: impl IntoIterator<Item = &'static str>,
+    ) -> RequestContext<RoleServer> {
+        let request = axum::http::Request::builder().uri("/mcp").body(()).unwrap();
+        let (mut parts, _) = request.into_parts();
+        parts.extensions.insert(AccessContext {
+            principal: Principal {
+                id: principal.to_string(),
+                tenant: Some("test-tenant".to_string()),
+                roles: roles.into_iter().map(str::to_string).collect(),
+                scopes: scopes.into_iter().map(str::to_string).collect(),
+                allowed_clusters: Some(BTreeSet::from(["local-dev".to_string()])),
+            },
+            client: Some("oauth-test".to_string()),
+        });
+        let mut context = RequestContext::new(NumberOrString::Number(id), peer.clone());
+        context.extensions.insert(parts);
+        context
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    fn local_context(peer: &rmcp::service::Peer<RoleServer>, id: i64) -> RequestContext<RoleServer> {
+        RequestContext::new(NumberOrString::Number(id), peer.clone())
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    fn list_topics_request(limit: Option<u32>, cursor: Option<String>) -> CallToolRequestParams {
+        let mut arguments = serde_json::Map::new();
+        arguments.insert("cluster".to_string(), json!("local-dev"));
+        if let Some(limit) = limit {
+            arguments.insert("limit".to_string(), json!(limit));
+        }
+        if let Some(cursor) = cursor {
+            arguments.insert("cursor".to_string(), json!(cursor));
+        }
+        CallToolRequestParams::new("rocketmq_list_topics").with_arguments(arguments)
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    fn complete_tool_response(response: CallToolResponse) -> rmcp::model::CallToolResult {
+        match response {
+            CallToolResponse::Complete(result) => result,
+            response => panic!("expected a completed tool response, got {response:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9912
- Fixes #9912

### Brief Description

Introduce a closed `VisibilityClass` with `standard` and `sensitive` values, derive it from verified principal scopes and local stdio profiles, and bind it to every Tool and live Resource query. Query cache, bounded snapshot, singleflight, and cursor state now share within a visibility class while remaining isolated across classes, without retaining principal or credential material.

The change preserves the read-only Admin Core boundary, existing authorization and sanitization behavior, bounded pagination, lifecycle ownership, and public MCP schemas. README and production-validation guidance document the two-class partitioning contract.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-mcp -- --check` passed.
- `python scripts/check_read_only_boundary.py` passed.
- `cargo test --locked --lib protocol::server::tests --features streamable-http` passed: 7 tests.
- `cargo test --locked --lib adapter::query_facade::tests` passed: 40 tests.
- `cargo test --locked --lib guard::http_auth::tests --features streamable-http` passed: 4 tests.
- `cargo test --locked` passed: 173 library tests, 5 binary tests, 1 compatibility test, and 3 integration tests; 1 live-cluster integration test was ignored because its external environment was not configured.
- `cargo test --locked --all-features` passed: 201 library tests, 5 binary tests, 1 compatibility test, and 3 integration tests; the same live-cluster integration test was ignored.
- `cargo check --locked` and `cargo check --locked --all-features` passed.
- `cargo clippy --locked --all-targets --features streamable-http -- -D warnings` passed.
- `cargo doc --locked --no-deps` passed.
- `git diff --check` and the read-only boundary audit passed; Tool and protocol contract snapshots are unchanged, and no pending snapshot artifacts exist.
- `cargo fmt --all -- --check` remains blocked by the pre-existing Windows path-length error `os error 206`; the package-scoped format check above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added standard and sensitive query visibility classes based on access scopes and local profiles.
  - Query results and cached state are shared within the same visibility class while remaining isolated across classes.
  - Added protection against using cursors across visibility classes.
  - Added cancellation-aware query handling for resource reads and tool requests.
- **Documentation**
  - Updated configuration and production-validation guidance with visibility mappings, cache behavior, and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->