### PR TITLE
[ISSUE #9920]🚀Add typed Broker and Proxy read tools to RocketMQ MCP

### DIFF
--- a/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml
+++ b/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml
@@ -69,6 +69,12 @@ default = true
 # secret_key_env = "ROCKETMQ_MCP_RMQ_SECRET_KEY"
 # security_token_env = "ROCKETMQ_MCP_RMQ_SECURITY_TOKEN"
 
+[[clusters.proxies]]
+name = "proxy-local"
+# Internal endpoint: never exposed through Tool schemas, output, logs, audit,
+# cache keys, or configuration Debug formatting.
+endpoint = "127.0.0.1:8081"
+
 [security]
 profile = "diagnose"
 allow_change_planning = false

--- a/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml
+++ b/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml
@@ -8,6 +8,7 @@ allow_tools = [
   "rocketmq_list_consumer_groups",
   "rocketmq_get_consumer_lag",
   "rocketmq_describe_broker",
+  "rocketmq_get_broker_config_summary",
 ]
 deny_tools = ["*"]
 
@@ -16,6 +17,9 @@ include = ["read_only"]
 allowed_clusters = ["*"]
 allow_tools = [
   "rocketmq_diagnose_consumer_lag",
+  "rocketmq_get_broker_diagnostics",
+  "rocketmq_get_broker_log_filter_state",
+  "rocketmq_get_proxy_drain_state",
 ]
 
 [roles.operator]

--- a/rocketmq-ai/rocketmq-mcp/src/adapter.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter.rs
@@ -15,4 +15,5 @@
 //! Adapters from MCP tool contracts to existing RocketMQ Rust admin services.
 
 pub(crate) mod admin_session;
+mod admin_session_projection;
 pub(crate) mod query_facade;

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
@@ -20,10 +20,15 @@ use rocketmq_admin_core::core::broker::BrokerQueryAdmin;
 use rocketmq_admin_core::core::broker::BrokerRuntimeTargetStatus;
 use rocketmq_admin_core::core::broker::ListBrokersRequest;
 use rocketmq_admin_core::core::broker::ProbeBrokerRuntimeTargetRequest;
+use rocketmq_admin_core::core::broker::QueryBrokerAllowlistedConfigTargetRequest;
+use rocketmq_admin_core::core::broker::QueryBrokerDiagnosticsTargetRequest;
+use rocketmq_admin_core::core::broker::QueryBrokerLogFilterStateTargetRequest;
 use rocketmq_admin_core::core::consumer::ConsumerQueryAdmin;
 use rocketmq_admin_core::core::consumer::ExactConsumerGroupEnrichmentRequest;
 use rocketmq_admin_core::core::consumer::ListConsumerGroupsRequest;
 use rocketmq_admin_core::core::consumer::QueryConsumerLagRequest;
+use rocketmq_admin_core::core::proxy::ProxyQueryAdmin;
+use rocketmq_admin_core::core::proxy::QueryProxyDrainStateRequest;
 use rocketmq_admin_core::core::security::AdminCredentials;
 use rocketmq_admin_core::core::topic::GetTopicRouteRequest;
 use rocketmq_admin_core::core::topic::TopicInventoryAdmin;
@@ -34,12 +39,19 @@ use rocketmq_admin_core::read_client_adapter::ReadAdminBuilder;
 use rocketmq_admin_core::read_client_adapter::ReadAdminGuard;
 use serde::Serialize;
 
+use crate::adapter::admin_session_projection::bounded_proxy_operation_id;
+use crate::adapter::admin_session_projection::map_broker_diagnostics;
+use crate::adapter::admin_session_projection::safe_operation_id;
 use crate::model::contract::observed_at_from_millis;
 use crate::model::contract::QueryPayload;
+use crate::tools::broker_tools::BrokerDiagnosticsOutput;
 use crate::tools::cluster_tools::BrokerSummary;
+use crate::tools::config_tools::BrokerConfigSummaryOutput;
+use crate::tools::config_tools::BrokerLogFilterStateOutput;
 use crate::tools::consumer_tools::ConsumerGroupSummary;
 use crate::tools::consumer_tools::QueueLag;
 use crate::tools::executor::ToolExecutionError;
+use crate::tools::proxy_tools::ProxyDrainStateOutput;
 use crate::tools::topic_tools::TopicRouteBroker;
 use crate::tools::topic_tools::TopicRouteQueue;
 
@@ -122,6 +134,52 @@ pub(crate) trait AdminSession: Send {
         &mut self,
         broker_name: &str,
     ) -> impl Future<Output = Result<BrokerRuntimeTargetStatus, ToolExecutionError>> + Send;
+
+    fn broker_diagnostics(
+        &mut self,
+        _broker_name: &str,
+    ) -> impl Future<Output = Result<QueryPayload<BrokerDiagnosticsOutput>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "exact Broker diagnostics are unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn broker_config_summary(
+        &mut self,
+        _broker_name: &str,
+    ) -> impl Future<Output = Result<QueryPayload<BrokerConfigSummaryOutput>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "exact Broker configuration is unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn broker_log_filter_state(
+        &mut self,
+        _broker_name: &str,
+        _logger: &str,
+    ) -> impl Future<Output = Result<QueryPayload<BrokerLogFilterStateOutput>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "exact Broker log-filter state is unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn proxy_drain_state(
+        &mut self,
+        _proxy_name: &str,
+        _proxy_endpoint: &str,
+    ) -> impl Future<Output = Result<QueryPayload<ProxyDrainStateOutput>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "Proxy drain state is unavailable".to_string(),
+            ))
+        }
+    }
 
     fn shutdown(self) -> impl Future<Output = Result<(), ToolExecutionError>> + Send;
 }
@@ -417,6 +475,174 @@ impl AdminSession for AdminCoreSession {
             .map_err(ToolExecutionError::backend)
     }
 
+    async fn broker_diagnostics(
+        &mut self,
+        broker_name: &str,
+    ) -> Result<QueryPayload<BrokerDiagnosticsOutput>, ToolExecutionError> {
+        let request =
+            QueryBrokerDiagnosticsTargetRequest::try_new(self.cluster.rocketmq_cluster_name.clone(), broker_name)
+                .map_err(map_logical_admin_error)?;
+        let result = self
+            .admin_mut()?
+            .query_broker_diagnostics_target_with_evidence(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        let cluster = self.cluster.name.clone();
+        Ok(QueryPayload::from_admin(result).map(|result| BrokerDiagnosticsOutput {
+            cluster,
+            broker_name: request.broker_name().to_string(),
+            diagnostics_schema_version: rocketmq_admin_core::core::broker::BROKER_DIAGNOSTICS_SCHEMA_VERSION
+                .to_string(),
+            observed_at_millis: result.observed_at_millis,
+            brokers: result.brokers.iter().map(map_broker_diagnostics).collect(),
+            unavailable_brokers: result.unavailable_brokers,
+        }))
+    }
+
+    async fn broker_config_summary(
+        &mut self,
+        broker_name: &str,
+    ) -> Result<QueryPayload<BrokerConfigSummaryOutput>, ToolExecutionError> {
+        let request =
+            QueryBrokerAllowlistedConfigTargetRequest::try_new(self.cluster.rocketmq_cluster_name.clone(), broker_name)
+                .map_err(map_logical_admin_error)?;
+        let result = self
+            .admin_mut()?
+            .query_allowlisted_config_target_with_evidence(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        let cluster = self.cluster.name.clone();
+        Ok(QueryPayload::from_admin(result).map(|rows| BrokerConfigSummaryOutput {
+            cluster,
+            broker_name: request.broker_name().to_string(),
+            brokers: rows
+                .into_iter()
+                .map(|row| crate::tools::config_tools::BrokerConfigSummaryRow {
+                    broker_name: row.broker_name,
+                    broker_id: row.broker_id,
+                    generation: row.config.generation,
+                    send_message_thread_pool_nums: row.config.send_message_thread_pool_nums,
+                    pull_message_thread_pool_nums: row.config.pull_message_thread_pool_nums,
+                    flush_delay_offset_interval_ms: row.config.flush_delay_offset_interval_ms,
+                    max_client_event_count: row.config.max_client_event_count,
+                })
+                .collect(),
+        }))
+    }
+
+    async fn broker_log_filter_state(
+        &mut self,
+        broker_name: &str,
+        logger: &str,
+    ) -> Result<QueryPayload<BrokerLogFilterStateOutput>, ToolExecutionError> {
+        let request = QueryBrokerLogFilterStateTargetRequest::try_new(
+            self.cluster.rocketmq_cluster_name.clone(),
+            broker_name,
+            logger,
+        )
+        .map_err(map_logical_admin_error)?;
+        let result = self
+            .admin_mut()?
+            .query_log_filter_state_target_with_evidence(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        let cluster = self.cluster.name.clone();
+        let payload = QueryPayload::from_admin(result);
+        let mut sanitized = false;
+        let brokers = payload
+            .data
+            .into_iter()
+            .map(|row| {
+                let (active_operation_id, active_sanitized) = safe_operation_id(row.state.active_operation_id);
+                let (last_completed_operation_id, completed_sanitized) =
+                    safe_operation_id(row.state.last_completed_operation_id);
+                sanitized |= active_sanitized || completed_sanitized;
+                crate::tools::config_tools::BrokerLogFilterStateRow {
+                    broker_name: row.broker_name,
+                    broker_id: row.broker_id,
+                    state_schema_version: rocketmq_admin_core::core::broker::BROKER_LOG_FILTER_STATE_SCHEMA_VERSION
+                        .to_string(),
+                    supported: row.state.supported,
+                    logger: request.logger().to_string(),
+                    level: row.state.level.map(|level| match level {
+                        rocketmq_admin_core::core::broker::BrokerLogLevel::Info => {
+                            crate::tools::config_tools::BrokerLogLevel::Info
+                        }
+                        rocketmq_admin_core::core::broker::BrokerLogLevel::Debug => {
+                            crate::tools::config_tools::BrokerLogLevel::Debug
+                        }
+                    }),
+                    active_operation_id,
+                    last_completed_operation_id,
+                    expires_at_millis: row.state.expires_at_millis,
+                }
+            })
+            .collect();
+        let mut warnings = payload.warnings;
+        if sanitized {
+            warnings.push("broker_log_filter_operation_id_sanitized".to_string());
+        }
+        Ok(QueryPayload::new(
+            BrokerLogFilterStateOutput {
+                cluster,
+                broker_name: request.broker_name().to_string(),
+                logger: request.logger().to_string(),
+                brokers,
+            },
+            payload.partial,
+            warnings,
+            payload.source_failures,
+        ))
+    }
+
+    async fn proxy_drain_state(
+        &mut self,
+        proxy_name: &str,
+        proxy_endpoint: &str,
+    ) -> Result<QueryPayload<ProxyDrainStateOutput>, ToolExecutionError> {
+        let request = QueryProxyDrainStateRequest {
+            proxy_addr: proxy_endpoint.to_string(),
+        };
+        let state = self
+            .admin_mut()?
+            .query_drain_state(&request)
+            .await
+            .map_err(|_| ToolExecutionError::Backend("Proxy drain source is unavailable".to_string()))?;
+        let (operation_id, warnings) = bounded_proxy_operation_id(state.operation_id);
+        let output = ProxyDrainStateOutput {
+            cluster: self.cluster.name.clone(),
+            proxy_name: proxy_name.to_string(),
+            state_schema_version: "rocketmq.proxy-drain.v1".to_string(),
+            phase: match state.phase {
+                rocketmq_admin_core::core::proxy::ProxyDrainPhase::Accepting => {
+                    crate::tools::proxy_tools::ProxyDrainPhase::Accepting
+                }
+                rocketmq_admin_core::core::proxy::ProxyDrainPhase::Draining => {
+                    crate::tools::proxy_tools::ProxyDrainPhase::Draining
+                }
+                rocketmq_admin_core::core::proxy::ProxyDrainPhase::Drained => {
+                    crate::tools::proxy_tools::ProxyDrainPhase::Drained
+                }
+            },
+            operation_id,
+            admission_open: state.admission_open,
+            routing_open: state.routing_open,
+            readiness_published: state.readiness_published,
+            zero_pending: state.zero_pending,
+            pending: crate::tools::proxy_tools::ProxyDrainPending {
+                active_connections: state.pending.active_connections,
+                sessions: state.pending.sessions,
+                receipt_handles: state.pending.receipt_handles,
+                prepared_transactions: state.pending.prepared_transactions,
+                telemetry_links: state.pending.telemetry_links,
+                remoting_channels: state.pending.remoting_channels,
+                telemetry_commands: state.pending.telemetry_commands,
+                rpc_in_flight: state.pending.rpc_in_flight,
+            },
+        };
+        Ok(QueryPayload::new(output, false, warnings, Vec::new()))
+    }
+
     async fn shutdown(mut self) -> Result<(), ToolExecutionError> {
         #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
         if let Some(session) = self.test_session.take() {
@@ -584,5 +810,17 @@ fn map_broker_summary(row: &rocketmq_admin_core::core::broker::BrokerSummary) ->
         hour: row.hour.clone(),
         space: row.space.clone(),
         broker_active: row.broker_active,
+    }
+}
+
+fn map_logical_admin_error(error: rocketmq_admin_core::core::AdminError) -> ToolExecutionError {
+    match error {
+        rocketmq_admin_core::core::AdminError::InvalidArgument { field, reason } => {
+            ToolExecutionError::InvalidArguments(format!("{field}: {reason}"))
+        }
+        rocketmq_admin_core::core::AdminError::NotFound { resource, name } => {
+            ToolExecutionError::InvalidArguments(format!("{resource} not found: {name}"))
+        }
+        _ => ToolExecutionError::Backend("RocketMQ logical target source is unavailable".to_string()),
     }
 }

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session_projection.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session_projection.rs
@@ -1,0 +1,380 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) fn map_broker_diagnostics(
+    row: &rocketmq_admin_core::core::broker::BrokerDiagnostics,
+) -> crate::tools::broker_tools::BrokerDiagnosticsRow {
+    use crate::tools::broker_tools as output;
+    use rocketmq_admin_core::core::broker as admin;
+
+    let (broker_role, broker_role_sanitized) = row
+        .config
+        .as_ref()
+        .map(|value| project_broker_role(&value.broker_role))
+        .unzip();
+    let (store_type, store_type_sanitized) = row
+        .config
+        .as_ref()
+        .map(|value| project_store_type(&value.store_type))
+        .unzip();
+    let (ha_role, ha_role_sanitized) = project_ha_role(row.ha.role.as_deref());
+    let (ack_policy, ack_policy_sanitized) = project_ha_ack_policy(row.ha.ack_policy.as_deref());
+    let (decision_code, decision_code_sanitized) = project_ha_decision_code(row.ha.decision_code.as_deref());
+    let (background_state, background_state_sanitized) = row
+        .background_index_rebuild
+        .as_ref()
+        .map(|value| project_background_index_rebuild_state(&value.state))
+        .unzip();
+    let mut warnings = row
+        .warnings
+        .iter()
+        .filter(|warning| {
+            matches!(
+                warning.as_str(),
+                "broker_diagnostics_fields_missing" | "broker_diagnostics_contract_unsupported"
+            )
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if broker_role_sanitized.unwrap_or(false)
+        || store_type_sanitized.unwrap_or(false)
+        || ha_role_sanitized
+        || ack_policy_sanitized
+        || decision_code_sanitized
+        || background_state_sanitized.unwrap_or(false)
+        || warnings.len() != row.warnings.len()
+    {
+        warnings.push("broker_diagnostics_value_sanitized".to_string());
+    }
+    warnings.sort();
+    warnings.dedup();
+
+    output::BrokerDiagnosticsRow {
+        broker_name: row.broker_name.clone(),
+        broker_id: row.broker_id,
+        observed_at_millis: row.observed_at_millis,
+        coverage: match row.coverage {
+            admin::BrokerDiagnosticsCoverage::Available => output::BrokerDiagnosticsCoverage::Available,
+            admin::BrokerDiagnosticsCoverage::Partial => output::BrokerDiagnosticsCoverage::Partial,
+            admin::BrokerDiagnosticsCoverage::Unsupported => output::BrokerDiagnosticsCoverage::Unsupported,
+        },
+        readiness: row.readiness.as_ref().map(|value| output::BrokerReadinessDiagnostics {
+            ready: value.ready,
+            active: value.active,
+            shutdown: value.shutdown,
+            registration_accepting: value.registration_accepting,
+            registration_configured: value.registration_configured,
+        }),
+        config: row.config.as_ref().map(|value| output::BrokerRuntimeConfigSummary {
+            generation: value.generation,
+            broker_role: broker_role.unwrap_or(output::BrokerRole::Unknown),
+            store_type: store_type.unwrap_or(output::BrokerStoreType::Unknown),
+            timer_wheel_enabled: value.timer_wheel_enabled,
+            transient_store_pool_enabled: value.transient_store_pool_enabled,
+            tiered_store_configured: value.tiered_store_configured,
+        }),
+        store_health: row.store_health.as_ref().map(|value| output::StoreHealthDiagnostics {
+            writeable: value.writeable,
+            last_flush_error: value.last_flush_error,
+            os_page_cache_busy: value.os_page_cache_busy,
+            transient_store_pool_deficient: value.transient_store_pool_deficient,
+            dispatch_behind_bytes: value.dispatch_behind_bytes,
+            shutdown: value.shutdown,
+            ha_pending_request_count: value.ha_pending_request_count,
+            ha_pending_oldest_wait_millis: value.ha_pending_oldest_wait_millis,
+            sync_flush: output::SyncFlushDiagnostics {
+                queue_depth: value.sync_flush.queue_depth,
+                timeout_total: value.sync_flush.timeout_total,
+                oldest_wait_millis: value.sync_flush.oldest_wait_millis,
+            },
+        }),
+        ha: output::HaDiagnostics {
+            supported: row.ha.supported,
+            role: ha_role,
+            master_epoch: row.ha.master_epoch,
+            sync_state_set_epoch: row.ha.sync_state_set_epoch,
+            sync_state_set_size: row.ha.sync_state_set_size,
+            max_replica_lag_bytes: row.ha.max_replica_lag_bytes,
+            ack_policy,
+            required_ack_count: row.ha.required_ack_count,
+            decision_code,
+        },
+        recovery: row.recovery.as_ref().map(|value| output::RecoveryDiagnostics {
+            available: value.available,
+            total_duration_millis: value.total_duration_millis,
+            phase_count: value.phase_count,
+            failed_phase_count: value.failed_phase_count,
+            fallback_phase_count: value.fallback_phase_count,
+            fallback_reason_present: value.fallback_reason_present,
+            scanned_bytes: value.scanned_bytes,
+            recovered_messages: value.recovered_messages,
+            invalid_messages: value.invalid_messages,
+            truncated_files: value.truncated_files,
+            index_files_removed: value.index_files_removed,
+            index_files_rebuilt: value.index_files_rebuilt,
+        }),
+        background_index_rebuild: row.background_index_rebuild.as_ref().map(|value| {
+            output::BackgroundIndexRebuildDiagnostics {
+                state: background_state.unwrap_or(output::BackgroundIndexRebuildState::Unknown),
+                effective_enabled: value.effective_enabled,
+                gray_mode: value.gray_mode,
+                current_safe_offset: value.current_safe_offset,
+                target_offset: value.target_offset,
+                backlog_bytes: value.backlog_bytes,
+                rebuilt_bytes: value.rebuilt_bytes,
+                rebuilt_messages: value.rebuilt_messages,
+                failure_count: value.failure_count,
+                bytes_per_second: value.bytes_per_second,
+            }
+        }),
+        rocksdb: output::RocksDbMaintenanceDiagnostics {
+            supported: row.rocksdb.supported,
+            maintenance_running: row.rocksdb.maintenance_running,
+            message_maintenance_running: row.rocksdb.message_maintenance_running,
+        },
+        tiered: output::TieredDispatchDiagnostics {
+            configured: row.tiered.configured,
+            dispatch_ready: row.tiered.dispatch_ready,
+            minimum_pinned_wal_segment: row.tiered.minimum_pinned_wal_segment,
+        },
+        auth: output::AuthSecurityDiagnostics {
+            supported: row.auth.supported,
+            authentication_enabled: row.auth.authentication_enabled,
+            authorization_enabled: row.auth.authorization_enabled,
+            acl_file_watch_enabled: row.auth.acl_file_watch_enabled,
+            acl_generation: row.auth.acl_generation,
+            acl_reload_attempts: row.auth.acl_reload_attempts,
+            acl_reload_successes: row.auth.acl_reload_successes,
+            acl_reload_failures: row.auth.acl_reload_failures,
+            acl_reload_skipped: row.auth.acl_reload_skipped,
+            credential_rotation_supported: row.auth.credential_rotation_supported,
+        },
+        warnings,
+    }
+}
+
+pub(super) fn bounded_proxy_operation_id(operation_id: Option<String>) -> (Option<String>, Vec<String>) {
+    let (operation_id, sanitized) = safe_operation_id(operation_id);
+    let warnings = sanitized
+        .then_some("proxy_operation_id_sanitized".to_string())
+        .into_iter()
+        .collect();
+    (operation_id, warnings)
+}
+
+pub(super) fn safe_operation_id(operation_id: Option<String>) -> (Option<String>, bool) {
+    match operation_id {
+        Some(value) if safe_runtime_token(&value, 128) => (Some(value), false),
+        Some(_) => (None, true),
+        None => (None, false),
+    }
+}
+
+fn project_broker_role(value: &str) -> (crate::tools::broker_tools::BrokerRole, bool) {
+    use crate::tools::broker_tools::BrokerRole;
+
+    match value {
+        "ASYNC_MASTER" => (BrokerRole::AsyncMaster, false),
+        "SYNC_MASTER" => (BrokerRole::SyncMaster, false),
+        "SLAVE" => (BrokerRole::Slave, false),
+        _ => (BrokerRole::Unknown, true),
+    }
+}
+
+fn project_store_type(value: &str) -> (crate::tools::broker_tools::BrokerStoreType, bool) {
+    use crate::tools::broker_tools::BrokerStoreType;
+
+    match value {
+        "LocalFile" => (BrokerStoreType::LocalFile, false),
+        "RocksDB" => (BrokerStoreType::RocksDb, false),
+        _ => (BrokerStoreType::Unknown, true),
+    }
+}
+
+fn project_ha_role(value: Option<&str>) -> (Option<crate::tools::broker_tools::HaRole>, bool) {
+    use crate::tools::broker_tools::HaRole;
+
+    match value {
+        Some("master") => (Some(HaRole::Master), false),
+        Some("replica") => (Some(HaRole::Replica), false),
+        Some(_) => (None, true),
+        None => (None, false),
+    }
+}
+
+fn project_ha_ack_policy(value: Option<&str>) -> (Option<crate::tools::broker_tools::HaAckPolicy>, bool) {
+    use crate::tools::broker_tools::HaAckPolicy;
+
+    match value {
+        Some("all_in_sync_set") => (Some(HaAckPolicy::AllInSyncSet), false),
+        Some("local_durable") => (Some(HaAckPolicy::LocalDurable), false),
+        Some("replica_count") => (Some(HaAckPolicy::ReplicaCount), false),
+        Some(_) => (None, true),
+        None => (None, false),
+    }
+}
+
+fn project_ha_decision_code(value: Option<&str>) -> (Option<crate::tools::broker_tools::HaDecisionCode>, bool) {
+    use crate::tools::broker_tools::HaDecisionCode;
+
+    match value {
+        Some("waiting_for_replica_progress") => (Some(HaDecisionCode::WaitingForReplicaProgress), false),
+        Some("not_observed") => (Some(HaDecisionCode::NotObserved), false),
+        Some(_) => (None, true),
+        None => (None, false),
+    }
+}
+
+fn project_background_index_rebuild_state(
+    value: &str,
+) -> (crate::tools::broker_tools::BackgroundIndexRebuildState, bool) {
+    use crate::tools::broker_tools::BackgroundIndexRebuildState;
+
+    match value {
+        "idle" => (BackgroundIndexRebuildState::Idle, false),
+        "running" => (BackgroundIndexRebuildState::Running, false),
+        "paused" => (BackgroundIndexRebuildState::Paused, false),
+        "completed" => (BackgroundIndexRebuildState::Completed, false),
+        "retrying" => (BackgroundIndexRebuildState::Retrying, false),
+        "failed" => (BackgroundIndexRebuildState::Failed, false),
+        "shutdown" => (BackgroundIndexRebuildState::Shutdown, false),
+        _ => (BackgroundIndexRebuildState::Unknown, true),
+    }
+}
+
+fn safe_runtime_token(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::broker_tools as output;
+    use rocketmq_admin_core::core::broker as admin;
+
+    #[test]
+    fn mcp_projection_drops_operation_ids_that_can_encode_topology_or_secrets() {
+        assert_eq!(
+            safe_operation_id(Some("operation-123".to_string())),
+            (Some("operation-123".to_string()), false)
+        );
+        assert_eq!(safe_operation_id(Some("incident/123.op".to_string())), (None, true));
+        assert_eq!(
+            bounded_proxy_operation_id(Some("https://private-proxy.internal/token".to_string())),
+            (None, vec!["proxy_operation_id_sanitized".to_string()])
+        );
+    }
+
+    #[test]
+    fn mcp_projection_replaces_non_allowlisted_diagnostic_tokens() {
+        assert_eq!(
+            project_broker_role("ASYNC_MASTER"),
+            (crate::tools::broker_tools::BrokerRole::AsyncMaster, false)
+        );
+        assert_eq!(
+            project_broker_role("supersecret123"),
+            (crate::tools::broker_tools::BrokerRole::Unknown, true)
+        );
+    }
+
+    #[test]
+    fn diagnostic_projection_downgrades_unknown_backend_classifications() {
+        let row = admin::BrokerDiagnostics {
+            broker_name: "broker-a".to_string(),
+            broker_id: 0,
+            observed_at_millis: Some(42),
+            coverage: admin::BrokerDiagnosticsCoverage::Available,
+            readiness: None,
+            config: Some(admin::BrokerConfigSummary {
+                generation: 7,
+                broker_role: "private-role".to_string(),
+                store_type: "private-store".to_string(),
+                timer_wheel_enabled: false,
+                transient_store_pool_enabled: false,
+                tiered_store_configured: false,
+            }),
+            store_health: None,
+            ha: admin::HaDiagnostics {
+                supported: true,
+                role: Some("private-role".to_string()),
+                ack_policy: Some("private-policy".to_string()),
+                decision_code: Some("private-decision".to_string()),
+                ..Default::default()
+            },
+            recovery: None,
+            background_index_rebuild: Some(admin::BackgroundIndexRebuildDiagnostics {
+                state: "private-state".to_string(),
+                effective_enabled: false,
+                gray_mode: false,
+                current_safe_offset: 0,
+                target_offset: 0,
+                backlog_bytes: 0,
+                rebuilt_bytes: 0,
+                rebuilt_messages: 0,
+                failure_count: 0,
+                bytes_per_second: 0,
+            }),
+            rocksdb: admin::RocksDbMaintenanceDiagnostics {
+                supported: false,
+                maintenance_running: None,
+                message_maintenance_running: None,
+            },
+            tiered: admin::TieredDispatchDiagnostics {
+                configured: false,
+                dispatch_ready: None,
+                minimum_pinned_wal_segment: None,
+            },
+            auth: admin::AuthSecurityDiagnostics {
+                supported: false,
+                authentication_enabled: None,
+                authorization_enabled: None,
+                acl_file_watch_enabled: None,
+                acl_generation: None,
+                acl_reload_attempts: None,
+                acl_reload_successes: None,
+                acl_reload_failures: None,
+                acl_reload_skipped: None,
+                credential_rotation_supported: false,
+            },
+            warnings: Vec::new(),
+        };
+
+        let projected = map_broker_diagnostics(&row);
+        let config = projected
+            .config
+            .as_ref()
+            .expect("config projection should remain present");
+        assert_eq!(config.broker_role, output::BrokerRole::Unknown);
+        assert_eq!(config.store_type, output::BrokerStoreType::Unknown);
+        assert_eq!(projected.ha.role, None);
+        assert_eq!(projected.ha.ack_policy, None);
+        assert_eq!(projected.ha.decision_code, None);
+        assert_eq!(
+            projected
+                .background_index_rebuild
+                .as_ref()
+                .expect("background rebuild projection should remain present")
+                .state,
+            output::BackgroundIndexRebuildState::Unknown
+        );
+        assert_eq!(projected.warnings, vec!["broker_diagnostics_value_sanitized"]);
+        assert!(!serde_json::to_string(&projected)
+            .expect("projected diagnostics should serialize")
+            .contains("private-"));
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
@@ -50,16 +50,24 @@ use crate::model::contract::SCHEMA_VERSION;
 use crate::model::diagnosis::DiagnosisReport;
 use crate::service::diagnosis_collector::ConsumerLagEvidence;
 use crate::service::diagnosis_rules;
+use crate::tools::broker_tools::BrokerDiagnosticsArgs;
+use crate::tools::broker_tools::BrokerDiagnosticsOutput;
 use crate::tools::broker_tools::DescribeBrokerArgs;
 use crate::tools::broker_tools::DescribeBrokerOutput;
 use crate::tools::cluster_tools::ClusterOverviewArgs;
 use crate::tools::cluster_tools::ClusterOverviewOutput;
+use crate::tools::config_tools::BrokerConfigSummaryArgs;
+use crate::tools::config_tools::BrokerConfigSummaryOutput;
+use crate::tools::config_tools::BrokerLogFilterStateArgs;
+use crate::tools::config_tools::BrokerLogFilterStateOutput;
 use crate::tools::consumer_tools::ListConsumerGroupsArgs;
 use crate::tools::consumer_tools::ListConsumerGroupsOutput;
 use crate::tools::consumer_tools::QueryConsumerLagArgs;
 use crate::tools::consumer_tools::QueryConsumerLagOutput;
 use crate::tools::diagnosis_tools::DiagnoseConsumerLagArgs;
 use crate::tools::executor::ToolExecutionError;
+use crate::tools::proxy_tools::ProxyDrainStateArgs;
+use crate::tools::proxy_tools::ProxyDrainStateOutput;
 use crate::tools::topic_tools::DescribeTopicArgs;
 use crate::tools::topic_tools::DescribeTopicOutput;
 use crate::tools::topic_tools::ListTopicsArgs;
@@ -160,6 +168,50 @@ pub(crate) trait ReadOnlyQuery: Clone + Send + Sync + 'static {
         &self,
         args: DescribeBrokerArgs,
     ) -> impl Future<Output = Result<QueryResult<DescribeBrokerOutput>, ToolExecutionError>> + Send;
+
+    fn broker_diagnostics(
+        &self,
+        _args: BrokerDiagnosticsArgs,
+    ) -> impl Future<Output = Result<QueryResult<BrokerDiagnosticsOutput>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "exact Broker diagnostics are unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn broker_config_summary(
+        &self,
+        _args: BrokerConfigSummaryArgs,
+    ) -> impl Future<Output = Result<QueryResult<BrokerConfigSummaryOutput>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "exact Broker configuration is unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn broker_log_filter_state(
+        &self,
+        _args: BrokerLogFilterStateArgs,
+    ) -> impl Future<Output = Result<QueryResult<BrokerLogFilterStateOutput>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "exact Broker log-filter state is unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn proxy_drain_state(
+        &self,
+        _args: ProxyDrainStateArgs,
+    ) -> impl Future<Output = Result<QueryResult<ProxyDrainStateOutput>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "Proxy drain state is unavailable".to_string(),
+            ))
+        }
+    }
 
     fn diagnose_consumer_lag(
         &self,
@@ -543,6 +595,126 @@ where
             .await
     }
 
