### PR TITLE
[ISSUE #9941]🚀Add typed Consumer group details and progress tools to RocketMQ MCP

### DIFF
--- a/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml
+++ b/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml
@@ -16,6 +16,8 @@ allow_tools = [
   "rocketmq_get_consumer_group_config_state",
   "rocketmq_get_topic_stats",
   "rocketmq_get_topic_config",
+  "rocketmq_get_consumer_group_details",
+  "rocketmq_get_consumer_progress",
 ]
 deny_tools = ["*"]
 

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
@@ -61,6 +61,9 @@ use crate::tools::config_tools::ConsumerGroupConfigStateRow;
 use crate::tools::config_tools::TopicConfigStateOutput;
 use crate::tools::config_tools::TopicConfigStateRow;
 use crate::tools::consumer_tools::ConsumerGroupSummary;
+use crate::tools::consumer_tools::ConsumerProgressQueueRow;
+use crate::tools::consumer_tools::ConsumerProgressState;
+use crate::tools::consumer_tools::GetConsumerGroupDetailsOutput;
 use crate::tools::consumer_tools::QueueLag;
 use crate::tools::executor::ToolExecutionError;
 use crate::tools::proxy_tools::ProxyDrainStateOutput;
@@ -68,6 +71,7 @@ use crate::tools::topic_tools::TopicRouteBroker;
 use crate::tools::topic_tools::TopicRouteQueue;
 use crate::tools::topic_tools::TopicStatsQueueRow;
 
+mod consumer_observation;
 mod topic_observation;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,6 +94,19 @@ pub(crate) struct SessionConsumerLag {
     pub total_lag: i64,
     pub consume_tps: f64,
     pub inflight_total: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SessionConsumerProgress {
+    pub state: ConsumerProgressState,
+    pub topic_count: usize,
+    pub queue_count: usize,
+    pub total_lag: u64,
+    pub max_queue_lag: u64,
+    pub total_inflight: u64,
+    pub consume_tps: f64,
+    pub queues: Vec<ConsumerProgressQueueRow>,
+    pub truncated: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -208,6 +225,28 @@ pub(crate) trait AdminSession: Send {
         topic: &str,
         consumer_group: &str,
     ) -> impl Future<Output = Result<QueryPayload<SessionConsumerLag>, ToolExecutionError>> + Send;
+
+    fn consumer_group_details(
+        &mut self,
+        _consumer_group: &str,
+    ) -> impl Future<Output = Result<QueryPayload<GetConsumerGroupDetailsOutput>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "consumer group details are unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn consumer_progress(
+        &mut self,
+        _consumer_group: &str,
+    ) -> impl Future<Output = Result<QueryPayload<SessionConsumerProgress>, ToolExecutionError>> + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "consumer progress is unavailable".to_string(),
+            ))
+        }
+    }
 
     fn probe_broker_runtime_target(
         &mut self,
@@ -492,6 +531,20 @@ impl AdminSession for AdminCoreSession {
             return session.topic_config(topic).await;
         }
         self.query_topic_config_observation(topic).await
+    }
+
+    async fn consumer_group_details(
+        &mut self,
+        consumer_group: &str,
+    ) -> Result<QueryPayload<GetConsumerGroupDetailsOutput>, ToolExecutionError> {
+        self.query_consumer_group_details_observation(consumer_group).await
+    }
+
+    async fn consumer_progress(
+        &mut self,
+        consumer_group: &str,
+    ) -> Result<QueryPayload<SessionConsumerProgress>, ToolExecutionError> {
+        self.query_consumer_progress_observation(consumer_group).await
     }
 
     async fn consumer_groups(&mut self) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session/consumer_observation.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session/consumer_observation.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_admin_core::core::consumer_observation as admin;
