### PR TITLE
[ISSUE #9937]🚀Add typed Topic statistics and configuration inspection tools to RocketMQ MCP

### DIFF
--- a/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml
+++ b/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml
@@ -14,6 +14,8 @@ allow_tools = [
   "rocketmq_get_message_metadata",
   "rocketmq_get_topic_config_state",
   "rocketmq_get_consumer_group_config_state",
+  "rocketmq_get_topic_stats",
+  "rocketmq_get_topic_config",
 ]
 deny_tools = ["*"]
 

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
@@ -66,6 +66,9 @@ use crate::tools::executor::ToolExecutionError;
 use crate::tools::proxy_tools::ProxyDrainStateOutput;
 use crate::tools::topic_tools::TopicRouteBroker;
 use crate::tools::topic_tools::TopicRouteQueue;
+use crate::tools::topic_tools::TopicStatsQueueRow;
+
+mod topic_observation;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ResolvedCluster {
@@ -87,6 +90,14 @@ pub(crate) struct SessionConsumerLag {
     pub total_lag: i64,
     pub consume_tps: f64,
     pub inflight_total: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionTopicStats {
+    pub total_message_count: u64,
+    pub queue_count: usize,
+    pub queues: Vec<TopicStatsQueueRow>,
+    pub truncated: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,6 +144,29 @@ pub(crate) trait AdminSession: Send {
         &mut self,
         topic: &str,
     ) -> impl Future<Output = Result<SessionTopicRoute, ToolExecutionError>> + Send;
+
+    fn topic_stats(
+        &mut self,
+        _topic: &str,
+    ) -> impl Future<Output = Result<QueryPayload<SessionTopicStats>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "Topic statistics are unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn topic_config(
+        &mut self,
+        _topic: &str,
+    ) -> impl Future<Output = Result<QueryPayload<crate::tools::config_tools::GetTopicConfigOutput>, ToolExecutionError>>
+           + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "Topic configuration is unavailable".to_string(),
+            ))
+        }
+    }
 
     fn consumer_groups(
         &mut self,
@@ -439,6 +473,25 @@ impl AdminSession for AdminCoreSession {
             .collect::<Vec<_>>();
         queues.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
         Ok(SessionTopicRoute { brokers, queues })
+    }
+
+    async fn topic_stats(&mut self, topic: &str) -> Result<QueryPayload<SessionTopicStats>, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.topic_stats(topic).await;
+        }
+        self.query_topic_stats_observation(topic).await
+    }
+
+    async fn topic_config(
+        &mut self,
+        topic: &str,
+    ) -> Result<QueryPayload<crate::tools::config_tools::GetTopicConfigOutput>, ToolExecutionError> {
+        #[cfg(all(test, feature = "streamable-http", feature = "stdio"))]
+        if let Some(session) = &mut self.test_session {
+            return session.topic_config(topic).await;
+        }
+        self.query_topic_config_observation(topic).await
     }
 
     async fn consumer_groups(&mut self) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session/topic_observation.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session/topic_observation.rs