+    pub(crate) async fn broker_diagnostics(
+        &self,
+        mut args: BrokerDiagnosticsArgs,
+    ) -> Result<QueryResult<BrokerDiagnosticsOutput>, ToolExecutionError> {
+        args.cluster = normalized_logical_identifier("cluster", &args.cluster)?;
+        args.broker_name = normalized_logical_identifier("broker_name", &args.broker_name)?;
+        let cluster = self.resolve_required_cluster(&args.cluster)?;
+        let key = self.cache_key(
+            "broker_diagnostics",
+            &cluster.name,
+            &format!("broker={}", args.broker_name),
+        );
+        let ttl = Duration::from_millis(self.config.cache.broker_metrics_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.broker_diagnostics(&args.broker_name).await })
+                    })
+                    .await
+                },
+            )
+            .await
+    }
+
+    pub(crate) async fn broker_config_summary(
+        &self,
+        mut args: BrokerConfigSummaryArgs,
+    ) -> Result<QueryResult<BrokerConfigSummaryOutput>, ToolExecutionError> {
+        args.cluster = normalized_logical_identifier("cluster", &args.cluster)?;
+        args.broker_name = normalized_logical_identifier("broker_name", &args.broker_name)?;
+        let cluster = self.resolve_required_cluster(&args.cluster)?;
+        let key = self.cache_key(
+            "broker_config_summary",
+            &cluster.name,
+            &format!("broker={}", args.broker_name),
+        );
+        let ttl = Duration::from_millis(self.config.cache.broker_metrics_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.broker_config_summary(&args.broker_name).await })
+                    })
+                    .await
+                },
+            )
+            .await
+    }
+
+    pub(crate) async fn broker_log_filter_state(
+        &self,
+        mut args: BrokerLogFilterStateArgs,
+    ) -> Result<QueryResult<BrokerLogFilterStateOutput>, ToolExecutionError> {
+        args.cluster = normalized_logical_identifier("cluster", &args.cluster)?;
+        args.broker_name = normalized_logical_identifier("broker_name", &args.broker_name)?;
+        args.logger = normalized_broker_logger(&args.logger)?;
+        let cluster = self.resolve_required_cluster(&args.cluster)?;
+        let key = self.cache_key(
+            "broker_log_filter_state",
+            &cluster.name,
+            &format!("broker={}|logger={}", args.broker_name, args.logger),
+        );
+        let ttl = Duration::from_millis(self.config.cache.broker_metrics_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.broker_log_filter_state(&args.broker_name, &args.logger).await })
+                    })
+                    .await
+                },
+            )
+            .await
+    }
+
+    pub(crate) async fn proxy_drain_state(
+        &self,
+        mut args: ProxyDrainStateArgs,
+    ) -> Result<QueryResult<ProxyDrainStateOutput>, ToolExecutionError> {
+        args.cluster = normalized_logical_identifier("cluster", &args.cluster)?;
+        args.proxy_name = normalized_logical_identifier("proxy_name", &args.proxy_name)?;
+        let cluster = self.resolve_required_cluster(&args.cluster)?;
+        let proxy_endpoint = self
+            .resolve_proxy_endpoint(&cluster.name, &args.proxy_name)?
+            .to_string();
+        let key = self.cache_key(
+            "proxy_drain_state",
+            &cluster.name,
+            &format!("proxy={}", args.proxy_name),
+        );
+        let ttl = Duration::from_millis(self.config.cache.broker_metrics_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.proxy_drain_state(&args.proxy_name, &proxy_endpoint).await })
+                    })
+                    .await
+                },
+            )
+            .await
+    }
+
     pub(crate) async fn diagnose_consumer_lag(
         &self,
         mut args: DiagnoseConsumerLagArgs,
@@ -882,6 +1054,30 @@ where
         })
     }
 
