### PR TITLE
[ISSUE #9929]Update cheetah-string dependency to version 3.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ uuid = { version = "1.23.3", features = [
 futures = "0.3"
 hickory-resolver = { version = "0.26.1", default-features = false, features = ["system-config", "tokio"] }
 
-cheetah-string = { version = "3.0.0", features = ["serde", "bytes", "simd"] }
+cheetah-string = { version = "3.1.0", features = ["serde", "bytes", "simd"] }
 
 flate2   = "1.1.9"
 dashmap  = "6.2.1"

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
@@ -960,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "cheetah-string"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352256e2fe5dedcda13ebaefb12a6a7d7012ce0706f874bc469bd131c0b0f2ef"
+checksum = "0b57c1a05a24835a7eb67f14f7aade9e6d2bb683ccce58cd0ab0ce16224881fa"
 dependencies = [
  "bytes",
  "memchr",

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -314,17 +314,6 @@ dependencies = [
 
 [[package]]
 name = "cheetah-string"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34617d68520087a27a373f84fa30b683ef46c83603143e861a22fdcd65daab55"
-dependencies = [
- "bytes",
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "cheetah-string"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b57c1a05a24835a7eb67f14f7aade9e6d2bb683ccce58cd0ab0ce16224881fa"
@@ -2559,7 +2548,7 @@ name = "rocketmq-admin-core"
 version = "1.0.0"
 dependencies = [
  "bytes",
- "cheetah-string 3.1.0",
+ "cheetah-string",
  "futures",
  "regex",
  "rocketmq-client-rust",
@@ -2583,7 +2572,7 @@ dependencies = [
  "aes-gcm",
  "arc-swap",
  "base64 0.23.1",
- "cheetah-string 3.1.0",
+ "cheetah-string",
  "chrono",
  "hex",
  "hmac 0.13.0",
@@ -2614,7 +2603,7 @@ version = "1.0.0"
 dependencies = [
  "arc-swap",
  "bytes",
- "cheetah-string 3.1.0",
+ "cheetah-string",
  "dashmap",
  "futures",
  "num_cpus",
@@ -2653,7 +2642,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
- "cheetah-string 2.1.0",
+ "cheetah-string",
  "chrono",
  "fs4",
  "futures-util",
@@ -2702,7 +2691,7 @@ dependencies = [
  "base64 0.23.1",
  "byteorder",
  "bytes",
- "cheetah-string 3.1.0",
+ "cheetah-string",
  "chrono",
  "crc",
  "dashmap",
@@ -2725,7 +2714,7 @@ name = "rocketmq-observability"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "cheetah-string 3.1.0",
+ "cheetah-string",
  "chrono",
  "chrono-tz",
  "dashmap",
@@ -2758,7 +2747,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "bytes",
- "cheetah-string 3.1.0",
+ "cheetah-string",
  "chrono",
  "flate2",
  "itoa",
@@ -2779,7 +2768,7 @@ dependencies = [
 name = "rocketmq-runtime"
 version = "1.0.0"
 dependencies = [
- "cheetah-string 3.1.0",
+ "cheetah-string",
  "chrono",
  "config",
  "cron",
@@ -2805,7 +2794,7 @@ dependencies = [
 name = "rocketmq-security-api"
 version = "1.0.0"
 dependencies = [
- "cheetah-string 3.1.0",
+ "cheetah-string",
  "serde",
  "thiserror",
  "zeroize",
@@ -2820,7 +2809,7 @@ dependencies = [
  "bitvec",
  "bytemuck",
  "bytes",
- "cheetah-string 3.1.0",
+ "cheetah-string",
  "dashmap",
  "flate2",
  "flume 0.12.0",

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
@@ -12,7 +12,7 @@ description = "RocketMQ Dashboard Web backend"
 [dependencies]
 anyhow = "1.0.103"
 axum = "0.8"
-cheetah-string = { version = "2.1.0", features = ["serde", "bytes", "simd"] }
+cheetah-string = { version = "3.1.0", features = ["serde", "bytes", "simd"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 base64 = "0.22"
 getrandom = "0.3"

--- a/rocketmq-example/Cargo.toml
+++ b/rocketmq-example/Cargo.toml
@@ -39,7 +39,7 @@ resolver = "3"
 [dependencies]
 
 [dev-dependencies]
-cheetah-string       = { version = "3.0.0", features = ["serde", "bytes", "simd"] }
+cheetah-string       = { version = "3.1.0", features = ["serde", "bytes", "simd"] }
 rand                 = "0.8.6"
 rocketmq-client-rust = { version = "1.0.0", path = "../rocketmq-client" }
 rocketmq-error       = { version = "1.0.0", path = "../rocketmq-error" }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9929

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the internal string-processing component to a newer compatible version.
  * Preserved existing serialization, byte-handling, and performance features.
  * No user-facing functionality or public interfaces changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->