@@ -1,0 +1,107 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_admin_core::core::topic_observation::QueryTopicConfigRequest;
+use rocketmq_admin_core::core::topic_observation::QueryTopicStatsRequest;
+use rocketmq_admin_core::core::topic_observation::TopicConfigDifferenceField as AdminDifference;
+use rocketmq_admin_core::core::topic_observation::TopicObservationQueryAdmin;
+use rocketmq_admin_core::core::topic_observation::MAX_TOPIC_STATS_ROWS;
+
+use super::map_logical_admin_error;
+use super::AdminCoreSession;
+use super::SessionTopicStats;
+use crate::model::contract::observed_at;
+use crate::model::contract::observed_at_from_millis;
+use crate::model::contract::QueryPayload;
+use crate::tools::config_tools::GetTopicConfigOutput;
+use crate::tools::config_tools::TopicConfigDifferenceField;
+use crate::tools::config_tools::TopicConfigObservationRow;
+use crate::tools::executor::ToolExecutionError;
+use crate::tools::topic_tools::TopicStatsQueueRow;
+
+impl AdminCoreSession {
+    pub(super) async fn query_topic_stats_observation(
+        &mut self,
+        topic: &str,
+    ) -> Result<QueryPayload<SessionTopicStats>, ToolExecutionError> {
+        let request =
+            QueryTopicStatsRequest::try_new(self.cluster.rocketmq_cluster_name.clone(), topic, MAX_TOPIC_STATS_ROWS)
+                .map_err(|_| ToolExecutionError::InvalidArguments("invalid Topic statistics selector".to_string()))?;
+        let result = self
+            .admin_mut()?
+            .query_topic_stats(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        Ok(QueryPayload::from_admin(result).map(|result| SessionTopicStats {
+            total_message_count: result.total_message_count,
+            queue_count: result.queue_count,
+            queues: result
+                .queues
+                .into_iter()
+                .map(|row| TopicStatsQueueRow {
+                    broker_name: row.broker_name,
+                    queue_id: row.queue_id,
+                    min_offset: row.min_offset,
+                    max_offset: row.max_offset,
+                    message_count: row.message_count,
+                    last_update_at: observed_at_from_millis(row.last_update_timestamp),
+                })
+                .collect(),
+            truncated: result.truncated,
+        }))
+    }
+
+    pub(super) async fn query_topic_config_observation(
+        &mut self,
+        topic: &str,
+    ) -> Result<QueryPayload<GetTopicConfigOutput>, ToolExecutionError> {
+        let request = QueryTopicConfigRequest::try_new(self.cluster.rocketmq_cluster_name.clone(), topic)
+            .map_err(|_| ToolExecutionError::InvalidArguments("invalid Topic configuration selector".to_string()))?;
+        let result = self
+            .admin_mut()?
+            .query_topic_config(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        let cluster = self.cluster.name.clone();
+        Ok(QueryPayload::from_admin(result).map(|result| GetTopicConfigOutput {
+            cluster,
+            topic: result.topic,
+            brokers: result
+                .brokers
+                .into_iter()
+                .map(|row| TopicConfigObservationRow {
+                    broker_name: row.broker_name,
+                    version: row.version,
+                    read_queue_nums: row.read_queue_nums,
+                    write_queue_nums: row.write_queue_nums,
+                    perm: row.perm,
+                    order: row.order,
+                    message_type: row.message_type,
+                })
+                .collect(),
+            inconsistent_fields: result
+                .inconsistent_fields
+                .into_iter()
+                .map(|field| match field {
+                    AdminDifference::ReadQueueNums => TopicConfigDifferenceField::ReadQueueNums,
+                    AdminDifference::WriteQueueNums => TopicConfigDifferenceField::WriteQueueNums,
+                    AdminDifference::Perm => TopicConfigDifferenceField::Perm,
+                    AdminDifference::Order => TopicConfigDifferenceField::Order,
+                    AdminDifference::MessageType => TopicConfigDifferenceField::MessageType,
+                })
+                .collect(),
+            generated_at: observed_at(),
+        }))
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
@@ -91,6 +91,8 @@ use crate::tools::topic_tools::ListTopicsOutput;
 use crate::tools::topic_tools::QueryTopicRouteArgs;
 use crate::tools::topic_tools::QueryTopicRouteOutput;
 
+mod topic_observation;
+
 #[derive(Debug, Clone)]
 pub(crate) struct WorkflowControl {
     timeout: Duration,
@@ -153,6 +155,30 @@ pub(crate) trait ReadOnlyQuery: Clone + Send + Sync + 'static {
         &self,
         args: QueryTopicRouteArgs,
     ) -> impl Future<Output = Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError>> + Send;
+
+    fn topic_stats(
+        &self,
+        _args: crate::tools::topic_tools::GetTopicStatsArgs,
+    ) -> impl Future<Output = Result<QueryResult<crate::tools::topic_tools::GetTopicStatsOutput>, ToolExecutionError>> + Send
+    {
+        async {
+            Err(ToolExecutionError::Backend(
+                "Topic statistics are unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn topic_config(
+        &self,
+        _args: crate::tools::config_tools::GetTopicConfigArgs,
+    ) -> impl Future<Output = Result<QueryResult<crate::tools::config_tools::GetTopicConfigOutput>, ToolExecutionError>> + Send
+    {
+        async {
+            Err(ToolExecutionError::Backend(
+                "Topic configuration is unavailable".to_string(),
+            ))
+        }
+    }
 
     fn list_consumer_groups(
         &self,
@@ -1442,6 +1468,20 @@ where
         args: QueryTopicRouteArgs,
     ) -> Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError> {
         QueryFacade::query_topic_route(self, args).await
+    }
+
+    async fn topic_stats(
+        &self,
+        args: crate::tools::topic_tools::GetTopicStatsArgs,
+    ) -> Result<QueryResult<crate::tools::topic_tools::GetTopicStatsOutput>, ToolExecutionError> {
+        QueryFacade::topic_stats(self, args).await
+    }
+
+    async fn topic_config(
+        &self,
+        args: crate::tools::config_tools::GetTopicConfigArgs,
+    ) -> Result<QueryResult<crate::tools::config_tools::GetTopicConfigOutput>, ToolExecutionError> {
+        QueryFacade::topic_config(self, args).await
     }
 
     async fn list_consumer_groups(

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade/topic_observation.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade/topic_observation.rs
@@ -1,0 +1,463 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use super::normalized_identifier;
+use super::normalized_logical_identifier;
+use super::query_result_from_snapshot;
+use super::AdminSession;
+use super::AdminSessionFactory;
+use super::QueryFacade;
+use crate::adapter::admin_session::SessionTopicStats;
+use crate::infrastructure::snapshot::SnapshotKind;
+use crate::infrastructure::snapshot::SnapshotRequest;
+use crate::infrastructure::snapshot::SnapshotSelectionMode;
+use crate::infrastructure::snapshot::SnapshotWeight;
+use crate::model::contract::QueryResult;
+use crate::tools::config_tools::GetTopicConfigArgs;
+use crate::tools::config_tools::GetTopicConfigOutput;
+use crate::tools::executor::ToolExecutionError;
+use crate::tools::topic_tools::GetTopicStatsArgs;
+use crate::tools::topic_tools::GetTopicStatsOutput;
+
+impl<F> QueryFacade<F>
+where
+    F: AdminSessionFactory,
+{
+    pub(crate) async fn topic_stats(
+        &self,
+        mut args: GetTopicStatsArgs,
+    ) -> Result<QueryResult<GetTopicStatsOutput>, ToolExecutionError> {
+        args.cluster = normalized_logical_identifier("cluster", &args.cluster)?;
+        args.topic = normalized_identifier("topic", &args.topic)?;
+        let cluster = self.resolve_required_cluster(&args.cluster)?;
+        let request = SnapshotRequest::try_new_with_selection(
+            SnapshotKind::TopicStats,
+            cluster.name.clone(),
+            format!("topic={}", args.topic),
+            SnapshotSelectionMode::ExactIdentifier,
+            &args.page,
+            self.visibility_class.as_str(),
+        )?;
+        let topic = args.topic.clone();
+        let snapshot = self
+            .snapshots
+            .get_or_load(
+                request,
+                args.page.cursor.as_deref(),
+                self.cursor_snapshot_ttl(),
+                self.snapshot_response_ttl(self.config.cache.topic_list_ttl_ms),
+                |stats: &SessionTopicStats| SnapshotWeight::detail(stats.queues.len()),
+                &self.control.cancellation,
+                || {
+                    self.run_workflow(cluster.clone(), move |session, _| {
+                        Box::pin(async move { session.topic_stats(&topic).await })
+                    })
+                },
+            )
+            .await?;
+        let page = self.snapshots.page(&snapshot, &snapshot.payload.data.queues)?;
+        let stats = &snapshot.payload.data;
+        let payload = snapshot.payload.completeness().wrap(GetTopicStatsOutput {
+            cluster: cluster.name,
+            topic: args.topic,
+            total_message_count: stats.total_message_count,
+            queue_count: stats.queue_count,
+            truncated: stats.truncated,
+            page,
+            generated_at: snapshot.observed_at.clone(),
+        });
+        Ok(query_result_from_snapshot(&snapshot, payload))
+    }
+
+    pub(crate) async fn topic_config(
+        &self,
+        mut args: GetTopicConfigArgs,
+    ) -> Result<QueryResult<GetTopicConfigOutput>, ToolExecutionError> {
+        args.cluster = normalized_logical_identifier("cluster", &args.cluster)?;
+        args.topic = normalized_identifier("topic", &args.topic)?;
+        let cluster = self.resolve_required_cluster(&args.cluster)?;
+        let key = self.cache_key("topic_config", &cluster.name, &format!("topic={}", args.topic));
+        let ttl = Duration::from_millis(self.config.cache.topic_list_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.topic_config(&args.topic).await })
+                    })
+                    .await
+                },
+            )
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use rocketmq_admin_core::core::broker::BrokerRuntimeTargetStatus;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::adapter::admin_session::AdminSession;
+    use crate::adapter::admin_session::ResolvedCluster;
+    use crate::adapter::admin_session::SessionConsumerLag;
+    use crate::adapter::admin_session::SessionTopicRoute;
+    use crate::config::McpConfig;
+    use crate::guard::context::VisibilityClass;
+    use crate::model::contract::CacheStatus;
+    use crate::model::contract::PageRequest;
+    use crate::model::contract::QueryPayload;
+    use crate::model::contract::QuerySource;
+    use crate::model::contract::SourceFailure;
+    use crate::model::contract::SourceFailureCode;
+    use crate::tools::cluster_tools::BrokerSummary;
+    use crate::tools::config_tools::TopicConfigDifferenceField;
+    use crate::tools::config_tools::TopicConfigObservationRow;
+    use crate::tools::consumer_tools::ConsumerGroupSummary;
+    use crate::tools::topic_tools::TopicStatsQueueRow;
+
+    #[derive(Debug, Default)]
+    struct Counters {
+        starts: AtomicUsize,
+        shutdowns: AtomicUsize,
+        stats: AtomicUsize,
+        configs: AtomicUsize,
+        stats_entered: AtomicBool,
+    }
+
+    #[derive(Clone, Default)]
+    struct Factory {
+        counters: Arc<Counters>,
+        partial: bool,
+        hang_stats: bool,
+        hang_config: bool,
+    }
+
+    impl AdminSessionFactory for Factory {
+        type Session = Session;
+
+        async fn start(&self, cluster: ResolvedCluster) -> Result<Self::Session, ToolExecutionError> {
+            self.counters.starts.fetch_add(1, Ordering::SeqCst);
+            Ok(Session {
+                cluster,
+                counters: self.counters.clone(),
+                partial: self.partial,
+                hang_stats: self.hang_stats,
+                hang_config: self.hang_config,
+            })
+        }
+    }
+
+    struct Session {
+        cluster: ResolvedCluster,
+        counters: Arc<Counters>,
+        partial: bool,
+        hang_stats: bool,
+        hang_config: bool,
+    }
+
+    impl AdminSession for Session {
+        async fn broker_rows(&mut self) -> Result<QueryPayload<Vec<BrokerSummary>>, ToolExecutionError> {
+            Ok(QueryPayload::complete(Vec::new()))
+        }
+
+        async fn topic_inventory(&mut self) -> Result<Vec<String>, ToolExecutionError> {
+            Ok(Vec::new())
+        }
+
+        async fn topic_route(&mut self, _topic: &str) -> Result<SessionTopicRoute, ToolExecutionError> {
+            Ok(SessionTopicRoute {
+                brokers: Vec::new(),
+                queues: Vec::new(),
+            })
+        }
+
+        async fn topic_stats(&mut self, _topic: &str) -> Result<QueryPayload<SessionTopicStats>, ToolExecutionError> {
+            self.counters.stats.fetch_add(1, Ordering::SeqCst);
+            self.counters.stats_entered.store(true, Ordering::SeqCst);
+            if self.hang_stats {
+                std::future::pending::<()>().await;
+            }
+            let data = SessionTopicStats {
+                total_message_count: 60,
+                queue_count: 3,
+                queues: (0..3)
+                    .map(|queue_id| TopicStatsQueueRow {
+                        broker_name: "broker-a".to_string(),
+                        queue_id,
+                        min_offset: i64::from(queue_id) * 10,
+                        max_offset: i64::from(queue_id) * 10 + 20,
+                        message_count: 20,
+                        last_update_at: Some("1970-01-01T00:00:01.000Z".to_string()),
+                    })
+                    .collect(),
+                truncated: false,
+            };
+            Ok(if self.partial {
+                QueryPayload::new(
+                    data,
+                    true,
+                    Vec::new(),
+                    vec![SourceFailure::new(
+                        QuerySource::TopicStats,
+                        SourceFailureCode::Timeout,
+                        true,
+                        "broker-b",
+                    )],
+                )
+            } else {
+                QueryPayload::complete(data)
+            })
+        }
+
+        async fn topic_config(
+            &mut self,
+            topic: &str,
+        ) -> Result<QueryPayload<GetTopicConfigOutput>, ToolExecutionError> {
+            self.counters.configs.fetch_add(1, Ordering::SeqCst);
+            if self.hang_config {
+                std::future::pending::<()>().await;
+            }
+            let data = GetTopicConfigOutput {
+                cluster: self.cluster.name.clone(),
+                topic: topic.to_string(),
+                brokers: vec![TopicConfigObservationRow {
+                    broker_name: "broker-a".to_string(),
+                    version: 9,
+                    read_queue_nums: 8,
+                    write_queue_nums: 8,
+                    perm: 6,
+                    order: false,
+                    message_type: "NORMAL".to_string(),
+                }],
+                inconsistent_fields: vec![TopicConfigDifferenceField::ReadQueueNums],
+                generated_at: "1970-01-01T00:00:01.000Z".to_string(),
+            };
+            Ok(if self.partial {
+                QueryPayload::new(
+                    data,
+                    true,
+                    Vec::new(),
+                    vec![SourceFailure::new(
+                        QuerySource::TopicConfig,
+                        SourceFailureCode::Timeout,
+                        true,
+                        "broker-b",
+                    )],
+                )
+            } else {
+                QueryPayload::complete(data)
+            })
+        }
+
+        async fn consumer_groups(&mut self) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
+            Ok(QueryPayload::complete(Vec::new()))
+        }
+
+        async fn consumer_lag(
+            &mut self,
+            _topic: &str,
+            _consumer_group: &str,
+        ) -> Result<QueryPayload<SessionConsumerLag>, ToolExecutionError> {
+            Ok(QueryPayload::complete(SessionConsumerLag {
+                queues: Vec::new(),
+                total_lag: 0,
+                consume_tps: 0.0,
+                inflight_total: 0,
+            }))
+        }
+
+        async fn probe_broker_runtime_target(
+            &mut self,
+            _broker_name: &str,
+        ) -> Result<BrokerRuntimeTargetStatus, ToolExecutionError> {
+            Ok(BrokerRuntimeTargetStatus::NotFound)
+        }
+
+        async fn shutdown(self) -> Result<(), ToolExecutionError> {
+            self.counters.shutdowns.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn config() -> McpConfig {
+        McpConfig::load(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("conf")
+                .join("mcp.example.toml"),
+        )
+        .unwrap()
+    }
+
+    fn stats_args(topic: &str, limit: u32, cursor: Option<String>) -> GetTopicStatsArgs {
+        GetTopicStatsArgs {
+            cluster: "local-dev".to_string(),
+            topic: topic.to_string(),
+            page: PageRequest {
+                limit: Some(limit),
+                cursor,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn continuation_pages_use_one_snapshot_and_bind_all_request_context() {
+        let factory = Factory {
+            partial: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config(), factory);
+        let first = facade.topic_stats(stats_args("orders", 1, None)).await.unwrap();
+        let cursor = first.data.page.next_cursor.clone().unwrap();
+        let second = facade
+            .topic_stats(stats_args("orders", 1, Some(cursor.clone())))
+            .await
+            .unwrap();
+
+        assert_eq!(first.data.page.items[0].queue_id, 0);
+        assert_eq!(second.data.page.items[0].queue_id, 1);
+        assert_eq!(first.partial, second.partial);
+        assert_eq!(first.warnings, second.warnings);
+        assert_eq!(first.source_failures, second.source_failures);
+        assert_eq!(counters.stats.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+
+        assert!(facade
+            .topic_stats(stats_args("payments", 1, Some(cursor.clone())))
+            .await
+            .is_err());
+        assert!(facade
+            .topic_stats(stats_args("orders", 2, Some(cursor.clone())))
+            .await
+            .is_err());
+        let sensitive = facade.clone().with_visibility_class(VisibilityClass::Sensitive);
+        assert!(sensitive
+            .topic_stats(stats_args("orders", 1, Some(cursor)))
+            .await
+            .is_err());
+        assert_eq!(counters.stats.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn disabled_response_cache_reloads_first_page_but_preserves_continuations() {
+        let mut config = config();
+        config.cache.enabled = false;
+        let factory = Factory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config, factory);
+        let first = facade.topic_stats(stats_args("orders", 1, None)).await.unwrap();
+        facade
+            .topic_stats(stats_args("orders", 1, first.data.page.next_cursor.clone()))
+            .await
+            .unwrap();
+        facade.topic_stats(stats_args("orders", 1, None)).await.unwrap();
+        assert_eq!(counters.stats.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn configuration_cache_hit_preserves_safe_data_and_completeness() {
+        let factory = Factory {
+            partial: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config(), factory);
+        let args = GetTopicConfigArgs {
+            cluster: "local-dev".to_string(),
+            topic: "orders".to_string(),
+        };
+        let first = facade.topic_config(args.clone()).await.unwrap();
+        let second = facade.topic_config(args).await.unwrap();
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(second.cache_status, CacheStatus::Hit);
+        assert_eq!(first.data, second.data);
+        assert_eq!(first.partial, second.partial);
+        assert_eq!(first.warnings, second.warnings);
+        assert_eq!(first.source_failures, second.source_failures);
+        assert_eq!(counters.configs.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+        let json = serde_json::to_string(&first.data).unwrap();
+        assert!(!json.contains("addr"));
+        assert!(!json.contains("attribute"));
+    }
+
+    #[tokio::test]
+    async fn cancellation_still_shuts_down_the_admin_session() {
+        let factory = Factory {
+            hang_stats: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let cancellation = CancellationToken::new();
+        let facade = QueryFacade::with_factory(config(), factory).with_cancellation(cancellation.clone());
+        let task = tokio::spawn(async move { facade.topic_stats(stats_args("orders", 1, None)).await });
+        for _ in 0..10_000 {
+            if counters.stats_entered.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(counters.stats_entered.load(Ordering::SeqCst));
+        cancellation.cancel();
+        assert!(matches!(task.await.unwrap(), Err(ToolExecutionError::Cancelled)));
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn both_topic_observation_timeouts_shutdown_the_started_session() {
+        let stats_factory = Factory {
+            hang_stats: true,
+            ..Default::default()
+        };
+        let stats_counters = stats_factory.counters.clone();
+        let control = super::super::WorkflowControl::new(Duration::from_millis(10), CancellationToken::new());
+        let stats_facade = QueryFacade::with_factory_and_control(config(), stats_factory, control);
+        assert!(matches!(
+            stats_facade.topic_stats(stats_args("orders", 1, None)).await,
+            Err(ToolExecutionError::TimedOut { timeout_ms: 10 })
+        ));
+        assert_eq!(stats_counters.shutdowns.load(Ordering::SeqCst), 1);
+
+        let config_factory = Factory {
+            hang_config: true,
+            ..Default::default()
+        };
+        let config_counters = config_factory.counters.clone();
+        let control = super::super::WorkflowControl::new(Duration::from_millis(10), CancellationToken::new());
+        let config_facade = QueryFacade::with_factory_and_control(config(), config_factory, control);
+        assert!(matches!(
+            config_facade
+                .topic_config(GetTopicConfigArgs {
+                    cluster: "local-dev".to_string(),
+                    topic: "orders".to_string(),
+                })
+                .await,
+            Err(ToolExecutionError::TimedOut { timeout_ms: 10 })
+        ));
+        assert_eq!(config_counters.shutdowns.load(Ordering::SeqCst), 1);
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp/src/guard.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/guard.rs
@@ -505,6 +505,8 @@ fn requires_explicit_cluster(tool_name: &str) -> bool {
             | "rocketmq_get_message_metadata"
             | "rocketmq_get_topic_config_state"
             | "rocketmq_get_consumer_group_config_state"
+            | "rocketmq_get_topic_stats"
+            | "rocketmq_get_topic_config"
     )
 }
 
@@ -552,6 +554,8 @@ mod tests {
             "rocketmq_get_broker_config_summary",
             "rocketmq_get_broker_log_filter_state",
             "rocketmq_get_proxy_drain_state",
+            "rocketmq_get_topic_stats",
+            "rocketmq_get_topic_config",
         ] {
             let arguments = serde_json::json!({ "cluster": "   " }).as_object().unwrap().clone();
             let error = guard

--- a/rocketmq-ai/rocketmq-mcp/src/infrastructure/snapshot.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/infrastructure/snapshot.rs
@@ -48,6 +48,7 @@ use crate::tools::consumer_tools::QueueLag;
 use crate::tools::executor::ToolExecutionError;
 use crate::tools::topic_tools::TopicRouteBroker;
 use crate::tools::topic_tools::TopicRouteQueue;
+use crate::tools::topic_tools::TopicStatsQueueRow;
 
 const CURSOR_PREFIX: &str = "rmq-s2-";
 const MAX_SNAPSHOT_ENTRIES: usize = 10_000;
@@ -141,6 +142,14 @@ impl RetainedSize for TopicRouteQueue {
     }
 }
 
+impl RetainedSize for TopicStatsQueueRow {
+    fn retained_heap_size(&self) -> usize {
+        self.broker_name
+            .retained_heap_size()
+            .saturating_add(self.last_update_at.retained_heap_size())
+    }
+}
+
 impl RetainedSize for QueueLag {
     fn retained_heap_size(&self) -> usize {
         self.topic
@@ -160,6 +169,12 @@ impl RetainedSize for SessionTopicRoute {
 }
 
 impl RetainedSize for SessionConsumerLag {
+    fn retained_heap_size(&self) -> usize {
+        self.queues.retained_heap_size()
+    }
+}
+
+impl RetainedSize for crate::adapter::admin_session::SessionTopicStats {
     fn retained_heap_size(&self) -> usize {
         self.queues.retained_heap_size()
     }
@@ -202,6 +217,7 @@ pub(crate) enum SnapshotKind {
     TopicInventory,
     ConsumerGroupInventory,
     TopicRoute,
+    TopicStats,
     ConsumerLag,
     ConsumerConnections,
     ProducerConnections,
@@ -213,6 +229,7 @@ impl SnapshotKind {
             Self::TopicInventory => "topic_inventory",
             Self::ConsumerGroupInventory => "consumer_group_inventory",
             Self::TopicRoute => "topic_route",
+            Self::TopicStats => "topic_stats",
             Self::ConsumerLag => "consumer_lag",
             Self::ConsumerConnections => "consumer_connections",
             Self::ProducerConnections => "producer_connections",

--- a/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
@@ -35,6 +35,7 @@ pub enum QuerySource {
     ConsumerConnection,
     ProducerConnection,
     TopicConfig,
+    TopicStats,
     ConsumerGroupConfig,
     SubscriptionGroups,
     TopicRoute,
@@ -111,6 +112,7 @@ impl SourceFailure {
             AdminSource::ConsumerConnection => QuerySource::ConsumerConnection,
             AdminSource::ProducerConnection => QuerySource::ProducerConnection,
             AdminSource::TopicConfig => QuerySource::TopicConfig,
+            AdminSource::TopicStats => QuerySource::TopicStats,
             AdminSource::ConsumerGroupConfig => QuerySource::ConsumerGroupConfig,
             AdminSource::SubscriptionGroups => QuerySource::SubscriptionGroups,
         };

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -302,6 +302,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -514,6 +515,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -775,6 +777,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -999,6 +1002,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -1377,6 +1381,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -1617,6 +1622,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -1889,6 +1895,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -2506,6 +2513,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -2947,6 +2955,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -3190,6 +3199,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -3449,6 +3459,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -3945,6 +3956,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -4258,6 +4270,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -4514,6 +4527,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -4733,6 +4747,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -4887,6 +4902,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -5190,6 +5206,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -5290,6 +5307,507 @@ expression: surface
         "type": "object"
       },
       "title": "RocketMQ consumer group configuration state"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ Topic statistics"
+      },
+      "description": "Get a bounded snapshot page of deterministic per-queue Topic statistics and aggregate totals.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "cursor": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "default": null,
+            "format": "uint32",
+            "maximum": 200,
+            "minimum": 1,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_topic_stats",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "GetTopicStatsOutput": {
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "generated_at": {
+                "type": "string"
+              },
+              "has_more": {
+                "type": "boolean"
+              },
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/TopicStatsQueueRow"
+                },
+                "type": "array"
+              },
+              "next_cursor": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "queue_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "topic": {
+                "type": "string"
+              },
+              "total_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_message_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "cluster",
+              "topic",
+              "total_message_count",
+              "queue_count",
+              "truncated",
+              "items",
+              "count",
+              "total_count",
+              "has_more",
+              "generated_at"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
+          "TopicStatsQueueRow": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "last_update_at": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "max_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "message_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "min_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "queue_id": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "queue_id",
+              "min_offset",
+              "max_offset",
+              "message_count"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetTopicStatsOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ Topic statistics"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ Topic configuration"
+      },
+      "description": "Get fixed address-free Topic configuration observations and semantic differences across Brokers.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_topic_config",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "GetTopicConfigOutput": {
+            "properties": {
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/TopicConfigObservationRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "generated_at": {
+                "type": "string"
+              },
+              "inconsistent_fields": {
+                "items": {
+                  "$ref": "#/$defs/TopicConfigDifferenceField"
+                },
+                "type": "array"
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "topic",
+              "brokers",
+              "inconsistent_fields",
+              "generated_at"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
+          "TopicConfigDifferenceField": {
+            "enum": [
+              "read_queue_nums",
+              "write_queue_nums",
+              "perm",
+              "order",
+              "message_type"
+            ],
+            "type": "string"
+          },
+          "TopicConfigObservationRow": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "message_type": {
+                "type": "string"
+              },
+              "order": {
+                "type": "boolean"
+              },
+              "perm": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "read_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "version": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "write_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "version",
+              "read_queue_nums",
+              "write_queue_nums",
+              "perm",
+              "order",
+              "message_type"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetTopicConfigOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ Topic configuration"
     }
   ]
 }

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -302,6 +302,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -514,6 +515,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -775,6 +777,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -999,6 +1002,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -1377,6 +1381,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -1617,6 +1622,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -1889,6 +1895,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -2506,6 +2513,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -2947,6 +2955,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -3190,6 +3199,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -3449,6 +3459,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -3945,6 +3956,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -4258,6 +4270,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -4514,6 +4527,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -4733,6 +4747,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -4887,6 +4902,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -5190,6 +5206,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -5290,6 +5307,507 @@ expression: surface
         "type": "object"
       },
       "title": "RocketMQ consumer group configuration state"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ Topic statistics"
+      },
+      "description": "Get a bounded snapshot page of deterministic per-queue Topic statistics and aggregate totals.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "cursor": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "default": null,
+            "format": "uint32",
+            "maximum": 200,
+            "minimum": 1,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_topic_stats",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "GetTopicStatsOutput": {
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "generated_at": {
+                "type": "string"
+              },
+              "has_more": {
+                "type": "boolean"
+              },
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/TopicStatsQueueRow"
+                },
+                "type": "array"
+              },
+              "next_cursor": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "queue_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "topic": {
+                "type": "string"
+              },
+              "total_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_message_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "cluster",
+              "topic",
+              "total_message_count",
+              "queue_count",
+              "truncated",
+              "items",
+              "count",
+              "total_count",
+              "has_more",
+              "generated_at"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
+          "TopicStatsQueueRow": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "last_update_at": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "max_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "message_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "min_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "queue_id": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "queue_id",
+              "min_offset",
+              "max_offset",
+              "message_count"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetTopicStatsOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ Topic statistics"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ Topic configuration"
+      },
+      "description": "Get fixed address-free Topic configuration observations and semantic differences across Brokers.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "topic": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "topic"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_topic_config",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "GetTopicConfigOutput": {
+            "properties": {
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/TopicConfigObservationRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "generated_at": {
+                "type": "string"
+              },
+              "inconsistent_fields": {
+                "items": {
+                  "$ref": "#/$defs/TopicConfigDifferenceField"
+                },
+                "type": "array"
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "cluster",
+              "topic",
+              "brokers",
+              "inconsistent_fields",
+              "generated_at"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          },
+          "TopicConfigDifferenceField": {
+            "enum": [
+              "read_queue_nums",
+              "write_queue_nums",
+              "perm",
+              "order",
+              "message_type"
+            ],
+            "type": "string"
+          },
+          "TopicConfigObservationRow": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "message_type": {
+                "type": "string"
+              },
+              "order": {
+                "type": "boolean"
+              },
+              "perm": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "read_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "version": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "write_queue_nums": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "version",
+              "read_queue_nums",
+              "write_queue_nums",
+              "perm",
+              "order",
+              "message_type"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetTopicConfigOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ Topic configuration"
     },
     {
       "annotations": {
@@ -5470,6 +5988,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -5733,6 +6252,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -5992,6 +6512,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -6255,6 +6776,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"
@@ -6530,6 +7052,7 @@ expression: surface
               "consumer_connection",
               "producer_connection",
               "topic_config",
+              "topic_stats",
               "consumer_group_config",
               "subscription_groups",
               "topic_route"

--- a/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs
@@ -50,6 +50,8 @@ pub enum ToolId {
     GetMessageMetadata,
     GetTopicConfigState,
     GetConsumerGroupConfigState,
+    GetTopicStats,
+    GetTopicConfig,
     #[cfg(feature = "change-planning")]
     PlanCreateTopic,
     #[cfg(feature = "change-planning")]
@@ -81,6 +83,8 @@ impl ToolId {
         Self::GetMessageMetadata,
         Self::GetTopicConfigState,
         Self::GetConsumerGroupConfigState,
+        Self::GetTopicStats,
+        Self::GetTopicConfig,
         #[cfg(feature = "change-planning")]
         Self::PlanCreateTopic,
         #[cfg(feature = "change-planning")]
@@ -221,6 +225,20 @@ impl ToolId {
                 "Get version-CAS observations for one Consumer Group at bounded logical Brokers.",
                 RiskLevel::ReadOnly,
             ),
+            Self::GetTopicStats => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_topic_stats",
+                "RocketMQ Topic statistics",
+                "Get a bounded snapshot page of deterministic per-queue Topic statistics and aggregate totals.",
+                RiskLevel::ReadOnly,
+            ),
+            Self::GetTopicConfig => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_topic_config",
+                "RocketMQ Topic configuration",
+                "Get fixed address-free Topic configuration observations and semantic differences across Brokers.",
+                RiskLevel::ReadOnly,
+            ),
             #[cfg(feature = "change-planning")]
             Self::PlanCreateTopic => ToolDescriptor::read_only(
                 self,
@@ -319,6 +337,12 @@ impl ToolId {
                 config_tools::ConsumerGroupConfigStateArgs,
                 config_tools::ConsumerGroupConfigStateOutput,
             >(),
+            Self::GetTopicStats => {
+                descriptor.build::<topic_tools::GetTopicStatsArgs, topic_tools::GetTopicStatsOutput>()
+            }
+            Self::GetTopicConfig => {
+                descriptor.build::<config_tools::GetTopicConfigArgs, config_tools::GetTopicConfigOutput>()
+            }
             #[cfg(feature = "change-planning")]
             Self::PlanCreateTopic => descriptor.build::<change_tools::CreateTopicArgs, change_tools::ChangePlan>(),
             #[cfg(feature = "change-planning")]
@@ -468,9 +492,9 @@ mod tests {
             ]
         );
         #[cfg(not(feature = "change-planning"))]
-        assert_eq!(names.len(), 17);
+        assert_eq!(names.len(), 19);
         #[cfg(feature = "change-planning")]
-        assert_eq!(names.len(), 22);
+        assert_eq!(names.len(), 24);
     }
 
     #[test]
@@ -481,6 +505,8 @@ mod tests {
             ToolId::GetMessageMetadata,
             ToolId::GetTopicConfigState,
             ToolId::GetConsumerGroupConfigState,
+            ToolId::GetTopicStats,
+            ToolId::GetTopicConfig,
         ];
         for tool_id in expected {
             let descriptor = tool_id.descriptor();

--- a/rocketmq-ai/rocketmq-mcp/src/tools/config_tools.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/config_tools.rs
@@ -16,6 +16,13 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
+mod observation;
+
+pub use observation::GetTopicConfigArgs;
+pub use observation::GetTopicConfigOutput;
+pub use observation::TopicConfigDifferenceField;
+pub use observation::TopicConfigObservationRow;
+
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct BrokerConfigSummaryArgs {

--- a/rocketmq-ai/rocketmq-mcp/src/tools/config_tools/observation.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/config_tools/observation.rs
@@ -1,0 +1,54 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetTopicConfigArgs {
+    pub cluster: String,
+    pub topic: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum TopicConfigDifferenceField {
+    ReadQueueNums,
+    WriteQueueNums,
+    Perm,
+    Order,
+    MessageType,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct TopicConfigObservationRow {
+    pub broker_name: String,
+    pub version: u64,
+    pub read_queue_nums: u32,
+    pub write_queue_nums: u32,
+    pub perm: u32,
+    pub order: bool,
+    pub message_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct GetTopicConfigOutput {
+    pub cluster: String,
+    pub topic: String,
+    pub brokers: Vec<TopicConfigObservationRow>,
+    pub inconsistent_fields: Vec<TopicConfigDifferenceField>,
+    pub generated_at: String,
+}

--- a/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
@@ -681,6 +681,42 @@ where
                     success_unlinked_result(descriptor, request_id, cluster, summary, output)
                 })
             }
+            ToolId::GetTopicStats => {
+                let args = match decode_args::<topic_tools::GetTopicStatsArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.topic_stats(args).await.and_then(|output| {
+                    let summary = summary_topic_stats(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
+            ToolId::GetTopicConfig => {
+                let args = match decode_args::<config_tools::GetTopicConfigArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.topic_config(args).await.and_then(|output| {
+                    let summary = summary_topic_config(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
             #[cfg(feature = "change-planning")]
             ToolId::PlanCreateTopic => {
                 let args = match decode_args::<change_tools::CreateTopicArgs>(arguments.clone()) {
@@ -1121,6 +1157,23 @@ fn summary_consumer_group_config_state(output: &config_tools::ConsumerGroupConfi
     )
 }
 
+fn summary_topic_stats(output: &topic_tools::GetTopicStatsOutput) -> String {
+    format!(
+        "Topic {} on cluster {} returned {} of {} queue statistics.",
+        output.topic, output.cluster, output.page.count, output.queue_count
+    )
+}
+
+fn summary_topic_config(output: &config_tools::GetTopicConfigOutput) -> String {
+    format!(
+        "Topic {} on cluster {} returned {} Broker configurations with {} semantic differences.",
+        output.topic,
+        output.cluster,
+        output.brokers.len(),
+        output.inconsistent_fields.len()
+    )
+}
+
 #[cfg(feature = "change-planning")]
 fn summary_change_plan(output: &change_tools::ChangePlan) -> String {
     format!(
@@ -1458,6 +1511,66 @@ mod tests {
                 cluster: args.cluster,
                 group: args.group,
                 brokers,
+            }))
+        }
+
+        async fn topic_stats(
+            &self,
+            args: topic_tools::GetTopicStatsArgs,
+        ) -> Result<QueryResult<topic_tools::GetTopicStatsOutput>, ToolExecutionError> {
+            let broker_name = if args.topic == "oversized" {
+                "x".repeat(2 * 1024 * 1024)
+            } else {
+                "broker-a".to_string()
+            };
+            let items = vec![topic_tools::TopicStatsQueueRow {
+                broker_name,
+                queue_id: 0,
+                min_offset: 0,
+                max_offset: 10,
+                message_count: 10,
+                last_update_at: None,
+            }];
+            Ok(QueryResult::bypass(topic_tools::GetTopicStatsOutput {
+                cluster: args.cluster,
+                topic: args.topic,
+                total_message_count: 10,
+                queue_count: 1,
+                truncated: false,
+                page: crate::model::contract::Page {
+                    count: items.len(),
+                    total_count: items.len(),
+                    items,
+                    has_more: false,
+                    next_cursor: None,
+                },
+                generated_at: "transient-test-time".to_string(),
+            }))
+        }
+
+        async fn topic_config(
+            &self,
+            args: config_tools::GetTopicConfigArgs,
+        ) -> Result<QueryResult<config_tools::GetTopicConfigOutput>, ToolExecutionError> {
+            let broker_name = if args.topic == "oversized" {
+                "x".repeat(2 * 1024 * 1024)
+            } else {
+                "broker-a".to_string()
+            };
+            Ok(QueryResult::bypass(config_tools::GetTopicConfigOutput {
+                cluster: args.cluster,
+                topic: args.topic,
+                brokers: vec![config_tools::TopicConfigObservationRow {
+                    broker_name,
+                    version: 1,
+                    read_queue_nums: 8,
+                    write_queue_nums: 8,
+                    perm: 6,
+                    order: false,
+                    message_type: "NORMAL".to_string(),
+                }],
+                inconsistent_fields: Vec::new(),
+                generated_at: "transient-test-time".to_string(),
             }))
         }
 
@@ -1807,6 +1920,14 @@ mod tests {
                 ToolId::GetConsumerGroupConfigState,
                 serde_json::json!({"cluster":"local-dev","group":"group-a","broker_names":["broker-a"]}),
             ),
+            (
+                ToolId::GetTopicStats,
+                serde_json::json!({"cluster":"local-dev","topic":"orders","limit":1}),
+            ),
+            (
+                ToolId::GetTopicConfig,
+                serde_json::json!({"cluster":"local-dev","topic":"orders"}),
+            ),
         ];
         for (tool, arguments) in calls {
             let result = executor
@@ -1866,6 +1987,14 @@ mod tests {
             (
                 ToolId::GetConsumerGroupConfigState,
                 serde_json::json!({"cluster":"local-dev","group":"group-a","broker_names":["broker-a"]}),
+            ),
+            (
+                ToolId::GetTopicStats,
+                serde_json::json!({"cluster":"local-dev","topic":"orders","limit":1}),
+            ),
+            (
+                ToolId::GetTopicConfig,
+                serde_json::json!({"cluster":"local-dev","topic":"orders"}),
             ),
         ];
         for (tool, arguments) in calls {
@@ -1946,6 +2075,14 @@ mod tests {
             (
                 ToolId::GetConsumerGroupConfigState,
                 serde_json::json!({"cluster":"local-dev","group":"oversized","broker_names":["broker-a"]}),
+            ),
+            (
+                ToolId::GetTopicStats,
+                serde_json::json!({"cluster":"local-dev","topic":"oversized"}),
+            ),
+            (
+                ToolId::GetTopicConfig,
+                serde_json::json!({"cluster":"local-dev","topic":"oversized"}),
             ),
         ];
         for (tool, arguments) in calls {

--- a/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
@@ -164,6 +164,9 @@ fn normalize_source_failure(value: &Value) -> Option<Value> {
             | "producer_connection"
             | "subscription_groups"
             | "topic_route"
+            | "topic_config"
+            | "consumer_group_config"
+            | "topic_stats"
     ) || !matches!(
         code,
         "source_unavailable" | "timeout" | "permission_denied" | "not_found" | "rate_limited" | "invalid_response"
@@ -350,6 +353,50 @@ mod tests {
         assert!(!serialized.contains("10.0.0.1"));
         assert!(!serialized.contains("secret backend body"));
         assert!(!serialized.contains("raw_error"));
+    }
+
+    #[test]
+    fn config_and_topic_stats_sources_keep_only_closed_failure_metadata() {
+        let output = apply(json!({
+            "partial": true,
+            "warnings": ["source_failures_present"],
+            "source_failures": [
+                {
+                    "source": "topic_config",
+                    "code": "timeout",
+                    "retryable": true,
+                    "logical_target": "broker-a",
+                    "backend_text": "must not escape"
+                },
+                {
+                    "source": "consumer_group_config",
+                    "code": "not_found",
+                    "retryable": false,
+                    "logical_target": "broker-b",
+                    "address": "10.0.0.1:10911"
+                },
+                {
+                    "source": "topic_stats",
+                    "code": "invalid_response",
+                    "retryable": false,
+                    "logical_target": "broker-c",
+                    "attributes": { "secret": "value" }
+                }
+            ],
+            "data": {}
+        }))
+        .unwrap();
+
+        let failures = output["source_failures"].as_array().unwrap();
+        assert_eq!(failures.len(), 3);
+        assert_eq!(failures[0]["source"], "consumer_group_config");
+        assert_eq!(failures[1]["source"], "topic_config");
+        assert_eq!(failures[2]["source"], "topic_stats");
+        let serialized = output.to_string();
+        assert!(!serialized.contains("backend_text"));
+        assert!(!serialized.contains("address"));
+        assert!(!serialized.contains("attributes"));
+        assert!(!serialized.contains("must not escape"));
     }
 
     #[test]

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
@@ -132,6 +132,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -344,6 +345,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -605,6 +607,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -829,6 +832,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -1207,6 +1211,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -1447,6 +1452,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -1719,6 +1725,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -2336,6 +2343,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -2777,6 +2785,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -3020,6 +3029,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -3279,6 +3289,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -3775,6 +3786,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -4088,6 +4100,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -4344,6 +4357,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -4563,6 +4577,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -4717,6 +4732,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -5020,6 +5036,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -5120,5 +5137,506 @@ expression: contracts
       "type": "object"
     },
     "title": "RocketMQ consumer group configuration state"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ Topic statistics"
+    },
+    "description": "Get a bounded snapshot page of deterministic per-queue Topic statistics and aggregate totals.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "cursor": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "default": null,
+          "format": "uint32",
+          "maximum": 200,
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_topic_stats",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "GetTopicStatsOutput": {
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "generated_at": {
+              "type": "string"
+            },
+            "has_more": {
+              "type": "boolean"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/TopicStatsQueueRow"
+              },
+              "type": "array"
+            },
+            "next_cursor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "queue_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "topic": {
+              "type": "string"
+            },
+            "total_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "total_message_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "truncated": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "cluster",
+            "topic",
+            "total_message_count",
+            "queue_count",
+            "truncated",
+            "items",
+            "count",
+            "total_count",
+            "has_more",
+            "generated_at"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
+        "TopicStatsQueueRow": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "last_update_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "max_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "message_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "min_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "queue_id": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "queue_id",
+            "min_offset",
+            "max_offset",
+            "message_count"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetTopicStatsOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ Topic statistics"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ Topic configuration"
+    },
+    "description": "Get fixed address-free Topic configuration observations and semantic differences across Brokers.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_topic_config",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "GetTopicConfigOutput": {
+          "properties": {
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/TopicConfigObservationRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "generated_at": {
+              "type": "string"
+            },
+            "inconsistent_fields": {
+              "items": {
+                "$ref": "#/$defs/TopicConfigDifferenceField"
+              },
+              "type": "array"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "topic",
+            "brokers",
+            "inconsistent_fields",
+            "generated_at"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
+        "TopicConfigDifferenceField": {
+          "enum": [
+            "read_queue_nums",
+            "write_queue_nums",
+            "perm",
+            "order",
+            "message_type"
+          ],
+          "type": "string"
+        },
+        "TopicConfigObservationRow": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "message_type": {
+              "type": "string"
+            },
+            "order": {
+              "type": "boolean"
+            },
+            "perm": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "read_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "version": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "write_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "version",
+            "read_queue_nums",
+            "write_queue_nums",
+            "perm",
+            "order",
+            "message_type"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetTopicConfigOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ Topic configuration"
   }
 ]

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
@@ -132,6 +132,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -344,6 +345,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -605,6 +607,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -829,6 +832,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -1207,6 +1211,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -1447,6 +1452,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -1719,6 +1725,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -2336,6 +2343,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -2777,6 +2785,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -3020,6 +3029,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -3279,6 +3289,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -3775,6 +3786,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -4088,6 +4100,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -4344,6 +4357,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -4563,6 +4577,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -4717,6 +4732,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -5020,6 +5036,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -5120,6 +5137,507 @@ expression: contracts
       "type": "object"
     },
     "title": "RocketMQ consumer group configuration state"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ Topic statistics"
+    },
+    "description": "Get a bounded snapshot page of deterministic per-queue Topic statistics and aggregate totals.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "cursor": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "default": null,
+          "format": "uint32",
+          "maximum": 200,
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_topic_stats",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "GetTopicStatsOutput": {
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "generated_at": {
+              "type": "string"
+            },
+            "has_more": {
+              "type": "boolean"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/TopicStatsQueueRow"
+              },
+              "type": "array"
+            },
+            "next_cursor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "queue_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "topic": {
+              "type": "string"
+            },
+            "total_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "total_message_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "truncated": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "cluster",
+            "topic",
+            "total_message_count",
+            "queue_count",
+            "truncated",
+            "items",
+            "count",
+            "total_count",
+            "has_more",
+            "generated_at"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
+        "TopicStatsQueueRow": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "last_update_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "max_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "message_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "min_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "queue_id": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "queue_id",
+            "min_offset",
+            "max_offset",
+            "message_count"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetTopicStatsOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ Topic statistics"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ Topic configuration"
+    },
+    "description": "Get fixed address-free Topic configuration observations and semantic differences across Brokers.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "topic"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_topic_config",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "GetTopicConfigOutput": {
+          "properties": {
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/TopicConfigObservationRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "generated_at": {
+              "type": "string"
+            },
+            "inconsistent_fields": {
+              "items": {
+                "$ref": "#/$defs/TopicConfigDifferenceField"
+              },
+              "type": "array"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cluster",
+            "topic",
+            "brokers",
+            "inconsistent_fields",
+            "generated_at"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        },
+        "TopicConfigDifferenceField": {
+          "enum": [
+            "read_queue_nums",
+            "write_queue_nums",
+            "perm",
+            "order",
+            "message_type"
+          ],
+          "type": "string"
+        },
+        "TopicConfigObservationRow": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "message_type": {
+              "type": "string"
+            },
+            "order": {
+              "type": "boolean"
+            },
+            "perm": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "read_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "version": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "write_queue_nums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "version",
+            "read_queue_nums",
+            "write_queue_nums",
+            "perm",
+            "order",
+            "message_type"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetTopicConfigOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ Topic configuration"
   },
   {
     "annotations": {
@@ -5300,6 +5818,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -5563,6 +6082,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -5822,6 +6342,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -6085,6 +6606,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"
@@ -6360,6 +6882,7 @@ expression: contracts
             "consumer_connection",
             "producer_connection",
             "topic_config",
+            "topic_stats",
             "consumer_group_config",
             "subscription_groups",
             "topic_route"

--- a/rocketmq-ai/rocketmq-mcp/src/tools/topic_tools.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/topic_tools.rs
@@ -21,6 +21,12 @@ use serde::Serialize;
 use crate::model::contract::Page;
 use crate::model::contract::PageRequest;
 
+mod observation;
+
+pub use observation::GetTopicStatsArgs;
+pub use observation::GetTopicStatsOutput;
+pub use observation::TopicStatsQueueRow;
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ListTopicsArgs {

--- a/rocketmq-ai/rocketmq-mcp/src/tools/topic_tools/observation.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/topic_tools/observation.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::model::contract::Page;
+use crate::model::contract::PageRequest;
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetTopicStatsArgs {
+    pub cluster: String,
+    pub topic: String,
+    #[serde(flatten)]
+    pub page: PageRequest,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct TopicStatsQueueRow {
+    pub broker_name: String,
+    pub queue_id: i32,
+    pub min_offset: i64,
+    pub max_offset: i64,
+    pub message_count: u64,
+    pub last_update_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct GetTopicStatsOutput {
+    pub cluster: String,
+    pub topic: String,
+    pub total_message_count: u64,
+    pub queue_count: usize,
+    pub truncated: bool,
+    #[serde(flatten)]
+    #[schemars(flatten)]
+    pub page: Page<TopicStatsQueueRow>,
+    pub generated_at: String,
+}

--- a/rocketmq-client/src/admin.rs
+++ b/rocketmq-client/src/admin.rs
@@ -20,6 +20,8 @@ pub mod default_mq_admin_ext_impl;
 mod mq_admin_mutation_ext;
 #[cfg(feature = "admin-read")]
 mod mq_admin_read_ext;
+#[cfg(feature = "admin-read")]
+mod mq_admin_topic_stats_read_ext;
 
 #[cfg(feature = "admin-full")]
 pub use capability::AuthAdmin;
@@ -75,3 +77,5 @@ pub use mq_admin_read_ext::ReadFailureCode;
 pub use mq_admin_read_ext::SubscriptionGroupConfigVersioned;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_read_ext::TopicConfigVersioned;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_topic_stats_read_ext::MQAdminTopicStatsReadExt;

--- a/rocketmq-client/src/admin/mq_admin_topic_stats_read_ext.rs
+++ b/rocketmq-client/src/admin/mq_admin_topic_stats_read_ext.rs
@@ -1,0 +1,54 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Exact-Broker, read-only Topic statistics capability.
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::admin::topic_stats_table::TopicStatsTable;
+use rocketmq_protocol::protocol::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader;
+
+use super::default_mq_admin_ext::DefaultMQAdminExt;
+
+/// Additive capability for reading Topic statistics from one already resolved
+/// Broker target. Address resolution remains the responsibility of a trusted
+/// adapter and addresses never cross this trait's result boundary.
+#[allow(async_fn_in_trait)]
+pub trait MQAdminTopicStatsReadExt: Send {
+    /// Reads the Topic statistics exposed by one exact Broker.
+    async fn topic_stats_at(
+        &self,
+        broker_addr: CheetahString,
+        topic: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<TopicStatsTable>;
+}
+
+impl MQAdminTopicStatsReadExt for DefaultMQAdminExt {
+    async fn topic_stats_at(
+        &self,
+        broker_addr: CheetahString,
+        topic: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<TopicStatsTable> {
+        self.inner()
+            .mq_client_api()?
+            .get_topic_stats_info(
+                &broker_addr,
+                GetTopicStatsInfoRequestHeader {
+                    topic,
+                    topic_request_header: None,
+                },
+                self.inner().remoting_timeout_millis()?,
+            )
+            .await
+    }
+}

--- a/rocketmq-client/src/public_api.rs
+++ b/rocketmq-client/src/public_api.rs
@@ -39,6 +39,8 @@ pub use crate::admin::MQAdminReadExt;
 #[cfg(feature = "admin-read")]
 pub use crate::admin::MQAdminTopicInventoryReadExt;
 #[cfg(feature = "admin-read")]
+pub use crate::admin::MQAdminTopicStatsReadExt;
+#[cfg(feature = "admin-read")]
 pub use crate::admin::MessageMetadataRead;
 #[cfg(feature = "admin-full")]
 pub use crate::admin::OffsetAdmin;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
@@ -104,6 +104,11 @@ use crate::core::topic::TopicQueryAdmin;
 use crate::core::topic::TopicQueue;
 use crate::core::topic::TopicRoute;
 use crate::core::topic::TopicSummary;
+use crate::core::topic_observation::QueryTopicConfigRequest;
+use crate::core::topic_observation::QueryTopicConfigResult;
+use crate::core::topic_observation::QueryTopicStatsRequest;
+use crate::core::topic_observation::QueryTopicStatsResult;
+use crate::core::topic_observation::TopicObservationQueryAdmin;
 use crate::core::AdminError;
 use crate::core::AdminFuture;
 use crate::core::AdminResult;
@@ -1186,6 +1191,28 @@ impl ConfigStateQueryAdmin for ReadAdminSession {
         Box::pin(async move {
             self.ensure_open()?;
             crate::read_queries::query_consumer_group_config_state(&self.inner, request).await
+        })
+    }
+}
+
+impl TopicObservationQueryAdmin for ReadAdminSession {
+    fn query_topic_stats<'a>(
+        &'a mut self,
+        request: &'a QueryTopicStatsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryTopicStatsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            crate::topic_observation::query_topic_stats(&self.inner, request).await
+        })
+    }
+
+    fn query_topic_config<'a>(
+        &'a mut self,
+        request: &'a QueryTopicConfigRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryTopicConfigResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            crate::topic_observation::query_topic_config(&self.inner, request).await
         })
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic_observation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic_observation.rs
@@ -1,0 +1,1237 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Read-client implementation of address-free Topic observations.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use cheetah_string::CheetahString;
+use rocketmq_client_rust::DefaultMQAdminExt;
+use rocketmq_client_rust::MQAdminReadExt;
+use rocketmq_client_rust::MQAdminTopicStatsReadExt;
+use rocketmq_client_rust::TopicConfigVersioned;
+use rocketmq_error::RocketMQError;
+use rocketmq_model::common::mix_all;
+use rocketmq_protocol::protocol::admin::topic_stats_table::TopicStatsTable;
+use rocketmq_protocol::protocol::body::broker_body::cluster_info::ClusterInfo;
+use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
+
+use crate::core::broker::is_valid_remoting_endpoint;
+use crate::core::query::AdminQueryFailureCode;
+use crate::core::query::AdminQueryResult;
+use crate::core::query::AdminQuerySource;
+use crate::core::query::AdminSourceFailure;
+use crate::core::topic_observation::QueryTopicConfigRequest;
+use crate::core::topic_observation::QueryTopicConfigResult;
+use crate::core::topic_observation::QueryTopicStatsRequest;
+use crate::core::topic_observation::QueryTopicStatsResult;
+use crate::core::topic_observation::TopicConfigDifferenceField;
+use crate::core::topic_observation::TopicConfigObservationRow;
+use crate::core::topic_observation::TopicStatsQueueRow;
+use crate::core::topic_observation::MAX_TOPIC_OBSERVATION_TARGETS;
+use crate::core::topic_observation::TOPIC_STATS_TOTAL_SATURATED_WARNING;
+use crate::core::topic_observation::TOPIC_STATS_TRUNCATED_WARNING;
+use crate::core::AdminError;
+use crate::core::AdminResult;
+
+type BrokerTarget = (String, CheetahString);
+
+#[allow(async_fn_in_trait)]
+trait TopicObservationSource: Send {
+    async fn cluster_info(&self) -> Result<ClusterInfo, RocketMQError>;
+    async fn topic_route(&self, topic: &str) -> Result<Option<TopicRouteData>, RocketMQError>;
+    async fn topic_stats(&self, broker_addr: CheetahString, topic: &str) -> Result<TopicStatsTable, RocketMQError>;
+    async fn topic_config(
+        &self,
+        broker_addr: CheetahString,
+        topic: &str,
+    ) -> Result<TopicConfigVersioned, RocketMQError>;
+}
+
+impl TopicObservationSource for DefaultMQAdminExt {
+    async fn cluster_info(&self) -> Result<ClusterInfo, RocketMQError> {
+        MQAdminReadExt::examine_broker_cluster_info(self).await
+    }
+
+    async fn topic_route(&self, topic: &str) -> Result<Option<TopicRouteData>, RocketMQError> {
+        MQAdminReadExt::examine_topic_route_info(self, CheetahString::from(topic)).await
+    }
+
+    async fn topic_stats(&self, broker_addr: CheetahString, topic: &str) -> Result<TopicStatsTable, RocketMQError> {
+        MQAdminTopicStatsReadExt::topic_stats_at(self, broker_addr, CheetahString::from(topic)).await
+    }
+
+    async fn topic_config(
+        &self,
+        broker_addr: CheetahString,
+        topic: &str,
+    ) -> Result<TopicConfigVersioned, RocketMQError> {
+        MQAdminReadExt::topic_config_with_version(self, broker_addr, CheetahString::from(topic)).await
+    }
+}
+
+pub(crate) async fn query_topic_stats(
+    admin: &DefaultMQAdminExt,
+    request: &QueryTopicStatsRequest,
+) -> AdminResult<AdminQueryResult<QueryTopicStatsResult>> {
+    query_topic_stats_from(admin, request).await
+}
+
+pub(crate) async fn query_topic_config(
+    admin: &DefaultMQAdminExt,
+    request: &QueryTopicConfigRequest,
+) -> AdminResult<AdminQueryResult<QueryTopicConfigResult>> {
+    query_topic_config_from(admin, request).await
+}
+
+async fn query_topic_stats_from<S: TopicObservationSource>(
+    source: &S,
+    request: &QueryTopicStatsRequest,
+) -> AdminResult<AdminQueryResult<QueryTopicStatsResult>> {
+    let request = QueryTopicStatsRequest::try_new(&request.cluster, &request.topic, request.max_rows)?;
+    let (targets, mut failures) =
+        resolve_topic_targets(source, &request.cluster, &request.topic, AdminQuerySource::TopicStats).await?;
+    let mut retained = BTreeMap::<(String, i32), TopicStatsQueueRow>::new();
+    let mut successful_sources = 0usize;
+    let mut queue_count = 0usize;
+    let mut total_message_count = 0u128;
+    let mut truncated = false;
+
+    for (broker_name, broker_addr) in targets {
+        match source.topic_stats(broker_addr, &request.topic).await {
+            Ok(stats) => {
+                let (rows, invalid_response) = normalize_topic_stats(&broker_name, &request.topic, stats);
+                if !rows.is_empty() || !invalid_response {
+                    successful_sources += 1;
+                }
+                if invalid_response {
+                    failures.push(AdminSourceFailure::new(
+                        AdminQuerySource::TopicStats,
+                        AdminQueryFailureCode::InvalidResponse,
+                        false,
+                        &broker_name,
+                    ));
+                }
+                queue_count = queue_count.saturating_add(rows.len());
+                for row in rows {
+                    total_message_count = total_message_count.saturating_add(u128::from(row.message_count));
+                    retained.insert((row.broker_name.clone(), row.queue_id), row);
+                    if retained.len() > request.max_rows {
+                        retained.pop_last();
+                        truncated = true;
+                    }
+                }
+            }
+            Err(error) => failures.push(source_failure(AdminQuerySource::TopicStats, &broker_name, &error)),
+        }
+    }
+
+    let saturated = total_message_count > u128::from(u64::MAX);
+    let result = QueryTopicStatsResult {
+        topic: request.topic,
+        total_message_count: total_message_count.min(u128::from(u64::MAX)) as u64,
+        queue_count,
+        queues: retained.into_values().collect(),
+        truncated,
+    };
+    let mut result = AdminQueryResult::from_sources(result, successful_sources, failures)?;
+    if truncated {
+        result.partial = true;
+        result.warnings.push(TOPIC_STATS_TRUNCATED_WARNING.to_string());
+    }
+    if saturated {
+        result.partial = true;
+        result.warnings.push(TOPIC_STATS_TOTAL_SATURATED_WARNING.to_string());
+    }
+    result.warnings.sort();
+    result.warnings.dedup();
+    Ok(result)
+}
+
+async fn query_topic_config_from<S: TopicObservationSource>(
+    source: &S,
+    request: &QueryTopicConfigRequest,
+) -> AdminResult<AdminQueryResult<QueryTopicConfigResult>> {
+    let request = QueryTopicConfigRequest::try_new(&request.cluster, &request.topic)?;
+    let (targets, mut failures) =
+        resolve_topic_targets(source, &request.cluster, &request.topic, AdminQuerySource::TopicConfig).await?;
+    let mut brokers = Vec::new();
+    let mut successful_sources = 0usize;
+    for (broker_name, broker_addr) in targets {
+        match source.topic_config(broker_addr, &request.topic).await {
+            Ok(snapshot) => {
+                successful_sources += 1;
+                brokers.push(config_row(broker_name, snapshot));
+            }
+            Err(error) => failures.push(source_failure(AdminQuerySource::TopicConfig, &broker_name, &error)),
+        }
+    }
+    brokers.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    let inconsistent_fields = topic_config_differences(&brokers);
+    AdminQueryResult::from_sources(
+        QueryTopicConfigResult {
+            topic: request.topic,
+            brokers,
+            inconsistent_fields,
+        },
+        successful_sources,
+        failures,
+    )
+}
+
+async fn resolve_topic_targets<S: TopicObservationSource>(
+    source: &S,
+    cluster: &str,
+    topic: &str,
+    failure_source: AdminQuerySource,
+) -> AdminResult<(Vec<BrokerTarget>, Vec<AdminSourceFailure>)> {
+    let cluster_info = source
+        .cluster_info()
+        .await
+        .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+    let route = source
+        .topic_route(topic)
+        .await
+        .map_err(|error| backend_error("examine_topic_route_info", error))?
+        .ok_or_else(|| AdminError::not_found("topic", topic))?;
+    selected_cluster_route_masters(&cluster_info, &route, cluster, failure_source)
+}
+
+fn selected_cluster_route_masters(
+    cluster_info: &ClusterInfo,
+    route: &TopicRouteData,
+    cluster: &str,
+    source: AdminQuerySource,
+) -> AdminResult<(Vec<BrokerTarget>, Vec<AdminSourceFailure>)> {
+    let cluster_brokers = cluster_info
+        .cluster_addr_table
+        .as_ref()
+        .and_then(|table| table.get(cluster))
+        .ok_or_else(|| AdminError::not_found("cluster", cluster))?;
+    let mut route_brokers = BTreeSet::new();
+    let mut failures = Vec::new();
+    for broker in &route.broker_datas {
+        let broker_name = broker.broker_name().as_str();
+        let listed_in_selected_cluster = cluster_brokers.contains(broker_name);
+        if broker.cluster() != cluster {
+            if listed_in_selected_cluster {
+                failures.push(invalid_response_failure(source, broker_name));
+            }
+            continue;
+        }
+        if !listed_in_selected_cluster || !safe_broker_name(broker_name) {
+            failures.push(invalid_response_failure(source, broker_name));
+            continue;
+        }
+        route_brokers.insert(broker_name.to_string());
+    }
+    if route_brokers.is_empty() {
+        if !failures.is_empty() {
+            return Ok((Vec::new(), failures));
+        }
+        return Err(AdminError::not_found("topic route in selected cluster", cluster));
+    }
+    if route_brokers.len() > MAX_TOPIC_OBSERVATION_TARGETS {
+        return Err(AdminError::backend_view(
+            "resolve_topic_observation_targets",
+            "TOPIC_OBSERVATION_TARGET_LIMIT_EXCEEDED",
+            "Topic route has too many selected-cluster Broker targets",
+            None,
+            422,
+            false,
+        ));
+    }
+
+    let broker_table = cluster_info.broker_addr_table.as_ref();
+    let mut targets = Vec::new();
+    for broker_name in route_brokers {
+        let Some(broker) = broker_table.and_then(|table| table.get(broker_name.as_str())) else {
+            failures.push(invalid_response_failure(source, &broker_name));
+            continue;
+        };
+        if broker.cluster() != cluster || broker.broker_name().as_str() != broker_name {
+            failures.push(invalid_response_failure(source, &broker_name));
+            continue;
+        }
+        let master = broker
+            .broker_addrs()
+            .get(&mix_all::MASTER_ID)
+            .filter(|address| is_valid_remoting_endpoint(address.as_str()));
+        match master {
+            Some(address) => targets.push((broker_name, address.clone())),
+            None => failures.push(invalid_response_failure(source, &broker_name)),
+        }
+    }
+    Ok((targets, failures))
+}
+
+fn normalize_topic_stats(broker_name: &str, topic: &str, stats: TopicStatsTable) -> (Vec<TopicStatsQueueRow>, bool) {
+    let mut rows = BTreeMap::<i32, TopicStatsQueueRow>::new();
+    let mut invalid = false;
+    for (queue, offset) in stats.into_offset_table() {
+        let min_offset = offset.get_min_offset();
+        let max_offset = offset.get_max_offset();
+        let last_update_timestamp = offset.get_last_update_timestamp();
+        let Some(message_count) = max_offset
+            .checked_sub(min_offset)
+            .and_then(|count| u64::try_from(count).ok())
+        else {
+            invalid = true;
+            continue;
+        };
+        if queue.topic_str() != topic
+            || queue.broker_name().as_str() != broker_name
+            || queue.queue_id() < 0
+            || min_offset < 0
+            || last_update_timestamp < 0
+        {
+            invalid = true;
+            continue;
+        }
+        let row = TopicStatsQueueRow {
+            broker_name: broker_name.to_string(),
+            queue_id: queue.queue_id(),
+            min_offset,
+            max_offset,
+            message_count,
+            last_update_timestamp,
+        };
+        match rows.entry(row.queue_id) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(row);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                invalid = true;
+                if stats_row_value(&row) < stats_row_value(entry.get()) {
+                    entry.insert(row);
+                }
+            }
+        }
+    }
+    (rows.into_values().collect(), invalid)
+}
+
+fn stats_row_value(row: &TopicStatsQueueRow) -> (i64, i64, u64, i64) {
+    (
+        row.min_offset,
+        row.max_offset,
+        row.message_count,
+        row.last_update_timestamp,
+    )
+}
+
+fn config_row(broker_name: String, snapshot: TopicConfigVersioned) -> TopicConfigObservationRow {
+    let config = snapshot.config;
+    TopicConfigObservationRow {
+        broker_name,
+        version: snapshot.version,
+        read_queue_nums: config.read_queue_nums,
+        write_queue_nums: config.write_queue_nums,
+        perm: config.perm,
+        order: config.order,
+        message_type: config.get_topic_message_type().to_string(),
+    }
+}
+
+fn topic_config_differences(rows: &[TopicConfigObservationRow]) -> Vec<TopicConfigDifferenceField> {
+    let Some(baseline) = rows.first() else {
+        return Vec::new();
+    };
+    let mut differences = Vec::new();
+    if rows.iter().any(|row| row.read_queue_nums != baseline.read_queue_nums) {
+        differences.push(TopicConfigDifferenceField::ReadQueueNums);
+    }
+    if rows.iter().any(|row| row.write_queue_nums != baseline.write_queue_nums) {
+        differences.push(TopicConfigDifferenceField::WriteQueueNums);
+    }
+    if rows.iter().any(|row| row.perm != baseline.perm) {
+        differences.push(TopicConfigDifferenceField::Perm);
+    }
+    if rows.iter().any(|row| row.order != baseline.order) {
+        differences.push(TopicConfigDifferenceField::Order);
+    }
+    if rows.iter().any(|row| row.message_type != baseline.message_type) {
+        differences.push(TopicConfigDifferenceField::MessageType);
+    }
+    differences
+}
+
+fn safe_broker_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 128
+        && name.is_ascii()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+}
+
+fn invalid_response_failure(source: AdminQuerySource, broker_name: &str) -> AdminSourceFailure {
+    AdminSourceFailure::new(source, AdminQueryFailureCode::InvalidResponse, false, broker_name)
+}
+
+fn source_failure(source: AdminQuerySource, broker_name: &str, error: &RocketMQError) -> AdminSourceFailure {
+    let view = error.boundary_view();
+    let code = match view.http().status.as_u16() {
+        401 | 403 => AdminQueryFailureCode::PermissionDenied,
+        404 => AdminQueryFailureCode::NotFound,
+        408 | 504 => AdminQueryFailureCode::Timeout,
+        429 => AdminQueryFailureCode::RateLimited,
+        400 | 413 | 422 => AdminQueryFailureCode::InvalidResponse,
+        _ => AdminQueryFailureCode::SourceUnavailable,
+    };
+    AdminSourceFailure::new(source, code, view.is_retryable(), broker_name)
+}
+
+fn backend_error(operation: &'static str, error: RocketMQError) -> AdminError {
+    let view = error.boundary_view();
+    AdminError::backend_view(
+        operation,
+        view.code().as_str(),
+        view.message(),
+        (!view.context().is_empty()).then(|| view.context().to_string()),
+        view.http().status.as_u16(),
+        view.is_retryable(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    use rocketmq_model::common::config::TopicConfig;
+    use rocketmq_model::message::MessageQueue;
+    use rocketmq_protocol::protocol::admin::topic_offset::TopicOffset;
+    use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
+
+    use super::*;
+    use crate::core::topic_observation::MAX_TOPIC_STATS_ROWS;
+
+    const ADDRESS_A: &str = "127.0.0.1:10911";
+    const ADDRESS_B: &str = "127.0.0.2:10911";
+    const ADDRESS_C: &str = "127.0.0.3:10911";
+
+    #[derive(Default)]
+    struct FakeSource {
+        cluster_info: ClusterInfo,
+        route: Option<TopicRouteData>,
+        stats: BTreeMap<String, TestResult<TopicStatsTable>>,
+        configs: BTreeMap<String, TestResult<TopicConfigVersioned>>,
+        stats_calls: Mutex<Vec<String>>,
+        config_calls: Mutex<Vec<String>>,
+    }
+
+    #[derive(Clone)]
+    enum TestResult<T> {
+        Value(T),
+        Failure(&'static str),
+    }
+
+    impl TopicObservationSource for FakeSource {
+        async fn cluster_info(&self) -> Result<ClusterInfo, RocketMQError> {
+            Ok(self.cluster_info.clone())
+        }
+
+        async fn topic_route(&self, _topic: &str) -> Result<Option<TopicRouteData>, RocketMQError> {
+            Ok(self.route.clone())
+        }
+
+        async fn topic_stats(
+            &self,
+            broker_addr: CheetahString,
+            _topic: &str,
+        ) -> Result<TopicStatsTable, RocketMQError> {
+            self.stats_calls.lock().unwrap().push(broker_addr.to_string());
+            match self.stats.get(broker_addr.as_str()) {
+                Some(TestResult::Value(stats)) => Ok(stats.clone()),
+                Some(TestResult::Failure(reason)) => Err(test_error(reason)),
+                None => Ok(TopicStatsTable::new()),
+            }
+        }
+
+        async fn topic_config(
+            &self,
+            broker_addr: CheetahString,
+            _topic: &str,
+        ) -> Result<TopicConfigVersioned, RocketMQError> {
+            self.config_calls.lock().unwrap().push(broker_addr.to_string());
+            match self.configs.get(broker_addr.as_str()) {
+                Some(TestResult::Value(config)) => Ok(config.clone()),
+                Some(TestResult::Failure(reason)) => Err(test_error(reason)),
+                None => Ok(TopicConfigVersioned {
+                    version: 1,
+                    config: TopicConfig::new("orders"),
+                }),
+            }
+        }
+    }
+
+    fn topology(brokers: &[(&str, &str, &str)]) -> (ClusterInfo, TopicRouteData) {
+        let mut broker_table = HashMap::new();
+        let mut cluster_table = HashMap::<CheetahString, HashSet<CheetahString>>::new();
+        let mut route_brokers = Vec::new();
+        for (cluster, broker, address) in brokers {
+            let data = BrokerData::new(
+                (*cluster).into(),
+                (*broker).into(),
+                HashMap::from([(mix_all::MASTER_ID, (*address).into())]),
+                None,
+            );
+            broker_table.insert((*broker).into(), data.clone());
+            cluster_table
+                .entry((*cluster).into())
+                .or_default()
+                .insert((*broker).into());
+            route_brokers.push(data);
+        }
+        (
+            ClusterInfo::new(Some(broker_table), Some(cluster_table)),
+            TopicRouteData {
+                broker_datas: route_brokers,
+                ..Default::default()
+            },
+        )
+    }
+
+    fn stats(broker_name: &str, rows: &[(i32, i64, i64, i64)]) -> TopicStatsTable {
+        let mut table = TopicStatsTable::new();
+        for (queue_id, min, max, timestamp) in rows {
+            insert_stats_row(&mut table, "orders", broker_name, *queue_id, *min, *max, *timestamp);
+        }
+        table
+    }
+
+    fn insert_stats_row(
+        table: &mut TopicStatsTable,
+        topic: &str,
+        broker_name: &str,
+        queue_id: i32,
+        min_offset: i64,
+        max_offset: i64,
+        last_update_timestamp: i64,
+    ) {
+        let mut offset = TopicOffset::new();
+        offset.set_min_offset(min_offset);
+        offset.set_max_offset(max_offset);
+        offset.set_last_update_timestamp(last_update_timestamp);
+        table
+            .get_offset_table_mut()
+            .insert(MessageQueue::from_parts(topic, broker_name, queue_id), offset);
+    }
+
+    fn source_with_two_clusters() -> FakeSource {
+        let (cluster_info, route) = topology(&[
+            ("cluster-a", "broker-b", ADDRESS_B),
+            ("cluster-a", "broker-a", ADDRESS_A),
+            ("cluster-b", "broker-c", ADDRESS_C),
+        ]);
+        FakeSource {
+            cluster_info,
+            route: Some(route),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn statistics_select_cluster_masters_sort_bound_and_aggregate_safely() {
+        let mut source = source_with_two_clusters();
+        source.stats.insert(
+            ADDRESS_A.to_string(),
+            TestResult::Value(stats("broker-a", &[(2, 5, 9, 20), (0, 1, 4, 10)])),
+        );
+        source.stats.insert(
+            ADDRESS_B.to_string(),
+            TestResult::Value(stats("broker-b", &[(1, 0, 8, 30)])),
+        );
+        let result = query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 2).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.partial);
+        assert_eq!(result.warnings, [TOPIC_STATS_TRUNCATED_WARNING]);
+        assert_eq!(result.data.total_message_count, 15);
+        assert_eq!(result.data.queue_count, 3);
+        assert!(result.data.truncated);
+        assert_eq!(
+            result
+                .data
+                .queues
+                .iter()
+                .map(|row| (row.broker_name.as_str(), row.queue_id))
+                .collect::<Vec<_>>(),
+            [("broker-a", 0), ("broker-a", 2)]
+        );
+    }
+
+    #[tokio::test]
+    async fn statistics_preserve_partial_and_total_failure_without_backend_text() {
+        let mut source = source_with_two_clusters();
+        source.stats.insert(
+            ADDRESS_A.to_string(),
+            TestResult::Value(stats("broker-a", &[(0, 0, 5, 10)])),
+        );
+        source
+            .stats
+            .insert(ADDRESS_B.to_string(), TestResult::Failure("secret-internal-b"));
+        let request = QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap();
+        let partial = query_topic_stats_from(&source, &request).await.unwrap();
+        assert!(partial.partial);
+        assert_eq!(partial.source_failures.len(), 1);
+        assert_eq!(partial.source_failures[0].logical_target(), "broker-b");
+        assert!(!serde_json::to_string(&partial).unwrap().contains("secret-internal-b"));
+
+        source
+            .stats
+            .insert(ADDRESS_A.to_string(), TestResult::Failure("secret-internal-a"));
+        let error = query_topic_stats_from(&source, &request).await.unwrap_err();
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+        assert!(!error.to_string().contains("secret-internal"));
+    }
+
+    #[tokio::test]
+    async fn malformed_statistics_are_partial_and_never_underflow() {
+        let mut source = source_with_two_clusters();
+        source.stats.insert(
+            ADDRESS_A.to_string(),
+            TestResult::Value(stats("broker-a", &[(0, 9, 3, 10), (1, 1, 4, 10)])),
+        );
+        source
+            .stats
+            .insert(ADDRESS_B.to_string(), TestResult::Value(TopicStatsTable::new()));
+        let result = query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+        )
+        .await
+        .unwrap();
+        assert!(result.partial);
+        assert_eq!(result.data.total_message_count, 3);
+        assert_eq!(result.data.queues.len(), 1);
+        assert_eq!(result.source_failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+    }
+
+    #[test]
+    fn statistics_reject_negative_and_checked_sub_overflow_boundaries() {
+        let mut malformed = TopicStatsTable::new();
+        insert_stats_row(&mut malformed, "orders", "broker-a", 0, -1, 1, 1);
+        insert_stats_row(&mut malformed, "orders", "broker-a", 1, 0, -1, 1);
+        insert_stats_row(&mut malformed, "orders", "broker-a", 2, 0, 1, -1);
+        insert_stats_row(&mut malformed, "orders", "broker-a", 3, i64::MIN, i64::MAX, 1);
+        insert_stats_row(&mut malformed, "orders", "broker-a", 4, 0, 1, 1);
+
+        let (rows, invalid) = normalize_topic_stats("broker-a", "orders", malformed);
+
+        assert!(invalid);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].queue_id, 4);
+        assert_eq!(rows[0].message_count, 1);
+    }
+
+    #[test]
+    fn statistics_require_exact_topic_broker_and_nonnegative_queue_identity() {
+        let mut single_mismatch = TopicStatsTable::new();
+        insert_stats_row(&mut single_mismatch, "other-topic", "broker-a", 0, 0, 1, 1);
+        let (rows, invalid) = normalize_topic_stats("broker-a", "orders", single_mismatch);
+        assert!(invalid);
+        assert!(rows.is_empty());
+
+        let mut multiple_mismatches = TopicStatsTable::new();
+        insert_stats_row(&mut multiple_mismatches, "orders", "broker-forged", 0, 0, 1, 1);
+        insert_stats_row(&mut multiple_mismatches, "orders", "broker-a", -1, 0, 1, 1);
+        let (rows, invalid) = normalize_topic_stats("broker-a", "orders", multiple_mismatches);
+        assert!(invalid);
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn valid_and_mismatched_rows_are_partial_without_rewriting_the_owner() {
+        let (cluster_info, route) = topology(&[("cluster-a", "broker-a", ADDRESS_A)]);
+        let mut mixed = TopicStatsTable::new();
+        insert_stats_row(&mut mixed, "orders", "broker-a", 0, 0, 7, 1);
+        insert_stats_row(&mut mixed, "orders", "broker-forged", 1, 0, 100, 1);
+        let source = FakeSource {
+            cluster_info,
+            route: Some(route),
+            stats: BTreeMap::from([(ADDRESS_A.to_string(), TestResult::Value(mixed))]),
+            ..Default::default()
+        };
+
+        let result = query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.partial);
+        assert_eq!(result.data.queue_count, 1);
+        assert_eq!(result.data.total_message_count, 7);
+        assert_eq!(result.data.queues[0].broker_name, "broker-a");
+        assert_eq!(result.source_failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+    }
+
+    #[tokio::test]
+    async fn only_identity_mismatches_are_a_total_source_failure() {
+        let (cluster_info, route) = topology(&[("cluster-a", "broker-a", ADDRESS_A)]);
+        let mut mismatched = TopicStatsTable::new();
+        insert_stats_row(&mut mismatched, "orders", "broker-forged", 0, 0, 1, 1);
+        insert_stats_row(&mut mismatched, "other-topic", "broker-a", 1, 0, 1, 1);
+        let source = FakeSource {
+            cluster_info,
+            route: Some(route),
+            stats: BTreeMap::from([(ADDRESS_A.to_string(), TestResult::Value(mismatched))]),
+            ..Default::default()
+        };
+
+        let error = query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+        assert_eq!(source.stats_calls.lock().unwrap().as_slice(), [ADDRESS_A]);
+    }
+
+    #[tokio::test]
+    async fn the_same_queue_id_on_distinct_exact_brokers_is_valid() {
+        let mut source = source_with_two_clusters();
+        source.stats.insert(
+            ADDRESS_A.to_string(),
+            TestResult::Value(stats("broker-a", &[(0, 0, 3, 1)])),
+        );
+        source.stats.insert(
+            ADDRESS_B.to_string(),
+            TestResult::Value(stats("broker-b", &[(0, 0, 5, 1)])),
+        );
+
+        let result = query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.partial);
+        assert_eq!(result.data.queue_count, 2);
+        assert_eq!(result.data.total_message_count, 8);
+        assert_eq!(
+            result
+                .data
+                .queues
+                .iter()
+                .map(|row| (row.broker_name.as_str(), row.queue_id))
+                .collect::<Vec<_>>(),
+            [("broker-a", 0), ("broker-b", 0)]
+        );
+    }
+
+    #[tokio::test]
+    async fn malicious_owner_duplicate_cannot_replace_or_double_count_the_exact_source_row() {
+        let mut source = source_with_two_clusters();
+        let mut duplicate_stats = TopicStatsTable::new();
+        insert_stats_row(&mut duplicate_stats, "orders", "broker-a", 0, 5, 15, 10);
+        insert_stats_row(&mut duplicate_stats, "orders", "forged-broker", 0, 1, 4, 10);
+        source
+            .stats
+            .insert(ADDRESS_A.to_string(), TestResult::Value(duplicate_stats));
+        source
+            .stats
+            .insert(ADDRESS_B.to_string(), TestResult::Value(TopicStatsTable::new()));
+
+        let result = query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.partial);
+        assert_eq!(result.data.queue_count, 1);
+        assert_eq!(result.data.total_message_count, 10);
+        assert_eq!(result.data.queues.len(), 1);
+        assert_eq!(result.data.queues[0].min_offset, 5);
+        assert_eq!(result.source_failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+    }
+
+    #[tokio::test]
+    async fn statistics_saturate_the_public_total_with_one_stable_warning() {
+        let addresses = [ADDRESS_A, ADDRESS_B, ADDRESS_C];
+        let brokers = ["broker-a", "broker-b", "broker-c"];
+        let (cluster_info, route) = topology(&[
+            ("cluster-a", brokers[0], addresses[0]),
+            ("cluster-a", brokers[1], addresses[1]),
+            ("cluster-a", brokers[2], addresses[2]),
+        ]);
+        let mut source = FakeSource {
+            cluster_info,
+            route: Some(route),
+            ..Default::default()
+        };
+        for (broker, address) in brokers.into_iter().zip(addresses) {
+            source.stats.insert(
+                address.to_string(),
+                TestResult::Value(stats(broker, &[(0, 0, i64::MAX, 1)])),
+            );
+        }
+
+        let result = query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.partial);
+        assert_eq!(result.data.queue_count, 3);
+        assert_eq!(result.data.total_message_count, u64::MAX);
+        assert_eq!(result.warnings, [TOPIC_STATS_TOTAL_SATURATED_WARNING]);
+        assert!(result.source_failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn retained_row_boundary_is_exact_stable_and_aggregates_all_unique_rows() {
+        let (cluster_info, route) = topology(&[("cluster-a", "broker-a", ADDRESS_A)]);
+        let mut exact = TopicStatsTable::new();
+        for queue_id in (0..MAX_TOPIC_STATS_ROWS as i32).rev() {
+            insert_stats_row(&mut exact, "orders", "broker-a", queue_id, 0, 1, 1);
+        }
+        let exact_source = FakeSource {
+            cluster_info: cluster_info.clone(),
+            route: Some(route.clone()),
+            stats: BTreeMap::from([(ADDRESS_A.to_string(), TestResult::Value(exact))]),
+            ..Default::default()
+        };
+        let request = QueryTopicStatsRequest::try_new("cluster-a", "orders", MAX_TOPIC_STATS_ROWS).unwrap();
+        let exact_result = query_topic_stats_from(&exact_source, &request).await.unwrap();
+        assert!(!exact_result.partial);
+        assert!(!exact_result.data.truncated);
+        assert_eq!(exact_result.data.queue_count, MAX_TOPIC_STATS_ROWS);
+        assert_eq!(exact_result.data.total_message_count, MAX_TOPIC_STATS_ROWS as u64);
+        assert_eq!(exact_result.data.queues.first().unwrap().queue_id, 0);
+        assert_eq!(
+            exact_result.data.queues.last().unwrap().queue_id,
+            MAX_TOPIC_STATS_ROWS as i32 - 1
+        );
+
+        let mut over = TopicStatsTable::new();
+        for queue_id in (0..=MAX_TOPIC_STATS_ROWS as i32).rev() {
+            insert_stats_row(&mut over, "orders", "broker-a", queue_id, 0, 1, 1);
+        }
+        let over_source = FakeSource {
+            cluster_info,
+            route: Some(route),
+            stats: BTreeMap::from([(ADDRESS_A.to_string(), TestResult::Value(over))]),
+            ..Default::default()
+        };
+        let over_result = query_topic_stats_from(&over_source, &request).await.unwrap();
+        assert!(over_result.partial);
+        assert!(over_result.data.truncated);
+        assert_eq!(over_result.data.queue_count, MAX_TOPIC_STATS_ROWS + 1);
+        assert_eq!(over_result.data.total_message_count, MAX_TOPIC_STATS_ROWS as u64 + 1);
+        assert_eq!(over_result.data.queues.len(), MAX_TOPIC_STATS_ROWS);
+        assert_eq!(over_result.data.queues.first().unwrap().queue_id, 0);
+        assert_eq!(
+            over_result.data.queues.last().unwrap().queue_id,
+            MAX_TOPIC_STATS_ROWS as i32 - 1
+        );
+        assert_eq!(over_result.warnings, [TOPIC_STATS_TRUNCATED_WARNING]);
+    }
+
+    #[tokio::test]
+    async fn configuration_is_fixed_sorted_and_versions_do_not_create_differences() {
+        let mut source = source_with_two_clusters();
+        let config = |version, read_queue_nums, message_type: &str| {
+            let mut config = TopicConfig::with_queues("orders", read_queue_nums, 8);
+            config.perm = 6;
+            config.attributes.insert("message.type".into(), message_type.into());
+            config
+                .attributes
+                .insert("secret.attribute".into(), "must-not-escape".into());
+            TopicConfigVersioned { version, config }
+        };
+        source
+            .configs
+            .insert(ADDRESS_A.to_string(), TestResult::Value(config(10, 8, "NORMAL")));
+        source
+            .configs
+            .insert(ADDRESS_B.to_string(), TestResult::Value(config(99, 16, "FIFO")));
+        let result = query_topic_config_from(
+            &source,
+            &QueryTopicConfigRequest::try_new("cluster-a", "orders").unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.partial);
+        assert_eq!(
+            result.data.inconsistent_fields,
+            [
+                TopicConfigDifferenceField::ReadQueueNums,
+                TopicConfigDifferenceField::MessageType,
+            ]
+        );
+        assert_eq!(result.data.brokers[0].broker_name, "broker-a");
+        assert_eq!(result.data.brokers[0].version, 10);
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(!json.contains("internal-a"));
+        assert!(!json.contains("secret.attribute"));
+        assert!(!json.contains("must-not-escape"));
+    }
+
+    #[tokio::test]
+    async fn configuration_version_only_changes_are_observation_evidence_not_differences() {
+        let mut source = source_with_two_clusters();
+        let mut config = TopicConfig::with_queues("orders", 8, 16);
+        config.perm = 6;
+        config.order = true;
+        config.attributes.insert("message.type".into(), "FIFO".into());
+        source.configs.insert(
+            ADDRESS_A.to_string(),
+            TestResult::Value(TopicConfigVersioned {
+                version: 10,
+                config: config.clone(),
+            }),
+        );
+        source.configs.insert(
+            ADDRESS_B.to_string(),
+            TestResult::Value(TopicConfigVersioned { version: 99, config }),
+        );
+
+        let result = query_topic_config_from(
+            &source,
+            &QueryTopicConfigRequest::try_new("cluster-a", "orders").unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.partial);
+        assert_eq!(result.data.brokers[0].version, 10);
+        assert_eq!(result.data.brokers[1].version, 99);
+        assert!(result.data.inconsistent_fields.is_empty());
+    }
+
+    #[tokio::test]
+    async fn configuration_reports_all_closed_semantic_differences_in_stable_order() {
+        let mut source = source_with_two_clusters();
+        let mut baseline = TopicConfig::with_queues("orders", 8, 8);
+        baseline.perm = 6;
+        baseline.order = false;
+        baseline.attributes.insert("message.type".into(), "NORMAL".into());
+        let mut different = TopicConfig::with_queues("orders", 16, 32);
+        different.perm = 4;
+        different.order = true;
+        different.attributes.insert("message.type".into(), "FIFO".into());
+        source.configs.insert(
+            ADDRESS_A.to_string(),
+            TestResult::Value(TopicConfigVersioned {
+                version: 1,
+                config: baseline,
+            }),
+        );
+        source.configs.insert(
+            ADDRESS_B.to_string(),
+            TestResult::Value(TopicConfigVersioned {
+                version: 1,
+                config: different,
+            }),
+        );
+
+        let result = query_topic_config_from(
+            &source,
+            &QueryTopicConfigRequest::try_new("cluster-a", "orders").unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.data.inconsistent_fields,
+            [
+                TopicConfigDifferenceField::ReadQueueNums,
+                TopicConfigDifferenceField::WriteQueueNums,
+                TopicConfigDifferenceField::Perm,
+                TopicConfigDifferenceField::Order,
+                TopicConfigDifferenceField::MessageType,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn configuration_preserves_partial_and_total_failure_semantics() {
+        let mut source = source_with_two_clusters();
+        source.configs.insert(
+            ADDRESS_A.to_string(),
+            TestResult::Value(TopicConfigVersioned {
+                version: 7,
+                config: TopicConfig::new("orders"),
+            }),
+        );
+        source
+            .configs
+            .insert(ADDRESS_B.to_string(), TestResult::Failure("secret-internal-b"));
+        let request = QueryTopicConfigRequest::try_new("cluster-a", "orders").unwrap();
+        let partial = query_topic_config_from(&source, &request).await.unwrap();
+        assert!(partial.partial);
+        assert_eq!(partial.data.brokers.len(), 1);
+        assert_eq!(partial.source_failures[0].logical_target(), "broker-b");
+        assert!(!serde_json::to_string(&partial).unwrap().contains("secret-internal-b"));
+
+        source
+            .configs
+            .insert(ADDRESS_A.to_string(), TestResult::Failure("secret-internal-a"));
+        let error = query_topic_config_from(&source, &request).await.unwrap_err();
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+        assert!(!error.to_string().contains("secret-internal"));
+    }
+
+    #[tokio::test]
+    async fn same_name_from_another_cluster_is_invalid_and_never_queried() {
+        let (cluster_info, mut route) = topology(&[("cluster-a", "broker-a", ADDRESS_A)]);
+        route.broker_datas[0].set_cluster("cluster-b".into());
+        let source = FakeSource {
+            cluster_info,
+            route: Some(route),
+            ..Default::default()
+        };
+
+        let error = query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+        assert!(source.stats_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn table_records_must_match_the_selected_cluster_and_lookup_name_without_rpc() {
+        for corruption in ["cluster", "name"] {
+            let (mut cluster_info, route) = topology(&[("cluster-a", "broker-a", ADDRESS_A)]);
+            let record = cluster_info
+                .broker_addr_table
+                .as_mut()
+                .unwrap()
+                .get_mut("broker-a")
+                .unwrap();
+            match corruption {
+                "cluster" => record.set_cluster("cluster-b".into()),
+                "name" => record.set_broker_name("broker-forged".into()),
+                _ => unreachable!(),
+            }
+
+            let (targets, failures) =
+                selected_cluster_route_masters(&cluster_info, &route, "cluster-a", AdminQuerySource::TopicStats)
+                    .unwrap();
+            assert!(targets.is_empty(), "corruption={corruption}");
+            assert_eq!(failures.len(), 1, "corruption={corruption}");
+            assert_eq!(failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+            assert_eq!(failures[0].logical_target(), "broker-a");
+
+            let source = FakeSource {
+                cluster_info,
+                route: Some(route),
+                ..Default::default()
+            };
+            let error = query_topic_stats_from(
+                &source,
+                &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+            assert!(source.stats_calls.lock().unwrap().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn master_endpoint_must_exist_and_pass_the_shared_remoting_validator_without_rpc() {
+        for invalid_master in [
+            None,
+            Some("https://secret.invalid:10911/path?token=value"),
+            Some("127.0.0.1:0"),
+        ] {
+            let (mut cluster_info, route) = topology(&[("cluster-a", "broker-a", ADDRESS_A)]);
+            let record = cluster_info
+                .broker_addr_table
+                .as_mut()
+                .unwrap()
+                .get_mut("broker-a")
+                .unwrap();
+            record.broker_addrs_mut().remove(&mix_all::MASTER_ID);
+            if let Some(invalid_master) = invalid_master {
+                record
+                    .broker_addrs_mut()
+                    .insert(mix_all::MASTER_ID, invalid_master.into());
+            }
+
+            let (targets, failures) =
+                selected_cluster_route_masters(&cluster_info, &route, "cluster-a", AdminQuerySource::TopicStats)
+                    .unwrap();
+            assert!(targets.is_empty());
+            assert_eq!(failures.len(), 1);
+            assert_eq!(failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+            assert_eq!(failures[0].logical_target(), "broker-a");
+            assert!(!serde_json::to_string(&failures).unwrap().contains("secret.invalid"));
+
+            let source = FakeSource {
+                cluster_info,
+                route: Some(route),
+                ..Default::default()
+            };
+            let error = query_topic_stats_from(
+                &source,
+                &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+            assert!(source.stats_calls.lock().unwrap().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_topology_is_partial_beside_a_valid_target_and_never_receives_an_rpc() {
+        let mut source = source_with_two_clusters();
+        source
+            .cluster_info
+            .broker_addr_table
+            .as_mut()
+            .unwrap()
+            .get_mut("broker-b")
+            .unwrap()
+            .broker_addrs_mut()
+            .insert(mix_all::MASTER_ID, "invalid-master".into());
+        source.stats.insert(
+            ADDRESS_A.to_string(),
+            TestResult::Value(stats("broker-a", &[(0, 0, 5, 10)])),
+        );
+
+        let result = query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.partial);
+        assert_eq!(result.data.total_message_count, 5);
+        assert_eq!(result.source_failures.len(), 1);
+        assert_eq!(result.source_failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+        assert_eq!(result.source_failures[0].logical_target(), "broker-b");
+        assert_eq!(source.stats_calls.lock().unwrap().as_slice(), [ADDRESS_A]);
+    }
+
+    #[test]
+    fn target_resolution_accepts_exactly_the_target_limit() {
+        let mut broker_table = HashMap::new();
+        let mut cluster_brokers = HashSet::new();
+        let mut route_brokers = Vec::new();
+        for index in 0..MAX_TOPIC_OBSERVATION_TARGETS {
+            let broker_name = format!("broker-{index:02}");
+            let address = format!("127.0.0.1:{}", 10_000 + index);
+            let data = BrokerData::new(
+                "cluster-a".into(),
+                broker_name.clone().into(),
+                HashMap::from([(mix_all::MASTER_ID, address.into())]),
+                None,
+            );
+            broker_table.insert(broker_name.clone().into(), data.clone());
+            cluster_brokers.insert(broker_name.into());
+            route_brokers.push(data);
+        }
+        let cluster_info = ClusterInfo::new(
+            Some(broker_table),
+            Some(HashMap::from([("cluster-a".into(), cluster_brokers)])),
+        );
+        let route = TopicRouteData {
+            broker_datas: route_brokers,
+            ..Default::default()
+        };
+
+        let (targets, failures) =
+            selected_cluster_route_masters(&cluster_info, &route, "cluster-a", AdminQuerySource::TopicStats).unwrap();
+        assert_eq!(targets.len(), MAX_TOPIC_OBSERVATION_TARGETS);
+        assert!(failures.is_empty());
+    }
+
+    #[test]
+    fn target_resolution_rejects_oversized_selected_cluster_routes() {
+        let mut broker_table = HashMap::new();
+        let mut cluster_brokers = HashSet::new();
+        let mut route_brokers = Vec::new();
+        for index in 0..=MAX_TOPIC_OBSERVATION_TARGETS {
+            let broker_name = format!("broker-{index:02}");
+            let data = BrokerData::new(
+                "cluster-a".into(),
+                broker_name.clone().into(),
+                HashMap::from([(mix_all::MASTER_ID, format!("internal-{index:02}").into())]),
+                None,
+            );
+            broker_table.insert(broker_name.clone().into(), data.clone());
+            cluster_brokers.insert(broker_name.into());
+            route_brokers.push(data);
+        }
+        let cluster_info = ClusterInfo::new(
+            Some(broker_table),
+            Some(HashMap::from([("cluster-a".into(), cluster_brokers)])),
+        );
+        let route = TopicRouteData {
+            broker_datas: route_brokers,
+            ..Default::default()
+        };
+
+        let error = selected_cluster_route_masters(&cluster_info, &route, "cluster-a", AdminQuerySource::TopicStats)
+            .unwrap_err();
+        assert_eq!(error.code(), Some("TOPIC_OBSERVATION_TARGET_LIMIT_EXCEEDED"));
+    }
+
+    #[tokio::test]
+    async fn missing_topic_and_cross_cluster_route_fail_closed() {
+        let mut source = source_with_two_clusters();
+        source.route = None;
+        assert!(matches!(
+            query_topic_config_from(
+                &source,
+                &QueryTopicConfigRequest::try_new("cluster-a", "orders").unwrap()
+            )
+            .await,
+            Err(AdminError::NotFound { .. })
+        ));
+
+        let (cluster_info, route) = topology(&[("cluster-b", "broker-c", ADDRESS_C)]);
+        source.cluster_info = cluster_info;
+        source.route = Some(route);
+        assert!(query_topic_stats_from(
+            &source,
+            &QueryTopicStatsRequest::try_new("cluster-a", "orders", 10).unwrap()
+        )
+        .await
+        .is_err());
+    }
+
+    fn test_error(reason: &str) -> RocketMQError {
+        RocketMQError::ResponseProcessFailed {
+            operation: "topic_observation_test",
+            reason: reason.to_string(),
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/mod.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/mod.rs
@@ -40,6 +40,7 @@ pub mod release_checkpoint;
 pub mod security;
 pub mod static_topic;
 pub mod topic;
+pub mod topic_observation;
 
 pub use self::error::AdminError;
 pub use self::error::AdminResult;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/query.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/query.rs
@@ -42,6 +42,7 @@ pub enum AdminQuerySource {
     ConsumerConnection,
     ProducerConnection,
     TopicConfig,
+    TopicStats,
     ConsumerGroupConfig,
     SubscriptionGroups,
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/topic_observation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/topic_observation.rs
@@ -1,0 +1,167 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Typed, address-free Topic observation contracts.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::core::error::required;
+use crate::core::query::AdminQueryResult;
+use crate::core::AdminError;
+use crate::core::AdminFuture;
+use crate::core::AdminResult;
+
+/// Maximum logical Broker masters queried by one Topic observation.
+pub const MAX_TOPIC_OBSERVATION_TARGETS: usize = 64;
+/// Maximum queue rows retained by one Topic statistics observation.
+pub const MAX_TOPIC_STATS_ROWS: usize = 10_000;
+/// Stable warning emitted when queue rows are omitted by the retained-row cap.
+pub const TOPIC_STATS_TRUNCATED_WARNING: &str = "topic_stats_rows_truncated";
+/// Stable warning emitted when an aggregate exceeds the public integer range.
+pub const TOPIC_STATS_TOTAL_SATURATED_WARNING: &str = "topic_stats_total_saturated";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryTopicStatsRequest {
+    pub cluster: String,
+    pub topic: String,
+    pub max_rows: usize,
+}
+
+impl QueryTopicStatsRequest {
+    pub fn try_new(cluster: impl Into<String>, topic: impl Into<String>, max_rows: usize) -> AdminResult<Self> {
+        if !(1..=MAX_TOPIC_STATS_ROWS).contains(&max_rows) {
+            return Err(AdminError::invalid_argument(
+                "max_rows",
+                format!("must be between 1 and {MAX_TOPIC_STATS_ROWS}"),
+            ));
+        }
+        Ok(Self {
+            cluster: required("cluster", cluster)?,
+            topic: required("topic", topic)?,
+            max_rows,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopicStatsQueueRow {
+    pub broker_name: String,
+    pub queue_id: i32,
+    pub min_offset: i64,
+    pub max_offset: i64,
+    pub message_count: u64,
+    pub last_update_timestamp: i64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryTopicStatsResult {
+    pub topic: String,
+    pub total_message_count: u64,
+    pub queue_count: usize,
+    pub queues: Vec<TopicStatsQueueRow>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryTopicConfigRequest {
+    pub cluster: String,
+    pub topic: String,
+}
+
+impl QueryTopicConfigRequest {
+    pub fn try_new(cluster: impl Into<String>, topic: impl Into<String>) -> AdminResult<Self> {
+        Ok(Self {
+            cluster: required("cluster", cluster)?,
+            topic: required("topic", topic)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopicConfigObservationRow {
+    pub broker_name: String,
+    pub version: u64,
+    pub read_queue_nums: u32,
+    pub write_queue_nums: u32,
+    pub perm: u32,
+    pub order: bool,
+    pub message_type: String,
+}
+
+/// Semantic Topic configuration fields compared across Brokers. Metadata
+/// versions are observation evidence and are intentionally not differences.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TopicConfigDifferenceField {
+    ReadQueueNums,
+    WriteQueueNums,
+    Perm,
+    Order,
+    MessageType,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryTopicConfigResult {
+    pub topic: String,
+    pub brokers: Vec<TopicConfigObservationRow>,
+    pub inconsistent_fields: Vec<TopicConfigDifferenceField>,
+}
+
+/// Evidence-aware read-only Topic observations.
+pub trait TopicObservationQueryAdmin: Send {
+    fn query_topic_stats<'a>(
+        &'a mut self,
+        request: &'a QueryTopicStatsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryTopicStatsResult>>;
+
+    fn query_topic_config<'a>(
+        &'a mut self,
+        request: &'a QueryTopicConfigRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryTopicConfigResult>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requests_trim_required_values_and_bound_statistics_rows() {
+        let stats = QueryTopicStatsRequest::try_new(" cluster-a ", " orders ", MAX_TOPIC_STATS_ROWS).unwrap();
+        assert_eq!(stats.cluster, "cluster-a");
+        assert_eq!(stats.topic, "orders");
+        assert!(QueryTopicStatsRequest::try_new("cluster-a", "orders", 0).is_err());
+        assert!(QueryTopicStatsRequest::try_new("cluster-a", "orders", MAX_TOPIC_STATS_ROWS + 1).is_err());
+
+        let config = QueryTopicConfigRequest::try_new(" cluster-a ", " orders ").unwrap();
+        assert_eq!(config.cluster, "cluster-a");
+        assert_eq!(config.topic, "orders");
+        assert!(QueryTopicConfigRequest::try_new("cluster-a", " ").is_err());
+    }
+
+    #[test]
+    fn difference_fields_have_a_closed_stable_wire_order() {
+        let fields = [
+            TopicConfigDifferenceField::ReadQueueNums,
+            TopicConfigDifferenceField::WriteQueueNums,
+            TopicConfigDifferenceField::Perm,
+            TopicConfigDifferenceField::Order,
+            TopicConfigDifferenceField::MessageType,
+        ];
+        assert_eq!(
+            serde_json::to_value(fields).unwrap(),
+            serde_json::json!(["read_queue_nums", "write_queue_nums", "perm", "order", "message_type"])
+        );
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
@@ -31,6 +31,10 @@ mod exact_broker;
 #[path = "client_adapter/read_queries.rs"]
 mod read_queries;
 
+#[cfg(feature = "read-client-adapter")]
+#[path = "client_adapter/topic_observation.rs"]
+mod topic_observation;
+
 #[cfg(feature = "client-adapter")]
 pub mod client_adapter;
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9937
- Fixes #9937

### Brief Description

This change adds the typed Topic-observation slice to the default read-only RocketMQ MCP server:

- Add a narrow exact-Broker Topic statistics read extension and typed Admin Core requests, results, evidence, and query adapter.
- Register `rocketmq_get_topic_stats` and `rocketmq_get_topic_config` as the only new tools, both read-only, idempotent, cluster-scoped, and protected by `rocketmq:read`.
- Resolve only selected-cluster route masters, keep Broker addresses internal, bound and sort statistics, preserve partial and total-failure evidence, and page statistics from one snapshot.
- Return a fixed Topic configuration projection with stable semantic differences across Brokers, excluding arbitrary attributes and version-only differences.
- Route both tools through the shared cache, snapshot, timeout, cancellation, shutdown, audit, sanitization, row, and byte policies, and update the default and all-feature contract snapshots.

### How Did You Test This Change?

Passed from the repository root:

- `cargo fmt -p rocketmq-client-rust -- --check`
- `cargo fmt -p rocketmq-admin-core -- --check`
- `cargo test -p rocketmq-admin-core --features read-client-adapter topic_observation` (24 focused tests passed)
- `cargo test -p rocketmq-admin-core --features read-client-adapter` (85 unit tests and 10 integration tests passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`

Passed from `rocketmq-ai/rocketmq-mcp`:

- `cargo fmt -p rocketmq-mcp -- --check`
- `cargo test --locked topic_observation` (5 focused tests passed)
- `cargo check --locked`
- `python scripts/check_read_only_boundary.py`
- `cargo test --locked` (214 library tests, 5 binary tests, 1 compatibility test, and 3 integration tests passed; 1 external-cluster E2E test was ignored because its required environment was not configured)
- `cargo test --locked --all-features` (242 library tests, 5 binary tests, 1 compatibility test, and 3 integration tests passed; the same external-cluster E2E test was ignored)
- `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`
- `cargo doc --locked --no-deps`
- Snapshot audit: all four intended default/all-feature contract snapshots matched their tests and no `.snap.new` files remained.

Known baseline limitations:

- `cargo fmt --all -- --check` reaches Windows OS error 206 because the all-package rustfmt command line is too long; all three affected package-scoped format checks pass.
- `cargo test -p rocketmq-client-rust --no-default-features --features admin-read --lib` reaches two existing E0433 errors in the unchanged `mq_client_api_impl` unit tests because `TopicConfig` is imported only with `admin-mutation`. The root all-feature strict Clippy and every MCP/Admin Core validation above pass.