+use rocketmq_admin_core::core::consumer_observation::ConsumerObservationQueryAdmin;
+
+use super::map_logical_admin_error;
+use super::AdminCoreSession;
+use super::SessionConsumerProgress;
+use crate::model::contract::observed_at;
+use crate::model::contract::observed_at_from_millis;
+use crate::model::contract::QueryPayload;
+use crate::tools::consumer_tools as tool;
+use crate::tools::executor::ToolExecutionError;
+
+impl AdminCoreSession {
+    pub(super) async fn query_consumer_group_details_observation(
+        &mut self,
+        consumer_group: &str,
+    ) -> Result<QueryPayload<tool::GetConsumerGroupDetailsOutput>, ToolExecutionError> {
+        let request = admin::QueryConsumerGroupDetailsRequest::try_new(
+            self.cluster.rocketmq_cluster_name.clone(),
+            consumer_group,
+        )
+        .map_err(|_| ToolExecutionError::InvalidArguments("invalid consumer group selector".to_string()))?;
+        let result = self
+            .admin_mut()?
+            .query_consumer_group_details(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        let cluster = self.cluster.name.clone();
+        Ok(
+            QueryPayload::from_admin(result).map(|result| tool::GetConsumerGroupDetailsOutput {
+                cluster,
+                consumer_group: result.consumer_group,
+                total_connection_count: result.total_connection_count,
+                brokers: result
+                    .brokers
+                    .into_iter()
+                    .map(|row| tool::ConsumerGroupDetailsBrokerRow {
+                        broker_name: row.broker_name,
+                        config_state: match row.config_state {
+                            admin::ConsumerGroupConfigState::Present => tool::ConsumerGroupConfigPresence::Present,
+                            admin::ConsumerGroupConfigState::Absent => tool::ConsumerGroupConfigPresence::Absent,
+                        },
+                        config_version: row.config_version,
+                        consume_enable: row.consume_enable,
+                        consume_from_min_enable: row.consume_from_min_enable,
+                        consume_broadcast_enable: row.consume_broadcast_enable,
+                        consume_message_orderly: row.consume_message_orderly,
+                        retry_queue_nums: row.retry_queue_nums,
+                        retry_max_times: row.retry_max_times,
+                        notify_consumer_ids_changed_enable: row.notify_consumer_ids_changed_enable,
+                        consume_timeout_minutes: row.consume_timeout_minutes,
+                        connection_state: row.connection_state.map(|state| match state {
+                            admin::ConsumerConnectionState::Online => tool::ConsumerConnectionState::Online,
+                            admin::ConsumerConnectionState::Offline => tool::ConsumerConnectionState::Offline,
+                        }),
+                        connection_count: row.connection_count,
+                        consume_type: row.consume_type.map(|value| match value {
+                            admin::ConsumerConsumeType::Pull => tool::ConsumerConsumeType::Pull,
+                            admin::ConsumerConsumeType::Push => tool::ConsumerConsumeType::Push,
+                            admin::ConsumerConsumeType::Pop => tool::ConsumerConsumeType::Pop,
+                            admin::ConsumerConsumeType::Unknown => tool::ConsumerConsumeType::Unknown,
+                        }),
+                        message_model: row.message_model.map(|value| match value {
+                            admin::ConsumerMessageModel::Broadcasting => tool::ConsumerMessageModel::Broadcasting,
+                            admin::ConsumerMessageModel::Clustering => tool::ConsumerMessageModel::Clustering,
+                            admin::ConsumerMessageModel::Unknown => tool::ConsumerMessageModel::Unknown,
+                        }),
+                        consume_from_where: row.consume_from_where.map(|value| match value {
+                            admin::ConsumerConsumeFromWhere::LastOffset => tool::ConsumerConsumeFromWhere::LastOffset,
+                            admin::ConsumerConsumeFromWhere::LastOffsetAndMinFirst => {
+                                tool::ConsumerConsumeFromWhere::LastOffsetAndMinFirst
+                            }
+                            admin::ConsumerConsumeFromWhere::MinOffset => tool::ConsumerConsumeFromWhere::MinOffset,
+                            admin::ConsumerConsumeFromWhere::MaxOffset => tool::ConsumerConsumeFromWhere::MaxOffset,
+                            admin::ConsumerConsumeFromWhere::FirstOffset => tool::ConsumerConsumeFromWhere::FirstOffset,
+                            admin::ConsumerConsumeFromWhere::Timestamp => tool::ConsumerConsumeFromWhere::Timestamp,
+                            admin::ConsumerConsumeFromWhere::Unknown => tool::ConsumerConsumeFromWhere::Unknown,
+                        }),
+                    })
+                    .collect(),
+                generated_at: observed_at(),
+            }),
+        )
+    }
+
+    pub(super) async fn query_consumer_progress_observation(
+        &mut self,
+        consumer_group: &str,
+    ) -> Result<QueryPayload<SessionConsumerProgress>, ToolExecutionError> {
+        let request = admin::QueryConsumerProgressRequest::try_new(
+            self.cluster.rocketmq_cluster_name.clone(),
+            consumer_group,
+            admin::MAX_CONSUMER_PROGRESS_ROWS,
+        )
+        .map_err(|_| ToolExecutionError::InvalidArguments("invalid consumer progress selector".to_string()))?;
+        let result = self
+            .admin_mut()?
+            .query_consumer_progress(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        Ok(QueryPayload::from_admin(result).map(|result| SessionConsumerProgress {
+            state: match result.state {
+                admin::ConsumerProgressState::NoConsumption => tool::ConsumerProgressState::NoConsumption,
+                admin::ConsumerProgressState::Observed => tool::ConsumerProgressState::Observed,
+            },
+            topic_count: result.topic_count,
+            queue_count: result.queue_count,
+            total_lag: result.total_lag,
+            max_queue_lag: result.max_queue_lag,
+            total_inflight: result.total_inflight,
+            consume_tps: result.consume_tps,
+            queues: result
+                .queues
+                .into_iter()
+                .map(|row| tool::ConsumerProgressQueueRow {
+                    topic: row.topic,
+                    broker_name: row.broker_name,
+                    queue_id: row.queue_id,
+                    broker_offset: row.broker_offset,
+                    consumer_offset: row.consumer_offset,
+                    pull_offset: row.pull_offset,
+                    lag: row.lag,
+                    inflight: row.inflight,
+                    last_observed_at: observed_at_from_millis(row.last_timestamp),
+                })
+                .collect(),
+            truncated: result.truncated,
+        }))
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
@@ -91,6 +91,7 @@ use crate::tools::topic_tools::ListTopicsOutput;
 use crate::tools::topic_tools::QueryTopicRouteArgs;
 use crate::tools::topic_tools::QueryTopicRouteOutput;
 
+mod consumer_observation;
 mod topic_observation;
 
 #[derive(Debug, Clone)]
@@ -227,6 +228,32 @@ pub(crate) trait ReadOnlyQuery: Clone + Send + Sync + 'static {
         &self,
         args: QueryConsumerLagArgs,
     ) -> impl Future<Output = Result<QueryResult<QueryConsumerLagOutput>, ToolExecutionError>> + Send;
+
+    fn consumer_group_details(
+        &self,
+        _args: crate::tools::consumer_tools::GetConsumerGroupDetailsArgs,
+    ) -> impl Future<
+        Output = Result<QueryResult<crate::tools::consumer_tools::GetConsumerGroupDetailsOutput>, ToolExecutionError>,
+    > + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "consumer group details are unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn consumer_progress(
+        &self,
+        _args: crate::tools::consumer_tools::GetConsumerProgressArgs,
+    ) -> impl Future<
+        Output = Result<QueryResult<crate::tools::consumer_tools::GetConsumerProgressOutput>, ToolExecutionError>,
+    > + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "consumer progress is unavailable".to_string(),
+            ))
+        }
+    }
 
     fn describe_broker(
         &self,
@@ -1504,6 +1531,20 @@ where
         args: QueryConsumerLagArgs,
     ) -> Result<QueryResult<QueryConsumerLagOutput>, ToolExecutionError> {
         QueryFacade::query_consumer_lag(self, args).await
+    }
+
+    async fn consumer_group_details(
+        &self,
+        args: crate::tools::consumer_tools::GetConsumerGroupDetailsArgs,
+    ) -> Result<QueryResult<crate::tools::consumer_tools::GetConsumerGroupDetailsOutput>, ToolExecutionError> {
+        QueryFacade::consumer_group_details(self, args).await
+    }
+
+    async fn consumer_progress(
+        &self,
+        args: crate::tools::consumer_tools::GetConsumerProgressArgs,
+    ) -> Result<QueryResult<crate::tools::consumer_tools::GetConsumerProgressOutput>, ToolExecutionError> {
+        QueryFacade::consumer_progress(self, args).await
     }
 
     async fn describe_broker(

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade/consumer_observation.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade/consumer_observation.rs
@@ -1,0 +1,438 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use super::normalized_identifier;
+use super::normalized_logical_identifier;
+use super::query_result_from_snapshot;
+use super::AdminSession;
+use super::AdminSessionFactory;
+use super::QueryFacade;
+use crate::adapter::admin_session::SessionConsumerProgress;
+use crate::infrastructure::snapshot::SnapshotKind;
+use crate::infrastructure::snapshot::SnapshotRequest;
+use crate::infrastructure::snapshot::SnapshotSelectionMode;
+use crate::infrastructure::snapshot::SnapshotWeight;
+use crate::model::contract::QueryResult;
+use crate::tools::consumer_tools::GetConsumerGroupDetailsArgs;
+use crate::tools::consumer_tools::GetConsumerGroupDetailsOutput;
+use crate::tools::consumer_tools::GetConsumerProgressArgs;
+use crate::tools::consumer_tools::GetConsumerProgressOutput;
+use crate::tools::executor::ToolExecutionError;
+
+impl<F> QueryFacade<F>
+where
+    F: AdminSessionFactory,
+{
+    pub(crate) async fn consumer_group_details(
+        &self,
+        mut args: GetConsumerGroupDetailsArgs,
+    ) -> Result<QueryResult<GetConsumerGroupDetailsOutput>, ToolExecutionError> {
+        args.cluster = normalized_logical_identifier("cluster", &args.cluster)?;
+        args.consumer_group = normalized_identifier("consumer_group", &args.consumer_group)?;
+        let cluster = self.resolve_required_cluster(&args.cluster)?;
+        let key = self.cache_key(
+            "consumer_group_details",
+            &cluster.name,
+            &format!("consumer_group={}", args.consumer_group),
+        );
+        let ttl = Duration::from_millis(self.config.cache.consumer_lag_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.consumer_group_details(&args.consumer_group).await })
+                    })
+                    .await
+                },
+            )
+            .await
+    }
+
+    pub(crate) async fn consumer_progress(
+        &self,
+        mut args: GetConsumerProgressArgs,
+    ) -> Result<QueryResult<GetConsumerProgressOutput>, ToolExecutionError> {
+        args.cluster = normalized_logical_identifier("cluster", &args.cluster)?;
+        args.consumer_group = normalized_identifier("consumer_group", &args.consumer_group)?;
+        let cluster = self.resolve_required_cluster(&args.cluster)?;
+        let request = SnapshotRequest::try_new_with_selection(
+            SnapshotKind::ConsumerProgress,
+            cluster.name.clone(),
+            format!("consumer_group={}", args.consumer_group),
+            SnapshotSelectionMode::ExactIdentifier,
+            &args.page,
+            self.visibility_class.as_str(),
+        )?;
+        let consumer_group = args.consumer_group.clone();
+        let snapshot = self
+            .snapshots
+            .get_or_load(
+                request,
+                args.page.cursor.as_deref(),
+                self.cursor_snapshot_ttl(),
+                self.snapshot_response_ttl(self.config.cache.consumer_lag_ttl_ms),
+                |progress: &SessionConsumerProgress| SnapshotWeight::detail(progress.queues.len()),
+                &self.control.cancellation,
+                || {
+                    self.run_workflow(cluster.clone(), move |session, _| {
+                        Box::pin(async move { session.consumer_progress(&consumer_group).await })
+                    })
+                },
+            )
+            .await?;
+        let progress = &snapshot.payload.data;
+        let page = self.snapshots.page(&snapshot, &progress.queues)?;
+        let payload = snapshot.payload.completeness().wrap(GetConsumerProgressOutput {
+            cluster: cluster.name,
+            consumer_group: args.consumer_group,
+            state: progress.state.clone(),
+            topic_count: progress.topic_count,
+            queue_count: progress.queue_count,
+            total_lag: progress.total_lag,
+            max_queue_lag: progress.max_queue_lag,
+            total_inflight: progress.total_inflight,
+            consume_tps: progress.consume_tps,
+            truncated: progress.truncated,
+            page,
+            generated_at: snapshot.observed_at.clone(),
+        });
+        Ok(query_result_from_snapshot(&snapshot, payload))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use rocketmq_admin_core::core::broker::BrokerRuntimeTargetStatus;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::adapter::admin_session::AdminSession;
+    use crate::adapter::admin_session::ResolvedCluster;
+    use crate::adapter::admin_session::SessionConsumerLag;
+    use crate::adapter::admin_session::SessionTopicRoute;
+    use crate::config::McpConfig;
+    use crate::guard::context::VisibilityClass;
+    use crate::model::contract::CacheStatus;
+    use crate::model::contract::PageRequest;
+    use crate::model::contract::QueryPayload;
+    use crate::tools::cluster_tools::BrokerSummary;
+    use crate::tools::consumer_tools::ConsumerConnectionState;
+    use crate::tools::consumer_tools::ConsumerGroupConfigPresence;
+    use crate::tools::consumer_tools::ConsumerGroupDetailsBrokerRow;
+    use crate::tools::consumer_tools::ConsumerGroupSummary;
+    use crate::tools::consumer_tools::ConsumerProgressQueueRow;
+    use crate::tools::consumer_tools::ConsumerProgressState;
+
+    #[derive(Debug, Default)]
+    struct Counters {
+        starts: AtomicUsize,
+        shutdowns: AtomicUsize,
+        details: AtomicUsize,
+        progress: AtomicUsize,
+        progress_entered: AtomicBool,
+    }
+
+    #[derive(Clone, Default)]
+    struct Factory {
+        counters: Arc<Counters>,
+        hang_progress: bool,
+    }
+
+    impl AdminSessionFactory for Factory {
+        type Session = Session;
+
+        async fn start(&self, cluster: ResolvedCluster) -> Result<Self::Session, ToolExecutionError> {
+            self.counters.starts.fetch_add(1, Ordering::SeqCst);
+            Ok(Session {
+                cluster,
+                counters: self.counters.clone(),
+                hang_progress: self.hang_progress,
+            })
+        }
+    }
+
+    struct Session {
+        cluster: ResolvedCluster,
+        counters: Arc<Counters>,
+        hang_progress: bool,
+    }
+
+    impl AdminSession for Session {
+        async fn broker_rows(&mut self) -> Result<QueryPayload<Vec<BrokerSummary>>, ToolExecutionError> {
+            Ok(QueryPayload::complete(Vec::new()))
+        }
+
+        async fn topic_inventory(&mut self) -> Result<Vec<String>, ToolExecutionError> {
+            Ok(Vec::new())
+        }
+
+        async fn topic_route(&mut self, _topic: &str) -> Result<SessionTopicRoute, ToolExecutionError> {
+            Ok(SessionTopicRoute {
+                brokers: Vec::new(),
+                queues: Vec::new(),
+            })
+        }
+
+        async fn consumer_groups(&mut self) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
+            Ok(QueryPayload::complete(Vec::new()))
+        }
+
+        async fn consumer_lag(
+            &mut self,
+            _topic: &str,
+            _consumer_group: &str,
+        ) -> Result<QueryPayload<SessionConsumerLag>, ToolExecutionError> {
+            Ok(QueryPayload::complete(SessionConsumerLag {
+                queues: Vec::new(),
+                total_lag: 0,
+                consume_tps: 0.0,
+                inflight_total: 0,
+            }))
+        }
+
+        async fn consumer_group_details(
+            &mut self,
+            consumer_group: &str,
+        ) -> Result<QueryPayload<GetConsumerGroupDetailsOutput>, ToolExecutionError> {
+            self.counters.details.fetch_add(1, Ordering::SeqCst);
+            Ok(QueryPayload::complete(GetConsumerGroupDetailsOutput {
+                cluster: self.cluster.name.clone(),
+                consumer_group: consumer_group.to_string(),
+                total_connection_count: 0,
+                brokers: vec![ConsumerGroupDetailsBrokerRow {
+                    broker_name: "broker-a".to_string(),
+                    config_state: ConsumerGroupConfigPresence::Present,
+                    config_version: Some(1),
+                    consume_enable: Some(true),
+                    consume_from_min_enable: Some(false),
+                    consume_broadcast_enable: Some(false),
+                    consume_message_orderly: Some(false),
+                    retry_queue_nums: Some(1),
+                    retry_max_times: Some(1),
+                    notify_consumer_ids_changed_enable: Some(true),
+                    consume_timeout_minutes: Some(1),
+                    connection_state: Some(ConsumerConnectionState::Offline),
+                    connection_count: 0,
+                    consume_type: None,
+                    message_model: None,
+                    consume_from_where: None,
+                }],
+                generated_at: "session-time".to_string(),
+            }))
+        }
+
+        async fn consumer_progress(
+            &mut self,
+            _consumer_group: &str,
+        ) -> Result<QueryPayload<SessionConsumerProgress>, ToolExecutionError> {
+            self.counters.progress.fetch_add(1, Ordering::SeqCst);
+            self.counters.progress_entered.store(true, Ordering::SeqCst);
+            if self.hang_progress {
+                std::future::pending::<()>().await;
+            }
+            Ok(QueryPayload::complete(SessionConsumerProgress {
+                state: ConsumerProgressState::Observed,
+                topic_count: 1,
+                queue_count: 3,
+                total_lag: 3,
+                max_queue_lag: 1,
+                total_inflight: 0,
+                consume_tps: 1.0,
+                queues: (0..3)
+                    .map(|queue_id| ConsumerProgressQueueRow {
+                        topic: "orders".to_string(),
+                        broker_name: "broker-a".to_string(),
+                        queue_id,
+                        broker_offset: i64::from(queue_id) + 1,
+                        consumer_offset: i64::from(queue_id),
+                        pull_offset: i64::from(queue_id),
+                        lag: 1,
+                        inflight: 0,
+                        last_observed_at: None,
+                    })
+                    .collect(),
+                truncated: false,
+            }))
+        }
+
+        async fn probe_broker_runtime_target(
+            &mut self,
+            _broker_name: &str,
+        ) -> Result<BrokerRuntimeTargetStatus, ToolExecutionError> {
+            Ok(BrokerRuntimeTargetStatus::NotFound)
+        }
+
+        async fn shutdown(self) -> Result<(), ToolExecutionError> {
+            self.counters.shutdowns.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn config() -> McpConfig {
+        McpConfig::load(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("conf")
+                .join("mcp.example.toml"),
+        )
+        .unwrap()
+    }
+
+    fn progress_args(group: &str, limit: u32, cursor: Option<String>) -> GetConsumerProgressArgs {
+        GetConsumerProgressArgs {
+            cluster: "local-dev".to_string(),
+            consumer_group: group.to_string(),
+            page: PageRequest {
+                limit: Some(limit),
+                cursor,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn continuation_is_zero_rpc_and_binds_group_limit_and_visibility() {
+        let factory = Factory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config(), factory);
+        let first = facade
+            .consumer_progress(progress_args("group-a", 1, None))
+            .await
+            .unwrap();
+        let cursor = first.data.page.next_cursor.unwrap();
+        let second = facade
+            .consumer_progress(progress_args("group-a", 1, Some(cursor.clone())))
+            .await
+            .unwrap();
+        assert_eq!((first.data.topic_count, first.data.queue_count), (1, 3));
+        assert_eq!((first.data.total_lag, first.data.max_queue_lag), (3, 1));
+        assert_eq!(first.data.page.items[0].queue_id, 0);
+        assert_eq!(second.data.page.items[0].queue_id, 1);
+        assert_eq!(counters.progress.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+        assert!(facade
+            .consumer_progress(progress_args("group-b", 1, Some(cursor.clone())))
+            .await
+            .is_err());
+        assert!(facade
+            .consumer_progress(progress_args("group-a", 2, Some(cursor.clone())))
+            .await
+            .is_err());
+        assert!(facade
+            .clone()
+            .with_visibility_class(VisibilityClass::Sensitive)
+            .consumer_progress(progress_args("group-a", 1, Some(cursor)))
+            .await
+            .is_err());
+        assert_eq!(counters.progress.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_disabled_reloads_first_pages_but_keeps_existing_cursor() {
+        let mut configuration = config();
+        configuration.cache.enabled = false;
+        let factory = Factory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(configuration, factory);
+        let first = facade
+            .consumer_progress(progress_args("group-a", 1, None))
+            .await
+            .unwrap();
+        facade
+            .consumer_progress(progress_args("group-a", 1, first.data.page.next_cursor))
+            .await
+            .unwrap();
+        facade
+            .consumer_progress(progress_args("group-a", 1, None))
+            .await
+            .unwrap();
+        let details = GetConsumerGroupDetailsArgs {
+            cluster: "local-dev".to_string(),
+            consumer_group: "group-a".to_string(),
+        };
+        facade.consumer_group_details(details.clone()).await.unwrap();
+        facade.consumer_group_details(details).await.unwrap();
+        assert_eq!(counters.progress.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.details.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn details_cache_hits_and_output_has_no_sensitive_shapes() {
+        let factory = Factory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config(), factory);
+        let args = GetConsumerGroupDetailsArgs {
+            cluster: "local-dev".to_string(),
+            consumer_group: "group-a".to_string(),
+        };
+        let first = facade.consumer_group_details(args.clone()).await.unwrap();
+        let second = facade.consumer_group_details(args).await.unwrap();
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(second.cache_status, CacheStatus::Hit);
+        assert_eq!(counters.details.load(Ordering::SeqCst), 1);
+        let wire = serde_json::to_string(&first.data).unwrap();
+        for forbidden in ["client_id", "client_addr", "subscription", "attributes", "raw_error"] {
+            assert!(!wire.contains(forbidden));
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_and_timeout_shutdown_progress_sessions() {
+        let factory = Factory {
+            hang_progress: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let cancellation = CancellationToken::new();
+        let facade = QueryFacade::with_factory(config(), factory).with_cancellation(cancellation.clone());
+        let query = facade.consumer_progress(progress_args("group-a", 1, None));
+        tokio::pin!(query);
+        loop {
+            tokio::select! {
+                result = &mut query => panic!("query completed before cancellation: {result:?}"),
+                () = tokio::task::yield_now() => {
+                    if counters.progress_entered.load(Ordering::SeqCst) {
+                        break;
+                    }
+                }
+            }
+        }
+        cancellation.cancel();
+        assert!(matches!(query.await, Err(ToolExecutionError::Cancelled)));
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+
+        let factory = Factory {
+            hang_progress: true,
+            ..Default::default()
+        };
+        let counters = factory.counters.clone();
+        let control = super::super::WorkflowControl::new(Duration::from_millis(10), CancellationToken::new());
+        let facade = QueryFacade::with_factory_and_control(config(), factory, control);
+        assert!(matches!(
+            facade.consumer_progress(progress_args("group-a", 1, None)).await,
+            Err(ToolExecutionError::TimedOut { timeout_ms: 10 })
+        ));
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp/src/guard.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/guard.rs
@@ -507,6 +507,8 @@ fn requires_explicit_cluster(tool_name: &str) -> bool {
             | "rocketmq_get_consumer_group_config_state"
             | "rocketmq_get_topic_stats"
             | "rocketmq_get_topic_config"
+            | "rocketmq_get_consumer_group_details"
+            | "rocketmq_get_consumer_progress"
     )
 }
 
@@ -556,6 +558,8 @@ mod tests {
             "rocketmq_get_proxy_drain_state",
             "rocketmq_get_topic_stats",
             "rocketmq_get_topic_config",
+            "rocketmq_get_consumer_group_details",
+            "rocketmq_get_consumer_progress",
         ] {
             let arguments = serde_json::json!({ "cluster": "   " }).as_object().unwrap().clone();
             let error = guard

--- a/rocketmq-ai/rocketmq-mcp/src/infrastructure/snapshot.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/infrastructure/snapshot.rs
@@ -33,6 +33,7 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use crate::adapter::admin_session::SessionConsumerLag;
+use crate::adapter::admin_session::SessionConsumerProgress;
 use crate::adapter::admin_session::SessionTopicRoute;
 use crate::infrastructure::cache::CacheMetricsSnapshot;
 use crate::model::contract::observed_at;
@@ -44,6 +45,7 @@ use crate::model::contract::SourceFailure;
 use crate::model::contract::DEFAULT_PAGE_LIMIT;
 use crate::model::contract::MAX_PAGE_LIMIT;
 use crate::model::contract::SCHEMA_VERSION;
+use crate::tools::consumer_tools::ConsumerProgressQueueRow;
 use crate::tools::consumer_tools::QueueLag;
 use crate::tools::executor::ToolExecutionError;
 use crate::tools::topic_tools::TopicRouteBroker;
@@ -160,6 +162,15 @@ impl RetainedSize for QueueLag {
     }
 }
 
+impl RetainedSize for ConsumerProgressQueueRow {
+    fn retained_heap_size(&self) -> usize {
+        self.topic
+            .retained_heap_size()
+            .saturating_add(self.broker_name.retained_heap_size())
+            .saturating_add(self.last_observed_at.retained_heap_size())
+    }
+}
+
 impl RetainedSize for SessionTopicRoute {
     fn retained_heap_size(&self) -> usize {
         self.brokers
@@ -169,6 +180,12 @@ impl RetainedSize for SessionTopicRoute {
 }
 
 impl RetainedSize for SessionConsumerLag {
+    fn retained_heap_size(&self) -> usize {
+        self.queues.retained_heap_size()
+    }
+}
+
+impl RetainedSize for SessionConsumerProgress {
     fn retained_heap_size(&self) -> usize {
         self.queues.retained_heap_size()
     }
@@ -219,6 +236,7 @@ pub(crate) enum SnapshotKind {
     TopicRoute,
     TopicStats,
     ConsumerLag,
+    ConsumerProgress,
     ConsumerConnections,
     ProducerConnections,
 }
@@ -231,6 +249,7 @@ impl SnapshotKind {
             Self::TopicRoute => "topic_route",
             Self::TopicStats => "topic_stats",
             Self::ConsumerLag => "consumer_lag",
+            Self::ConsumerProgress => "consumer_progress",
             Self::ConsumerConnections => "consumer_connections",
             Self::ProducerConnections => "producer_connections",
         }

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -5808,6 +5808,665 @@ expression: surface
         "type": "object"
       },
       "title": "RocketMQ Topic configuration"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ consumer group details"
+      },
+      "description": "Get fixed address-free configuration and connection observations for one consumer group.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "consumer_group"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_consumer_group_details",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ConsumerConnectionState": {
+            "enum": [
+              "online",
+              "offline"
+            ],
+            "type": "string"
+          },
+          "ConsumerConsumeFromWhere": {
+            "enum": [
+              "last_offset",
+              "last_offset_and_min_first",
+              "min_offset",
+              "max_offset",
+              "first_offset",
+              "timestamp",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "ConsumerConsumeType": {
+            "enum": [
+              "pull",
+              "push",
+              "pop",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "ConsumerGroupConfigPresence": {
+            "enum": [
+              "present",
+              "absent"
+            ],
+            "type": "string"
+          },
+          "ConsumerGroupDetailsBrokerRow": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "config_state": {
+                "$ref": "#/$defs/ConsumerGroupConfigPresence"
+              },
+              "config_version": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "connection_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "connection_state": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ConsumerConnectionState"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "consume_broadcast_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "consume_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "consume_from_min_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "consume_from_where": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ConsumerConsumeFromWhere"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "consume_message_orderly": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "consume_timeout_minutes": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "consume_type": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ConsumerConsumeType"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "message_model": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ConsumerMessageModel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "notify_consumer_ids_changed_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "retry_max_times": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "retry_queue_nums": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "broker_name",
+              "config_state",
+              "connection_count"
+            ],
+            "type": "object"
+          },
+          "ConsumerMessageModel": {
+            "enum": [
+              "broadcasting",
+              "clustering",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "GetConsumerGroupDetailsOutput": {
+            "properties": {
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/ConsumerGroupDetailsBrokerRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "consumer_group": {
+                "type": "string"
+              },
+              "generated_at": {
+                "type": "string"
+              },
+              "total_connection_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "cluster",
+              "consumer_group",
+              "total_connection_count",
+              "brokers",
+              "generated_at"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetConsumerGroupDetailsOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer group details"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ consumer progress"
+      },
+      "description": "Get a bounded snapshot page of deterministic per-queue progress and complete aggregate totals.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "cursor": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "default": null,
+            "format": "uint32",
+            "maximum": 200,
+            "minimum": 1,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "cluster",
+          "consumer_group"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_consumer_progress",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ConsumerProgressQueueRow": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "broker_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "consumer_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "inflight": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "lag": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "last_observed_at": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pull_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "queue_id": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "topic",
+              "broker_name",
+              "queue_id",
+              "broker_offset",
+              "consumer_offset",
+              "pull_offset",
+              "lag",
+              "inflight"
+            ],
+            "type": "object"
+          },
+          "ConsumerProgressState": {
+            "enum": [
+              "no_consumption",
+              "observed"
+            ],
+            "type": "string"
+          },
+          "GetConsumerProgressOutput": {
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "consume_tps": {
+                "format": "double",
+                "type": "number"
+              },
+              "consumer_group": {
+                "type": "string"
+              },
+              "count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "generated_at": {
+                "type": "string"
+              },
+              "has_more": {
+                "type": "boolean"
+              },
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ConsumerProgressQueueRow"
+                },
+                "type": "array"
+              },
+              "max_queue_lag": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "next_cursor": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "queue_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "state": {
+                "$ref": "#/$defs/ConsumerProgressState"
+              },
+              "topic_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_inflight": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_lag": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "cluster",
+              "consumer_group",
+              "state",
+              "topic_count",
+              "queue_count",
+              "total_lag",
+              "max_queue_lag",
+              "total_inflight",
+              "consume_tps",
+              "truncated",
+              "items",
+              "count",
+              "total_count",
+              "has_more",
+              "generated_at"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetConsumerProgressOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer progress"
     }
   ]
 }

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -5815,6 +5815,665 @@ expression: surface
         "idempotentHint": true,
         "openWorldHint": true,
         "readOnlyHint": true,
+        "title": "RocketMQ consumer group details"
+      },
+      "description": "Get fixed address-free configuration and connection observations for one consumer group.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster",
+          "consumer_group"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_consumer_group_details",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ConsumerConnectionState": {
+            "enum": [
+              "online",
+              "offline"
+            ],
+            "type": "string"
+          },
+          "ConsumerConsumeFromWhere": {
+            "enum": [
+              "last_offset",
+              "last_offset_and_min_first",
+              "min_offset",
+              "max_offset",
+              "first_offset",
+              "timestamp",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "ConsumerConsumeType": {
+            "enum": [
+              "pull",
+              "push",
+              "pop",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "ConsumerGroupConfigPresence": {
+            "enum": [
+              "present",
+              "absent"
+            ],
+            "type": "string"
+          },
+          "ConsumerGroupDetailsBrokerRow": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "config_state": {
+                "$ref": "#/$defs/ConsumerGroupConfigPresence"
+              },
+              "config_version": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "connection_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "connection_state": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ConsumerConnectionState"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "consume_broadcast_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "consume_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "consume_from_min_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "consume_from_where": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ConsumerConsumeFromWhere"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "consume_message_orderly": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "consume_timeout_minutes": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "consume_type": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ConsumerConsumeType"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "message_model": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ConsumerMessageModel"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "notify_consumer_ids_changed_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "retry_max_times": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "retry_queue_nums": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "broker_name",
+              "config_state",
+              "connection_count"
+            ],
+            "type": "object"
+          },
+          "ConsumerMessageModel": {
+            "enum": [
+              "broadcasting",
+              "clustering",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "GetConsumerGroupDetailsOutput": {
+            "properties": {
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/ConsumerGroupDetailsBrokerRow"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "consumer_group": {
+                "type": "string"
+              },
+              "generated_at": {
+                "type": "string"
+              },
+              "total_connection_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "cluster",
+              "consumer_group",
+              "total_connection_count",
+              "brokers",
+              "generated_at"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetConsumerGroupDetailsOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer group details"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ consumer progress"
+      },
+      "description": "Get a bounded snapshot page of deterministic per-queue progress and complete aggregate totals.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "consumer_group": {
+            "type": "string"
+          },
+          "cursor": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "default": null,
+            "format": "uint32",
+            "maximum": 200,
+            "minimum": 1,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "cluster",
+          "consumer_group"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_consumer_progress",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ConsumerProgressQueueRow": {
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "broker_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "consumer_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "inflight": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "lag": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "last_observed_at": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pull_offset": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "queue_id": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "topic": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "topic",
+              "broker_name",
+              "queue_id",
+              "broker_offset",
+              "consumer_offset",
+              "pull_offset",
+              "lag",
+              "inflight"
+            ],
+            "type": "object"
+          },
+          "ConsumerProgressState": {
+            "enum": [
+              "no_consumption",
+              "observed"
+            ],
+            "type": "string"
+          },
+          "GetConsumerProgressOutput": {
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "consume_tps": {
+                "format": "double",
+                "type": "number"
+              },
+              "consumer_group": {
+                "type": "string"
+              },
+              "count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "generated_at": {
+                "type": "string"
+              },
+              "has_more": {
+                "type": "boolean"
+              },
+              "items": {
+                "items": {
+                  "$ref": "#/$defs/ConsumerProgressQueueRow"
+                },
+                "type": "array"
+              },
+              "max_queue_lag": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "next_cursor": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "queue_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "state": {
+                "$ref": "#/$defs/ConsumerProgressState"
+              },
+              "topic_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_inflight": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_lag": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "cluster",
+              "consumer_group",
+              "state",
+              "topic_count",
+              "queue_count",
+              "total_lag",
+              "max_queue_lag",
+              "total_inflight",
+              "consume_tps",
+              "truncated",
+              "items",
+              "count",
+              "total_count",
+              "has_more",
+              "generated_at"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetConsumerProgressOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ consumer progress"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
         "title": "RocketMQ create topic plan"
       },
       "description": "Generate a non-mutating topic creation plan.",

--- a/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs
@@ -52,6 +52,8 @@ pub enum ToolId {
     GetConsumerGroupConfigState,
     GetTopicStats,
     GetTopicConfig,
+    GetConsumerGroupDetails,
+    GetConsumerProgress,
     #[cfg(feature = "change-planning")]
     PlanCreateTopic,
     #[cfg(feature = "change-planning")]
@@ -85,6 +87,8 @@ impl ToolId {
         Self::GetConsumerGroupConfigState,
         Self::GetTopicStats,
         Self::GetTopicConfig,
+        Self::GetConsumerGroupDetails,
+        Self::GetConsumerProgress,
         #[cfg(feature = "change-planning")]
         Self::PlanCreateTopic,
         #[cfg(feature = "change-planning")]
@@ -239,6 +243,20 @@ impl ToolId {
                 "Get fixed address-free Topic configuration observations and semantic differences across Brokers.",
                 RiskLevel::ReadOnly,
             ),
+            Self::GetConsumerGroupDetails => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_consumer_group_details",
+                "RocketMQ consumer group details",
+                "Get fixed address-free configuration and connection observations for one consumer group.",
+                RiskLevel::ReadOnly,
+            ),
+            Self::GetConsumerProgress => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_consumer_progress",
+                "RocketMQ consumer progress",
+                "Get a bounded snapshot page of deterministic per-queue progress and complete aggregate totals.",
+                RiskLevel::ReadOnly,
+            ),
             #[cfg(feature = "change-planning")]
             Self::PlanCreateTopic => ToolDescriptor::read_only(
                 self,
@@ -343,6 +361,14 @@ impl ToolId {
             Self::GetTopicConfig => {
                 descriptor.build::<config_tools::GetTopicConfigArgs, config_tools::GetTopicConfigOutput>()
             }
+            Self::GetConsumerGroupDetails => descriptor.build::<
+                consumer_tools::GetConsumerGroupDetailsArgs,
+                consumer_tools::GetConsumerGroupDetailsOutput,
+            >(),
+            Self::GetConsumerProgress => descriptor.build::<
+                consumer_tools::GetConsumerProgressArgs,
+                consumer_tools::GetConsumerProgressOutput,
+            >(),
             #[cfg(feature = "change-planning")]
             Self::PlanCreateTopic => descriptor.build::<change_tools::CreateTopicArgs, change_tools::ChangePlan>(),
             #[cfg(feature = "change-planning")]
@@ -492,9 +518,9 @@ mod tests {
             ]
         );
         #[cfg(not(feature = "change-planning"))]
-        assert_eq!(names.len(), 19);
+        assert_eq!(names.len(), 21);
         #[cfg(feature = "change-planning")]
-        assert_eq!(names.len(), 24);
+        assert_eq!(names.len(), 26);
     }
 
     #[test]
@@ -507,6 +533,8 @@ mod tests {
             ToolId::GetConsumerGroupConfigState,
             ToolId::GetTopicStats,
             ToolId::GetTopicConfig,
+            ToolId::GetConsumerGroupDetails,
+            ToolId::GetConsumerProgress,
         ];
         for tool_id in expected {
             let descriptor = tool_id.descriptor();

--- a/rocketmq-ai/rocketmq-mcp/src/tools/consumer_tools.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/consumer_tools.rs
@@ -95,3 +95,129 @@ pub struct QueryConsumerLagOutput {
     pub page: Page<QueueLag>,
     pub generated_at: String,
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetConsumerGroupDetailsArgs {
+    pub cluster: String,
+    pub consumer_group: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerGroupConfigPresence {
+    Present,
+    Absent,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerConnectionState {
+    Online,
+    Offline,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerConsumeType {
+    Pull,
+    Push,
+    Pop,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerMessageModel {
+    Broadcasting,
+    Clustering,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerConsumeFromWhere {
+    LastOffset,
+    LastOffsetAndMinFirst,
+    MinOffset,
+    MaxOffset,
+    FirstOffset,
+    Timestamp,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ConsumerGroupDetailsBrokerRow {
+    pub broker_name: String,
+    pub config_state: ConsumerGroupConfigPresence,
+    pub config_version: Option<u64>,
+    pub consume_enable: Option<bool>,
+    pub consume_from_min_enable: Option<bool>,
+    pub consume_broadcast_enable: Option<bool>,
+    pub consume_message_orderly: Option<bool>,
+    pub retry_queue_nums: Option<i32>,
+    pub retry_max_times: Option<i32>,
+    pub notify_consumer_ids_changed_enable: Option<bool>,
+    pub consume_timeout_minutes: Option<i32>,
+    pub connection_state: Option<ConsumerConnectionState>,
+    pub connection_count: u64,
+    pub consume_type: Option<ConsumerConsumeType>,
+    pub message_model: Option<ConsumerMessageModel>,
+    pub consume_from_where: Option<ConsumerConsumeFromWhere>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct GetConsumerGroupDetailsOutput {
+    pub cluster: String,
+    pub consumer_group: String,
+    pub total_connection_count: u64,
+    pub brokers: Vec<ConsumerGroupDetailsBrokerRow>,
+    pub generated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetConsumerProgressArgs {
+    pub cluster: String,
+    pub consumer_group: String,
+    #[serde(flatten)]
+    pub page: PageRequest,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerProgressState {
+    NoConsumption,
+    Observed,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ConsumerProgressQueueRow {
+    pub topic: String,
+    pub broker_name: String,
+    pub queue_id: i32,
+    pub broker_offset: i64,
+    pub consumer_offset: i64,
+    pub pull_offset: i64,
+    pub lag: u64,
+    pub inflight: u64,
+    pub last_observed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct GetConsumerProgressOutput {
+    pub cluster: String,
+    pub consumer_group: String,
+    pub state: ConsumerProgressState,
+    pub topic_count: usize,
+    pub queue_count: usize,
+    pub total_lag: u64,
+    pub max_queue_lag: u64,
+    pub total_inflight: u64,
+    pub consume_tps: f64,
+    pub truncated: bool,
+    #[serde(flatten)]
+    #[schemars(flatten)]
+    pub page: Page<ConsumerProgressQueueRow>,
+    pub generated_at: String,
+}

--- a/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
@@ -717,6 +717,42 @@ where
                     success_unlinked_result(descriptor, request_id, cluster, summary, output)
                 })
             }
+            ToolId::GetConsumerGroupDetails => {
+                let args = match decode_args::<consumer_tools::GetConsumerGroupDetailsArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.consumer_group_details(args).await.and_then(|output| {
+                    let summary = summary_consumer_group_details(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
+            ToolId::GetConsumerProgress => {
+                let args = match decode_args::<consumer_tools::GetConsumerProgressArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.consumer_progress(args).await.and_then(|output| {
+                    let summary = summary_consumer_progress(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
             #[cfg(feature = "change-planning")]
             ToolId::PlanCreateTopic => {
                 let args = match decode_args::<change_tools::CreateTopicArgs>(arguments.clone()) {
@@ -1174,6 +1210,23 @@ fn summary_topic_config(output: &config_tools::GetTopicConfigOutput) -> String {
     )
 }
 
+fn summary_consumer_group_details(output: &consumer_tools::GetConsumerGroupDetailsOutput) -> String {
+    format!(
+        "Consumer group {} on cluster {} returned {} Broker observations and {} total connections.",
+        output.consumer_group,
+        output.cluster,
+        output.brokers.len(),
+        output.total_connection_count
+    )
+}
+
+fn summary_consumer_progress(output: &consumer_tools::GetConsumerProgressOutput) -> String {
+    format!(
+        "Consumer group {} on cluster {} returned {} of {} queue progress rows with total lag {}.",
+        output.consumer_group, output.cluster, output.page.count, output.queue_count, output.total_lag
+    )
+}
+
 #[cfg(feature = "change-planning")]
 fn summary_change_plan(output: &change_tools::ChangePlan) -> String {
     format!(
@@ -1574,6 +1627,83 @@ mod tests {
             }))
         }
 
+        async fn consumer_group_details(
+            &self,
+            args: consumer_tools::GetConsumerGroupDetailsArgs,
+        ) -> Result<QueryResult<consumer_tools::GetConsumerGroupDetailsOutput>, ToolExecutionError> {
+            let broker_name = if args.consumer_group == "oversized" {
+                "x".repeat(2 * 1024 * 1024)
+            } else {
+                "broker-a".to_string()
+            };
+            Ok(QueryResult::bypass(consumer_tools::GetConsumerGroupDetailsOutput {
+                cluster: args.cluster,
+                consumer_group: args.consumer_group,
+                total_connection_count: 0,
+                brokers: vec![consumer_tools::ConsumerGroupDetailsBrokerRow {
+                    broker_name,
+                    config_state: consumer_tools::ConsumerGroupConfigPresence::Present,
+                    config_version: Some(1),
+                    consume_enable: Some(true),
+                    consume_from_min_enable: Some(false),
+                    consume_broadcast_enable: Some(false),
+                    consume_message_orderly: Some(false),
+                    retry_queue_nums: Some(1),
+                    retry_max_times: Some(1),
+                    notify_consumer_ids_changed_enable: Some(true),
+                    consume_timeout_minutes: Some(1),
+                    connection_state: Some(consumer_tools::ConsumerConnectionState::Offline),
+                    connection_count: 0,
+                    consume_type: None,
+                    message_model: None,
+                    consume_from_where: None,
+                }],
+                generated_at: "transient-test-time".to_string(),
+            }))
+        }
+
+        async fn consumer_progress(
+            &self,
+            args: consumer_tools::GetConsumerProgressArgs,
+        ) -> Result<QueryResult<consumer_tools::GetConsumerProgressOutput>, ToolExecutionError> {
+            let broker_name = if args.consumer_group == "oversized" {
+                "x".repeat(2 * 1024 * 1024)
+            } else {
+                "broker-a".to_string()
+            };
+            let items = vec![consumer_tools::ConsumerProgressQueueRow {
+                topic: "orders".to_string(),
+                broker_name,
+                queue_id: 0,
+                broker_offset: 1,
+                consumer_offset: 1,
+                pull_offset: 1,
+                lag: 0,
+                inflight: 0,
+                last_observed_at: None,
+            }];
+            Ok(QueryResult::bypass(consumer_tools::GetConsumerProgressOutput {
+                cluster: args.cluster,
+                consumer_group: args.consumer_group,
+                state: consumer_tools::ConsumerProgressState::Observed,
+                topic_count: 1,
+                queue_count: 1,
+                total_lag: 0,
+                max_queue_lag: 0,
+                total_inflight: 0,
+                consume_tps: 0.0,
+                truncated: false,
+                page: crate::model::contract::Page {
+                    count: items.len(),
+                    total_count: items.len(),
+                    items,
+                    has_more: false,
+                    next_cursor: None,
+                },
+                generated_at: "transient-test-time".to_string(),
+            }))
+        }
+
         async fn diagnose_consumer_lag(
             &self,
             _args: diagnosis_tools::DiagnoseConsumerLagArgs,
@@ -1928,6 +2058,14 @@ mod tests {
                 ToolId::GetTopicConfig,
                 serde_json::json!({"cluster":"local-dev","topic":"orders"}),
             ),
+            (
+                ToolId::GetConsumerGroupDetails,
+                serde_json::json!({"cluster":"local-dev","consumer_group":"group-a"}),
+            ),
+            (
+                ToolId::GetConsumerProgress,
+                serde_json::json!({"cluster":"local-dev","consumer_group":"group-a","limit":1}),
+            ),
         ];
         for (tool, arguments) in calls {
             let result = executor
@@ -1995,6 +2133,14 @@ mod tests {
             (
                 ToolId::GetTopicConfig,
                 serde_json::json!({"cluster":"local-dev","topic":"orders"}),
+            ),
+            (
+                ToolId::GetConsumerGroupDetails,
+                serde_json::json!({"cluster":"local-dev","consumer_group":"group-a"}),
+            ),
+            (
+                ToolId::GetConsumerProgress,
+                serde_json::json!({"cluster":"local-dev","consumer_group":"group-a","limit":1}),
             ),
         ];
         for (tool, arguments) in calls {
@@ -2083,6 +2229,14 @@ mod tests {
             (
                 ToolId::GetTopicConfig,
                 serde_json::json!({"cluster":"local-dev","topic":"oversized"}),
+            ),
+            (
+                ToolId::GetConsumerGroupDetails,
+                serde_json::json!({"cluster":"local-dev","consumer_group":"oversized"}),
+            ),
+            (
+                ToolId::GetConsumerProgress,
+                serde_json::json!({"cluster":"local-dev","consumer_group":"oversized"}),
             ),
         ];
         for (tool, arguments) in calls {

--- a/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
@@ -381,6 +381,13 @@ mod tests {
                     "retryable": false,
                     "logical_target": "broker-c",
                     "attributes": { "secret": "value" }
+                },
+                {
+                    "source": "consumer_connection",
+                    "code": "source_unavailable",
+                    "retryable": true,
+                    "logical_target": "broker-d",
+                    "client_id": "must not escape"
                 }
             ],
             "data": {}
@@ -388,10 +395,11 @@ mod tests {
         .unwrap();
 
         let failures = output["source_failures"].as_array().unwrap();
-        assert_eq!(failures.len(), 3);
-        assert_eq!(failures[0]["source"], "consumer_group_config");
-        assert_eq!(failures[1]["source"], "topic_config");
-        assert_eq!(failures[2]["source"], "topic_stats");
+        assert_eq!(failures.len(), 4);
+        assert_eq!(failures[0]["source"], "consumer_connection");
+        assert_eq!(failures[1]["source"], "consumer_group_config");
+        assert_eq!(failures[2]["source"], "topic_config");
+        assert_eq!(failures[3]["source"], "topic_stats");
         let serialized = output.to_string();
         assert!(!serialized.contains("backend_text"));
         assert!(!serialized.contains("address"));

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
@@ -5638,5 +5638,664 @@ expression: contracts
       "type": "object"
     },
     "title": "RocketMQ Topic configuration"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ consumer group details"
+    },
+    "description": "Get fixed address-free configuration and connection observations for one consumer group.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "consumer_group"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_consumer_group_details",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ConsumerConnectionState": {
+          "enum": [
+            "online",
+            "offline"
+          ],
+          "type": "string"
+        },
+        "ConsumerConsumeFromWhere": {
+          "enum": [
+            "last_offset",
+            "last_offset_and_min_first",
+            "min_offset",
+            "max_offset",
+            "first_offset",
+            "timestamp",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "ConsumerConsumeType": {
+          "enum": [
+            "pull",
+            "push",
+            "pop",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "ConsumerGroupConfigPresence": {
+          "enum": [
+            "present",
+            "absent"
+          ],
+          "type": "string"
+        },
+        "ConsumerGroupDetailsBrokerRow": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "config_state": {
+              "$ref": "#/$defs/ConsumerGroupConfigPresence"
+            },
+            "config_version": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "connection_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "connection_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ConsumerConnectionState"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "consume_broadcast_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consume_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consume_from_min_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consume_from_where": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ConsumerConsumeFromWhere"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "consume_message_orderly": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consume_timeout_minutes": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "consume_type": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ConsumerConsumeType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "message_model": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ConsumerMessageModel"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "notify_consumer_ids_changed_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "retry_max_times": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "retry_queue_nums": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "broker_name",
+            "config_state",
+            "connection_count"
+          ],
+          "type": "object"
+        },
+        "ConsumerMessageModel": {
+          "enum": [
+            "broadcasting",
+            "clustering",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "GetConsumerGroupDetailsOutput": {
+          "properties": {
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/ConsumerGroupDetailsBrokerRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "consumer_group": {
+              "type": "string"
+            },
+            "generated_at": {
+              "type": "string"
+            },
+            "total_connection_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "cluster",
+            "consumer_group",
+            "total_connection_count",
+            "brokers",
+            "generated_at"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetConsumerGroupDetailsOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer group details"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ consumer progress"
+    },
+    "description": "Get a bounded snapshot page of deterministic per-queue progress and complete aggregate totals.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group": {
+          "type": "string"
+        },
+        "cursor": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "default": null,
+          "format": "uint32",
+          "maximum": 200,
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "cluster",
+        "consumer_group"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_consumer_progress",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ConsumerProgressQueueRow": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "broker_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "consumer_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "inflight": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "lag": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "last_observed_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pull_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "queue_id": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "broker_name",
+            "queue_id",
+            "broker_offset",
+            "consumer_offset",
+            "pull_offset",
+            "lag",
+            "inflight"
+          ],
+          "type": "object"
+        },
+        "ConsumerProgressState": {
+          "enum": [
+            "no_consumption",
+            "observed"
+          ],
+          "type": "string"
+        },
+        "GetConsumerProgressOutput": {
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "consume_tps": {
+              "format": "double",
+              "type": "number"
+            },
+            "consumer_group": {
+              "type": "string"
+            },
+            "count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "generated_at": {
+              "type": "string"
+            },
+            "has_more": {
+              "type": "boolean"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ConsumerProgressQueueRow"
+              },
+              "type": "array"
+            },
+            "max_queue_lag": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "next_cursor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "queue_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "state": {
+              "$ref": "#/$defs/ConsumerProgressState"
+            },
+            "topic_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "total_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "total_inflight": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "total_lag": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "truncated": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "cluster",
+            "consumer_group",
+            "state",
+            "topic_count",
+            "queue_count",
+            "total_lag",
+            "max_queue_lag",
+            "total_inflight",
+            "consume_tps",
+            "truncated",
+            "items",
+            "count",
+            "total_count",
+            "has_more",
+            "generated_at"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetConsumerProgressOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer progress"
   }
 ]

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
@@ -5645,6 +5645,665 @@ expression: contracts
       "idempotentHint": true,
       "openWorldHint": true,
       "readOnlyHint": true,
+      "title": "RocketMQ consumer group details"
+    },
+    "description": "Get fixed address-free configuration and connection observations for one consumer group.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster",
+        "consumer_group"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_consumer_group_details",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ConsumerConnectionState": {
+          "enum": [
+            "online",
+            "offline"
+          ],
+          "type": "string"
+        },
+        "ConsumerConsumeFromWhere": {
+          "enum": [
+            "last_offset",
+            "last_offset_and_min_first",
+            "min_offset",
+            "max_offset",
+            "first_offset",
+            "timestamp",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "ConsumerConsumeType": {
+          "enum": [
+            "pull",
+            "push",
+            "pop",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "ConsumerGroupConfigPresence": {
+          "enum": [
+            "present",
+            "absent"
+          ],
+          "type": "string"
+        },
+        "ConsumerGroupDetailsBrokerRow": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "config_state": {
+              "$ref": "#/$defs/ConsumerGroupConfigPresence"
+            },
+            "config_version": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "connection_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "connection_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ConsumerConnectionState"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "consume_broadcast_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consume_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consume_from_min_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consume_from_where": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ConsumerConsumeFromWhere"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "consume_message_orderly": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consume_timeout_minutes": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "consume_type": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ConsumerConsumeType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "message_model": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ConsumerMessageModel"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "notify_consumer_ids_changed_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "retry_max_times": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "retry_queue_nums": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "broker_name",
+            "config_state",
+            "connection_count"
+          ],
+          "type": "object"
+        },
+        "ConsumerMessageModel": {
+          "enum": [
+            "broadcasting",
+            "clustering",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "GetConsumerGroupDetailsOutput": {
+          "properties": {
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/ConsumerGroupDetailsBrokerRow"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "consumer_group": {
+              "type": "string"
+            },
+            "generated_at": {
+              "type": "string"
+            },
+            "total_connection_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "cluster",
+            "consumer_group",
+            "total_connection_count",
+            "brokers",
+            "generated_at"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetConsumerGroupDetailsOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer group details"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ consumer progress"
+    },
+    "description": "Get a bounded snapshot page of deterministic per-queue progress and complete aggregate totals.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "consumer_group": {
+          "type": "string"
+        },
+        "cursor": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "default": null,
+          "format": "uint32",
+          "maximum": 200,
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "cluster",
+        "consumer_group"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_consumer_progress",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ConsumerProgressQueueRow": {
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "broker_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "consumer_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "inflight": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "lag": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "last_observed_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pull_offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "queue_id": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "broker_name",
+            "queue_id",
+            "broker_offset",
+            "consumer_offset",
+            "pull_offset",
+            "lag",
+            "inflight"
+          ],
+          "type": "object"
+        },
+        "ConsumerProgressState": {
+          "enum": [
+            "no_consumption",
+            "observed"
+          ],
+          "type": "string"
+        },
+        "GetConsumerProgressOutput": {
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "consume_tps": {
+              "format": "double",
+              "type": "number"
+            },
+            "consumer_group": {
+              "type": "string"
+            },
+            "count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "generated_at": {
+              "type": "string"
+            },
+            "has_more": {
+              "type": "boolean"
+            },
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ConsumerProgressQueueRow"
+              },
+              "type": "array"
+            },
+            "max_queue_lag": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "next_cursor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "queue_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "state": {
+              "$ref": "#/$defs/ConsumerProgressState"
+            },
+            "topic_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "total_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "total_inflight": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "total_lag": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "truncated": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "cluster",
+            "consumer_group",
+            "state",
+            "topic_count",
+            "queue_count",
+            "total_lag",
+            "max_queue_lag",
+            "total_inflight",
+            "consume_tps",
+            "truncated",
+            "items",
+            "count",
+            "total_count",
+            "has_more",
+            "generated_at"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetConsumerProgressOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ consumer progress"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
       "title": "RocketMQ create topic plan"
     },
     "description": "Generate a non-mutating topic creation plan.",

--- a/rocketmq-client/src/admin.rs
+++ b/rocketmq-client/src/admin.rs
@@ -16,6 +16,8 @@
 mod capability;
 pub mod default_mq_admin_ext;
 pub mod default_mq_admin_ext_impl;
+#[cfg(feature = "admin-read")]
+mod mq_admin_consumer_observation_read_ext;
 #[cfg(feature = "admin-mutation")]
 mod mq_admin_mutation_ext;
 #[cfg(feature = "admin-read")]
@@ -37,6 +39,14 @@ pub use capability::RouteAdmin;
 pub use capability::TopicAdmin;
 pub use default_mq_admin_ext::DefaultMQAdminExt;
 pub use default_mq_admin_ext_impl::DefaultMQAdminExtImpl;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_consumer_observation_read_ext::ConsumerConnectionRead;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_consumer_observation_read_ext::ConsumerGroupConfigRead;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_consumer_observation_read_ext::ConsumerProgressRead;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_consumer_observation_read_ext::MQAdminConsumerObservationReadExt;
 #[cfg(feature = "admin-mutation")]
 pub use mq_admin_mutation_ext::BrokerConfigPatchOutcome;
 #[cfg(feature = "admin-mutation")]

--- a/rocketmq-client/src/admin/mq_admin_consumer_observation_read_ext.rs
+++ b/rocketmq-client/src/admin/mq_admin_consumer_observation_read_ext.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Exact-Broker, read-only Consumer observation capability.
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats;
+use rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection;
+
+use super::default_mq_admin_ext::DefaultMQAdminExt;
+use super::mq_admin_read_ext::MQAdminReadExt;
+use super::mq_admin_read_ext::SubscriptionGroupConfigVersioned;
+
+#[derive(Debug, Clone)]
+pub enum ConsumerGroupConfigRead {
+    Present(Box<SubscriptionGroupConfigVersioned>),
+    Absent,
+}
+
+#[derive(Debug, Clone)]
+pub enum ConsumerConnectionRead {
+    Online(ConsumerConnection),
+    Offline,
+}
+
+#[derive(Debug)]
+pub enum ConsumerProgressRead {
+    Observed(ConsumeStats),
+    Absent,
+}
+
+#[allow(async_fn_in_trait)]
+pub trait MQAdminConsumerObservationReadExt: Send {
+    async fn consumer_group_config_at(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<ConsumerGroupConfigRead>;
+
+    async fn consumer_connection_at(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<ConsumerConnectionRead>;
+
+    async fn consumer_progress_at(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<ConsumerProgressRead>;
+}
+
+impl MQAdminConsumerObservationReadExt for DefaultMQAdminExt {
+    async fn consumer_group_config_at(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<ConsumerGroupConfigRead> {
+        match MQAdminReadExt::subscription_group_config_with_version(self, broker_addr, consumer_group).await {
+            Ok(config) => Ok(ConsumerGroupConfigRead::Present(Box::new(config))),
+            Err(error) if broker_response_is(&error, ResponseCode::SubscriptionGroupNotExist) => {
+                Ok(ConsumerGroupConfigRead::Absent)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn consumer_connection_at(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<ConsumerConnectionRead> {
+        match MQAdminReadExt::observe_consumer_connection_at(self, consumer_group, broker_addr).await {
+            Ok(connection) if connection.get_connection_set().is_empty() => Ok(ConsumerConnectionRead::Offline),
+            Ok(connection) => Ok(ConsumerConnectionRead::Online(connection)),
+            Err(error) if broker_response_is(&error, ResponseCode::ConsumerNotOnline) => {
+                Ok(ConsumerConnectionRead::Offline)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn consumer_progress_at(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<ConsumerProgressRead> {
+        match MQAdminReadExt::examine_consume_stats(self, consumer_group, None, None, Some(broker_addr), None).await {
+            Ok(stats) => Ok(ConsumerProgressRead::Observed(stats)),
+            Err(error) if broker_response_is(&error, ResponseCode::SubscriptionGroupNotExist) => {
+                Ok(ConsumerProgressRead::Absent)
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn broker_response_is(error: &RocketMQError, expected: ResponseCode) -> bool {
+    matches!(
+        error,
+        RocketMQError::BrokerOperationFailed { code, .. } if *code == expected.to_i32()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_exact_broker_response_codes_are_closed_states() {
+        let missing = RocketMQError::broker_operation_failed(
+            "BROKER_OPERATION",
+            ResponseCode::SubscriptionGroupNotExist.to_i32(),
+            "must not be inspected",
+        );
+        let offline = RocketMQError::broker_operation_failed(
+            "BROKER_OPERATION",
+            ResponseCode::ConsumerNotOnline.to_i32(),
+            "must not be inspected",
+        );
+        let unavailable = RocketMQError::broker_operation_failed(
+            "BROKER_OPERATION",
+            ResponseCode::SystemError.to_i32(),
+            "consumer not online",
+        );
+
+        assert!(broker_response_is(&missing, ResponseCode::SubscriptionGroupNotExist));
+        assert!(broker_response_is(&offline, ResponseCode::ConsumerNotOnline));
+        assert!(!broker_response_is(&unavailable, ResponseCode::ConsumerNotOnline));
+    }
+}

--- a/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
@@ -1494,9 +1494,10 @@ impl MQClientAPIImpl {
                 return rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats::decode(body.as_ref());
             }
         }
-        Err(mq_client_err!(
+        Err(client_broker_err!(
             response.code(),
-            response.remark().map_or("".to_string(), |s| s.to_string())
+            response.remark().map_or("".to_string(), |s| s.to_string()),
+            addr.to_string()
         ))
     }
 

--- a/rocketmq-client/src/implementation/mq_client_api_impl/admin/versioned_config.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/admin/versioned_config.rs
@@ -555,9 +555,10 @@ impl MQClientAPIImpl {
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             return subscription_group_config_versioned_from_response(&response);
         }
-        Err(mq_client_err!(
+        Err(client_broker_err!(
             response.code(),
-            response.remark().map_or_else(String::new, |remark| remark.to_string())
+            response.remark().map_or_else(String::new, |remark| remark.to_string()),
+            broker_addr
         ))
     }
 }

--- a/rocketmq-client/src/public_api.rs
+++ b/rocketmq-client/src/public_api.rs
@@ -28,8 +28,16 @@ pub use crate::admin::BrokerReadFailure;
 pub use crate::admin::ConsumeStatsReadResult;
 #[cfg(feature = "admin-full")]
 pub use crate::admin::ConsumerAdmin;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::ConsumerConnectionRead;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::ConsumerGroupConfigRead;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::ConsumerProgressRead;
 pub use crate::admin::DefaultMQAdminExt;
 pub use crate::admin::DefaultMQAdminExtImpl;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::MQAdminConsumerObservationReadExt;
 #[cfg(feature = "admin-read")]
 pub use crate::admin::MQAdminMessageReadExt;
 #[cfg(feature = "admin-mutation")]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer_observation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer_observation.rs
@@ -1,0 +1,763 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Read-client implementation of address-free Consumer observations.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use cheetah_string::CheetahString;
+use rocketmq_client_rust::ConsumerConnectionRead;
+use rocketmq_client_rust::ConsumerGroupConfigRead;
+use rocketmq_client_rust::ConsumerProgressRead;
+use rocketmq_client_rust::DefaultMQAdminExt;
+use rocketmq_client_rust::MQAdminConsumerObservationReadExt;
+use rocketmq_client_rust::MQAdminReadExt;
+use rocketmq_client_rust::SubscriptionGroupConfigVersioned;
+use rocketmq_error::RocketMQError;
+use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_model::common::mix_all;
+use rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats;
+use rocketmq_protocol::protocol::body::broker_body::cluster_info::ClusterInfo;
+use rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType;
+use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
+
+use crate::core::broker::is_valid_remoting_endpoint;
+use crate::core::consumer_observation::*;
+use crate::core::query::AdminQueryFailureCode;
+use crate::core::query::AdminQueryResult;
+use crate::core::query::AdminQuerySource;
+use crate::core::query::AdminSourceFailure;
+use crate::core::AdminError;
+use crate::core::AdminResult;
+
+type BrokerTarget = (String, CheetahString);
+const MAX_CONSUMER_PROGRESS_SOURCE_ROWS: usize = 50_000;
+const MAX_CONSUMER_PROGRESS_QUERY_ROWS: usize = 50_000;
+
+#[allow(async_fn_in_trait)]
+trait ConsumerObservationSource: Send {
+    async fn cluster_info(&self) -> Result<ClusterInfo, RocketMQError>;
+    async fn consumer_route(&self, consumer_group: &str) -> Result<Option<TopicRouteData>, RocketMQError>;
+    async fn group_config(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: &str,
+    ) -> Result<ConsumerGroupConfigRead, RocketMQError>;
+    async fn connection(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: &str,
+    ) -> Result<ConsumerConnectionRead, RocketMQError>;
+    async fn progress(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: &str,
+    ) -> Result<ConsumerProgressRead, RocketMQError>;
+}
+
+impl ConsumerObservationSource for DefaultMQAdminExt {
+    async fn cluster_info(&self) -> Result<ClusterInfo, RocketMQError> {
+        MQAdminReadExt::examine_broker_cluster_info(self).await
+    }
+
+    async fn consumer_route(&self, consumer_group: &str) -> Result<Option<TopicRouteData>, RocketMQError> {
+        MQAdminReadExt::examine_topic_route_info(self, CheetahString::from(mix_all::get_retry_topic(consumer_group)))
+            .await
+    }
+
+    async fn group_config(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: &str,
+    ) -> Result<ConsumerGroupConfigRead, RocketMQError> {
+        MQAdminConsumerObservationReadExt::consumer_group_config_at(
+            self,
+            broker_addr,
+            CheetahString::from(consumer_group),
+        )
+        .await
+    }
+
+    async fn connection(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: &str,
+    ) -> Result<ConsumerConnectionRead, RocketMQError> {
+        MQAdminConsumerObservationReadExt::consumer_connection_at(
+            self,
+            broker_addr,
+            CheetahString::from(consumer_group),
+        )
+        .await
+    }
+
+    async fn progress(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: &str,
+    ) -> Result<ConsumerProgressRead, RocketMQError> {
+        MQAdminConsumerObservationReadExt::consumer_progress_at(self, broker_addr, CheetahString::from(consumer_group))
+            .await
+    }
+}
+
+pub(crate) async fn query_consumer_group_details(
+    admin: &DefaultMQAdminExt,
+    request: &QueryConsumerGroupDetailsRequest,
+) -> AdminResult<AdminQueryResult<QueryConsumerGroupDetailsResult>> {
+    query_consumer_group_details_from(admin, request).await
+}
+
+pub(crate) async fn query_consumer_progress(
+    admin: &DefaultMQAdminExt,
+    request: &QueryConsumerProgressRequest,
+) -> AdminResult<AdminQueryResult<QueryConsumerProgressResult>> {
+    query_consumer_progress_from(admin, request).await
+}
+
+async fn query_consumer_group_details_from<S: ConsumerObservationSource>(
+    source: &S,
+    request: &QueryConsumerGroupDetailsRequest,
+) -> AdminResult<AdminQueryResult<QueryConsumerGroupDetailsResult>> {
+    let request = QueryConsumerGroupDetailsRequest::try_new(&request.cluster, &request.consumer_group)?;
+    let (targets, mut failures) = resolve_consumer_targets(
+        source,
+        &request.cluster,
+        &request.consumer_group,
+        AdminQuerySource::ConsumerGroupConfig,
+    )
+    .await?;
+    let mut rows = Vec::new();
+    let mut configured = Vec::new();
+    let mut absent_count = 0usize;
+
+    for (broker_name, broker_addr) in targets {
+        match source.group_config(broker_addr.clone(), &request.consumer_group).await {
+            Ok(ConsumerGroupConfigRead::Present(snapshot)) => {
+                rows.push(config_row(&broker_name, &snapshot));
+                configured.push((broker_name, broker_addr, rows.len() - 1));
+            }
+            Ok(ConsumerGroupConfigRead::Absent) => {
+                absent_count += 1;
+                rows.push(absent_config_row(broker_name));
+            }
+            Err(error) => failures.push(source_failure(
+                AdminQuerySource::ConsumerGroupConfig,
+                &broker_name,
+                &error,
+            )),
+        }
+    }
+
+    if configured.is_empty() {
+        if !failures.is_empty() {
+            return AdminQueryResult::from_sources(QueryConsumerGroupDetailsResult::default(), 0, failures);
+        }
+        if absent_count > 0 {
+            return Err(AdminError::not_found("consumer group", request.consumer_group));
+        }
+    }
+
+    let successful_configs = configured.len();
+    let mut total_connection_count = 0u128;
+    for (broker_name, broker_addr, row_index) in configured {
+        match source.connection(broker_addr, &request.consumer_group).await {
+            Ok(ConsumerConnectionRead::Offline) => {
+                rows[row_index].connection_state = Some(ConsumerConnectionState::Offline);
+            }
+            Ok(ConsumerConnectionRead::Online(connection)) => {
+                let count = connection.get_connection_set().len() as u128;
+                total_connection_count = total_connection_count.saturating_add(count);
+                let row = &mut rows[row_index];
+                row.connection_state = Some(ConsumerConnectionState::Online);
+                row.connection_count = count.min(u128::from(u64::MAX)) as u64;
+                row.consume_type = Some(map_consume_type(connection.get_consume_type()));
+                row.message_model = Some(map_message_model(connection.get_message_model()));
+                row.consume_from_where = Some(map_consume_from_where(connection.get_consume_from_where()));
+            }
+            Err(error) => failures.push(source_failure(
+                AdminQuerySource::ConsumerConnection,
+                &broker_name,
+                &error,
+            )),
+        }
+    }
+
+    rows.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    let saturated = total_connection_count > u128::from(u64::MAX);
+    let mut result = AdminQueryResult::from_sources(
+        QueryConsumerGroupDetailsResult {
+            consumer_group: request.consumer_group,
+            total_connection_count: total_connection_count.min(u128::from(u64::MAX)) as u64,
+            brokers: rows,
+        },
+        successful_configs,
+        failures,
+    )?;
+    if saturated {
+        result.partial = true;
+        result
+            .warnings
+            .push(CONSUMER_DETAILS_TOTAL_SATURATED_WARNING.to_string());
+        result.warnings.sort();
+        result.warnings.dedup();
+    }
+    Ok(result)
+}
+
+async fn query_consumer_progress_from<S: ConsumerObservationSource>(
+    source: &S,
+    request: &QueryConsumerProgressRequest,
+) -> AdminResult<AdminQueryResult<QueryConsumerProgressResult>> {
+    let request = QueryConsumerProgressRequest::try_new(&request.cluster, &request.consumer_group, request.max_rows)?;
+    let (targets, mut failures) = resolve_consumer_targets(
+        source,
+        &request.cluster,
+        &request.consumer_group,
+        AdminQuerySource::ConsumerGroupConfig,
+    )
+    .await?;
+    let mut configured = Vec::new();
+    let mut absent_count = 0usize;
+    for (broker_name, broker_addr) in targets {
+        match source.group_config(broker_addr.clone(), &request.consumer_group).await {
+            Ok(ConsumerGroupConfigRead::Present(_)) => configured.push((broker_name, broker_addr)),
+            Ok(ConsumerGroupConfigRead::Absent) => absent_count += 1,
+            Err(error) => failures.push(source_failure(
+                AdminQuerySource::ConsumerGroupConfig,
+                &broker_name,
+                &error,
+            )),
+        }
+    }
+    if configured.is_empty() {
+        if !failures.is_empty() {
+            return AdminQueryResult::from_sources(empty_progress_result(&request.consumer_group), 0, failures);
+        }
+        if absent_count > 0 {
+            return Err(AdminError::not_found("consumer group", request.consumer_group));
+        }
+    }
+
+    let mut collector = BoundedProgressCollector::new(request.max_rows);
+    let mut successful_statistics = 0usize;
+    let mut observed_nonempty = false;
+    let mut consume_tps = 0.0f64;
+    let mut invalid_tps = false;
+    let mut tps_saturated = false;
+    for (broker_name, broker_addr) in configured {
+        match source.progress(broker_addr, &request.consumer_group).await {
+            Ok(ConsumerProgressRead::Absent) => failures.push(AdminSourceFailure::new(
+                AdminQuerySource::ConsumerStatistics,
+                AdminQueryFailureCode::NotFound,
+                false,
+                &broker_name,
+            )),
+            Ok(ConsumerProgressRead::Observed(stats)) => {
+                let tps = stats.get_consume_tps();
+                let source_invalid_tps = !tps.is_finite() || tps < 0.0;
+                let observation = collector.observe_source(&broker_name, stats);
+                let source_succeeded = !observation.had_offsets || observation.valid_rows > 0;
+                if source_succeeded {
+                    successful_statistics += 1;
+                    observed_nonempty |= observation.had_offsets;
+                    if source_invalid_tps {
+                        invalid_tps = true;
+                    } else {
+                        let next = consume_tps + tps;
+                        if next.is_finite() {
+                            consume_tps = next;
+                        } else {
+                            consume_tps = f64::MAX;
+                            tps_saturated = true;
+                        }
+                    }
+                }
+                if observation.invalid || source_invalid_tps {
+                    failures.push(invalid_response_failure(
+                        AdminQuerySource::ConsumerStatistics,
+                        &broker_name,
+                    ));
+                }
+            }
+            Err(error) => failures.push(source_failure(
+                AdminQuerySource::ConsumerStatistics,
+                &broker_name,
+                &error,
+            )),
+        }
+    }
+
+    let truncated = collector.queue_count > request.max_rows;
+    let saturated = collector.aggregates_saturated
+        || collector.total_lag > u128::from(u64::MAX)
+        || collector.total_inflight > u128::from(u64::MAX)
+        || tps_saturated;
+    let result_topic_count = collector.topics.len();
+    let result_queue_count = collector.queue_count;
+    let result_total_lag = collector.total_lag.min(u128::from(u64::MAX)) as u64;
+    let result_max_queue_lag = collector.max_queue_lag;
+    let result_total_inflight = collector.total_inflight.min(u128::from(u64::MAX)) as u64;
+    let queues = collector.into_rows();
+    let result = QueryConsumerProgressResult {
+        consumer_group: request.consumer_group,
+        state: if observed_nonempty {
+            ConsumerProgressState::Observed
+        } else {
+            ConsumerProgressState::NoConsumption
+        },
+        topic_count: result_topic_count,
+        queue_count: result_queue_count,
+        total_lag: result_total_lag,
+        max_queue_lag: result_max_queue_lag,
+        total_inflight: result_total_inflight,
+        consume_tps,
+        queues,
+        truncated,
+    };
+    let mut result = AdminQueryResult::from_sources(result, successful_statistics, failures)?;
+    if truncated {
+        result.partial = true;
+        result.warnings.push(CONSUMER_PROGRESS_TRUNCATED_WARNING.to_string());
+    }
+    if saturated {
+        result.partial = true;
+        result
+            .warnings
+            .push(CONSUMER_PROGRESS_TOTAL_SATURATED_WARNING.to_string());
+    }
+    if invalid_tps {
+        result.partial = true;
+        result.warnings.push(CONSUMER_PROGRESS_INVALID_TPS_WARNING.to_string());
+    }
+    result.warnings.sort();
+    result.warnings.dedup();
+    Ok(result)
+}
+
+async fn resolve_consumer_targets<S: ConsumerObservationSource>(
+    source: &S,
+    cluster: &str,
+    consumer_group: &str,
+    failure_source: AdminQuerySource,
+) -> AdminResult<(Vec<BrokerTarget>, Vec<AdminSourceFailure>)> {
+    let cluster_info = source
+        .cluster_info()
+        .await
+        .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+    let route = source
+        .consumer_route(consumer_group)
+        .await
+        .map_err(|error| backend_error("examine_consumer_route_info", error))?
+        .ok_or_else(|| AdminError::not_found("consumer group", consumer_group))?;
+    selected_cluster_route_masters(&cluster_info, &route, cluster, failure_source)
+}
+
+fn selected_cluster_route_masters(
+    cluster_info: &ClusterInfo,
+    route: &TopicRouteData,
+    cluster: &str,
+    source: AdminQuerySource,
+) -> AdminResult<(Vec<BrokerTarget>, Vec<AdminSourceFailure>)> {
+    let cluster_brokers = cluster_info
+        .cluster_addr_table
+        .as_ref()
+        .and_then(|table| table.get(cluster))
+        .ok_or_else(|| AdminError::not_found("cluster", cluster))?;
+    let mut route_brokers = BTreeSet::new();
+    let mut failures = Vec::new();
+    for broker in &route.broker_datas {
+        let broker_name = broker.broker_name().as_str();
+        let listed = cluster_brokers.contains(broker_name);
+        if broker.cluster() != cluster {
+            if listed {
+                failures.push(invalid_response_failure(source, broker_name));
+            }
+            continue;
+        }
+        if !listed || !safe_logical_name(broker_name) {
+            failures.push(invalid_response_failure(source, broker_name));
+            continue;
+        }
+        route_brokers.insert(broker_name.to_string());
+    }
+    if route_brokers.is_empty() {
+        if !failures.is_empty() {
+            return Ok((Vec::new(), failures));
+        }
+        return Err(AdminError::not_found("consumer route in selected cluster", cluster));
+    }
+    if route_brokers.len() > MAX_CONSUMER_OBSERVATION_TARGETS {
+        return Err(AdminError::backend_view(
+            "resolve_consumer_observation_targets",
+            "CONSUMER_OBSERVATION_TARGET_LIMIT_EXCEEDED",
+            "Consumer route has too many selected-cluster Broker targets",
+            None,
+            422,
+            false,
+        ));
+    }
+    let broker_table = cluster_info.broker_addr_table.as_ref();
+    // Consuming the BTreeSet fixes Broker query order by logical name. Query-wide progress budget
+    // ownership is therefore deterministic when a later source would cross the remaining bound.
+    let mut targets = Vec::new();
+    for broker_name in route_brokers {
+        let Some(broker) = broker_table.and_then(|table| table.get(broker_name.as_str())) else {
+            failures.push(invalid_response_failure(source, &broker_name));
+            continue;
+        };
+        if broker.cluster() != cluster || broker.broker_name().as_str() != broker_name {
+            failures.push(invalid_response_failure(source, &broker_name));
+            continue;
+        }
+        match broker
+            .broker_addrs()
+            .get(&mix_all::MASTER_ID)
+            .filter(|address| is_valid_remoting_endpoint(address.as_str()))
+        {
+            Some(address) => targets.push((broker_name, address.clone())),
+            None => failures.push(invalid_response_failure(source, &broker_name)),
+        }
+    }
+    Ok((targets, failures))
+}
+
+fn config_row(broker_name: &str, snapshot: &SubscriptionGroupConfigVersioned) -> ConsumerGroupDetailsBrokerRow {
+    let config = &snapshot.config;
+    ConsumerGroupDetailsBrokerRow {
+        broker_name: broker_name.to_string(),
+        config_state: ConsumerGroupConfigState::Present,
+        config_version: Some(snapshot.version),
+        consume_enable: Some(config.consume_enable()),
+        consume_from_min_enable: Some(config.consume_from_min_enable()),
+        consume_broadcast_enable: Some(config.consume_broadcast_enable()),
+        consume_message_orderly: Some(config.consume_message_orderly()),
+        retry_queue_nums: Some(config.retry_queue_nums()),
+        retry_max_times: Some(config.retry_max_times()),
+        notify_consumer_ids_changed_enable: Some(config.notify_consumer_ids_changed_enable()),
+        consume_timeout_minutes: Some(config.consume_timeout_minute()),
+        connection_state: None,
+        connection_count: 0,
+        consume_type: None,
+        message_model: None,
+        consume_from_where: None,
+    }
+}
+
+fn absent_config_row(broker_name: String) -> ConsumerGroupDetailsBrokerRow {
+    ConsumerGroupDetailsBrokerRow {
+        broker_name,
+        config_state: ConsumerGroupConfigState::Absent,
+        config_version: None,
+        consume_enable: None,
+        consume_from_min_enable: None,
+        consume_broadcast_enable: None,
+        consume_message_orderly: None,
+        retry_queue_nums: None,
+        retry_max_times: None,
+        notify_consumer_ids_changed_enable: None,
+        consume_timeout_minutes: None,
+        connection_state: None,
+        connection_count: 0,
+        consume_type: None,
+        message_model: None,
+        consume_from_where: None,
+    }
+}
+
+type ProgressRowKey = (String, String, i32);
+
+struct SourceProgressObservation {
+    had_offsets: bool,
+    valid_rows: usize,
+    invalid: bool,
+}
+
+/// Retains only the lexicographically smallest requested queue rows while computing complete
+/// aggregates. The decoded response table remains bounded by the remoting transport body limit;
+/// this collector never creates a second full row table or vector.
+struct BoundedProgressCollector {
+    limit: usize,
+    rows: BTreeMap<ProgressRowKey, ConsumerProgressQueueRow>,
+    // Exact topic counting requires one name per distinct topic, bounded by the fixed per-source
+    // row cap and the 64-target topology cap, rather than one full queue-row copy.
+    topics: BTreeSet<String>,
+    // Broker targets are unique by topology resolution and capped at 64. Keeping the names here
+    // makes a future accidental repeated source fail closed instead of double-counting aggregates.
+    observed_brokers: BTreeSet<String>,
+    decoded_rows: usize,
+    queue_count: usize,
+    total_lag: u128,
+    total_inflight: u128,
+    max_queue_lag: u64,
+    aggregates_saturated: bool,
+    #[cfg(test)]
+    max_retained_len: usize,
+}
+
+impl BoundedProgressCollector {
+    fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            rows: BTreeMap::new(),
+            topics: BTreeSet::new(),
+            observed_brokers: BTreeSet::new(),
+            decoded_rows: 0,
+            queue_count: 0,
+            total_lag: 0,
+            total_inflight: 0,
+            max_queue_lag: 0,
+            aggregates_saturated: false,
+            #[cfg(test)]
+            max_retained_len: 0,
+        }
+    }
+
+    fn observe_source(&mut self, broker_name: &str, stats: ConsumeStats) -> SourceProgressObservation {
+        let had_offsets = !stats.offset_table.is_empty();
+        // Decoding is already bounded by the remoting transport body limit. Reject before cloning
+        // any row or topic when a decoded source still exceeds this fixed observation-layer cap.
+        if stats.offset_table.len() > MAX_CONSUMER_PROGRESS_SOURCE_ROWS {
+            return SourceProgressObservation {
+                had_offsets,
+                valid_rows: 0,
+                invalid: true,
+            };
+        }
+        let Some(reserved_rows) = self.decoded_rows.checked_add(stats.offset_table.len()) else {
+            return SourceProgressObservation {
+                had_offsets,
+                valid_rows: 0,
+                invalid: true,
+            };
+        };
+        if reserved_rows > MAX_CONSUMER_PROGRESS_QUERY_ROWS {
+            return SourceProgressObservation {
+                had_offsets,
+                valid_rows: 0,
+                invalid: true,
+            };
+        }
+        if self.observed_brokers.contains(broker_name) {
+            return SourceProgressObservation {
+                had_offsets,
+                valid_rows: 0,
+                invalid: true,
+            };
+        }
+        // Reserve the whole source before any topic/row clone, broker-set insertion, or aggregate
+        // update. A rejected source is never partially admitted and consumes no query budget.
+        self.decoded_rows = reserved_rows;
+        self.observed_brokers.insert(broker_name.to_string());
+
+        let mut valid_rows = 0usize;
+        let mut invalid = false;
+        // `offset_table` is a HashMap keyed by the exact wire topic, broker name, and queue id.
+        // The checks below do not trim or normalize any key component, so one decoded table cannot
+        // produce a normalized-key collision. Distinct Broker sources also have distinct exact
+        // broker names, as enforced above and by topology resolution.
+        for (queue, offset) in stats.offset_table {
+            let topic = queue.topic_str();
+            let broker_offset = offset.get_broker_offset();
+            let consumer_offset = offset.get_consumer_offset();
+            let pull_offset = offset.get_pull_offset();
+            let last_timestamp = offset.get_last_timestamp();
+            let valid = safe_topic_name(topic)
+                && queue.broker_name().as_str() == broker_name
+                && queue.queue_id() >= 0
+                && broker_offset >= 0
+                && consumer_offset >= 0
+                && pull_offset >= 0
+                && last_timestamp >= 0;
+            let Some(lag) = broker_offset
+                .checked_sub(consumer_offset)
+                .and_then(|value| u64::try_from(value).ok())
+            else {
+                invalid = true;
+                continue;
+            };
+            let Some(inflight) = pull_offset
+                .checked_sub(consumer_offset)
+                .and_then(|value| u64::try_from(value).ok())
+            else {
+                invalid = true;
+                continue;
+            };
+            if !valid {
+                invalid = true;
+                continue;
+            }
+
+            valid_rows = valid_rows.saturating_add(1);
+            let row = ConsumerProgressQueueRow {
+                topic: topic.to_string(),
+                broker_name: broker_name.to_string(),
+                queue_id: queue.queue_id(),
+                broker_offset,
+                consumer_offset,
+                pull_offset,
+                lag,
+                inflight,
+                last_timestamp,
+            };
+            self.observe_unique_row(row);
+        }
+        debug_assert!(self.decoded_rows <= MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+        debug_assert!(self.topics.len() <= self.decoded_rows);
+        debug_assert!(self.rows.len() <= self.limit);
+        SourceProgressObservation {
+            had_offsets,
+            valid_rows,
+            invalid,
+        }
+    }
+
+    fn observe_unique_row(&mut self, row: ConsumerProgressQueueRow) {
+        self.topics.insert(row.topic.clone());
+        let Some(queue_count) = self.queue_count.checked_add(1) else {
+            self.queue_count = usize::MAX;
+            self.aggregates_saturated = true;
+            return;
+        };
+        self.queue_count = queue_count;
+        self.total_lag = self.total_lag.checked_add(u128::from(row.lag)).unwrap_or_else(|| {
+            self.aggregates_saturated = true;
+            u128::MAX
+        });
+        self.total_inflight = self
+            .total_inflight
+            .checked_add(u128::from(row.inflight))
+            .unwrap_or_else(|| {
+                self.aggregates_saturated = true;
+                u128::MAX
+            });
+        self.max_queue_lag = self.max_queue_lag.max(row.lag);
+
+        let key = (row.topic.clone(), row.broker_name.clone(), row.queue_id);
+        if self.rows.len() < self.limit {
+            self.rows.insert(key, row);
+        } else if self.rows.last_key_value().is_some_and(|(last, _)| key < *last) {
+            self.rows.pop_last();
+            self.rows.insert(key, row);
+        }
+        #[cfg(test)]
+        {
+            self.max_retained_len = self.max_retained_len.max(self.rows.len());
+        }
+    }
+
+    fn into_rows(self) -> Vec<ConsumerProgressQueueRow> {
+        self.rows.into_values().collect()
+    }
+}
+
+fn empty_progress_result(consumer_group: &str) -> QueryConsumerProgressResult {
+    QueryConsumerProgressResult {
+        consumer_group: consumer_group.to_string(),
+        state: ConsumerProgressState::NoConsumption,
+        topic_count: 0,
+        queue_count: 0,
+        total_lag: 0,
+        max_queue_lag: 0,
+        total_inflight: 0,
+        consume_tps: 0.0,
+        queues: Vec::new(),
+        truncated: false,
+    }
+}
+
+fn map_consume_type(value: Option<ConsumeType>) -> ConsumerConsumeType {
+    match value {
+        Some(ConsumeType::ConsumeActively) => ConsumerConsumeType::Pull,
+        Some(ConsumeType::ConsumePassively) => ConsumerConsumeType::Push,
+        Some(ConsumeType::ConsumePop) => ConsumerConsumeType::Pop,
+        None => ConsumerConsumeType::Unknown,
+    }
+}
+
+fn map_message_model(value: Option<MessageModel>) -> ConsumerMessageModel {
+    match value {
+        Some(MessageModel::Broadcasting) => ConsumerMessageModel::Broadcasting,
+        Some(MessageModel::Clustering) => ConsumerMessageModel::Clustering,
+        None => ConsumerMessageModel::Unknown,
+    }
+}
+
+#[allow(deprecated)]
+fn map_consume_from_where(value: Option<ConsumeFromWhere>) -> ConsumerConsumeFromWhere {
+    match value {
+        Some(ConsumeFromWhere::ConsumeFromLastOffset) => ConsumerConsumeFromWhere::LastOffset,
+        Some(ConsumeFromWhere::ConsumeFromLastOffsetAndFromMinWhenBootFirst) => {
+            ConsumerConsumeFromWhere::LastOffsetAndMinFirst
+        }
+        Some(ConsumeFromWhere::ConsumeFromMinOffset) => ConsumerConsumeFromWhere::MinOffset,
+        Some(ConsumeFromWhere::ConsumeFromMaxOffset) => ConsumerConsumeFromWhere::MaxOffset,
+        Some(ConsumeFromWhere::ConsumeFromFirstOffset) => ConsumerConsumeFromWhere::FirstOffset,
+        Some(ConsumeFromWhere::ConsumeFromTimestamp) => ConsumerConsumeFromWhere::Timestamp,
+        None => ConsumerConsumeFromWhere::Unknown,
+    }
+}
+
+fn safe_logical_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 128
+        && name.is_ascii()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+}
+
+fn safe_topic_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 255
+        && name.is_ascii()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '%' | '-' | '_' | '|'))
+}
+
+fn invalid_response_failure(source: AdminQuerySource, broker_name: &str) -> AdminSourceFailure {
+    AdminSourceFailure::new(source, AdminQueryFailureCode::InvalidResponse, false, broker_name)
+}
+
+fn source_failure(source: AdminQuerySource, broker_name: &str, error: &RocketMQError) -> AdminSourceFailure {
+    let view = error.boundary_view();
+    let code = match view.http().status.as_u16() {
+        401 | 403 => AdminQueryFailureCode::PermissionDenied,
+        404 => AdminQueryFailureCode::NotFound,
+        408 | 504 => AdminQueryFailureCode::Timeout,
+        429 => AdminQueryFailureCode::RateLimited,
+        400 | 413 | 422 => AdminQueryFailureCode::InvalidResponse,
+        _ => AdminQueryFailureCode::SourceUnavailable,
+    };
+    AdminSourceFailure::new(source, code, view.is_retryable(), broker_name)
+}
+
+fn backend_error(operation: &'static str, error: RocketMQError) -> AdminError {
+    let view = error.boundary_view();
+    AdminError::backend_view(
+        operation,
+        view.code().as_str(),
+        view.message(),
+        (!view.context().is_empty()).then(|| view.context().to_string()),
+        view.http().status.as_u16(),
+        view.is_retryable(),
+    )
+}
+
+#[cfg(test)]
+#[path = "consumer_observation_tests.rs"]
+mod tests;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer_observation_tests.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer_observation_tests.rs
@@ -1,0 +1,1034 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use rocketmq_model::message::MessageQueue;
+use rocketmq_protocol::protocol::admin::offset_wrapper::OffsetWrapper;
+use rocketmq_protocol::protocol::body::connection::Connection;
+use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
+use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+
+use super::*;
+
+const ADDRESS_A: &str = "127.0.0.1:10911";
+const ADDRESS_B: &str = "127.0.0.2:10911";
+const ADDRESS_C: &str = "127.0.0.3:10911";
+const SLAVE_ADDRESS_A: &str = "127.0.0.1:20911";
+
+#[derive(Clone)]
+enum ConfigReply {
+    Present(Box<SubscriptionGroupConfigVersioned>),
+    Absent,
+    Failure(&'static str),
+}
+
+#[derive(Clone)]
+enum ConnectionReply {
+    Online(rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection),
+    Offline,
+    Failure(&'static str),
+}
+
+enum ProgressReply {
+    Observed(ConsumeStats),
+    Absent,
+    Failure(&'static str),
+}
+
+#[derive(Default)]
+struct FakeSource {
+    cluster_info: ClusterInfo,
+    route: Option<TopicRouteData>,
+    configs: BTreeMap<String, ConfigReply>,
+    connections: BTreeMap<String, ConnectionReply>,
+    progress: Mutex<BTreeMap<String, ProgressReply>>,
+    config_calls: Mutex<Vec<String>>,
+    connection_calls: Mutex<Vec<String>>,
+    progress_calls: Mutex<Vec<String>>,
+}
+
+impl ConsumerObservationSource for FakeSource {
+    async fn cluster_info(&self) -> Result<ClusterInfo, RocketMQError> {
+        Ok(self.cluster_info.clone())
+    }
+
+    async fn consumer_route(&self, _consumer_group: &str) -> Result<Option<TopicRouteData>, RocketMQError> {
+        Ok(self.route.clone())
+    }
+
+    async fn group_config(
+        &self,
+        broker_addr: CheetahString,
+        _consumer_group: &str,
+    ) -> Result<ConsumerGroupConfigRead, RocketMQError> {
+        self.config_calls.lock().unwrap().push(broker_addr.to_string());
+        match self.configs.get(broker_addr.as_str()) {
+            Some(ConfigReply::Present(config)) => Ok(ConsumerGroupConfigRead::Present(config.clone())),
+            Some(ConfigReply::Absent) | None => Ok(ConsumerGroupConfigRead::Absent),
+            Some(ConfigReply::Failure(reason)) => Err(test_error(reason)),
+        }
+    }
+
+    async fn connection(
+        &self,
+        broker_addr: CheetahString,
+        _consumer_group: &str,
+    ) -> Result<ConsumerConnectionRead, RocketMQError> {
+        self.connection_calls.lock().unwrap().push(broker_addr.to_string());
+        match self.connections.get(broker_addr.as_str()) {
+            Some(ConnectionReply::Online(connection)) => Ok(ConsumerConnectionRead::Online(connection.clone())),
+            Some(ConnectionReply::Offline) | None => Ok(ConsumerConnectionRead::Offline),
+            Some(ConnectionReply::Failure(reason)) => Err(test_error(reason)),
+        }
+    }
+
+    async fn progress(
+        &self,
+        broker_addr: CheetahString,
+        _consumer_group: &str,
+    ) -> Result<ConsumerProgressRead, RocketMQError> {
+        self.progress_calls.lock().unwrap().push(broker_addr.to_string());
+        match self.progress.lock().unwrap().remove(broker_addr.as_str()) {
+            Some(ProgressReply::Observed(stats)) => Ok(ConsumerProgressRead::Observed(stats)),
+            Some(ProgressReply::Absent) | None => Ok(ConsumerProgressRead::Absent),
+            Some(ProgressReply::Failure(reason)) => Err(test_error(reason)),
+        }
+    }
+}
+
+fn topology(brokers: &[(&str, &str, &str)]) -> (ClusterInfo, TopicRouteData) {
+    let mut broker_table = HashMap::new();
+    let mut cluster_table = HashMap::<CheetahString, HashSet<CheetahString>>::new();
+    let mut route_brokers = Vec::new();
+    for (cluster, broker, address) in brokers {
+        let data = BrokerData::new(
+            (*cluster).into(),
+            (*broker).into(),
+            HashMap::from([(mix_all::MASTER_ID, (*address).into())]),
+            None,
+        );
+        broker_table.insert((*broker).into(), data.clone());
+        cluster_table
+            .entry((*cluster).into())
+            .or_default()
+            .insert((*broker).into());
+        route_brokers.push(data);
+    }
+    (
+        ClusterInfo::new(Some(broker_table), Some(cluster_table)),
+        TopicRouteData {
+            broker_datas: route_brokers,
+            ..Default::default()
+        },
+    )
+}
+
+fn source(brokers: &[(&str, &str, &str)]) -> FakeSource {
+    let (cluster_info, route) = topology(brokers);
+    FakeSource {
+        cluster_info,
+        route: Some(route),
+        ..Default::default()
+    }
+}
+
+#[derive(Clone, Copy)]
+enum EmbeddedTopologyCorruption {
+    RouteCluster,
+    BrokerTableName,
+}
+
+fn corrupt_embedded_topology(source: &mut FakeSource, broker_name: &str, corruption: EmbeddedTopologyCorruption) {
+    match corruption {
+        EmbeddedTopologyCorruption::RouteCluster => source
+            .route
+            .as_mut()
+            .unwrap()
+            .broker_datas
+            .iter_mut()
+            .find(|broker| broker.broker_name().as_str() == broker_name)
+            .unwrap()
+            .set_cluster("cluster-b".into()),
+        EmbeddedTopologyCorruption::BrokerTableName => source
+            .cluster_info
+            .broker_addr_table
+            .as_mut()
+            .unwrap()
+            .get_mut(broker_name)
+            .unwrap()
+            .set_broker_name("forged-broker".into()),
+    }
+}
+
+fn add_slave(source: &mut FakeSource, broker_name: &str, slave_address: &str) {
+    source
+        .cluster_info
+        .broker_addr_table
+        .as_mut()
+        .unwrap()
+        .get_mut(broker_name)
+        .unwrap()
+        .broker_addrs_mut()
+        .insert(1, slave_address.into());
+    source
+        .route
+        .as_mut()
+        .unwrap()
+        .broker_datas
+        .iter_mut()
+        .find(|broker| broker.broker_name().as_str() == broker_name)
+        .unwrap()
+        .broker_addrs_mut()
+        .insert(1, slave_address.into());
+}
+
+fn config(version: u64) -> ConfigReply {
+    let mut config = SubscriptionGroupConfig::new("group-a".into());
+    config.set_retry_queue_nums(2);
+    config.set_retry_max_times(17);
+    config.set_consume_timeout_minute(16);
+    ConfigReply::Present(Box::new(SubscriptionGroupConfigVersioned { version, config }))
+}
+
+fn connection(count: usize) -> ConnectionReply {
+    let mut observation = rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection::new();
+    observation.set_consume_type(ConsumeType::ConsumePassively);
+    observation.set_message_model(MessageModel::Clustering);
+    observation.set_consume_from_where(ConsumeFromWhere::ConsumeFromLastOffset);
+    for index in 0..count {
+        let mut client = Connection::new();
+        client.set_client_id(format!("secret-client-{index}").into());
+        client.set_client_addr(format!("10.0.0.{index}:12000").into());
+        observation.insert_connection(client);
+    }
+    ConnectionReply::Online(observation)
+}
+
+fn stats(broker_name: &str, rows: &[(i32, i64, i64, i64, i64)], consume_tps: f64) -> ConsumeStats {
+    let mut stats = ConsumeStats::new();
+    stats.set_consume_tps(consume_tps);
+    for (queue_id, broker_offset, consumer_offset, pull_offset, timestamp) in rows {
+        insert_row(
+            &mut stats,
+            "orders",
+            broker_name,
+            *queue_id,
+            *broker_offset,
+            *consumer_offset,
+            *pull_offset,
+            *timestamp,
+        );
+    }
+    stats
+}
+
+fn stats_with_count(broker_name: &str, row_count: usize, unique_topics: bool) -> ConsumeStats {
+    let mut stats = ConsumeStats::new();
+    for queue_id in 0..row_count {
+        let topic = if unique_topics {
+            format!("topic-{broker_name}-{queue_id}")
+        } else {
+            "orders".to_string()
+        };
+        insert_row(&mut stats, &topic, broker_name, queue_id as i32, 1, 0, 1, 1);
+    }
+    stats
+}
+
+fn progress_source_with_counts(row_counts: &[usize]) -> FakeSource {
+    let owned = row_counts
+        .iter()
+        .enumerate()
+        .map(|(index, _)| {
+            (
+                "cluster-a".to_string(),
+                format!("broker-{index:02}"),
+                format!("127.0.0.1:{}", 10_000 + index),
+            )
+        })
+        .collect::<Vec<_>>();
+    let borrowed = owned
+        .iter()
+        .map(|(cluster, broker, address)| (cluster.as_str(), broker.as_str(), address.as_str()))
+        .collect::<Vec<_>>();
+    let mut source = source(&borrowed);
+    for ((_, broker, address), row_count) in owned.iter().zip(row_counts) {
+        source.configs.insert(address.clone(), config(1));
+        source.progress.lock().unwrap().insert(
+            address.clone(),
+            ProgressReply::Observed(stats_with_count(broker, *row_count, false)),
+        );
+    }
+    source
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_row(
+    stats: &mut ConsumeStats,
+    topic: &str,
+    broker_name: &str,
+    queue_id: i32,
+    broker_offset: i64,
+    consumer_offset: i64,
+    pull_offset: i64,
+    timestamp: i64,
+) {
+    let mut offset = OffsetWrapper::new();
+    offset.set_broker_offset(broker_offset);
+    offset.set_consumer_offset(consumer_offset);
+    offset.set_pull_offset(pull_offset);
+    offset.set_last_timestamp(timestamp);
+    stats
+        .get_offset_table_mut()
+        .insert(MessageQueue::from_parts(topic, broker_name, queue_id), offset);
+}
+
+fn details_request() -> QueryConsumerGroupDetailsRequest {
+    QueryConsumerGroupDetailsRequest::try_new("cluster-a", "group-a").unwrap()
+}
+
+fn progress_request(max_rows: usize) -> QueryConsumerProgressRequest {
+    QueryConsumerProgressRequest::try_new("cluster-a", "group-a", max_rows).unwrap()
+}
+
+#[tokio::test]
+async fn details_are_sorted_typed_partial_and_address_free() {
+    let mut source = source(&[
+        ("cluster-a", "broker-b", ADDRESS_B),
+        ("cluster-a", "broker-a", ADDRESS_A),
+        ("cluster-b", "broker-c", ADDRESS_C),
+    ]);
+    source.configs.insert(ADDRESS_A.to_string(), config(7));
+    source.configs.insert(ADDRESS_B.to_string(), config(8));
+    source.connections.insert(ADDRESS_A.to_string(), connection(2));
+    source
+        .connections
+        .insert(ADDRESS_B.to_string(), ConnectionReply::Failure("secret endpoint"));
+
+    let result = query_consumer_group_details_from(&source, &details_request())
+        .await
+        .unwrap();
+
+    assert!(result.partial);
+    assert_eq!(result.data.total_connection_count, 2);
+    assert_eq!(result.data.brokers[0].broker_name, "broker-a");
+    assert_eq!(
+        result.data.brokers[0].connection_state,
+        Some(ConsumerConnectionState::Online)
+    );
+    assert_eq!(result.data.brokers[0].consume_type, Some(ConsumerConsumeType::Push));
+    assert_eq!(result.data.brokers[1].connection_state, None);
+    assert_eq!(result.source_failures[0].logical_target(), "broker-b");
+    let wire = serde_json::to_string(&result).unwrap();
+    for secret in [
+        "127.0.0",
+        "10.0.0",
+        "secret-client",
+        "secret endpoint",
+        "subscription",
+        "attributes",
+    ] {
+        assert!(!wire.contains(secret), "secret={secret}");
+    }
+}
+
+#[tokio::test]
+async fn details_map_offline_and_all_absent_or_no_valid_config_semantics() {
+    let mut offline = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+    offline.configs.insert(ADDRESS_A.to_string(), config(1));
+    offline
+        .connections
+        .insert(ADDRESS_A.to_string(), ConnectionReply::Offline);
+    let result = query_consumer_group_details_from(&offline, &details_request())
+        .await
+        .unwrap();
+    assert!(!result.partial);
+    assert_eq!(
+        result.data.brokers[0].connection_state,
+        Some(ConsumerConnectionState::Offline)
+    );
+
+    let mut absent = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+    absent.configs.insert(ADDRESS_A.to_string(), ConfigReply::Absent);
+    let error = query_consumer_group_details_from(&absent, &details_request())
+        .await
+        .unwrap_err();
+    assert!(matches!(error, AdminError::NotFound { .. }));
+    assert!(absent.connection_calls.lock().unwrap().is_empty());
+
+    let mut mixed = source(&[
+        ("cluster-a", "broker-a", ADDRESS_A),
+        ("cluster-a", "broker-b", ADDRESS_B),
+    ]);
+    mixed.configs.insert(ADDRESS_A.to_string(), ConfigReply::Absent);
+    mixed
+        .configs
+        .insert(ADDRESS_B.to_string(), ConfigReply::Failure("private"));
+    let error = query_consumer_group_details_from(&mixed, &details_request())
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+    assert!(mixed.connection_calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn progress_distinguishes_empty_zero_and_nonzero_lag_and_preserves_partial() {
+    let mut empty = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+    empty.configs.insert(ADDRESS_A.to_string(), config(1));
+    empty
+        .progress
+        .lock()
+        .unwrap()
+        .insert(ADDRESS_A.to_string(), ProgressReply::Observed(ConsumeStats::new()));
+    let result = query_consumer_progress_from(&empty, &progress_request(10))
+        .await
+        .unwrap();
+    assert_eq!(result.data.state, ConsumerProgressState::NoConsumption);
+    assert_eq!(result.data.queue_count, 0);
+
+    let mut zero = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+    zero.configs.insert(ADDRESS_A.to_string(), config(1));
+    zero.progress.lock().unwrap().insert(
+        ADDRESS_A.to_string(),
+        ProgressReply::Observed(stats("broker-a", &[(0, 10, 10, 10, 1)], 2.5)),
+    );
+    let result = query_consumer_progress_from(&zero, &progress_request(10))
+        .await
+        .unwrap();
+    assert_eq!(result.data.state, ConsumerProgressState::Observed);
+    assert_eq!(result.data.total_lag, 0);
+    assert_eq!(result.data.consume_tps, 2.5);
+
+    let mut partial = source(&[
+        ("cluster-a", "broker-a", ADDRESS_A),
+        ("cluster-a", "broker-b", ADDRESS_B),
+    ]);
+    partial.configs.insert(ADDRESS_A.to_string(), config(1));
+    partial.configs.insert(ADDRESS_B.to_string(), config(1));
+    partial.progress.lock().unwrap().insert(
+        ADDRESS_A.to_string(),
+        ProgressReply::Observed(stats("broker-a", &[(0, 20, 10, 15, 9)], 1.0)),
+    );
+    partial
+        .progress
+        .lock()
+        .unwrap()
+        .insert(ADDRESS_B.to_string(), ProgressReply::Failure("private"));
+    let result = query_consumer_progress_from(&partial, &progress_request(10))
+        .await
+        .unwrap();
+    assert!(result.partial);
+    assert_eq!((result.data.total_lag, result.data.total_inflight), (10, 5));
+    assert_eq!(result.data.queues[0].last_timestamp, 9);
+    assert!(!serde_json::to_string(&result).unwrap().contains("private"));
+}
+
+#[tokio::test]
+async fn all_progress_sources_failing_or_absent_is_total_failure() {
+    for reply in [ProgressReply::Failure("private"), ProgressReply::Absent] {
+        let mut source = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+        source.configs.insert(ADDRESS_A.to_string(), config(1));
+        source.progress.lock().unwrap().insert(ADDRESS_A.to_string(), reply);
+        let error = query_consumer_progress_from(&source, &progress_request(10))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+    }
+}
+
+#[test]
+fn progress_wire_fields_are_fail_closed_and_valid_rows_are_not_rewritten() {
+    let invalid_rows = [
+        ("bad topic", "broker-a", 0, 10, 1, 2, 1),
+        ("orders", "forged", 0, 10, 1, 2, 1),
+        ("orders", "broker-a", -1, 10, 1, 2, 1),
+        ("orders", "broker-a", 1, -1, 0, 0, 1),
+        ("orders", "broker-a", 2, 1, -1, 0, 1),
+        ("orders", "broker-a", 3, 1, 0, -1, 1),
+        ("orders", "broker-a", 4, 1, 0, 0, -1),
+        ("orders", "broker-a", 5, 1, 2, 2, 1),
+        ("orders", "broker-a", 6, 2, 1, 0, 1),
+    ];
+    let mut malformed = ConsumeStats::new();
+    for row in invalid_rows {
+        insert_row(&mut malformed, row.0, row.1, row.2, row.3, row.4, row.5, row.6);
+    }
+    insert_row(&mut malformed, "orders", "broker-a", 7, 10, 4, 8, 9);
+    let mut collector = BoundedProgressCollector::new(10);
+    let observation = collector.observe_source("broker-a", malformed);
+    assert!(observation.invalid);
+    assert_eq!(observation.valid_rows, 1);
+    assert_eq!(collector.rows.len(), 1);
+    assert_eq!(collector.rows.values().next().unwrap().queue_id, 7);
+    assert_eq!(
+        (
+            collector.rows.values().next().unwrap().lag,
+            collector.rows.values().next().unwrap().inflight
+        ),
+        (6, 4)
+    );
+}
+
+#[test]
+fn exact_wire_keys_and_raw_table_uniqueness_prevent_normalized_collisions() {
+    let mut observation = ConsumeStats::new();
+    insert_row(&mut observation, "orders", "broker-a", 0, 20, 10, 15, 2);
+    // An exact duplicate/conflict replaces the same decoded HashMap key before collection, so it
+    // cannot be counted twice. No trim or case normalization is applied to otherwise distinct keys.
+    insert_row(&mut observation, "orders", "broker-a", 0, 19, 10, 15, 3);
+    insert_row(&mut observation, "orders", "broker-a", 1, 3, 2, 2, 4);
+    insert_row(&mut observation, "orders-", "broker-a", 1, 5, 2, 4, 5);
+    insert_row(&mut observation, "orders", "broker-a ", 2, 9, 1, 2, 6);
+    assert_eq!(observation.get_offset_table().len(), 4);
+
+    let mut collector = BoundedProgressCollector::new(10);
+    let source = collector.observe_source("broker-a", observation);
+    assert!(source.invalid);
+    assert_eq!(source.valid_rows, 3);
+    assert_eq!(collector.queue_count, 3);
+    assert_eq!(collector.topics.len(), 2);
+    assert_eq!(collector.rows.len(), 3);
+    assert_eq!(collector.rows.values().next().unwrap().broker_offset, 19);
+
+    let duplicate_source = collector.observe_source("broker-a", ConsumeStats::new());
+    assert!(duplicate_source.invalid);
+    assert_eq!(duplicate_source.valid_rows, 0);
+    assert_eq!(collector.queue_count, 3);
+    assert_eq!(collector.decoded_rows, 4);
+}
+
+#[tokio::test]
+async fn retention_is_sorted_and_aggregates_every_unique_row_before_truncation() {
+    let mut source = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+    source.configs.insert(ADDRESS_A.to_string(), config(1));
+    let mut observation = ConsumeStats::new();
+    for queue_id in (0..=MAX_CONSUMER_PROGRESS_ROWS as i32).rev() {
+        let (topic, broker_offset) = if queue_id == MAX_CONSUMER_PROGRESS_ROWS as i32 {
+            ("returns", 2)
+        } else {
+            ("orders", 1)
+        };
+        insert_row(
+            &mut observation,
+            topic,
+            "broker-a",
+            queue_id,
+            broker_offset,
+            0,
+            broker_offset,
+            1,
+        );
+    }
+    source
+        .progress
+        .lock()
+        .unwrap()
+        .insert(ADDRESS_A.to_string(), ProgressReply::Observed(observation));
+    let result = query_consumer_progress_from(&source, &progress_request(MAX_CONSUMER_PROGRESS_ROWS))
+        .await
+        .unwrap();
+    assert!(result.partial);
+    assert!(result.data.truncated);
+    assert_eq!(result.data.topic_count, 2);
+    assert_eq!(result.data.queue_count, MAX_CONSUMER_PROGRESS_ROWS + 1);
+    assert_eq!(result.data.total_lag, MAX_CONSUMER_PROGRESS_ROWS as u64 + 2);
+    assert_eq!(result.data.max_queue_lag, 2);
+    assert_eq!(result.data.queues.len(), MAX_CONSUMER_PROGRESS_ROWS);
+    assert_eq!(result.data.queues.first().unwrap().queue_id, 0);
+    assert_eq!(
+        result.data.queues.last().unwrap().queue_id,
+        MAX_CONSUMER_PROGRESS_ROWS as i32 - 1
+    );
+    assert!(result
+        .warnings
+        .iter()
+        .any(|warning| warning == CONSUMER_PROGRESS_TRUNCATED_WARNING));
+}
+
+#[test]
+fn fifty_thousand_wire_rows_keep_only_bounded_top_k_and_full_aggregates() {
+    const WIRE_ROWS: i32 = 50_000;
+    assert_eq!(WIRE_ROWS as usize, MAX_CONSUMER_PROGRESS_SOURCE_ROWS);
+    assert_eq!(WIRE_ROWS as usize, MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    let mut stats = ConsumeStats::new();
+    for queue_id in (0..WIRE_ROWS).rev() {
+        insert_row(
+            &mut stats,
+            "orders",
+            "broker-a",
+            queue_id,
+            i64::from(queue_id) + 1,
+            0,
+            i64::from(queue_id) + 1,
+            1,
+        );
+    }
+
+    let mut collector = BoundedProgressCollector::new(MAX_CONSUMER_PROGRESS_ROWS);
+    let observation = collector.observe_source("broker-a", stats);
+    assert!(!observation.invalid);
+    assert_eq!(observation.valid_rows, WIRE_ROWS as usize);
+    assert_eq!(collector.max_retained_len, MAX_CONSUMER_PROGRESS_ROWS);
+    assert_eq!(collector.rows.len(), MAX_CONSUMER_PROGRESS_ROWS);
+    assert_eq!(collector.decoded_rows, MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    assert_eq!(collector.topics.len(), 1);
+    assert_eq!(collector.queue_count, WIRE_ROWS as usize);
+    assert_eq!(
+        collector.total_lag,
+        u128::from(WIRE_ROWS as u64) * u128::from((WIRE_ROWS + 1) as u64) / 2
+    );
+    assert_eq!(collector.total_inflight, collector.total_lag);
+    assert_eq!(collector.max_queue_lag, WIRE_ROWS as u64);
+    assert_eq!(collector.rows.first_key_value().unwrap().1.queue_id, 0);
+    assert_eq!(
+        collector.rows.last_key_value().unwrap().1.queue_id,
+        MAX_CONSUMER_PROGRESS_ROWS as i32 - 1
+    );
+
+    let mut oversized = ConsumeStats::new();
+    for queue_id in 0..=WIRE_ROWS {
+        insert_row(&mut oversized, "orders", "broker-b", queue_id, 1, 0, 1, 1);
+    }
+    let mut rejected = BoundedProgressCollector::new(MAX_CONSUMER_PROGRESS_ROWS);
+    let observation = rejected.observe_source("broker-b", oversized);
+    assert!(observation.invalid);
+    assert_eq!(observation.valid_rows, 0);
+    assert_eq!(rejected.queue_count, 0);
+    assert_eq!(rejected.decoded_rows, 0);
+    assert_eq!(rejected.total_lag, 0);
+    assert_eq!(rejected.total_inflight, 0);
+    assert_eq!(rejected.max_queue_lag, 0);
+    assert!(rejected.topics.is_empty());
+    assert!(rejected.rows.is_empty());
+    assert_eq!(rejected.max_retained_len, 0);
+}
+
+#[test]
+fn query_budget_is_exact_bounded_and_empty_sources_consume_zero() {
+    let half = MAX_CONSUMER_PROGRESS_QUERY_ROWS / 2;
+    let mut collector = BoundedProgressCollector::new(10);
+    let first = collector.observe_source("broker-a", stats_with_count("broker-a", half, true));
+    let second = collector.observe_source(
+        "broker-b",
+        stats_with_count("broker-b", MAX_CONSUMER_PROGRESS_QUERY_ROWS - half, true),
+    );
+    assert!(!first.invalid);
+    assert!(!second.invalid);
+    assert_eq!(collector.decoded_rows, MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    assert_eq!(collector.queue_count, MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    assert_eq!(collector.topics.len(), MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    assert!(collector.topics.len() <= MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    assert_eq!(collector.rows.len(), 10);
+    assert_eq!(collector.max_retained_len, 10);
+
+    let empty = collector.observe_source("broker-c", ConsumeStats::new());
+    assert!(!empty.invalid);
+    assert!(!empty.had_offsets);
+    assert_eq!(collector.decoded_rows, MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+
+    let rejected = collector.observe_source("broker-d", stats_with_count("broker-d", 1, false));
+    assert!(rejected.invalid);
+    assert_eq!(rejected.valid_rows, 0);
+    assert_eq!(collector.decoded_rows, MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    assert_eq!(collector.queue_count, MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    assert_eq!(collector.topics.len(), MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    assert_eq!(collector.rows.len(), 10);
+}
+
+#[tokio::test]
+async fn oversized_source_is_total_failure_or_partial_without_polluting_aggregates() {
+    let oversized_stats = |broker_name: &str| {
+        let mut observation = ConsumeStats::new();
+        for queue_id in 0..=MAX_CONSUMER_PROGRESS_SOURCE_ROWS as i32 {
+            insert_row(&mut observation, "orders", broker_name, queue_id, 1, 0, 1, 1);
+        }
+        observation
+    };
+
+    let mut only_oversized = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+    only_oversized.configs.insert(ADDRESS_A.to_string(), config(1));
+    only_oversized.progress.lock().unwrap().insert(
+        ADDRESS_A.to_string(),
+        ProgressReply::Observed(oversized_stats("broker-a")),
+    );
+    let error = query_consumer_progress_from(&only_oversized, &progress_request(10))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+
+    let mut mixed = source(&[
+        ("cluster-a", "broker-a", ADDRESS_A),
+        ("cluster-a", "broker-b", ADDRESS_B),
+    ]);
+    mixed.configs.insert(ADDRESS_A.to_string(), config(1));
+    mixed.configs.insert(ADDRESS_B.to_string(), config(1));
+    mixed.progress.lock().unwrap().insert(
+        ADDRESS_A.to_string(),
+        ProgressReply::Observed(stats("broker-a", &[(0, 9, 4, 7, 1)], 2.0)),
+    );
+    mixed.progress.lock().unwrap().insert(
+        ADDRESS_B.to_string(),
+        ProgressReply::Observed(oversized_stats("broker-b")),
+    );
+    let result = query_consumer_progress_from(&mixed, &progress_request(10))
+        .await
+        .unwrap();
+    assert!(result.partial);
+    assert_eq!(result.data.topic_count, 1);
+    assert_eq!(result.data.queue_count, 1);
+    assert_eq!(result.data.total_lag, 5);
+    assert_eq!(result.data.max_queue_lag, 5);
+    assert_eq!(result.data.total_inflight, 3);
+    assert_eq!(result.data.consume_tps, 2.0);
+    assert_eq!(result.data.queues.len(), 1);
+    assert_eq!(result.source_failures.len(), 1);
+    assert_eq!(result.source_failures[0].logical_target(), "broker-b");
+    assert_eq!(result.source_failures[0].code(), AdminQueryFailureCode::InvalidResponse);
+}
+
+#[tokio::test]
+async fn query_budget_rejects_whole_later_source_and_preserves_partial_or_total_semantics() {
+    {
+        let mut partial = source(&[
+            ("cluster-a", "broker-a", ADDRESS_A),
+            ("cluster-a", "broker-b", ADDRESS_B),
+        ]);
+        partial.configs.insert(ADDRESS_A.to_string(), config(1));
+        partial.configs.insert(ADDRESS_B.to_string(), config(1));
+        partial.progress.lock().unwrap().insert(
+            ADDRESS_A.to_string(),
+            ProgressReply::Observed(stats_with_count("broker-a", 25_000, false)),
+        );
+        partial.progress.lock().unwrap().insert(
+            ADDRESS_B.to_string(),
+            ProgressReply::Observed(stats_with_count("broker-b", 25_001, false)),
+        );
+        let result = query_consumer_progress_from(&partial, &progress_request(10))
+            .await
+            .unwrap();
+        assert!(result.partial);
+        assert_eq!(result.data.topic_count, 1);
+        assert_eq!(result.data.queue_count, 25_000);
+        assert_eq!(result.data.total_lag, 25_000);
+        assert_eq!(result.data.max_queue_lag, 1);
+        assert_eq!(result.source_failures.len(), 1);
+        assert_eq!(result.source_failures[0].logical_target(), "broker-b");
+        assert_eq!(
+            partial.progress_calls.lock().unwrap().as_slice(),
+            [ADDRESS_A, ADDRESS_B]
+        );
+    }
+
+    {
+        let mut total = source(&[
+            ("cluster-a", "broker-a", ADDRESS_A),
+            ("cluster-a", "broker-b", ADDRESS_B),
+        ]);
+        total.configs.insert(ADDRESS_A.to_string(), config(1));
+        total.configs.insert(ADDRESS_B.to_string(), config(1));
+        total.progress.lock().unwrap().insert(
+            ADDRESS_A.to_string(),
+            ProgressReply::Observed(stats_with_count(
+                "forged-broker",
+                MAX_CONSUMER_PROGRESS_QUERY_ROWS,
+                false,
+            )),
+        );
+        total.progress.lock().unwrap().insert(
+            ADDRESS_B.to_string(),
+            ProgressReply::Observed(stats_with_count("broker-b", 1, false)),
+        );
+        let error = query_consumer_progress_from(&total, &progress_request(10))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+        assert_eq!(total.progress_calls.lock().unwrap().as_slice(), [ADDRESS_A, ADDRESS_B]);
+    }
+
+    {
+        let mut empty_first = source(&[
+            ("cluster-a", "broker-a", ADDRESS_A),
+            ("cluster-a", "broker-b", ADDRESS_B),
+        ]);
+        empty_first.configs.insert(ADDRESS_A.to_string(), config(1));
+        empty_first.configs.insert(ADDRESS_B.to_string(), config(1));
+        empty_first
+            .progress
+            .lock()
+            .unwrap()
+            .insert(ADDRESS_A.to_string(), ProgressReply::Observed(ConsumeStats::new()));
+        empty_first.progress.lock().unwrap().insert(
+            ADDRESS_B.to_string(),
+            ProgressReply::Observed(stats_with_count("broker-b", MAX_CONSUMER_PROGRESS_QUERY_ROWS, false)),
+        );
+        let result = query_consumer_progress_from(&empty_first, &progress_request(10))
+            .await
+            .unwrap();
+        assert!(result.source_failures.is_empty());
+        assert_eq!(result.data.queue_count, MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+        assert_eq!(result.data.total_lag, MAX_CONSUMER_PROGRESS_QUERY_ROWS as u64);
+        assert_eq!(
+            empty_first.progress_calls.lock().unwrap().as_slice(),
+            [ADDRESS_A, ADDRESS_B]
+        );
+    }
+}
+
+#[tokio::test]
+async fn sixty_four_sources_have_deterministic_exact_and_over_budget_ownership() {
+    let mut exact_counts = vec![781usize; MAX_CONSUMER_OBSERVATION_TARGETS];
+    *exact_counts.last_mut().unwrap() = 797;
+    assert_eq!(exact_counts.iter().sum::<usize>(), MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    let exact = progress_source_with_counts(&exact_counts);
+    let result = query_consumer_progress_from(&exact, &progress_request(10))
+        .await
+        .unwrap();
+    assert!(result.source_failures.is_empty());
+    assert_eq!(result.data.queue_count, MAX_CONSUMER_PROGRESS_QUERY_ROWS);
+    assert_eq!(result.data.total_lag, MAX_CONSUMER_PROGRESS_QUERY_ROWS as u64);
+
+    let mut over_counts = exact_counts;
+    *over_counts.last_mut().unwrap() += 1;
+    assert_eq!(over_counts.iter().sum::<usize>(), MAX_CONSUMER_PROGRESS_QUERY_ROWS + 1);
+    let over = progress_source_with_counts(&over_counts);
+    let result = query_consumer_progress_from(&over, &progress_request(10))
+        .await
+        .unwrap();
+    let accepted_rows = 781usize * (MAX_CONSUMER_OBSERVATION_TARGETS - 1);
+    assert!(result.partial);
+    assert_eq!(result.data.queue_count, accepted_rows);
+    assert_eq!(result.data.total_lag, accepted_rows as u64);
+    assert_eq!(result.source_failures.len(), 1);
+    assert_eq!(result.source_failures[0].logical_target(), "broker-63");
+    assert_eq!(
+        over.progress_calls.lock().unwrap().len(),
+        MAX_CONSUMER_OBSERVATION_TARGETS
+    );
+}
+
+#[tokio::test]
+async fn totals_saturate_and_invalid_tps_is_excluded_with_stable_warnings() {
+    let mut source = source(&[
+        ("cluster-a", "broker-a", ADDRESS_A),
+        ("cluster-a", "broker-b", ADDRESS_B),
+        ("cluster-a", "broker-c", ADDRESS_C),
+    ]);
+    for (address, broker, tps) in [
+        (ADDRESS_A, "broker-a", f64::MAX),
+        (ADDRESS_B, "broker-b", f64::MAX),
+        (ADDRESS_C, "broker-c", f64::NAN),
+    ] {
+        source.configs.insert(address.to_string(), config(1));
+        source.progress.lock().unwrap().insert(
+            address.to_string(),
+            ProgressReply::Observed(stats(broker, &[(0, i64::MAX, 0, i64::MAX, 1)], tps)),
+        );
+    }
+    let result = query_consumer_progress_from(&source, &progress_request(10))
+        .await
+        .unwrap();
+    assert!(result.partial);
+    assert_eq!(result.data.topic_count, 1);
+    assert_eq!(result.data.total_lag, u64::MAX);
+    assert_eq!(result.data.max_queue_lag, i64::MAX as u64);
+    assert_eq!(result.data.total_inflight, u64::MAX);
+    assert_eq!(result.data.consume_tps, f64::MAX);
+    assert!(result
+        .warnings
+        .iter()
+        .any(|warning| warning == CONSUMER_PROGRESS_TOTAL_SATURATED_WARNING));
+    assert!(result
+        .warnings
+        .iter()
+        .any(|warning| warning == CONSUMER_PROGRESS_INVALID_TPS_WARNING));
+}
+
+#[tokio::test]
+async fn corrupt_topology_is_zero_rpc_or_partial_beside_valid_evidence() {
+    let mut invalid = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+    invalid
+        .cluster_info
+        .broker_addr_table
+        .as_mut()
+        .unwrap()
+        .get_mut("broker-a")
+        .unwrap()
+        .set_cluster("cluster-b".into());
+    let error = query_consumer_group_details_from(&invalid, &details_request())
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+    assert!(invalid.config_calls.lock().unwrap().is_empty());
+
+    let mut mixed = source(&[
+        ("cluster-a", "broker-a", ADDRESS_A),
+        ("cluster-a", "broker-b", ADDRESS_B),
+    ]);
+    mixed
+        .cluster_info
+        .broker_addr_table
+        .as_mut()
+        .unwrap()
+        .get_mut("broker-b")
+        .unwrap()
+        .broker_addrs_mut()
+        .insert(mix_all::MASTER_ID, "https://private.invalid/token".into());
+    mixed.configs.insert(ADDRESS_A.to_string(), config(1));
+    mixed
+        .connections
+        .insert(ADDRESS_A.to_string(), ConnectionReply::Offline);
+    let result = query_consumer_group_details_from(&mixed, &details_request())
+        .await
+        .unwrap();
+    assert!(result.partial);
+    assert_eq!(result.data.brokers.len(), 1);
+    assert_eq!(mixed.config_calls.lock().unwrap().as_slice(), [ADDRESS_A]);
+}
+
+#[tokio::test]
+async fn embedded_cluster_and_broker_name_corruption_are_zero_rpc_for_both_tools() {
+    for corruption in [
+        EmbeddedTopologyCorruption::RouteCluster,
+        EmbeddedTopologyCorruption::BrokerTableName,
+    ] {
+        let mut details = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+        corrupt_embedded_topology(&mut details, "broker-a", corruption);
+        let error = query_consumer_group_details_from(&details, &details_request())
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+        assert!(details.config_calls.lock().unwrap().is_empty());
+        assert!(details.connection_calls.lock().unwrap().is_empty());
+
+        let mut progress = source(&[("cluster-a", "broker-a", ADDRESS_A)]);
+        corrupt_embedded_topology(&mut progress, "broker-a", corruption);
+        let error = query_consumer_progress_from(&progress, &progress_request(10))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+        assert!(progress.config_calls.lock().unwrap().is_empty());
+        assert!(progress.progress_calls.lock().unwrap().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn mixed_embedded_corruption_queries_only_valid_master_for_both_tools() {
+    for corruption in [
+        EmbeddedTopologyCorruption::RouteCluster,
+        EmbeddedTopologyCorruption::BrokerTableName,
+    ] {
+        let brokers = [
+            ("cluster-a", "broker-a", ADDRESS_A),
+            ("cluster-a", "broker-b", ADDRESS_B),
+        ];
+        let mut details = source(&brokers);
+        add_slave(&mut details, "broker-a", SLAVE_ADDRESS_A);
+        corrupt_embedded_topology(&mut details, "broker-b", corruption);
+        details.configs.insert(ADDRESS_A.to_string(), config(1));
+        details
+            .connections
+            .insert(ADDRESS_A.to_string(), ConnectionReply::Offline);
+        let result = query_consumer_group_details_from(&details, &details_request())
+            .await
+            .unwrap();
+        assert!(result.partial);
+        assert_eq!(result.data.brokers.len(), 1);
+        assert_eq!(details.config_calls.lock().unwrap().as_slice(), [ADDRESS_A]);
+        assert_eq!(details.connection_calls.lock().unwrap().as_slice(), [ADDRESS_A]);
+        assert!(!details
+            .config_calls
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|address| address == SLAVE_ADDRESS_A));
+        assert!(!details
+            .connection_calls
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|address| address == SLAVE_ADDRESS_A));
+
+        let mut progress = source(&brokers);
+        add_slave(&mut progress, "broker-a", SLAVE_ADDRESS_A);
+        corrupt_embedded_topology(&mut progress, "broker-b", corruption);
+        progress.configs.insert(ADDRESS_A.to_string(), config(1));
+        progress.progress.lock().unwrap().insert(
+            ADDRESS_A.to_string(),
+            ProgressReply::Observed(stats("broker-a", &[(0, 3, 1, 2, 1)], 1.0)),
+        );
+        let result = query_consumer_progress_from(&progress, &progress_request(10))
+            .await
+            .unwrap();
+        assert!(result.partial);
+        assert_eq!(result.data.queue_count, 1);
+        assert_eq!(progress.config_calls.lock().unwrap().as_slice(), [ADDRESS_A]);
+        assert_eq!(progress.progress_calls.lock().unwrap().as_slice(), [ADDRESS_A]);
+        assert!(!progress
+            .config_calls
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|address| address == SLAVE_ADDRESS_A));
+        assert!(!progress
+            .progress_calls
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|address| address == SLAVE_ADDRESS_A));
+    }
+}
+
+#[test]
+fn target_cap_accepts_64_and_rejects_65() {
+    for count in [MAX_CONSUMER_OBSERVATION_TARGETS, MAX_CONSUMER_OBSERVATION_TARGETS + 1] {
+        let owned = (0..count)
+            .map(|index| {
+                (
+                    "cluster-a".to_string(),
+                    format!("broker-{index:02}"),
+                    format!("127.0.0.1:{}", 10_000 + index),
+                )
+            })
+            .collect::<Vec<_>>();
+        let borrowed = owned
+            .iter()
+            .map(|(cluster, broker, address)| (cluster.as_str(), broker.as_str(), address.as_str()))
+            .collect::<Vec<_>>();
+        let (cluster_info, route) = topology(&borrowed);
+        let resolved = selected_cluster_route_masters(
+            &cluster_info,
+            &route,
+            "cluster-a",
+            AdminQuerySource::ConsumerGroupConfig,
+        );
+        if count == MAX_CONSUMER_OBSERVATION_TARGETS {
+            assert_eq!(resolved.unwrap().0.len(), count);
+        } else {
+            assert_eq!(
+                resolved.unwrap_err().code(),
+                Some("CONSUMER_OBSERVATION_TARGET_LIMIT_EXCEEDED")
+            );
+        }
+    }
+}
+
+fn test_error(reason: &str) -> RocketMQError {
+    RocketMQError::ResponseProcessFailed {
+        operation: "consumer_observation_test",
+        reason: reason.to_string(),
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
@@ -80,6 +80,11 @@ use crate::core::config_state::TopicConfigStateRequest;
 use crate::core::config_state::TopicConfigStateResult;
 use crate::core::consumer;
 use crate::core::consumer::ConsumerQueryAdmin;
+use crate::core::consumer_observation::ConsumerObservationQueryAdmin;
+use crate::core::consumer_observation::QueryConsumerGroupDetailsRequest;
+use crate::core::consumer_observation::QueryConsumerGroupDetailsResult;
+use crate::core::consumer_observation::QueryConsumerProgressRequest;
+use crate::core::consumer_observation::QueryConsumerProgressResult;
 use crate::core::message::MessageMetadataQueryAdmin;
 use crate::core::message::MessageMetadataRequest;
 use crate::core::proxy::ProxyDrainPending;
@@ -1213,6 +1218,28 @@ impl TopicObservationQueryAdmin for ReadAdminSession {
         Box::pin(async move {
             self.ensure_open()?;
             crate::topic_observation::query_topic_config(&self.inner, request).await
+        })
+    }
+}
+
+impl ConsumerObservationQueryAdmin for ReadAdminSession {
+    fn query_consumer_group_details<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerGroupDetailsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerGroupDetailsResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            crate::consumer_observation::query_consumer_group_details(&self.inner, request).await
+        })
+    }
+
+    fn query_consumer_progress<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerProgressRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerProgressResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            crate::consumer_observation::query_consumer_progress(&self.inner, request).await
         })
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer_observation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer_observation.rs
@@ -1,0 +1,226 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Typed, address-free Consumer observation contracts.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::core::error::required;
+use crate::core::query::AdminQueryResult;
+use crate::core::AdminError;
+use crate::core::AdminFuture;
+use crate::core::AdminResult;
+
+pub const MAX_CONSUMER_OBSERVATION_TARGETS: usize = 64;
+pub const MAX_CONSUMER_PROGRESS_ROWS: usize = 10_000;
+pub const CONSUMER_DETAILS_TOTAL_SATURATED_WARNING: &str = "consumer_details_total_connections_saturated";
+pub const CONSUMER_PROGRESS_TRUNCATED_WARNING: &str = "consumer_progress_rows_truncated";
+pub const CONSUMER_PROGRESS_TOTAL_SATURATED_WARNING: &str = "consumer_progress_total_saturated";
+pub const CONSUMER_PROGRESS_INVALID_TPS_WARNING: &str = "consumer_progress_invalid_tps_excluded";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryConsumerGroupDetailsRequest {
+    pub cluster: String,
+    pub consumer_group: String,
+}
+
+impl QueryConsumerGroupDetailsRequest {
+    pub fn try_new(cluster: impl Into<String>, consumer_group: impl Into<String>) -> AdminResult<Self> {
+        Ok(Self {
+            cluster: required("cluster", cluster)?,
+            consumer_group: required("consumer_group", consumer_group)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryConsumerProgressRequest {
+    pub cluster: String,
+    pub consumer_group: String,
+    pub max_rows: usize,
+}
+
+impl QueryConsumerProgressRequest {
+    pub fn try_new(
+        cluster: impl Into<String>,
+        consumer_group: impl Into<String>,
+        max_rows: usize,
+    ) -> AdminResult<Self> {
+        if !(1..=MAX_CONSUMER_PROGRESS_ROWS).contains(&max_rows) {
+            return Err(AdminError::invalid_argument(
+                "max_rows",
+                format!("must be between 1 and {MAX_CONSUMER_PROGRESS_ROWS}"),
+            ));
+        }
+        Ok(Self {
+            cluster: required("cluster", cluster)?,
+            consumer_group: required("consumer_group", consumer_group)?,
+            max_rows,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerGroupConfigState {
+    Present,
+    Absent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerConnectionState {
+    Online,
+    Offline,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerConsumeType {
+    Pull,
+    Push,
+    Pop,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerMessageModel {
+    Broadcasting,
+    Clustering,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerConsumeFromWhere {
+    LastOffset,
+    LastOffsetAndMinFirst,
+    MinOffset,
+    MaxOffset,
+    FirstOffset,
+    Timestamp,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsumerGroupDetailsBrokerRow {
+    pub broker_name: String,
+    pub config_state: ConsumerGroupConfigState,
+    pub config_version: Option<u64>,
+    pub consume_enable: Option<bool>,
+    pub consume_from_min_enable: Option<bool>,
+    pub consume_broadcast_enable: Option<bool>,
+    pub consume_message_orderly: Option<bool>,
+    pub retry_queue_nums: Option<i32>,
+    pub retry_max_times: Option<i32>,
+    pub notify_consumer_ids_changed_enable: Option<bool>,
+    pub consume_timeout_minutes: Option<i32>,
+    pub connection_state: Option<ConsumerConnectionState>,
+    pub connection_count: u64,
+    pub consume_type: Option<ConsumerConsumeType>,
+    pub message_model: Option<ConsumerMessageModel>,
+    pub consume_from_where: Option<ConsumerConsumeFromWhere>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryConsumerGroupDetailsResult {
+    pub consumer_group: String,
+    pub total_connection_count: u64,
+    pub brokers: Vec<ConsumerGroupDetailsBrokerRow>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerProgressState {
+    NoConsumption,
+    Observed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsumerProgressQueueRow {
+    pub topic: String,
+    pub broker_name: String,
+    pub queue_id: i32,
+    pub broker_offset: i64,
+    pub consumer_offset: i64,
+    pub pull_offset: i64,
+    pub lag: u64,
+    pub inflight: u64,
+    pub last_timestamp: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QueryConsumerProgressResult {
+    pub consumer_group: String,
+    pub state: ConsumerProgressState,
+    pub topic_count: usize,
+    pub queue_count: usize,
+    pub total_lag: u64,
+    pub max_queue_lag: u64,
+    pub total_inflight: u64,
+    pub consume_tps: f64,
+    pub queues: Vec<ConsumerProgressQueueRow>,
+    pub truncated: bool,
+}
+
+pub trait ConsumerObservationQueryAdmin: Send {
+    fn query_consumer_group_details<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerGroupDetailsRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerGroupDetailsResult>>;
+
+    fn query_consumer_progress<'a>(
+        &'a mut self,
+        request: &'a QueryConsumerProgressRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryConsumerProgressResult>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requests_are_required_and_progress_retention_is_bounded() {
+        let details = QueryConsumerGroupDetailsRequest::try_new(" cluster-a ", " group-a ").unwrap();
+        assert_eq!(details.cluster, "cluster-a");
+        assert_eq!(details.consumer_group, "group-a");
+        assert!(QueryConsumerGroupDetailsRequest::try_new("cluster-a", " ").is_err());
+        assert!(QueryConsumerProgressRequest::try_new("cluster-a", "group-a", 0).is_err());
+        assert!(QueryConsumerProgressRequest::try_new("cluster-a", "group-a", MAX_CONSUMER_PROGRESS_ROWS).is_ok());
+        assert!(QueryConsumerProgressRequest::try_new("cluster-a", "group-a", MAX_CONSUMER_PROGRESS_ROWS + 1).is_err());
+    }
+
+    #[test]
+    fn public_states_are_closed_snake_case_values() {
+        assert_eq!(
+            serde_json::to_value(ConsumerConnectionState::Offline).unwrap(),
+            "offline"
+        );
+        assert_eq!(
+            serde_json::to_value(ConsumerProgressState::NoConsumption).unwrap(),
+            "no_consumption"
+        );
+        assert_eq!(serde_json::to_value(ConsumerConsumeType::Push).unwrap(), "push");
+        assert_eq!(
+            serde_json::to_value(ConsumerMessageModel::Clustering).unwrap(),
+            "clustering"
+        );
+        assert_eq!(
+            serde_json::to_value(ConsumerConsumeFromWhere::Timestamp).unwrap(),
+            "timestamp"
+        );
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/mod.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/mod.rs
@@ -27,6 +27,7 @@ pub mod client_connection;
 pub mod clock;
 pub mod config_state;
 pub mod consumer;
+pub mod consumer_observation;
 pub mod consumer_workspace;
 pub mod dashboard;
 pub mod error;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
@@ -24,6 +24,10 @@
 pub mod core;
 
 #[cfg(feature = "read-client-adapter")]
+#[path = "client_adapter/consumer_observation.rs"]
+mod consumer_observation;
+
+#[cfg(feature = "read-client-adapter")]
 #[path = "client_adapter/exact_broker.rs"]
 mod exact_broker;
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9941
- Fixes #9941

### Brief Description

- Add the default read-only `rocketmq_get_consumer_group_details` and `rocketmq_get_consumer_progress` tools with strict arguments, closed output states, bounded rows, deterministic pagination, and evidence-aware partial and total failure semantics.
- Extend the narrow client read API and `rocketmq-admin-core` read adapter with typed Consumer observation contracts that resolve selected-cluster master Brokers without exposing addresses, client identities, subscriptions, arbitrary configuration, or backend error text.
- Route both tools through the shared Admin Session, `QueryFacade`, authorization, timeout, cancellation, sanitization, audit, cache-visibility, snapshot, and explicit shutdown boundaries.
- Update default and all-feature contract snapshots to 21 and 26 tools. Resources, resource templates, and prompts remain unchanged at 7, 10, and 2.
- Keep the default MCP dependency boundary read-only; this change adds no mutation adapter, Resource, Prompt, transport behavior, shell, CLI, subprocess, or arbitrary RPC surface.

### How Did You Test This Change?

Passed:

- `cargo fmt -p rocketmq-client-rust -- --check`
- `cargo fmt -p rocketmq-admin-core -- --check`
- `cargo test -p rocketmq-admin-core --features read-client-adapter consumer_observation` (19 passed)
- `cargo test -p rocketmq-admin-core --features read-client-adapter` (104 unit and 10 integration tests passed)
- `cargo fmt -p rocketmq-mcp -- --check`
- `INSTA_UPDATE=no cargo test --locked consumer_observation` (4 passed)
- `INSTA_UPDATE=no cargo test --locked consumer` (10 passed)
- `INSTA_UPDATE=no cargo test --locked` (227 passed, 1 external-cluster test ignored)
- `INSTA_UPDATE=no cargo test --locked --all-features` (255 passed, 1 external-cluster test ignored)
- `cargo check --locked`
- `python scripts/check_read_only_boundary.py`
- `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`
- `cargo doc --locked --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`
- Snapshot audit with `INSTA_UPDATE=no`; no `.snap.new` files were produced.

Known baseline and platform constraints:

- `cargo fmt --all -- --check` from the standalone MCP workspace returns Windows OS error 206 while expanding all local path packages. The affected package-scoped format checks pass.
- `cargo test -p rocketmq-client-rust --no-default-features --features admin-read --lib` stops before test execution with two existing E0433 errors for undeclared `TopicConfig` references in `rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs`; that file is unchanged by this PR.
- Runtime audit was not run because this PR does not change runtime ownership or blocking boundaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only tools to view consumer group details, including broker configuration and connection status.
  * Added consumer progress reporting with queue-level lag, offsets, in-flight messages, TPS, and pagination.
  * Added explicit cluster selection and validation for both tools.
  * Added tool discovery, structured results, caching, truncation indicators, and failure metadata handling.
* **Bug Fixes**
  * Improved broker-related error context for administrative read operations.
  * Ensured sensitive connection details are excluded from output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->