### PR TITLE
[ISSUE #9924]♻️Add descriptor-validated error views

### DIFF
--- a/rocketmq-error/src/context.rs
+++ b/rocketmq-error/src/context.rs
@@ -207,7 +207,8 @@ impl ErrorContextField {
     ///
     /// Public callers can obtain fields only through
     /// [`ErrorContext::public_fields`], which excludes diagnostic and
-    /// secret-presence entries.
+    /// secret-presence entries. Descriptor-validated views apply their own
+    /// descriptor declaration ordering before exposing context fields.
     #[inline]
     pub fn value(&self) -> FieldValueRef<'_> {
         self.value.as_ref()
@@ -298,6 +299,7 @@ impl ErrorContext {
             .filter(|field| matches!(field.visibility(), ContextVisibility::Public))
     }
 
+    /// Returns retained fields to crate-private descriptor validators.
     pub(crate) fn fields(&self) -> &[ErrorContextField] {
         &self.fields
     }

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -69,6 +69,7 @@ mod recovery;
 mod shared;
 mod spec;
 mod unified;
+mod view;
 
 // Re-export new error types as primary API
 // Re-export auth error types from unified module
@@ -147,3 +148,10 @@ pub use unified::RpcClientError;
 pub use unified::SerializationError;
 pub use unified::ServiceError as UnifiedServiceError;
 pub use unified::ToolsError;
+pub use view::DiagnosticFields;
+pub use view::DiagnosticView;
+pub use view::PublicErrorView;
+pub use view::PublicFields;
+pub use view::ViewContextViolation;
+pub use view::ViewFieldRef;
+pub use view::ViewValueRef;

--- a/rocketmq-error/src/view.rs
+++ b/rocketmq-error/src/view.rs
@@ -1,0 +1,501 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::iter::FusedIterator;
+use std::slice;
+
+use crate::context::ErrorContextField;
+use crate::context::FieldValueRef;
+use crate::CanonicalCondition;
+use crate::ContextVisibility;
+use crate::ErrorCode;
+use crate::ErrorContext;
+use crate::ErrorDescriptor;
+use crate::ErrorSeverity;
+use crate::FieldSchema;
+use crate::ProjectionSpec;
+use crate::RecoveryHint;
+
+/// A descriptor/context contract violation discovered while creating a safe view.
+///
+/// Violations carry only catalog schema metadata. They never include a runtime
+/// context value, source error, or backtrace.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ViewContextViolation {
+    /// A retained context field is not declared by the selected descriptor.
+    UndeclaredField {
+        /// The selected descriptor's stable code.
+        descriptor: ErrorCode,
+        /// The schema retained by the context.
+        actual: FieldSchema,
+    },
+    /// A retained context field has the same name as a descriptor field but a different schema.
+    SchemaMismatch {
+        /// The selected descriptor's stable code.
+        descriptor: ErrorCode,
+        /// The schema required by the descriptor.
+        expected: FieldSchema,
+        /// The schema retained by the context.
+        actual: FieldSchema,
+    },
+}
+
+impl fmt::Debug for ViewContextViolation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UndeclaredField { descriptor, actual } => formatter
+                .debug_struct("UndeclaredField")
+                .field("descriptor", descriptor)
+                .field("actual", actual)
+                .finish(),
+            Self::SchemaMismatch {
+                descriptor,
+                expected,
+                actual,
+            } => formatter
+                .debug_struct("SchemaMismatch")
+                .field("descriptor", descriptor)
+                .field("expected", expected)
+                .field("actual", actual)
+                .finish(),
+        }
+    }
+}
+
+impl fmt::Display for ViewContextViolation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UndeclaredField { descriptor, actual } => {
+                write!(
+                    formatter,
+                    "context field `{}` is not declared by {descriptor}",
+                    actual.name()
+                )
+            }
+            Self::SchemaMismatch {
+                descriptor,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "context field `{}` does not match the schema declared by {descriptor}: expected {:?}, got {:?}",
+                actual.name(),
+                expected,
+                actual,
+            ),
+        }
+    }
+}
+
+/// A borrowed public projection of one descriptor-validated error context.
+///
+/// This view exposes only the descriptor's stable identity, fixed public
+/// message, explicitly public context fields, and descriptor-owned protocol
+/// projections. It borrows its inputs and performs no allocation after the
+/// [`ErrorContext`] has been constructed.
+///
+/// ```compile_fail,E0616
+/// use rocketmq_error::{ErrorContext, PublicErrorView, ROUTE_TOPIC_NOT_FOUND};
+///
+/// let context = ErrorContext::new();
+/// let view = PublicErrorView::try_new(&ROUTE_TOPIC_NOT_FOUND, &context).unwrap();
+/// let _ = view.context;
+/// ```
+pub struct PublicErrorView<'a> {
+    descriptor: &'static ErrorDescriptor,
+    context: &'a ErrorContext,
+}
+
+impl<'a> PublicErrorView<'a> {
+    /// Validates `context` against `descriptor` and creates a public safe view.
+    ///
+    /// Every retained context field must exactly match a schema declared by
+    /// `descriptor`. Missing fields are valid because descriptor schemas do
+    /// not currently define required values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ViewContextViolation`] for the first retained context field
+    /// that is undeclared or has a different complete schema.
+    pub fn try_new(
+        descriptor: &'static ErrorDescriptor,
+        context: &'a ErrorContext,
+    ) -> Result<Self, ViewContextViolation> {
+        validate_context(descriptor, context)?;
+        Ok(Self { descriptor, context })
+    }
+
+    /// Returns the stable catalog code.
+    #[inline]
+    pub const fn code(&self) -> ErrorCode {
+        self.descriptor.code()
+    }
+
+    /// Returns the descriptor's fixed public message.
+    #[inline]
+    pub const fn message(&self) -> &'static str {
+        self.descriptor.public_message()
+    }
+
+    /// Iterates present public fields in descriptor declaration order.
+    #[inline]
+    pub fn fields(&self) -> PublicFields<'a> {
+        PublicFields::new(self.descriptor, self.context)
+    }
+
+    /// Returns descriptor-owned boundary projections.
+    #[inline]
+    pub const fn projection(&self) -> ProjectionSpec {
+        self.descriptor.projection()
+    }
+
+    /// Returns whether context construction normalized, discarded, or truncated a value.
+    #[inline]
+    pub const fn is_truncated(&self) -> bool {
+        self.context.is_truncated()
+    }
+}
+
+impl fmt::Debug for PublicErrorView<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PublicErrorView")
+            .field("code", &self.code())
+            .field("message", &self.message())
+            .field("fields", &self.fields())
+            .field("projection", &self.projection())
+            .field("truncated", &self.is_truncated())
+            .finish()
+    }
+}
+
+/// A borrowed controlled-diagnostics projection of one descriptor-validated context.
+///
+/// `DiagnosticView` exposes descriptor-approved diagnostic fields and
+/// key-only secret-presence markers for operational diagnostics. It must not
+/// be serialized into public protocol responses. Like [`PublicErrorView`], it
+/// borrows its inputs and performs no allocation after [`ErrorContext`] has
+/// been constructed.
+pub struct DiagnosticView<'a> {
+    descriptor: &'static ErrorDescriptor,
+    context: &'a ErrorContext,
+}
+
+impl<'a> DiagnosticView<'a> {
+    /// Validates `context` against `descriptor` and creates a controlled diagnostic view.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ViewContextViolation`] for the first retained context field
+    /// that is undeclared or has a different complete schema.
+    pub fn try_new(
+        descriptor: &'static ErrorDescriptor,
+        context: &'a ErrorContext,
+    ) -> Result<Self, ViewContextViolation> {
+        validate_context(descriptor, context)?;
+        Ok(Self { descriptor, context })
+    }
+
+    /// Returns the stable catalog code.
+    #[inline]
+    pub const fn code(&self) -> ErrorCode {
+        self.descriptor.code()
+    }
+
+    /// Returns the descriptor's fixed public message.
+    #[inline]
+    pub const fn message(&self) -> &'static str {
+        self.descriptor.public_message()
+    }
+
+    /// Returns the descriptor's protocol-independent canonical condition.
+    #[inline]
+    pub const fn condition(&self) -> CanonicalCondition {
+        self.descriptor.condition()
+    }
+
+    /// Returns the descriptor's operational severity.
+    #[inline]
+    pub const fn severity(&self) -> ErrorSeverity {
+        self.descriptor.severity()
+    }
+
+    /// Returns the descriptor's recovery advice.
+    #[inline]
+    pub const fn recovery_hint(&self) -> RecoveryHint {
+        self.descriptor.recovery_hint()
+    }
+
+    /// Iterates present public, diagnostic, and redacted secret-presence fields.
+    #[inline]
+    pub fn fields(&self) -> DiagnosticFields<'a> {
+        DiagnosticFields::new(self.descriptor, self.context)
+    }
+
+    /// Returns descriptor-owned boundary projections.
+    #[inline]
+    pub const fn projection(&self) -> ProjectionSpec {
+        self.descriptor.projection()
+    }
+
+    /// Returns whether context construction normalized, discarded, or truncated a value.
+    #[inline]
+    pub const fn is_truncated(&self) -> bool {
+        self.context.is_truncated()
+    }
+}
+
+impl fmt::Debug for DiagnosticView<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DiagnosticView")
+            .field("code", &self.code())
+            .field("message", &self.message())
+            .field("condition", &self.condition())
+            .field("severity", &self.severity())
+            .field("recovery_hint", &self.recovery_hint())
+            .field("fields", &self.fields())
+            .field("projection", &self.projection())
+            .field("truncated", &self.is_truncated())
+            .finish()
+    }
+}
+
+/// A borrowed descriptor-ordered iterator over public context fields.
+#[derive(Clone)]
+pub struct PublicFields<'a> {
+    inner: ViewFields<'a>,
+}
+
+impl<'a> PublicFields<'a> {
+    fn new(descriptor: &'static ErrorDescriptor, context: &'a ErrorContext) -> Self {
+        Self {
+            inner: ViewFields::new(descriptor, context),
+        }
+    }
+}
+
+impl<'a> Iterator for PublicFields<'a> {
+    type Item = ViewFieldRef<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next_field(false)
+    }
+}
+
+impl FusedIterator for PublicFields<'_> {}
+
+impl fmt::Debug for PublicFields<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_list().entries(self.clone()).finish()
+    }
+}
+
+/// A borrowed descriptor-ordered iterator over controlled diagnostic fields.
+#[derive(Clone)]
+pub struct DiagnosticFields<'a> {
+    inner: ViewFields<'a>,
+}
+
+impl<'a> DiagnosticFields<'a> {
+    fn new(descriptor: &'static ErrorDescriptor, context: &'a ErrorContext) -> Self {
+        Self {
+            inner: ViewFields::new(descriptor, context),
+        }
+    }
+}
+
+impl<'a> Iterator for DiagnosticFields<'a> {
+    type Item = ViewFieldRef<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next_field(true)
+    }
+}
+
+impl FusedIterator for DiagnosticFields<'_> {}
+
+impl fmt::Debug for DiagnosticFields<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_list().entries(self.clone()).finish()
+    }
+}
+
+#[derive(Clone)]
+struct ViewFields<'a> {
+    descriptor_fields: slice::Iter<'static, FieldSchema>,
+    context: &'a ErrorContext,
+}
+
+impl<'a> ViewFields<'a> {
+    fn new(descriptor: &'static ErrorDescriptor, context: &'a ErrorContext) -> Self {
+        Self {
+            descriptor_fields: descriptor.fields().iter(),
+            context,
+        }
+    }
+
+    fn next_field(&mut self, include_diagnostic: bool) -> Option<ViewFieldRef<'a>> {
+        for schema in self.descriptor_fields.by_ref() {
+            if !include_visibility(schema.visibility(), include_diagnostic) {
+                continue;
+            }
+            let Some(field) = self.context.fields().iter().find(|field| field.schema() == *schema) else {
+                continue;
+            };
+            return Some(ViewFieldRef { field });
+        }
+        None
+    }
+}
+
+fn include_visibility(visibility: ContextVisibility, include_diagnostic: bool) -> bool {
+    match visibility {
+        ContextVisibility::Public => true,
+        ContextVisibility::Diagnostic | ContextVisibility::SecretPresenceOnly => include_diagnostic,
+    }
+}
+
+/// A borrowed field exposed by a descriptor-validated view.
+pub struct ViewFieldRef<'a> {
+    field: &'a ErrorContextField,
+}
+
+impl<'a> ViewFieldRef<'a> {
+    /// Returns the descriptor-approved external field name.
+    #[inline]
+    pub const fn name(&self) -> &'static str {
+        self.field.name()
+    }
+
+    /// Returns the descriptor-approved field visibility.
+    #[inline]
+    pub const fn visibility(&self) -> ContextVisibility {
+        self.field.visibility()
+    }
+
+    /// Returns the safe borrowed value for this field.
+    ///
+    /// Secret-presence fields always return [`ViewValueRef::Redacted`].
+    #[inline]
+    pub fn value(&self) -> ViewValueRef<'a> {
+        match self.field.value() {
+            FieldValueRef::Text(value) => ViewValueRef::Text(value),
+            FieldValueRef::I64(value) => ViewValueRef::I64(value),
+            FieldValueRef::U64(value) => ViewValueRef::U64(value),
+            FieldValueRef::Bool(value) => ViewValueRef::Bool(value),
+            FieldValueRef::Presence => ViewValueRef::Redacted,
+        }
+    }
+}
+
+impl fmt::Debug for ViewFieldRef<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ViewFieldRef")
+            .field("name", &self.name())
+            .field("visibility", &self.visibility())
+            .field("value", &self.value())
+            .finish()
+    }
+}
+
+/// A safe borrowed value exposed by a descriptor-validated view.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ViewValueRef<'a> {
+    /// Bounded normalized text.
+    Text(&'a str),
+    /// A signed integer.
+    I64(i64),
+    /// An unsigned integer.
+    U64(u64),
+    /// A Boolean value.
+    Bool(bool),
+    /// A key-only marker for secret-bearing input.
+    Redacted,
+}
+
+impl fmt::Debug for ViewValueRef<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Text(value) => value.fmt(formatter),
+            Self::I64(value) => value.fmt(formatter),
+            Self::U64(value) => value.fmt(formatter),
+            Self::Bool(value) => value.fmt(formatter),
+            Self::Redacted => formatter.write_str("<redacted>"),
+        }
+    }
+}
+
+fn validate_context(descriptor: &'static ErrorDescriptor, context: &ErrorContext) -> Result<(), ViewContextViolation> {
+    for field in context.fields() {
+        let actual = field.schema();
+        let Some(expected) = descriptor
+            .fields()
+            .iter()
+            .find(|expected| expected.name() == actual.name())
+        else {
+            return Err(ViewContextViolation::UndeclaredField {
+                descriptor: descriptor.code(),
+                actual,
+            });
+        };
+        if *expected != actual {
+            return Err(ViewContextViolation::SchemaMismatch {
+                descriptor: descriptor.code(),
+                expected: *expected,
+                actual,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fields;
+
+    const BOOLEAN_CODE: ErrorCode = match ErrorCode::try_new("test.view.boolean") {
+        Some(code) => code,
+        None => panic!("synthetic test code must be valid"),
+    };
+    static BOOLEAN_FIELDS: [FieldSchema; 1] = [fields::ATTEMPTED.schema()];
+    static BOOLEAN_DESCRIPTOR: ErrorDescriptor = match ErrorDescriptor::try_new(
+        BOOLEAN_CODE,
+        CanonicalCondition::Internal,
+        "Synthetic Boolean view test",
+        ErrorSeverity::Info,
+        RecoveryHint::Never,
+        crate::ROUTE_TOPIC_NOT_FOUND.projection(),
+        &BOOLEAN_FIELDS,
+    ) {
+        Some(descriptor) => descriptor,
+        None => panic!("synthetic Boolean descriptor must be valid"),
+    };
+
+    #[test]
+    fn synthetic_boolean_descriptor_exposes_a_borrowed_boolean_value() {
+        let context = ErrorContext::new().with_bool(fields::ATTEMPTED, true);
+        let public = PublicErrorView::try_new(&BOOLEAN_DESCRIPTOR, &context).expect("public view");
+        let diagnostic = DiagnosticView::try_new(&BOOLEAN_DESCRIPTOR, &context).expect("diagnostic view");
+
+        assert!(public.fields().next().is_none());
+        assert_eq!(
+            diagnostic.fields().next().expect("Boolean field").value(),
+            ViewValueRef::Bool(true)
+        );
+    }
+}

--- a/rocketmq-error/tests/error_safe_views.rs
+++ b/rocketmq-error/tests/error_safe_views.rs
@@ -1,0 +1,297 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::iter::FusedIterator;
+
+use rocketmq_error::fields;
+use rocketmq_error::ContextVisibility;
+use rocketmq_error::DiagnosticView;
+use rocketmq_error::ErrorContext;
+use rocketmq_error::FieldValueKind;
+use rocketmq_error::PublicErrorView;
+use rocketmq_error::ViewContextViolation;
+use rocketmq_error::ViewValueRef;
+use rocketmq_error::ALL_DESCRIPTORS;
+use rocketmq_error::AUTH_CREDENTIALS_INVALID;
+use rocketmq_error::AUTH_PERMISSION_DENIED;
+use rocketmq_error::CORE_INTERNAL_FAILURE;
+use rocketmq_error::ROUTE_TOPIC_NOT_FOUND;
+use rocketmq_error::STORAGE_COMMIT_LOG_CORRUPT_RECORD;
+use rocketmq_error::TRANSPORT_CONNECTION_TIMEOUT;
+
+const SENTINEL: &str = "Bearer token-secret secret_key=sk signature=sig password=pw\r\nsource-message";
+
+#[test]
+fn every_descriptor_accepts_empty_context_with_exact_identity_and_projection() {
+    let context = ErrorContext::new();
+
+    for descriptor in ALL_DESCRIPTORS {
+        let public = PublicErrorView::try_new(descriptor, &context).expect("public view");
+        let diagnostic = DiagnosticView::try_new(descriptor, &context).expect("diagnostic view");
+
+        assert_eq!(public.code(), descriptor.code());
+        assert_eq!(public.message(), descriptor.public_message());
+        assert_eq!(public.projection(), descriptor.projection());
+        assert!(!public.is_truncated());
+        assert!(public.fields().next().is_none());
+
+        assert_eq!(diagnostic.code(), descriptor.code());
+        assert_eq!(diagnostic.message(), descriptor.public_message());
+        assert_eq!(diagnostic.condition(), descriptor.condition());
+        assert_eq!(diagnostic.severity(), descriptor.severity());
+        assert_eq!(diagnostic.recovery_hint(), descriptor.recovery_hint());
+        assert_eq!(diagnostic.projection(), descriptor.projection());
+        assert!(!diagnostic.is_truncated());
+        assert!(diagnostic.fields().next().is_none());
+    }
+}
+
+#[test]
+fn public_and_diagnostic_views_filter_fields_in_descriptor_order() {
+    let context = ErrorContext::new()
+        .with_text(fields::REMOTE_ADDR, "10.0.0.8:10911")
+        .with_u64(fields::TIMEOUT_MS, 500);
+    let public = PublicErrorView::try_new(&TRANSPORT_CONNECTION_TIMEOUT, &context).expect("public view");
+    let diagnostic = DiagnosticView::try_new(&TRANSPORT_CONNECTION_TIMEOUT, &context).expect("diagnostic view");
+
+    let public_fields = public.fields().collect::<Vec<_>>();
+    assert_eq!(public_fields.len(), 1);
+    assert_eq!(public_fields[0].name(), "timeout_ms");
+    assert_eq!(public_fields[0].visibility(), ContextVisibility::Public);
+    assert_eq!(public_fields[0].value(), ViewValueRef::U64(500));
+
+    let diagnostic_fields = diagnostic.fields().collect::<Vec<_>>();
+    assert_eq!(diagnostic_fields.len(), 2);
+    assert_eq!(diagnostic_fields[0].name(), "timeout_ms");
+    assert_eq!(diagnostic_fields[0].value(), ViewValueRef::U64(500));
+    assert_eq!(diagnostic_fields[1].name(), "remote_addr");
+    assert_eq!(diagnostic_fields[1].visibility(), ContextVisibility::Diagnostic);
+    assert_eq!(diagnostic_fields[1].value(), ViewValueRef::Text("10.0.0.8:10911"));
+
+    let sparse_context = ErrorContext::new().with_text(fields::REMOTE_ADDR, "10.0.0.9:10911");
+    let sparse =
+        DiagnosticView::try_new(&TRANSPORT_CONNECTION_TIMEOUT, &sparse_context).expect("sparse diagnostic view");
+    let sparse_fields = sparse.fields().collect::<Vec<_>>();
+    assert_eq!(sparse_fields.len(), 1);
+    assert_eq!(sparse_fields[0].name(), "remote_addr");
+    assert_eq!(sparse_fields[0].value(), ViewValueRef::Text("10.0.0.9:10911"));
+}
+
+#[test]
+fn visibility_and_value_kinds_are_exposed_only_when_catalog_allows_them() {
+    let route_context = ErrorContext::new().with_text(fields::TOPIC, "orders");
+    let route = PublicErrorView::try_new(&ROUTE_TOPIC_NOT_FOUND, &route_context).expect("route public view");
+    assert_eq!(
+        route.fields().next().expect("topic").value(),
+        ViewValueRef::Text("orders")
+    );
+
+    let storage_context = ErrorContext::new().with_i64(fields::DECLARED_SIZE, -1);
+    let storage =
+        DiagnosticView::try_new(&STORAGE_COMMIT_LOG_CORRUPT_RECORD, &storage_context).expect("storage diagnostic view");
+    assert_eq!(
+        storage.fields().next().expect("declared size").value(),
+        ViewValueRef::I64(-1)
+    );
+
+    let secret_context = ErrorContext::new().with_secret_presence(fields::CREDENTIALS_PRESENT);
+    let public = PublicErrorView::try_new(&AUTH_CREDENTIALS_INVALID, &secret_context).expect("public view");
+    let diagnostic = DiagnosticView::try_new(&AUTH_CREDENTIALS_INVALID, &secret_context).expect("diagnostic view");
+    assert!(public.fields().next().is_none());
+    let secret = diagnostic.fields().next().expect("secret presence marker");
+    assert_eq!(secret.name(), "credentials_present");
+    assert_eq!(secret.visibility(), ContextVisibility::SecretPresenceOnly);
+    assert_eq!(secret.value(), ViewValueRef::Redacted);
+
+    let boolean_context = ErrorContext::new().with_bool(fields::ATTEMPTED, true);
+    let violation = PublicErrorView::try_new(&ROUTE_TOPIC_NOT_FOUND, &boolean_context)
+        .expect_err("the catalog declares no Boolean field");
+    let ViewContextViolation::UndeclaredField { actual, .. } = violation else {
+        panic!("Boolean context field must be undeclared");
+    };
+    assert_eq!(actual.value_kind(), FieldValueKind::Bool);
+}
+
+#[test]
+fn diagnostic_view_exposes_diagnostic_text_and_key_only_secret_markers() {
+    let context = ErrorContext::new()
+        .with_text(fields::OPERATION_DIAGNOSTIC, "compact")
+        .with_secret_presence(fields::SOURCE_PRESENT);
+    let public = PublicErrorView::try_new(&CORE_INTERNAL_FAILURE, &context).expect("public view");
+    let diagnostic = DiagnosticView::try_new(&CORE_INTERNAL_FAILURE, &context).expect("diagnostic view");
+
+    assert!(public.fields().next().is_none());
+    let fields = diagnostic.fields().collect::<Vec<_>>();
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name(), "operation");
+    assert_eq!(fields[0].visibility(), ContextVisibility::Diagnostic);
+    assert_eq!(fields[0].value(), ViewValueRef::Text("compact"));
+    assert_eq!(fields[1].name(), "source_present");
+    assert_eq!(fields[1].visibility(), ContextVisibility::SecretPresenceOnly);
+    assert_eq!(fields[1].value(), ViewValueRef::Redacted);
+}
+
+#[test]
+fn validation_returns_the_first_full_schema_violation_for_both_views() {
+    let undeclared_context = ErrorContext::new()
+        .with_text(fields::ADDR, "10.0.0.8:10911")
+        .with_text(fields::OPERATION_DIAGNOSTIC, "ignored-after-first");
+    let public_undeclared = PublicErrorView::try_new(&ROUTE_TOPIC_NOT_FOUND, &undeclared_context)
+        .expect_err("address is not declared for route lookup");
+    let diagnostic_undeclared = DiagnosticView::try_new(&ROUTE_TOPIC_NOT_FOUND, &undeclared_context)
+        .expect_err("address is not declared for route lookup");
+    assert_eq!(public_undeclared, diagnostic_undeclared);
+    assert_eq!(
+        public_undeclared,
+        ViewContextViolation::UndeclaredField {
+            descriptor: ROUTE_TOPIC_NOT_FOUND.code(),
+            actual: fields::ADDR.schema(),
+        }
+    );
+
+    let mismatch_context = ErrorContext::new()
+        .with_text(fields::OPERATION_DIAGNOSTIC, "private operation")
+        .with_text(fields::ADDR, "ignored-after-first");
+    let public_mismatch = PublicErrorView::try_new(&AUTH_PERMISSION_DENIED, &mismatch_context)
+        .expect_err("operation visibility must exactly match the descriptor");
+    let diagnostic_mismatch = DiagnosticView::try_new(&AUTH_PERMISSION_DENIED, &mismatch_context)
+        .expect_err("operation visibility must exactly match the descriptor");
+    assert_eq!(public_mismatch, diagnostic_mismatch);
+    assert_eq!(
+        public_mismatch,
+        ViewContextViolation::SchemaMismatch {
+            descriptor: AUTH_PERMISSION_DENIED.code(),
+            expected: fields::OPERATION.schema(),
+            actual: fields::OPERATION_DIAGNOSTIC.schema(),
+        }
+    );
+}
+
+#[test]
+fn normalized_and_duplicate_valid_contexts_remain_viewable_and_report_truncation() {
+    let oversized_topic = format!("orders-{}", "x".repeat(256));
+    let normalized = ErrorContext::new().with_text(fields::TOPIC, &oversized_topic);
+    let public = PublicErrorView::try_new(&ROUTE_TOPIC_NOT_FOUND, &normalized).expect("normalized public view");
+    let diagnostic = DiagnosticView::try_new(&ROUTE_TOPIC_NOT_FOUND, &normalized).expect("normalized diagnostic view");
+    assert!(public.is_truncated());
+    assert!(diagnostic.is_truncated());
+    let ViewValueRef::Text(topic) = public.fields().next().expect("topic").value() else {
+        panic!("topic must remain text");
+    };
+    assert!(topic.len() <= 127);
+    assert!(topic.starts_with("orders-"));
+
+    let duplicate = ErrorContext::new()
+        .with_text(fields::OPERATION, "publish")
+        .with_text(fields::OPERATION_DIAGNOSTIC, "discarded diagnostic operation");
+    let public = PublicErrorView::try_new(&AUTH_PERMISSION_DENIED, &duplicate).expect("duplicate public view");
+    let diagnostic = DiagnosticView::try_new(&AUTH_PERMISSION_DENIED, &duplicate).expect("duplicate diagnostic view");
+    assert!(public.is_truncated());
+    assert!(diagnostic.is_truncated());
+    assert_eq!(
+        public.fields().next().expect("operation").value(),
+        ViewValueRef::Text("publish")
+    );
+    assert_eq!(
+        diagnostic.fields().next().expect("operation").value(),
+        ViewValueRef::Text("publish")
+    );
+}
+
+#[test]
+fn field_iterators_are_fused_and_borrow_text_without_projection_allocations() {
+    fn requires_fused<I: FusedIterator>(_: I) {}
+
+    let context = ErrorContext::new()
+        .with_text(fields::REMOTE_ADDR, "10.0.0.8:10911")
+        .with_u64(fields::TIMEOUT_MS, 500);
+    let public = PublicErrorView::try_new(&TRANSPORT_CONNECTION_TIMEOUT, &context).expect("public view");
+    let diagnostic = DiagnosticView::try_new(&TRANSPORT_CONNECTION_TIMEOUT, &context).expect("diagnostic view");
+    requires_fused(public.fields());
+    requires_fused(diagnostic.fields());
+
+    let public_text = context.public_fields().next().expect("timeout is public");
+    assert_eq!(public_text.name(), "timeout_ms");
+    let diagnostic_field = diagnostic.fields().nth(1).expect("remote address");
+    let ViewValueRef::Text(remote_addr) = diagnostic_field.value() else {
+        panic!("remote address must remain borrowed text");
+    };
+    let context_remote = context.public_fields().find(|field| field.name() == "remote_addr");
+    assert!(
+        context_remote.is_none(),
+        "diagnostic address must not enter public context iteration"
+    );
+    assert_eq!(remote_addr, "10.0.0.8:10911");
+
+    let mut fields = public.fields();
+    assert_eq!(fields.next().expect("timeout").name(), "timeout_ms");
+    assert!(fields.next().is_none());
+    assert!(fields.next().is_none());
+}
+
+#[test]
+fn secret_sentinel_never_enters_safe_views_or_violations() {
+    let secret_context = ErrorContext::new().with_secret_presence(fields::CREDENTIALS_PRESENT);
+    let public = PublicErrorView::try_new(&AUTH_CREDENTIALS_INVALID, &secret_context).expect("public view");
+    let diagnostic = DiagnosticView::try_new(&AUTH_CREDENTIALS_INVALID, &secret_context).expect("diagnostic view");
+    let safe_output = format!(
+        "{public:?} {diagnostic:?} {:?}",
+        diagnostic.fields().collect::<Vec<_>>()
+    );
+    assert!(safe_output.contains("<redacted>"));
+    assert!(!safe_output.contains(SENTINEL));
+    assert!(!safe_output.contains("token-secret"));
+
+    let invalid_context = ErrorContext::new().with_text(fields::ADDR, SENTINEL);
+    let violation = PublicErrorView::try_new(&ROUTE_TOPIC_NOT_FOUND, &invalid_context)
+        .expect_err("undeclared address must not create a partial view");
+    let violation_output = format!("{violation:?} {violation}");
+    assert!(!violation_output.contains(SENTINEL));
+    assert!(!violation_output.contains("token-secret"));
+}
+
+#[test]
+fn safe_view_api_keeps_representation_private_and_does_not_add_text_or_serde_contracts() {
+    let crate_root = include_str!("../src/lib.rs");
+    let view_source = include_str!("../src/view.rs");
+
+    assert!(crate_root.contains("mod view;"));
+    assert!(!crate_root.contains("pub mod view;"));
+    for reexport in [
+        "pub use view::PublicErrorView;",
+        "pub use view::DiagnosticView;",
+        "pub use view::PublicFields;",
+        "pub use view::DiagnosticFields;",
+        "pub use view::ViewFieldRef;",
+        "pub use view::ViewValueRef;",
+        "pub use view::ViewContextViolation;",
+    ] {
+        assert!(crate_root.contains(reexport), "missing root re-export: {reexport}");
+    }
+    assert_eq!(view_source.matches("pub fn try_new").count(), 2);
+    assert!(!view_source.contains("pub descriptor:"));
+    assert!(!view_source.contains("pub context:"));
+    assert!(!view_source.contains("pub fn context("));
+    assert!(!view_source.contains("impl fmt::Display for PublicErrorView"));
+    assert!(!view_source.contains("impl fmt::Display for DiagnosticView"));
+    assert!(!view_source.contains("impl fmt::Display for PublicFields"));
+    assert!(!view_source.contains("impl fmt::Display for DiagnosticFields"));
+    assert!(!view_source.contains("serde::Serialize"));
+    assert!(view_source.contains("impl fmt::Debug for PublicErrorView"));
+    assert!(view_source.contains("impl fmt::Debug for DiagnosticView"));
+    assert!(view_source.contains("impl FusedIterator for PublicFields"));
+    assert!(view_source.contains("impl FusedIterator for DiagnosticFields"));
+    assert!(!view_source.contains("Vec<"));
+    assert!(!view_source.contains("Box<"));
+}

--- a/rocketmq-error/tests/typed_error_public_api.rs
+++ b/rocketmq-error/tests/typed_error_public_api.rs
@@ -62,6 +62,7 @@ fn error_crate_public_api_exposes_only_typed_error_surface() {
         "recovery",
         "spec",
         "unified",
+        "view",
     ] {
         assert!(
             !source.contains(&format!("pub mod {module};")),
@@ -84,4 +85,12 @@ fn error_crate_public_api_exposes_only_typed_error_surface() {
     let projection: rocketmq_error::ProjectionSpec = descriptor.projection();
     assert_eq!(descriptor, &rocketmq_error::ROUTE_TOPIC_NOT_FOUND);
     assert_eq!(projection.grpc().status, rocketmq_error::GrpcStatusCode::NotFound);
+
+    let context = rocketmq_error::ErrorContext::new();
+    let public = rocketmq_error::PublicErrorView::try_new(&rocketmq_error::ROUTE_TOPIC_NOT_FOUND, &context)
+        .expect("public view");
+    let diagnostic = rocketmq_error::DiagnosticView::try_new(&rocketmq_error::ROUTE_TOPIC_NOT_FOUND, &context)
+        .expect("diagnostic view");
+    assert_eq!(public.code(), descriptor.code());
+    assert_eq!(diagnostic.projection(), projection);
 }

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -812,6 +812,16 @@ def check_redaction_guards() -> list[Finding]:
             "pub fn public_fields(&self)",
             "pub const fn is_truncated(&self) -> bool",
         ],
+        ROOT / "rocketmq-error" / "src" / "view.rs": [
+            "pub struct PublicErrorView",
+            "pub struct DiagnosticView",
+            "pub enum ViewContextViolation",
+            "ViewValueRef::Redacted",
+        ],
+        ROOT / "rocketmq-error" / "tests" / "error_safe_views.rs": [
+            "const SENTINEL",
+            "secret_sentinel_never_enters_safe_views_or_violations",
+        ],
         ROOT / "rocketmq-error" / "tests" / "error_context_redaction.rs": [
             "error_context_redacts_sensitive_fields",
         ],


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9924
- Fixes #9924

### Brief Description

- Adds borrowed, descriptor-validated public and diagnostic error views with deterministic schema validation.
- Exposes descriptor-ordered safe field iterators with redacted secret-presence markers and descriptor-owned projections.
- Adds privacy, redaction, truncation, ordering, and value-kind coverage without changing the transitional boundary or CLI views.

### How Did You Test This Change?

- Root validation passed: `cargo fmt -p rocketmq-error -- --check`, focused `rocketmq-error` tests, `cargo test -p rocketmq-error`, `cargo test -p rocketmq-error --all-features`, `cargo doc -p rocketmq-error --no-deps`, and workspace Clippy with warnings denied.
- `./scripts/check-error-hygiene.ps1` reports 21 findings that are exactly baseline-identical to clean `origin/main`.
- `rocketmq-example` Clippy passed; its format check encountered Windows error 206 from the long worktree path.
- The SRE workspace check, Clippy, documentation, and source-boundary checks passed; its all-feature test profile has three known `unknown=["mcp"]` control-plane failures.
- Dashboard backend format checks encountered Windows error 206, while Clippy and build retain the known query-depth overflow at `src/main.rs:51`.
- CI was not awaited, as requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safe public and diagnostic error views with descriptor metadata, filtered fields, projections, truncation status, and diagnostic details.
  * Added structured validation for undeclared fields and schema mismatches.
  * Added redaction for sensitive values while preserving secret-presence indicators.
  * Added typed field and value representations for consistent error inspection.

* **Documentation**
  * Clarified context field ordering and validation behavior.

* **Tests**
  * Added comprehensive coverage for filtering, validation, truncation, redaction, and field iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->