### PR TITLE
[ISSUE #9926]♻️Remove owner-specific dependency features from rocketmq-error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,9 +4408,6 @@ dependencies = [
 name = "rocketmq-error"
 version = "1.0.0"
 dependencies = [
- "anyhow",
- "config",
- "serde_json",
  "thiserror 2.0.20",
 ]
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2896,8 +2896,6 @@ dependencies = [
 name = "rocketmq-error"
 version = "1.0.0"
 dependencies = [
- "anyhow",
- "serde_json",
  "thiserror",
 ]
 

--- a/rocketmq-ai/rocketmq-mcp/Cargo.lock
+++ b/rocketmq-ai/rocketmq-mcp/Cargo.lock
@@ -3246,8 +3246,6 @@ dependencies = [
 name = "rocketmq-error"
 version = "1.0.0"
 dependencies = [
- "anyhow",
- "serde_json",
  "thiserror",
 ]
 

--- a/rocketmq-ai/rocketmq-sre/Cargo.lock
+++ b/rocketmq-ai/rocketmq-sre/Cargo.lock
@@ -3397,8 +3397,6 @@ dependencies = [
 name = "rocketmq-error"
 version = "1.0.0"
 dependencies = [
- "anyhow",
- "serde_json",
  "thiserror",
 ]
 

--- a/rocketmq-broker/src/controller/replicas_manager.rs
+++ b/rocketmq-broker/src/controller/replicas_manager.rs
@@ -21,6 +21,7 @@ use crate::config::broker_config::BrokerConfig;
 use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::SerializationError;
 use rocketmq_model::common::broker::broker_role::BrokerRole;
 use rocketmq_model::common::mix_all::MASTER_ID;
 use rocketmq_protocol::protocol::body::epoch_entry_cache::EpochEntry;
@@ -355,7 +356,8 @@ impl ReplicasManager {
             broker_id,
             register_check_code: format!("{};{}", self.broker_address, current_millis()),
         };
-        let content = serde_json::to_vec(&record)?;
+        let content =
+            serde_json::to_vec(&record).map_err(|error| SerializationError::source("serialize", "JSON", error))?;
         Ok(ControllerBrokerIdPersistencePlan::PersistPending {
             target: self.temp_metadata_path.clone(),
             content,
@@ -398,7 +400,8 @@ impl ReplicasManager {
         };
         Ok(Some(ControllerBrokerIdCommitSnapshot {
             target: self.metadata_path.clone(),
-            content: serde_json::to_vec(&record)?,
+            content: serde_json::to_vec(&record)
+                .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
             record,
             temporary: self.temp_metadata_path.clone(),
         }))

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -24,6 +24,7 @@ use bytes::Bytes;
 use cheetah_string::CheetahString;
 use dns_lookup::lookup_host;
 use rocketmq_error::RocketMQError;
+use rocketmq_error::SerializationError;
 use rocketmq_model::common::broker::broker_identity::BrokerIdentity;
 use rocketmq_model::common::config::TopicConfig;
 use rocketmq_model::common::message::message_client_id_setter::MessageClientIDSetter;
@@ -1165,7 +1166,9 @@ impl BrokerOuterAPI {
         let mut response = self.remoting_client.invoke_request(Some(addr), request, 3000).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.take_body() {
-                return Ok(Some(serde_json::from_slice(body.as_ref())?));
+                return serde_json::from_slice(body.as_ref())
+                    .map(Some)
+                    .map_err(|error| SerializationError::source("deserialize", "JSON", error).into());
             }
             Ok(None)
         } else {
@@ -1312,7 +1315,7 @@ impl BrokerOuterAPI {
                 .body()
                 .map(|body| serde_json::from_slice(body.as_ref()))
                 .transpose()
-                .map_err(Into::into),
+                .map_err(|error| SerializationError::source("deserialize", "JSON", error).into()),
             _ => Err(RocketMQError::BrokerOperationFailed {
                 operation: "send_heartbeat_to_controller",
                 code: response.code(),
@@ -1341,7 +1344,7 @@ impl BrokerOuterAPI {
                 .body()
                 .map(|body| serde_json::from_slice(body.as_ref()))
                 .transpose()
-                .map_err(Into::into),
+                .map_err(|error| SerializationError::source("deserialize", "JSON", error).into()),
             _ => Err(RocketMQError::BrokerOperationFailed {
                 operation: "send_heartbeat_to_controller_sync",
                 code: response.code(),

--- a/rocketmq-broker/src/transaction/transaction_metrics.rs
+++ b/rocketmq-broker/src/transaction/transaction_metrics.rs
@@ -27,6 +27,7 @@ use parking_lot::Mutex;
 use parking_lot::RwLock;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::SerializationError;
 use rocketmq_runtime::common::time_utils::current_millis;
 use serde::Deserialize;
 use serde::Serialize;
@@ -140,7 +141,8 @@ impl TransactionMetrics {
             generation,
             topics: self.inner.topics.read().clone(),
         };
-        let body = serde_json::to_vec(&checkpoint)?;
+        let body =
+            serde_json::to_vec(&checkpoint).map_err(|error| SerializationError::source("serialize", "JSON", error))?;
         write_checkpoint(&self.inner.checkpoint_path, &body)?;
         self.inner.generation.store(generation, Ordering::Release);
         if self.inner.revision.load(Ordering::Acquire) == snapshot_revision {
@@ -172,7 +174,8 @@ fn read_checkpoint(path: &Path) -> RocketMQResult<Option<TransactionMetricsCheck
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error.into()),
     };
-    let checkpoint: TransactionMetricsCheckpoint = serde_json::from_slice(&body)?;
+    let checkpoint: TransactionMetricsCheckpoint =
+        serde_json::from_slice(&body).map_err(|error| SerializationError::source("deserialize", "JSON", error))?;
     if checkpoint.version != CHECKPOINT_VERSION {
         return Err(RocketMQError::ConfigInvalidValue {
             key: "transactionMetrics.version",
@@ -220,4 +223,38 @@ fn backup_path(path: &Path) -> PathBuf {
 
 fn temporary_path(path: &Path) -> PathBuf {
     PathBuf::from(format!("{}.tmp", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as StdError;
+    use std::fs;
+
+    use rocketmq_error::RocketMQError;
+
+    use super::read_checkpoint;
+
+    #[test]
+    fn invalid_checkpoint_preserves_json_source_and_public_boundary() {
+        let directory = tempfile::tempdir().expect("create temporary checkpoint directory");
+        let checkpoint_path = directory.path().join("transaction-metrics.json");
+        fs::write(&checkpoint_path, b"not json").expect("write invalid checkpoint");
+
+        let error = read_checkpoint(&checkpoint_path).expect_err("invalid checkpoint must fail to decode");
+
+        assert_eq!(error.to_string(), "deserialize failed (JSON)");
+        assert_eq!(error.boundary_view().message(), "Serialization failed");
+        assert!(StdError::source(&error)
+            .expect("outer error must preserve the source")
+            .downcast_ref::<serde_json::Error>()
+            .is_some());
+
+        let RocketMQError::Serialization(serialization) = &error else {
+            panic!("invalid JSON must map to a serialization error");
+        };
+        assert!(StdError::source(serialization)
+            .expect("serialization error must preserve the JSON source")
+            .downcast_ref::<serde_json::Error>()
+            .is_some());
+    }
 }

--- a/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
@@ -15,6 +15,7 @@
 use super::request_builder::*;
 use super::response_decoder::*;
 use super::*;
+use rocketmq_error::SerializationError;
 use rocketmq_model::topic::TopicConfig;
 use rocketmq_protocol::protocol::body::subscription_group_wrapper::SubscriptionGroupWrapper;
 use rocketmq_protocol::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
@@ -22,10 +23,16 @@ use rocketmq_protocol::protocol::header::get_all_subscription_group_request_head
 use rocketmq_protocol::protocol::header::get_all_topic_config_request_header::GetAllTopicConfigRequestHeader;
 use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use rocketmq_protocol::protocol::DataVersion;
+use serde::de::DeserializeOwned;
 
 #[cfg(feature = "admin-full")]
 mod compatibility;
 mod versioned_config;
+
+fn decode_admin_json<T: DeserializeOwned>(bytes: &[u8]) -> RocketMQResult<T> {
+    serde_json::from_slice(bytes)
+        .map_err(|error| RocketMQError::from(SerializationError::source("deserialize", "JSON", error)))
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MetadataPageAction {
@@ -1507,7 +1514,7 @@ impl MQClientAPIImpl {
             .await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
-                let body: QueryConsumeTimeSpanBody = serde_json::from_slice(body.as_ref())?;
+                let body: QueryConsumeTimeSpanBody = decode_admin_json(body.as_ref())?;
                 return Ok(body.consume_time_span_set);
             }
         }
@@ -1554,7 +1561,7 @@ impl MQClientAPIImpl {
             .await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
-                return serde_json::from_slice(body.as_ref()).map_err(Into::into);
+                return decode_admin_json(body.as_ref());
             }
         }
         Err(mq_client_err!(
@@ -1685,7 +1692,7 @@ impl MQClientAPIImpl {
             let body = response
                 .get_body()
                 .ok_or_else(|| mq_client_err!("query_subscription_by_consumer response body is empty".to_string()))?;
-            let response_body: QuerySubscriptionResponseBody = serde_json::from_slice(body.as_ref())?;
+            let response_body: QuerySubscriptionResponseBody = decode_admin_json(body.as_ref())?;
             return response_body.subscription_data.ok_or_else(|| {
                 mq_client_err!("query_subscription_by_consumer response subscriptionData is empty".to_string())
             });
@@ -3578,5 +3585,27 @@ mod metadata_pagination_tests {
         assert_eq!(groups.sequence, 0);
         assert!(groups.groups.is_empty());
         assert_eq!(groups.version.as_ref(), Some(&second));
+    }
+}
+
+#[cfg(test)]
+mod json_error_boundary_tests {
+    use std::error::Error as StdError;
+
+    #[test]
+    fn admin_json_decode_preserves_source_and_public_boundary() {
+        let error = super::decode_admin_json::<serde_json::Value>(b"invalid").unwrap_err();
+
+        assert_eq!(error.to_string(), "deserialize failed (JSON)");
+        assert_eq!(error.boundary_view().message(), "Serialization failed");
+
+        let direct_source = StdError::source(&error).expect("JSON error source");
+        assert!(direct_source.downcast_ref::<serde_json::Error>().is_some());
+
+        let rocketmq_error::RocketMQError::Serialization(serialization) = &error else {
+            panic!("expected serialization error");
+        };
+        let json = StdError::source(serialization).expect("JSON error source");
+        assert!(json.downcast_ref::<serde_json::Error>().is_some());
     }
 }

--- a/rocketmq-client/src/implementation/mq_client_api_impl/admin/compatibility.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/admin/compatibility.rs
@@ -80,7 +80,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
-                let body: QueryConsumeTimeSpanBody = serde_json::from_slice(body.as_ref())?;
+                let body: QueryConsumeTimeSpanBody = super::decode_admin_json(body.as_ref())?;
                 return Ok(body.consume_time_span_set);
             }
         }
@@ -338,7 +338,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
             let body = response
                 .get_body()
                 .ok_or_else(|| mq_client_err!("query_subscription_by_consumer response body is empty"))?;
-            let response_body: QuerySubscriptionResponseBody = serde_json::from_slice(body.as_ref())?;
+            let response_body: QuerySubscriptionResponseBody = super::decode_admin_json(body.as_ref())?;
             return response_body
                 .subscription_data
                 .ok_or_else(|| mq_client_err!("query_subscription_by_consumer response subscriptionData is empty"));

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
@@ -5790,8 +5790,6 @@ dependencies = [
 name = "rocketmq-error"
 version = "1.0.0"
 dependencies = [
- "anyhow",
- "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -3849,8 +3849,6 @@ dependencies = [
 name = "rocketmq-error"
 version = "1.0.0"
 dependencies = [
- "anyhow",
- "serde_json",
  "thiserror 2.0.20",
 ]
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -2669,8 +2669,6 @@ dependencies = [
 name = "rocketmq-error"
 version = "1.0.0"
 dependencies = [
- "anyhow",
- "serde_json",
  "thiserror",
 ]
 

--- a/rocketmq-error/Cargo.toml
+++ b/rocketmq-error/Cargo.toml
@@ -28,11 +28,3 @@ description            = "Rocketmq rust error module"
 rust-version.workspace = true
 [dependencies]
 thiserror.workspace = true
-anyhow              = { workspace = true }
-serde_json          = { workspace = true, optional = true }
-config              = { workspace = true, optional = true }
-
-[features]
-default     = []
-with_serde  = ["serde_json"] # alias for downstreams already using serde_json
-with_config = ["config"]     # alias for downstreams already using config

--- a/rocketmq-error/README-zh_cn.md
+++ b/rocketmq-error/README-zh_cn.md
@@ -267,19 +267,13 @@ assert_eq!(
 - `Error`
 - `Critical`
 
-## Feature Flags
+## 依赖边界
 
-默认 feature 集为空。
-
-| Feature | 启用内容 |
-| --- | --- |
-| `with_serde` | 将 `serde_json` 转换为 `SerializationError` 和 `RocketMQError` |
-| `with_config` | 将 `config::ConfigError` 转换为 `RocketMQError` |
-
-```toml
-[dependencies]
-rocketmq-error = { version = "1.0.0", features = ["with_serde", "with_config"] }
-```
+`rocketmq-error` 没有可选 feature，也不依赖 JSON 或配置实现。执行 JSON
+操作的 crate 在转换为 `RocketMQError` 前，使用
+`SerializationError::source("serialize", "JSON", error)` 或
+`SerializationError::source("deserialize", "JSON", error)` 保留类型化原因。
+边界视图仍只暴露固定的公开消息，不会暴露渲染后的原因文本。
 
 ## 使用模式
 

--- a/rocketmq-error/README.md
+++ b/rocketmq-error/README.md
@@ -307,19 +307,14 @@ Current severities are:
 - `Error`
 - `Critical`
 
-## Feature Flags
+## Dependency Boundary
 
-The default feature set is empty.
-
-| Feature | Enables |
-| --- | --- |
-| `with_serde` | `serde_json` conversion into `SerializationError` and `RocketMQError` |
-| `with_config` | `config::ConfigError` conversion into `RocketMQError` |
-
-```toml
-[dependencies]
-rocketmq-error = { version = "1.0.0", features = ["with_serde", "with_config"] }
-```
+`rocketmq-error` has no opt-in features and does not depend on JSON or
+configuration implementations. The crate that performs JSON work preserves its
+typed cause with `SerializationError::source("serialize", "JSON", error)` or
+`SerializationError::source("deserialize", "JSON", error)` before converting
+to `RocketMQError`. Boundary views continue to expose only the fixed public
+message, never rendered source text.
 
 ## Usage Patterns
 

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -1323,24 +1323,6 @@ impl From<std::str::Utf8Error> for RocketMQError {
     }
 }
 
-#[cfg(feature = "with_serde")]
-impl From<serde_json::Error> for RocketMQError {
-    #[inline]
-    fn from(e: serde_json::Error) -> Self {
-        Self::Serialization(SerializationError::from(e))
-    }
-}
-
-#[cfg(feature = "with_config")]
-impl From<config::ConfigError> for RocketMQError {
-    fn from(e: config::ConfigError) -> Self {
-        Self::ConfigParseFailed {
-            key: "unknown",
-            reason: e.to_string(),
-        }
-    }
-}
-
 // ============================================================================
 // Service Error (moved from ServiceError)
 // ============================================================================

--- a/rocketmq-error/src/unified/serialization.rs
+++ b/rocketmq-error/src/unified/serialization.rs
@@ -85,11 +85,6 @@ pub enum SerializationError {
     #[error("UTF-8 encoding error: {0}")]
     Utf8Error(#[from] std::str::Utf8Error),
 
-    /// JSON serialization error
-    #[cfg(feature = "with_serde")]
-    #[error("JSON error: {0}")]
-    JsonError(String),
-
     /// Protobuf serialization error
     #[error("Protobuf error: {0}")]
     ProtobufError(String),
@@ -184,13 +179,6 @@ impl SerializationError {
     }
 }
 
-#[cfg(feature = "with_serde")]
-impl From<serde_json::Error> for SerializationError {
-    fn from(e: serde_json::Error) -> Self {
-        Self::JsonError(e.to_string())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,14 +229,5 @@ mod tests {
             err.to_string(),
             "UTF-8 encoding error: invalid utf-8 sequence of 1 bytes from index 1"
         );
-    }
-
-    #[cfg(feature = "with_serde")]
-    #[test]
-    fn test_json_error() {
-        let json_result: Result<serde_json::Value, _> = serde_json::from_str("{ invalid }");
-        let json_error = json_result.err().unwrap();
-        let err = SerializationError::from(json_error);
-        assert!(err.to_string().contains("JSON error"));
     }
 }

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -2123,8 +2123,6 @@ dependencies = [
 name = "rocketmq-error"
 version = "1.0.0"
 dependencies = [
- "anyhow",
- "serde_json",
  "thiserror",
 ]
 

--- a/rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.lock
+++ b/rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.lock
@@ -18,12 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "cheetah-string"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352256e2fe5dedcda13ebaefb12a6a7d7012ce0706f874bc469bd131c0b0f2ef"
+checksum = "0b57c1a05a24835a7eb67f14f7aade9e6d2bb683ccce58cd0ab0ce16224881fa"
 dependencies = [
  "bytes",
  "memchr",
@@ -703,8 +697,6 @@ dependencies = [
 name = "rocketmq-error"
 version = "1.0.0"
 dependencies = [
- "anyhow",
- "serde_json",
  "thiserror",
 ]
 

--- a/rocketmq-model/Cargo.toml
+++ b/rocketmq-model/Cargo.toml
@@ -39,7 +39,7 @@ dashmap.workspace = true
 flate2 = { version = "1.1.9", features = ["zlib"], default-features = false }
 local-ip-address = "0.6.13"
 lz4_flex = { version = "0.14", features = ["alloc"], default-features = false }
-rocketmq-error = { workspace = true, features = ["with_serde"] }
+rocketmq-error.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 simd-json = { version = "0.17.0", optional = true }

--- a/rocketmq-model/src/utils/serde_json_utils.rs
+++ b/rocketmq-model/src/utils/serde_json_utils.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_error::SerializationError;
+
 pub struct SerdeJsonUtils;
 
 impl SerdeJsonUtils {
@@ -41,7 +43,7 @@ impl SerdeJsonUtils {
     where
         T: serde::de::DeserializeOwned,
     {
-        Ok(serde_json::from_str(json)?)
+        Ok(serde_json::from_str(json).map_err(|error| SerializationError::source("deserialize", "JSON", error))?)
     }
 
     /// Deserialize JSON from a byte slice into a Rust type.
@@ -50,7 +52,7 @@ impl SerdeJsonUtils {
     where
         T: serde::de::DeserializeOwned,
     {
-        Ok(serde_json::from_slice(json)?)
+        Ok(serde_json::from_slice(json).map_err(|error| SerializationError::source("deserialize", "JSON", error))?)
     }
 
     /// Serialize a Rust type into a JSON string (compact format).
@@ -59,7 +61,7 @@ impl SerdeJsonUtils {
     where
         T: serde::Serialize,
     {
-        Ok(serde_json::to_string(value)?)
+        Ok(serde_json::to_string(value).map_err(|error| SerializationError::source("serialize", "JSON", error))?)
     }
 
     /// Serialize a Rust type into a JSON string (pretty-printed format).
@@ -68,7 +70,8 @@ impl SerdeJsonUtils {
     where
         T: serde::Serialize,
     {
-        Ok(serde_json::to_string_pretty(value)?)
+        Ok(serde_json::to_string_pretty(value)
+            .map_err(|error| SerializationError::source("serialize", "JSON", error))?)
     }
 
     /// Serialize a Rust type into a JSON byte vector (compact format).
@@ -77,7 +80,7 @@ impl SerdeJsonUtils {
     where
         T: serde::Serialize,
     {
-        Ok(serde_json::to_vec(value)?)
+        Ok(serde_json::to_vec(value).map_err(|error| SerializationError::source("serialize", "JSON", error))?)
     }
 
     /// Serialize a Rust type into a JSON byte vector (pretty-printed format).
@@ -86,12 +89,14 @@ impl SerdeJsonUtils {
     where
         T: serde::Serialize,
     {
-        Ok(serde_json::to_vec_pretty(value)?)
+        Ok(serde_json::to_vec_pretty(value).map_err(|error| SerializationError::source("serialize", "JSON", error))?)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as StdError;
+
     use serde_json::json;
     use serde_json::Value;
 
@@ -109,6 +114,23 @@ mod tests {
         let json = "invalid";
         let result: Result<Value, _> = SerdeJsonUtils::from_json_str(json);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn json_decode_preserves_source_and_public_boundary() {
+        let error = SerdeJsonUtils::from_json_str::<Value>("invalid").unwrap_err();
+
+        assert_eq!(error.to_string(), "deserialize failed (JSON)");
+        assert_eq!(error.boundary_view().message(), "Serialization failed");
+
+        let direct_source = StdError::source(&error).expect("JSON error source");
+        assert!(direct_source.downcast_ref::<serde_json::Error>().is_some());
+
+        let rocketmq_error::RocketMQError::Serialization(serialization) = &error else {
+            panic!("expected serialization error");
+        };
+        let json = StdError::source(serialization).expect("JSON error source");
+        assert!(json.downcast_ref::<serde_json::Error>().is_some());
     }
 
     #[test]

--- a/rocketmq-model/src/utils/simd_json_utils.rs
+++ b/rocketmq-model/src/utils/simd_json_utils.rs
@@ -174,7 +174,8 @@ impl SimdJsonUtils {
         T: serde::Serialize,
     {
         // simd-json doesn't support pretty printing, fall back to serde_json
-        Ok(serde_json::to_string_pretty(value)?)
+        Ok(serde_json::to_string_pretty(value)
+            .map_err(|error| SerializationError::source("serialize", "JSON", error))?)
     }
 
     /// Serialize a Rust type into a JSON byte vector (compact format) using SIMD acceleration.
@@ -219,7 +220,7 @@ impl SimdJsonUtils {
         T: serde::Serialize,
     {
         // simd-json doesn't support pretty printing, fall back to serde_json
-        Ok(serde_json::to_vec_pretty(value)?)
+        Ok(serde_json::to_vec_pretty(value).map_err(|error| SerializationError::source("serialize", "JSON", error))?)
     }
 
     /// Serialize a Rust type into a JSON byte vector using a preallocated writer.

--- a/rocketmq-protocol/Cargo.toml
+++ b/rocketmq-protocol/Cargo.toml
@@ -37,7 +37,7 @@ flate2 = { version = "1.1.9", features = ["zlib"], default-features = false }
 lz4_flex = { version = "0.14", default-features = false, features = ["alloc"] }
 itoa = "1.0.18"
 memchr = "2.8.0"
-rocketmq-error = { workspace = true, features = ["with_serde"] }
+rocketmq-error.workspace = true
 bytemuck = "1.25.0"
 chrono = "0.4.45"
 rocketmq-macros.workspace = true

--- a/rocketmq-protocol/src/protocol.rs
+++ b/rocketmq-protocol/src/protocol.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::Ordering;
 
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
+use rocketmq_error::SerializationError;
 use serde::ser::SerializeStruct;
 use serde::Deserialize;
 use serde::Serialize;
@@ -230,20 +231,21 @@ pub trait RemotingDeserializable {
 
 impl<T: Serialize> RemotingSerializable for T {
     fn encode(&self) -> rocketmq_error::RocketMQResult<Vec<u8>> {
-        Ok(serde_json::to_vec(self)?)
+        Ok(serde_json::to_vec(self).map_err(|error| SerializationError::source("serialize", "JSON", error))?)
     }
     fn serialize_json(&self) -> rocketmq_error::RocketMQResult<String> {
-        Ok(serde_json::to_string(self)?)
+        Ok(serde_json::to_string(self).map_err(|error| SerializationError::source("serialize", "JSON", error))?)
     }
     fn serialize_json_pretty(&self) -> rocketmq_error::RocketMQResult<String> {
-        Ok(serde_json::to_string_pretty(self)?)
+        Ok(serde_json::to_string_pretty(self)
+            .map_err(|error| SerializationError::source("serialize", "JSON", error))?)
     }
 }
 
 impl<T: serde::de::DeserializeOwned> RemotingDeserializable for T {
     type Output = T;
     fn decode(bytes: &[u8]) -> rocketmq_error::RocketMQResult<Self::Output> {
-        Ok(serde_json::from_slice(bytes)?)
+        Ok(serde_json::from_slice(bytes).map_err(|error| SerializationError::source("deserialize", "JSON", error))?)
     }
 }
 
@@ -423,5 +425,62 @@ impl SerializeType {
 
     pub fn get_code(&self) -> u8 {
         *self as u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as StdError;
+
+    use serde::Deserialize;
+    use serde::Serialize;
+    use serde::Serializer;
+
+    use super::RemotingDeserializable;
+    use super::RemotingSerializable;
+
+    struct FailingJsonSerialize;
+
+    impl Serialize for FailingJsonSerialize {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            Err(<S::Error as serde::ser::Error>::custom(
+                "forced JSON serialization failure",
+            ))
+        }
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct DecodedValue;
+
+    fn assert_json_source(error: &rocketmq_error::RocketMQError) {
+        let direct_source = StdError::source(error).expect("JSON error source");
+        assert!(direct_source.downcast_ref::<serde_json::Error>().is_some());
+
+        let rocketmq_error::RocketMQError::Serialization(serialization) = error else {
+            panic!("expected serialization error");
+        };
+        let json = StdError::source(serialization).expect("JSON error source");
+        assert!(json.downcast_ref::<serde_json::Error>().is_some());
+    }
+
+    #[test]
+    fn protocol_json_encode_preserves_source_and_public_boundary() {
+        let error = FailingJsonSerialize.encode().unwrap_err();
+
+        assert_eq!(error.to_string(), "serialize failed (JSON)");
+        assert_eq!(error.boundary_view().message(), "Serialization failed");
+        assert_json_source(&error);
+    }
+
+    #[test]
+    fn protocol_json_decode_preserves_source_and_public_boundary() {
+        let error = DecodedValue::decode(b"invalid").unwrap_err();
+
+        assert_eq!(error.to_string(), "deserialize failed (JSON)");
+        assert_eq!(error.boundary_view().message(), "Serialization failed");
+        assert_json_source(&error);
     }
 }

--- a/rocketmq-protocol/src/protocol/admin/consume_stats.rs
+++ b/rocketmq-protocol/src/protocol/admin/consume_stats.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use rocketmq_error::SerializationError;
 use rocketmq_model::message::MessageQueue;
 use serde::Deserialize;
 use serde::Serialize;
@@ -102,11 +103,17 @@ impl ConsumeStats {
             }
             append_message_queue_object_key(&mut body, queue)?;
             body.push(':');
-            body.push_str(&serde_json::to_string(offset)?);
+            body.push_str(
+                &serde_json::to_string(offset)
+                    .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+            );
         }
 
         body.push_str("},\"consumeTps\":");
-        body.push_str(&serde_json::to_string(&self.consume_tps)?);
+        body.push_str(
+            &serde_json::to_string(&self.consume_tps)
+                .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+        );
         body.push('}');
         Ok(body)
     }
@@ -166,9 +173,15 @@ pub(crate) fn append_message_queue_object_key(
 ) -> rocketmq_error::RocketMQResult<()> {
     output.push('{');
     output.push_str("\"topic\":");
-    output.push_str(&serde_json::to_string(queue.topic_str())?);
+    output.push_str(
+        &serde_json::to_string(queue.topic_str())
+            .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+    );
     output.push_str(",\"brokerName\":");
-    output.push_str(&serde_json::to_string(queue.broker_name().as_str())?);
+    output.push_str(
+        &serde_json::to_string(queue.broker_name().as_str())
+            .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+    );
     output.push_str(",\"queueId\":");
     output.push_str(&queue.queue_id().to_string());
     output.push('}');

--- a/rocketmq-protocol/src/protocol/admin/consume_stats_list.rs
+++ b/rocketmq-protocol/src/protocol/admin/consume_stats_list.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use rocketmq_error::SerializationError;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -55,7 +56,10 @@ impl ConsumeStatsList {
                 if group_index > 0 {
                     body.push(',');
                 }
-                body.push_str(&serde_json::to_string(group)?);
+                body.push_str(
+                    &serde_json::to_string(group)
+                        .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+                );
                 body.push(':');
                 body.push('[');
                 for (stats_index, stats) in stats_list.iter().enumerate() {
@@ -71,7 +75,10 @@ impl ConsumeStatsList {
 
         body.push_str("],\"brokerAddr\":");
         match &self.broker_addr {
-            Some(broker_addr) => body.push_str(&serde_json::to_string(broker_addr)?),
+            Some(broker_addr) => body.push_str(
+                &serde_json::to_string(broker_addr)
+                    .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+            ),
             None => body.push_str("null"),
         }
         body.push_str(",\"totalDiff\":");

--- a/rocketmq-protocol/src/protocol/body/consumer_running_info.rs
+++ b/rocketmq-protocol/src/protocol/body/consumer_running_info.rs
@@ -18,6 +18,7 @@ use std::fmt::Display;
 
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::SerializationError;
 use rocketmq_model::message::MessageQueue;
 use serde::Deserialize;
 use serde::Serialize;
@@ -91,20 +92,35 @@ impl ConsumerRunningInfo {
     pub fn to_java_compatible_json(&self) -> RocketMQResult<String> {
         let mut body = String::new();
         body.push_str("{\"properties\":");
-        body.push_str(&serde_json::to_string(&self.properties)?);
+        body.push_str(
+            &serde_json::to_string(&self.properties)
+                .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+        );
         body.push_str(",\"subscriptionSet\":");
-        body.push_str(&serde_json::to_string(&self.subscription_set)?);
+        body.push_str(
+            &serde_json::to_string(&self.subscription_set)
+                .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+        );
         body.push_str(",\"mqTable\":{");
         append_process_queue_map(&mut body, &self.mq_table)?;
         body.push_str("},\"mqPopTable\":{");
         append_pop_process_queue_map(&mut body, &self.mq_pop_table)?;
         body.push_str("},\"statusTable\":");
-        body.push_str(&serde_json::to_string(&self.status_table)?);
+        body.push_str(
+            &serde_json::to_string(&self.status_table)
+                .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+        );
         body.push_str(",\"userConsumerInfo\":");
-        body.push_str(&serde_json::to_string(&self.user_consumer_info)?);
+        body.push_str(
+            &serde_json::to_string(&self.user_consumer_info)
+                .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+        );
         if let Some(jstack) = &self.jstack {
             body.push_str(",\"jstack\":");
-            body.push_str(&serde_json::to_string(jstack)?);
+            body.push_str(
+                &serde_json::to_string(jstack)
+                    .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+            );
         }
         body.push('}');
         Ok(body)
@@ -177,7 +193,9 @@ fn append_process_queue_map(
         }
         append_message_queue_object_key(output, queue)?;
         output.push(':');
-        output.push_str(&serde_json::to_string(info)?);
+        output.push_str(
+            &serde_json::to_string(info).map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+        );
     }
     Ok(())
 }
@@ -192,7 +210,9 @@ fn append_pop_process_queue_map(
         }
         append_message_queue_object_key(output, queue)?;
         output.push(':');
-        output.push_str(&serde_json::to_string(info)?);
+        output.push_str(
+            &serde_json::to_string(info).map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+        );
     }
     Ok(())
 }

--- a/rocketmq-protocol/src/protocol/body/response/get_consumer_status_body.rs
+++ b/rocketmq-protocol/src/protocol/body/response/get_consumer_status_body.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use rocketmq_error::SerializationError;
 use rocketmq_model::message::MessageQueue;
 use serde::Deserialize;
 use serde::Serialize;
@@ -64,7 +65,10 @@ impl GetConsumerStatusBody {
             if index > 0 {
                 body.push(',');
             }
-            body.push_str(&serde_json::to_string(client_id.as_str())?);
+            body.push_str(
+                &serde_json::to_string(client_id.as_str())
+                    .map_err(|error| SerializationError::source("serialize", "JSON", error))?,
+            );
             body.push_str(":{");
             append_offset_map(&mut body, offsets)?;
             body.push('}');


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9926
- Fixes #9926

### Brief Description

Remove owner-specific dependency features and automatic JSON/config conversions from `rocketmq-error`. Move JSON failures to their model, protocol, client, and broker owners while preserving typed `serde_json::Error` sources and fixed public boundary messages.

### How Did You Test This Change?

- Root all-targets, all-features Clippy completed without warnings.
- The focused client source-chain test passed in a single-job, isolated target.
- The renamed-consumer fixture completed two consecutive locked offline checks after its regenerated lock resolution.
- `rocketmq-error` passed normal-dependency tree inspection plus no-default-features and all-features checks.
- The mandatory MCP locked check, read-only boundary check, default and all-features tests, streamable HTTP Clippy, and documentation build completed successfully.

### Error Dependency Boundary

`rocketmq-error` now has only its dependency-neutral runtime dependency. The removed `with_serde` and `with_config` features, `JsonError` variant, and owner-specific `From` conversions are not retained as aliases or compatibility wrappers.

### Owner Mapping Coverage

Thirty-eight owner failure paths are covered by thirty-four lexical `SerializationError::source` bridges: twenty-six model/protocol bridges, one private client decoder serving five client paths, and seven broker bridges. Each bridge records a static JSON operation and preserves the original typed source.

### Public Behavior

Existing result signatures, wire formats, Java-compatible JSON behavior, remoting codes, headers, and fixed public error messages remain unchanged. Focused source-chain coverage verifies that the public message remains fixed while the underlying JSON error stays available through `Error::source`.

### Lockfile Resolution

The root and eight standalone lock records remove the obsolete `rocketmq-error` dependency entries. The renamed-consumer fixture also removes its unreachable `anyhow` record and resolves `cheetah-string` 3.1.0 solely to follow upstream #9929 after rebasing; that synchronization is not a dependency or API change of this pull request.

### Documentation

The English and Chinese `rocketmq-error` READMEs no longer advertise removed features or owner-specific automatic conversions, and describe explicit owner-side serialization mapping instead.

### Validation Exceptions

- `./scripts/check-error-hygiene.ps1` exited 1 with the exact 21 pre-existing repository findings and no additions; the relevant boundary checks reported OK.
- MCP `cargo fmt --all -- --check` remains blocked on Windows by the pre-existing path-length error 206.
- An initial broad filtered client test encountered the Windows page-file error 1455 and a subsequent compiler internal error while compiling unrelated integration targets. The single-job `--lib` focused source-chain test then passed 1/1.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized JSON serialization and deserialization failures across broker, client, model, and protocol operations.
  - Errors now consistently present the public message “Serialization failed” while retaining detailed underlying causes for diagnostics.
  - Improved error handling for administrative responses, checkpoints, heartbeats, metrics, and protocol payloads.

- **Documentation**
  - Clarified error-handling boundaries and JSON serialization guidance in the error-handling documentation.

- **Tests**
  - Added coverage verifying consistent public messages and preserved underlying JSON error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->