+    fn resolve_required_cluster(&self, cluster: &str) -> Result<ResolvedCluster, ToolExecutionError> {
+        if cluster.trim().is_empty() {
+            return Err(ToolExecutionError::InvalidArguments(
+                "cluster must not be empty".to_string(),
+            ));
+        }
+        self.resolve_cluster(Some(cluster))
+    }
+
+    fn resolve_proxy_endpoint<'a>(
+        &'a self,
+        cluster_name: &str,
+        proxy_name: &str,
+    ) -> Result<&'a str, ToolExecutionError> {
+        self.config
+            .clusters
+            .iter()
+            .find(|cluster| cluster.name == cluster_name)
+            .and_then(|cluster| cluster.proxy_endpoint(proxy_name))
+            .ok_or_else(|| {
+                ToolExecutionError::InvalidArguments(format!("proxy not found in cluster {cluster_name}: {proxy_name}"))
+            })
+    }
+
     fn cache_key(&self, kind: &str, cluster: &str, parameters: &str) -> String {
         format!(
             "{SCHEMA_VERSION}|{}|{kind}|cluster={}|{parameters}",
@@ -956,6 +1152,34 @@ where
         args: DescribeBrokerArgs,
     ) -> Result<QueryResult<DescribeBrokerOutput>, ToolExecutionError> {
         QueryFacade::describe_broker(self, args).await
+    }
+
+    async fn broker_diagnostics(
+        &self,
+        args: BrokerDiagnosticsArgs,
+    ) -> Result<QueryResult<BrokerDiagnosticsOutput>, ToolExecutionError> {
+        QueryFacade::broker_diagnostics(self, args).await
+    }
+
+    async fn broker_config_summary(
+        &self,
+        args: BrokerConfigSummaryArgs,
+    ) -> Result<QueryResult<BrokerConfigSummaryOutput>, ToolExecutionError> {
+        QueryFacade::broker_config_summary(self, args).await
+    }
+
+    async fn broker_log_filter_state(
+        &self,
+        args: BrokerLogFilterStateArgs,
+    ) -> Result<QueryResult<BrokerLogFilterStateOutput>, ToolExecutionError> {
+        QueryFacade::broker_log_filter_state(self, args).await
+    }
+
+    async fn proxy_drain_state(
+        &self,
+        args: ProxyDrainStateArgs,
+    ) -> Result<QueryResult<ProxyDrainStateOutput>, ToolExecutionError> {
+        QueryFacade::proxy_drain_state(self, args).await
     }
 
     async fn diagnose_consumer_lag(
@@ -1186,6 +1410,53 @@ fn normalized_identifier(field: &str, value: &str) -> Result<String, ToolExecuti
     Ok(value.to_string())
 }
 
+fn normalized_logical_identifier(field: &str, value: &str) -> Result<String, ToolExecutionError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 100
+        || value.parse::<std::net::IpAddr>().is_ok()
+        || value.parse::<std::net::SocketAddr>().is_ok()
+        || value.contains([':', '/', '\\', '@', '=', '&', '?'])
+        || value.chars().any(char::is_control)
+        || !value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        Err(ToolExecutionError::InvalidArguments(format!(
+            "{field} must be a logical identifier of at most 100 bytes"
+        )))
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+fn normalized_broker_logger(logger: &str) -> Result<String, ToolExecutionError> {
+    if logger != logger.trim()
+        || logger.is_empty()
+        || logger.len() > 128
+        || !logger
+            .strip_prefix("rocketmq_broker::")
+            .is_some_and(valid_rust_module_path)
+    {
+        Err(ToolExecutionError::InvalidArguments(
+            "logger must be an allowlisted rocketmq_broker:: target of at most 128 bytes".to_string(),
+        ))
+    } else {
+        Ok(logger.to_string())
+    }
+}
+
+fn valid_rust_module_path(path: &str) -> bool {
+    !path.is_empty()
+        && path.split("::").all(|segment| {
+            let mut characters = segment.chars();
+            characters
+                .next()
+                .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+                && characters.all(|character| character.is_ascii_alphanumeric() || character == '_')
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::AtomicBool;
@@ -1215,6 +1486,11 @@ mod tests {
         starts: AtomicUsize,
         shutdowns: AtomicUsize,
         broker_queries: AtomicUsize,
+        broker_diagnostics_queries: AtomicUsize,
+        broker_config_queries: AtomicUsize,
+        broker_log_filter_queries: AtomicUsize,
+        proxy_drain_queries: AtomicUsize,
+        proxy_endpoint_mismatches: AtomicUsize,
         topic_inventory_queries: AtomicUsize,
         consumer_group_queries: AtomicUsize,
         consumer_group_inventory_queries: AtomicUsize,
@@ -1276,6 +1552,7 @@ mod tests {
         failed_selected_broker: bool,
         overflow_failed_selected_broker: bool,
         partial_sources: bool,
+        fail_exact_read: bool,
         hang_broker_query: bool,
         hang_topic_inventory: bool,
         topic_inventory_gate: Option<Arc<TopicInventoryGate>>,
@@ -1302,6 +1579,7 @@ mod tests {
                 failed_selected_broker: self.failed_selected_broker,
                 overflow_failed_selected_broker: self.overflow_failed_selected_broker,
                 partial_sources: self.partial_sources,
+                fail_exact_read: self.fail_exact_read,
                 hang_broker_query: self.hang_broker_query,
                 hang_topic_inventory: self.hang_topic_inventory,
                 topic_inventory_gate: self.topic_inventory_gate.clone(),
@@ -1325,6 +1603,7 @@ mod tests {
         failed_selected_broker: bool,
         overflow_failed_selected_broker: bool,
         partial_sources: bool,
+        fail_exact_read: bool,
         hang_broker_query: bool,
         hang_topic_inventory: bool,
         topic_inventory_gate: Option<Arc<TopicInventoryGate>>,
@@ -1517,6 +1796,115 @@ mod tests {
             }
         }
 
+        async fn broker_diagnostics(
+            &mut self,
+            broker_name: &str,
+        ) -> Result<QueryPayload<BrokerDiagnosticsOutput>, ToolExecutionError> {
+            self.counters.broker_diagnostics_queries.fetch_add(1, Ordering::SeqCst);
+            if self.hang_broker_query {
+                std::future::pending::<()>().await;
+            }
+            if self.fail_exact_read {
+                return Err(ToolExecutionError::backend("exact read failed"));
+            }
+            let output = BrokerDiagnosticsOutput {
+                cluster: self.cluster.name.clone(),
+                broker_name: broker_name.to_string(),
+                diagnostics_schema_version: "1".to_string(),
+                observed_at_millis: 1,
+                brokers: Vec::new(),
+                unavailable_brokers: usize::from(self.partial_sources),
+            };
+            Ok(if self.partial_sources {
+                partial_payload(output, QuerySource::BrokerRuntime, broker_name)
+            } else {
+                QueryPayload::complete(output)
+            })
+        }
+
+        async fn broker_config_summary(
+            &mut self,
+            broker_name: &str,
+        ) -> Result<QueryPayload<BrokerConfigSummaryOutput>, ToolExecutionError> {
+            self.counters.broker_config_queries.fetch_add(1, Ordering::SeqCst);
+            if self.fail_exact_read {
+                return Err(ToolExecutionError::backend("exact read failed"));
+            }
+            let output = BrokerConfigSummaryOutput {
+                cluster: self.cluster.name.clone(),
+                broker_name: broker_name.to_string(),
+                brokers: Vec::new(),
+            };
+            Ok(if self.partial_sources {
+                partial_payload(output, QuerySource::BrokerConfig, broker_name)
+            } else {
+                QueryPayload::complete(output)
+            })
+        }
+
+        async fn broker_log_filter_state(
+            &mut self,
+            broker_name: &str,
+            logger: &str,
+        ) -> Result<QueryPayload<BrokerLogFilterStateOutput>, ToolExecutionError> {
+            self.counters.broker_log_filter_queries.fetch_add(1, Ordering::SeqCst);
+            if self.fail_exact_read {
+                return Err(ToolExecutionError::backend("exact read failed"));
+            }
+            let output = BrokerLogFilterStateOutput {
+                cluster: self.cluster.name.clone(),
+                broker_name: broker_name.to_string(),
+                logger: logger.to_string(),
+                brokers: Vec::new(),
+            };
+            Ok(if self.partial_sources {
+                partial_payload(output, QuerySource::BrokerLogFilter, broker_name)
+            } else {
+                QueryPayload::complete(output)
+            })
+        }
+
+        async fn proxy_drain_state(
+            &mut self,
+            proxy_name: &str,
+            proxy_endpoint: &str,
+        ) -> Result<QueryPayload<ProxyDrainStateOutput>, ToolExecutionError> {
+            self.counters.proxy_drain_queries.fetch_add(1, Ordering::SeqCst);
+            if self.fail_exact_read {
+                return Err(ToolExecutionError::backend("exact read failed"));
+            }
+            let expected_endpoint = if self.cluster.name == "secondary" {
+                "proxy-secondary.internal:8081"
+            } else {
+                "127.0.0.1:8081"
+            };
+            if proxy_endpoint != expected_endpoint {
+                self.counters.proxy_endpoint_mismatches.fetch_add(1, Ordering::SeqCst);
+            }
+            let output = ProxyDrainStateOutput {
+                cluster: self.cluster.name.clone(),
+                proxy_name: proxy_name.to_string(),
+                state_schema_version: "1".to_string(),
+                phase: crate::tools::proxy_tools::ProxyDrainPhase::Accepting,
+                operation_id: None,
+                admission_open: true,
+                routing_open: true,
+                readiness_published: true,
+                zero_pending: true,
+                pending: crate::tools::proxy_tools::ProxyDrainPending {
+                    active_connections: 0,
+                    sessions: 0,
+                    receipt_handles: 0,
+                    prepared_transactions: 0,
+                    telemetry_links: 0,
+                    remoting_channels: 0,
+                    telemetry_commands: 0,
+                    rpc_in_flight: 0,
+                },
+            };
+            Ok(QueryPayload::complete(output))
+        }
+
         async fn shutdown(self) -> Result<(), ToolExecutionError> {
             self.counters.shutdowns.fetch_add(1, Ordering::SeqCst);
             Ok(())
@@ -1550,8 +1938,15 @@ mod tests {
             consumer_groups: ListConsumerGroupsArgs,
             consumer_lag: QueryConsumerLagArgs,
             broker: DescribeBrokerArgs,
+            exact_reads: (
+                BrokerDiagnosticsArgs,
+                BrokerConfigSummaryArgs,
+                BrokerLogFilterStateArgs,
+                ProxyDrainStateArgs,
+            ),
             diagnosis: DiagnoseConsumerLagArgs,
         ) {
+            let (broker_diagnostics, broker_config, broker_log_filter, proxy_drain) = exact_reads;
             assert_send(query.cluster_overview(cluster_overview));
             assert_send(query.list_topics(list_topics));
             assert_send(query.describe_topic(describe_topic));
@@ -1559,6 +1954,10 @@ mod tests {
             assert_send(query.list_consumer_groups(consumer_groups));
             assert_send(query.query_consumer_lag(consumer_lag));
             assert_send(query.describe_broker(broker));
+            assert_send(query.broker_diagnostics(broker_diagnostics));
+            assert_send(query.broker_config_summary(broker_config));
+            assert_send(query.broker_log_filter_state(broker_log_filter));
+            assert_send(query.proxy_drain_state(proxy_drain));
             assert_send(query.diagnose_consumer_lag(diagnosis));
         }
 
@@ -1591,12 +1990,309 @@ mod tests {
                 cluster: "local-dev".to_string(),
                 broker_name: "broker-a".to_string(),
             },
+            (
+                BrokerDiagnosticsArgs {
+                    cluster: "local-dev".to_string(),
+                    broker_name: "broker-a".to_string(),
+                },
+                BrokerConfigSummaryArgs {
+                    cluster: "local-dev".to_string(),
+                    broker_name: "broker-a".to_string(),
+                },
+                BrokerLogFilterStateArgs {
+                    cluster: "local-dev".to_string(),
+                    broker_name: "broker-a".to_string(),
+                    logger: "rocketmq_broker::processor".to_string(),
+                },
+                ProxyDrainStateArgs {
+                    cluster: "local-dev".to_string(),
+                    proxy_name: "proxy-local".to_string(),
+                },
+            ),
             DiagnoseConsumerLagArgs {
                 cluster: "local-dev".to_string(),
                 topic: "orders".to_string(),
                 consumer_group: "order-service".to_string(),
             },
         );
+    }
+
+    #[tokio::test]
+    async fn exact_read_tools_cache_complete_and_partial_evidence_without_requerying() {
+        let factory = FakeSessionFactory {
+            partial_sources: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+
+        let diagnostics = || BrokerDiagnosticsArgs {
+            cluster: "local-dev".to_string(),
+            broker_name: "broker-a".to_string(),
+        };
+        let first = facade.broker_diagnostics(diagnostics()).await.unwrap();
+        let replay = facade.broker_diagnostics(diagnostics()).await.unwrap();
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(replay.cache_status, CacheStatus::Hit);
+        assert_eq!(first.partial, replay.partial);
+        assert_eq!(first.warnings, replay.warnings);
+        assert_eq!(first.source_failures, replay.source_failures);
+
+        let config = || BrokerConfigSummaryArgs {
+            cluster: "local-dev".to_string(),
+            broker_name: "broker-a".to_string(),
+        };
+        let first = facade.broker_config_summary(config()).await.unwrap();
+        let replay = facade.broker_config_summary(config()).await.unwrap();
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(replay.cache_status, CacheStatus::Hit);
+        assert_eq!(first.partial, replay.partial);
+        assert_eq!(first.warnings, replay.warnings);
+        assert_eq!(first.source_failures, replay.source_failures);
+
+        let log_filter = || BrokerLogFilterStateArgs {
+            cluster: "local-dev".to_string(),
+            broker_name: "broker-a".to_string(),
+            logger: "rocketmq_broker::processor".to_string(),
+        };
+        let first = facade.broker_log_filter_state(log_filter()).await.unwrap();
+        let replay = facade.broker_log_filter_state(log_filter()).await.unwrap();
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(replay.cache_status, CacheStatus::Hit);
+        assert_eq!(first.partial, replay.partial);
+        assert_eq!(first.warnings, replay.warnings);
+        assert_eq!(first.source_failures, replay.source_failures);
+
+        let proxy = || ProxyDrainStateArgs {
+            cluster: "local-dev".to_string(),
+            proxy_name: "proxy-local".to_string(),
+        };
+        let first = facade.proxy_drain_state(proxy()).await.unwrap();
+        let replay = facade.proxy_drain_state(proxy()).await.unwrap();
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(replay.cache_status, CacheStatus::Hit);
+        assert!(!first.partial);
+        assert!(first.source_failures.is_empty());
+
+        assert_eq!(counters.broker_diagnostics_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.broker_config_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.broker_log_filter_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.proxy_drain_queries.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 4);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn exact_read_tool_cache_isolates_visibility_classes() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+        let standard = facade.clone().with_visibility_class(VisibilityClass::Standard);
+        let sensitive = facade.with_visibility_class(VisibilityClass::Sensitive);
+        let args = || BrokerDiagnosticsArgs {
+            cluster: "local-dev".to_string(),
+            broker_name: "broker-a".to_string(),
+        };
+
+        assert_eq!(
+            standard.broker_diagnostics(args()).await.unwrap().cache_status,
+            CacheStatus::Miss
+        );
+        assert_eq!(
+            sensitive.broker_diagnostics(args()).await.unwrap().cache_status,
+            CacheStatus::Miss
+        );
+        assert_eq!(counters.broker_diagnostics_queries.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn exact_read_tool_cancellation_shuts_down_the_started_session() {
+        let factory = FakeSessionFactory {
+            hang_broker_query: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let cancellation = CancellationToken::new();
+        let control = WorkflowControl::new(Duration::from_secs(30), cancellation.clone());
+        let facade = QueryFacade::with_factory_and_control(example_config(), factory, control);
+        let task = tokio::spawn(async move {
+            facade
+                .broker_diagnostics(BrokerDiagnosticsArgs {
+                    cluster: "local-dev".to_string(),
+                    broker_name: "broker-a".to_string(),
+                })
+                .await
+        });
+        wait_for_atomic_count(&counters.broker_diagnostics_queries, 1).await;
+        cancellation.cancel();
+
+        assert!(matches!(task.await.unwrap(), Err(ToolExecutionError::Cancelled)));
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn exact_read_tool_timeout_shuts_down_the_started_session() {
+        let factory = FakeSessionFactory {
+            hang_broker_query: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let control = WorkflowControl::new(Duration::from_millis(10), CancellationToken::new());
+        let facade = QueryFacade::with_factory_and_control(example_config(), factory, control);
+        let result = facade
+            .broker_diagnostics(BrokerDiagnosticsArgs {
+                cluster: "local-dev".to_string(),
+                broker_name: "broker-a".to_string(),
+            })
+            .await;
+
+        assert!(matches!(result, Err(ToolExecutionError::TimedOut { timeout_ms: 10 })));
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn exact_read_backend_failures_shutdown_every_started_session() {
+        let factory = FakeSessionFactory {
+            fail_exact_read: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+
+        assert!(matches!(
+            facade
+                .broker_diagnostics(BrokerDiagnosticsArgs {
+                    cluster: "local-dev".to_string(),
+                    broker_name: "broker-a".to_string(),
+                })
+                .await,
+            Err(ToolExecutionError::Backend(_))
+        ));
+        assert!(matches!(
+            facade
+                .broker_config_summary(BrokerConfigSummaryArgs {
+                    cluster: "local-dev".to_string(),
+                    broker_name: "broker-a".to_string(),
+                })
+                .await,
+            Err(ToolExecutionError::Backend(_))
+        ));
+        assert!(matches!(
+            facade
+                .broker_log_filter_state(BrokerLogFilterStateArgs {
+                    cluster: "local-dev".to_string(),
+                    broker_name: "broker-a".to_string(),
+                    logger: "rocketmq_broker::processor".to_string(),
+                })
+                .await,
+            Err(ToolExecutionError::Backend(_))
+        ));
+        assert!(matches!(
+            facade
+                .proxy_drain_state(ProxyDrainStateArgs {
+                    cluster: "local-dev".to_string(),
+                    proxy_name: "proxy-local".to_string(),
+                })
+                .await,
+            Err(ToolExecutionError::Backend(_))
+        ));
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 4);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn exact_read_tools_require_explicit_cluster_and_strict_logger() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config(), factory);
+
+        assert!(matches!(
+            facade
+                .broker_diagnostics(BrokerDiagnosticsArgs {
+                    cluster: "   ".to_string(),
+                    broker_name: "broker-a".to_string(),
+                })
+                .await,
+            Err(ToolExecutionError::InvalidArguments(_))
+        ));
+        assert!(matches!(
+            facade
+                .broker_config_summary(BrokerConfigSummaryArgs {
+                    cluster: "".to_string(),
+                    broker_name: "broker-a".to_string(),
+                })
+                .await,
+            Err(ToolExecutionError::InvalidArguments(_))
+        ));
+        assert!(matches!(
+            facade
+                .broker_log_filter_state(BrokerLogFilterStateArgs {
+                    cluster: "local-dev".to_string(),
+                    broker_name: "broker-a".to_string(),
+                    logger: "rocketmq_broker::processor target".to_string(),
+                })
+                .await,
+            Err(ToolExecutionError::InvalidArguments(_))
+        ));
+        assert!(matches!(
+            facade
+                .proxy_drain_state(ProxyDrainStateArgs {
+                    cluster: "\t".to_string(),
+                    proxy_name: "proxy-local".to_string(),
+                })
+                .await,
+            Err(ToolExecutionError::InvalidArguments(_))
+        ));
+        let endpoint_cluster = "10.0.0.8:9876";
+        let error = facade
+            .broker_diagnostics(BrokerDiagnosticsArgs {
+                cluster: endpoint_cluster.to_string(),
+                broker_name: "broker-a".to_string(),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ToolExecutionError::InvalidArguments(_)));
+        assert!(!error.to_string().contains(endpoint_cluster));
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn proxy_alias_resolution_is_cluster_local_and_never_uses_an_unknown_alias() {
+        let factory = FakeSessionFactory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(example_config_with_secondary_proxy(), factory);
+
+        let local = facade
+            .proxy_drain_state(ProxyDrainStateArgs {
+                cluster: "local-dev".to_string(),
+                proxy_name: "proxy-local".to_string(),
+            })
+            .await
+            .unwrap();
+        let secondary = facade
+            .proxy_drain_state(ProxyDrainStateArgs {
+                cluster: "secondary".to_string(),
+                proxy_name: "proxy-local".to_string(),
+            })
+            .await
+            .unwrap();
+        let starts = counters.starts.load(Ordering::SeqCst);
+        let missing = facade
+            .proxy_drain_state(ProxyDrainStateArgs {
+                cluster: "local-dev".to_string(),
+                proxy_name: "proxy-missing".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(local.data.cluster, "local-dev");
+        assert_eq!(secondary.data.cluster, "secondary");
+        assert!(matches!(missing, ToolExecutionError::InvalidArguments(_)));
+        assert_eq!(counters.starts.load(Ordering::SeqCst), starts);
+        assert_eq!(counters.proxy_endpoint_mismatches.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -3152,6 +3848,17 @@ mod tests {
     fn example_config_with_physical_cluster() -> McpConfig {
         let mut config = example_config();
         config.clusters[0].rocketmq_cluster_name = Some("DefaultCluster".to_string());
+        config
+    }
+
+    fn example_config_with_secondary_proxy() -> McpConfig {
+        let mut config = example_config();
+        let mut secondary = config.clusters[0].clone();
+        secondary.name = "secondary".to_string();
+        secondary.namesrv_addr = "secondary-namesrv.internal:9876".to_string();
+        secondary.default = Some(false);
+        secondary.proxies[0].endpoint = "proxy-secondary.internal:8081".to_string();
+        config.clusters.push(secondary);
         config
     }
 

--- a/rocketmq-ai/rocketmq-mcp/src/config.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/config.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeSet;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -200,6 +201,21 @@ impl McpConfig {
             if let Some(credentials) = &cluster.credentials {
                 credentials.validate_reference(&cluster.name)?;
                 credentials.resolve(&cluster.name)?;
+            }
+            let mut proxy_names = BTreeSet::new();
+            for proxy in &cluster.proxies {
+                validate_logical_alias("clusters.proxies.name", &proxy.name)?;
+                if !rocketmq_admin_core::core::broker::is_valid_remoting_endpoint(&proxy.endpoint) {
+                    return Err(McpError::InvalidConfig(
+                        "clusters.proxies.endpoint must be a single bounded remoting host:port".to_string(),
+                    ));
+                }
+                if !proxy_names.insert(proxy.name.as_str()) {
+                    return Err(McpError::InvalidConfig(format!(
+                        "clusters `{}` contains duplicate Proxy alias `{}`",
+                        cluster.name, proxy.name
+                    )));
+                }
             }
         }
 
@@ -635,7 +651,7 @@ pub enum JwtAlgorithm {
     Rs256,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, PartialEq, Eq)]
 pub struct ClusterConfig {
     pub name: String,
     pub namesrv_addr: String,
@@ -653,6 +669,9 @@ pub struct ClusterConfig {
     /// Secret values are never accepted inline in the MCP configuration.
     #[serde(default)]
     pub credentials: Option<ClusterCredentialReference>,
+    /// Logical Proxy aliases. Endpoints are internal-only topology data.
+    #[serde(default)]
+    pub proxies: Vec<ProxyAlias>,
 }
 
 impl ClusterConfig {
@@ -665,6 +684,45 @@ impl ClusterConfig {
             .as_ref()
             .map(|reference| reference.resolve(&self.name))
             .transpose()
+    }
+
+    pub(crate) fn proxy_endpoint(&self, proxy_name: &str) -> Option<&str> {
+        self.proxies
+            .iter()
+            .find(|proxy| proxy.name == proxy_name)
+            .map(|proxy| proxy.endpoint.as_str())
+    }
+}
+
+impl std::fmt::Debug for ClusterConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ClusterConfig")
+            .field("name", &self.name)
+            .field("namesrv_addr", &self.namesrv_addr)
+            .field("default", &self.default)
+            .field("rocketmq_cluster_name", &self.rocketmq_cluster_name)
+            .field("tenant", &self.tenant)
+            .field("credentials", &self.credentials)
+            .field("proxies", &self.proxies)
+            .finish()
+    }
+}
+
+#[derive(Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ProxyAlias {
+    pub name: String,
+    pub endpoint: String,
+}
+
+impl std::fmt::Debug for ProxyAlias {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ProxyAlias")
+            .field("name", &self.name)
+            .field("endpoint", &"[REDACTED]")
+            .finish()
     }
 }
 
@@ -892,6 +950,26 @@ fn validate_non_empty(field: &str, value: &str) -> Result<(), McpError> {
     Ok(())
 }
 
+fn validate_logical_alias(field: &str, value: &str) -> Result<(), McpError> {
+    if value != value.trim()
+        || value.is_empty()
+        || value.len() > 100
+        || value.parse::<std::net::IpAddr>().is_ok()
+        || value.parse::<std::net::SocketAddr>().is_ok()
+        || value.contains([':', '/', '\\', '@', '=', '&', '?'])
+        || value.chars().any(char::is_control)
+        || !value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        Err(McpError::InvalidConfig(format!(
+            "{field} must be a logical identifier of at most 100 bytes"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
 fn validate_jwks_ca_file(path: &Path) -> Result<(), McpError> {
     let bytes = std::fs::read(path).map_err(|error| {
         McpError::InvalidConfig(format!(
@@ -976,6 +1054,110 @@ mod tests {
         assert_eq!(config.audit.queue_max_bytes, 1024 * 1024);
         assert_eq!(config.logging.filter.as_deref(), Some("info"));
         assert!(config.server.log_level.is_none());
+        assert_eq!(config.clusters[0].proxies.len(), 1);
+        assert_eq!(config.clusters[0].proxy_endpoint("proxy-local"), Some("127.0.0.1:8081"));
+    }
+
+    #[test]
+    fn cluster_proxy_aliases_are_optional_validated_and_cluster_scoped() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::copy(
+            example_config_path()
+                .parent()
+                .expect("example config has a parent")
+                .join("permissions.example.toml"),
+            temp.path().join("permissions.example.toml"),
+        )
+        .unwrap();
+        let example = std::fs::read_to_string(example_config_path()).unwrap();
+        let (prefix, proxy_and_suffix) = example.split_once("[[clusters.proxies]]").unwrap();
+        let (_, suffix) = proxy_and_suffix.split_once("[security]").unwrap();
+        let legacy_path = temp.path().join("legacy-mcp.toml");
+        std::fs::write(&legacy_path, format!("{prefix}[security]{suffix}")).unwrap();
+        let legacy = McpConfig::load(&legacy_path).expect("legacy TOML without proxies must deserialize");
+        assert!(legacy.clusters[0].proxies.is_empty());
+
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.clusters[0].proxies.clear();
+        config
+            .validate()
+            .expect("legacy configurations without proxies remain valid");
+        assert_eq!(config.clusters[0].proxy_endpoint("proxy-local"), None);
+
+        config.clusters[0].proxies = vec![
+            ProxyAlias {
+                name: "proxy-a".to_string(),
+                endpoint: "internal-a:8081".to_string(),
+            },
+            ProxyAlias {
+                name: "proxy-a".to_string(),
+                endpoint: "internal-b:8081".to_string(),
+            },
+        ];
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate Proxy alias"));
+
+        config.clusters[0].proxies[1].name = "proxy-b".to_string();
+        config.clusters[0].proxies[1].endpoint.clear();
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("clusters.proxies.endpoint"));
+
+        config.clusters[0].proxies[1].endpoint = "https://internal-b:8081/path".to_string();
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("clusters.proxies.endpoint"));
+
+        config.clusters[0].proxies[1].endpoint = "internal-b:8081".to_string();
+        config.clusters[0].proxies[1].name = " proxy-b ".to_string();
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("clusters.proxies.name"));
+
+        config.clusters[0].proxies[1].name = "proxy-b".to_string();
+        config.clusters[0].proxies[1].endpoint = "internal-b:8081".to_string();
+        let mut secondary = config.clusters[0].clone();
+        secondary.name = "secondary".to_string();
+        secondary.namesrv_addr = "127.0.0.2:9876".to_string();
+        secondary.default = Some(false);
+        secondary.proxies = vec![ProxyAlias {
+            name: "proxy-a".to_string(),
+            endpoint: "secondary-internal:8081".to_string(),
+        }];
+        config.clusters.push(secondary);
+        config.validate().unwrap();
+        assert_eq!(config.clusters[0].proxy_endpoint("proxy-a"), Some("internal-a:8081"));
+        assert_eq!(
+            config.clusters[1].proxy_endpoint("proxy-a"),
+            Some("secondary-internal:8081")
+        );
+    }
+
+    #[test]
+    fn proxy_alias_debug_and_validation_never_expose_endpoints() {
+        const ENDPOINT_SENTINEL: &str = "private-proxy-endpoint.example:18081";
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.clusters[0].proxies = vec![ProxyAlias {
+            name: "proxy-a".to_string(),
+            endpoint: ENDPOINT_SENTINEL.to_string(),
+        }];
+        let debug = format!("{config:?}");
+        assert!(debug.contains("proxy-a"));
+        assert!(!debug.contains(ENDPOINT_SENTINEL));
+
+        config.clusters[0].proxies[0].name = "127.0.0.1:8081".to_string();
+        let error = config.validate().unwrap_err();
+        assert!(!error.to_string().contains(ENDPOINT_SENTINEL));
+        assert!(!format!("{error:?}").contains(ENDPOINT_SENTINEL));
     }
 
     #[test]

--- a/rocketmq-ai/rocketmq-mcp/src/guard.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/guard.rs
@@ -194,6 +194,12 @@ impl Guard {
             _cluster_permit: None,
         };
 
+        if requires_explicit_cluster(tool_name) && guarded.cluster.is_none() {
+            let error = GuardError::InvalidArgument("cluster must not be empty".to_string());
+            guarded.record_failure(error.to_string());
+            return Err(error);
+        }
+
         if let Err(error) = self.validate_cluster(context, arguments) {
             guarded.record_failure(error.to_string());
             return Err(error);
@@ -487,6 +493,16 @@ fn extract_cluster(arguments: &JsonObject) -> Option<String> {
         .map(ToString::to_string)
 }
 
+fn requires_explicit_cluster(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "rocketmq_get_broker_diagnostics"
+            | "rocketmq_get_broker_config_summary"
+            | "rocketmq_get_broker_log_filter_state"
+            | "rocketmq_get_proxy_drain_state"
+    )
+}
+
 fn hash_arguments(arguments: &JsonObject) -> String {
     let bytes = serde_json::to_vec(arguments).unwrap_or_default();
     let digest = Sha256::digest(bytes);
@@ -521,6 +537,23 @@ mod tests {
         let records = guard.audit_log().records();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].status, AuditStatus::Failure);
+    }
+
+    #[test]
+    fn exact_broker_and_proxy_tools_reject_blank_cluster_before_authorization() {
+        let guard = test_guard("diagnose", false, 60);
+        for tool in [
+            "rocketmq_get_broker_diagnostics",
+            "rocketmq_get_broker_config_summary",
+            "rocketmq_get_broker_log_filter_state",
+            "rocketmq_get_proxy_drain_state",
+        ] {
+            let arguments = serde_json::json!({ "cluster": "   " }).as_object().unwrap().clone();
+            let error = guard
+                .begin_tool_call(&guard.local_request_context(), tool, RiskLevel::ReadOnly, &arguments)
+                .unwrap_err();
+            assert!(matches!(error, GuardError::InvalidArgument(_)), "tool={tool}");
+        }
     }
 
     #[test]
@@ -721,6 +754,7 @@ mod tests {
                 rocketmq_cluster_name: None,
                 tenant: None,
                 credentials: None,
+                proxies: Vec::new(),
             }],
         )
         .unwrap()
@@ -751,6 +785,7 @@ mod tests {
                 rocketmq_cluster_name: None,
                 tenant: Some(tenant.to_string()),
                 credentials: None,
+                proxies: Vec::new(),
             }],
         )
         .unwrap()

--- a/rocketmq-ai/rocketmq-mcp/src/guard/http_auth.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/guard/http_auth.rs
@@ -537,6 +537,7 @@ mod tests {
                 rocketmq_cluster_name: None,
                 tenant: None,
                 credentials: None,
+                proxies: Vec::new(),
             }],
         )
         .unwrap()

--- a/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
@@ -29,6 +29,8 @@ pub const MAX_SOURCE_FAILURES: usize = 16;
 #[serde(rename_all = "snake_case")]
 pub enum QuerySource {
     BrokerRuntime,
+    BrokerConfig,
+    BrokerLogFilter,
     ConsumerStatistics,
     ConsumerConnection,
     ProducerConnection,
@@ -101,6 +103,8 @@ impl SourceFailure {
 
         let source = match failure.source() {
             AdminSource::BrokerRuntime => QuerySource::BrokerRuntime,
+            AdminSource::BrokerConfig => QuerySource::BrokerConfig,
+            AdminSource::BrokerLogFilter => QuerySource::BrokerLogFilter,
             AdminSource::ConsumerStatistics => QuerySource::ConsumerStatistics,
             AdminSource::ConsumerConnection => QuerySource::ConsumerConnection,
             AdminSource::ProducerConnection => QuerySource::ProducerConnection,

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -296,6 +296,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -504,6 +506,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -761,6 +765,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -981,6 +987,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -1355,6 +1363,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -1591,6 +1601,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -1859,6 +1871,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -1961,6 +1975,1558 @@ expression: surface
         "type": "object"
       },
       "title": "RocketMQ broker description"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ broker diagnostics"
+      },
+      "description": "Get bounded readiness, store, recovery, and security diagnostics for one logical Broker.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "broker_name"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_broker_diagnostics",
+      "outputSchema": {
+        "$defs": {
+          "AuthSecurityDiagnostics": {
+            "properties": {
+              "acl_file_watch_enabled": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "acl_generation": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "acl_reload_attempts": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "acl_reload_failures": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "acl_reload_skipped": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "acl_reload_successes": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "authentication_enabled": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "authorization_enabled": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "credential_rotation_supported": {
+                "type": "boolean"
+              },
+              "supported": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "supported",
+              "credential_rotation_supported"
+            ],
+            "type": "object"
+          },
+          "BackgroundIndexRebuildDiagnostics": {
+            "properties": {
+              "backlog_bytes": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "bytes_per_second": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "current_safe_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "effective_enabled": {
+                "type": "boolean"
+              },
+              "failure_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "gray_mode": {
+                "type": "boolean"
+              },
+              "rebuilt_bytes": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "rebuilt_messages": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "state": {
+                "$ref": "#/$defs/BackgroundIndexRebuildState"
+              },
+              "target_offset": {
+                "format": "int64",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "state",
+              "effective_enabled",
+              "gray_mode",
+              "current_safe_offset",
+              "target_offset",
+              "backlog_bytes",
+              "rebuilt_bytes",
+              "rebuilt_messages",
+              "failure_count",
+              "bytes_per_second"
+            ],
+            "type": "object"
+          },
+          "BackgroundIndexRebuildState": {
+            "enum": [
+              "idle",
+              "running",
+              "paused",
+              "completed",
+              "retrying",
+              "failed",
+              "shutdown",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "BrokerDiagnosticsCoverage": {
+            "enum": [
+              "available",
+              "partial",
+              "unsupported"
+            ],
+            "type": "string"
+          },
+          "BrokerDiagnosticsOutput": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerDiagnosticsRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "diagnostics_schema_version": {
+                "type": "string"
+              },
+              "observed_at_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "unavailable_brokers": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "diagnostics_schema_version",
+              "observed_at_millis",
+              "brokers",
+              "unavailable_brokers"
+            ],
+            "type": "object"
+          },
+          "BrokerDiagnosticsRow": {
+            "properties": {
+              "auth": {
+                "$ref": "#/$defs/AuthSecurityDiagnostics"
+              },
+              "background_index_rebuild": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/BackgroundIndexRebuildDiagnostics"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "config": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/BrokerRuntimeConfigSummary"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "coverage": {
+                "$ref": "#/$defs/BrokerDiagnosticsCoverage"
+              },
+              "ha": {
+                "$ref": "#/$defs/HaDiagnostics"
+              },
+              "observed_at_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "readiness": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/BrokerReadinessDiagnostics"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "recovery": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/RecoveryDiagnostics"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "rocksdb": {
+                "$ref": "#/$defs/RocksDbMaintenanceDiagnostics"
+              },
+              "store_health": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/StoreHealthDiagnostics"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "tiered": {
+                "$ref": "#/$defs/TieredDispatchDiagnostics"
+              },
+              "warnings": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id",
+              "coverage",
+              "ha",
+              "rocksdb",
+              "tiered",
+              "auth",
+              "warnings"
+            ],
+            "type": "object"
+          },
+          "BrokerReadinessDiagnostics": {
+            "properties": {
+              "active": {
+                "type": "boolean"
+              },
+              "ready": {
+                "type": "boolean"
+              },
+              "registration_accepting": {
+                "type": "boolean"
+              },
+              "registration_configured": {
+                "type": "boolean"
+              },
+              "shutdown": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "ready",
+              "active",
+              "shutdown",
+              "registration_accepting",
+              "registration_configured"
+            ],
+            "type": "object"
+          },
+          "BrokerRole": {
+            "enum": [
+              "ASYNC_MASTER",
+              "SYNC_MASTER",
+              "SLAVE",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "BrokerRuntimeConfigSummary": {
+            "properties": {
+              "broker_role": {
+                "$ref": "#/$defs/BrokerRole"
+              },
+              "generation": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "store_type": {
+                "$ref": "#/$defs/BrokerStoreType"
+              },
+              "tiered_store_configured": {
+                "type": "boolean"
+              },
+              "timer_wheel_enabled": {
+                "type": "boolean"
+              },
+              "transient_store_pool_enabled": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "generation",
+              "broker_role",
+              "store_type",
+              "timer_wheel_enabled",
+              "transient_store_pool_enabled",
+              "tiered_store_configured"
+            ],
+            "type": "object"
+          },
+          "BrokerStoreType": {
+            "enum": [
+              "LocalFile",
+              "RocksDB",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "HaAckPolicy": {
+            "enum": [
+              "all_in_sync_set",
+              "local_durable",
+              "replica_count"
+            ],
+            "type": "string"
+          },
+          "HaDecisionCode": {
+            "enum": [
+              "waiting_for_replica_progress",
+              "not_observed"
+            ],
+            "type": "string"
+          },
+          "HaDiagnostics": {
+            "properties": {
+              "ack_policy": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/HaAckPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "decision_code": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/HaDecisionCode"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "master_epoch": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "max_replica_lag_bytes": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "required_ack_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "role": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/HaRole"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "supported": {
+                "type": "boolean"
+              },
+              "sync_state_set_epoch": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sync_state_set_size": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "supported"
+            ],
+            "type": "object"
+          },
+          "HaRole": {
+            "enum": [
+              "master",
+              "replica"
+            ],
+            "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "RecoveryDiagnostics": {
+            "properties": {
+              "available": {
+                "type": "boolean"
+              },
+              "failed_phase_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "fallback_phase_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "fallback_reason_present": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "index_files_rebuilt": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "index_files_removed": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "invalid_messages": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "phase_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "recovered_messages": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "scanned_bytes": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "total_duration_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "truncated_files": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "available"
+            ],
+            "type": "object"
+          },
+          "RocksDbMaintenanceDiagnostics": {
+            "properties": {
+              "maintenance_running": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "message_maintenance_running": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "supported": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "supported"
+            ],
+            "type": "object"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
+          "StoreHealthDiagnostics": {
+            "properties": {
+              "dispatch_behind_bytes": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "ha_pending_oldest_wait_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "ha_pending_request_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "last_flush_error": {
+                "type": "boolean"
+              },
+              "os_page_cache_busy": {
+                "type": "boolean"
+              },
+              "shutdown": {
+                "type": "boolean"
+              },
+              "sync_flush": {
+                "$ref": "#/$defs/SyncFlushDiagnostics"
+              },
+              "transient_store_pool_deficient": {
+                "type": "boolean"
+              },
+              "writeable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "writeable",
+              "last_flush_error",
+              "os_page_cache_busy",
+              "transient_store_pool_deficient",
+              "dispatch_behind_bytes",
+              "shutdown",
+              "ha_pending_request_count",
+              "ha_pending_oldest_wait_millis",
+              "sync_flush"
+            ],
+            "type": "object"
+          },
+          "SyncFlushDiagnostics": {
+            "properties": {
+              "oldest_wait_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "queue_depth": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "timeout_total": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "queue_depth",
+              "timeout_total",
+              "oldest_wait_millis"
+            ],
+            "type": "object"
+          },
+          "TieredDispatchDiagnostics": {
+            "properties": {
+              "configured": {
+                "type": "boolean"
+              },
+              "dispatch_ready": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "minimum_pinned_wal_segment": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "configured"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/BrokerDiagnosticsOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ broker diagnostics"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ broker configuration summary"
+      },
+      "description": "Get the fixed allowlisted configuration summary for one logical Broker.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "broker_name"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_broker_config_summary",
+      "outputSchema": {
+        "$defs": {
+          "BrokerConfigSummaryOutput": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerConfigSummaryRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "brokers"
+            ],
+            "type": "object"
+          },
+          "BrokerConfigSummaryRow": {
+            "properties": {
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "flush_delay_offset_interval_ms": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "generation": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "max_client_event_count": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "pull_message_thread_pool_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "send_message_thread_pool_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id",
+              "generation"
+            ],
+            "type": "object"
+          },
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/BrokerConfigSummaryOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ broker configuration summary"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ broker log-filter state"
+      },
+      "description": "Get the temporary state of one allowlisted rocketmq_broker logger target.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "logger": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "broker_name",
+          "logger"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_broker_log_filter_state",
+      "outputSchema": {
+        "$defs": {
+          "BrokerLogFilterStateOutput": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerLogFilterStateRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "logger": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "logger",
+              "brokers"
+            ],
+            "type": "object"
+          },
+          "BrokerLogFilterStateRow": {
+            "properties": {
+              "active_operation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "expires_at_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "last_completed_operation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "level": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/BrokerLogLevel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "logger": {
+                "type": "string"
+              },
+              "state_schema_version": {
+                "type": "string"
+              },
+              "supported": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id",
+              "state_schema_version",
+              "supported",
+              "logger"
+            ],
+            "type": "object"
+          },
+          "BrokerLogLevel": {
+            "enum": [
+              "INFO",
+              "DEBUG"
+            ],
+            "type": "string"
+          },
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/BrokerLogFilterStateOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ broker log-filter state"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ Proxy drain state"
+      },
+      "description": "Get bounded drain progress for one configured logical Proxy alias.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "proxy_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "proxy_name"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_proxy_drain_state",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ProxyDrainPending": {
+            "properties": {
+              "active_connections": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "prepared_transactions": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "receipt_handles": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "remoting_channels": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "rpc_in_flight": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sessions": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "telemetry_commands": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "telemetry_links": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "active_connections",
+              "sessions",
+              "receipt_handles",
+              "prepared_transactions",
+              "telemetry_links",
+              "remoting_channels",
+              "telemetry_commands",
+              "rpc_in_flight"
+            ],
+            "type": "object"
+          },
+          "ProxyDrainPhase": {
+            "enum": [
+              "accepting",
+              "draining",
+              "drained"
+            ],
+            "type": "string"
+          },
+          "ProxyDrainStateOutput": {
+            "properties": {
+              "admission_open": {
+                "type": "boolean"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "operation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pending": {
+                "$ref": "#/$defs/ProxyDrainPending"
+              },
+              "phase": {
+                "$ref": "#/$defs/ProxyDrainPhase"
+              },
+              "proxy_name": {
+                "type": "string"
+              },
+              "readiness_published": {
+                "type": "boolean"
+              },
+              "routing_open": {
+                "type": "boolean"
+              },
+              "state_schema_version": {
+                "type": "string"
+              },
+              "zero_pending": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "cluster",
+              "proxy_name",
+              "state_schema_version",
+              "phase",
+              "admission_open",
+              "routing_open",
+              "readiness_published",
+              "zero_pending",
+              "pending"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/ProxyDrainStateOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ Proxy drain state"
     },
     {
       "annotations": {
@@ -2351,6 +3917,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -296,6 +296,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -504,6 +506,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -761,6 +765,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -981,6 +987,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -1355,6 +1363,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -1591,6 +1601,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -1859,6 +1871,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -1961,6 +1975,1558 @@ expression: surface
         "type": "object"
       },
       "title": "RocketMQ broker description"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ broker diagnostics"
+      },
+      "description": "Get bounded readiness, store, recovery, and security diagnostics for one logical Broker.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "broker_name"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_broker_diagnostics",
+      "outputSchema": {
+        "$defs": {
+          "AuthSecurityDiagnostics": {
+            "properties": {
+              "acl_file_watch_enabled": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "acl_generation": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "acl_reload_attempts": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "acl_reload_failures": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "acl_reload_skipped": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "acl_reload_successes": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "authentication_enabled": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "authorization_enabled": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "credential_rotation_supported": {
+                "type": "boolean"
+              },
+              "supported": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "supported",
+              "credential_rotation_supported"
+            ],
+            "type": "object"
+          },
+          "BackgroundIndexRebuildDiagnostics": {
+            "properties": {
+              "backlog_bytes": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "bytes_per_second": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "current_safe_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "effective_enabled": {
+                "type": "boolean"
+              },
+              "failure_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "gray_mode": {
+                "type": "boolean"
+              },
+              "rebuilt_bytes": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "rebuilt_messages": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "state": {
+                "$ref": "#/$defs/BackgroundIndexRebuildState"
+              },
+              "target_offset": {
+                "format": "int64",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "state",
+              "effective_enabled",
+              "gray_mode",
+              "current_safe_offset",
+              "target_offset",
+              "backlog_bytes",
+              "rebuilt_bytes",
+              "rebuilt_messages",
+              "failure_count",
+              "bytes_per_second"
+            ],
+            "type": "object"
+          },
+          "BackgroundIndexRebuildState": {
+            "enum": [
+              "idle",
+              "running",
+              "paused",
+              "completed",
+              "retrying",
+              "failed",
+              "shutdown",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "BrokerDiagnosticsCoverage": {
+            "enum": [
+              "available",
+              "partial",
+              "unsupported"
+            ],
+            "type": "string"
+          },
+          "BrokerDiagnosticsOutput": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerDiagnosticsRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "diagnostics_schema_version": {
+                "type": "string"
+              },
+              "observed_at_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "unavailable_brokers": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "diagnostics_schema_version",
+              "observed_at_millis",
+              "brokers",
+              "unavailable_brokers"
+            ],
+            "type": "object"
+          },
+          "BrokerDiagnosticsRow": {
+            "properties": {
+              "auth": {
+                "$ref": "#/$defs/AuthSecurityDiagnostics"
+              },
+              "background_index_rebuild": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/BackgroundIndexRebuildDiagnostics"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "config": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/BrokerRuntimeConfigSummary"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "coverage": {
+                "$ref": "#/$defs/BrokerDiagnosticsCoverage"
+              },
+              "ha": {
+                "$ref": "#/$defs/HaDiagnostics"
+              },
+              "observed_at_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "readiness": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/BrokerReadinessDiagnostics"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "recovery": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/RecoveryDiagnostics"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "rocksdb": {
+                "$ref": "#/$defs/RocksDbMaintenanceDiagnostics"
+              },
+              "store_health": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/StoreHealthDiagnostics"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "tiered": {
+                "$ref": "#/$defs/TieredDispatchDiagnostics"
+              },
+              "warnings": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id",
+              "coverage",
+              "ha",
+              "rocksdb",
+              "tiered",
+              "auth",
+              "warnings"
+            ],
+            "type": "object"
+          },
+          "BrokerReadinessDiagnostics": {
+            "properties": {
+              "active": {
+                "type": "boolean"
+              },
+              "ready": {
+                "type": "boolean"
+              },
+              "registration_accepting": {
+                "type": "boolean"
+              },
+              "registration_configured": {
+                "type": "boolean"
+              },
+              "shutdown": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "ready",
+              "active",
+              "shutdown",
+              "registration_accepting",
+              "registration_configured"
+            ],
+            "type": "object"
+          },
+          "BrokerRole": {
+            "enum": [
+              "ASYNC_MASTER",
+              "SYNC_MASTER",
+              "SLAVE",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "BrokerRuntimeConfigSummary": {
+            "properties": {
+              "broker_role": {
+                "$ref": "#/$defs/BrokerRole"
+              },
+              "generation": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "store_type": {
+                "$ref": "#/$defs/BrokerStoreType"
+              },
+              "tiered_store_configured": {
+                "type": "boolean"
+              },
+              "timer_wheel_enabled": {
+                "type": "boolean"
+              },
+              "transient_store_pool_enabled": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "generation",
+              "broker_role",
+              "store_type",
+              "timer_wheel_enabled",
+              "transient_store_pool_enabled",
+              "tiered_store_configured"
+            ],
+            "type": "object"
+          },
+          "BrokerStoreType": {
+            "enum": [
+              "LocalFile",
+              "RocksDB",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "HaAckPolicy": {
+            "enum": [
+              "all_in_sync_set",
+              "local_durable",
+              "replica_count"
+            ],
+            "type": "string"
+          },
+          "HaDecisionCode": {
+            "enum": [
+              "waiting_for_replica_progress",
+              "not_observed"
+            ],
+            "type": "string"
+          },
+          "HaDiagnostics": {
+            "properties": {
+              "ack_policy": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/HaAckPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "decision_code": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/HaDecisionCode"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "master_epoch": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "max_replica_lag_bytes": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "required_ack_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "role": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/HaRole"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "supported": {
+                "type": "boolean"
+              },
+              "sync_state_set_epoch": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sync_state_set_size": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "supported"
+            ],
+            "type": "object"
+          },
+          "HaRole": {
+            "enum": [
+              "master",
+              "replica"
+            ],
+            "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "RecoveryDiagnostics": {
+            "properties": {
+              "available": {
+                "type": "boolean"
+              },
+              "failed_phase_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "fallback_phase_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "fallback_reason_present": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "index_files_rebuilt": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "index_files_removed": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "invalid_messages": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "phase_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "recovered_messages": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "scanned_bytes": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "total_duration_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "truncated_files": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "available"
+            ],
+            "type": "object"
+          },
+          "RocksDbMaintenanceDiagnostics": {
+            "properties": {
+              "maintenance_running": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "message_maintenance_running": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "supported": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "supported"
+            ],
+            "type": "object"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
+          "StoreHealthDiagnostics": {
+            "properties": {
+              "dispatch_behind_bytes": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "ha_pending_oldest_wait_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "ha_pending_request_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "last_flush_error": {
+                "type": "boolean"
+              },
+              "os_page_cache_busy": {
+                "type": "boolean"
+              },
+              "shutdown": {
+                "type": "boolean"
+              },
+              "sync_flush": {
+                "$ref": "#/$defs/SyncFlushDiagnostics"
+              },
+              "transient_store_pool_deficient": {
+                "type": "boolean"
+              },
+              "writeable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "writeable",
+              "last_flush_error",
+              "os_page_cache_busy",
+              "transient_store_pool_deficient",
+              "dispatch_behind_bytes",
+              "shutdown",
+              "ha_pending_request_count",
+              "ha_pending_oldest_wait_millis",
+              "sync_flush"
+            ],
+            "type": "object"
+          },
+          "SyncFlushDiagnostics": {
+            "properties": {
+              "oldest_wait_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "queue_depth": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "timeout_total": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "queue_depth",
+              "timeout_total",
+              "oldest_wait_millis"
+            ],
+            "type": "object"
+          },
+          "TieredDispatchDiagnostics": {
+            "properties": {
+              "configured": {
+                "type": "boolean"
+              },
+              "dispatch_ready": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "minimum_pinned_wal_segment": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "configured"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/BrokerDiagnosticsOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ broker diagnostics"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ broker configuration summary"
+      },
+      "description": "Get the fixed allowlisted configuration summary for one logical Broker.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "broker_name"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_broker_config_summary",
+      "outputSchema": {
+        "$defs": {
+          "BrokerConfigSummaryOutput": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerConfigSummaryRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "brokers"
+            ],
+            "type": "object"
+          },
+          "BrokerConfigSummaryRow": {
+            "properties": {
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "flush_delay_offset_interval_ms": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "generation": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "max_client_event_count": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "pull_message_thread_pool_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "send_message_thread_pool_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id",
+              "generation"
+            ],
+            "type": "object"
+          },
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/BrokerConfigSummaryOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ broker configuration summary"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ broker log-filter state"
+      },
+      "description": "Get the temporary state of one allowlisted rocketmq_broker logger target.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "broker_name": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "logger": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "broker_name",
+          "logger"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_broker_log_filter_state",
+      "outputSchema": {
+        "$defs": {
+          "BrokerLogFilterStateOutput": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerLogFilterStateRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "logger": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "broker_name",
+              "logger",
+              "brokers"
+            ],
+            "type": "object"
+          },
+          "BrokerLogFilterStateRow": {
+            "properties": {
+              "active_operation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "expires_at_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "last_completed_operation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "level": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/BrokerLogLevel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "logger": {
+                "type": "string"
+              },
+              "state_schema_version": {
+                "type": "string"
+              },
+              "supported": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id",
+              "state_schema_version",
+              "supported",
+              "logger"
+            ],
+            "type": "object"
+          },
+          "BrokerLogLevel": {
+            "enum": [
+              "INFO",
+              "DEBUG"
+            ],
+            "type": "string"
+          },
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/BrokerLogFilterStateOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ broker log-filter state"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ Proxy drain state"
+      },
+      "description": "Get bounded drain progress for one configured logical Proxy alias.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "proxy_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "proxy_name"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_proxy_drain_state",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ProxyDrainPending": {
+            "properties": {
+              "active_connections": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "prepared_transactions": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "receipt_handles": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "remoting_channels": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "rpc_in_flight": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "sessions": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "telemetry_commands": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "telemetry_links": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "active_connections",
+              "sessions",
+              "receipt_handles",
+              "prepared_transactions",
+              "telemetry_links",
+              "remoting_channels",
+              "telemetry_commands",
+              "rpc_in_flight"
+            ],
+            "type": "object"
+          },
+          "ProxyDrainPhase": {
+            "enum": [
+              "accepting",
+              "draining",
+              "drained"
+            ],
+            "type": "string"
+          },
+          "ProxyDrainStateOutput": {
+            "properties": {
+              "admission_open": {
+                "type": "boolean"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "operation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pending": {
+                "$ref": "#/$defs/ProxyDrainPending"
+              },
+              "phase": {
+                "$ref": "#/$defs/ProxyDrainPhase"
+              },
+              "proxy_name": {
+                "type": "string"
+              },
+              "readiness_published": {
+                "type": "boolean"
+              },
+              "routing_open": {
+                "type": "boolean"
+              },
+              "state_schema_version": {
+                "type": "string"
+              },
+              "zero_pending": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "cluster",
+              "proxy_name",
+              "state_schema_version",
+              "phase",
+              "admission_open",
+              "routing_open",
+              "readiness_published",
+              "zero_pending",
+              "pending"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/ProxyDrainStateOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ Proxy drain state"
     },
     {
       "annotations": {
@@ -2351,6 +3917,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -2692,6 +4260,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -2951,6 +4521,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -3206,6 +4778,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -3465,6 +5039,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",
@@ -3736,6 +5312,8 @@ expression: surface
           "QuerySource": {
             "enum": [
               "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
               "consumer_statistics",
               "consumer_connection",
               "producer_connection",

--- a/rocketmq-ai/rocketmq-mcp/src/tools.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools.rs
@@ -19,8 +19,10 @@ pub mod catalog;
 #[cfg(feature = "change-planning")]
 pub mod change_tools;
 pub mod cluster_tools;
+pub mod config_tools;
 pub mod consumer_tools;
 pub mod diagnosis_tools;
 pub mod executor;
 pub mod output_policy;
+pub mod proxy_tools;
 pub mod topic_tools;

--- a/rocketmq-ai/rocketmq-mcp/src/tools/broker_tools.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/broker_tools.rs
@@ -35,3 +35,345 @@ pub struct DescribeBrokerOutput {
     pub brokers: Vec<BrokerSummary>,
     pub generated_at: String,
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrokerDiagnosticsArgs {
+    pub cluster: String,
+    pub broker_name: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BrokerDiagnosticsCoverage {
+    Available,
+    Partial,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BrokerReadinessDiagnostics {
+    pub ready: bool,
+    pub active: bool,
+    pub shutdown: bool,
+    pub registration_accepting: bool,
+    pub registration_configured: bool,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub enum BrokerRole {
+    #[serde(rename = "ASYNC_MASTER")]
+    AsyncMaster,
+    #[serde(rename = "SYNC_MASTER")]
+    SyncMaster,
+    #[serde(rename = "SLAVE")]
+    Slave,
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub enum BrokerStoreType {
+    #[serde(rename = "LocalFile")]
+    LocalFile,
+    #[serde(rename = "RocksDB")]
+    RocksDb,
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BrokerRuntimeConfigSummary {
+    pub generation: u64,
+    pub broker_role: BrokerRole,
+    pub store_type: BrokerStoreType,
+    pub timer_wheel_enabled: bool,
+    pub transient_store_pool_enabled: bool,
+    pub tiered_store_configured: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct SyncFlushDiagnostics {
+    pub queue_depth: u64,
+    pub timeout_total: u64,
+    pub oldest_wait_millis: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct StoreHealthDiagnostics {
+    pub writeable: bool,
+    pub last_flush_error: bool,
+    pub os_page_cache_busy: bool,
+    pub transient_store_pool_deficient: bool,
+    pub dispatch_behind_bytes: i64,
+    pub shutdown: bool,
+    pub ha_pending_request_count: u64,
+    pub ha_pending_oldest_wait_millis: u64,
+    pub sync_flush: SyncFlushDiagnostics,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HaRole {
+    Master,
+    Replica,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HaAckPolicy {
+    AllInSyncSet,
+    LocalDurable,
+    ReplicaCount,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HaDecisionCode {
+    WaitingForReplicaProgress,
+    NotObserved,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct HaDiagnostics {
+    pub supported: bool,
+    pub role: Option<HaRole>,
+    pub master_epoch: Option<i32>,
+    pub sync_state_set_epoch: Option<i32>,
+    pub sync_state_set_size: Option<u64>,
+    pub max_replica_lag_bytes: Option<u64>,
+    pub ack_policy: Option<HaAckPolicy>,
+    pub required_ack_count: Option<u64>,
+    pub decision_code: Option<HaDecisionCode>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct RecoveryDiagnostics {
+    pub available: bool,
+    pub total_duration_millis: Option<u64>,
+    pub phase_count: Option<u64>,
+    pub failed_phase_count: Option<u64>,
+    pub fallback_phase_count: Option<u64>,
+    pub fallback_reason_present: Option<bool>,
+    pub scanned_bytes: Option<u64>,
+    pub recovered_messages: Option<u64>,
+    pub invalid_messages: Option<u64>,
+    pub truncated_files: Option<u64>,
+    pub index_files_removed: Option<u64>,
+    pub index_files_rebuilt: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundIndexRebuildState {
+    Idle,
+    Running,
+    Paused,
+    Completed,
+    Retrying,
+    Failed,
+    Shutdown,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BackgroundIndexRebuildDiagnostics {
+    pub state: BackgroundIndexRebuildState,
+    pub effective_enabled: bool,
+    pub gray_mode: bool,
+    pub current_safe_offset: i64,
+    pub target_offset: i64,
+    pub backlog_bytes: i64,
+    pub rebuilt_bytes: u64,
+    pub rebuilt_messages: u64,
+    pub failure_count: u64,
+    pub bytes_per_second: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct RocksDbMaintenanceDiagnostics {
+    pub supported: bool,
+    pub maintenance_running: Option<bool>,
+    pub message_maintenance_running: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct TieredDispatchDiagnostics {
+    pub configured: bool,
+    pub dispatch_ready: Option<bool>,
+    pub minimum_pinned_wal_segment: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct AuthSecurityDiagnostics {
+    pub supported: bool,
+    pub authentication_enabled: Option<bool>,
+    pub authorization_enabled: Option<bool>,
+    pub acl_file_watch_enabled: Option<bool>,
+    pub acl_generation: Option<u64>,
+    pub acl_reload_attempts: Option<u64>,
+    pub acl_reload_successes: Option<u64>,
+    pub acl_reload_failures: Option<u64>,
+    pub acl_reload_skipped: Option<u64>,
+    pub credential_rotation_supported: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BrokerDiagnosticsRow {
+    pub broker_name: String,
+    pub broker_id: u64,
+    pub observed_at_millis: Option<u64>,
+    pub coverage: BrokerDiagnosticsCoverage,
+    pub readiness: Option<BrokerReadinessDiagnostics>,
+    pub config: Option<BrokerRuntimeConfigSummary>,
+    pub store_health: Option<StoreHealthDiagnostics>,
+    pub ha: HaDiagnostics,
+    pub recovery: Option<RecoveryDiagnostics>,
+    pub background_index_rebuild: Option<BackgroundIndexRebuildDiagnostics>,
+    pub rocksdb: RocksDbMaintenanceDiagnostics,
+    pub tiered: TieredDispatchDiagnostics,
+    pub auth: AuthSecurityDiagnostics,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BrokerDiagnosticsOutput {
+    pub cluster: String,
+    pub broker_name: String,
+    pub diagnostics_schema_version: String,
+    pub observed_at_millis: u64,
+    pub brokers: Vec<BrokerDiagnosticsRow>,
+    pub unavailable_brokers: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::de::DeserializeOwned;
+    use serde_json::json;
+
+    use super::*;
+
+    fn schema_enum_values<T: JsonSchema>() -> serde_json::Value {
+        serde_json::to_value(schemars::schema_for!(T))
+            .expect("enum schema should serialize")
+            .get("enum")
+            .cloned()
+            .expect("enum schema should expose a closed value set")
+    }
+
+    fn assert_unknown_wire_value_is_rejected<T>()
+    where
+        T: DeserializeOwned + std::fmt::Debug,
+    {
+        assert!(serde_json::from_value::<T>(json!("future_backend_value")).is_err());
+    }
+
+    #[test]
+    fn broker_diagnostic_enums_serialize_and_publish_closed_schemas() {
+        assert_eq!(
+            serde_json::to_value([
+                BrokerRole::AsyncMaster,
+                BrokerRole::SyncMaster,
+                BrokerRole::Slave,
+                BrokerRole::Unknown,
+            ])
+            .expect("broker roles should serialize"),
+            json!(["ASYNC_MASTER", "SYNC_MASTER", "SLAVE", "unknown"])
+        );
+        assert_eq!(
+            schema_enum_values::<BrokerRole>(),
+            json!(["ASYNC_MASTER", "SYNC_MASTER", "SLAVE", "unknown"])
+        );
+
+        assert_eq!(
+            serde_json::to_value([
+                BrokerStoreType::LocalFile,
+                BrokerStoreType::RocksDb,
+                BrokerStoreType::Unknown,
+            ])
+            .expect("store types should serialize"),
+            json!(["LocalFile", "RocksDB", "unknown"])
+        );
+        assert_eq!(
+            schema_enum_values::<BrokerStoreType>(),
+            json!(["LocalFile", "RocksDB", "unknown"])
+        );
+
+        assert_eq!(
+            serde_json::to_value([HaRole::Master, HaRole::Replica]).expect("HA roles should serialize"),
+            json!(["master", "replica"])
+        );
+        assert_eq!(schema_enum_values::<HaRole>(), json!(["master", "replica"]));
+
+        assert_eq!(
+            serde_json::to_value([
+                HaAckPolicy::AllInSyncSet,
+                HaAckPolicy::LocalDurable,
+                HaAckPolicy::ReplicaCount,
+            ])
+            .expect("HA acknowledgement policies should serialize"),
+            json!(["all_in_sync_set", "local_durable", "replica_count"])
+        );
+        assert_eq!(
+            schema_enum_values::<HaAckPolicy>(),
+            json!(["all_in_sync_set", "local_durable", "replica_count"])
+        );
+
+        assert_eq!(
+            serde_json::to_value([HaDecisionCode::WaitingForReplicaProgress, HaDecisionCode::NotObserved,])
+                .expect("HA decision codes should serialize"),
+            json!(["waiting_for_replica_progress", "not_observed"])
+        );
+        assert_eq!(
+            schema_enum_values::<HaDecisionCode>(),
+            json!(["waiting_for_replica_progress", "not_observed"])
+        );
+
+        assert_eq!(
+            serde_json::to_value([
+                BackgroundIndexRebuildState::Idle,
+                BackgroundIndexRebuildState::Running,
+                BackgroundIndexRebuildState::Paused,
+                BackgroundIndexRebuildState::Completed,
+                BackgroundIndexRebuildState::Retrying,
+                BackgroundIndexRebuildState::Failed,
+                BackgroundIndexRebuildState::Shutdown,
+                BackgroundIndexRebuildState::Unknown,
+            ])
+            .expect("background rebuild states should serialize"),
+            json!([
+                "idle",
+                "running",
+                "paused",
+                "completed",
+                "retrying",
+                "failed",
+                "shutdown",
+                "unknown"
+            ])
+        );
+        assert_eq!(
+            schema_enum_values::<BackgroundIndexRebuildState>(),
+            json!([
+                "idle",
+                "running",
+                "paused",
+                "completed",
+                "retrying",
+                "failed",
+                "shutdown",
+                "unknown"
+            ])
+        );
+    }
+
+    #[test]
+    fn broker_diagnostic_enums_reject_arbitrary_wire_values() {
+        assert_unknown_wire_value_is_rejected::<BrokerRole>();
+        assert_unknown_wire_value_is_rejected::<BrokerStoreType>();
+        assert_unknown_wire_value_is_rejected::<HaRole>();
+        assert_unknown_wire_value_is_rejected::<HaAckPolicy>();
+        assert_unknown_wire_value_is_rejected::<HaDecisionCode>();
+        assert_unknown_wire_value_is_rejected::<BackgroundIndexRebuildState>();
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs
@@ -23,8 +23,10 @@ use crate::tools::broker_tools;
 #[cfg(feature = "change-planning")]
 use crate::tools::change_tools;
 use crate::tools::cluster_tools;
+use crate::tools::config_tools;
 use crate::tools::consumer_tools;
 use crate::tools::diagnosis_tools;
+use crate::tools::proxy_tools;
 use crate::tools::topic_tools;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,6 +38,10 @@ pub enum ToolId {
     ListConsumerGroups,
     GetConsumerLag,
     DescribeBroker,
+    GetBrokerDiagnostics,
+    GetBrokerConfigSummary,
+    GetBrokerLogFilterState,
+    GetProxyDrainState,
     DiagnoseConsumerLag,
     #[cfg(feature = "change-planning")]
     PlanCreateTopic,
@@ -58,6 +64,10 @@ impl ToolId {
         Self::ListConsumerGroups,
         Self::GetConsumerLag,
         Self::DescribeBroker,
+        Self::GetBrokerDiagnostics,
+        Self::GetBrokerConfigSummary,
+        Self::GetBrokerLogFilterState,
+        Self::GetProxyDrainState,
         Self::DiagnoseConsumerLag,
         #[cfg(feature = "change-planning")]
         Self::PlanCreateTopic,
@@ -128,6 +138,34 @@ impl ToolId {
                 "RocketMQ broker description",
                 "Describe broker state without exposing internal addresses by default.",
                 RiskLevel::ReadOnly,
+            ),
+            Self::GetBrokerDiagnostics => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_broker_diagnostics",
+                "RocketMQ broker diagnostics",
+                "Get bounded readiness, store, recovery, and security diagnostics for one logical Broker.",
+                RiskLevel::Diagnose,
+            ),
+            Self::GetBrokerConfigSummary => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_broker_config_summary",
+                "RocketMQ broker configuration summary",
+                "Get the fixed allowlisted configuration summary for one logical Broker.",
+                RiskLevel::ReadOnly,
+            ),
+            Self::GetBrokerLogFilterState => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_broker_log_filter_state",
+                "RocketMQ broker log-filter state",
+                "Get the temporary state of one allowlisted rocketmq_broker logger target.",
+                RiskLevel::Diagnose,
+            ),
+            Self::GetProxyDrainState => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_proxy_drain_state",
+                "RocketMQ Proxy drain state",
+                "Get bounded drain progress for one configured logical Proxy alias.",
+                RiskLevel::Diagnose,
             ),
             Self::DiagnoseConsumerLag => ToolDescriptor::read_only(
                 self,
@@ -200,6 +238,18 @@ impl ToolId {
             }
             Self::DescribeBroker => {
                 descriptor.build::<broker_tools::DescribeBrokerArgs, broker_tools::DescribeBrokerOutput>()
+            }
+            Self::GetBrokerDiagnostics => {
+                descriptor.build::<broker_tools::BrokerDiagnosticsArgs, broker_tools::BrokerDiagnosticsOutput>()
+            }
+            Self::GetBrokerConfigSummary => {
+                descriptor.build::<config_tools::BrokerConfigSummaryArgs, config_tools::BrokerConfigSummaryOutput>()
+            }
+            Self::GetBrokerLogFilterState => {
+                descriptor.build::<config_tools::BrokerLogFilterStateArgs, config_tools::BrokerLogFilterStateOutput>()
+            }
+            Self::GetProxyDrainState => {
+                descriptor.build::<proxy_tools::ProxyDrainStateArgs, proxy_tools::ProxyDrainStateOutput>()
             }
             Self::DiagnoseConsumerLag => {
                 descriptor.build::<diagnosis_tools::DiagnoseConsumerLagArgs, crate::model::diagnosis::DiagnosisReport>()
@@ -336,7 +386,7 @@ mod tests {
             .map(|tool_id| tool_id.descriptor().name)
             .collect::<Vec<_>>();
         assert_eq!(
-            &names[..8],
+            &names[..12],
             &[
                 "rocketmq_get_cluster_overview",
                 "rocketmq_list_topics",
@@ -345,11 +395,40 @@ mod tests {
                 "rocketmq_list_consumer_groups",
                 "rocketmq_get_consumer_lag",
                 "rocketmq_describe_broker",
+                "rocketmq_get_broker_diagnostics",
+                "rocketmq_get_broker_config_summary",
+                "rocketmq_get_broker_log_filter_state",
+                "rocketmq_get_proxy_drain_state",
                 "rocketmq_diagnose_consumer_lag",
             ]
         );
         #[cfg(not(feature = "change-planning"))]
-        assert_eq!(names.len(), 8);
+        assert_eq!(names.len(), 12);
+    }
+
+    #[test]
+    fn broker_and_proxy_contracts_have_exact_risk_and_read_only_annotations() {
+        let expected = [
+            (ToolId::GetBrokerDiagnostics, RiskLevel::Diagnose),
+            (ToolId::GetBrokerConfigSummary, RiskLevel::ReadOnly),
+            (ToolId::GetBrokerLogFilterState, RiskLevel::Diagnose),
+            (ToolId::GetProxyDrainState, RiskLevel::Diagnose),
+        ];
+        for (tool_id, risk) in expected {
+            let descriptor = tool_id.descriptor();
+            assert_eq!(descriptor.risk_level, risk);
+            assert!(descriptor.annotations.read_only);
+            assert!(!descriptor.annotations.destructive);
+            assert!(descriptor.annotations.idempotent);
+            let definition = tool_id.definition();
+            assert!(definition.output_schema.is_some());
+            assert_eq!(
+                definition.input_schema.get("additionalProperties"),
+                Some(&serde_json::Value::Bool(false)),
+                "{} must reject unknown arguments",
+                descriptor.name
+            );
+        }
     }
 
     #[test]

--- a/rocketmq-ai/rocketmq-mcp/src/tools/config_tools.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/config_tools.rs
@@ -1,0 +1,78 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrokerConfigSummaryArgs {
+    pub cluster: String,
+    pub broker_name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BrokerConfigSummaryRow {
+    pub broker_name: String,
+    pub broker_id: u64,
+    pub generation: u64,
+    pub send_message_thread_pool_nums: Option<u32>,
+    pub pull_message_thread_pool_nums: Option<u32>,
+    pub flush_delay_offset_interval_ms: Option<u64>,
+    pub max_client_event_count: Option<i32>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BrokerConfigSummaryOutput {
+    pub cluster: String,
+    pub broker_name: String,
+    pub brokers: Vec<BrokerConfigSummaryRow>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrokerLogFilterStateArgs {
+    pub cluster: String,
+    pub broker_name: String,
+    pub logger: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum BrokerLogLevel {
+    Info,
+    Debug,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BrokerLogFilterStateRow {
+    pub broker_name: String,
+    pub broker_id: u64,
+    pub state_schema_version: String,
+    pub supported: bool,
+    pub logger: String,
+    pub level: Option<BrokerLogLevel>,
+    pub active_operation_id: Option<String>,
+    pub last_completed_operation_id: Option<String>,
+    pub expires_at_millis: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct BrokerLogFilterStateOutput {
+    pub cluster: String,
+    pub broker_name: String,
+    pub logger: String,
+    pub brokers: Vec<BrokerLogFilterStateRow>,
+}

--- a/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
@@ -44,9 +44,11 @@ use crate::tools::catalog::ToolId;
 #[cfg(feature = "change-planning")]
 use crate::tools::change_tools;
 use crate::tools::cluster_tools;
+use crate::tools::config_tools;
 use crate::tools::consumer_tools;
 use crate::tools::diagnosis_tools;
 use crate::tools::output_policy;
+use crate::tools::proxy_tools;
 use crate::tools::topic_tools;
 
 #[derive(Debug, thiserror::Error)]
@@ -489,6 +491,78 @@ where
                     success_result(descriptor, request_id, cluster, summary, output, resource)
                 })
             }
+            ToolId::GetBrokerDiagnostics => {
+                let args = match decode_args::<broker_tools::BrokerDiagnosticsArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.broker_diagnostics(args).await.and_then(|output| {
+                    let summary = summary_broker_diagnostics(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
+            ToolId::GetBrokerConfigSummary => {
+                let args = match decode_args::<config_tools::BrokerConfigSummaryArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.broker_config_summary(args).await.and_then(|output| {
+                    let summary = summary_broker_config(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
+            ToolId::GetBrokerLogFilterState => {
+                let args = match decode_args::<config_tools::BrokerLogFilterStateArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.broker_log_filter_state(args).await.and_then(|output| {
+                    let summary = summary_broker_log_filter(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
+            ToolId::GetProxyDrainState => {
+                let args = match decode_args::<proxy_tools::ProxyDrainStateArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.proxy_drain_state(args).await.and_then(|output| {
+                    let summary = summary_proxy_drain(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
             ToolId::DiagnoseConsumerLag => {
                 let args = match decode_args::<diagnosis_tools::DiagnoseConsumerLagArgs>(arguments.clone()) {
                     Ok(args) => args,
@@ -696,6 +770,20 @@ where
     render_success(descriptor, summary, envelope, Some(resource))
 }
 
+fn success_unlinked_result<T>(
+    descriptor: ToolDescriptor,
+    request_id: &str,
+    cluster: String,
+    summary: String,
+    output: QueryResult<T>,
+) -> Result<CallToolResult, ToolExecutionError>
+where
+    T: Serialize,
+{
+    let envelope = ToolResponse::from_query(request_id, cluster, output);
+    render_success(descriptor, summary, envelope, None)
+}
+
 #[cfg(feature = "change-planning")]
 fn success_live_result<T>(
     descriptor: ToolDescriptor,
@@ -858,6 +946,41 @@ fn summary_describe_broker(output: &broker_tools::DescribeBrokerOutput) -> Strin
     )
 }
 
+fn summary_broker_diagnostics(output: &broker_tools::BrokerDiagnosticsOutput) -> String {
+    format!(
+        "Broker {} on cluster {} returned {} diagnostic rows.",
+        output.broker_name,
+        output.cluster,
+        output.brokers.len()
+    )
+}
+
+fn summary_broker_config(output: &config_tools::BrokerConfigSummaryOutput) -> String {
+    format!(
+        "Broker {} on cluster {} returned {} allowlisted configuration rows.",
+        output.broker_name,
+        output.cluster,
+        output.brokers.len()
+    )
+}
+
+fn summary_broker_log_filter(output: &config_tools::BrokerLogFilterStateOutput) -> String {
+    format!(
+        "Broker {} on cluster {} returned {} log-filter state rows for {}.",
+        output.broker_name,
+        output.cluster,
+        output.brokers.len(),
+        output.logger
+    )
+}
+
+fn summary_proxy_drain(output: &proxy_tools::ProxyDrainStateOutput) -> String {
+    format!(
+        "Proxy {} on cluster {} is in {:?} drain phase.",
+        output.proxy_name, output.cluster, output.phase
+    )
+}
+
 #[cfg(feature = "change-planning")]
 fn summary_change_plan(output: &change_tools::ChangePlan) -> String {
     format!(
@@ -985,6 +1108,80 @@ mod tests {
             _args: broker_tools::DescribeBrokerArgs,
         ) -> Result<QueryResult<broker_tools::DescribeBrokerOutput>, ToolExecutionError> {
             unimplemented!("not needed by this test")
+        }
+
+        async fn broker_diagnostics(
+            &self,
+            args: broker_tools::BrokerDiagnosticsArgs,
+        ) -> Result<QueryResult<broker_tools::BrokerDiagnosticsOutput>, ToolExecutionError> {
+            if self.fail {
+                return Err(ToolExecutionError::backend(
+                    "private-proxy-endpoint.example:18081 token=super-secret",
+                ));
+            }
+            Ok(QueryResult::bypass(broker_tools::BrokerDiagnosticsOutput {
+                cluster: args.cluster,
+                broker_name: args.broker_name,
+                diagnostics_schema_version: "rocketmq.admin-broker-diagnostics.v1".to_string(),
+                observed_at_millis: 1,
+                brokers: Vec::new(),
+                unavailable_brokers: 0,
+            }))
+        }
+
+        async fn broker_config_summary(
+            &self,
+            args: config_tools::BrokerConfigSummaryArgs,
+        ) -> Result<QueryResult<config_tools::BrokerConfigSummaryOutput>, ToolExecutionError> {
+            Ok(QueryResult::bypass(config_tools::BrokerConfigSummaryOutput {
+                cluster: args.cluster,
+                broker_name: args.broker_name,
+                brokers: Vec::new(),
+            }))
+        }
+
+        async fn broker_log_filter_state(
+            &self,
+            args: config_tools::BrokerLogFilterStateArgs,
+        ) -> Result<QueryResult<config_tools::BrokerLogFilterStateOutput>, ToolExecutionError> {
+            Ok(QueryResult::bypass(config_tools::BrokerLogFilterStateOutput {
+                cluster: args.cluster,
+                broker_name: args.broker_name,
+                logger: args.logger,
+                brokers: Vec::new(),
+            }))
+        }
+
+        async fn proxy_drain_state(
+            &self,
+            args: proxy_tools::ProxyDrainStateArgs,
+        ) -> Result<QueryResult<proxy_tools::ProxyDrainStateOutput>, ToolExecutionError> {
+            if self.fail {
+                return Err(ToolExecutionError::backend(
+                    "private-proxy-endpoint.example:18081 token=super-secret",
+                ));
+            }
+            Ok(QueryResult::bypass(proxy_tools::ProxyDrainStateOutput {
+                cluster: args.cluster,
+                proxy_name: args.proxy_name,
+                state_schema_version: "rocketmq.proxy-drain.v1".to_string(),
+                phase: proxy_tools::ProxyDrainPhase::Accepting,
+                operation_id: None,
+                admission_open: true,
+                routing_open: true,
+                readiness_published: true,
+                zero_pending: true,
+                pending: proxy_tools::ProxyDrainPending {
+                    active_connections: 0,
+                    sessions: 0,
+                    receipt_handles: 0,
+                    prepared_transactions: 0,
+                    telemetry_links: 0,
+                    remoting_channels: 0,
+                    telemetry_commands: 0,
+                    rpc_in_flight: 0,
+                },
+            }))
         }
 
         async fn diagnose_consumer_lag(
@@ -1170,6 +1367,164 @@ mod tests {
         assert_eq!(records[0].status, AuditStatus::Failure);
     }
 
+    #[tokio::test]
+    async fn broker_and_proxy_tools_dispatch_without_resource_links() {
+        let executor = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            test_guard("diagnose"),
+        );
+        let calls = [
+            (
+                ToolId::GetBrokerDiagnostics,
+                serde_json::json!({"cluster": "local-dev", "broker_name": "broker-a"}),
+            ),
+            (
+                ToolId::GetBrokerConfigSummary,
+                serde_json::json!({"cluster": "local-dev", "broker_name": "broker-a"}),
+            ),
+            (
+                ToolId::GetBrokerLogFilterState,
+                serde_json::json!({
+                    "cluster": "local-dev",
+                    "broker_name": "broker-a",
+                    "logger": "rocketmq_broker::processor"
+                }),
+            ),
+            (
+                ToolId::GetProxyDrainState,
+                serde_json::json!({"cluster": "local-dev", "proxy_name": "proxy-a"}),
+            ),
+        ];
+        for (tool, arguments) in calls {
+            let result = executor
+                .call(
+                    CallToolRequestParams::new(tool.descriptor().name)
+                        .with_arguments(arguments.as_object().unwrap().clone()),
+                )
+                .await
+                .unwrap();
+            assert_eq!(result.is_error, Some(false), "{}", tool.descriptor().name);
+            assert!(result
+                .content
+                .iter()
+                .all(|content| content.as_resource_link().is_none()));
+            assert!(result.structured_content.is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn broker_and_proxy_tools_reject_unknown_fields_and_enforce_scopes() {
+        let diagnose = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            test_guard("diagnose"),
+        );
+        let invalid_calls = [
+            (
+                ToolId::GetBrokerDiagnostics,
+                serde_json::json!({"cluster": "local-dev", "broker_name": "broker-a", "extra": true}),
+            ),
+            (
+                ToolId::GetBrokerConfigSummary,
+                serde_json::json!({"cluster": "local-dev", "broker_name": "broker-a", "extra": true}),
+            ),
+            (
+                ToolId::GetBrokerLogFilterState,
+                serde_json::json!({
+                    "cluster": "local-dev",
+                    "broker_name": "broker-a",
+                    "logger": "rocketmq_broker::processor",
+                    "extra": true
+                }),
+            ),
+            (
+                ToolId::GetProxyDrainState,
+                serde_json::json!({"cluster": "local-dev", "proxy_name": "proxy-a", "endpoint": "secret"}),
+            ),
+        ];
+        for (tool, arguments) in invalid_calls {
+            let invalid = diagnose
+                .call(
+                    CallToolRequestParams::new(tool.descriptor().name)
+                        .with_arguments(arguments.as_object().unwrap().clone()),
+                )
+                .await
+                .unwrap();
+            assert_eq!(invalid.is_error, Some(true), "{}", tool.descriptor().name);
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&content_text(&invalid)).unwrap()["code"],
+                "invalid_arguments"
+            );
+        }
+
+        let read_only = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            test_guard("read_only"),
+        );
+        let denied = read_only
+            .call(
+                CallToolRequestParams::new(ToolId::GetBrokerDiagnostics.descriptor().name).with_arguments(
+                    serde_json::json!({"cluster": "local-dev", "broker_name": "broker-a"})
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(denied.is_error, Some(true));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&content_text(&denied)).unwrap()["code"],
+            "unauthorized_scope"
+        );
+
+        let allowed = read_only
+            .call(
+                CallToolRequestParams::new(ToolId::GetBrokerConfigSummary.descriptor().name).with_arguments(
+                    serde_json::json!({"cluster": "local-dev", "broker_name": "broker-a"})
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(allowed.is_error, Some(false));
+    }
+
+    #[tokio::test]
+    async fn proxy_backend_failure_never_exposes_internal_endpoint() {
+        let result = ToolExecutor::new(
+            FakeAdapter {
+                fail: true,
+                partial: false,
+            },
+            test_guard("diagnose"),
+        )
+        .call(
+            CallToolRequestParams::new(ToolId::GetProxyDrainState.descriptor().name).with_arguments(
+                serde_json::json!({"cluster": "local-dev", "proxy_name": "proxy-a"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .unwrap();
+        let text = content_text(&result);
+        assert_eq!(result.is_error, Some(true));
+        assert!(!text.contains("private-proxy-endpoint"));
+        assert!(!text.contains("super-secret"));
+    }
+
     #[cfg(feature = "change-planning")]
     #[tokio::test]
     async fn runtime_policy_denies_change_planning_by_default() {
@@ -1312,6 +1667,7 @@ mod tests {
                 rocketmq_cluster_name: None,
                 tenant: None,
                 credentials: None,
+                proxies: Vec::new(),
             }],
         )
         .unwrap()

--- a/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
@@ -157,6 +157,8 @@ fn normalize_source_failure(value: &Value) -> Option<Value> {
     if !matches!(
         source,
         "broker_runtime"
+            | "broker_config"
+            | "broker_log_filter"
             | "consumer_statistics"
             | "consumer_connection"
             | "producer_connection"
@@ -241,6 +243,12 @@ fn is_internal_topology_key(key: &str) -> bool {
             | "namesrvaddrs"
             | "brokeraddr"
             | "brokeraddrs"
+            | "proxyaddr"
+            | "proxyaddrs"
+            | "proxyendpoint"
+            | "proxyendpoints"
+            | "endpoint"
+            | "endpoints"
             | "clientip"
             | "clientaddr"
             | "remoteaddr"
@@ -266,7 +274,9 @@ mod tests {
                     "broker_name": "broker-a",
                     "broker_addr": "127.0.0.1:10911",
                     "broker_addrs": {"0": "127.0.0.1:10911"},
-                    "client_ip": "127.0.0.1"
+                    "client_ip": "127.0.0.1",
+                    "proxy_endpoint": "private-proxy.internal:8081",
+                    "endpoint": "private-proxy.internal:8081"
                 }]
             }
         }))
@@ -276,6 +286,7 @@ mod tests {
         assert!(!serialized.contains("namesrv_addr"));
         assert!(!serialized.contains("broker_addr"));
         assert!(!serialized.contains("client_ip"));
+        assert!(!serialized.contains("private-proxy.internal"));
         assert!(serialized.contains("broker-a"));
     }
 

--- a/rocketmq-ai/rocketmq-mcp/src/tools/proxy_tools.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/proxy_tools.rs
@@ -1,0 +1,58 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ProxyDrainStateArgs {
+    pub cluster: String,
+    pub proxy_name: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProxyDrainPhase {
+    Accepting,
+    Draining,
+    Drained,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ProxyDrainPending {
+    pub active_connections: usize,
+    pub sessions: usize,
+    pub receipt_handles: usize,
+    pub prepared_transactions: usize,
+    pub telemetry_links: usize,
+    pub remoting_channels: usize,
+    pub telemetry_commands: usize,
+    pub rpc_in_flight: usize,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ProxyDrainStateOutput {
+    pub cluster: String,
+    pub proxy_name: String,
+    pub state_schema_version: String,
+    pub phase: ProxyDrainPhase,
+    pub operation_id: Option<String>,
+    pub admission_open: bool,
+    pub routing_open: bool,
+    pub readiness_published: bool,
+    pub zero_pending: bool,
+    pub pending: ProxyDrainPending,
+}

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
@@ -126,6 +126,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -334,6 +336,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -591,6 +595,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -811,6 +817,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -1185,6 +1193,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -1421,6 +1431,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -1689,6 +1701,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -1791,6 +1805,1558 @@ expression: contracts
       "type": "object"
     },
     "title": "RocketMQ broker description"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ broker diagnostics"
+    },
+    "description": "Get bounded readiness, store, recovery, and security diagnostics for one logical Broker.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "broker_name"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_broker_diagnostics",
+    "outputSchema": {
+      "$defs": {
+        "AuthSecurityDiagnostics": {
+          "properties": {
+            "acl_file_watch_enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "acl_generation": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "acl_reload_attempts": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "acl_reload_failures": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "acl_reload_skipped": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "acl_reload_successes": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "authentication_enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "authorization_enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "credential_rotation_supported": {
+              "type": "boolean"
+            },
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "supported",
+            "credential_rotation_supported"
+          ],
+          "type": "object"
+        },
+        "BackgroundIndexRebuildDiagnostics": {
+          "properties": {
+            "backlog_bytes": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "bytes_per_second": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "current_safe_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "effective_enabled": {
+              "type": "boolean"
+            },
+            "failure_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "gray_mode": {
+              "type": "boolean"
+            },
+            "rebuilt_bytes": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "rebuilt_messages": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "state": {
+              "$ref": "#/$defs/BackgroundIndexRebuildState"
+            },
+            "target_offset": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "state",
+            "effective_enabled",
+            "gray_mode",
+            "current_safe_offset",
+            "target_offset",
+            "backlog_bytes",
+            "rebuilt_bytes",
+            "rebuilt_messages",
+            "failure_count",
+            "bytes_per_second"
+          ],
+          "type": "object"
+        },
+        "BackgroundIndexRebuildState": {
+          "enum": [
+            "idle",
+            "running",
+            "paused",
+            "completed",
+            "retrying",
+            "failed",
+            "shutdown",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "BrokerDiagnosticsCoverage": {
+          "enum": [
+            "available",
+            "partial",
+            "unsupported"
+          ],
+          "type": "string"
+        },
+        "BrokerDiagnosticsOutput": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerDiagnosticsRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "diagnostics_schema_version": {
+              "type": "string"
+            },
+            "observed_at_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "unavailable_brokers": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "diagnostics_schema_version",
+            "observed_at_millis",
+            "brokers",
+            "unavailable_brokers"
+          ],
+          "type": "object"
+        },
+        "BrokerDiagnosticsRow": {
+          "properties": {
+            "auth": {
+              "$ref": "#/$defs/AuthSecurityDiagnostics"
+            },
+            "background_index_rebuild": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BackgroundIndexRebuildDiagnostics"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BrokerRuntimeConfigSummary"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "coverage": {
+              "$ref": "#/$defs/BrokerDiagnosticsCoverage"
+            },
+            "ha": {
+              "$ref": "#/$defs/HaDiagnostics"
+            },
+            "observed_at_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "readiness": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BrokerReadinessDiagnostics"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RecoveryDiagnostics"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "rocksdb": {
+              "$ref": "#/$defs/RocksDbMaintenanceDiagnostics"
+            },
+            "store_health": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoreHealthDiagnostics"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "tiered": {
+              "$ref": "#/$defs/TieredDispatchDiagnostics"
+            },
+            "warnings": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id",
+            "coverage",
+            "ha",
+            "rocksdb",
+            "tiered",
+            "auth",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "BrokerReadinessDiagnostics": {
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ready": {
+              "type": "boolean"
+            },
+            "registration_accepting": {
+              "type": "boolean"
+            },
+            "registration_configured": {
+              "type": "boolean"
+            },
+            "shutdown": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "ready",
+            "active",
+            "shutdown",
+            "registration_accepting",
+            "registration_configured"
+          ],
+          "type": "object"
+        },
+        "BrokerRole": {
+          "enum": [
+            "ASYNC_MASTER",
+            "SYNC_MASTER",
+            "SLAVE",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "BrokerRuntimeConfigSummary": {
+          "properties": {
+            "broker_role": {
+              "$ref": "#/$defs/BrokerRole"
+            },
+            "generation": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "store_type": {
+              "$ref": "#/$defs/BrokerStoreType"
+            },
+            "tiered_store_configured": {
+              "type": "boolean"
+            },
+            "timer_wheel_enabled": {
+              "type": "boolean"
+            },
+            "transient_store_pool_enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "generation",
+            "broker_role",
+            "store_type",
+            "timer_wheel_enabled",
+            "transient_store_pool_enabled",
+            "tiered_store_configured"
+          ],
+          "type": "object"
+        },
+        "BrokerStoreType": {
+          "enum": [
+            "LocalFile",
+            "RocksDB",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "HaAckPolicy": {
+          "enum": [
+            "all_in_sync_set",
+            "local_durable",
+            "replica_count"
+          ],
+          "type": "string"
+        },
+        "HaDecisionCode": {
+          "enum": [
+            "waiting_for_replica_progress",
+            "not_observed"
+          ],
+          "type": "string"
+        },
+        "HaDiagnostics": {
+          "properties": {
+            "ack_policy": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/HaAckPolicy"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "decision_code": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/HaDecisionCode"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "master_epoch": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "max_replica_lag_bytes": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "required_ack_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "role": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/HaRole"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "supported": {
+              "type": "boolean"
+            },
+            "sync_state_set_epoch": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "sync_state_set_size": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "supported"
+          ],
+          "type": "object"
+        },
+        "HaRole": {
+          "enum": [
+            "master",
+            "replica"
+          ],
+          "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "RecoveryDiagnostics": {
+          "properties": {
+            "available": {
+              "type": "boolean"
+            },
+            "failed_phase_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "fallback_phase_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "fallback_reason_present": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "index_files_rebuilt": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "index_files_removed": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "invalid_messages": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "phase_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "recovered_messages": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "scanned_bytes": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "total_duration_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "truncated_files": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "available"
+          ],
+          "type": "object"
+        },
+        "RocksDbMaintenanceDiagnostics": {
+          "properties": {
+            "maintenance_running": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "message_maintenance_running": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "supported"
+          ],
+          "type": "object"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
+        "StoreHealthDiagnostics": {
+          "properties": {
+            "dispatch_behind_bytes": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "ha_pending_oldest_wait_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "ha_pending_request_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "last_flush_error": {
+              "type": "boolean"
+            },
+            "os_page_cache_busy": {
+              "type": "boolean"
+            },
+            "shutdown": {
+              "type": "boolean"
+            },
+            "sync_flush": {
+              "$ref": "#/$defs/SyncFlushDiagnostics"
+            },
+            "transient_store_pool_deficient": {
+              "type": "boolean"
+            },
+            "writeable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "writeable",
+            "last_flush_error",
+            "os_page_cache_busy",
+            "transient_store_pool_deficient",
+            "dispatch_behind_bytes",
+            "shutdown",
+            "ha_pending_request_count",
+            "ha_pending_oldest_wait_millis",
+            "sync_flush"
+          ],
+          "type": "object"
+        },
+        "SyncFlushDiagnostics": {
+          "properties": {
+            "oldest_wait_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "queue_depth": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "timeout_total": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "queue_depth",
+            "timeout_total",
+            "oldest_wait_millis"
+          ],
+          "type": "object"
+        },
+        "TieredDispatchDiagnostics": {
+          "properties": {
+            "configured": {
+              "type": "boolean"
+            },
+            "dispatch_ready": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minimum_pinned_wal_segment": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "configured"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/BrokerDiagnosticsOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ broker diagnostics"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ broker configuration summary"
+    },
+    "description": "Get the fixed allowlisted configuration summary for one logical Broker.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "broker_name"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_broker_config_summary",
+    "outputSchema": {
+      "$defs": {
+        "BrokerConfigSummaryOutput": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerConfigSummaryRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "brokers"
+          ],
+          "type": "object"
+        },
+        "BrokerConfigSummaryRow": {
+          "properties": {
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "flush_delay_offset_interval_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "generation": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "max_client_event_count": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "pull_message_thread_pool_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "send_message_thread_pool_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id",
+            "generation"
+          ],
+          "type": "object"
+        },
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/BrokerConfigSummaryOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ broker configuration summary"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ broker log-filter state"
+    },
+    "description": "Get the temporary state of one allowlisted rocketmq_broker logger target.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "logger": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "broker_name",
+        "logger"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_broker_log_filter_state",
+    "outputSchema": {
+      "$defs": {
+        "BrokerLogFilterStateOutput": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerLogFilterStateRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "logger": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "logger",
+            "brokers"
+          ],
+          "type": "object"
+        },
+        "BrokerLogFilterStateRow": {
+          "properties": {
+            "active_operation_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "expires_at_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "last_completed_operation_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "level": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BrokerLogLevel"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "logger": {
+              "type": "string"
+            },
+            "state_schema_version": {
+              "type": "string"
+            },
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id",
+            "state_schema_version",
+            "supported",
+            "logger"
+          ],
+          "type": "object"
+        },
+        "BrokerLogLevel": {
+          "enum": [
+            "INFO",
+            "DEBUG"
+          ],
+          "type": "string"
+        },
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/BrokerLogFilterStateOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ broker log-filter state"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ Proxy drain state"
+    },
+    "description": "Get bounded drain progress for one configured logical Proxy alias.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "proxy_name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "proxy_name"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_proxy_drain_state",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ProxyDrainPending": {
+          "properties": {
+            "active_connections": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "prepared_transactions": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "receipt_handles": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "remoting_channels": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "rpc_in_flight": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sessions": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "telemetry_commands": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "telemetry_links": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "active_connections",
+            "sessions",
+            "receipt_handles",
+            "prepared_transactions",
+            "telemetry_links",
+            "remoting_channels",
+            "telemetry_commands",
+            "rpc_in_flight"
+          ],
+          "type": "object"
+        },
+        "ProxyDrainPhase": {
+          "enum": [
+            "accepting",
+            "draining",
+            "drained"
+          ],
+          "type": "string"
+        },
+        "ProxyDrainStateOutput": {
+          "properties": {
+            "admission_open": {
+              "type": "boolean"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "operation_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pending": {
+              "$ref": "#/$defs/ProxyDrainPending"
+            },
+            "phase": {
+              "$ref": "#/$defs/ProxyDrainPhase"
+            },
+            "proxy_name": {
+              "type": "string"
+            },
+            "readiness_published": {
+              "type": "boolean"
+            },
+            "routing_open": {
+              "type": "boolean"
+            },
+            "state_schema_version": {
+              "type": "string"
+            },
+            "zero_pending": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "cluster",
+            "proxy_name",
+            "state_schema_version",
+            "phase",
+            "admission_open",
+            "routing_open",
+            "readiness_published",
+            "zero_pending",
+            "pending"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/ProxyDrainStateOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ Proxy drain state"
   },
   {
     "annotations": {
@@ -2181,6 +3747,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
@@ -126,6 +126,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -334,6 +336,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -591,6 +595,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -811,6 +817,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -1185,6 +1193,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -1421,6 +1431,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -1689,6 +1701,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -1791,6 +1805,1558 @@ expression: contracts
       "type": "object"
     },
     "title": "RocketMQ broker description"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ broker diagnostics"
+    },
+    "description": "Get bounded readiness, store, recovery, and security diagnostics for one logical Broker.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "broker_name"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_broker_diagnostics",
+    "outputSchema": {
+      "$defs": {
+        "AuthSecurityDiagnostics": {
+          "properties": {
+            "acl_file_watch_enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "acl_generation": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "acl_reload_attempts": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "acl_reload_failures": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "acl_reload_skipped": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "acl_reload_successes": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "authentication_enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "authorization_enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "credential_rotation_supported": {
+              "type": "boolean"
+            },
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "supported",
+            "credential_rotation_supported"
+          ],
+          "type": "object"
+        },
+        "BackgroundIndexRebuildDiagnostics": {
+          "properties": {
+            "backlog_bytes": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "bytes_per_second": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "current_safe_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "effective_enabled": {
+              "type": "boolean"
+            },
+            "failure_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "gray_mode": {
+              "type": "boolean"
+            },
+            "rebuilt_bytes": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "rebuilt_messages": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "state": {
+              "$ref": "#/$defs/BackgroundIndexRebuildState"
+            },
+            "target_offset": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "state",
+            "effective_enabled",
+            "gray_mode",
+            "current_safe_offset",
+            "target_offset",
+            "backlog_bytes",
+            "rebuilt_bytes",
+            "rebuilt_messages",
+            "failure_count",
+            "bytes_per_second"
+          ],
+          "type": "object"
+        },
+        "BackgroundIndexRebuildState": {
+          "enum": [
+            "idle",
+            "running",
+            "paused",
+            "completed",
+            "retrying",
+            "failed",
+            "shutdown",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "BrokerDiagnosticsCoverage": {
+          "enum": [
+            "available",
+            "partial",
+            "unsupported"
+          ],
+          "type": "string"
+        },
+        "BrokerDiagnosticsOutput": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerDiagnosticsRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "diagnostics_schema_version": {
+              "type": "string"
+            },
+            "observed_at_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "unavailable_brokers": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "diagnostics_schema_version",
+            "observed_at_millis",
+            "brokers",
+            "unavailable_brokers"
+          ],
+          "type": "object"
+        },
+        "BrokerDiagnosticsRow": {
+          "properties": {
+            "auth": {
+              "$ref": "#/$defs/AuthSecurityDiagnostics"
+            },
+            "background_index_rebuild": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BackgroundIndexRebuildDiagnostics"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BrokerRuntimeConfigSummary"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "coverage": {
+              "$ref": "#/$defs/BrokerDiagnosticsCoverage"
+            },
+            "ha": {
+              "$ref": "#/$defs/HaDiagnostics"
+            },
+            "observed_at_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "readiness": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BrokerReadinessDiagnostics"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RecoveryDiagnostics"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "rocksdb": {
+              "$ref": "#/$defs/RocksDbMaintenanceDiagnostics"
+            },
+            "store_health": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/StoreHealthDiagnostics"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "tiered": {
+              "$ref": "#/$defs/TieredDispatchDiagnostics"
+            },
+            "warnings": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id",
+            "coverage",
+            "ha",
+            "rocksdb",
+            "tiered",
+            "auth",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "BrokerReadinessDiagnostics": {
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ready": {
+              "type": "boolean"
+            },
+            "registration_accepting": {
+              "type": "boolean"
+            },
+            "registration_configured": {
+              "type": "boolean"
+            },
+            "shutdown": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "ready",
+            "active",
+            "shutdown",
+            "registration_accepting",
+            "registration_configured"
+          ],
+          "type": "object"
+        },
+        "BrokerRole": {
+          "enum": [
+            "ASYNC_MASTER",
+            "SYNC_MASTER",
+            "SLAVE",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "BrokerRuntimeConfigSummary": {
+          "properties": {
+            "broker_role": {
+              "$ref": "#/$defs/BrokerRole"
+            },
+            "generation": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "store_type": {
+              "$ref": "#/$defs/BrokerStoreType"
+            },
+            "tiered_store_configured": {
+              "type": "boolean"
+            },
+            "timer_wheel_enabled": {
+              "type": "boolean"
+            },
+            "transient_store_pool_enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "generation",
+            "broker_role",
+            "store_type",
+            "timer_wheel_enabled",
+            "transient_store_pool_enabled",
+            "tiered_store_configured"
+          ],
+          "type": "object"
+        },
+        "BrokerStoreType": {
+          "enum": [
+            "LocalFile",
+            "RocksDB",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "HaAckPolicy": {
+          "enum": [
+            "all_in_sync_set",
+            "local_durable",
+            "replica_count"
+          ],
+          "type": "string"
+        },
+        "HaDecisionCode": {
+          "enum": [
+            "waiting_for_replica_progress",
+            "not_observed"
+          ],
+          "type": "string"
+        },
+        "HaDiagnostics": {
+          "properties": {
+            "ack_policy": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/HaAckPolicy"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "decision_code": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/HaDecisionCode"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "master_epoch": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "max_replica_lag_bytes": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "required_ack_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "role": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/HaRole"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "supported": {
+              "type": "boolean"
+            },
+            "sync_state_set_epoch": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "sync_state_set_size": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "supported"
+          ],
+          "type": "object"
+        },
+        "HaRole": {
+          "enum": [
+            "master",
+            "replica"
+          ],
+          "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "RecoveryDiagnostics": {
+          "properties": {
+            "available": {
+              "type": "boolean"
+            },
+            "failed_phase_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "fallback_phase_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "fallback_reason_present": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "index_files_rebuilt": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "index_files_removed": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "invalid_messages": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "phase_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "recovered_messages": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "scanned_bytes": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "total_duration_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "truncated_files": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "available"
+          ],
+          "type": "object"
+        },
+        "RocksDbMaintenanceDiagnostics": {
+          "properties": {
+            "maintenance_running": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "message_maintenance_running": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "supported"
+          ],
+          "type": "object"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
+        "StoreHealthDiagnostics": {
+          "properties": {
+            "dispatch_behind_bytes": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "ha_pending_oldest_wait_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "ha_pending_request_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "last_flush_error": {
+              "type": "boolean"
+            },
+            "os_page_cache_busy": {
+              "type": "boolean"
+            },
+            "shutdown": {
+              "type": "boolean"
+            },
+            "sync_flush": {
+              "$ref": "#/$defs/SyncFlushDiagnostics"
+            },
+            "transient_store_pool_deficient": {
+              "type": "boolean"
+            },
+            "writeable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "writeable",
+            "last_flush_error",
+            "os_page_cache_busy",
+            "transient_store_pool_deficient",
+            "dispatch_behind_bytes",
+            "shutdown",
+            "ha_pending_request_count",
+            "ha_pending_oldest_wait_millis",
+            "sync_flush"
+          ],
+          "type": "object"
+        },
+        "SyncFlushDiagnostics": {
+          "properties": {
+            "oldest_wait_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "queue_depth": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "timeout_total": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "queue_depth",
+            "timeout_total",
+            "oldest_wait_millis"
+          ],
+          "type": "object"
+        },
+        "TieredDispatchDiagnostics": {
+          "properties": {
+            "configured": {
+              "type": "boolean"
+            },
+            "dispatch_ready": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minimum_pinned_wal_segment": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "configured"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/BrokerDiagnosticsOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ broker diagnostics"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ broker configuration summary"
+    },
+    "description": "Get the fixed allowlisted configuration summary for one logical Broker.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "broker_name"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_broker_config_summary",
+    "outputSchema": {
+      "$defs": {
+        "BrokerConfigSummaryOutput": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerConfigSummaryRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "brokers"
+          ],
+          "type": "object"
+        },
+        "BrokerConfigSummaryRow": {
+          "properties": {
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "flush_delay_offset_interval_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "generation": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "max_client_event_count": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "pull_message_thread_pool_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "send_message_thread_pool_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id",
+            "generation"
+          ],
+          "type": "object"
+        },
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/BrokerConfigSummaryOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ broker configuration summary"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ broker log-filter state"
+    },
+    "description": "Get the temporary state of one allowlisted rocketmq_broker logger target.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_name": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "logger": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "broker_name",
+        "logger"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_broker_log_filter_state",
+    "outputSchema": {
+      "$defs": {
+        "BrokerLogFilterStateOutput": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerLogFilterStateRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "logger": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "broker_name",
+            "logger",
+            "brokers"
+          ],
+          "type": "object"
+        },
+        "BrokerLogFilterStateRow": {
+          "properties": {
+            "active_operation_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "expires_at_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "last_completed_operation_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "level": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BrokerLogLevel"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "logger": {
+              "type": "string"
+            },
+            "state_schema_version": {
+              "type": "string"
+            },
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id",
+            "state_schema_version",
+            "supported",
+            "logger"
+          ],
+          "type": "object"
+        },
+        "BrokerLogLevel": {
+          "enum": [
+            "INFO",
+            "DEBUG"
+          ],
+          "type": "string"
+        },
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/BrokerLogFilterStateOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ broker log-filter state"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ Proxy drain state"
+    },
+    "description": "Get bounded drain progress for one configured logical Proxy alias.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "proxy_name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "proxy_name"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_proxy_drain_state",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ProxyDrainPending": {
+          "properties": {
+            "active_connections": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "prepared_transactions": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "receipt_handles": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "remoting_channels": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "rpc_in_flight": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sessions": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "telemetry_commands": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "telemetry_links": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "active_connections",
+            "sessions",
+            "receipt_handles",
+            "prepared_transactions",
+            "telemetry_links",
+            "remoting_channels",
+            "telemetry_commands",
+            "rpc_in_flight"
+          ],
+          "type": "object"
+        },
+        "ProxyDrainPhase": {
+          "enum": [
+            "accepting",
+            "draining",
+            "drained"
+          ],
+          "type": "string"
+        },
+        "ProxyDrainStateOutput": {
+          "properties": {
+            "admission_open": {
+              "type": "boolean"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "operation_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pending": {
+              "$ref": "#/$defs/ProxyDrainPending"
+            },
+            "phase": {
+              "$ref": "#/$defs/ProxyDrainPhase"
+            },
+            "proxy_name": {
+              "type": "string"
+            },
+            "readiness_published": {
+              "type": "boolean"
+            },
+            "routing_open": {
+              "type": "boolean"
+            },
+            "state_schema_version": {
+              "type": "string"
+            },
+            "zero_pending": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "cluster",
+            "proxy_name",
+            "state_schema_version",
+            "phase",
+            "admission_open",
+            "routing_open",
+            "readiness_published",
+            "zero_pending",
+            "pending"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/ProxyDrainStateOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ Proxy drain state"
   },
   {
     "annotations": {
@@ -2181,6 +3747,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -2522,6 +4090,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -2781,6 +4351,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -3036,6 +4608,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -3295,6 +4869,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",
@@ -3566,6 +5142,8 @@ expression: contracts
         "QuerySource": {
           "enum": [
             "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
             "consumer_statistics",
             "consumer_connection",
             "producer_connection",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/broker.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/broker.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
+use rocketmq_client_rust::DefaultMQAdminExt;
 use rocketmq_client_rust::{BrokerAdmin as _, RouteAdmin as _};
 use rocketmq_error::RocketMQError;
 use rocketmq_protocol::protocol::body::kv_table::KVTable;
@@ -22,7 +23,9 @@ use crate::core::broker::project_broker_diagnostics;
 use crate::core::broker::project_broker_log_filter_state;
 use crate::core::broker::BrokerAdmin;
 use crate::core::broker::BrokerAllowlistedConfig;
+use crate::core::broker::BrokerAllowlistedConfigTarget;
 use crate::core::broker::BrokerLogFilterState;
+use crate::core::broker::BrokerLogFilterStateTarget;
 use crate::core::broker::BrokerRuntimeTargetStatus;
 use crate::core::broker::BrokerSummary;
 use crate::core::broker::ListBrokersRequest;
@@ -31,9 +34,12 @@ use crate::core::broker::ProbeBrokerRuntimeRequest;
 use crate::core::broker::ProbeBrokerRuntimeResult;
 use crate::core::broker::ProbeBrokerRuntimeTargetRequest;
 use crate::core::broker::QueryBrokerAllowlistedConfigRequest;
+use crate::core::broker::QueryBrokerAllowlistedConfigTargetRequest;
 use crate::core::broker::QueryBrokerDiagnosticsRequest;
 use crate::core::broker::QueryBrokerDiagnosticsResult;
+use crate::core::broker::QueryBrokerDiagnosticsTargetRequest;
 use crate::core::broker::QueryBrokerLogFilterStateRequest;
+use crate::core::broker::QueryBrokerLogFilterStateTargetRequest;
 use crate::core::query::AdminQueryFailureCode;
 use crate::core::query::AdminQueryResult;
 use crate::core::query::AdminQuerySource;
@@ -353,6 +359,61 @@ impl BrokerAdmin for AdminSession {
         })
     }
 
+    fn query_broker_diagnostics_target_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryBrokerDiagnosticsTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryBrokerDiagnosticsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let (targets, mut failures) = exact_broker_targets(
+                &self.inner,
+                request.cluster(),
+                request.broker_name(),
+                AdminQuerySource::BrokerRuntime,
+            )
+            .await?;
+            let observed_at_millis = self.clock.now_millis();
+            let mut brokers = Vec::new();
+            let mut successful_sources = 0usize;
+            for (broker_id, broker_addr) in targets {
+                let logical_target = broker_instance_target(request.broker_name(), broker_id);
+                match self.inner.fetch_broker_runtime_stats(broker_addr).await {
+                    Ok(runtime) => {
+                        successful_sources += 1;
+                        brokers.push(project_broker_diagnostics(
+                            request.broker_name().to_string(),
+                            broker_id,
+                            &runtime,
+                        ));
+                    }
+                    Err(error) => {
+                        failures.push(source_failure(AdminQuerySource::BrokerRuntime, &logical_target, &error))
+                    }
+                }
+            }
+            brokers.sort_by_key(|broker| broker.broker_id);
+            let unavailable_brokers = failures.len();
+            let partial_diagnostics = brokers
+                .iter()
+                .any(|broker| broker.coverage != crate::core::broker::BrokerDiagnosticsCoverage::Available);
+            let data = QueryBrokerDiagnosticsResult {
+                schema_version: crate::core::broker::BROKER_DIAGNOSTICS_SCHEMA_VERSION.to_owned(),
+                observed_at_millis,
+                brokers,
+                unavailable_brokers,
+                partial: unavailable_brokers > 0 || partial_diagnostics,
+            };
+            let mut result = AdminQueryResult::from_sources(data, successful_sources, failures)?;
+            if partial_diagnostics {
+                result.partial = true;
+                result.warnings.push("broker_diagnostics_incomplete".to_string());
+                result.warnings.sort();
+                result.warnings.dedup();
+            }
+            Ok(result)
+        })
+    }
+
     fn query_allowlisted_config<'a>(
         &'a mut self,
         request: &'a QueryBrokerAllowlistedConfigRequest,
@@ -375,6 +436,50 @@ impl BrokerAdmin for AdminSession {
         })
     }
 
+    fn query_allowlisted_config_target_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryBrokerAllowlistedConfigTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerAllowlistedConfigTarget>>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let (targets, mut failures) = exact_broker_targets(
+                &self.inner,
+                request.cluster(),
+                request.broker_name(),
+                AdminQuerySource::BrokerConfig,
+            )
+            .await?;
+            let mut rows = Vec::new();
+            let mut successful_sources = 0usize;
+            for (broker_id, broker_addr) in targets {
+                let logical_target = broker_instance_target(request.broker_name(), broker_id);
+                match rocketmq_client_rust::MQAdminReadExt::get_broker_config_allowlisted(&self.inner, broker_addr)
+                    .await
+                {
+                    Ok(config) => {
+                        successful_sources += 1;
+                        rows.push(BrokerAllowlistedConfigTarget {
+                            broker_name: request.broker_name().to_string(),
+                            broker_id,
+                            config: BrokerAllowlistedConfig {
+                                generation: config.generation,
+                                send_message_thread_pool_nums: config.send_message_thread_pool_nums,
+                                pull_message_thread_pool_nums: config.pull_message_thread_pool_nums,
+                                flush_delay_offset_interval_ms: config.flush_delay_offset_interval_ms,
+                                max_client_event_count: config.max_client_event_count,
+                            },
+                        });
+                    }
+                    Err(error) => {
+                        failures.push(source_failure(AdminQuerySource::BrokerConfig, &logical_target, &error))
+                    }
+                }
+            }
+            rows.sort_by_key(|row| row.broker_id);
+            AdminQueryResult::from_sources(rows, successful_sources, failures)
+        })
+    }
+
     fn query_log_filter_state<'a>(
         &'a mut self,
         request: &'a QueryBrokerLogFilterStateRequest,
@@ -389,6 +494,61 @@ impl BrokerAdmin for AdminSession {
             Ok(project_broker_log_filter_state(request.logger.clone(), &runtime))
         })
     }
+
+    fn query_log_filter_state_target_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryBrokerLogFilterStateTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerLogFilterStateTarget>>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let (targets, mut failures) = exact_broker_targets(
+                &self.inner,
+                request.cluster(),
+                request.broker_name(),
+                AdminQuerySource::BrokerLogFilter,
+            )
+            .await?;
+            let mut rows = Vec::new();
+            let mut successful_sources = 0usize;
+            for (broker_id, broker_addr) in targets {
+                let logical_target = broker_instance_target(request.broker_name(), broker_id);
+                match self.inner.fetch_broker_runtime_stats(broker_addr).await {
+                    Ok(runtime) => {
+                        successful_sources += 1;
+                        rows.push(BrokerLogFilterStateTarget {
+                            broker_name: request.broker_name().to_string(),
+                            broker_id,
+                            state: project_broker_log_filter_state(request.logger().to_string(), &runtime),
+                        });
+                    }
+                    Err(error) => failures.push(source_failure(
+                        AdminQuerySource::BrokerLogFilter,
+                        &logical_target,
+                        &error,
+                    )),
+                }
+            }
+            rows.sort_by_key(|row| row.broker_id);
+            AdminQueryResult::from_sources(rows, successful_sources, failures)
+        })
+    }
+}
+
+async fn exact_broker_targets(
+    admin: &DefaultMQAdminExt,
+    cluster: &str,
+    broker_name: &str,
+    source: AdminQuerySource,
+) -> Result<(Vec<(u64, CheetahString)>, Vec<AdminSourceFailure>), AdminError> {
+    let cluster_info = admin
+        .examine_broker_cluster_info()
+        .await
+        .map_err(|error| AdminError::backend("examine_broker_cluster_info", error.to_string()))?;
+    crate::exact_broker::resolve_exact_broker_targets(cluster_info, cluster, broker_name, source)
+}
+
+fn broker_instance_target(broker_name: &str, broker_id: u64) -> String {
+    format!("{broker_name}.{broker_id}")
 }
 
 fn source_failure(source: AdminQuerySource, logical_target: &str, error: &RocketMQError) -> AdminSourceFailure {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/exact_broker.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/exact_broker.rs
@@ -1,0 +1,318 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::body::broker_body::cluster_info::ClusterInfo;
+
+use crate::core::broker::MAX_EXACT_BROKER_INSTANCES;
+use crate::core::query::AdminQueryFailureCode;
+use crate::core::query::AdminQuerySource;
+use crate::core::query::AdminSourceFailure;
+use crate::core::AdminError;
+use crate::core::AdminResult;
+
+pub(crate) type ExactBrokerTargetResolution = (Vec<(u64, CheetahString)>, Vec<AdminSourceFailure>);
+
+pub(crate) fn resolve_exact_broker_targets(
+    cluster_info: ClusterInfo,
+    cluster: &str,
+    broker_name: &str,
+    source: AdminQuerySource,
+) -> AdminResult<ExactBrokerTargetResolution> {
+    let cluster_table = cluster_info.cluster_addr_table.as_ref().ok_or_else(|| {
+        AdminError::backend(
+            "resolve_exact_broker_targets",
+            "NameServer cluster metadata is unavailable",
+        )
+    })?;
+    let broker_names = cluster_table.get(cluster).cloned().unwrap_or_default();
+    if !broker_names.iter().any(|candidate| candidate.as_str() == broker_name) {
+        return Err(AdminError::not_found("broker", broker_name));
+    }
+
+    let broker_table = cluster_info.broker_addr_table.ok_or_else(|| {
+        AdminError::backend(
+            "resolve_exact_broker_targets",
+            "NameServer Broker metadata is unavailable",
+        )
+    })?;
+    let Some(broker) = broker_table.get(broker_name) else {
+        return Ok((
+            Vec::new(),
+            vec![AdminSourceFailure::new(
+                source,
+                AdminQueryFailureCode::InvalidResponse,
+                false,
+                broker_name,
+            )],
+        ));
+    };
+    if broker.cluster() != cluster || broker.broker_name().as_str() != broker_name {
+        return Ok((
+            Vec::new(),
+            vec![AdminSourceFailure::new(
+                source,
+                AdminQueryFailureCode::InvalidResponse,
+                false,
+                broker_name,
+            )],
+        ));
+    }
+    if broker.broker_addrs().is_empty() {
+        return Ok((
+            Vec::new(),
+            vec![AdminSourceFailure::new(
+                source,
+                AdminQueryFailureCode::InvalidResponse,
+                false,
+                broker_name,
+            )],
+        ));
+    }
+    if broker.broker_addrs().len() > MAX_EXACT_BROKER_INSTANCES {
+        return Err(AdminError::backend(
+            "resolve_exact_broker_targets",
+            "logical Broker has too many physical instances",
+        ));
+    }
+
+    let mut endpoint_counts = BTreeMap::<&str, usize>::new();
+    for endpoint in broker.broker_addrs().values() {
+        *endpoint_counts.entry(endpoint.as_str()).or_default() += 1;
+    }
+    if endpoint_counts.values().any(|count| *count > 1) {
+        return Ok((
+            Vec::new(),
+            vec![AdminSourceFailure::new(
+                source,
+                AdminQueryFailureCode::InvalidResponse,
+                false,
+                broker_name,
+            )],
+        ));
+    }
+
+    let mut targets = Vec::new();
+    let mut failures = Vec::new();
+    for (broker_id, address) in broker.broker_addrs() {
+        let logical_target = broker_instance_target(broker_name, *broker_id);
+        if !crate::core::broker::is_valid_remoting_endpoint(address.as_str()) {
+            failures.push(AdminSourceFailure::new(
+                source,
+                AdminQueryFailureCode::InvalidResponse,
+                false,
+                logical_target,
+            ));
+        } else {
+            targets.push((*broker_id, address.clone()));
+        }
+    }
+    targets.sort_by(|left, right| left.0.cmp(&right.0).then(left.1.cmp(&right.1)));
+    Ok((targets, failures))
+}
+
+fn broker_instance_target(broker_name: &str, broker_id: u64) -> String {
+    format!("{broker_name}.{broker_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
+
+    use super::*;
+
+    const CLUSTER: &str = "DefaultCluster";
+    const BROKER: &str = "broker-a";
+
+    #[test]
+    fn resolves_single_and_multiple_instances_in_broker_id_order() {
+        let (single, failures) = resolve_exact_broker_targets(
+            cluster_info([(0, "broker-a.internal:10911")]),
+            CLUSTER,
+            BROKER,
+            AdminQuerySource::BrokerRuntime,
+        )
+        .unwrap();
+        assert_eq!(single.iter().map(|(id, _)| *id).collect::<Vec<_>>(), vec![0]);
+        assert!(failures.is_empty());
+
+        let (multiple, failures) = resolve_exact_broker_targets(
+            cluster_info([
+                (2, "broker-a-2.internal:10911"),
+                (0, "broker-a-0.internal:10911"),
+                (1, "broker-a-1.internal:10911"),
+            ]),
+            CLUSTER,
+            BROKER,
+            AdminQuerySource::BrokerRuntime,
+        )
+        .unwrap();
+        assert_eq!(multiple.iter().map(|(id, _)| *id).collect::<Vec<_>>(), vec![0, 1, 2]);
+        assert!(failures.is_empty());
+    }
+
+    #[test]
+    fn differentiates_not_found_from_missing_or_inconsistent_metadata() {
+        let missing =
+            resolve_exact_broker_targets(ClusterInfo::default(), CLUSTER, BROKER, AdminQuerySource::BrokerRuntime)
+                .unwrap_err();
+        assert!(matches!(missing, AdminError::Backend { .. }));
+
+        let not_found = resolve_exact_broker_targets(
+            ClusterInfo::new(Some(HashMap::new()), Some(HashMap::new())),
+            CLUSTER,
+            BROKER,
+            AdminQuerySource::BrokerRuntime,
+        )
+        .unwrap_err();
+        assert!(matches!(not_found, AdminError::NotFound { .. }));
+
+        let mut wrong_cluster = cluster_info([(0, "broker-a.internal:10911")]);
+        wrong_cluster
+            .broker_addr_table
+            .as_mut()
+            .unwrap()
+            .get_mut(BROKER)
+            .unwrap()
+            .set_cluster("OtherCluster".into());
+        let (targets, failures) =
+            resolve_exact_broker_targets(wrong_cluster, CLUSTER, BROKER, AdminQuerySource::BrokerRuntime).unwrap();
+        assert!(targets.is_empty());
+        assert_eq!(failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+
+        let mut wrong_name = cluster_info([(0, "broker-a.internal:10911")]);
+        wrong_name
+            .broker_addr_table
+            .as_mut()
+            .unwrap()
+            .get_mut(BROKER)
+            .unwrap()
+            .set_broker_name("broker-b".into());
+        let (targets, failures) =
+            resolve_exact_broker_targets(wrong_name, CLUSTER, BROKER, AdminQuerySource::BrokerRuntime).unwrap();
+        assert!(targets.is_empty());
+        assert_eq!(failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+    }
+
+    #[test]
+    fn enforces_entry_cap_before_filtering_and_rejects_duplicate_endpoints() {
+        let sixty_four = (0..64)
+            .map(|id| (id, format!("broker-a-{id}.internal:10911")))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            resolve_exact_broker_targets(
+                cluster_info(sixty_four.iter().map(|(id, endpoint)| (*id, endpoint.as_str()))),
+                CLUSTER,
+                BROKER,
+                AdminQuerySource::BrokerRuntime,
+            )
+            .unwrap()
+            .0
+            .len(),
+            64
+        );
+
+        let sixty_five = (0..65)
+            .map(|id| {
+                (
+                    id,
+                    if id == 64 {
+                        "".to_string()
+                    } else {
+                        format!("broker-a-{id}.internal:10911")
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        let overflow = resolve_exact_broker_targets(
+            cluster_info(sixty_five.iter().map(|(id, endpoint)| (*id, endpoint.as_str()))),
+            CLUSTER,
+            BROKER,
+            AdminQuerySource::BrokerRuntime,
+        )
+        .unwrap_err();
+        assert!(matches!(overflow, AdminError::Backend { .. }));
+
+        let (targets, failures) = resolve_exact_broker_targets(
+            cluster_info([(0, "duplicate.internal:10911"), (1, "duplicate.internal:10911")]),
+            CLUSTER,
+            BROKER,
+            AdminQuerySource::BrokerRuntime,
+        )
+        .unwrap();
+        assert!(targets.is_empty());
+        assert_eq!(failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+    }
+
+    #[test]
+    fn blank_instance_is_a_partial_source_failure() {
+        let (targets, failures) = resolve_exact_broker_targets(
+            cluster_info([(0, "broker-a.internal:10911"), (1, "")]),
+            CLUSTER,
+            BROKER,
+            AdminQuerySource::BrokerRuntime,
+        )
+        .unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].logical_target(), "broker-a.1");
+    }
+
+    #[test]
+    fn exact_source_aggregation_preserves_partial_rows_and_rejects_total_failure() {
+        let (targets, failures) = resolve_exact_broker_targets(
+            cluster_info([(0, "broker-a.internal:10911"), (1, "")]),
+            CLUSTER,
+            BROKER,
+            AdminQuerySource::BrokerRuntime,
+        )
+        .unwrap();
+        let partial = crate::core::query::AdminQueryResult::from_sources(targets.clone(), targets.len(), failures)
+            .expect("one physical source succeeded");
+        assert!(partial.partial);
+        assert_eq!(partial.data, targets);
+        assert_eq!(partial.source_failures.len(), 1);
+
+        let (targets, failures) = resolve_exact_broker_targets(
+            cluster_info([(0, "")]),
+            CLUSTER,
+            BROKER,
+            AdminQuerySource::BrokerRuntime,
+        )
+        .unwrap();
+        let error = crate::core::query::AdminQueryResult::from_sources(targets, 0, failures)
+            .expect_err("all physical sources failed");
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+    }
+
+    fn cluster_info<'a>(addresses: impl IntoIterator<Item = (u64, &'a str)>) -> ClusterInfo {
+        let broker_addrs = addresses
+            .into_iter()
+            .map(|(id, endpoint)| (id, CheetahString::from(endpoint)))
+            .collect();
+        let broker = BrokerData::new(CLUSTER.into(), BROKER.into(), broker_addrs, None);
+        ClusterInfo::new(
+            Some(HashMap::from([(BROKER.into(), broker)])),
+            Some(HashMap::from([(
+                CLUSTER.into(),
+                HashSet::from([CheetahString::from(BROKER)]),
+            )])),
+        )
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
@@ -45,7 +45,9 @@ use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use crate::core::broker::project_broker_diagnostics;
 use crate::core::broker::project_broker_log_filter_state;
 use crate::core::broker::BrokerAllowlistedConfig;
+use crate::core::broker::BrokerAllowlistedConfigTarget;
 use crate::core::broker::BrokerLogFilterState;
+use crate::core::broker::BrokerLogFilterStateTarget;
 use crate::core::broker::BrokerQueryAdmin;
 use crate::core::broker::BrokerRuntimeTargetStatus;
 use crate::core::broker::BrokerSummary;
@@ -55,9 +57,12 @@ use crate::core::broker::ProbeBrokerRuntimeRequest;
 use crate::core::broker::ProbeBrokerRuntimeResult;
 use crate::core::broker::ProbeBrokerRuntimeTargetRequest;
 use crate::core::broker::QueryBrokerAllowlistedConfigRequest;
+use crate::core::broker::QueryBrokerAllowlistedConfigTargetRequest;
 use crate::core::broker::QueryBrokerDiagnosticsRequest;
 use crate::core::broker::QueryBrokerDiagnosticsResult;
+use crate::core::broker::QueryBrokerDiagnosticsTargetRequest;
 use crate::core::broker::QueryBrokerLogFilterStateRequest;
+use crate::core::broker::QueryBrokerLogFilterStateTargetRequest;
 use crate::core::client_connection::ClientConnectionObservation;
 use crate::core::client_connection::ClientConnectionQueryAdmin;
 use crate::core::client_connection::ListProducerConnectionsRequest;
@@ -680,6 +685,63 @@ impl BrokerQueryAdmin for ReadAdminSession {
         })
     }
 
+    fn query_broker_diagnostics_target_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryBrokerDiagnosticsTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryBrokerDiagnosticsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let (targets, mut failures) = exact_broker_targets(
+                &self.inner,
+                request.cluster(),
+                request.broker_name(),
+                AdminQuerySource::BrokerRuntime,
+            )
+            .await?;
+            let observed_at_millis = self.clock.now_millis();
+            let mut brokers = Vec::new();
+            let mut successful_sources = 0usize;
+            for (broker_id, broker_addr) in targets {
+                let logical_target = broker_instance_target(request.broker_name(), broker_id);
+                match self.inner.fetch_broker_runtime_stats(broker_addr).await {
+                    Ok(runtime) => {
+                        successful_sources += 1;
+                        brokers.push(project_broker_diagnostics(
+                            request.broker_name().to_string(),
+                            broker_id,
+                            &runtime,
+                        ));
+                    }
+                    Err(error) => failures.push(source_failure_from_error(
+                        AdminQuerySource::BrokerRuntime,
+                        &logical_target,
+                        &error,
+                    )),
+                }
+            }
+            brokers.sort_by_key(|broker| broker.broker_id);
+            let unavailable_brokers = failures.len();
+            let partial_diagnostics = brokers
+                .iter()
+                .any(|broker| broker.coverage != crate::core::broker::BrokerDiagnosticsCoverage::Available);
+            let data = QueryBrokerDiagnosticsResult {
+                schema_version: crate::core::broker::BROKER_DIAGNOSTICS_SCHEMA_VERSION.to_owned(),
+                observed_at_millis,
+                brokers,
+                unavailable_brokers,
+                partial: unavailable_brokers > 0 || partial_diagnostics,
+            };
+            let mut result = AdminQueryResult::from_sources(data, successful_sources, failures)?;
+            if partial_diagnostics {
+                result.partial = true;
+                result.warnings.push("broker_diagnostics_incomplete".to_string());
+                result.warnings.sort();
+                result.warnings.dedup();
+            }
+            Ok(result)
+        })
+    }
+
     fn query_allowlisted_config<'a>(
         &'a mut self,
         request: &'a QueryBrokerAllowlistedConfigRequest,
@@ -691,6 +753,44 @@ impl BrokerQueryAdmin for ReadAdminSession {
                 .await
                 .map(project_allowlisted_config)
                 .map_err(|error| backend_error("get_broker_config_allowlisted", error))
+        })
+    }
+
+    fn query_allowlisted_config_target_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryBrokerAllowlistedConfigTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerAllowlistedConfigTarget>>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let (targets, mut failures) = exact_broker_targets(
+                &self.inner,
+                request.cluster(),
+                request.broker_name(),
+                AdminQuerySource::BrokerConfig,
+            )
+            .await?;
+            let mut rows = Vec::new();
+            let mut successful_sources = 0usize;
+            for (broker_id, broker_addr) in targets {
+                let logical_target = broker_instance_target(request.broker_name(), broker_id);
+                match self.inner.get_broker_config_allowlisted(broker_addr).await {
+                    Ok(config) => {
+                        successful_sources += 1;
+                        rows.push(BrokerAllowlistedConfigTarget {
+                            broker_name: request.broker_name().to_string(),
+                            broker_id,
+                            config: project_allowlisted_config(config),
+                        });
+                    }
+                    Err(error) => failures.push(source_failure_from_error(
+                        AdminQuerySource::BrokerConfig,
+                        &logical_target,
+                        &error,
+                    )),
+                }
+            }
+            rows.sort_by_key(|row| row.broker_id);
+            AdminQueryResult::from_sources(rows, successful_sources, failures)
         })
     }
 
@@ -706,6 +806,44 @@ impl BrokerQueryAdmin for ReadAdminSession {
                 .await
                 .map_err(|error| backend_error("fetch_broker_runtime_stats", error))?;
             Ok(project_broker_log_filter_state(request.logger.clone(), &runtime))
+        })
+    }
+
+    fn query_log_filter_state_target_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryBrokerLogFilterStateTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerLogFilterStateTarget>>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let (targets, mut failures) = exact_broker_targets(
+                &self.inner,
+                request.cluster(),
+                request.broker_name(),
+                AdminQuerySource::BrokerLogFilter,
+            )
+            .await?;
+            let mut rows = Vec::new();
+            let mut successful_sources = 0usize;
+            for (broker_id, broker_addr) in targets {
+                let logical_target = broker_instance_target(request.broker_name(), broker_id);
+                match self.inner.fetch_broker_runtime_stats(broker_addr).await {
+                    Ok(runtime) => {
+                        successful_sources += 1;
+                        rows.push(BrokerLogFilterStateTarget {
+                            broker_name: request.broker_name().to_string(),
+                            broker_id,
+                            state: project_broker_log_filter_state(request.logger().to_string(), &runtime),
+                        });
+                    }
+                    Err(error) => failures.push(source_failure_from_error(
+                        AdminQuerySource::BrokerLogFilter,
+                        &logical_target,
+                        &error,
+                    )),
+                }
+            }
+            rows.sort_by_key(|row| row.broker_id);
+            AdminQueryResult::from_sources(rows, successful_sources, failures)
         })
     }
 }
@@ -1594,6 +1732,23 @@ async fn cluster_broker_targets(admin: &DefaultMQAdminExt, cluster: &str) -> Adm
         .into_iter()
         .map(|(broker_name, _, address)| (broker_name, address))
         .collect())
+}
+
+async fn exact_broker_targets(
+    admin: &DefaultMQAdminExt,
+    cluster: &str,
+    broker_name: &str,
+    source: AdminQuerySource,
+) -> AdminResult<(Vec<(u64, CheetahString)>, Vec<AdminSourceFailure>)> {
+    let cluster_info = admin
+        .examine_broker_cluster_info()
+        .await
+        .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+    crate::exact_broker::resolve_exact_broker_targets(cluster_info, cluster, broker_name, source)
+}
+
+fn broker_instance_target(broker_name: &str, broker_id: u64) -> String {
+    format!("{broker_name}.{broker_id}")
 }
 
 async fn cluster_broker_targets_with_evidence(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker.rs
@@ -32,6 +32,8 @@ use crate::core::AdminResult;
 pub const BROKER_DIAGNOSTICS_SCHEMA_VERSION: &str = "rocketmq.admin-broker-diagnostics.v1";
 /// Stable schema version emitted by the bounded Broker log-filter query.
 pub const BROKER_LOG_FILTER_STATE_SCHEMA_VERSION: &str = "rocketmq.admin-broker-log-filter-state.v1";
+/// Maximum number of physical instances accepted for one logical Broker.
+pub const MAX_EXACT_BROKER_INSTANCES: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ListBrokersRequest {
@@ -120,6 +122,54 @@ impl QueryBrokerDiagnosticsRequest {
         Ok(Self {
             cluster: required("cluster", cluster)?,
         })
+    }
+}
+
+/// Exact logical Broker target for bounded diagnostics queries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct QueryBrokerDiagnosticsTargetRequest {
+    cluster: String,
+    broker_name: String,
+}
+
+impl QueryBrokerDiagnosticsTargetRequest {
+    /// Creates a diagnostics request for one logical Broker name in one cluster.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `cluster` is blank or `broker_name` is not a
+    /// bounded logical name. Network addresses are intentionally rejected.
+    pub fn try_new(cluster: impl Into<String>, broker_name: impl Into<String>) -> AdminResult<Self> {
+        Ok(Self {
+            cluster: required("cluster", cluster)?,
+            broker_name: logical_broker_name(broker_name)?,
+        })
+    }
+
+    #[must_use]
+    pub fn cluster(&self) -> &str {
+        &self.cluster
+    }
+
+    #[must_use]
+    pub fn broker_name(&self) -> &str {
+        &self.broker_name
+    }
+}
+
+impl<'de> Deserialize<'de> for QueryBrokerDiagnosticsTargetRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct WireRequest {
+            cluster: String,
+            broker_name: String,
+        }
+        let wire = WireRequest::deserialize(deserializer)?;
+        Self::try_new(wire.cluster, wire.broker_name).map_err(serde::de::Error::custom)
     }
 }
 
@@ -301,6 +351,54 @@ impl QueryBrokerAllowlistedConfigRequest {
     }
 }
 
+/// Exact logical Broker target for fixed allowlisted configuration reads.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct QueryBrokerAllowlistedConfigTargetRequest {
+    cluster: String,
+    broker_name: String,
+}
+
+impl QueryBrokerAllowlistedConfigTargetRequest {
+    /// Creates a fixed allowlisted configuration request for one logical Broker.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `cluster` is blank or `broker_name` is not a
+    /// bounded logical name. Network addresses are intentionally rejected.
+    pub fn try_new(cluster: impl Into<String>, broker_name: impl Into<String>) -> AdminResult<Self> {
+        Ok(Self {
+            cluster: required("cluster", cluster)?,
+            broker_name: logical_broker_name(broker_name)?,
+        })
+    }
+
+    #[must_use]
+    pub fn cluster(&self) -> &str {
+        &self.cluster
+    }
+
+    #[must_use]
+    pub fn broker_name(&self) -> &str {
+        &self.broker_name
+    }
+}
+
+impl<'de> Deserialize<'de> for QueryBrokerAllowlistedConfigTargetRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct WireRequest {
+            cluster: String,
+            broker_name: String,
+        }
+        let wire = WireRequest::deserialize(deserializer)?;
+        Self::try_new(wire.cluster, wire.broker_name).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Fixed, non-sensitive Broker properties supported by supervised SRE changes.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BrokerAllowlistedConfig {
@@ -309,6 +407,14 @@ pub struct BrokerAllowlistedConfig {
     pub pull_message_thread_pool_nums: Option<u32>,
     pub flush_delay_offset_interval_ms: Option<u64>,
     pub max_client_event_count: Option<i32>,
+}
+
+/// One address-free Broker instance configuration observation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrokerAllowlistedConfigTarget {
+    pub broker_name: String,
+    pub broker_id: u64,
+    pub config: BrokerAllowlistedConfig,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -357,6 +463,67 @@ impl QueryBrokerLogFilterStateRequest {
     }
 }
 
+/// Exact logical Broker target for one allowlisted logger read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct QueryBrokerLogFilterStateTargetRequest {
+    cluster: String,
+    broker_name: String,
+    logger: String,
+}
+
+impl QueryBrokerLogFilterStateTargetRequest {
+    /// Creates a log-filter query for one logical Broker and logger namespace.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `cluster` is blank, `broker_name` is not a
+    /// bounded logical name, or `logger` is not a strict ASCII Rust module path
+    /// rooted at `rocketmq_broker`.
+    pub fn try_new(
+        cluster: impl Into<String>,
+        broker_name: impl Into<String>,
+        logger: impl Into<String>,
+    ) -> AdminResult<Self> {
+        Ok(Self {
+            cluster: required("cluster", cluster)?,
+            broker_name: logical_broker_name(broker_name)?,
+            logger: logical_broker_logger(logger)?,
+        })
+    }
+
+    #[must_use]
+    pub fn cluster(&self) -> &str {
+        &self.cluster
+    }
+
+    #[must_use]
+    pub fn broker_name(&self) -> &str {
+        &self.broker_name
+    }
+
+    #[must_use]
+    pub fn logger(&self) -> &str {
+        &self.logger
+    }
+}
+
+impl<'de> Deserialize<'de> for QueryBrokerLogFilterStateTargetRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct WireRequest {
+            cluster: String,
+            broker_name: String,
+            logger: String,
+        }
+        let wire = WireRequest::deserialize(deserializer)?;
+        Self::try_new(wire.cluster, wire.broker_name, wire.logger).map_err(serde::de::Error::custom)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BrokerLogFilterState {
     pub schema_version: String,
@@ -366,6 +533,14 @@ pub struct BrokerLogFilterState {
     pub active_operation_id: Option<String>,
     pub last_completed_operation_id: Option<String>,
     pub expires_at_millis: Option<u64>,
+}
+
+/// One address-free Broker instance log-filter observation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrokerLogFilterStateTarget {
+    pub broker_name: String,
+    pub broker_id: u64,
+    pub state: BrokerLogFilterState,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -466,10 +641,44 @@ pub trait BrokerAdmin: Send {
         request: &'a QueryBrokerDiagnosticsRequest,
     ) -> AdminFuture<'a, QueryBrokerDiagnosticsResult>;
 
+    /// Evidence-aware exact logical-target diagnostics query.
+    ///
+    /// Explicit metadata non-membership is `NotFound`. Missing or inconsistent
+    /// metadata is a backend error. Partial physical-source success returns rows
+    /// with bounded evidence; total source failure returns an error.
+    fn query_broker_diagnostics_target_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a QueryBrokerDiagnosticsTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryBrokerDiagnosticsResult>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "query_broker_diagnostics_target",
+                "exact Broker diagnostics are not implemented by this adapter",
+            ))
+        })
+    }
+
     fn query_allowlisted_config<'a>(
         &'a mut self,
         request: &'a QueryBrokerAllowlistedConfigRequest,
     ) -> AdminFuture<'a, BrokerAllowlistedConfig>;
+
+    /// Evidence-aware exact logical-target allowlisted configuration query.
+    ///
+    /// Explicit metadata non-membership is `NotFound`. Missing or inconsistent
+    /// metadata is a backend error. Partial physical-source success returns rows
+    /// with bounded evidence; total source failure returns an error.
+    fn query_allowlisted_config_target_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a QueryBrokerAllowlistedConfigTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerAllowlistedConfigTarget>>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "query_allowlisted_config_target",
+                "exact Broker configuration query is not implemented by this adapter",
+            ))
+        })
+    }
 
     fn query_log_filter_state<'a>(
         &'a mut self,
@@ -479,6 +688,23 @@ pub trait BrokerAdmin: Send {
             Err(crate::core::AdminError::backend(
                 "query_log_filter_state",
                 "typed Broker log-filter query is not implemented by this adapter",
+            ))
+        })
+    }
+
+    /// Evidence-aware exact logical-target log-filter query.
+    ///
+    /// Explicit metadata non-membership is `NotFound`. Missing or inconsistent
+    /// metadata is a backend error. Partial physical-source success returns rows
+    /// with bounded evidence; total source failure returns an error.
+    fn query_log_filter_state_target_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a QueryBrokerLogFilterStateTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerLogFilterStateTarget>>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "query_log_filter_state_target",
+                "exact Broker log-filter query is not implemented by this adapter",
             ))
         })
     }
@@ -527,10 +753,44 @@ pub trait BrokerQueryAdmin: Send {
         request: &'a QueryBrokerDiagnosticsRequest,
     ) -> AdminFuture<'a, QueryBrokerDiagnosticsResult>;
 
+    /// Evidence-aware exact logical-target diagnostics query.
+    ///
+    /// Explicit metadata non-membership is `NotFound`. Missing or inconsistent
+    /// metadata is a backend error. Partial physical-source success returns rows
+    /// with bounded evidence; total source failure returns an error.
+    fn query_broker_diagnostics_target_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a QueryBrokerDiagnosticsTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryBrokerDiagnosticsResult>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "query_broker_diagnostics_target",
+                "exact Broker diagnostics are not implemented by this adapter",
+            ))
+        })
+    }
+
     fn query_allowlisted_config<'a>(
         &'a mut self,
         request: &'a QueryBrokerAllowlistedConfigRequest,
     ) -> AdminFuture<'a, BrokerAllowlistedConfig>;
+
+    /// Evidence-aware exact logical-target allowlisted configuration query.
+    ///
+    /// Explicit metadata non-membership is `NotFound`. Missing or inconsistent
+    /// metadata is a backend error. Partial physical-source success returns rows
+    /// with bounded evidence; total source failure returns an error.
+    fn query_allowlisted_config_target_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a QueryBrokerAllowlistedConfigTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerAllowlistedConfigTarget>>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "query_allowlisted_config_target",
+                "exact Broker configuration query is not implemented by this adapter",
+            ))
+        })
+    }
 
     fn query_log_filter_state<'a>(
         &'a mut self,
@@ -540,6 +800,23 @@ pub trait BrokerQueryAdmin: Send {
             Err(crate::core::AdminError::backend(
                 "query_log_filter_state",
                 "typed Broker log-filter query is not implemented by this adapter",
+            ))
+        })
+    }
+
+    /// Evidence-aware exact logical-target log-filter query.
+    ///
+    /// Explicit metadata non-membership is `NotFound`. Missing or inconsistent
+    /// metadata is a backend error. Partial physical-source success returns rows
+    /// with bounded evidence; total source failure returns an error.
+    fn query_log_filter_state_target_with_evidence<'a>(
+        &'a mut self,
+        _request: &'a QueryBrokerLogFilterStateTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerLogFilterStateTarget>>> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "query_log_filter_state_target",
+                "exact Broker log-filter query is not implemented by this adapter",
             ))
         })
     }
@@ -585,6 +862,13 @@ impl<T: BrokerAdmin + ?Sized> BrokerQueryAdmin for T {
         BrokerAdmin::query_broker_diagnostics(self, request)
     }
 
+    fn query_broker_diagnostics_target_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryBrokerDiagnosticsTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryBrokerDiagnosticsResult>> {
+        BrokerAdmin::query_broker_diagnostics_target_with_evidence(self, request)
+    }
+
     fn query_allowlisted_config<'a>(
         &'a mut self,
         request: &'a QueryBrokerAllowlistedConfigRequest,
@@ -592,11 +876,25 @@ impl<T: BrokerAdmin + ?Sized> BrokerQueryAdmin for T {
         BrokerAdmin::query_allowlisted_config(self, request)
     }
 
+    fn query_allowlisted_config_target_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryBrokerAllowlistedConfigTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerAllowlistedConfigTarget>>> {
+        BrokerAdmin::query_allowlisted_config_target_with_evidence(self, request)
+    }
+
     fn query_log_filter_state<'a>(
         &'a mut self,
         request: &'a QueryBrokerLogFilterStateRequest,
     ) -> AdminFuture<'a, BrokerLogFilterState> {
         BrokerAdmin::query_log_filter_state(self, request)
+    }
+
+    fn query_log_filter_state_target_with_evidence<'a>(
+        &'a mut self,
+        request: &'a QueryBrokerLogFilterStateTargetRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<Vec<BrokerLogFilterStateTarget>>> {
+        BrokerAdmin::query_log_filter_state_target_with_evidence(self, request)
     }
 }
 
@@ -690,6 +988,112 @@ fn broker_logger(logger: impl Into<String>) -> AdminResult<String> {
     }
 }
 
+fn logical_broker_name(broker_name: impl Into<String>) -> AdminResult<String> {
+    let broker_name = required("broker_name", broker_name)?;
+    if broker_name.len() > 100
+        || broker_name.parse::<std::net::IpAddr>().is_ok()
+        || broker_name.parse::<std::net::SocketAddr>().is_ok()
+        || broker_name.contains([':', '/', '\\', '@', '=', '&', '?'])
+        || broker_name.chars().any(char::is_control)
+        || !broker_name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        Err(crate::core::AdminError::invalid_argument(
+            "broker_name",
+            "must be a logical Broker identifier of at most 100 bytes",
+        ))
+    } else {
+        Ok(broker_name)
+    }
+}
+
+/// Returns whether a value is one bounded RocketMQ remoting `host:port` endpoint.
+///
+/// DNS names, IPv4, and bracketed IPv6 are supported. URLs, user information,
+/// paths, queries, whitespace, zero ports, and unbracketed IPv6 are rejected.
+#[must_use]
+pub fn is_valid_remoting_endpoint(endpoint: &str) -> bool {
+    if endpoint.is_empty()
+        || endpoint.len() > 512
+        || endpoint.chars().any(char::is_whitespace)
+        || endpoint
+            .chars()
+            .any(|character| matches!(character, '/' | '\\' | '?' | '#' | '@' | '='))
+    {
+        return false;
+    }
+    let (host, port) = if let Some(rest) = endpoint.strip_prefix('[') {
+        let Some((host, port)) = rest.split_once("]:") else {
+            return false;
+        };
+        if host.parse::<std::net::Ipv6Addr>().is_err() {
+            return false;
+        }
+        (host, port)
+    } else {
+        let Some((host, port)) = endpoint.rsplit_once(':') else {
+            return false;
+        };
+        if host.contains(':') || !valid_remoting_host(host) {
+            return false;
+        }
+        (host, port)
+    };
+    !host.is_empty() && port.parse::<u16>().is_ok_and(|port| port != 0)
+}
+
+fn valid_remoting_host(host: &str) -> bool {
+    if host.parse::<std::net::Ipv4Addr>().is_ok() {
+        return true;
+    }
+    if host
+        .chars()
+        .all(|character| character.is_ascii_digit() || character == '.')
+    {
+        return false;
+    }
+    !host.is_empty()
+        && host.len() <= 253
+        && host.split('.').all(|label| {
+            !label.is_empty()
+                && label.len() <= 63
+                && !label.starts_with('-')
+                && !label.ends_with('-')
+                && label
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || character == '-')
+        })
+}
+
+fn logical_broker_logger(logger: impl Into<String>) -> AdminResult<String> {
+    let logger = logger.into();
+    let valid = logger == logger.trim()
+        && logger.len() <= 128
+        && logger
+            .strip_prefix("rocketmq_broker::")
+            .is_some_and(valid_rust_module_path);
+    if valid {
+        Ok(logger)
+    } else {
+        Err(crate::core::AdminError::invalid_argument(
+            "logger",
+            "must be an allowlisted rocketmq_broker:: target of at most 128 bytes",
+        ))
+    }
+}
+
+fn valid_rust_module_path(path: &str) -> bool {
+    !path.is_empty()
+        && path.split("::").all(|segment| {
+            let mut characters = segment.chars();
+            characters
+                .next()
+                .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+                && characters.all(|character| character.is_ascii_alphanumeric() || character == '_')
+        })
+}
+
 fn bounded_operation_id(operation_id: impl Into<String>) -> AdminResult<String> {
     let operation_id = required("operation_id", operation_id)?;
     if operation_id.len() > 128 || operation_id.chars().any(char::is_control) {
@@ -736,7 +1140,10 @@ fn effective_log_level(filter: &str, logger: &str) -> Option<BrokerLogLevel> {
 #[cfg(any(feature = "read-client-adapter", test))]
 pub(crate) fn project_broker_diagnostics(broker_name: String, broker_id: u64, runtime: &KVTable) -> BrokerDiagnostics {
     let schema = runtime_value(runtime, "sreDiagnosticsSchemaVersion");
-    if schema != Some("rocketmq.broker-diagnostics.v1") {
+    if !matches!(
+        schema,
+        Some("rocketmq.broker-diagnostics.v1" | "rocketmq.broker-diagnostics.legacy")
+    ) {
         return unsupported_diagnostics(broker_name, broker_id);
     }
 
@@ -964,9 +1371,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn diagnostics_projection_uses_real_generation_and_never_serializes_unknown_kv_fields() {
+    fn diagnostics_projection_accepts_the_current_broker_contract_and_uses_safe_fields_only() {
         let table = HashMap::from([
-            ("sreDiagnosticsSchemaVersion", "rocketmq.broker-diagnostics.v1"),
+            ("sreDiagnosticsSchemaVersion", "rocketmq.broker-diagnostics.legacy"),
             ("sreDiagnosticsObservedAtMillis", "1000"),
             ("brokerConfigGeneration", "9"),
             ("brokerReady", "true"),
@@ -975,7 +1382,7 @@ mod tests {
             ("brokerRegistrationAccepting", "true"),
             ("brokerRegistrationConfigured", "true"),
             ("brokerRole", "ASYNC_MASTER"),
-            ("storeType", "local"),
+            ("storeType", "LocalFile"),
             ("timerWheelEnabled", "false"),
             ("transientStorePoolEnabled", "false"),
             ("tieredStoreConfigured", "false"),
@@ -1019,6 +1426,10 @@ mod tests {
         let diagnostics = project_broker_diagnostics("broker-a".to_owned(), 0, &KVTable { table });
 
         assert_eq!(diagnostics.config.as_ref().map(|config| config.generation), Some(9));
+        assert_eq!(
+            diagnostics.config.as_ref().map(|config| config.store_type.as_str()),
+            Some("LocalFile")
+        );
         assert_eq!(diagnostics.coverage, BrokerDiagnosticsCoverage::Available);
         let encoded = serde_json::to_string(&diagnostics).expect("diagnostics should serialize");
         assert!(!encoded.contains("secretAccessKey"));
@@ -1030,6 +1441,63 @@ mod tests {
         let diagnostics = project_broker_diagnostics("broker-a".to_owned(), 0, &KVTable { table: HashMap::new() });
         assert_eq!(diagnostics.coverage, BrokerDiagnosticsCoverage::Unsupported);
         assert!(diagnostics.config.is_none());
+    }
+
+    #[test]
+    fn logical_broker_requests_validate_construction_and_deserialization() {
+        let diagnostics = QueryBrokerDiagnosticsTargetRequest::try_new("DefaultCluster", "broker-a").unwrap();
+        assert_eq!(diagnostics.cluster(), "DefaultCluster");
+        assert_eq!(diagnostics.broker_name(), "broker-a");
+        assert!(QueryBrokerDiagnosticsTargetRequest::try_new("DefaultCluster", "127.0.0.1:10911").is_err());
+        assert!(serde_json::from_str::<QueryBrokerDiagnosticsTargetRequest>(
+            r#"{"cluster":"DefaultCluster","broker_name":"broker-a","broker_addr":"secret:10911"}"#,
+        )
+        .is_err());
+
+        let config = serde_json::from_str::<QueryBrokerAllowlistedConfigTargetRequest>(
+            r#"{"cluster":"DefaultCluster","broker_name":"broker-a"}"#,
+        )
+        .unwrap();
+        assert_eq!(config.cluster(), "DefaultCluster");
+        assert_eq!(config.broker_name(), "broker-a");
+
+        let log = QueryBrokerLogFilterStateTargetRequest::try_new(
+            "DefaultCluster",
+            "broker-a",
+            "rocketmq_broker::processor::send_message",
+        )
+        .unwrap();
+        assert_eq!(log.logger(), "rocketmq_broker::processor::send_message");
+        for invalid in [
+            "rocketmq_broker::",
+            "rocketmq_broker::processor::",
+            "rocketmq_broker::processor target",
+            "rocketmq_broker::127.0.0.1:10911",
+            " rocketmq_broker::processor",
+        ] {
+            assert!(QueryBrokerLogFilterStateTargetRequest::try_new("DefaultCluster", "broker-a", invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn remoting_endpoint_validation_accepts_only_one_safe_host_and_port() {
+        for valid in ["127.0.0.1:10911", "broker-a.internal:10911", "[2001:db8::1]:10911"] {
+            assert!(is_valid_remoting_endpoint(valid), "endpoint={valid}");
+        }
+        for invalid in [
+            "https://broker-a.internal:10911",
+            "broker-a.internal:10911/path",
+            "user@broker-a.internal:10911",
+            "broker-a.internal:10911?token=secret",
+            " broker-a.internal:10911",
+            "broker-a.internal:10911 ",
+            "2001:db8::1:10911",
+            "broker-a.internal:0",
+            "broker-a.internal:65536",
+            "999.999.999.999:10911",
+        ] {
+            assert!(!is_valid_remoting_endpoint(invalid), "endpoint={invalid}");
+        }
     }
 
     #[test]
@@ -1085,5 +1553,44 @@ mod tests {
         assert!(!encoded.contains("sreLogFilterEffective"));
         assert!(!encoded.contains("secretToken"));
         assert!(!encoded.contains("must-not-escape"));
+    }
+
+    #[test]
+    fn address_log_filter_apis_preserve_their_legacy_acceptance_contract() {
+        let query = QueryBrokerLogFilterStateRequest::try_new(
+            " broker.internal:10911 ",
+            " rocketmq_broker::processor/legacy-target ",
+        )
+        .unwrap();
+        assert_eq!(query.broker_addr, "broker.internal:10911");
+        assert_eq!(query.logger, "rocketmq_broker::processor/legacy-target");
+
+        let request = SetBrokerLogFilterTtlRequest::try_new(
+            "broker.internal:10911",
+            "rocketmq_broker::processor/legacy-target",
+            BrokerLogLevel::Debug,
+            60,
+            "incident/123.op",
+        )
+        .unwrap();
+        assert_eq!(request.operation_id, "incident/123.op");
+    }
+
+    #[test]
+    fn legacy_log_filter_projection_preserves_bounded_operation_identifiers() {
+        let table = HashMap::from([
+            ("sreLogFilterControlSupported", "true"),
+            ("sreLogFilterEffective", "rocketmq_broker::processor=debug"),
+            ("sreLogFilterActiveOperationId", "http://secret.internal/token"),
+        ])
+        .into_iter()
+        .map(|(key, value)| (CheetahString::from(key), CheetahString::from(value)))
+        .collect();
+        let state = project_broker_log_filter_state("rocketmq_broker::processor".to_owned(), &KVTable { table });
+
+        assert_eq!(
+            state.active_operation_id.as_deref(),
+            Some("http://secret.internal/token")
+        );
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/query.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/query.rs
@@ -36,6 +36,8 @@ pub const SOURCE_FAILURE_OVERFLOW_WARNING: &str = "source_failures_truncated";
 #[serde(rename_all = "snake_case")]
 pub enum AdminQuerySource {
     BrokerRuntime,
+    BrokerConfig,
+    BrokerLogFilter,
     ConsumerStatistics,
     ConsumerConnection,
     ProducerConnection,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
@@ -23,6 +23,10 @@
 
 pub mod core;
 
+#[cfg(feature = "read-client-adapter")]
+#[path = "client_adapter/exact_broker.rs"]
+mod exact_broker;
+
 #[cfg(feature = "client-adapter")]
 pub mod client_adapter;
 

--- a/rocketmq-transport/src/clients/client.rs
+++ b/rocketmq-transport/src/clients/client.rs
@@ -255,7 +255,6 @@ where
         {
             tracing::warn!(
                 code,
-                address = %session.remote_addr(),
                 session_id = session.session_id(),
                 "received client response without a matching pending request",
             );

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -397,7 +397,8 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
             .filter_map(|address| match NameServerEndpoint::legacy(address.clone()) {
                 Ok(endpoint) => Some(endpoint),
                 Err(error) => {
-                    warn!(%address, ?error, "ignored invalid legacy NameServer endpoint");
+                    let _ = error;
+                    warn!("ignored invalid legacy NameServer endpoint");
                     None
                 }
             })
@@ -452,10 +453,11 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
     fn scan_idle_connections(&self) {
         let idle_threshold = self.tokio_client_config.maintenance.idle_scan_interval;
         let now_millis = current_millis();
-        for addr in self.connection_registry.remove_unhealthy_or_idle(|client| {
+        let removed = self.connection_registry.remove_unhealthy_or_idle(|client| {
             idle_threshold.is_some_and(|threshold| client.idle_for_at(now_millis) >= threshold)
-        }) {
-            warn!("[SCAN] Removed idle/unhealthy connection: {}", addr);
+        });
+        if !removed.is_empty() {
+            warn!(removed = removed.len(), "[SCAN] Removed idle/unhealthy connections");
         }
     }
 }

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/compatibility.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/compatibility.rs
@@ -42,8 +42,8 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
     pub(super) fn is_address_reachable_inner(&self, addr: &CheetahString) {
         match self.reconcile_cached_connection_inner(addr) {
             CachedConnectionState::Healthy => {}
-            CachedConnectionState::UnhealthyRetired => warn!("Removed unhealthy connection for {}", addr),
-            CachedConnectionState::Absent => debug!("No connection found for {}", addr),
+            CachedConnectionState::UnhealthyRetired => warn!("Removed unhealthy connection"),
+            CachedConnectionState::Absent => debug!("No connection found"),
         }
     }
 
@@ -51,7 +51,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
         for addr in &addrs {
             let key = CheetahString::from(addr.as_str());
             if !self.connection_registry.remove_sessions_by_identity(&key).is_empty() {
-                info!("Closed client connection for {}", addr);
+                info!("Closed client connection");
             }
         }
     }

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/connect_flight.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/connect_flight.rs
@@ -121,6 +121,14 @@ where
     flight: Arc<ConnectFlight<PR>>,
 }
 
+fn connection_worker_task_name(_endpoint: &CheetahString) -> String {
+    "rocketmq.transport.connect".to_string()
+}
+
+fn log_connection_failure(_endpoint: &CheetahString, endpoint_kind: &'static str) {
+    error!(endpoint_kind, "Failed to connect");
+}
+
 impl<PR> FlightCompletionGuard<PR>
 where
     PR: Sync + Clone + Send + 'static,
@@ -179,7 +187,8 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
         match self.create_client_until(addr, RequestDeadline::after(duration)).await {
             Ok(client) => client,
             Err(error) => {
-                error!(remote_addr = %addr, error = ?error, "Failed to create remoting client");
+                let _ = error;
+                error!("Failed to create remoting client");
                 None
             }
         }
@@ -239,10 +248,8 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
             let lease_for_task = lease.clone();
             let connect_timeout = self.tokio_client_config.connect.timeout;
             let commit_fence = worker_owner.commit_fence();
-            let spawned = self.spawn_worker_task_with_owner(
-                &worker_owner,
-                format!("rocketmq.transport.connect.{target}"),
-                async move {
+            let spawned =
+                self.spawn_worker_task_with_owner(&worker_owner, connection_worker_task_name(&target), async move {
                     let _completion_guard = completion_guard;
                     client.connect_attempts.fetch_add(1, Ordering::Relaxed);
                     let result = client
@@ -260,8 +267,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                         Err(RocketMQError::ClientNotStarted)
                     };
                     flight_for_task.complete(result);
-                },
-            );
+                });
             if spawned.is_none() {
                 flight.complete_not_started();
                 self.connection_registry.remove_flight_if_matches(&target, &flight);
@@ -279,6 +285,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
         commit_fence: &ConnectionCommitFence,
     ) -> RocketMQResult<Option<TransportSession<PR>>> {
         deadline.ensure_before_send(addr.to_string())?;
+        let endpoint_kind = if lease.is_some() { "nameserver" } else { "direct" };
         if !self.matches_connection_commit_fence(commit_fence) {
             return Err(RocketMQError::ClientNotStarted);
         }
@@ -301,7 +308,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                 .allow_request(),
         };
         if !allowed {
-            warn!("Circuit breaker OPEN for {}, rejecting connection attempt", addr);
+            warn!(endpoint_kind, "Circuit breaker OPEN, rejecting connection attempt");
             return Ok(None);
         }
 
@@ -363,7 +370,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                             && self.can_commit_endpoint_lease(session_lease.as_ref())
                     }) {
                     Some(client) => {
-                        info!("Successfully created client for {}", addr);
+                        info!(endpoint_kind, "Successfully created client");
                         Ok(Some(client))
                     }
                     None => {
@@ -378,7 +385,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                 }
             }
             Err(error) => {
-                error!(remote_addr = %addr, error = ?error, "Failed to connect");
+                log_connection_failure(addr, endpoint_kind);
                 if !self.matches_connection_commit_fence(commit_fence) {
                     return Err(RocketMQError::ClientNotStarted);
                 }
@@ -405,6 +412,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
 #[cfg(test)]
 mod tests {
     use std::error::Error as _;
+    use std::fmt;
     use std::io;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
@@ -415,9 +423,65 @@ mod tests {
     use tokio::sync::Barrier;
     use tokio::sync::Notify;
     use tokio::task::JoinSet;
+    use tracing::field::Field;
+    use tracing::field::Visit;
+    use tracing::span::Attributes;
+    use tracing::span::Id;
+    use tracing::span::Record;
+    use tracing::Event;
+    use tracing::Metadata;
+    use tracing::Subscriber;
 
     use super::*;
     use crate::request_processor::default_request_processor::DefaultRequestProcessor;
+
+    struct CapturingSubscriber(Arc<std::sync::Mutex<String>>);
+
+    impl Subscriber for CapturingSubscriber {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            let mut output = self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            event.record(&mut StringVisitor(&mut output));
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
+
+    struct StringVisitor<'a>(&'a mut String);
+
+    impl Visit for StringVisitor<'_> {
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            use std::fmt::Write as _;
+
+            let _ = write!(self.0, "{}={value:?};", field.name());
+        }
+    }
+
+    #[test]
+    fn direct_endpoint_is_absent_from_connection_logs_and_worker_names() {
+        let endpoint = CheetahString::from_static_str("proxy-secret.internal:18081");
+        let captured = Arc::new(std::sync::Mutex::new(String::new()));
+        tracing::subscriber::with_default(CapturingSubscriber(Arc::clone(&captured)), || {
+            log_connection_failure(&endpoint, "direct");
+        });
+
+        let logs = captured.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(!logs.contains(endpoint.as_str()));
+        assert!(!connection_worker_task_name(&endpoint).contains(endpoint.as_str()));
+    }
 
     async fn assert_connect_flight_preserves_failure(error: RocketMQError) {
         const WAITERS: usize = 3;

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/nameserver.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/nameserver.rs
@@ -345,8 +345,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
         self.telemetry
             .record_nameserver_failover(TransportNameServerFailoverReason::Draining);
         let client = self.clone();
-        let task_name = format!("rocketmq.transport.nameserver-drain.{identity}");
-        let spawned = self.spawn_worker_task(task_name, async move {
+        let spawned = self.spawn_worker_task("rocketmq.transport.nameserver-drain", async move {
             let _drain_guard = drain_guard;
             let report = session.drain_and_close(drain_timeout).await;
             if !client.endpoint_state.is_current(&lease) {
@@ -382,7 +381,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                     }
                 }
             }
-            debug!(%addr, "Cached nameserver is unhealthy, selecting new one");
+            debug!("Cached nameserver is unhealthy, selecting new one");
             self.telemetry
                 .record_nameserver_failover(TransportNameServerFailoverReason::Unhealthy);
         }
@@ -432,8 +431,8 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
         });
         if candidates.is_empty() {
             error!(
-                configured = ?identities,
-                available = ?state.available(),
+                configured = identities.len(),
+                available = state.available().len(),
                 "Failed to select healthy nameserver"
             );
             return Ok(None);
@@ -449,7 +448,6 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                 continue;
             };
             info!(
-                selected = %identity,
                 p99 = ?self.nameserver_health.p99(&identity, &lease),
                 errors = self.nameserver_health.error_count(&identity, &lease),
                 "Selected nameserver"
@@ -523,9 +521,9 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
         for (identity, lease, is_available) in results {
             if lease.is_some_and(|lease| self.endpoint_state.update_availability(&lease, &identity, is_available)) {
                 if is_available {
-                    info!(%identity, "Nameserver is now available");
+                    info!("Nameserver is now available");
                 } else {
-                    warn!(%identity, "Nameserver is now unavailable");
+                    warn!("Nameserver is now unavailable");
                 }
             }
         }

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/request.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/request.rs
@@ -58,18 +58,17 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
             .is_some()
     }
 
-    fn start_go_away_drain(&self, identity: CheetahString, session: TransportSession<PR>) {
+    fn start_go_away_drain(&self, _identity: CheetahString, session: TransportSession<PR>) {
         session.begin_drain();
         let drain_timeout = session.max_pending_request_age();
-        let task_name = format!("rocketmq.transport.go-away-drain.{identity}");
-        let spawned = self.spawn_worker_task(task_name, async move {
+        let spawned = self.spawn_worker_task("rocketmq.transport.go-away-drain", async move {
             let report = session.drain_and_close(drain_timeout).await;
             if !report.is_healthy() {
                 warn!(report = %report.to_json(), "GO_AWAY session drain was unhealthy");
             }
         });
         if spawned.is_none() {
-            warn!(%identity, "GO_AWAY session drain could not be scheduled because the client is shutting down");
+            warn!("GO_AWAY session drain could not be scheduled because the client is shutting down");
         }
     }
 
@@ -157,7 +156,6 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                 let selection_generation = selection.state.generation();
                 let mut client = selection.session;
                 debug!(
-                    selected = %metric_identity,
                     generation = selection_generation,
                     "Sending one-way request to selected nameserver"
                 );
@@ -228,16 +226,15 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
             if target == "<nameserver>" {
                 if let Some(state) = nameserver_diagnostics.as_ref() {
                     error!(
-                        "Failed to get client for <nameserver>. Diagnostics: configured_list={:?}, available_set={:?}, \\
-                         cached_choice={:?}, connections={}",
-                        state.endpoints(),
-                        state.available(),
-                        state.chosen(),
-                        self.connection_registry.len()
+                        configured = state.endpoints().len(),
+                        available = state.available().len(),
+                        cached_choice = state.chosen().is_some(),
+                        connections = self.connection_registry.len(),
+                        "Failed to get client for <nameserver>"
                     );
                 }
             } else {
-                error!("Failed to get client for {}", target);
+                error!("Failed to get client for direct endpoint");
             }
 
             RocketMQError::network_connection_failed(target.clone(), "Failed to connect")
@@ -313,7 +310,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                             true,
                         );
                         debug!(
-                            remote_addr = %identity,
+                            endpoint_kind = if nameserver_request { "nameserver" } else { "direct" },
                             elapsed_ms = latency.as_millis() as u64,
                             "request completed with GO_AWAY retry disabled"
                         );
@@ -397,7 +394,7 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                         true,
                     );
                     debug!(
-                        remote_addr = %identity,
+                        endpoint_kind = if nameserver_request { "nameserver" } else { "direct" },
                         nameserver_generation = ?nameserver_generation,
                         elapsed_ms = latency.as_millis() as u64,
                         "request completed"
@@ -425,9 +422,8 @@ impl<PR: Send + Sync + Clone + 'static> TransportClient<PR> {
                         false,
                     );
                     warn!(
-                        remote_addr = %identity,
+                        endpoint_kind = if nameserver_request { "nameserver" } else { "direct" },
                         elapsed_ms = latency.as_millis() as u64,
-                        error = ?error,
                         "request failed"
                     );
                     return Err(error);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9920
- Fixes #9920

### Brief Description

Adds four typed, read-only RocketMQ MCP operations for exact Broker diagnostics, fixed allowlisted Broker configuration, Broker log-filter state, and Proxy drain state.

The change adds narrow logical-target and evidence-aware Admin Core reads, resolves Broker and Proxy endpoints only inside the server, preserves partial source evidence, and exposes the new contracts through the shared query facade, authorization, visibility-isolated cache, output policy, audit, and MCP catalog/executor paths. It preserves the existing address-based Admin Core APIs and does not add Resources, Prompts, mutation support, CLI or shell execution, arbitrary RPC, or arbitrary configuration access.

Completion checklist:

- [x] Four canonical tools are discoverable and callable with stable schemas.
- [x] Every argument contract rejects unknown fields and accepts logical targets only.
- [x] Broker multi-instance results are deterministic, bounded, and evidence-aware.
- [x] Proxy endpoints and Broker addresses do not cross MCP output, error, audit, log, or cache boundaries.
- [x] Broker configuration is restricted to the fixed Admin Core allowlist.
- [x] Diagnose and read scopes are enforced exactly as documented.
- [x] Default and all-feature tool and protocol snapshots contain only the four expected additions.
- [x] The default MCP dependency boundary remains read-only.

### How Did You Test This Change?

Passed:

- `cargo fmt -p rocketmq-admin-core -- --check`
- `cargo fmt -p rocketmq-transport -- --check`
- `cargo test -p rocketmq-admin-core`
- `cargo test -p rocketmq-admin-core --features read-client-adapter`
- `cargo test -p rocketmq-transport`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`
- `cargo fmt -p rocketmq-mcp -- --check`
- `cargo check --locked` from `rocketmq-ai/rocketmq-mcp`
- `python scripts/check_read_only_boundary.py` from `rocketmq-ai/rocketmq-mcp`
- `cargo test --locked` from `rocketmq-ai/rocketmq-mcp` (the external-cluster E2E test remains ignored because no isolated cluster was configured)
- `cargo test --locked --all-features` from `rocketmq-ai/rocketmq-mcp` (the same external-cluster E2E test remains ignored)
- `cargo clippy --locked --all-targets --features streamable-http -- -D warnings` from `rocketmq-ai/rocketmq-mcp`
- `cargo doc --locked --no-deps` from `rocketmq-ai/rocketmq-mcp`
- Direct consumer profiles for RocketMQ Example, Dashboard Tauri, and Dashboard GPUI; GPUI also passed 166 tests.
- The RocketMQ SRE format, check, Clippy, documentation, source-layout, and execution-dependency boundary commands.

Pre-existing baseline findings, reproduced without changing unrelated code:

- `cargo test -p rocketmq-admin-core --features client-adapter` passes 201 of 202 tests; the remaining unchanged message-service test expects raw backend text that the latest default branch now redacts. The focused failure reproduces on a clean latest-default-branch checkout.
- Standalone `cargo fmt --all -- --check` commands fail on this Windows checkout with OS error 206; package-scoped formatting passes for the changed packages.
- The error-hygiene guard reports existing findings in Broker, Store, and Transport sources; the same findings reproduce on a clean latest-default-branch checkout.
- Dashboard Web backend Clippy and build reproduce the existing recursion-depth overflow at `src/main.rs:51`.
- RocketMQ SRE all-feature tests reproduce three existing semantic-registry failures with `unknown=["mcp"]`; its remaining routed validations pass.
- The runtime-audit result is not claimed because that script performs fingerprint-based baseline validation; its generated temporary reports were removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only tools for broker diagnostics, configuration summaries, log-filter status, and proxy drain status.
  * Added support for configuring logical proxy aliases with validated endpoints.
  * Added permissions for read-only and diagnostic operations.

* **Security & Privacy**
  * Improved sanitization of diagnostic values, operation IDs, internal endpoints, and transport logs.

* **Bug Fixes**
  * Diagnostic queries now require an explicit cluster and provide clearer partial-result information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->