### PR TITLE
[ISSUE #9951]🚀Add typed HA, Controller, and NameServer observation tools to RocketMQ MCP

### DIFF
--- a/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml
+++ b/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml
@@ -75,6 +75,12 @@ name = "proxy-local"
 # cache keys, or configuration Debug formatting.
 endpoint = "127.0.0.1:8081"
 
+[[clusters.controllers]]
+name = "controller-local"
+# Internal endpoint: never exposed through Tool schemas, output, errors, logs,
+# audit records, cache keys, or configuration Debug formatting.
+endpoint = "127.0.0.1:9878"
+
 [security]
 profile = "diagnose"
 allow_change_planning = false

--- a/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml
+++ b/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml
@@ -18,6 +18,7 @@ allow_tools = [
   "rocketmq_get_topic_config",
   "rocketmq_get_consumer_group_details",
   "rocketmq_get_consumer_progress",
+  "rocketmq_get_nameserver_config_summary",
 ]
 deny_tools = ["*"]
 
@@ -29,6 +30,8 @@ allow_tools = [
   "rocketmq_get_broker_diagnostics",
   "rocketmq_get_broker_log_filter_state",
   "rocketmq_get_proxy_drain_state",
+  "rocketmq_get_ha_status",
+  "rocketmq_get_controller_metadata",
 ]
 
 [roles.operator]

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session.rs
@@ -72,14 +72,29 @@ use crate::tools::topic_tools::TopicRouteQueue;
 use crate::tools::topic_tools::TopicStatsQueueRow;
 
 mod consumer_observation;
+mod infrastructure_observation;
 mod topic_observation;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct ResolvedCluster {
     pub name: String,
     pub rocketmq_cluster_name: String,
     pub namesrv_addr: String,
     pub credentials: Option<AdminCredentials>,
+    pub controller_targets: Vec<rocketmq_admin_core::read_client_adapter::ControllerObservationTarget>,
+}
+
+impl std::fmt::Debug for ResolvedCluster {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ResolvedCluster")
+            .field("name", &self.name)
+            .field("rocketmq_cluster_name", &self.rocketmq_cluster_name)
+            .field("namesrv_addr", &"[REDACTED]")
+            .field("credentials", &self.credentials.as_ref().map(|_| "[REDACTED]"))
+            .field("controller_targets", &self.controller_targets)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -357,6 +372,52 @@ pub(crate) trait AdminSession: Send {
         }
     }
 
+    fn ha_status(
+        &mut self,
+        _broker_names: &[String],
+        _include_sync_state: bool,
+        _controller_names: &[String],
+    ) -> impl Future<
+        Output = Result<QueryPayload<crate::tools::infrastructure_tools::GetHaStatusOutput>, ToolExecutionError>,
+    > + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "HA observations are unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn controller_metadata(
+        &mut self,
+        _controller_names: &[String],
+    ) -> impl Future<
+        Output = Result<
+            QueryPayload<crate::tools::infrastructure_tools::GetControllerMetadataOutput>,
+            ToolExecutionError,
+        >,
+    > + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "Controller metadata is unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn nameserver_config_summary(
+        &mut self,
+    ) -> impl Future<
+        Output = Result<
+            QueryPayload<crate::tools::infrastructure_tools::GetNameserverConfigSummaryOutput>,
+            ToolExecutionError,
+        >,
+    > + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "NameServer configuration is unavailable".to_string(),
+            ))
+        }
+    }
+
     fn shutdown(self) -> impl Future<Output = Result<(), ToolExecutionError>> + Send;
 }
 
@@ -412,7 +473,9 @@ impl AdminSessionFactory for AdminCoreSessionFactory {
                 test_session: Some(factory.start()),
             });
         }
-        let mut builder = ReadAdminBuilder::new(self.client_runtime.clone()).namesrv_addr(cluster.namesrv_addr.clone());
+        let mut builder = ReadAdminBuilder::new(self.client_runtime.clone())
+            .namesrv_addr(cluster.namesrv_addr.clone())
+            .controller_targets(cluster.controller_targets.clone());
         if let Some(credentials) = cluster.credentials.clone() {
             builder = builder.credentials(credentials);
         }
@@ -1044,6 +1107,30 @@ impl AdminSession for AdminCoreSession {
                     .collect(),
             }),
         )
+    }
+
+    async fn ha_status(
+        &mut self,
+        broker_names: &[String],
+        include_sync_state: bool,
+        controller_names: &[String],
+    ) -> Result<QueryPayload<crate::tools::infrastructure_tools::GetHaStatusOutput>, ToolExecutionError> {
+        self.query_ha_status_observation(broker_names, include_sync_state, controller_names)
+            .await
+    }
+
+    async fn controller_metadata(
+        &mut self,
+        controller_names: &[String],
+    ) -> Result<QueryPayload<crate::tools::infrastructure_tools::GetControllerMetadataOutput>, ToolExecutionError> {
+        self.query_controller_metadata_observation(controller_names).await
+    }
+
+    async fn nameserver_config_summary(
+        &mut self,
+    ) -> Result<QueryPayload<crate::tools::infrastructure_tools::GetNameserverConfigSummaryOutput>, ToolExecutionError>
+    {
+        self.query_nameserver_config_summary_observation().await
     }
 
     async fn shutdown(mut self) -> Result<(), ToolExecutionError> {

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session/infrastructure_observation.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/admin_session/infrastructure_observation.rs
@@ -1,0 +1,202 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_admin_core::core::infrastructure_observation as admin;
+use rocketmq_admin_core::core::infrastructure_observation::InfrastructureObservationQueryAdmin;
+
+use super::map_logical_admin_error;
+use super::AdminCoreSession;
+use crate::model::contract::QueryPayload;
+use crate::tools::executor::ToolExecutionError;
+use crate::tools::infrastructure_tools as tool;
+
+impl AdminCoreSession {
+    pub(super) async fn query_ha_status_observation(
+        &mut self,
+        broker_names: &[String],
+        include_sync_state: bool,
+        controller_names: &[String],
+    ) -> Result<QueryPayload<tool::GetHaStatusOutput>, ToolExecutionError> {
+        let request = admin::QueryHaStatusRequest::try_new(
+            self.cluster.rocketmq_cluster_name.clone(),
+            broker_names.iter().cloned(),
+            include_sync_state,
+            controller_names.iter().cloned(),
+        )
+        .map_err(map_logical_admin_error)?;
+        let result = self
+            .admin_mut()?
+            .query_ha_status(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        let cluster = self.cluster.name.clone();
+        Ok(QueryPayload::from_admin(result).map(|result| tool::GetHaStatusOutput {
+            cluster,
+            brokers: result
+                .brokers
+                .into_iter()
+                .map(|broker| tool::BrokerHaObservation {
+                    broker_name: broker.broker_name,
+                    broker_id: broker.broker_id,
+                    master_commit_log_max_offset: broker.master_commit_log_max_offset,
+                    in_sync_slave_count: broker.in_sync_slave_count,
+                    pending_group_transfer_request_count: broker.pending_group_transfer_request_count,
+                    pending_group_transfer_oldest_wait_millis: broker.pending_group_transfer_oldest_wait_millis,
+                    group_transfer_ack_notify_count: broker.group_transfer_ack_notify_count,
+                    connections: broker
+                        .connections
+                        .into_iter()
+                        .map(|connection| tool::HaConnectionObservation {
+                            replica: logical_broker(connection.replica),
+                            slave_ack_offset: connection.slave_ack_offset,
+                            diff: connection.diff,
+                            in_sync: connection.in_sync,
+                            transferred_bytes_per_second: connection.transferred_bytes_per_second,
+                            transfer_from_where: connection.transfer_from_where,
+                        })
+                        .collect(),
+                })
+                .collect(),
+            controller_sync_states: result
+                .controller_sync_states
+                .into_iter()
+                .map(|state| tool::ControllerSyncStateObservation {
+                    controller_name: state.controller_name,
+                    brokers: state
+                        .brokers
+                        .into_iter()
+                        .map(|broker| tool::BrokerSyncStateObservation {
+                            broker_name: broker.broker_name,
+                            master_broker_id: broker.master_broker_id,
+                            master_epoch: broker.master_epoch,
+                            sync_state_set_epoch: broker.sync_state_set_epoch,
+                            in_sync_replicas: broker.in_sync_replicas.into_iter().map(logical_broker).collect(),
+                            not_in_sync_replicas: broker.not_in_sync_replicas.into_iter().map(logical_broker).collect(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }))
+    }
+
+    pub(super) async fn query_controller_metadata_observation(
+        &mut self,
+        controller_names: &[String],
+    ) -> Result<QueryPayload<tool::GetControllerMetadataOutput>, ToolExecutionError> {
+        let request = admin::QueryControllerMetadataRequest::try_new(
+            self.cluster.rocketmq_cluster_name.clone(),
+            controller_names.iter().cloned(),
+        )
+        .map_err(map_logical_admin_error)?;
+        let result = self
+            .admin_mut()?
+            .query_controller_metadata(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        let cluster = self.cluster.name.clone();
+        Ok(
+            QueryPayload::from_admin(result).map(|result| tool::GetControllerMetadataOutput {
+                cluster,
+                controllers: result
+                    .controllers
+                    .into_iter()
+                    .map(|controller| tool::ControllerMetadataObservation {
+                        controller_name: controller.controller_name,
+                        group: controller.group,
+                        leader_id: controller.leader_id,
+                        is_leader: controller.is_leader,
+                        peer_count: controller.peer_count,
+                        last_log_index: controller.last_log_index,
+                        committed_log_index: controller.committed_log_index,
+                        applied_log_index: controller.applied_log_index,
+                    })
+                    .collect(),
+            }),
+        )
+    }
+
+    pub(super) async fn query_nameserver_config_summary_observation(
+        &mut self,
+    ) -> Result<QueryPayload<tool::GetNameserverConfigSummaryOutput>, ToolExecutionError> {
+        let request = admin::QueryNameserverConfigSummaryRequest::try_new(self.cluster.rocketmq_cluster_name.clone())
+            .map_err(map_logical_admin_error)?;
+        let result = self
+            .admin_mut()?
+            .query_nameserver_config_summary(&request)
+            .await
+            .map_err(map_logical_admin_error)?;
+        let cluster = self.cluster.name.clone();
+        Ok(
+            QueryPayload::from_admin(result).map(|result| tool::GetNameserverConfigSummaryOutput {
+                cluster,
+                nameservers: result
+                    .nameservers
+                    .into_iter()
+                    .map(|nameserver| tool::NameserverConfigObservation {
+                        nameserver_name: nameserver.nameserver_name,
+                        values: tool::NameserverConfigValues {
+                            cluster_test: nameserver.values.cluster_test,
+                            order_message_enable: nameserver.values.order_message_enable,
+                            return_order_topic_config_to_broker: nameserver.values.return_order_topic_config_to_broker,
+                            client_request_thread_pool_nums: nameserver.values.client_request_thread_pool_nums,
+                            client_request_thread_pool_queue_capacity: nameserver
+                                .values
+                                .client_request_thread_pool_queue_capacity,
+                            scan_not_active_broker_interval_ms: nameserver.values.scan_not_active_broker_interval_ms,
+                            unregister_broker_queue_capacity: nameserver.values.unregister_broker_queue_capacity,
+                            support_acting_master: nameserver.values.support_acting_master,
+                        },
+                    })
+                    .collect(),
+                inconsistent_fields: result
+                    .inconsistent_fields
+                    .into_iter()
+                    .map(|field| match field {
+                        admin::NameserverConfigDifferenceField::ClusterTest => {
+                            tool::NameserverConfigDifferenceField::ClusterTest
+                        }
+                        admin::NameserverConfigDifferenceField::OrderMessageEnable => {
+                            tool::NameserverConfigDifferenceField::OrderMessageEnable
+                        }
+                        admin::NameserverConfigDifferenceField::ReturnOrderTopicConfigToBroker => {
+                            tool::NameserverConfigDifferenceField::ReturnOrderTopicConfigToBroker
+                        }
+                        admin::NameserverConfigDifferenceField::ClientRequestThreadPoolNums => {
+                            tool::NameserverConfigDifferenceField::ClientRequestThreadPoolNums
+                        }
+                        admin::NameserverConfigDifferenceField::ClientRequestThreadPoolQueueCapacity => {
+                            tool::NameserverConfigDifferenceField::ClientRequestThreadPoolQueueCapacity
+                        }
+                        admin::NameserverConfigDifferenceField::ScanNotActiveBrokerIntervalMs => {
+                            tool::NameserverConfigDifferenceField::ScanNotActiveBrokerIntervalMs
+                        }
+                        admin::NameserverConfigDifferenceField::UnregisterBrokerQueueCapacity => {
+                            tool::NameserverConfigDifferenceField::UnregisterBrokerQueueCapacity
+                        }
+                        admin::NameserverConfigDifferenceField::SupportActingMaster => {
+                            tool::NameserverConfigDifferenceField::SupportActingMaster
+                        }
+                    })
+                    .collect(),
+            }),
+        )
+    }
+}
+
+fn logical_broker(value: admin::LogicalBrokerInstance) -> tool::LogicalBrokerInstance {
+    tool::LogicalBrokerInstance {
+        broker_name: value.broker_name,
+        broker_id: value.broker_id,
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade.rs
@@ -92,6 +92,7 @@ use crate::tools::topic_tools::QueryTopicRouteArgs;
 use crate::tools::topic_tools::QueryTopicRouteOutput;
 
 mod consumer_observation;
+mod infrastructure_observation;
 mod topic_observation;
 
 #[derive(Debug, Clone)]
@@ -355,6 +356,51 @@ pub(crate) trait ReadOnlyQuery: Clone + Send + Sync + 'static {
         async {
             Err(ToolExecutionError::Backend(
                 "Consumer Group configuration state is unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn ha_status(
+        &self,
+        _args: crate::tools::infrastructure_tools::GetHaStatusArgs,
+    ) -> impl Future<
+        Output = Result<QueryResult<crate::tools::infrastructure_tools::GetHaStatusOutput>, ToolExecutionError>,
+    > + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "HA observations are unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn controller_metadata(
+        &self,
+        _args: crate::tools::infrastructure_tools::GetControllerMetadataArgs,
+    ) -> impl Future<
+        Output = Result<
+            QueryResult<crate::tools::infrastructure_tools::GetControllerMetadataOutput>,
+            ToolExecutionError,
+        >,
+    > + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "Controller metadata is unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn nameserver_config_summary(
+        &self,
+        _args: crate::tools::infrastructure_tools::GetNameserverConfigSummaryArgs,
+    ) -> impl Future<
+        Output = Result<
+            QueryResult<crate::tools::infrastructure_tools::GetNameserverConfigSummaryOutput>,
+            ToolExecutionError,
+        >,
+    > + Send {
+        async {
+            Err(ToolExecutionError::Backend(
+                "NameServer configuration is unavailable".to_string(),
             ))
         }
     }
@@ -1423,6 +1469,16 @@ where
             credentials: config
                 .resolve_admin_credentials()
                 .map_err(|error| ToolExecutionError::Backend(error.to_string()))?,
+            controller_targets: config
+                .controllers
+                .iter()
+                .map(|controller| {
+                    rocketmq_admin_core::read_client_adapter::ControllerObservationTarget::new(
+                        controller.name.clone(),
+                        controller.endpoint.clone(),
+                    )
+                })
+                .collect(),
         })
     }
 
@@ -1615,6 +1671,28 @@ where
         args: ConsumerGroupConfigStateArgs,
     ) -> Result<QueryResult<ConsumerGroupConfigStateOutput>, ToolExecutionError> {
         QueryFacade::consumer_group_config_state(self, args).await
+    }
+
+    async fn ha_status(
+        &self,
+        args: crate::tools::infrastructure_tools::GetHaStatusArgs,
+    ) -> Result<QueryResult<crate::tools::infrastructure_tools::GetHaStatusOutput>, ToolExecutionError> {
+        QueryFacade::ha_status(self, args).await
+    }
+
+    async fn controller_metadata(
+        &self,
+        args: crate::tools::infrastructure_tools::GetControllerMetadataArgs,
+    ) -> Result<QueryResult<crate::tools::infrastructure_tools::GetControllerMetadataOutput>, ToolExecutionError> {
+        QueryFacade::controller_metadata(self, args).await
+    }
+
+    async fn nameserver_config_summary(
+        &self,
+        args: crate::tools::infrastructure_tools::GetNameserverConfigSummaryArgs,
+    ) -> Result<QueryResult<crate::tools::infrastructure_tools::GetNameserverConfigSummaryOutput>, ToolExecutionError>
+    {
+        QueryFacade::nameserver_config_summary(self, args).await
     }
 
     async fn diagnose_consumer_lag(

--- a/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade/infrastructure_observation.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/adapter/query_facade/infrastructure_observation.rs
@@ -1,0 +1,490 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use rocketmq_admin_core::core::infrastructure_observation::QueryControllerMetadataRequest;
+use rocketmq_admin_core::core::infrastructure_observation::QueryHaStatusRequest;
+use rocketmq_admin_core::core::infrastructure_observation::QueryNameserverConfigSummaryRequest;
+
+use super::AdminSession;
+use super::AdminSessionFactory;
+use super::QueryFacade;
+use crate::model::contract::QueryResult;
+use crate::tools::executor::ToolExecutionError;
+use crate::tools::infrastructure_tools::GetControllerMetadataArgs;
+use crate::tools::infrastructure_tools::GetControllerMetadataOutput;
+use crate::tools::infrastructure_tools::GetHaStatusArgs;
+use crate::tools::infrastructure_tools::GetHaStatusOutput;
+use crate::tools::infrastructure_tools::GetNameserverConfigSummaryArgs;
+use crate::tools::infrastructure_tools::GetNameserverConfigSummaryOutput;
+
+impl<F> QueryFacade<F>
+where
+    F: AdminSessionFactory,
+{
+    pub(crate) async fn ha_status(
+        &self,
+        args: GetHaStatusArgs,
+    ) -> Result<QueryResult<GetHaStatusOutput>, ToolExecutionError> {
+        let request = QueryHaStatusRequest::try_new(
+            args.cluster,
+            args.broker_names,
+            args.include_sync_state,
+            args.controller_names,
+        )
+        .map_err(|_| ToolExecutionError::InvalidArguments("invalid HA observation selectors".to_string()))?;
+        let cluster = self.resolve_required_cluster(&request.cluster)?;
+        let key = self.cache_key(
+            "ha_status",
+            &cluster.name,
+            &format!(
+                "brokers={}|sync={}|controllers={}",
+                request.broker_names.join(","),
+                request.include_sync_state,
+                request.controller_names.join(",")
+            ),
+        );
+        let ttl = Duration::from_millis(self.config.cache.broker_metrics_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move {
+                            session
+                                .ha_status(
+                                    &request.broker_names,
+                                    request.include_sync_state,
+                                    &request.controller_names,
+                                )
+                                .await
+                        })
+                    })
+                    .await
+                },
+            )
+            .await
+    }
+
+    pub(crate) async fn controller_metadata(
+        &self,
+        args: GetControllerMetadataArgs,
+    ) -> Result<QueryResult<GetControllerMetadataOutput>, ToolExecutionError> {
+        let request = QueryControllerMetadataRequest::try_new(args.cluster, args.controller_names)
+            .map_err(|_| ToolExecutionError::InvalidArguments("invalid Controller selectors".to_string()))?;
+        let cluster = self.resolve_required_cluster(&request.cluster)?;
+        let key = self.cache_key(
+            "controller_metadata",
+            &cluster.name,
+            &format!("controllers={}", request.controller_names.join(",")),
+        );
+        let ttl = Duration::from_millis(self.config.cache.broker_metrics_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.controller_metadata(&request.controller_names).await })
+                    })
+                    .await
+                },
+            )
+            .await
+    }
+
+    pub(crate) async fn nameserver_config_summary(
+        &self,
+        args: GetNameserverConfigSummaryArgs,
+    ) -> Result<QueryResult<GetNameserverConfigSummaryOutput>, ToolExecutionError> {
+        let request = QueryNameserverConfigSummaryRequest::try_new(args.cluster)
+            .map_err(|_| ToolExecutionError::InvalidArguments("invalid cluster selector".to_string()))?;
+        let cluster = self.resolve_required_cluster(&request.cluster)?;
+        let key = self.cache_key("nameserver_config_summary", &cluster.name, "");
+        let ttl = Duration::from_millis(self.config.cache.broker_metrics_ttl_ms);
+        self.cache
+            .get_or_try_init_cancellable(
+                key,
+                ttl,
+                &self.control.cancellation,
+                || ToolExecutionError::Cancelled,
+                || async {
+                    self.run_workflow(cluster, move |session, _| {
+                        Box::pin(async move { session.nameserver_config_summary().await })
+                    })
+                    .await
+                },
+            )
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use rocketmq_admin_core::core::broker::BrokerRuntimeTargetStatus;
+
+    use super::*;
+    use crate::adapter::admin_session::AdminSession;
+    use crate::adapter::admin_session::ResolvedCluster;
+    use crate::adapter::admin_session::SessionConsumerLag;
+    use crate::adapter::admin_session::SessionTopicRoute;
+    use crate::config::McpConfig;
+    use crate::guard::context::VisibilityClass;
+    use crate::model::contract::CacheStatus;
+    use crate::model::contract::QueryPayload;
+    use crate::tools::cluster_tools::BrokerSummary;
+    use crate::tools::consumer_tools::ConsumerGroupSummary;
+    use crate::tools::infrastructure_tools::BrokerHaObservation;
+    use crate::tools::infrastructure_tools::ControllerMetadataObservation;
+    use crate::tools::infrastructure_tools::HaConnectionObservation;
+    use crate::tools::infrastructure_tools::LogicalBrokerInstance;
+    use crate::tools::infrastructure_tools::NameserverConfigObservation;
+    use crate::tools::infrastructure_tools::NameserverConfigValues;
+
+    #[derive(Debug, Default)]
+    struct Counters {
+        starts: AtomicUsize,
+        shutdowns: AtomicUsize,
+        ha: AtomicUsize,
+        controller: AtomicUsize,
+        nameserver: AtomicUsize,
+        oversized: AtomicBool,
+    }
+
+    #[derive(Clone, Default)]
+    struct Factory {
+        counters: Arc<Counters>,
+    }
+
+    impl AdminSessionFactory for Factory {
+        type Session = Session;
+
+        async fn start(&self, cluster: ResolvedCluster) -> Result<Self::Session, ToolExecutionError> {
+            self.counters.starts.fetch_add(1, Ordering::SeqCst);
+            Ok(Session {
+                cluster,
+                counters: self.counters.clone(),
+            })
+        }
+    }
+
+    struct Session {
+        cluster: ResolvedCluster,
+        counters: Arc<Counters>,
+    }
+
+    impl AdminSession for Session {
+        async fn broker_rows(&mut self) -> Result<QueryPayload<Vec<BrokerSummary>>, ToolExecutionError> {
+            Ok(QueryPayload::complete(Vec::new()))
+        }
+
+        async fn topic_inventory(&mut self) -> Result<Vec<String>, ToolExecutionError> {
+            Ok(Vec::new())
+        }
+
+        async fn topic_route(&mut self, _topic: &str) -> Result<SessionTopicRoute, ToolExecutionError> {
+            Ok(SessionTopicRoute {
+                brokers: Vec::new(),
+                queues: Vec::new(),
+            })
+        }
+
+        async fn consumer_groups(&mut self) -> Result<QueryPayload<Vec<ConsumerGroupSummary>>, ToolExecutionError> {
+            Ok(QueryPayload::complete(Vec::new()))
+        }
+
+        async fn consumer_lag(
+            &mut self,
+            _topic: &str,
+            _consumer_group: &str,
+        ) -> Result<QueryPayload<SessionConsumerLag>, ToolExecutionError> {
+            Ok(QueryPayload::complete(SessionConsumerLag {
+                queues: Vec::new(),
+                total_lag: 0,
+                consume_tps: 0.0,
+                inflight_total: 0,
+            }))
+        }
+
+        async fn probe_broker_runtime_target(
+            &mut self,
+            _broker_name: &str,
+        ) -> Result<BrokerRuntimeTargetStatus, ToolExecutionError> {
+            Ok(BrokerRuntimeTargetStatus::NotFound)
+        }
+
+        async fn ha_status(
+            &mut self,
+            broker_names: &[String],
+            _include_sync_state: bool,
+            _controller_names: &[String],
+        ) -> Result<QueryPayload<GetHaStatusOutput>, ToolExecutionError> {
+            self.counters.ha.fetch_add(1, Ordering::SeqCst);
+            let brokers = if broker_names == ["bounded"] {
+                bounded_ha_brokers()
+            } else {
+                self.counters
+                    .oversized
+                    .load(Ordering::SeqCst)
+                    .then(|| BrokerHaObservation {
+                        broker_name: "x".repeat(4 * 1024 * 1024),
+                        broker_id: 0,
+                        master_commit_log_max_offset: 0,
+                        in_sync_slave_count: 0,
+                        pending_group_transfer_request_count: 0,
+                        pending_group_transfer_oldest_wait_millis: 0,
+                        group_transfer_ack_notify_count: 0,
+                        connections: Vec::new(),
+                    })
+                    .into_iter()
+                    .collect()
+            };
+            Ok(QueryPayload::complete(GetHaStatusOutput {
+                cluster: self.cluster.name.clone(),
+                brokers,
+                controller_sync_states: Vec::new(),
+            }))
+        }
+
+        async fn controller_metadata(
+            &mut self,
+            _controller_names: &[String],
+        ) -> Result<QueryPayload<GetControllerMetadataOutput>, ToolExecutionError> {
+            self.counters.controller.fetch_add(1, Ordering::SeqCst);
+            let controllers = self
+                .counters
+                .oversized
+                .load(Ordering::SeqCst)
+                .then(|| ControllerMetadataObservation {
+                    controller_name: "x".repeat(4 * 1024 * 1024),
+                    group: None,
+                    leader_id: None,
+                    is_leader: None,
+                    peer_count: None,
+                    last_log_index: None,
+                    committed_log_index: None,
+                    applied_log_index: None,
+                })
+                .into_iter()
+                .collect();
+            Ok(QueryPayload::complete(GetControllerMetadataOutput {
+                cluster: self.cluster.name.clone(),
+                controllers,
+            }))
+        }
+
+        async fn nameserver_config_summary(
+            &mut self,
+        ) -> Result<QueryPayload<GetNameserverConfigSummaryOutput>, ToolExecutionError> {
+            self.counters.nameserver.fetch_add(1, Ordering::SeqCst);
+            let nameservers = self
+                .counters
+                .oversized
+                .load(Ordering::SeqCst)
+                .then(|| NameserverConfigObservation {
+                    nameserver_name: "x".repeat(4 * 1024 * 1024),
+                    values: NameserverConfigValues::default(),
+                })
+                .into_iter()
+                .collect();
+            Ok(QueryPayload::complete(GetNameserverConfigSummaryOutput {
+                cluster: self.cluster.name.clone(),
+                nameservers,
+                inconsistent_fields: Vec::new(),
+            }))
+        }
+
+        async fn shutdown(self) -> Result<(), ToolExecutionError> {
+            self.counters.shutdowns.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn config() -> McpConfig {
+        McpConfig::load(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("conf")
+                .join("mcp.example.toml"),
+        )
+        .unwrap()
+    }
+
+    fn bounded_ha_brokers() -> Vec<BrokerHaObservation> {
+        (0..16)
+            .map(|broker_index| {
+                let connection_count = if broker_index == 15 { 39 } else { 63 };
+                BrokerHaObservation {
+                    broker_name: format!("broker-{broker_index:02}"),
+                    broker_id: 0,
+                    master_commit_log_max_offset: 100,
+                    in_sync_slave_count: u32::try_from(connection_count).unwrap(),
+                    pending_group_transfer_request_count: 0,
+                    pending_group_transfer_oldest_wait_millis: 0,
+                    group_transfer_ack_notify_count: 0,
+                    connections: (1..=connection_count)
+                        .map(|replica_index| HaConnectionObservation {
+                            replica: LogicalBrokerInstance {
+                                broker_name: format!("broker-{broker_index:02}"),
+                                broker_id: u64::try_from(replica_index).unwrap(),
+                            },
+                            slave_ack_offset: 90,
+                            diff: 10,
+                            in_sync: true,
+                            transferred_bytes_per_second: 1,
+                            transfer_from_where: 80,
+                        })
+                        .collect(),
+                }
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn normalized_selectors_share_cache_within_but_not_across_visibility_and_shutdown() {
+        let factory = Factory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config(), factory);
+        let first = facade
+            .ha_status(GetHaStatusArgs {
+                cluster: "local-dev".to_string(),
+                broker_names: vec!["broker-b".to_string(), "broker-a".to_string(), "broker-b".to_string()],
+                include_sync_state: true,
+                controller_names: vec!["controller-b".to_string(), "controller-a".to_string()],
+            })
+            .await
+            .unwrap();
+        let second = facade
+            .ha_status(GetHaStatusArgs {
+                cluster: "local-dev".to_string(),
+                broker_names: vec!["broker-a".to_string(), "broker-b".to_string()],
+                include_sync_state: true,
+                controller_names: vec!["controller-a".to_string(), "controller-b".to_string()],
+            })
+            .await
+            .unwrap();
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(second.cache_status, CacheStatus::Hit);
+        facade
+            .clone()
+            .with_visibility_class(VisibilityClass::Sensitive)
+            .ha_status(GetHaStatusArgs {
+                cluster: "local-dev".to_string(),
+                broker_names: vec!["broker-a".to_string(), "broker-b".to_string()],
+                include_sync_state: true,
+                controller_names: vec!["controller-a".to_string(), "controller-b".to_string()],
+            })
+            .await
+            .unwrap();
+        assert_eq!(counters.ha.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 2);
+
+        assert!(facade
+            .controller_metadata(GetControllerMetadataArgs {
+                cluster: "local-dev".to_string(),
+                controller_names: vec!["controller-a".to_string(), "controller-a".to_string()],
+            })
+            .await
+            .is_err());
+        assert_eq!(
+            counters.starts.load(Ordering::SeqCst),
+            2,
+            "invalid selectors must be zero-session"
+        );
+    }
+
+    #[tokio::test]
+    async fn every_infrastructure_cache_entry_rejects_oversized_payloads_before_retention() {
+        let factory = Factory::default();
+        factory.counters.oversized.store(true, Ordering::SeqCst);
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config(), factory);
+        for _ in 0..2 {
+            assert_eq!(
+                facade
+                    .ha_status(GetHaStatusArgs {
+                        cluster: "local-dev".to_string(),
+                        broker_names: Vec::new(),
+                        include_sync_state: false,
+                        controller_names: Vec::new(),
+                    })
+                    .await
+                    .unwrap()
+                    .cache_status,
+                CacheStatus::Miss
+            );
+            assert_eq!(
+                facade
+                    .controller_metadata(GetControllerMetadataArgs {
+                        cluster: "local-dev".to_string(),
+                        controller_names: Vec::new(),
+                    })
+                    .await
+                    .unwrap()
+                    .cache_status,
+                CacheStatus::Miss
+            );
+            assert_eq!(
+                facade
+                    .nameserver_config_summary(GetNameserverConfigSummaryArgs {
+                        cluster: "local-dev".to_string(),
+                    })
+                    .await
+                    .unwrap()
+                    .cache_status,
+                CacheStatus::Miss
+            );
+        }
+        assert_eq!(counters.ha.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.controller.load(Ordering::SeqCst), 2);
+        assert_eq!(counters.nameserver.load(Ordering::SeqCst), 2);
+        assert_eq!(facade.cache_metrics().hits, 0);
+    }
+
+    #[tokio::test]
+    async fn bounded_nested_infrastructure_result_is_cached_before_executor_policy() {
+        let factory = Factory::default();
+        let counters = factory.counters.clone();
+        let facade = QueryFacade::with_factory(config(), factory);
+        let args = GetHaStatusArgs {
+            cluster: "local-dev".to_string(),
+            broker_names: vec!["bounded".to_string()],
+            include_sync_state: false,
+            controller_names: Vec::new(),
+        };
+        let first = facade.ha_status(args.clone()).await.unwrap();
+        let second = facade.ha_status(args).await.unwrap();
+        let rows = first
+            .data
+            .brokers
+            .iter()
+            .fold(0usize, |rows, broker| rows + 1 + broker.connections.len());
+        assert_eq!(rows, 1_000);
+        assert!(serde_json::to_vec(&first.data).unwrap().len() < 4 * 1024 * 1024);
+        assert_eq!(first.cache_status, CacheStatus::Miss);
+        assert_eq!(second.cache_status, CacheStatus::Hit);
+        assert_eq!(counters.ha.load(Ordering::SeqCst), 1);
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp/src/config.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/config.rs
@@ -184,9 +184,42 @@ impl McpConfig {
         }
 
         let mut default_count = 0usize;
+        let mut normalized_cluster_names = BTreeSet::new();
+        let mut infrastructure_endpoint_owners = BTreeSet::new();
         for cluster in &self.clusters {
             validate_non_empty("clusters.name", &cluster.name)?;
+            if !normalized_cluster_names.insert(cluster.name.trim().to_ascii_lowercase()) {
+                return Err(McpError::InvalidConfig(
+                    "cluster names must be unique after normalization".to_string(),
+                ));
+            }
             validate_non_empty("clusters.namesrv_addr", &cluster.namesrv_addr)?;
+            let nameserver_endpoints = cluster
+                .namesrv_addr
+                .split(';')
+                .map(str::trim)
+                .filter(|endpoint| !endpoint.is_empty())
+                .collect::<Vec<_>>();
+            if nameserver_endpoints.len()
+                > rocketmq_admin_core::core::infrastructure_observation::MAX_NAMESERVER_TARGETS
+            {
+                return Err(McpError::InvalidConfig(
+                    "clusters.namesrv_addr must contain at most 16 configured NameServers".to_string(),
+                ));
+            }
+            let mut unique_nameservers = BTreeSet::new();
+            for endpoint in nameserver_endpoints {
+                let Some(endpoint) = rocketmq_admin_core::core::broker::canonical_remoting_endpoint(endpoint) else {
+                    return Err(McpError::InvalidConfig(
+                        "clusters.namesrv_addr must contain unique bounded remoting host:port values".to_string(),
+                    ));
+                };
+                if !unique_nameservers.insert(endpoint.clone()) || !infrastructure_endpoint_owners.insert(endpoint) {
+                    return Err(McpError::InvalidConfig(
+                        "Controller and NameServer endpoints must have one global logical owner".to_string(),
+                    ));
+                }
+            }
             if let Some(rocketmq_cluster_name) = cluster.rocketmq_cluster_name.as_deref() {
                 validate_non_empty("clusters.rocketmq_cluster_name", rocketmq_cluster_name)?;
             }
@@ -215,6 +248,36 @@ impl McpConfig {
                         "clusters `{}` contains duplicate Proxy alias `{}`",
                         cluster.name, proxy.name
                     )));
+                }
+            }
+            if cluster.controllers.len() > rocketmq_admin_core::core::infrastructure_observation::MAX_CONTROLLER_TARGETS
+            {
+                return Err(McpError::InvalidConfig(
+                    "clusters.controllers must contain at most 32 configured Controllers".to_string(),
+                ));
+            }
+            let mut controller_names = BTreeSet::new();
+            let mut controller_endpoints = BTreeSet::new();
+            for controller in &cluster.controllers {
+                validate_logical_alias("clusters.controllers.name", &controller.name)?;
+                let Some(endpoint) =
+                    rocketmq_admin_core::core::broker::canonical_remoting_endpoint(&controller.endpoint)
+                else {
+                    return Err(McpError::InvalidConfig(
+                        "clusters.controllers.endpoint must be a single bounded remoting host:port".to_string(),
+                    ));
+                };
+                if !controller_names.insert(controller.name.as_str()) || !controller_endpoints.insert(endpoint.clone())
+                {
+                    return Err(McpError::InvalidConfig(format!(
+                        "clusters `{}` contains duplicate Controller configuration",
+                        cluster.name
+                    )));
+                }
+                if !infrastructure_endpoint_owners.insert(endpoint) {
+                    return Err(McpError::InvalidConfig(
+                        "Controller and NameServer endpoints must have one global logical owner".to_string(),
+                    ));
                 }
             }
         }
@@ -672,6 +735,9 @@ pub struct ClusterConfig {
     /// Logical Proxy aliases. Endpoints are internal-only topology data.
     #[serde(default)]
     pub proxies: Vec<ProxyAlias>,
+    /// Logical Controller aliases. Endpoints are internal-only topology data.
+    #[serde(default)]
+    pub controllers: Vec<ControllerAlias>,
 }
 
 impl ClusterConfig {
@@ -699,12 +765,13 @@ impl std::fmt::Debug for ClusterConfig {
         formatter
             .debug_struct("ClusterConfig")
             .field("name", &self.name)
-            .field("namesrv_addr", &self.namesrv_addr)
+            .field("namesrv_addr", &"[REDACTED]")
             .field("default", &self.default)
             .field("rocketmq_cluster_name", &self.rocketmq_cluster_name)
             .field("tenant", &self.tenant)
             .field("credentials", &self.credentials)
             .field("proxies", &self.proxies)
+            .field("controllers", &self.controllers)
             .finish()
     }
 }
@@ -714,6 +781,23 @@ impl std::fmt::Debug for ClusterConfig {
 pub struct ProxyAlias {
     pub name: String,
     pub endpoint: String,
+}
+
+#[derive(Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControllerAlias {
+    pub name: String,
+    pub endpoint: String,
+}
+
+impl std::fmt::Debug for ControllerAlias {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ControllerAlias")
+            .field("name", &self.name)
+            .field("endpoint", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl std::fmt::Debug for ProxyAlias {
@@ -1056,6 +1140,7 @@ mod tests {
         assert!(config.server.log_level.is_none());
         assert_eq!(config.clusters[0].proxies.len(), 1);
         assert_eq!(config.clusters[0].proxy_endpoint("proxy-local"), Some("127.0.0.1:8081"));
+        assert_eq!(config.clusters[0].controllers.len(), 1);
     }
 
     #[test]
@@ -1129,6 +1214,7 @@ mod tests {
         secondary.name = "secondary".to_string();
         secondary.namesrv_addr = "127.0.0.2:9876".to_string();
         secondary.default = Some(false);
+        secondary.controllers.clear();
         secondary.proxies = vec![ProxyAlias {
             name: "proxy-a".to_string(),
             endpoint: "secondary-internal:8081".to_string(),
@@ -1158,6 +1244,106 @@ mod tests {
         let error = config.validate().unwrap_err();
         assert!(!error.to_string().contains(ENDPOINT_SENTINEL));
         assert!(!format!("{error:?}").contains(ENDPOINT_SENTINEL));
+    }
+
+    #[test]
+    fn infrastructure_targets_are_bounded_unique_and_debug_redacted() {
+        const CONTROLLER_SENTINEL: &str = "private-controller.example:19878";
+        const NAMESERVER_SENTINEL: &str = "private-nameserver.example:19876";
+        let mut config = McpConfig::load(example_config_path()).unwrap();
+        config.clusters[0].controllers = vec![ControllerAlias {
+            name: "controller-a".to_string(),
+            endpoint: CONTROLLER_SENTINEL.to_string(),
+        }];
+        config.clusters[0].namesrv_addr = NAMESERVER_SENTINEL.to_string();
+        config.validate().unwrap();
+        let debug = format!("{config:?}");
+        assert!(debug.contains("controller-a"));
+        assert!(!debug.contains(CONTROLLER_SENTINEL));
+        assert!(!debug.contains(NAMESERVER_SENTINEL));
+
+        config.clusters[0].controllers = (0..=32)
+            .map(|index| ControllerAlias {
+                name: format!("controller-{index}"),
+                endpoint: format!("controller-{index}.internal:9878"),
+            })
+            .collect();
+        assert!(config.validate().unwrap_err().to_string().contains("at most 32"));
+
+        config.clusters[0].controllers = vec![
+            ControllerAlias {
+                name: "controller-a".to_string(),
+                endpoint: "controller-a.internal:9878".to_string(),
+            },
+            ControllerAlias {
+                name: "controller-a".to_string(),
+                endpoint: "controller-b.internal:9878".to_string(),
+            },
+        ];
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate Controller"));
+
+        config.clusters[0].controllers.clear();
+        config.clusters[0].namesrv_addr = (0..16)
+            .map(|index| format!("nameserver-{index}.internal:9876"))
+            .collect::<Vec<_>>()
+            .join(";");
+        config.validate().unwrap();
+        config.clusters[0].namesrv_addr.push_str(";nameserver-16.internal:9876");
+        assert!(config.validate().unwrap_err().to_string().contains("at most 16"));
+    }
+
+    #[test]
+    fn infrastructure_endpoint_ownership_is_global_canonical_and_redacted() {
+        fn two_clusters() -> McpConfig {
+            let mut config = McpConfig::load(example_config_path()).unwrap();
+            let mut second = config.clusters[0].clone();
+            second.name = "cluster-b".to_string();
+            second.default = Some(false);
+            second.namesrv_addr = "nameserver-b.internal:9876".to_string();
+            second.controllers = vec![ControllerAlias {
+                name: "controller-b".to_string(),
+                endpoint: "controller-b.internal:9878".to_string(),
+            }];
+            config.clusters.push(second);
+            config
+        }
+
+        let mut shared_controller = two_clusters();
+        shared_controller.clusters[0].controllers[0].endpoint = "SHARED.internal:9878".to_string();
+        shared_controller.clusters[1].controllers[0].endpoint = "shared.INTERNAL:9878".to_string();
+        assert_redacted_ownership_error(shared_controller, "SHARED.internal:9878");
+
+        let mut shared_nameserver = two_clusters();
+        shared_nameserver.clusters[0].namesrv_addr = "NS.Shared.internal:9876".to_string();
+        shared_nameserver.clusters[1].namesrv_addr = "ns.shared.INTERNAL:9876".to_string();
+        assert_redacted_ownership_error(shared_nameserver, "NS.Shared.internal:9876");
+
+        let mut equivalent_ipv6 = two_clusters();
+        equivalent_ipv6.clusters[0].namesrv_addr = "[2001:0db8:0:0:0:0:0:1]:9876".to_string();
+        equivalent_ipv6.clusters[1].namesrv_addr = "[2001:db8::1]:9876".to_string();
+        assert_redacted_ownership_error(equivalent_ipv6, "2001:db8");
+
+        let mut cross_kind = two_clusters();
+        cross_kind.clusters[0].namesrv_addr = "shared-kind.internal:9876".to_string();
+        cross_kind.clusters[1].controllers[0].endpoint = "SHARED-KIND.internal:9876".to_string();
+        assert_redacted_ownership_error(cross_kind, "shared-kind.internal:9876");
+
+        let mut duplicate_cluster = two_clusters();
+        duplicate_cluster.clusters[0].name = "Local-Dev".to_string();
+        duplicate_cluster.clusters[1].name = " local-dev ".to_string();
+        let error = duplicate_cluster.validate().unwrap_err();
+        assert!(error.to_string().contains("unique after normalization"));
+    }
+
+    fn assert_redacted_ownership_error(config: McpConfig, endpoint: &str) {
+        let error = config.validate().unwrap_err();
+        let rendered = format!("{error:?} {error}");
+        assert!(rendered.contains("one global logical owner"));
+        assert!(!rendered.to_ascii_lowercase().contains(&endpoint.to_ascii_lowercase()));
     }
 
     #[test]

--- a/rocketmq-ai/rocketmq-mcp/src/guard.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/guard.rs
@@ -509,6 +509,9 @@ fn requires_explicit_cluster(tool_name: &str) -> bool {
             | "rocketmq_get_topic_config"
             | "rocketmq_get_consumer_group_details"
             | "rocketmq_get_consumer_progress"
+            | "rocketmq_get_ha_status"
+            | "rocketmq_get_controller_metadata"
+            | "rocketmq_get_nameserver_config_summary"
     )
 }
 
@@ -768,6 +771,7 @@ mod tests {
                 tenant: None,
                 credentials: None,
                 proxies: Vec::new(),
+                controllers: Vec::new(),
             }],
         )
         .unwrap()
@@ -799,6 +803,7 @@ mod tests {
                 tenant: Some(tenant.to_string()),
                 credentials: None,
                 proxies: Vec::new(),
+                controllers: Vec::new(),
             }],
         )
         .unwrap()

--- a/rocketmq-ai/rocketmq-mcp/src/guard/http_auth.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/guard/http_auth.rs
@@ -538,6 +538,7 @@ mod tests {
                 tenant: None,
                 credentials: None,
                 proxies: Vec::new(),
+                controllers: Vec::new(),
             }],
         )
         .unwrap()

--- a/rocketmq-ai/rocketmq-mcp/src/infrastructure/cache.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/infrastructure/cache.rs
@@ -16,6 +16,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::future::Future;
+use std::mem::size_of;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -26,12 +27,20 @@ use tokio::sync::Mutex;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
+use serde::Serialize;
+
 use rocketmq_observability::metrics::mcp::McpCacheEvent;
 
+use crate::infrastructure::snapshot::RetainedSize;
 use crate::model::contract::observed_at;
 use crate::model::contract::CacheStatus;
 use crate::model::contract::QueryPayload;
 use crate::model::contract::QueryResult;
+
+const MAX_CACHE_ENTRY_BYTES: usize = 4 * 1024 * 1024;
+const MAX_CACHE_TOTAL_BYTES: usize = 64 * 1024 * 1024;
+const RETAINED_CACHE_ENTRY_OVERHEAD: usize = 2 * 1024;
+const ARC_ALLOCATION_OVERHEAD: usize = 2 * size_of::<usize>();
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct CacheMetricsSnapshot {
@@ -74,6 +83,8 @@ pub(crate) struct QueryCache {
 struct QueryCacheInner {
     enabled: bool,
     capacity: usize,
+    max_entry_bytes: usize,
+    max_total_bytes: usize,
     generation: AtomicU64,
     state: Mutex<CacheState>,
     flights: Mutex<HashMap<String, Weak<Mutex<()>>>>,
@@ -84,6 +95,7 @@ struct QueryCacheInner {
 struct CacheState {
     entries: HashMap<String, CacheEntry>,
     insertion_order: VecDeque<String>,
+    retained_bytes: usize,
 }
 
 struct CacheEntry {
@@ -91,14 +103,21 @@ struct CacheEntry {
     observed_at: String,
     inserted_at: Instant,
     expires_at: Instant,
+    retained_bytes: usize,
 }
 
 impl QueryCache {
     pub(crate) fn new(enabled: bool, capacity: usize) -> Self {
+        Self::with_byte_limits(enabled, capacity, MAX_CACHE_ENTRY_BYTES, MAX_CACHE_TOTAL_BYTES)
+    }
+
+    fn with_byte_limits(enabled: bool, capacity: usize, max_entry_bytes: usize, max_total_bytes: usize) -> Self {
         Self {
             inner: Arc::new(QueryCacheInner {
                 enabled,
                 capacity,
+                max_entry_bytes,
+                max_total_bytes,
                 generation: AtomicU64::new(0),
                 state: Mutex::new(CacheState::default()),
                 flights: Mutex::new(HashMap::new()),
@@ -115,7 +134,7 @@ impl QueryCache {
         load: Load,
     ) -> Result<QueryResult<T>, E>
     where
-        T: Clone + Send + Sync + 'static,
+        T: Clone + RetainedSize + Serialize + Send + Sync + 'static,
         Load: FnOnce() -> LoadFuture,
         LoadFuture: Future<Output = Result<T, E>>,
     {
@@ -139,7 +158,7 @@ impl QueryCache {
         load: Load,
     ) -> Result<QueryResult<T>, E>
     where
-        T: Clone + Send + Sync + 'static,
+        T: Clone + RetainedSize + Serialize + Send + Sync + 'static,
         Load: FnOnce() -> LoadFuture,
         LoadFuture: Future<Output = Result<QueryPayload<T>, E>>,
         Cancelled: FnOnce() -> E,
@@ -172,9 +191,17 @@ impl QueryCache {
 
         let generation = self.inner.generation.load(Ordering::Acquire);
         let payload = load().await?;
+        let source_retained_bytes = payload.retained_size();
         let observed_at = observed_at();
-        self.insert_if_current(key, payload.clone(), observed_at.clone(), ttl, generation)
-            .await;
+        self.insert_if_current(
+            key,
+            payload.clone(),
+            source_retained_bytes,
+            observed_at.clone(),
+            ttl,
+            generation,
+        )
+        .await;
         self.inner.metrics.misses.fetch_add(1, Ordering::Relaxed);
         rocketmq_observability::metrics::mcp::record_cache_event(McpCacheEvent::Miss);
         Ok(QueryResult::from_payload(payload, observed_at, 0, CacheStatus::Miss))
@@ -197,6 +224,9 @@ impl QueryCache {
         let removed = state.entries.len();
         state.entries.clear();
         state.insertion_order.clear();
+        state.entries.shrink_to_fit();
+        state.insertion_order.shrink_to_fit();
+        state.retained_bytes = 0;
         self.inner.metrics.invalidations.fetch_add(1, Ordering::Relaxed);
         rocketmq_observability::metrics::mcp::record_cache_event(McpCacheEvent::Invalidation);
         removed
@@ -226,25 +256,50 @@ impl QueryCache {
         Some(result)
     }
 
-    async fn insert_if_current<T>(&self, key: String, value: T, observed_at: String, ttl: Duration, generation: u64)
-    where
-        T: Send + Sync + 'static,
+    async fn insert_if_current<T>(
+        &self,
+        key: String,
+        value: QueryPayload<T>,
+        source_retained_bytes: usize,
+        observed_at: String,
+        ttl: Duration,
+        generation: u64,
+    ) where
+        T: RetainedSize + Serialize + Send + Sync + 'static,
     {
+        let Ok(mut serialized) = serde_json::to_vec(&value) else {
+            return;
+        };
+        serialized.shrink_to_fit();
+        let retained_bytes = retained_cache_entry_bytes(
+            &key,
+            &observed_at,
+            source_retained_bytes
+                .max(value.retained_size())
+                .max(serialized.capacity()),
+        );
+        if retained_bytes > self.inner.max_entry_bytes || retained_bytes > self.inner.max_total_bytes {
+            return;
+        }
         let mut state = self.inner.state.lock().await;
         if self.inner.generation.load(Ordering::Acquire) != generation {
             return;
         }
         remove_entry(&mut state, &key);
-        while state.entries.len() >= self.inner.capacity {
+        while state.entries.len() >= self.inner.capacity
+            || state.retained_bytes.saturating_add(retained_bytes) > self.inner.max_total_bytes
+        {
             let Some(oldest) = state.insertion_order.pop_front() else {
                 break;
             };
-            if state.entries.remove(&oldest).is_some() {
+            if let Some(entry) = state.entries.remove(&oldest) {
+                state.retained_bytes = state.retained_bytes.saturating_sub(entry.retained_bytes);
                 self.inner.metrics.evictions.fetch_add(1, Ordering::Relaxed);
                 rocketmq_observability::metrics::mcp::record_cache_event(McpCacheEvent::Eviction);
             }
         }
         let inserted_at = Instant::now();
+        state.retained_bytes = state.retained_bytes.saturating_add(retained_bytes);
         state.insertion_order.push_back(key.clone());
         state.entries.insert(
             key,
@@ -253,6 +308,7 @@ impl QueryCache {
                 observed_at,
                 inserted_at,
                 expires_at: inserted_at + ttl,
+                retained_bytes,
             },
         );
     }
@@ -272,12 +328,31 @@ impl QueryCache {
     async fn len(&self) -> usize {
         self.inner.state.lock().await.entries.len()
     }
+
+    #[cfg(test)]
+    async fn retained_bytes(&self) -> usize {
+        self.inner.state.lock().await.retained_bytes
+    }
 }
 
 fn remove_entry(state: &mut CacheState, key: &str) {
-    if state.entries.remove(key).is_some() {
+    if let Some(entry) = state.entries.remove(key) {
+        state.retained_bytes = state.retained_bytes.saturating_sub(entry.retained_bytes);
         state.insertion_order.retain(|candidate| candidate != key);
+        if state.entries.is_empty() {
+            state.entries.shrink_to_fit();
+            state.insertion_order.shrink_to_fit();
+        }
     }
+}
+
+fn retained_cache_entry_bytes(key: &String, observed_at: &String, payload_bytes: usize) -> usize {
+    size_of::<CacheEntry>()
+        .saturating_add(RETAINED_CACHE_ENTRY_OVERHEAD)
+        .saturating_add(ARC_ALLOCATION_OVERHEAD)
+        .saturating_add(key.capacity().saturating_mul(2))
+        .saturating_add(observed_at.capacity())
+        .saturating_add(payload_bytes)
 }
 
 #[cfg(test)]
@@ -295,6 +370,21 @@ mod tests {
     use crate::model::contract::SourceFailureCode;
 
     use super::*;
+
+    #[derive(Clone, Serialize)]
+    struct HiddenCapacityPayload {
+        visible: String,
+        #[serde(skip_serializing)]
+        hidden: String,
+    }
+
+    impl RetainedSize for HiddenCapacityPayload {
+        fn retained_heap_size(&self) -> usize {
+            self.visible
+                .retained_heap_size()
+                .saturating_add(self.hidden.retained_heap_size())
+        }
+    }
 
     #[tokio::test]
     async fn cache_returns_miss_then_hit_without_reloading() {
@@ -381,6 +471,139 @@ mod tests {
         assert_eq!(result.cache_status, CacheStatus::Miss);
         assert_eq!(calls.load(Ordering::SeqCst), 4);
         assert_eq!(cache.len().await, 2);
+    }
+
+    #[tokio::test]
+    async fn cache_enforces_exact_per_entry_and_global_retained_byte_limits() {
+        let key = "entry-a".to_string();
+        let observed = "2026-01-01T00:00:00Z".to_string();
+        let payload = QueryPayload::complete("x".repeat(128));
+        let mut serialized = serde_json::to_vec(&payload).unwrap();
+        serialized.shrink_to_fit();
+        let entry_bytes =
+            retained_cache_entry_bytes(&key, &observed, payload.retained_size().max(serialized.capacity()));
+        let ttl = Duration::from_secs(60);
+
+        let exact = QueryCache::with_byte_limits(true, 8, entry_bytes, entry_bytes * 2);
+        exact
+            .insert_if_current(
+                key.clone(),
+                payload.clone(),
+                payload.retained_size(),
+                observed.clone(),
+                ttl,
+                0,
+            )
+            .await;
+        assert_eq!(exact.len().await, 1);
+        assert_eq!(exact.retained_bytes().await, entry_bytes);
+
+        let below_entry = QueryCache::with_byte_limits(true, 8, entry_bytes - 1, entry_bytes * 2);
+        below_entry
+            .insert_if_current(
+                key.clone(),
+                payload.clone(),
+                payload.retained_size(),
+                observed.clone(),
+                ttl,
+                0,
+            )
+            .await;
+        assert_eq!(below_entry.len().await, 0);
+        assert_eq!(below_entry.retained_bytes().await, 0);
+
+        let global = QueryCache::with_byte_limits(true, 8, entry_bytes + 1, entry_bytes * 2);
+        global
+            .insert_if_current(key, payload.clone(), payload.retained_size(), observed.clone(), ttl, 0)
+            .await;
+        global
+            .insert_if_current(
+                "entry-b".to_string(),
+                payload.clone(),
+                payload.retained_size(),
+                observed.clone(),
+                ttl,
+                0,
+            )
+            .await;
+        assert_eq!(global.len().await, 2);
+        assert_eq!(global.retained_bytes().await, entry_bytes * 2);
+
+        let mut plus_one_observed = String::with_capacity(observed.capacity() + 1);
+        plus_one_observed.push_str(&observed);
+        plus_one_observed.push('x');
+        let plus_one_bytes = retained_cache_entry_bytes(
+            &"entry-c".to_string(),
+            &plus_one_observed,
+            payload.retained_size().max(serialized.capacity()),
+        );
+        assert_eq!(plus_one_bytes, entry_bytes + 1);
+        global
+            .insert_if_current(
+                "entry-c".to_string(),
+                payload.clone(),
+                payload.retained_size(),
+                plus_one_observed,
+                ttl,
+                0,
+            )
+            .await;
+        assert_eq!(
+            global.len().await,
+            1,
+            "one extra retained byte must evict both exact-size entries"
+        );
+        assert_eq!(global.retained_bytes().await, plus_one_bytes);
+        assert_eq!(global.metrics().evictions, 2);
+        assert_eq!(global.clear().await, 1);
+        assert_eq!(global.retained_bytes().await, 0);
+    }
+
+    #[tokio::test]
+    async fn oversized_payload_is_returned_but_never_retained_or_reused() {
+        let cache = QueryCache::new(true, 8);
+        let calls = Arc::new(AtomicUsize::new(0));
+        for _ in 0..2 {
+            let calls = calls.clone();
+            let result = cache
+                .get_or_try_init("infra:oversized".to_string(), Duration::from_secs(60), || async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, ()>("x".repeat(MAX_CACHE_ENTRY_BYTES))
+                })
+                .await
+                .unwrap();
+            assert_eq!(result.cache_status, CacheStatus::Miss);
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(cache.len().await, 0);
+        assert_eq!(cache.retained_bytes().await, 0);
+    }
+
+    #[tokio::test]
+    async fn hidden_excess_capacity_is_charged_and_never_cached() {
+        let cache = QueryCache::new(true, 8);
+        let calls = Arc::new(AtomicUsize::new(0));
+        for _ in 0..2 {
+            let calls = calls.clone();
+            let result = cache
+                .get_or_try_init("capacity:hidden".to_string(), Duration::from_secs(60), || async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    let mut hidden = String::with_capacity(MAX_CACHE_ENTRY_BYTES + 1);
+                    hidden.push('x');
+                    Ok::<_, ()>(HiddenCapacityPayload {
+                        visible: "ok".to_string(),
+                        hidden,
+                    })
+                })
+                .await
+                .unwrap();
+            assert_eq!(result.cache_status, CacheStatus::Miss);
+            assert!(result.data.hidden.capacity() > MAX_CACHE_ENTRY_BYTES);
+            assert!(serde_json::to_vec(&result.data).unwrap().len() < 64);
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(cache.len().await, 0);
+        assert_eq!(cache.retained_bytes().await, 0);
     }
 
     #[tokio::test]

--- a/rocketmq-ai/rocketmq-mcp/src/infrastructure/snapshot.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/infrastructure/snapshot.rs
@@ -206,6 +206,242 @@ impl<T: RetainedSize> RetainedSize for QueryPayload<T> {
     }
 }
 
+impl<T: RetainedSize> RetainedSize for Page<T> {
+    fn retained_heap_size(&self) -> usize {
+        self.items
+            .retained_heap_size()
+            .saturating_add(self.next_cursor.retained_heap_size())
+    }
+}
+
+impl RetainedSize for serde_json::Value {
+    fn retained_heap_size(&self) -> usize {
+        match self {
+            Self::String(value) => value.retained_heap_size(),
+            Self::Array(values) => values.retained_heap_size(),
+            Self::Object(values) => values.iter().fold(0usize, |total, (key, value)| {
+                total
+                    .saturating_add(size_of::<(String, serde_json::Value)>())
+                    .saturating_add(BTREE_MAP_ENTRY_ALLOCATION_OVERHEAD)
+                    .saturating_add(key.retained_heap_size())
+                    .saturating_add(value.retained_heap_size())
+            }),
+            Self::Null | Self::Bool(_) | Self::Number(_) => 0,
+        }
+    }
+}
+
+macro_rules! retained_heap_fields {
+    ($type:path => $($field:ident),+ $(,)?) => {
+        impl RetainedSize for $type {
+            fn retained_heap_size(&self) -> usize {
+                0usize$(.saturating_add(self.$field.retained_heap_size()))+
+            }
+        }
+    };
+}
+
+macro_rules! retained_heap_none {
+    ($($type:path),+ $(,)?) => {
+        $(
+            impl RetainedSize for $type {
+                fn retained_heap_size(&self) -> usize {
+                    0
+                }
+            }
+        )+
+    };
+}
+
+retained_heap_fields!(crate::tools::cluster_tools::BrokerSummary =>
+    cluster,
+    broker_name,
+    broker_addr,
+    version,
+    in_tps,
+    out_tps,
+    timer_progress,
+    page_cache_lock_time_millis,
+    hour,
+    space,
+);
+retained_heap_fields!(crate::tools::cluster_tools::ClusterOverviewOutput =>
+    cluster,
+    namesrv_addr,
+    brokers,
+    generated_at,
+);
+
+retained_heap_fields!(crate::tools::consumer_tools::ConsumerGroupSummary =>
+    group,
+    consume_type,
+    message_model,
+);
+retained_heap_fields!(crate::tools::consumer_tools::ListConsumerGroupsOutput =>
+    cluster,
+    namesrv_addr,
+    page,
+    generated_at,
+);
+retained_heap_fields!(crate::tools::consumer_tools::ConsumerGroupDetailsBrokerRow => broker_name);
+retained_heap_fields!(crate::tools::consumer_tools::GetConsumerGroupDetailsOutput =>
+    cluster,
+    consumer_group,
+    brokers,
+    generated_at,
+);
+
+retained_heap_fields!(crate::tools::broker_tools::DescribeBrokerOutput =>
+    cluster,
+    namesrv_addr,
+    broker_name,
+    brokers,
+    generated_at,
+);
+retained_heap_fields!(crate::tools::broker_tools::BrokerDiagnosticsRow => broker_name, warnings);
+retained_heap_fields!(crate::tools::broker_tools::BrokerDiagnosticsOutput =>
+    cluster,
+    broker_name,
+    diagnostics_schema_version,
+    brokers,
+);
+
+retained_heap_fields!(crate::tools::config_tools::BrokerConfigSummaryRow => broker_name);
+retained_heap_fields!(crate::tools::config_tools::BrokerConfigSummaryOutput =>
+    cluster,
+    broker_name,
+    brokers,
+);
+retained_heap_fields!(crate::tools::config_tools::BrokerLogFilterStateRow =>
+    broker_name,
+    state_schema_version,
+    logger,
+    active_operation_id,
+    last_completed_operation_id,
+);
+retained_heap_fields!(crate::tools::config_tools::BrokerLogFilterStateOutput =>
+    cluster,
+    broker_name,
+    logger,
+    brokers,
+);
+retained_heap_fields!(crate::tools::config_tools::TopicConfigStateRow => broker_name);
+retained_heap_fields!(crate::tools::config_tools::TopicConfigStateOutput => cluster, topic, brokers);
+retained_heap_fields!(crate::tools::config_tools::ConsumerGroupConfigStateRow => broker_name);
+retained_heap_fields!(crate::tools::config_tools::ConsumerGroupConfigStateOutput => cluster, group, brokers);
+retained_heap_fields!(crate::tools::config_tools::TopicConfigObservationRow => broker_name, message_type);
+retained_heap_none!(crate::tools::config_tools::TopicConfigDifferenceField);
+retained_heap_fields!(crate::tools::config_tools::GetTopicConfigOutput =>
+    cluster,
+    topic,
+    brokers,
+    inconsistent_fields,
+    generated_at,
+);
+
+retained_heap_fields!(crate::tools::proxy_tools::ProxyDrainStateOutput =>
+    cluster,
+    proxy_name,
+    state_schema_version,
+    operation_id,
+);
+retained_heap_fields!(crate::tools::message_tools::MessageMetadataOutput =>
+    cluster,
+    message_alias,
+    unique_message_alias,
+    topic,
+    born_at,
+    stored_at,
+);
+
+retained_heap_fields!(crate::tools::infrastructure_tools::LogicalBrokerInstance => broker_name);
+retained_heap_fields!(crate::tools::infrastructure_tools::HaConnectionObservation => replica);
+retained_heap_fields!(crate::tools::infrastructure_tools::BrokerHaObservation => broker_name, connections);
+retained_heap_fields!(crate::tools::infrastructure_tools::BrokerSyncStateObservation =>
+    broker_name,
+    in_sync_replicas,
+    not_in_sync_replicas,
+);
+retained_heap_fields!(crate::tools::infrastructure_tools::ControllerSyncStateObservation =>
+    controller_name,
+    brokers,
+);
+retained_heap_fields!(crate::tools::infrastructure_tools::GetHaStatusOutput =>
+    cluster,
+    brokers,
+    controller_sync_states,
+);
+retained_heap_fields!(crate::tools::infrastructure_tools::ControllerMetadataObservation =>
+    controller_name,
+    group,
+    leader_id,
+);
+retained_heap_fields!(crate::tools::infrastructure_tools::GetControllerMetadataOutput => cluster, controllers);
+retained_heap_none!(
+    crate::tools::infrastructure_tools::NameserverConfigValues,
+    crate::tools::infrastructure_tools::NameserverConfigDifferenceField,
+);
+retained_heap_fields!(crate::tools::infrastructure_tools::NameserverConfigObservation =>
+    nameserver_name,
+    values,
+);
+retained_heap_fields!(crate::tools::infrastructure_tools::GetNameserverConfigSummaryOutput =>
+    cluster,
+    nameservers,
+    inconsistent_fields,
+);
+
+retained_heap_fields!(crate::model::diagnosis::EvidenceItem =>
+    id,
+    source_tool,
+    observed_at,
+    query_hash,
+    payload,
+    error_code,
+    summary,
+);
+impl RetainedSize for crate::model::diagnosis::EvidencePayload {
+    fn retained_heap_size(&self) -> usize {
+        match self {
+            Self::ConsumerLag(value) | Self::TopicRoute(value) | Self::BrokerSummary(value) => {
+                value.retained_heap_size()
+            }
+        }
+    }
+}
+retained_heap_fields!(crate::model::diagnosis::EvidenceSnapshot =>
+    evidence_version,
+    query_hash,
+    cluster,
+    target,
+    observed_at,
+    items,
+);
+retained_heap_fields!(crate::model::diagnosis::ImpactItem => area, description);
+retained_heap_fields!(crate::model::diagnosis::Evidence => id, source_tool, summary, data);
+retained_heap_fields!(crate::model::diagnosis::RootCauseCandidate => cause, evidence_refs, reasoning);
+retained_heap_fields!(crate::model::diagnosis::Recommendation => action, priority, rationale, risk, verification);
+retained_heap_fields!(crate::model::diagnosis::MetricWatchItem => name, target, reason);
+retained_heap_fields!(crate::model::diagnosis::DiagnosisReport =>
+    report_type,
+    evidence_version,
+    rules_version,
+    cluster,
+    target,
+    policy_profile,
+    missing_evidence,
+    evidence_refs,
+    evidence_snapshot,
+    summary,
+    impacts,
+    evidences,
+    root_causes,
+    recommendations,
+    risks,
+    follow_up_metrics,
+    generated_at,
+);
+
 #[derive(Debug, Clone, Copy)]
 struct SnapshotLimits {
     max_entries: usize,

--- a/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/model/contract.rs
@@ -39,6 +39,10 @@ pub enum QuerySource {
     ConsumerGroupConfig,
     SubscriptionGroups,
     TopicRoute,
+    BrokerHaRuntime,
+    ControllerSyncState,
+    ControllerMetadata,
+    NameserverConfig,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -115,6 +119,10 @@ impl SourceFailure {
             AdminSource::TopicStats => QuerySource::TopicStats,
             AdminSource::ConsumerGroupConfig => QuerySource::ConsumerGroupConfig,
             AdminSource::SubscriptionGroups => QuerySource::SubscriptionGroups,
+            AdminSource::BrokerHaRuntime => QuerySource::BrokerHaRuntime,
+            AdminSource::ControllerSyncState => QuerySource::ControllerSyncState,
+            AdminSource::ControllerMetadata => QuerySource::ControllerMetadata,
+            AdminSource::NameserverConfig => QuerySource::NameserverConfig,
         };
         let code = match failure.code() {
             AdminCode::SourceUnavailable => SourceFailureCode::SourceUnavailable,
@@ -472,6 +480,10 @@ mod tests {
         for (admin_source, expected) in [
             (AdminQuerySource::TopicConfig, QuerySource::TopicConfig),
             (AdminQuerySource::ConsumerGroupConfig, QuerySource::ConsumerGroupConfig),
+            (AdminQuerySource::BrokerHaRuntime, QuerySource::BrokerHaRuntime),
+            (AdminQuerySource::ControllerSyncState, QuerySource::ControllerSyncState),
+            (AdminQuerySource::ControllerMetadata, QuerySource::ControllerMetadata),
+            (AdminQuerySource::NameserverConfig, QuerySource::NameserverConfig),
         ] {
             let failure =
                 AdminSourceFailure::new(admin_source, AdminQueryFailureCode::SourceUnavailable, true, "broker-a");

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/server.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/server.rs
@@ -552,10 +552,7 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(standard_tool.is_error, Some(false));
-        let cursor = standard_tool.structured_content.as_ref().unwrap()["data"]["next_cursor"]
-            .as_str()
-            .unwrap()
-            .to_string();
+        assert!(standard_tool.structured_content.as_ref().unwrap()["data"]["next_cursor"].is_string());
         assert_eq!(counters.topic_inventory_queries.load(Ordering::SeqCst), 1);
 
         let standard_resource = oauth_context(&peer, 2, "other-oauth-read", ["read_only"], ["rocketmq:read"]);
@@ -573,9 +570,29 @@ mod tests {
             "same-class Tool and Resource must share the retained snapshot"
         );
 
+        drop(running);
+        drop(client);
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn real_handlers_isolate_topic_snapshots_and_share_sensitive_visibility() {
+        let (_owner, server, counters) = test_server("diagnose", None);
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
+
+        running
+            .service()
+            .read_resource(
+                ReadResourceRequestParams::new("rocketmq://clusters/local-dev/topics?limit=1"),
+                oauth_context(&peer, 1, "oauth-read", ["read_only"], ["rocketmq:read"]),
+            )
+            .await
+            .unwrap();
+
         let sensitive = oauth_context(
             &peer,
-            3,
+            2,
             "oauth-diagnose",
             ["diagnose"],
             ["rocketmq:read", "rocketmq:diagnose"],
@@ -594,31 +611,7 @@ mod tests {
             "standard and sensitive snapshots must not share"
         );
 
-        let before_cursor_replay = counters.starts.load(Ordering::SeqCst);
-        let replay = complete_tool_response(
-            running
-                .service()
-                .call_tool(
-                    list_topics_request(Some(1), Some(cursor)),
-                    oauth_context(
-                        &peer,
-                        4,
-                        "oauth-diagnose",
-                        ["diagnose"],
-                        ["rocketmq:read", "rocketmq:diagnose"],
-                    ),
-                )
-                .await
-                .unwrap(),
-        );
-        assert_eq!(replay.is_error, Some(true));
-        assert_eq!(
-            counters.starts.load(Ordering::SeqCst),
-            before_cursor_replay,
-            "cross-class cursor rejection must not start an admin session"
-        );
-
-        let stdio_diagnose = local_context(&peer, 5);
+        let stdio_diagnose = local_context(&peer, 3);
         running
             .service()
             .read_resource(
@@ -633,6 +626,65 @@ mod tests {
             "local diagnose must share the sensitive class"
         );
 
+        drop(running);
+        drop(client);
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn real_handlers_reject_cross_visibility_cursor_without_session_work() {
+        let (_owner, server, counters) = test_server("diagnose", None);
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
+        let standard_tool = complete_tool_response(
+            running
+                .service()
+                .call_tool(
+                    list_topics_request(Some(1), None),
+                    oauth_context(&peer, 1, "oauth-read", ["read_only"], ["rocketmq:read"]),
+                )
+                .await
+                .unwrap(),
+        );
+        let cursor = standard_tool.structured_content.as_ref().unwrap()["data"]["next_cursor"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let before_cursor_replay = counters.starts.load(Ordering::SeqCst);
+        let replay = complete_tool_response(
+            running
+                .service()
+                .call_tool(
+                    list_topics_request(Some(1), Some(cursor)),
+                    oauth_context(
+                        &peer,
+                        2,
+                        "oauth-diagnose",
+                        ["diagnose"],
+                        ["rocketmq:read", "rocketmq:diagnose"],
+                    ),
+                )
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(replay.is_error, Some(true));
+        assert_eq!(
+            counters.starts.load(Ordering::SeqCst),
+            before_cursor_replay,
+            "cross-class cursor rejection must not start an admin session"
+        );
+        drop(running);
+        drop(client);
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn real_handlers_isolate_ordinary_cache_by_visibility() {
+        let (_owner, server, counters) = test_server("diagnose", None);
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
+
         let overview = || {
             CallToolRequestParams::new("rocketmq_get_cluster_overview")
                 .with_arguments(json!({"cluster": "local-dev"}).as_object().unwrap().clone())
@@ -641,7 +693,7 @@ mod tests {
             .service()
             .call_tool(
                 overview(),
-                oauth_context(&peer, 6, "oauth-read", ["read_only"], ["rocketmq:read"]),
+                oauth_context(&peer, 1, "oauth-read", ["read_only"], ["rocketmq:read"]),
             )
             .await
             .unwrap();
@@ -651,7 +703,7 @@ mod tests {
                 overview(),
                 oauth_context(
                     &peer,
-                    7,
+                    2,
                     "oauth-diagnose",
                     ["diagnose"],
                     ["rocketmq:read", "rocketmq:diagnose"],
@@ -663,7 +715,7 @@ mod tests {
             .service()
             .call_tool(
                 overview(),
-                oauth_context(&peer, 8, "another-read", ["read_only"], ["rocketmq:read"]),
+                oauth_context(&peer, 3, "another-read", ["read_only"], ["rocketmq:read"]),
             )
             .await
             .unwrap();
@@ -675,35 +727,39 @@ mod tests {
 
         drop(running);
         drop(client);
+    }
 
-        let (_owner, read_only_server, read_only_counters) = test_server("read_only", None);
-        let (read_only_running, read_only_client) = connected_test_server(read_only_server).await;
-        let read_only_peer = read_only_running.peer().clone();
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn real_handlers_map_local_read_only_to_standard_visibility() {
+        let (_owner, server, counters) = test_server("read_only", None);
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
 
-        read_only_running
+        running
             .service()
             .call_tool(
                 list_topics_request(None, None),
-                oauth_context(&read_only_peer, 9, "oauth-read", ["read_only"], ["rocketmq:read"]),
+                oauth_context(&peer, 1, "oauth-read", ["read_only"], ["rocketmq:read"]),
             )
             .await
             .unwrap();
-        read_only_running
+        running
             .service()
             .read_resource(
                 ReadResourceRequestParams::new("rocketmq://clusters/local-dev/topics"),
-                local_context(&read_only_peer, 10),
+                local_context(&peer, 2),
             )
             .await
             .unwrap();
         assert_eq!(
-            read_only_counters.topic_inventory_queries.load(Ordering::SeqCst),
+            counters.topic_inventory_queries.load(Ordering::SeqCst),
             1,
             "local read-only must use the standard HTTP read class"
         );
 
-        drop(read_only_running);
-        drop(read_only_client);
+        drop(running);
+        drop(client);
     }
 
     #[cfg(all(feature = "streamable-http", feature = "stdio"))]
@@ -805,6 +861,82 @@ mod tests {
 
         drop(denied_running);
         drop(denied_client);
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn diagnose_handler_discovers_all_infrastructure_tools() {
+        let (_owner, server, _counters) = test_server("diagnose", None);
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
+
+        let names = running
+            .service()
+            .list_tools(None, local_context(&peer, 1))
+            .await
+            .unwrap()
+            .tools
+            .into_iter()
+            .map(|tool| tool.name.to_string())
+            .collect::<BTreeSet<_>>();
+
+        assert!(names.contains("rocketmq_get_ha_status"));
+        assert!(names.contains("rocketmq_get_controller_metadata"));
+        assert!(names.contains("rocketmq_get_nameserver_config_summary"));
+        drop(running);
+        drop(client);
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn read_only_handler_discovers_only_read_infrastructure_tool() {
+        let (_owner, server, _counters) = test_server("read_only", None);
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
+
+        let names = running
+            .service()
+            .list_tools(None, local_context(&peer, 1))
+            .await
+            .unwrap()
+            .tools
+            .into_iter()
+            .map(|tool| tool.name.to_string())
+            .collect::<BTreeSet<_>>();
+
+        assert!(!names.contains("rocketmq_get_ha_status"));
+        assert!(!names.contains("rocketmq_get_controller_metadata"));
+        assert!(names.contains("rocketmq_get_nameserver_config_summary"));
+        drop(running);
+        drop(client);
+    }
+
+    #[cfg(all(feature = "streamable-http", feature = "stdio"))]
+    #[tokio::test]
+    async fn read_only_handler_denies_infrastructure_diagnosis_before_session_work() {
+        let (_owner, server, counters) = test_server("read_only", None);
+        let (running, client) = connected_test_server(server).await;
+        let peer = running.peer().clone();
+        let request = CallToolRequestParams::new("rocketmq_get_ha_status").with_arguments(
+            json!({"cluster": "local-dev", "endpoint": "private-controller.internal:9878"})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+
+        let denied = complete_tool_response(
+            running
+                .service()
+                .call_tool(request, local_context(&peer, 1))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(denied.is_error, Some(true));
+        assert_eq!(counters.starts.load(Ordering::SeqCst), 0);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 0);
+        drop(running);
+        drop(client);
     }
 
     #[cfg(all(feature = "streamable-http", feature = "stdio"))]
@@ -972,6 +1104,14 @@ mod tests {
             .into_iter()
             .map(|prompt| serde_json::to_value(prompt).expect("prompt descriptor serializes"))
             .collect::<Vec<_>>();
+
+        #[cfg(not(feature = "change-planning"))]
+        assert_eq!(tools.len(), 24);
+        #[cfg(feature = "change-planning")]
+        assert_eq!(tools.len(), 29);
+        assert_eq!(resources.len(), 7);
+        assert_eq!(resource_templates.as_array().unwrap().len(), 10);
+        assert_eq!(prompts.len(), 2);
 
         let surface = json!({
             "tools": tools,

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface.snap
@@ -305,7 +305,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -518,7 +522,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -780,7 +788,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -1005,7 +1017,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -1384,7 +1400,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -1625,7 +1645,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -1898,7 +1922,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -2516,7 +2544,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -2958,7 +2990,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -3202,7 +3238,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -3462,7 +3502,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -3959,7 +4003,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -4273,7 +4321,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -4530,7 +4582,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -4750,7 +4806,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -4905,7 +4965,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -5209,7 +5273,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -5438,7 +5506,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -5657,7 +5729,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -6053,7 +6129,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -6369,7 +6449,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -6467,6 +6551,878 @@ expression: surface
         "type": "object"
       },
       "title": "RocketMQ consumer progress"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ HA status"
+      },
+      "description": "Get bounded HA observations for logical master Brokers with optional configured Controller sync state.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "broker_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "controller_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "include_sync_state": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "cluster"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_ha_status",
+      "outputSchema": {
+        "$defs": {
+          "BrokerHaObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "connections": {
+                "items": {
+                  "$ref": "#/$defs/HaConnectionObservation"
+                },
+                "type": "array"
+              },
+              "group_transfer_ack_notify_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "in_sync_slave_count": {
+                "format": "uint32",
+                "maximum": 64,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "master_commit_log_max_offset": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "pending_group_transfer_oldest_wait_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "pending_group_transfer_request_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id",
+              "master_commit_log_max_offset",
+              "in_sync_slave_count",
+              "pending_group_transfer_request_count",
+              "pending_group_transfer_oldest_wait_millis",
+              "group_transfer_ack_notify_count",
+              "connections"
+            ],
+            "type": "object"
+          },
+          "BrokerSyncStateObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "in_sync_replicas": {
+                "items": {
+                  "$ref": "#/$defs/LogicalBrokerInstance"
+                },
+                "type": "array"
+              },
+              "master_broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "master_epoch": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "not_in_sync_replicas": {
+                "items": {
+                  "$ref": "#/$defs/LogicalBrokerInstance"
+                },
+                "type": "array"
+              },
+              "sync_state_set_epoch": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "master_broker_id",
+              "master_epoch",
+              "sync_state_set_epoch",
+              "in_sync_replicas",
+              "not_in_sync_replicas"
+            ],
+            "type": "object"
+          },
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ControllerSyncStateObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerSyncStateObservation"
+                },
+                "type": "array"
+              },
+              "controller_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "controller_name",
+              "brokers"
+            ],
+            "type": "object"
+          },
+          "GetHaStatusOutput": {
+            "additionalProperties": false,
+            "properties": {
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerHaObservation"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "controller_sync_states": {
+                "items": {
+                  "$ref": "#/$defs/ControllerSyncStateObservation"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "cluster",
+              "brokers",
+              "controller_sync_states"
+            ],
+            "type": "object"
+          },
+          "HaConnectionObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "diff": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "in_sync": {
+                "type": "boolean"
+              },
+              "replica": {
+                "$ref": "#/$defs/LogicalBrokerInstance"
+              },
+              "slave_ack_offset": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "transfer_from_where": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "transferred_bytes_per_second": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "replica",
+              "slave_ack_offset",
+              "diff",
+              "in_sync",
+              "transferred_bytes_per_second",
+              "transfer_from_where"
+            ],
+            "type": "object"
+          },
+          "LogicalBrokerInstance": {
+            "additionalProperties": false,
+            "properties": {
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetHaStatusOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ HA status"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ Controller metadata"
+      },
+      "description": "Get bounded metadata for configured logical Controller aliases.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "controller_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cluster"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_controller_metadata",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ControllerMetadataObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "applied_log_index": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "committed_log_index": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "controller_name": {
+                "type": "string"
+              },
+              "group": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_leader": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "last_log_index": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "leader_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "peer_count": {
+                "format": "uint",
+                "maximum": 32,
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "controller_name"
+            ],
+            "type": "object"
+          },
+          "GetControllerMetadataOutput": {
+            "additionalProperties": false,
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "controllers": {
+                "items": {
+                  "$ref": "#/$defs/ControllerMetadataObservation"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "cluster",
+              "controllers"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetControllerMetadataOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ Controller metadata"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ NameServer configuration summary"
+      },
+      "description": "Get fixed allowlisted configuration values and differences for configured NameServers.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_nameserver_config_summary",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "GetNameserverConfigSummaryOutput": {
+            "additionalProperties": false,
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "inconsistent_fields": {
+                "items": {
+                  "$ref": "#/$defs/NameserverConfigDifferenceField"
+                },
+                "type": "array"
+              },
+              "nameservers": {
+                "items": {
+                  "$ref": "#/$defs/NameserverConfigObservation"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "cluster",
+              "nameservers",
+              "inconsistent_fields"
+            ],
+            "type": "object"
+          },
+          "NameserverConfigDifferenceField": {
+            "enum": [
+              "cluster_test",
+              "order_message_enable",
+              "return_order_topic_config_to_broker",
+              "client_request_thread_pool_nums",
+              "client_request_thread_pool_queue_capacity",
+              "scan_not_active_broker_interval_ms",
+              "unregister_broker_queue_capacity",
+              "support_acting_master"
+            ],
+            "type": "string"
+          },
+          "NameserverConfigObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "nameserver_name": {
+                "type": "string"
+              },
+              "values": {
+                "$ref": "#/$defs/NameserverConfigValues"
+              }
+            },
+            "required": [
+              "nameserver_name",
+              "values"
+            ],
+            "type": "object"
+          },
+          "NameserverConfigValues": {
+            "additionalProperties": false,
+            "properties": {
+              "client_request_thread_pool_nums": {
+                "format": "int32",
+                "maximum": 4096,
+                "minimum": 1,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "client_request_thread_pool_queue_capacity": {
+                "format": "int32",
+                "maximum": 10000000,
+                "minimum": 1,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "cluster_test": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "order_message_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "return_order_topic_config_to_broker": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "scan_not_active_broker_interval_ms": {
+                "format": "uint64",
+                "maximum": 3600000,
+                "minimum": 1,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "support_acting_master": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "unregister_broker_queue_capacity": {
+                "format": "int32",
+                "maximum": 10000000,
+                "minimum": 1,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetNameserverConfigSummaryOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ NameServer configuration summary"
     }
   ]
 }

--- a/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/protocol/snapshots/rocketmq_mcp__protocol__server__tests__mcp_protocol_surface_with_change_planning.snap
@@ -305,7 +305,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -518,7 +522,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -780,7 +788,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -1005,7 +1017,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -1384,7 +1400,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -1625,7 +1645,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -1898,7 +1922,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -2516,7 +2544,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -2958,7 +2990,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -3202,7 +3238,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -3462,7 +3502,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -3959,7 +4003,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -4273,7 +4321,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -4530,7 +4582,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -4750,7 +4806,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -4905,7 +4965,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -5209,7 +5273,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -5438,7 +5506,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -5657,7 +5729,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -6053,7 +6129,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -6369,7 +6449,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -6467,6 +6551,878 @@ expression: surface
         "type": "object"
       },
       "title": "RocketMQ consumer progress"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ HA status"
+      },
+      "description": "Get bounded HA observations for logical master Brokers with optional configured Controller sync state.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "broker_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "controller_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "include_sync_state": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "cluster"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_ha_status",
+      "outputSchema": {
+        "$defs": {
+          "BrokerHaObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              },
+              "connections": {
+                "items": {
+                  "$ref": "#/$defs/HaConnectionObservation"
+                },
+                "type": "array"
+              },
+              "group_transfer_ack_notify_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "in_sync_slave_count": {
+                "format": "uint32",
+                "maximum": 64,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "master_commit_log_max_offset": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "pending_group_transfer_oldest_wait_millis": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "pending_group_transfer_request_count": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id",
+              "master_commit_log_max_offset",
+              "in_sync_slave_count",
+              "pending_group_transfer_request_count",
+              "pending_group_transfer_oldest_wait_millis",
+              "group_transfer_ack_notify_count",
+              "connections"
+            ],
+            "type": "object"
+          },
+          "BrokerSyncStateObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "broker_name": {
+                "type": "string"
+              },
+              "in_sync_replicas": {
+                "items": {
+                  "$ref": "#/$defs/LogicalBrokerInstance"
+                },
+                "type": "array"
+              },
+              "master_broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "master_epoch": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "not_in_sync_replicas": {
+                "items": {
+                  "$ref": "#/$defs/LogicalBrokerInstance"
+                },
+                "type": "array"
+              },
+              "sync_state_set_epoch": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "broker_name",
+              "master_broker_id",
+              "master_epoch",
+              "sync_state_set_epoch",
+              "in_sync_replicas",
+              "not_in_sync_replicas"
+            ],
+            "type": "object"
+          },
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ControllerSyncStateObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerSyncStateObservation"
+                },
+                "type": "array"
+              },
+              "controller_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "controller_name",
+              "brokers"
+            ],
+            "type": "object"
+          },
+          "GetHaStatusOutput": {
+            "additionalProperties": false,
+            "properties": {
+              "brokers": {
+                "items": {
+                  "$ref": "#/$defs/BrokerHaObservation"
+                },
+                "type": "array"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "controller_sync_states": {
+                "items": {
+                  "$ref": "#/$defs/ControllerSyncStateObservation"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "cluster",
+              "brokers",
+              "controller_sync_states"
+            ],
+            "type": "object"
+          },
+          "HaConnectionObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "diff": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "in_sync": {
+                "type": "boolean"
+              },
+              "replica": {
+                "$ref": "#/$defs/LogicalBrokerInstance"
+              },
+              "slave_ack_offset": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "transfer_from_where": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "transferred_bytes_per_second": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "replica",
+              "slave_ack_offset",
+              "diff",
+              "in_sync",
+              "transferred_bytes_per_second",
+              "transfer_from_where"
+            ],
+            "type": "object"
+          },
+          "LogicalBrokerInstance": {
+            "additionalProperties": false,
+            "properties": {
+              "broker_id": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "broker_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "broker_name",
+              "broker_id"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetHaStatusOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ HA status"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ Controller metadata"
+      },
+      "description": "Get bounded metadata for configured logical Controller aliases.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "controller_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cluster"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_controller_metadata",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "ControllerMetadataObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "applied_log_index": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "committed_log_index": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "controller_name": {
+                "type": "string"
+              },
+              "group": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_leader": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "last_log_index": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "leader_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "peer_count": {
+                "format": "uint",
+                "maximum": 32,
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "controller_name"
+            ],
+            "type": "object"
+          },
+          "GetControllerMetadataOutput": {
+            "additionalProperties": false,
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "controllers": {
+                "items": {
+                  "$ref": "#/$defs/ControllerMetadataObservation"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "cluster",
+              "controllers"
+            ],
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetControllerMetadataOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ Controller metadata"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "RocketMQ NameServer configuration summary"
+      },
+      "description": "Get fixed allowlisted configuration values and differences for configured NameServers.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "cluster": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster"
+        ],
+        "type": "object"
+      },
+      "name": "rocketmq_get_nameserver_config_summary",
+      "outputSchema": {
+        "$defs": {
+          "CacheStatus": {
+            "enum": [
+              "bypass",
+              "hit",
+              "miss"
+            ],
+            "type": "string"
+          },
+          "GetNameserverConfigSummaryOutput": {
+            "additionalProperties": false,
+            "properties": {
+              "cluster": {
+                "type": "string"
+              },
+              "inconsistent_fields": {
+                "items": {
+                  "$ref": "#/$defs/NameserverConfigDifferenceField"
+                },
+                "type": "array"
+              },
+              "nameservers": {
+                "items": {
+                  "$ref": "#/$defs/NameserverConfigObservation"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "cluster",
+              "nameservers",
+              "inconsistent_fields"
+            ],
+            "type": "object"
+          },
+          "NameserverConfigDifferenceField": {
+            "enum": [
+              "cluster_test",
+              "order_message_enable",
+              "return_order_topic_config_to_broker",
+              "client_request_thread_pool_nums",
+              "client_request_thread_pool_queue_capacity",
+              "scan_not_active_broker_interval_ms",
+              "unregister_broker_queue_capacity",
+              "support_acting_master"
+            ],
+            "type": "string"
+          },
+          "NameserverConfigObservation": {
+            "additionalProperties": false,
+            "properties": {
+              "nameserver_name": {
+                "type": "string"
+              },
+              "values": {
+                "$ref": "#/$defs/NameserverConfigValues"
+              }
+            },
+            "required": [
+              "nameserver_name",
+              "values"
+            ],
+            "type": "object"
+          },
+          "NameserverConfigValues": {
+            "additionalProperties": false,
+            "properties": {
+              "client_request_thread_pool_nums": {
+                "format": "int32",
+                "maximum": 4096,
+                "minimum": 1,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "client_request_thread_pool_queue_capacity": {
+                "format": "int32",
+                "maximum": 10000000,
+                "minimum": 1,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "cluster_test": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "order_message_enable": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "return_order_topic_config_to_broker": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "scan_not_active_broker_interval_ms": {
+                "format": "uint64",
+                "maximum": 3600000,
+                "minimum": 1,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "support_acting_master": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "unregister_broker_queue_capacity": {
+                "format": "int32",
+                "maximum": 10000000,
+                "minimum": 1,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "type": "object"
+          },
+          "QuerySource": {
+            "enum": [
+              "broker_runtime",
+              "broker_config",
+              "broker_log_filter",
+              "consumer_statistics",
+              "consumer_connection",
+              "producer_connection",
+              "topic_config",
+              "topic_stats",
+              "consumer_group_config",
+              "subscription_groups",
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
+            ],
+            "type": "string"
+          },
+          "SourceFailure": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "$ref": "#/$defs/SourceFailureCode"
+              },
+              "logical_target": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              },
+              "source": {
+                "$ref": "#/$defs/QuerySource"
+              }
+            },
+            "required": [
+              "source",
+              "code",
+              "retryable",
+              "logical_target"
+            ],
+            "type": "object"
+          },
+          "SourceFailureCode": {
+            "enum": [
+              "source_unavailable",
+              "timeout",
+              "permission_denied",
+              "not_found",
+              "rate_limited",
+              "invalid_response"
+            ],
+            "type": "string"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cache_status": {
+            "$ref": "#/$defs/CacheStatus"
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/$defs/GetNameserverConfigSummaryOutput"
+          },
+          "freshness_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": "string"
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "source_failures": {
+            "items": {
+              "$ref": "#/$defs/SourceFailure"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "request_id",
+          "cluster",
+          "observed_at",
+          "freshness_ms",
+          "cache_status",
+          "partial",
+          "warnings",
+          "data"
+        ],
+        "type": "object"
+      },
+      "title": "RocketMQ NameServer configuration summary"
     },
     {
       "annotations": {
@@ -6650,7 +7606,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -6914,7 +7874,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -7174,7 +8138,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -7438,7 +8406,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },
@@ -7714,7 +8686,11 @@ expression: surface
               "topic_stats",
               "consumer_group_config",
               "subscription_groups",
-              "topic_route"
+              "topic_route",
+              "broker_ha_runtime",
+              "controller_sync_state",
+              "controller_metadata",
+              "nameserver_config"
             ],
             "type": "string"
           },

--- a/rocketmq-ai/rocketmq-mcp/src/tools.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools.rs
@@ -24,6 +24,7 @@ pub mod connection_tools;
 pub mod consumer_tools;
 pub mod diagnosis_tools;
 pub mod executor;
+pub mod infrastructure_tools;
 pub mod message_tools;
 pub mod output_policy;
 pub mod proxy_tools;

--- a/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs
@@ -27,6 +27,7 @@ use crate::tools::config_tools;
 use crate::tools::connection_tools;
 use crate::tools::consumer_tools;
 use crate::tools::diagnosis_tools;
+use crate::tools::infrastructure_tools;
 use crate::tools::message_tools;
 use crate::tools::proxy_tools;
 use crate::tools::topic_tools;
@@ -54,6 +55,9 @@ pub enum ToolId {
     GetTopicConfig,
     GetConsumerGroupDetails,
     GetConsumerProgress,
+    GetHaStatus,
+    GetControllerMetadata,
+    GetNameserverConfigSummary,
     #[cfg(feature = "change-planning")]
     PlanCreateTopic,
     #[cfg(feature = "change-planning")]
@@ -89,6 +93,9 @@ impl ToolId {
         Self::GetTopicConfig,
         Self::GetConsumerGroupDetails,
         Self::GetConsumerProgress,
+        Self::GetHaStatus,
+        Self::GetControllerMetadata,
+        Self::GetNameserverConfigSummary,
         #[cfg(feature = "change-planning")]
         Self::PlanCreateTopic,
         #[cfg(feature = "change-planning")]
@@ -257,6 +264,27 @@ impl ToolId {
                 "Get a bounded snapshot page of deterministic per-queue progress and complete aggregate totals.",
                 RiskLevel::ReadOnly,
             ),
+            Self::GetHaStatus => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_ha_status",
+                "RocketMQ HA status",
+                "Get bounded HA observations for logical master Brokers with optional configured Controller sync state.",
+                RiskLevel::Diagnose,
+            ),
+            Self::GetControllerMetadata => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_controller_metadata",
+                "RocketMQ Controller metadata",
+                "Get bounded metadata for configured logical Controller aliases.",
+                RiskLevel::Diagnose,
+            ),
+            Self::GetNameserverConfigSummary => ToolDescriptor::read_only(
+                self,
+                "rocketmq_get_nameserver_config_summary",
+                "RocketMQ NameServer configuration summary",
+                "Get fixed allowlisted configuration values and differences for configured NameServers.",
+                RiskLevel::ReadOnly,
+            ),
             #[cfg(feature = "change-planning")]
             Self::PlanCreateTopic => ToolDescriptor::read_only(
                 self,
@@ -368,6 +396,18 @@ impl ToolId {
             Self::GetConsumerProgress => descriptor.build::<
                 consumer_tools::GetConsumerProgressArgs,
                 consumer_tools::GetConsumerProgressOutput,
+            >(),
+            Self::GetHaStatus => descriptor.build::<
+                infrastructure_tools::GetHaStatusArgs,
+                infrastructure_tools::GetHaStatusOutput,
+            >(),
+            Self::GetControllerMetadata => descriptor.build::<
+                infrastructure_tools::GetControllerMetadataArgs,
+                infrastructure_tools::GetControllerMetadataOutput,
+            >(),
+            Self::GetNameserverConfigSummary => descriptor.build::<
+                infrastructure_tools::GetNameserverConfigSummaryArgs,
+                infrastructure_tools::GetNameserverConfigSummaryOutput,
             >(),
             #[cfg(feature = "change-planning")]
             Self::PlanCreateTopic => descriptor.build::<change_tools::CreateTopicArgs, change_tools::ChangePlan>(),
@@ -518,9 +558,9 @@ mod tests {
             ]
         );
         #[cfg(not(feature = "change-planning"))]
-        assert_eq!(names.len(), 21);
+        assert_eq!(names.len(), 24);
         #[cfg(feature = "change-planning")]
-        assert_eq!(names.len(), 26);
+        assert_eq!(names.len(), 29);
     }
 
     #[test]
@@ -571,6 +611,31 @@ mod tests {
                 "{} must reject unknown arguments",
                 descriptor.name
             );
+        }
+    }
+
+    #[test]
+    fn infrastructure_contracts_have_exact_risk_and_no_target_addresses() {
+        for (tool_id, risk) in [
+            (ToolId::GetHaStatus, RiskLevel::Diagnose),
+            (ToolId::GetControllerMetadata, RiskLevel::Diagnose),
+            (ToolId::GetNameserverConfigSummary, RiskLevel::ReadOnly),
+        ] {
+            let descriptor = tool_id.descriptor();
+            assert_eq!(descriptor.risk_level, risk);
+            assert!(descriptor.annotations.read_only);
+            assert!(!descriptor.annotations.destructive);
+            let definition = tool_id.definition();
+            assert_eq!(
+                definition.input_schema.get("additionalProperties"),
+                Some(&serde_json::Value::Bool(false))
+            );
+            let properties = definition.input_schema["properties"].as_object().unwrap();
+            for forbidden in ["address", "addr", "endpoint"] {
+                assert!(properties
+                    .keys()
+                    .all(|key| !key.to_ascii_lowercase().contains(forbidden)));
+            }
         }
     }
 

--- a/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/executor.rs
@@ -48,6 +48,7 @@ use crate::tools::config_tools;
 use crate::tools::connection_tools;
 use crate::tools::consumer_tools;
 use crate::tools::diagnosis_tools;
+use crate::tools::infrastructure_tools;
 use crate::tools::message_tools;
 use crate::tools::output_policy;
 use crate::tools::proxy_tools;
@@ -753,6 +754,61 @@ where
                     success_unlinked_result(descriptor, request_id, cluster, summary, output)
                 })
             }
+            ToolId::GetHaStatus => {
+                let args = match decode_args::<infrastructure_tools::GetHaStatusArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.ha_status(args).await.and_then(|output| {
+                    let summary = summary_ha_status(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
+            ToolId::GetControllerMetadata => {
+                let args = match decode_args::<infrastructure_tools::GetControllerMetadataArgs>(arguments.clone()) {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.controller_metadata(args).await.and_then(|output| {
+                    let summary = summary_controller_metadata(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
+            ToolId::GetNameserverConfigSummary => {
+                let args = match decode_args::<infrastructure_tools::GetNameserverConfigSummaryArgs>(arguments.clone())
+                {
+                    Ok(args) => args,
+                    Err(error) => {
+                        return Ok(guarded_call.finish_result(error_result(
+                            descriptor.name,
+                            &tool_name,
+                            request_id,
+                            error,
+                        )));
+                    }
+                };
+                self.adapter.nameserver_config_summary(args).await.and_then(|output| {
+                    let summary = summary_nameserver_config(&output);
+                    let cluster = output.cluster.clone();
+                    success_unlinked_result(descriptor, request_id, cluster, summary, output)
+                })
+            }
             #[cfg(feature = "change-planning")]
             ToolId::PlanCreateTopic => {
                 let args = match decode_args::<change_tools::CreateTopicArgs>(arguments.clone()) {
@@ -1224,6 +1280,32 @@ fn summary_consumer_progress(output: &consumer_tools::GetConsumerProgressOutput)
     format!(
         "Consumer group {} on cluster {} returned {} of {} queue progress rows with total lag {}.",
         output.consumer_group, output.cluster, output.page.count, output.queue_count, output.total_lag
+    )
+}
+
+fn summary_ha_status(output: &infrastructure_tools::GetHaStatusOutput) -> String {
+    format!(
+        "Cluster {} returned {} logical master Broker HA observations and {} Controller sync-state observations.",
+        output.cluster,
+        output.brokers.len(),
+        output.controller_sync_states.len()
+    )
+}
+
+fn summary_controller_metadata(output: &infrastructure_tools::GetControllerMetadataOutput) -> String {
+    format!(
+        "Cluster {} returned metadata for {} configured logical Controllers.",
+        output.cluster,
+        output.controllers.len()
+    )
+}
+
+fn summary_nameserver_config(output: &infrastructure_tools::GetNameserverConfigSummaryOutput) -> String {
+    format!(
+        "Cluster {} returned {} allowlisted NameServer configuration summaries with {} differences.",
+        output.cluster,
+        output.nameservers.len(),
+        output.inconsistent_fields.len()
     )
 }
 
@@ -1704,12 +1786,81 @@ mod tests {
             }))
         }
 
+        async fn ha_status(
+            &self,
+            args: infrastructure_tools::GetHaStatusArgs,
+        ) -> Result<QueryResult<infrastructure_tools::GetHaStatusOutput>, ToolExecutionError> {
+            let brokers = if args.broker_names == ["bounded"] {
+                bounded_ha_brokers()
+            } else {
+                Vec::new()
+            };
+            Ok(QueryResult::bypass(infrastructure_tools::GetHaStatusOutput {
+                cluster: args.cluster,
+                brokers,
+                controller_sync_states: Vec::new(),
+            }))
+        }
+
+        async fn controller_metadata(
+            &self,
+            args: infrastructure_tools::GetControllerMetadataArgs,
+        ) -> Result<QueryResult<infrastructure_tools::GetControllerMetadataOutput>, ToolExecutionError> {
+            Ok(QueryResult::bypass(infrastructure_tools::GetControllerMetadataOutput {
+                cluster: args.cluster,
+                controllers: Vec::new(),
+            }))
+        }
+
+        async fn nameserver_config_summary(
+            &self,
+            args: infrastructure_tools::GetNameserverConfigSummaryArgs,
+        ) -> Result<QueryResult<infrastructure_tools::GetNameserverConfigSummaryOutput>, ToolExecutionError> {
+            Ok(QueryResult::bypass(
+                infrastructure_tools::GetNameserverConfigSummaryOutput {
+                    cluster: args.cluster,
+                    nameservers: Vec::new(),
+                    inconsistent_fields: Vec::new(),
+                },
+            ))
+        }
+
         async fn diagnose_consumer_lag(
             &self,
             _args: diagnosis_tools::DiagnoseConsumerLagArgs,
         ) -> Result<QueryResult<crate::model::diagnosis::DiagnosisReport>, ToolExecutionError> {
             unimplemented!("not needed by this test")
         }
+    }
+
+    fn bounded_ha_brokers() -> Vec<infrastructure_tools::BrokerHaObservation> {
+        (0..16)
+            .map(|broker_index| {
+                let connection_count = if broker_index == 15 { 39 } else { 63 };
+                infrastructure_tools::BrokerHaObservation {
+                    broker_name: format!("broker-{broker_index:02}"),
+                    broker_id: 0,
+                    master_commit_log_max_offset: 100,
+                    in_sync_slave_count: u32::try_from(connection_count).unwrap(),
+                    pending_group_transfer_request_count: 0,
+                    pending_group_transfer_oldest_wait_millis: 0,
+                    group_transfer_ack_notify_count: 0,
+                    connections: (1..=connection_count)
+                        .map(|replica_index| infrastructure_tools::HaConnectionObservation {
+                            replica: infrastructure_tools::LogicalBrokerInstance {
+                                broker_name: format!("broker-{broker_index:02}"),
+                                broker_id: u64::try_from(replica_index).unwrap(),
+                            },
+                            slave_ack_offset: 90,
+                            diff: 10,
+                            in_sync: true,
+                            transferred_bytes_per_second: 1,
+                            transfer_from_where: 80,
+                        })
+                        .collect(),
+                }
+            })
+            .collect()
     }
 
     #[tokio::test]
@@ -2021,6 +2172,102 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn infrastructure_tools_enforce_scope_before_schema_and_never_accept_addresses() {
+        let read_guard = test_guard("read_only");
+        let read_only = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            read_guard.clone(),
+        );
+        let denied_before_schema = read_only
+            .call(
+                CallToolRequestParams::new(ToolId::GetHaStatus.descriptor().name).with_arguments(
+                    serde_json::json!({
+                        "cluster": "local-dev",
+                        "endpoint": "private-controller.internal:9878"
+                    })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(denied_before_schema.is_error, Some(true));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&content_text(&denied_before_schema)).unwrap()["code"],
+            "unauthorized_scope"
+        );
+
+        let nameserver = read_only
+            .call(
+                CallToolRequestParams::new(ToolId::GetNameserverConfigSummary.descriptor().name)
+                    .with_arguments(serde_json::json!({"cluster": "local-dev"}).as_object().unwrap().clone()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(nameserver.is_error, Some(false));
+
+        let diagnose_guard = test_guard("diagnose");
+        let diagnose = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            diagnose_guard.clone(),
+        );
+        for (tool, arguments) in [
+            (
+                ToolId::GetHaStatus,
+                serde_json::json!({
+                    "cluster": "local-dev",
+                    "broker_names": ["broker-a"],
+                    "include_sync_state": true,
+                    "controller_names": ["controller-local"]
+                }),
+            ),
+            (
+                ToolId::GetControllerMetadata,
+                serde_json::json!({"cluster": "local-dev", "controller_names": ["controller-local"]}),
+            ),
+        ] {
+            let result = diagnose
+                .call(
+                    CallToolRequestParams::new(tool.descriptor().name)
+                        .with_arguments(arguments.as_object().unwrap().clone()),
+                )
+                .await
+                .unwrap();
+            assert_eq!(result.is_error, Some(false));
+            let wire = serde_json::to_string(&result).unwrap();
+            assert!(!wire.contains("private-controller"));
+        }
+        let invalid = diagnose
+            .call(
+                CallToolRequestParams::new(ToolId::GetControllerMetadata.descriptor().name).with_arguments(
+                    serde_json::json!({"cluster": "local-dev", "address": "10.20.30.40:9878"})
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invalid.is_error, Some(true));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&content_text(&invalid)).unwrap()["code"],
+            "invalid_arguments"
+        );
+        for records in [read_guard.audit_log().records(), diagnose_guard.audit_log().records()] {
+            let wire = serde_json::to_string(&records).unwrap();
+            assert!(!wire.contains("private-controller"));
+            assert!(!wire.contains("10.20.30.40"));
+        }
+    }
+
+    #[tokio::test]
     async fn new_read_tools_dispatch_without_resource_links_and_reject_unknown_fields() {
         let executor = ToolExecutor::new(
             FakeAdapter {
@@ -2256,6 +2503,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn exact_nested_infrastructure_budget_reaches_executor_without_output_too_large() {
+        let result = ToolExecutor::new(
+            FakeAdapter {
+                fail: false,
+                partial: false,
+            },
+            test_guard("diagnose"),
+        )
+        .call(
+            CallToolRequestParams::new(ToolId::GetHaStatus.descriptor().name).with_arguments(
+                serde_json::json!({
+                    "cluster":"local-dev",
+                    "broker_names":["bounded"],
+                    "include_sync_state":false
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.is_error, Some(false));
+        let structured = result.structured_content.unwrap();
+        assert_eq!(structured["data"]["brokers"].as_array().unwrap().len(), 16);
+        assert!(!structured["warnings"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("output_rows_truncated")));
+    }
+
+    #[tokio::test]
     async fn proxy_backend_failure_never_exposes_internal_endpoint() {
         let result = ToolExecutor::new(
             FakeAdapter {
@@ -2423,6 +2702,7 @@ mod tests {
                 tenant: None,
                 credentials: None,
                 proxies: Vec::new(),
+                controllers: Vec::new(),
             }],
         )
         .unwrap()

--- a/rocketmq-ai/rocketmq-mcp/src/tools/infrastructure_tools.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/infrastructure_tools.rs
@@ -1,0 +1,169 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Closed MCP contracts for infrastructure observations.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetHaStatusArgs {
+    pub cluster: String,
+    #[serde(default)]
+    pub broker_names: Vec<String>,
+    #[serde(default)]
+    pub include_sync_state: bool,
+    #[serde(default)]
+    pub controller_names: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LogicalBrokerInstance {
+    pub broker_name: String,
+    pub broker_id: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct HaConnectionObservation {
+    pub replica: LogicalBrokerInstance,
+    pub slave_ack_offset: u64,
+    pub diff: i64,
+    pub in_sync: bool,
+    pub transferred_bytes_per_second: u64,
+    pub transfer_from_where: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrokerHaObservation {
+    pub broker_name: String,
+    pub broker_id: u64,
+    pub master_commit_log_max_offset: u64,
+    #[schemars(range(max = 64))]
+    pub in_sync_slave_count: u32,
+    pub pending_group_transfer_request_count: u64,
+    pub pending_group_transfer_oldest_wait_millis: u64,
+    pub group_transfer_ack_notify_count: u64,
+    pub connections: Vec<HaConnectionObservation>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrokerSyncStateObservation {
+    pub broker_name: String,
+    pub master_broker_id: u64,
+    pub master_epoch: i32,
+    pub sync_state_set_epoch: i32,
+    pub in_sync_replicas: Vec<LogicalBrokerInstance>,
+    pub not_in_sync_replicas: Vec<LogicalBrokerInstance>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControllerSyncStateObservation {
+    pub controller_name: String,
+    pub brokers: Vec<BrokerSyncStateObservation>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetHaStatusOutput {
+    pub cluster: String,
+    pub brokers: Vec<BrokerHaObservation>,
+    pub controller_sync_states: Vec<ControllerSyncStateObservation>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetControllerMetadataArgs {
+    pub cluster: String,
+    #[serde(default)]
+    pub controller_names: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControllerMetadataObservation {
+    pub controller_name: String,
+    pub group: Option<String>,
+    pub leader_id: Option<String>,
+    pub is_leader: Option<bool>,
+    #[schemars(range(max = 32))]
+    pub peer_count: Option<usize>,
+    pub last_log_index: Option<u64>,
+    pub committed_log_index: Option<u64>,
+    pub applied_log_index: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetControllerMetadataOutput {
+    pub cluster: String,
+    pub controllers: Vec<ControllerMetadataObservation>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetNameserverConfigSummaryArgs {
+    pub cluster: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct NameserverConfigValues {
+    pub cluster_test: Option<bool>,
+    pub order_message_enable: Option<bool>,
+    pub return_order_topic_config_to_broker: Option<bool>,
+    #[schemars(range(min = 1, max = 4096))]
+    pub client_request_thread_pool_nums: Option<i32>,
+    #[schemars(range(min = 1, max = 10_000_000))]
+    pub client_request_thread_pool_queue_capacity: Option<i32>,
+    #[schemars(range(min = 1, max = 3_600_000))]
+    pub scan_not_active_broker_interval_ms: Option<u64>,
+    #[schemars(range(min = 1, max = 10_000_000))]
+    pub unregister_broker_queue_capacity: Option<i32>,
+    pub support_acting_master: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct NameserverConfigObservation {
+    pub nameserver_name: String,
+    pub values: NameserverConfigValues,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NameserverConfigDifferenceField {
+    ClusterTest,
+    OrderMessageEnable,
+    ReturnOrderTopicConfigToBroker,
+    ClientRequestThreadPoolNums,
+    ClientRequestThreadPoolQueueCapacity,
+    ScanNotActiveBrokerIntervalMs,
+    UnregisterBrokerQueueCapacity,
+    SupportActingMaster,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GetNameserverConfigSummaryOutput {
+    pub cluster: String,
+    pub nameservers: Vec<NameserverConfigObservation>,
+    pub inconsistent_fields: Vec<NameserverConfigDifferenceField>,
+}

--- a/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/output_policy.rs
@@ -68,19 +68,28 @@ pub(crate) fn apply_with_policy(mut value: Value, policy: OutputPolicy) -> Resul
 }
 
 fn bound_rows(value: &mut Value, max_rows: usize) -> bool {
+    let mut remaining = max_rows;
+    bound_rows_with_remaining(value, &mut remaining)
+}
+
+fn bound_rows_with_remaining(value: &mut Value, remaining: &mut usize) -> bool {
     match value {
         Value::Object(object) => {
             let mut changed = false;
-            for value in object.values_mut() {
-                changed |= bound_rows(value, max_rows);
+            for (key, value) in object.iter_mut() {
+                if !matches!(key.as_str(), "warnings" | "source_failures") {
+                    changed |= bound_rows_with_remaining(value, remaining);
+                }
             }
             changed
         }
         Value::Array(values) => {
-            let mut changed = values.len() > max_rows;
-            values.truncate(max_rows);
+            let retained = values.len().min(*remaining);
+            let mut changed = retained != values.len();
+            values.truncate(retained);
+            *remaining -= retained;
             for value in values {
-                changed |= bound_rows(value, max_rows);
+                changed |= bound_rows_with_remaining(value, remaining);
             }
             changed
         }
@@ -167,6 +176,10 @@ fn normalize_source_failure(value: &Value) -> Option<Value> {
             | "topic_config"
             | "consumer_group_config"
             | "topic_stats"
+            | "broker_ha_runtime"
+            | "controller_sync_state"
+            | "controller_metadata"
+            | "nameserver_config"
     ) || !matches!(
         code,
         "source_unavailable" | "timeout" | "permission_denied" | "not_found" | "rate_limited" | "invalid_response"
@@ -314,6 +327,49 @@ mod tests {
     }
 
     #[test]
+    fn nested_row_policy_uses_one_query_wide_exact_budget() {
+        let exact = apply_with_policy(
+            json!({
+                "partial": false,
+                "warnings": [],
+                "data": {"brokers": [{"connections": [1, 2]}]}
+            }),
+            OutputPolicy {
+                max_bytes: 1024,
+                max_rows: 3,
+            },
+        )
+        .unwrap();
+        assert_eq!(exact["partial"], false);
+        assert_eq!(exact["data"]["brokers"][0]["connections"].as_array().unwrap().len(), 2);
+
+        let overflow = apply_with_policy(
+            json!({
+                "partial": false,
+                "warnings": [],
+                "data": {"brokers": [{"connections": [1, 2, 3]}]}
+            }),
+            OutputPolicy {
+                max_bytes: 1024,
+                max_rows: 3,
+            },
+        )
+        .unwrap();
+        assert_eq!(overflow["partial"], true);
+        assert_eq!(
+            overflow["data"]["brokers"][0]["connections"]
+                .as_array()
+                .unwrap()
+                .as_slice(),
+            [json!(1), json!(2)]
+        );
+        assert!(overflow["warnings"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("output_rows_truncated")));
+    }
+
+    #[test]
     fn source_failure_policy_sanitizes_deduplicates_orders_and_caps_metadata() {
         let mut failures = (0..20)
             .rev()
@@ -405,6 +461,70 @@ mod tests {
         assert!(!serialized.contains("address"));
         assert!(!serialized.contains("attributes"));
         assert!(!serialized.contains("must not escape"));
+    }
+
+    #[test]
+    fn infrastructure_sources_preserve_only_closed_metadata_and_mixed_cap_order() {
+        let sources = [
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config",
+        ];
+        for source in sources {
+            let output = apply(json!({
+                "source_failures": [{
+                    "source": source,
+                    "code": "invalid_response",
+                    "retryable": false,
+                    "logical_target": "logical-a",
+                    "raw_error": "private endpoint and backend body"
+                }]
+            }))
+            .unwrap();
+            assert_eq!(
+                output["source_failures"][0],
+                json!({
+                    "source": source,
+                    "code": "invalid_response",
+                    "retryable": false,
+                    "logical_target": "logical-a"
+                })
+            );
+        }
+
+        let failures = (0..17)
+            .rev()
+            .map(|index| {
+                json!({
+                    "source": sources[index % sources.len()],
+                    "code": if index % 2 == 0 { "timeout" } else { "source_unavailable" },
+                    "retryable": index % 2 == 0,
+                    "logical_target": format!("logical-{index:02}"),
+                    "address": "10.0.0.1:9878",
+                    "backend_text": "must not survive"
+                })
+            })
+            .collect::<Vec<_>>();
+        let output = apply(json!({
+            "partial": true,
+            "warnings": ["source_failures_present"],
+            "source_failures": failures
+        }))
+        .unwrap();
+        let failures = output["source_failures"].as_array().unwrap();
+        assert_eq!(failures.len(), MAX_SOURCE_FAILURES);
+        assert!(failures
+            .windows(2)
+            .all(|pair| source_failure_key(&pair[0]) <= source_failure_key(&pair[1])));
+        for source in sources {
+            assert!(failures.iter().any(|failure| failure["source"] == source));
+        }
+        assert!(failures.iter().all(|failure| failure.as_object().unwrap().len() == 4));
+        let serialized = output.to_string();
+        assert!(!serialized.contains("10.0.0.1"));
+        assert!(!serialized.contains("backend_text"));
+        assert!(!serialized.contains("must not survive"));
     }
 
     #[test]

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata.snap
@@ -135,7 +135,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -348,7 +352,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -610,7 +618,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -835,7 +847,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -1214,7 +1230,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -1455,7 +1475,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -1728,7 +1752,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -2346,7 +2374,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -2788,7 +2820,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -3032,7 +3068,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -3292,7 +3332,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -3789,7 +3833,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -4103,7 +4151,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -4360,7 +4412,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -4580,7 +4636,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -4735,7 +4795,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -5039,7 +5103,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -5268,7 +5336,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -5487,7 +5559,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -5883,7 +5959,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -6199,7 +6279,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -6297,5 +6381,877 @@ expression: contracts
       "type": "object"
     },
     "title": "RocketMQ consumer progress"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ HA status"
+    },
+    "description": "Get bounded HA observations for logical master Brokers with optional configured Controller sync state.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_names": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "controller_names": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "include_sync_state": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "cluster"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_ha_status",
+    "outputSchema": {
+      "$defs": {
+        "BrokerHaObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "connections": {
+              "items": {
+                "$ref": "#/$defs/HaConnectionObservation"
+              },
+              "type": "array"
+            },
+            "group_transfer_ack_notify_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "in_sync_slave_count": {
+              "format": "uint32",
+              "maximum": 64,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "master_commit_log_max_offset": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pending_group_transfer_oldest_wait_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pending_group_transfer_request_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id",
+            "master_commit_log_max_offset",
+            "in_sync_slave_count",
+            "pending_group_transfer_request_count",
+            "pending_group_transfer_oldest_wait_millis",
+            "group_transfer_ack_notify_count",
+            "connections"
+          ],
+          "type": "object"
+        },
+        "BrokerSyncStateObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "in_sync_replicas": {
+              "items": {
+                "$ref": "#/$defs/LogicalBrokerInstance"
+              },
+              "type": "array"
+            },
+            "master_broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "master_epoch": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "not_in_sync_replicas": {
+              "items": {
+                "$ref": "#/$defs/LogicalBrokerInstance"
+              },
+              "type": "array"
+            },
+            "sync_state_set_epoch": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "master_broker_id",
+            "master_epoch",
+            "sync_state_set_epoch",
+            "in_sync_replicas",
+            "not_in_sync_replicas"
+          ],
+          "type": "object"
+        },
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ControllerSyncStateObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerSyncStateObservation"
+              },
+              "type": "array"
+            },
+            "controller_name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "controller_name",
+            "brokers"
+          ],
+          "type": "object"
+        },
+        "GetHaStatusOutput": {
+          "additionalProperties": false,
+          "properties": {
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerHaObservation"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "controller_sync_states": {
+              "items": {
+                "$ref": "#/$defs/ControllerSyncStateObservation"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "cluster",
+            "brokers",
+            "controller_sync_states"
+          ],
+          "type": "object"
+        },
+        "HaConnectionObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "diff": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "in_sync": {
+              "type": "boolean"
+            },
+            "replica": {
+              "$ref": "#/$defs/LogicalBrokerInstance"
+            },
+            "slave_ack_offset": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "transfer_from_where": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "transferred_bytes_per_second": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "replica",
+            "slave_ack_offset",
+            "diff",
+            "in_sync",
+            "transferred_bytes_per_second",
+            "transfer_from_where"
+          ],
+          "type": "object"
+        },
+        "LogicalBrokerInstance": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetHaStatusOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ HA status"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ Controller metadata"
+    },
+    "description": "Get bounded metadata for configured logical Controller aliases.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "controller_names": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cluster"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_controller_metadata",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ControllerMetadataObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "applied_log_index": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "committed_log_index": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "controller_name": {
+              "type": "string"
+            },
+            "group": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_leader": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "last_log_index": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "leader_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "peer_count": {
+              "format": "uint",
+              "maximum": 32,
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "controller_name"
+          ],
+          "type": "object"
+        },
+        "GetControllerMetadataOutput": {
+          "additionalProperties": false,
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "controllers": {
+              "items": {
+                "$ref": "#/$defs/ControllerMetadataObservation"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "cluster",
+            "controllers"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetControllerMetadataOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ Controller metadata"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ NameServer configuration summary"
+    },
+    "description": "Get fixed allowlisted configuration values and differences for configured NameServers.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_nameserver_config_summary",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "GetNameserverConfigSummaryOutput": {
+          "additionalProperties": false,
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "inconsistent_fields": {
+              "items": {
+                "$ref": "#/$defs/NameserverConfigDifferenceField"
+              },
+              "type": "array"
+            },
+            "nameservers": {
+              "items": {
+                "$ref": "#/$defs/NameserverConfigObservation"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "cluster",
+            "nameservers",
+            "inconsistent_fields"
+          ],
+          "type": "object"
+        },
+        "NameserverConfigDifferenceField": {
+          "enum": [
+            "cluster_test",
+            "order_message_enable",
+            "return_order_topic_config_to_broker",
+            "client_request_thread_pool_nums",
+            "client_request_thread_pool_queue_capacity",
+            "scan_not_active_broker_interval_ms",
+            "unregister_broker_queue_capacity",
+            "support_acting_master"
+          ],
+          "type": "string"
+        },
+        "NameserverConfigObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "nameserver_name": {
+              "type": "string"
+            },
+            "values": {
+              "$ref": "#/$defs/NameserverConfigValues"
+            }
+          },
+          "required": [
+            "nameserver_name",
+            "values"
+          ],
+          "type": "object"
+        },
+        "NameserverConfigValues": {
+          "additionalProperties": false,
+          "properties": {
+            "client_request_thread_pool_nums": {
+              "format": "int32",
+              "maximum": 4096,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "client_request_thread_pool_queue_capacity": {
+              "format": "int32",
+              "maximum": 10000000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "cluster_test": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "order_message_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "return_order_topic_config_to_broker": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "scan_not_active_broker_interval_ms": {
+              "format": "uint64",
+              "maximum": 3600000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "support_acting_master": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "unregister_broker_queue_capacity": {
+              "format": "int32",
+              "maximum": 10000000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetNameserverConfigSummaryOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ NameServer configuration summary"
   }
 ]

--- a/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
+++ b/rocketmq-ai/rocketmq-mcp/src/tools/snapshots/rocketmq_mcp__tools__catalog__tests__tool_contract_schema_metadata_with_change_planning.snap
@@ -135,7 +135,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -348,7 +352,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -610,7 +618,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -835,7 +847,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -1214,7 +1230,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -1455,7 +1475,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -1728,7 +1752,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -2346,7 +2374,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -2788,7 +2820,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -3032,7 +3068,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -3292,7 +3332,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -3789,7 +3833,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -4103,7 +4151,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -4360,7 +4412,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -4580,7 +4636,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -4735,7 +4795,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -5039,7 +5103,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -5268,7 +5336,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -5487,7 +5559,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -5883,7 +5959,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -6199,7 +6279,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -6297,6 +6381,878 @@ expression: contracts
       "type": "object"
     },
     "title": "RocketMQ consumer progress"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ HA status"
+    },
+    "description": "Get bounded HA observations for logical master Brokers with optional configured Controller sync state.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_names": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "controller_names": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "include_sync_state": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "cluster"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_ha_status",
+    "outputSchema": {
+      "$defs": {
+        "BrokerHaObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "connections": {
+              "items": {
+                "$ref": "#/$defs/HaConnectionObservation"
+              },
+              "type": "array"
+            },
+            "group_transfer_ack_notify_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "in_sync_slave_count": {
+              "format": "uint32",
+              "maximum": 64,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "master_commit_log_max_offset": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pending_group_transfer_oldest_wait_millis": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pending_group_transfer_request_count": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id",
+            "master_commit_log_max_offset",
+            "in_sync_slave_count",
+            "pending_group_transfer_request_count",
+            "pending_group_transfer_oldest_wait_millis",
+            "group_transfer_ack_notify_count",
+            "connections"
+          ],
+          "type": "object"
+        },
+        "BrokerSyncStateObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "in_sync_replicas": {
+              "items": {
+                "$ref": "#/$defs/LogicalBrokerInstance"
+              },
+              "type": "array"
+            },
+            "master_broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "master_epoch": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "not_in_sync_replicas": {
+              "items": {
+                "$ref": "#/$defs/LogicalBrokerInstance"
+              },
+              "type": "array"
+            },
+            "sync_state_set_epoch": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "master_broker_id",
+            "master_epoch",
+            "sync_state_set_epoch",
+            "in_sync_replicas",
+            "not_in_sync_replicas"
+          ],
+          "type": "object"
+        },
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ControllerSyncStateObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerSyncStateObservation"
+              },
+              "type": "array"
+            },
+            "controller_name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "controller_name",
+            "brokers"
+          ],
+          "type": "object"
+        },
+        "GetHaStatusOutput": {
+          "additionalProperties": false,
+          "properties": {
+            "brokers": {
+              "items": {
+                "$ref": "#/$defs/BrokerHaObservation"
+              },
+              "type": "array"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "controller_sync_states": {
+              "items": {
+                "$ref": "#/$defs/ControllerSyncStateObservation"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "cluster",
+            "brokers",
+            "controller_sync_states"
+          ],
+          "type": "object"
+        },
+        "HaConnectionObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "diff": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "in_sync": {
+              "type": "boolean"
+            },
+            "replica": {
+              "$ref": "#/$defs/LogicalBrokerInstance"
+            },
+            "slave_ack_offset": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "transfer_from_where": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "transferred_bytes_per_second": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "replica",
+            "slave_ack_offset",
+            "diff",
+            "in_sync",
+            "transferred_bytes_per_second",
+            "transfer_from_where"
+          ],
+          "type": "object"
+        },
+        "LogicalBrokerInstance": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "broker_name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "broker_name",
+            "broker_id"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetHaStatusOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ HA status"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ Controller metadata"
+    },
+    "description": "Get bounded metadata for configured logical Controller aliases.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        },
+        "controller_names": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cluster"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_controller_metadata",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "ControllerMetadataObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "applied_log_index": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "committed_log_index": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "controller_name": {
+              "type": "string"
+            },
+            "group": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_leader": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "last_log_index": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "leader_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "peer_count": {
+              "format": "uint",
+              "maximum": 32,
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "controller_name"
+          ],
+          "type": "object"
+        },
+        "GetControllerMetadataOutput": {
+          "additionalProperties": false,
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "controllers": {
+              "items": {
+                "$ref": "#/$defs/ControllerMetadataObservation"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "cluster",
+            "controllers"
+          ],
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetControllerMetadataOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ Controller metadata"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "RocketMQ NameServer configuration summary"
+    },
+    "description": "Get fixed allowlisted configuration values and differences for configured NameServers.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cluster"
+      ],
+      "type": "object"
+    },
+    "name": "rocketmq_get_nameserver_config_summary",
+    "outputSchema": {
+      "$defs": {
+        "CacheStatus": {
+          "enum": [
+            "bypass",
+            "hit",
+            "miss"
+          ],
+          "type": "string"
+        },
+        "GetNameserverConfigSummaryOutput": {
+          "additionalProperties": false,
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "inconsistent_fields": {
+              "items": {
+                "$ref": "#/$defs/NameserverConfigDifferenceField"
+              },
+              "type": "array"
+            },
+            "nameservers": {
+              "items": {
+                "$ref": "#/$defs/NameserverConfigObservation"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "cluster",
+            "nameservers",
+            "inconsistent_fields"
+          ],
+          "type": "object"
+        },
+        "NameserverConfigDifferenceField": {
+          "enum": [
+            "cluster_test",
+            "order_message_enable",
+            "return_order_topic_config_to_broker",
+            "client_request_thread_pool_nums",
+            "client_request_thread_pool_queue_capacity",
+            "scan_not_active_broker_interval_ms",
+            "unregister_broker_queue_capacity",
+            "support_acting_master"
+          ],
+          "type": "string"
+        },
+        "NameserverConfigObservation": {
+          "additionalProperties": false,
+          "properties": {
+            "nameserver_name": {
+              "type": "string"
+            },
+            "values": {
+              "$ref": "#/$defs/NameserverConfigValues"
+            }
+          },
+          "required": [
+            "nameserver_name",
+            "values"
+          ],
+          "type": "object"
+        },
+        "NameserverConfigValues": {
+          "additionalProperties": false,
+          "properties": {
+            "client_request_thread_pool_nums": {
+              "format": "int32",
+              "maximum": 4096,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "client_request_thread_pool_queue_capacity": {
+              "format": "int32",
+              "maximum": 10000000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "cluster_test": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "order_message_enable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "return_order_topic_config_to_broker": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "scan_not_active_broker_interval_ms": {
+              "format": "uint64",
+              "maximum": 3600000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "support_acting_master": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "unregister_broker_queue_capacity": {
+              "format": "int32",
+              "maximum": 10000000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "QuerySource": {
+          "enum": [
+            "broker_runtime",
+            "broker_config",
+            "broker_log_filter",
+            "consumer_statistics",
+            "consumer_connection",
+            "producer_connection",
+            "topic_config",
+            "topic_stats",
+            "consumer_group_config",
+            "subscription_groups",
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
+          ],
+          "type": "string"
+        },
+        "SourceFailure": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "$ref": "#/$defs/SourceFailureCode"
+            },
+            "logical_target": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "source": {
+              "$ref": "#/$defs/QuerySource"
+            }
+          },
+          "required": [
+            "source",
+            "code",
+            "retryable",
+            "logical_target"
+          ],
+          "type": "object"
+        },
+        "SourceFailureCode": {
+          "enum": [
+            "source_unavailable",
+            "timeout",
+            "permission_denied",
+            "not_found",
+            "rate_limited",
+            "invalid_response"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cache_status": {
+          "$ref": "#/$defs/CacheStatus"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/GetNameserverConfigSummaryOutput"
+        },
+        "freshness_ms": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_at": {
+          "type": "string"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "source_failures": {
+          "items": {
+            "$ref": "#/$defs/SourceFailure"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "cluster",
+        "observed_at",
+        "freshness_ms",
+        "cache_status",
+        "partial",
+        "warnings",
+        "data"
+      ],
+      "type": "object"
+    },
+    "title": "RocketMQ NameServer configuration summary"
   },
   {
     "annotations": {
@@ -6480,7 +7436,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -6744,7 +7704,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -7004,7 +7968,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -7268,7 +8236,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },
@@ -7544,7 +8516,11 @@ expression: contracts
             "topic_stats",
             "consumer_group_config",
             "subscription_groups",
-            "topic_route"
+            "topic_route",
+            "broker_ha_runtime",
+            "controller_sync_state",
+            "controller_metadata",
+            "nameserver_config"
           ],
           "type": "string"
         },

--- a/rocketmq-client/src/admin.rs
+++ b/rocketmq-client/src/admin.rs
@@ -18,6 +18,8 @@ pub mod default_mq_admin_ext;
 pub mod default_mq_admin_ext_impl;
 #[cfg(feature = "admin-read")]
 mod mq_admin_consumer_observation_read_ext;
+#[cfg(feature = "admin-read")]
+mod mq_admin_infrastructure_observation_read_ext;
 #[cfg(feature = "admin-mutation")]
 mod mq_admin_mutation_ext;
 #[cfg(feature = "admin-read")]
@@ -47,6 +49,12 @@ pub use mq_admin_consumer_observation_read_ext::ConsumerGroupConfigRead;
 pub use mq_admin_consumer_observation_read_ext::ConsumerProgressRead;
 #[cfg(feature = "admin-read")]
 pub use mq_admin_consumer_observation_read_ext::MQAdminConsumerObservationReadExt;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_infrastructure_observation_read_ext::InfrastructureObservationReadError;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_infrastructure_observation_read_ext::InfrastructureObservationReadErrorCode;
+#[cfg(feature = "admin-read")]
+pub use mq_admin_infrastructure_observation_read_ext::MQAdminInfrastructureObservationReadExt;
 #[cfg(feature = "admin-mutation")]
 pub use mq_admin_mutation_ext::BrokerConfigPatchOutcome;
 #[cfg(feature = "admin-mutation")]

--- a/rocketmq-client/src/admin/mq_admin_infrastructure_observation_read_ext.rs
+++ b/rocketmq-client/src/admin/mq_admin_infrastructure_observation_read_ext.rs
@@ -1,0 +1,198 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Exact-target infrastructure observations for the `admin-read` capability.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::body::broker_replicas_info::BrokerReplicasInfo;
+use rocketmq_protocol::protocol::body::ha_runtime_info::HARuntimeInfo;
+use rocketmq_protocol::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
+
+use super::default_mq_admin_ext::DefaultMQAdminExt;
+
+/// Stable failure classification for exact infrastructure observation RPCs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InfrastructureObservationReadErrorCode {
+    SourceUnavailable,
+    Timeout,
+    PermissionDenied,
+    NotFound,
+    RateLimited,
+    InvalidResponse,
+}
+
+/// Address-free error returned by infrastructure observation RPCs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InfrastructureObservationReadError {
+    code: InfrastructureObservationReadErrorCode,
+    retryable: bool,
+}
+
+impl InfrastructureObservationReadError {
+    pub const fn new(code: InfrastructureObservationReadErrorCode, retryable: bool) -> Self {
+        Self { code, retryable }
+    }
+
+    pub const fn code(self) -> InfrastructureObservationReadErrorCode {
+        self.code
+    }
+
+    pub const fn retryable(self) -> bool {
+        self.retryable
+    }
+}
+
+impl std::fmt::Display for InfrastructureObservationReadError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "infrastructure observation failed: {:?}", self.code)
+    }
+}
+
+impl std::error::Error for InfrastructureObservationReadError {}
+
+/// Additive read-only access to four existing exact-target admin RPCs.
+///
+/// Target endpoints are accepted only from trusted adapters. Neither returned
+/// errors nor their `Debug` representation retain endpoint or remote detail.
+#[allow(async_fn_in_trait)]
+pub trait MQAdminInfrastructureObservationReadExt: Send {
+    async fn broker_ha_runtime_at(
+        &self,
+        broker_endpoint: CheetahString,
+    ) -> Result<HARuntimeInfo, InfrastructureObservationReadError>;
+
+    async fn controller_sync_state_at(
+        &self,
+        controller_endpoint: CheetahString,
+        broker_names: Vec<CheetahString>,
+    ) -> Result<BrokerReplicasInfo, InfrastructureObservationReadError>;
+
+    async fn controller_metadata_at(
+        &self,
+        controller_endpoint: CheetahString,
+    ) -> Result<GetMetaDataResponseHeader, InfrastructureObservationReadError>;
+
+    async fn nameserver_config_at(
+        &self,
+        nameserver_endpoint: CheetahString,
+    ) -> Result<HashMap<CheetahString, CheetahString>, InfrastructureObservationReadError>;
+}
+
+impl MQAdminInfrastructureObservationReadExt for DefaultMQAdminExt {
+    async fn broker_ha_runtime_at(
+        &self,
+        broker_endpoint: CheetahString,
+    ) -> Result<HARuntimeInfo, InfrastructureObservationReadError> {
+        self.inner()
+            .mq_client_api()
+            .map_err(sanitized_error)?
+            .get_broker_ha_status(
+                broker_endpoint,
+                self.inner().remoting_timeout_millis().map_err(sanitized_error)?,
+            )
+            .await
+            .map_err(sanitized_error)
+    }
+
+    async fn controller_sync_state_at(
+        &self,
+        controller_endpoint: CheetahString,
+        broker_names: Vec<CheetahString>,
+    ) -> Result<BrokerReplicasInfo, InfrastructureObservationReadError> {
+        self.inner()
+            .mq_client_api()
+            .map_err(sanitized_error)?
+            .get_in_sync_state_data_at(
+                controller_endpoint,
+                broker_names,
+                self.inner().remoting_timeout_millis().map_err(sanitized_error)?,
+            )
+            .await
+            .map_err(sanitized_error)
+    }
+
+    async fn controller_metadata_at(
+        &self,
+        controller_endpoint: CheetahString,
+    ) -> Result<GetMetaDataResponseHeader, InfrastructureObservationReadError> {
+        self.inner()
+            .mq_client_api()
+            .map_err(sanitized_error)?
+            .get_controller_metadata(
+                controller_endpoint,
+                self.inner().remoting_timeout_millis().map_err(sanitized_error)?,
+            )
+            .await
+            .map_err(sanitized_error)
+    }
+
+    async fn nameserver_config_at(
+        &self,
+        nameserver_endpoint: CheetahString,
+    ) -> Result<HashMap<CheetahString, CheetahString>, InfrastructureObservationReadError> {
+        let mut responses = self
+            .inner()
+            .mq_client_api()
+            .map_err(sanitized_error)?
+            .get_name_server_config(
+                Some(vec![nameserver_endpoint.clone()]),
+                Duration::from_millis(self.inner().remoting_timeout_millis().map_err(sanitized_error)?),
+            )
+            .await
+            .map_err(sanitized_error)?
+            .ok_or_else(invalid_response)?;
+        if responses.len() != 1 {
+            return Err(invalid_response());
+        }
+        responses.remove(&nameserver_endpoint).ok_or_else(invalid_response)
+    }
+}
+
+fn sanitized_error(error: RocketMQError) -> InfrastructureObservationReadError {
+    let view = error.boundary_view();
+    let code = match view.http().status.as_u16() {
+        401 | 403 => InfrastructureObservationReadErrorCode::PermissionDenied,
+        404 => InfrastructureObservationReadErrorCode::NotFound,
+        408 | 504 => InfrastructureObservationReadErrorCode::Timeout,
+        429 => InfrastructureObservationReadErrorCode::RateLimited,
+        400 | 413 | 422 => InfrastructureObservationReadErrorCode::InvalidResponse,
+        _ => InfrastructureObservationReadErrorCode::SourceUnavailable,
+    };
+    InfrastructureObservationReadError::new(code, view.is_retryable())
+}
+
+const fn invalid_response() -> InfrastructureObservationReadError {
+    InfrastructureObservationReadError::new(InfrastructureObservationReadErrorCode::InvalidResponse, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_error_is_typed_and_never_retains_endpoint_detail() {
+        let error = sanitized_error(RocketMQError::network_connection_failed(
+            "10.23.45.67:10911",
+            "private-controller.internal:9878",
+        ));
+        assert_eq!(error.code(), InfrastructureObservationReadErrorCode::SourceUnavailable);
+        let rendered = format!("{error:?} {error}");
+        assert!(!rendered.contains("10.23.45.67"));
+        assert!(!rendered.contains("private-controller"));
+    }
+}

--- a/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
@@ -2327,7 +2327,9 @@ impl MQClientAPIImpl {
                             let body_str = String::from_utf8_lossy(body.as_ref()).to_string();
                             // if body_str contains =, return from Java version
                             let properties = if body_str.contains('=') {
-                                mix_all::string_to_properties(&body_str).unwrap_or_default()
+                                mix_all::string_to_properties(&body_str).ok_or_else(|| {
+                                    mq_client_err!("Failed to parse namesrv config properties".to_string())
+                                })?
                             } else {
                                 SerdeJsonUtils::from_json_str::<HashMap<CheetahString, CheetahString>>(&body_str)
                                     .map_err(|e| mq_client_err!(format!("Failed to parse namesrv config JSON: {e}")))?
@@ -2408,13 +2410,27 @@ impl MQClientAPIImpl {
         let controller_meta_data = self.get_controller_metadata(controller_address, timeout_millis).await?;
         let leader_address = controller_leader_address(controller_meta_data)?;
 
+        self.get_in_sync_state_data_at(leader_address, brokers, timeout_millis)
+            .await
+    }
+
+    /// Queries sync-state data at exactly the supplied Controller endpoint.
+    ///
+    /// Unlike [`Self::get_in_sync_state_data`], this method performs no metadata
+    /// lookup and never follows a Controller-advertised leader address.
+    pub async fn get_in_sync_state_data_at(
+        &self,
+        controller_address: CheetahString,
+        brokers: Vec<CheetahString>,
+        timeout_millis: u64,
+    ) -> RocketMQResult<BrokerReplicasInfo> {
         let request = self.create_remoting_command(RequestCode::ControllerGetSyncStateData);
         let body = serde_json::to_vec(&brokers)
             .map_err(|e| mq_client_err!(format!("Failed to serialize broker names: {}", e)))?;
         let request = request.set_body(body);
         let response = self
             .remoting_client
-            .invoke_request(Some(&leader_address), request, timeout_millis)
+            .invoke_request(Some(&controller_address), request, timeout_millis)
             .await?;
         match ResponseCode::from(response.code()) {
             ResponseCode::Success => {

--- a/rocketmq-client/src/public_api.rs
+++ b/rocketmq-client/src/public_api.rs
@@ -37,7 +37,13 @@ pub use crate::admin::ConsumerProgressRead;
 pub use crate::admin::DefaultMQAdminExt;
 pub use crate::admin::DefaultMQAdminExtImpl;
 #[cfg(feature = "admin-read")]
+pub use crate::admin::InfrastructureObservationReadError;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::InfrastructureObservationReadErrorCode;
+#[cfg(feature = "admin-read")]
 pub use crate::admin::MQAdminConsumerObservationReadExt;
+#[cfg(feature = "admin-read")]
+pub use crate::admin::MQAdminInfrastructureObservationReadExt;
 #[cfg(feature = "admin-read")]
 pub use crate::admin::MQAdminMessageReadExt;
 #[cfg(feature = "admin-mutation")]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/infrastructure_observation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/infrastructure_observation.rs
@@ -1,0 +1,1079 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Read-client implementation of address-free infrastructure observations.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+use rocketmq_client_rust::DefaultMQAdminExt;
+use rocketmq_client_rust::InfrastructureObservationReadError;
+use rocketmq_client_rust::InfrastructureObservationReadErrorCode;
+use rocketmq_client_rust::MQAdminInfrastructureObservationReadExt;
+use rocketmq_client_rust::MQAdminReadExt;
+use rocketmq_error::RocketMQError;
+use rocketmq_model::common::mix_all;
+use rocketmq_protocol::protocol::body::broker_body::cluster_info::ClusterInfo;
+use rocketmq_protocol::protocol::body::broker_replicas_info::BrokerReplicasInfo;
+use rocketmq_protocol::protocol::body::ha_runtime_info::HARuntimeInfo;
+use rocketmq_protocol::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
+
+use crate::core::broker::canonical_remoting_endpoint;
+use crate::core::infrastructure_observation::BrokerHaObservation;
+use crate::core::infrastructure_observation::BrokerSyncStateObservation;
+use crate::core::infrastructure_observation::ControllerMetadataObservation;
+use crate::core::infrastructure_observation::ControllerSyncStateObservation;
+use crate::core::infrastructure_observation::HaConnectionObservation;
+use crate::core::infrastructure_observation::LogicalBrokerInstance;
+use crate::core::infrastructure_observation::NameserverConfigDifferenceField;
+use crate::core::infrastructure_observation::NameserverConfigObservation;
+use crate::core::infrastructure_observation::NameserverConfigValues;
+use crate::core::infrastructure_observation::QueryControllerMetadataRequest;
+use crate::core::infrastructure_observation::QueryControllerMetadataResult;
+use crate::core::infrastructure_observation::QueryHaStatusRequest;
+use crate::core::infrastructure_observation::QueryHaStatusResult;
+use crate::core::infrastructure_observation::QueryNameserverConfigSummaryRequest;
+use crate::core::infrastructure_observation::QueryNameserverConfigSummaryResult;
+use crate::core::infrastructure_observation::MAX_BROKER_INSTANCES_PER_LOGICAL_BROKER;
+use crate::core::infrastructure_observation::MAX_CONTROLLER_PEERS;
+use crate::core::infrastructure_observation::MAX_CONTROLLER_TARGETS;
+use crate::core::infrastructure_observation::MAX_HA_BROKER_TARGETS;
+use crate::core::infrastructure_observation::MAX_HA_CONNECTIONS_PER_BROKER;
+use crate::core::infrastructure_observation::MAX_INFRASTRUCTURE_QUERY_ROWS;
+use crate::core::infrastructure_observation::MAX_NAMESERVER_TARGETS;
+use crate::core::infrastructure_observation::MAX_SYNC_BROKERS;
+use crate::core::infrastructure_observation::MAX_SYNC_REPLICAS_PER_BROKER;
+use crate::core::query::AdminQueryFailureCode;
+use crate::core::query::AdminQueryResult;
+use crate::core::query::AdminQuerySource;
+use crate::core::query::AdminSourceFailure;
+use crate::core::AdminError;
+use crate::core::AdminResult;
+use crate::read_client_adapter::ControllerObservationTarget;
+
+type ObservationResult<T> = Result<T, InfrastructureObservationReadError>;
+
+const MAX_NAMESERVER_THREAD_COUNT: i32 = 4_096;
+const MAX_NAMESERVER_QUEUE_CAPACITY: i32 = 10_000_000;
+const MAX_NAMESERVER_SCAN_INTERVAL_MILLIS: u64 = 3_600_000;
+const MAX_WIRE_I64: u64 = i64::MAX as u64;
+const MAX_REMOTING_ENDPOINT_BYTES: usize = 512;
+const MAX_CONTROLLER_PEERS_BYTES: usize =
+    MAX_CONTROLLER_PEERS * MAX_REMOTING_ENDPOINT_BYTES + (MAX_CONTROLLER_PEERS - 1);
+
+#[derive(Debug)]
+struct QueryRowBudget {
+    remaining: usize,
+}
+
+impl QueryRowBudget {
+    const fn new() -> Self {
+        Self {
+            remaining: MAX_INFRASTRUCTURE_QUERY_ROWS,
+        }
+    }
+
+    fn reserve_source(&mut self, rows: usize) -> bool {
+        let Some(remaining) = self.remaining.checked_sub(rows) else {
+            return false;
+        };
+        self.remaining = remaining;
+        true
+    }
+}
+
+#[allow(async_fn_in_trait)]
+trait InfrastructureObservationSource: Send {
+    async fn cluster_info(&self) -> Result<ClusterInfo, RocketMQError>;
+    async fn ha_runtime(&self, endpoint: CheetahString) -> ObservationResult<HARuntimeInfo>;
+    async fn sync_state(
+        &self,
+        endpoint: CheetahString,
+        broker_names: Vec<CheetahString>,
+    ) -> ObservationResult<BrokerReplicasInfo>;
+    async fn controller_metadata(&self, endpoint: CheetahString) -> ObservationResult<GetMetaDataResponseHeader>;
+    async fn nameserver_config(
+        &self,
+        endpoint: CheetahString,
+    ) -> ObservationResult<HashMap<CheetahString, CheetahString>>;
+}
+
+impl InfrastructureObservationSource for DefaultMQAdminExt {
+    async fn cluster_info(&self) -> Result<ClusterInfo, RocketMQError> {
+        MQAdminReadExt::examine_broker_cluster_info(self).await
+    }
+
+    async fn ha_runtime(&self, endpoint: CheetahString) -> ObservationResult<HARuntimeInfo> {
+        MQAdminInfrastructureObservationReadExt::broker_ha_runtime_at(self, endpoint).await
+    }
+
+    async fn sync_state(
+        &self,
+        endpoint: CheetahString,
+        broker_names: Vec<CheetahString>,
+    ) -> ObservationResult<BrokerReplicasInfo> {
+        MQAdminInfrastructureObservationReadExt::controller_sync_state_at(self, endpoint, broker_names).await
+    }
+
+    async fn controller_metadata(&self, endpoint: CheetahString) -> ObservationResult<GetMetaDataResponseHeader> {
+        MQAdminInfrastructureObservationReadExt::controller_metadata_at(self, endpoint).await
+    }
+
+    async fn nameserver_config(
+        &self,
+        endpoint: CheetahString,
+    ) -> ObservationResult<HashMap<CheetahString, CheetahString>> {
+        MQAdminInfrastructureObservationReadExt::nameserver_config_at(self, endpoint).await
+    }
+}
+
+pub(crate) fn validate_controller_targets(
+    mut targets: Vec<ControllerObservationTarget>,
+) -> AdminResult<Vec<ControllerObservationTarget>> {
+    if targets.len() > MAX_CONTROLLER_TARGETS {
+        return Err(AdminError::invalid_argument(
+            "controller_targets",
+            format!("must contain at most {MAX_CONTROLLER_TARGETS} configured Controllers"),
+        ));
+    }
+    targets.sort_by(|left, right| left.name().cmp(right.name()));
+    let mut names = BTreeSet::new();
+    let mut endpoints = BTreeSet::new();
+    for target in &targets {
+        if !safe_logical_identifier(target.name()) {
+            return Err(AdminError::invalid_argument(
+                "controller_targets",
+                "Controller names must be bounded logical aliases",
+            ));
+        }
+        let Some(endpoint) = canonical_remoting_endpoint(target.endpoint()) else {
+            return Err(AdminError::invalid_argument(
+                "controller_targets",
+                "Controller endpoints must be bounded remoting endpoints",
+            ));
+        };
+        if !names.insert(target.name()) || !endpoints.insert(endpoint) {
+            return Err(AdminError::invalid_argument(
+                "controller_targets",
+                "Controller names and endpoints must be unique",
+            ));
+        }
+    }
+    Ok(targets)
+}
+
+pub(crate) fn parse_nameserver_endpoints(value: &str) -> AdminResult<Vec<CheetahString>> {
+    let mut endpoints = value
+        .split(';')
+        .map(str::trim)
+        .filter(|endpoint| !endpoint.is_empty())
+        .collect::<Vec<_>>();
+    if endpoints.len() > MAX_NAMESERVER_TARGETS {
+        return Err(AdminError::invalid_argument(
+            "namesrv_addr",
+            format!("must contain at most {MAX_NAMESERVER_TARGETS} configured NameServers"),
+        ));
+    }
+    endpoints.sort_unstable_by_key(|endpoint| canonical_remoting_endpoint(endpoint));
+    let canonical = endpoints
+        .iter()
+        .map(|endpoint| canonical_remoting_endpoint(endpoint))
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| {
+            AdminError::invalid_argument(
+                "namesrv_addr",
+                "configured NameServers must be bounded remoting endpoints",
+            )
+        })?;
+    if canonical.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(AdminError::invalid_argument(
+            "namesrv_addr",
+            "configured NameServer endpoints must be unique",
+        ));
+    }
+    Ok(endpoints.into_iter().map(CheetahString::from).collect())
+}
+
+pub(crate) async fn query_ha_status(
+    source: &DefaultMQAdminExt,
+    controllers: &[ControllerObservationTarget],
+    request: &QueryHaStatusRequest,
+) -> AdminResult<AdminQueryResult<QueryHaStatusResult>> {
+    query_ha_status_from(source, controllers, request).await
+}
+
+pub(crate) async fn query_controller_metadata(
+    source: &DefaultMQAdminExt,
+    controllers: &[ControllerObservationTarget],
+    request: &QueryControllerMetadataRequest,
+) -> AdminResult<AdminQueryResult<QueryControllerMetadataResult>> {
+    query_controller_metadata_from(source, controllers, request).await
+}
+
+pub(crate) async fn query_nameserver_config_summary(
+    source: &DefaultMQAdminExt,
+    nameservers: &[CheetahString],
+    request: &QueryNameserverConfigSummaryRequest,
+) -> AdminResult<AdminQueryResult<QueryNameserverConfigSummaryResult>> {
+    query_nameserver_config_summary_from(source, nameservers, request).await
+}
+
+async fn query_ha_status_from<S: InfrastructureObservationSource>(
+    source: &S,
+    controllers: &[ControllerObservationTarget],
+    request: &QueryHaStatusRequest,
+) -> AdminResult<AdminQueryResult<QueryHaStatusResult>> {
+    let request = QueryHaStatusRequest::try_new(
+        &request.cluster,
+        request.broker_names.clone(),
+        request.include_sync_state,
+        request.controller_names.clone(),
+    )?;
+    let selected_controllers = if request.include_sync_state {
+        resolve_controller_targets(controllers, &request.controller_names)?
+    } else {
+        Vec::new()
+    };
+    let cluster_info = source
+        .cluster_info()
+        .await
+        .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+    let topology = resolve_ha_topology(&cluster_info, &request.cluster, &request.broker_names)?;
+
+    let mut failures = topology.failures;
+    let mut successful_sources = 0usize;
+    let mut brokers = Vec::new();
+    let mut row_budget = QueryRowBudget::new();
+    for target in topology.masters {
+        match source.ha_runtime(target.endpoint).await {
+            Ok(runtime) => {
+                match project_ha_runtime(
+                    &target.broker_name,
+                    target.broker_id,
+                    target.configured_slave_count,
+                    runtime,
+                    &topology.identities,
+                ) {
+                    Some(row) => {
+                        let rows = 1usize.saturating_add(row.connections.len());
+                        if row_budget.reserve_source(rows) {
+                            successful_sources += 1;
+                            brokers.push(row);
+                        } else {
+                            failures.push(invalid_failure(AdminQuerySource::BrokerHaRuntime, &target.broker_name));
+                        }
+                    }
+                    None => failures.push(invalid_failure(AdminQuerySource::BrokerHaRuntime, &target.broker_name)),
+                }
+            }
+            Err(error) => failures.push(observation_failure(
+                AdminQuerySource::BrokerHaRuntime,
+                &target.broker_name,
+                error,
+            )),
+        }
+    }
+
+    let broker_names = topology.selected_broker_names;
+    let wire_broker_names = broker_names.iter().map(CheetahString::from).collect::<Vec<_>>();
+    let mut controller_sync_states = Vec::new();
+    for target in selected_controllers {
+        let metadata = match source.controller_metadata(CheetahString::from(target.endpoint())).await {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                failures.push(observation_failure(
+                    AdminQuerySource::ControllerSyncState,
+                    target.name(),
+                    error,
+                ));
+                continue;
+            }
+        };
+        let Some(validated_metadata) = validate_controller_metadata(target.endpoint(), metadata) else {
+            failures.push(invalid_failure(AdminQuerySource::ControllerSyncState, target.name()));
+            continue;
+        };
+        let Some(leader_endpoint) = configured_controller_leader(controllers, &validated_metadata) else {
+            failures.push(invalid_failure(AdminQuerySource::ControllerSyncState, target.name()));
+            continue;
+        };
+        match source
+            .sync_state(CheetahString::from(leader_endpoint), wire_broker_names.clone())
+            .await
+        {
+            Ok(sync_state) => {
+                match project_sync_state(target.name(), sync_state, &broker_names, &topology.identities) {
+                    Some(row) => {
+                        let rows = controller_sync_state_rows(&row);
+                        if row_budget.reserve_source(rows) {
+                            successful_sources += 1;
+                            controller_sync_states.push(row);
+                        } else {
+                            failures.push(invalid_failure(AdminQuerySource::ControllerSyncState, target.name()));
+                        }
+                    }
+                    None => failures.push(invalid_failure(AdminQuerySource::ControllerSyncState, target.name())),
+                }
+            }
+            Err(error) => failures.push(observation_failure(
+                AdminQuerySource::ControllerSyncState,
+                target.name(),
+                error,
+            )),
+        }
+    }
+    brokers.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    controller_sync_states.sort_by(|left, right| left.controller_name.cmp(&right.controller_name));
+    AdminQueryResult::from_sources(
+        QueryHaStatusResult {
+            brokers,
+            controller_sync_states,
+        },
+        successful_sources,
+        failures,
+    )
+}
+
+async fn query_controller_metadata_from<S: InfrastructureObservationSource>(
+    source: &S,
+    controllers: &[ControllerObservationTarget],
+    request: &QueryControllerMetadataRequest,
+) -> AdminResult<AdminQueryResult<QueryControllerMetadataResult>> {
+    let request = QueryControllerMetadataRequest::try_new(&request.cluster, request.controller_names.clone())?;
+    let selected = resolve_controller_targets(controllers, &request.controller_names)?;
+    let mut successful_sources = 0usize;
+    let mut failures = Vec::new();
+    let mut rows = Vec::new();
+    for target in selected {
+        match source.controller_metadata(CheetahString::from(target.endpoint())).await {
+            Ok(header) => match validate_controller_metadata(target.endpoint(), header) {
+                Some(validated) => {
+                    successful_sources += 1;
+                    rows.push(validated.into_observation(target.name()));
+                }
+                None => failures.push(invalid_failure(AdminQuerySource::ControllerMetadata, target.name())),
+            },
+            Err(error) => failures.push(observation_failure(
+                AdminQuerySource::ControllerMetadata,
+                target.name(),
+                error,
+            )),
+        }
+    }
+    rows.sort_by(|left, right| left.controller_name.cmp(&right.controller_name));
+    AdminQueryResult::from_sources(
+        QueryControllerMetadataResult { controllers: rows },
+        successful_sources,
+        failures,
+    )
+}
+
+async fn query_nameserver_config_summary_from<S: InfrastructureObservationSource>(
+    source: &S,
+    nameservers: &[CheetahString],
+    request: &QueryNameserverConfigSummaryRequest,
+) -> AdminResult<AdminQueryResult<QueryNameserverConfigSummaryResult>> {
+    QueryNameserverConfigSummaryRequest::try_new(&request.cluster)?;
+    if nameservers.is_empty() {
+        return Err(AdminError::invalid_argument(
+            "namesrv_addr",
+            "no configured NameServer targets are available",
+        ));
+    }
+    if nameservers.len() > MAX_NAMESERVER_TARGETS {
+        return Err(AdminError::invalid_argument(
+            "namesrv_addr",
+            format!("must contain at most {MAX_NAMESERVER_TARGETS} configured NameServers"),
+        ));
+    }
+    let mut successful_sources = 0usize;
+    let mut failures = Vec::new();
+    let mut rows = Vec::new();
+    for (index, endpoint) in nameservers.iter().enumerate() {
+        let name = format!("nameserver-{}", index + 1);
+        match source.nameserver_config(endpoint.clone()).await {
+            Ok(config) => match parse_nameserver_config(&config) {
+                Some(values) => {
+                    successful_sources += 1;
+                    rows.push(NameserverConfigObservation {
+                        nameserver_name: name,
+                        values,
+                    });
+                }
+                None => failures.push(invalid_failure(AdminQuerySource::NameserverConfig, &name)),
+            },
+            Err(error) => failures.push(observation_failure(AdminQuerySource::NameserverConfig, &name, error)),
+        }
+    }
+    let inconsistent_fields = nameserver_differences(&rows);
+    AdminQueryResult::from_sources(
+        QueryNameserverConfigSummaryResult {
+            nameservers: rows,
+            inconsistent_fields,
+        },
+        successful_sources,
+        failures,
+    )
+}
+
+struct HaTopology {
+    masters: Vec<HaMasterTarget>,
+    identities: BTreeMap<String, Option<LogicalBrokerInstance>>,
+    selected_broker_names: BTreeSet<String>,
+    failures: Vec<AdminSourceFailure>,
+}
+
+struct HaMasterTarget {
+    broker_name: String,
+    broker_id: u64,
+    configured_slave_count: usize,
+    endpoint: CheetahString,
+}
+
+fn resolve_ha_topology(cluster_info: &ClusterInfo, cluster: &str, selectors: &[String]) -> AdminResult<HaTopology> {
+    let membership = cluster_info
+        .cluster_addr_table
+        .as_ref()
+        .and_then(|table| table.get(cluster))
+        .ok_or_else(|| AdminError::not_found("cluster", cluster))?;
+    let selected_broker_names = if selectors.is_empty() {
+        if membership.is_empty() {
+            return Err(AdminError::not_found("cluster", cluster));
+        }
+        if membership.len() > MAX_HA_BROKER_TARGETS {
+            return Err(target_limit_error());
+        }
+        membership.iter().map(ToString::to_string).collect::<BTreeSet<_>>()
+    } else {
+        for selector in selectors {
+            if !membership.contains(selector.as_str()) {
+                return Err(AdminError::not_found("broker", selector));
+            }
+        }
+        selectors.iter().cloned().collect()
+    };
+    if selected_broker_names.len() > MAX_HA_BROKER_TARGETS {
+        return Err(target_limit_error());
+    }
+
+    let broker_table = cluster_info.broker_addr_table.as_ref();
+    let mut identities = BTreeMap::<String, Option<LogicalBrokerInstance>>::new();
+    let mut failures = Vec::new();
+    let mut master_candidates = Vec::new();
+    for broker_name in &selected_broker_names {
+        let Some(broker) = broker_table.and_then(|table| table.get(broker_name.as_str())) else {
+            failures.push(invalid_failure(AdminQuerySource::BrokerHaRuntime, broker_name));
+            continue;
+        };
+        if broker.cluster() != cluster
+            || broker.broker_name().as_str() != broker_name
+            || !safe_logical_identifier(broker_name)
+        {
+            failures.push(invalid_failure(AdminQuerySource::BrokerHaRuntime, broker_name));
+            continue;
+        }
+        if broker.broker_addrs().is_empty() || broker.broker_addrs().len() > MAX_BROKER_INSTANCES_PER_LOGICAL_BROKER {
+            failures.push(invalid_failure(AdminQuerySource::BrokerHaRuntime, broker_name));
+            continue;
+        }
+        let mut local_endpoints = BTreeSet::new();
+        let mut local_identities = Vec::with_capacity(broker.broker_addrs().len());
+        let mut valid = true;
+        for (broker_id, endpoint) in broker.broker_addrs() {
+            let Some(canonical) = canonical_remoting_endpoint(endpoint.as_str()) else {
+                valid = false;
+                break;
+            };
+            if *broker_id > MAX_WIRE_I64 || !local_endpoints.insert(canonical.clone()) {
+                valid = false;
+                break;
+            }
+            local_identities.push((
+                canonical,
+                LogicalBrokerInstance {
+                    broker_name: broker_name.clone(),
+                    broker_id: *broker_id,
+                },
+            ));
+        }
+        let Some(master_endpoint) = broker.broker_addrs().get(&mix_all::MASTER_ID) else {
+            failures.push(invalid_failure(AdminQuerySource::BrokerHaRuntime, broker_name));
+            continue;
+        };
+        let Some(master_canonical) = canonical_remoting_endpoint(master_endpoint.as_str()) else {
+            failures.push(invalid_failure(AdminQuerySource::BrokerHaRuntime, broker_name));
+            continue;
+        };
+        if !valid {
+            failures.push(invalid_failure(AdminQuerySource::BrokerHaRuntime, broker_name));
+            continue;
+        }
+        for (endpoint, identity) in local_identities {
+            match identities.entry(endpoint) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(Some(identity));
+                }
+                std::collections::btree_map::Entry::Occupied(mut entry) => {
+                    entry.insert(None);
+                }
+            }
+        }
+        master_candidates.push((
+            broker_name.clone(),
+            master_endpoint.clone(),
+            master_canonical,
+            broker.broker_addrs().len() - 1,
+        ));
+    }
+
+    let mut masters = Vec::new();
+    for (broker_name, endpoint, canonical, configured_slave_count) in master_candidates {
+        if !identities
+            .get(&canonical)
+            .and_then(Option::as_ref)
+            .is_some_and(|identity| identity.broker_name == broker_name && identity.broker_id == mix_all::MASTER_ID)
+        {
+            failures.push(invalid_failure(AdminQuerySource::BrokerHaRuntime, &broker_name));
+            continue;
+        }
+        masters.push(HaMasterTarget {
+            broker_name,
+            broker_id: mix_all::MASTER_ID,
+            configured_slave_count,
+            endpoint,
+        });
+    }
+    Ok(HaTopology {
+        masters,
+        identities,
+        selected_broker_names,
+        failures,
+    })
+}
+
+fn target_limit_error() -> AdminError {
+    AdminError::backend_view(
+        "resolve_ha_targets",
+        "HA_OBSERVATION_TARGET_LIMIT_EXCEEDED",
+        "selected cluster has too many logical Broker masters",
+        None,
+        422,
+        false,
+    )
+}
+
+fn resolve_controller_targets<'a>(
+    configured: &'a [ControllerObservationTarget],
+    selectors: &[String],
+) -> AdminResult<Vec<&'a ControllerObservationTarget>> {
+    if configured.is_empty() {
+        return Err(AdminError::invalid_argument(
+            "controller_names",
+            "no configured logical Controller aliases are available",
+        ));
+    }
+    if configured.len() > MAX_CONTROLLER_TARGETS {
+        return Err(AdminError::invalid_argument(
+            "controller_names",
+            format!("must contain at most {MAX_CONTROLLER_TARGETS} configured Controllers"),
+        ));
+    }
+    let by_name = configured
+        .iter()
+        .map(|target| (target.name(), target))
+        .collect::<BTreeMap<_, _>>();
+    let names = if selectors.is_empty() {
+        by_name.keys().map(|name| (*name).to_string()).collect::<Vec<_>>()
+    } else {
+        selectors.to_vec()
+    };
+    let mut selected = Vec::with_capacity(names.len());
+    for name in names {
+        selected.push(
+            by_name
+                .get(name.as_str())
+                .copied()
+                .ok_or_else(|| AdminError::not_found("controller", &name))?,
+        );
+    }
+    Ok(selected)
+}
+
+fn project_ha_runtime(
+    broker_name: &str,
+    broker_id: u64,
+    configured_slave_count: usize,
+    runtime: HARuntimeInfo,
+    identities: &BTreeMap<String, Option<LogicalBrokerInstance>>,
+) -> Option<BrokerHaObservation> {
+    let reported_in_sync = usize::try_from(runtime.in_sync_slave_nums).ok()?;
+    let observed_in_sync = runtime
+        .ha_connection_info
+        .iter()
+        .filter(|connection| connection.in_sync)
+        .count();
+    if !runtime.master
+        || runtime.master_commit_log_max_offset > MAX_WIRE_I64
+        || reported_in_sync > MAX_HA_CONNECTIONS_PER_BROKER
+        || reported_in_sync > configured_slave_count
+        || observed_in_sync > reported_in_sync
+        || runtime.ha_connection_info.len() > MAX_HA_CONNECTIONS_PER_BROKER
+        || runtime.pending_group_transfer_request_count > MAX_WIRE_I64
+        || runtime.pending_group_transfer_oldest_wait_millis > MAX_WIRE_I64
+        || runtime.group_transfer_ack_notify_count > MAX_WIRE_I64
+    {
+        return None;
+    }
+    let mut connections = Vec::new();
+    let mut unique_ids = BTreeSet::new();
+    let mut unique_endpoints = BTreeSet::new();
+    for connection in runtime.ha_connection_info {
+        let canonical = canonical_remoting_endpoint(&connection.addr)?;
+        let replica = identities.get(&canonical).and_then(Option::as_ref)?.clone();
+        let expected_diff = runtime
+            .master_commit_log_max_offset
+            .checked_sub(connection.slave_ack_offset)?;
+        if replica.broker_name != broker_name
+            || replica.broker_id == mix_all::MASTER_ID
+            || replica.broker_id > MAX_WIRE_I64
+            || connection.slave_ack_offset > MAX_WIRE_I64
+            || connection.transfer_from_where > MAX_WIRE_I64
+            || connection.transferred_byte_in_second > MAX_WIRE_I64
+            || connection.slave_ack_offset > runtime.master_commit_log_max_offset
+            || connection.transfer_from_where > runtime.master_commit_log_max_offset
+            || connection.diff < 0
+            || u64::try_from(connection.diff).ok()? != expected_diff
+            || !unique_ids.insert(replica.broker_id)
+            || !unique_endpoints.insert(canonical)
+        {
+            return None;
+        }
+        connections.push(HaConnectionObservation {
+            replica,
+            slave_ack_offset: connection.slave_ack_offset,
+            diff: connection.diff,
+            in_sync: connection.in_sync,
+            transferred_bytes_per_second: connection.transferred_byte_in_second,
+            transfer_from_where: connection.transfer_from_where,
+        });
+    }
+    connections.sort_by(|left, right| {
+        left.replica
+            .broker_name
+            .cmp(&right.replica.broker_name)
+            .then(left.replica.broker_id.cmp(&right.replica.broker_id))
+    });
+    Some(BrokerHaObservation {
+        broker_name: broker_name.to_string(),
+        broker_id,
+        master_commit_log_max_offset: runtime.master_commit_log_max_offset,
+        in_sync_slave_count: u32::try_from(reported_in_sync).ok()?,
+        pending_group_transfer_request_count: runtime.pending_group_transfer_request_count,
+        pending_group_transfer_oldest_wait_millis: runtime.pending_group_transfer_oldest_wait_millis,
+        group_transfer_ack_notify_count: runtime.group_transfer_ack_notify_count,
+        connections,
+    })
+}
+
+fn project_sync_state(
+    controller_name: &str,
+    sync_state: BrokerReplicasInfo,
+    selected_brokers: &BTreeSet<String>,
+    identities: &BTreeMap<String, Option<LogicalBrokerInstance>>,
+) -> Option<ControllerSyncStateObservation> {
+    let table = sync_state.get_replicas_info_table();
+    if selected_brokers.is_empty()
+        || selected_brokers.len() > MAX_SYNC_BROKERS
+        || table.len() != selected_brokers.len()
+        || table.keys().map(|name| name.as_str()).collect::<BTreeSet<_>>()
+            != selected_brokers.iter().map(String::as_str).collect::<BTreeSet<_>>()
+    {
+        return None;
+    }
+    let mut brokers = Vec::new();
+    for (broker_name, replicas) in table {
+        if replicas.get_master_epoch() <= 0
+            || replicas.get_sync_state_set_epoch() <= 0
+            || replicas.get_master_broker_id() > MAX_WIRE_I64
+            || replicas.get_in_sync_replicas().len() > MAX_SYNC_REPLICAS_PER_BROKER
+            || replicas.get_not_in_sync_replicas().len() > MAX_SYNC_REPLICAS_PER_BROKER
+            || replicas
+                .get_in_sync_replicas()
+                .len()
+                .saturating_add(replicas.get_not_in_sync_replicas().len())
+                > MAX_SYNC_REPLICAS_PER_BROKER
+        {
+            return None;
+        }
+        let master_endpoint = canonical_remoting_endpoint(replicas.get_master_address())?;
+        let master = identities.get(&master_endpoint).and_then(Option::as_ref)?;
+        if master.broker_name != broker_name.as_str() || master.broker_id != replicas.get_master_broker_id() {
+            return None;
+        }
+        let mut seen = BTreeSet::new();
+        let mut in_sync_replicas = project_replicas(
+            replicas.get_in_sync_replicas(),
+            identities,
+            broker_name.as_str(),
+            &mut seen,
+        )?;
+        if !in_sync_replicas.iter().any(|replica| replica == master) {
+            return None;
+        }
+        let mut not_in_sync_replicas = project_replicas(
+            replicas.get_not_in_sync_replicas(),
+            identities,
+            broker_name.as_str(),
+            &mut seen,
+        )?;
+        in_sync_replicas.sort_by(logical_broker_order);
+        not_in_sync_replicas.sort_by(logical_broker_order);
+        brokers.push(BrokerSyncStateObservation {
+            broker_name: broker_name.to_string(),
+            master_broker_id: replicas.get_master_broker_id(),
+            master_epoch: replicas.get_master_epoch(),
+            sync_state_set_epoch: replicas.get_sync_state_set_epoch(),
+            in_sync_replicas,
+            not_in_sync_replicas,
+        });
+    }
+    brokers.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    Some(ControllerSyncStateObservation {
+        controller_name: controller_name.to_string(),
+        brokers,
+    })
+}
+
+fn project_replicas(
+    replicas: &[rocketmq_protocol::protocol::body::broker_replicas_info::ReplicaIdentity],
+    identities: &BTreeMap<String, Option<LogicalBrokerInstance>>,
+    broker_name: &str,
+    seen: &mut BTreeSet<(String, u64)>,
+) -> Option<Vec<LogicalBrokerInstance>> {
+    let mut rows = Vec::new();
+    for replica in replicas {
+        let canonical = canonical_remoting_endpoint(replica.get_broker_address().as_str())?;
+        let identity = identities.get(&canonical).and_then(Option::as_ref)?;
+        if replica.get_broker_name().as_str() != broker_name
+            || identity.broker_name != broker_name
+            || identity.broker_name != replica.get_broker_name().as_str()
+            || identity.broker_id != replica.get_broker_id()
+            || identity.broker_id > MAX_WIRE_I64
+            || !seen.insert((identity.broker_name.clone(), identity.broker_id))
+        {
+            return None;
+        }
+        rows.push(identity.clone());
+    }
+    Some(rows)
+}
+
+fn logical_broker_order(left: &LogicalBrokerInstance, right: &LogicalBrokerInstance) -> std::cmp::Ordering {
+    left.broker_name
+        .cmp(&right.broker_name)
+        .then(left.broker_id.cmp(&right.broker_id))
+}
+
+fn controller_sync_state_rows(state: &ControllerSyncStateObservation) -> usize {
+    state.brokers.iter().fold(1usize, |rows, broker| {
+        rows.saturating_add(1)
+            .saturating_add(broker.in_sync_replicas.len())
+            .saturating_add(broker.not_in_sync_replicas.len())
+    })
+}
+
+fn configured_controller_leader<'a>(
+    configured: &'a [ControllerObservationTarget],
+    metadata: &ValidatedControllerMetadata,
+) -> Option<&'a str> {
+    let leader = metadata.leader_endpoint.as_deref()?;
+    let mut owners = configured
+        .iter()
+        .filter(|target| canonical_remoting_endpoint(target.endpoint()).as_deref() == Some(leader));
+    let owner = owners.next()?;
+    owners.next().is_none().then_some(owner.endpoint())
+}
+
+struct ValidatedControllerMetadata {
+    group: Option<String>,
+    leader_id: Option<String>,
+    leader_endpoint: Option<String>,
+    is_leader: Option<bool>,
+    peer_count: Option<usize>,
+    last_log_index: Option<u64>,
+    committed_log_index: Option<u64>,
+    applied_log_index: Option<u64>,
+}
+
+impl ValidatedControllerMetadata {
+    fn into_observation(self, controller_name: &str) -> ControllerMetadataObservation {
+        ControllerMetadataObservation {
+            controller_name: controller_name.to_string(),
+            group: self.group,
+            leader_id: self.leader_id,
+            is_leader: self.is_leader,
+            peer_count: self.peer_count,
+            last_log_index: self.last_log_index,
+            committed_log_index: self.committed_log_index,
+            applied_log_index: self.applied_log_index,
+        }
+    }
+}
+
+fn validate_controller_metadata(
+    controller_endpoint: &str,
+    header: GetMetaDataResponseHeader,
+) -> Option<ValidatedControllerMetadata> {
+    let group = safe_optional_value(header.group.map(String::from))?;
+    let leader_id = match header.controller_leader_id.as_deref() {
+        None => None,
+        Some(value) => {
+            let value = value.parse::<u64>().ok()?;
+            Some((value <= MAX_WIRE_I64).then(|| value.to_string())?)
+        }
+    };
+    let leader_endpoint = match header.controller_leader_address.as_deref() {
+        None => None,
+        Some(endpoint) => Some(canonical_remoting_endpoint(endpoint)?),
+    };
+    if leader_id.is_some() != leader_endpoint.is_some() || leader_id.is_some() != header.is_leader.is_some() {
+        return None;
+    }
+    let peer_count = validate_controller_peers(header.peers.as_deref(), leader_endpoint.as_deref())?;
+    if leader_endpoint.is_some() && peer_count.is_none() {
+        return None;
+    }
+    if let (Some(is_leader), Some(leader)) = (header.is_leader, leader_endpoint.as_deref()) {
+        let is_target = canonical_remoting_endpoint(controller_endpoint).as_deref() == Some(leader);
+        if is_leader != is_target {
+            return None;
+        }
+    }
+    if !valid_log_progress(
+        header.last_log_index,
+        header.committed_log_index,
+        header.applied_log_index,
+    ) {
+        return None;
+    }
+    Some(ValidatedControllerMetadata {
+        group,
+        leader_id,
+        leader_endpoint,
+        is_leader: header.is_leader,
+        peer_count,
+        last_log_index: header.last_log_index,
+        committed_log_index: header.committed_log_index,
+        applied_log_index: header.applied_log_index,
+    })
+}
+
+fn validate_controller_peers(peers: Option<&str>, leader: Option<&str>) -> Option<Option<usize>> {
+    let Some(peers) = peers else {
+        return Some(None);
+    };
+    if peers.is_empty() || peers.len() > MAX_CONTROLLER_PEERS_BYTES {
+        return None;
+    }
+    let mut canonical = BTreeSet::new();
+    let mut count = 0usize;
+    for peer in peers.split(';').take(MAX_CONTROLLER_PEERS + 1) {
+        count = count.saturating_add(1);
+        if count > MAX_CONTROLLER_PEERS || peer.is_empty() || peer.trim() != peer {
+            return None;
+        }
+        let peer = peer.parse::<std::net::SocketAddr>().ok()?.to_string();
+        if !canonical.insert(peer) {
+            return None;
+        }
+    }
+    if canonical.len() != count || leader.is_some_and(|leader| !canonical.contains(leader)) {
+        return None;
+    }
+    Some(Some(count))
+}
+
+fn valid_log_progress(last: Option<u64>, committed: Option<u64>, applied: Option<u64>) -> bool {
+    if [last, committed, applied]
+        .into_iter()
+        .flatten()
+        .any(|value| value > MAX_WIRE_I64)
+    {
+        return false;
+    }
+    match (last, committed, applied) {
+        (None, None, None) | (Some(_), None, None) => true,
+        (Some(last), Some(committed), None) => last >= committed,
+        (Some(last), Some(committed), Some(applied)) => last >= committed && committed >= applied,
+        _ => false,
+    }
+}
+
+fn safe_optional_value(value: Option<String>) -> Option<Option<String>> {
+    match value {
+        None => Some(None),
+        Some(value) => {
+            let value = value.trim();
+            safe_logical_identifier(value).then(|| Some(value.to_string()))
+        }
+    }
+}
+
+fn parse_nameserver_config(config: &HashMap<CheetahString, CheetahString>) -> Option<NameserverConfigValues> {
+    Some(NameserverConfigValues {
+        cluster_test: parse_optional_bool(config, "clusterTest")?,
+        order_message_enable: parse_optional_bool(config, "orderMessageEnable")?,
+        return_order_topic_config_to_broker: parse_optional_bool(config, "returnOrderTopicConfigToBroker")?,
+        client_request_thread_pool_nums: parse_optional_bounded_i32(
+            config,
+            "clientRequestThreadPoolNums",
+            MAX_NAMESERVER_THREAD_COUNT,
+        )?,
+        client_request_thread_pool_queue_capacity: parse_optional_bounded_i32(
+            config,
+            "clientRequestThreadPoolQueueCapacity",
+            MAX_NAMESERVER_QUEUE_CAPACITY,
+        )?,
+        scan_not_active_broker_interval_ms: parse_optional_bounded_u64(
+            config,
+            "scanNotActiveBrokerInterval",
+            MAX_NAMESERVER_SCAN_INTERVAL_MILLIS,
+        )?,
+        unregister_broker_queue_capacity: parse_optional_bounded_i32(
+            config,
+            "unRegisterBrokerQueueCapacity",
+            MAX_NAMESERVER_QUEUE_CAPACITY,
+        )?,
+        support_acting_master: parse_optional_bool(config, "supportActingMaster")?,
+    })
+}
+
+fn parse_optional_bool(config: &HashMap<CheetahString, CheetahString>, key: &str) -> Option<Option<bool>> {
+    match config.get(key) {
+        None => Some(None),
+        Some(value) => match value.as_str() {
+            "true" => Some(Some(true)),
+            "false" => Some(Some(false)),
+            _ => None,
+        },
+    }
+}
+
+fn parse_optional_bounded_i32(
+    config: &HashMap<CheetahString, CheetahString>,
+    key: &str,
+    maximum: i32,
+) -> Option<Option<i32>> {
+    match config.get(key) {
+        None => Some(None),
+        Some(value) => value
+            .trim()
+            .parse::<i32>()
+            .ok()
+            .filter(|value| (1..=maximum).contains(value))
+            .map(Some),
+    }
+}
+
+fn parse_optional_bounded_u64(
+    config: &HashMap<CheetahString, CheetahString>,
+    key: &str,
+    maximum: u64,
+) -> Option<Option<u64>> {
+    match config.get(key) {
+        None => Some(None),
+        Some(value) => value
+            .trim()
+            .parse::<u64>()
+            .ok()
+            .filter(|value| (1..=maximum).contains(value))
+            .map(Some),
+    }
+}
+
+fn nameserver_differences(rows: &[NameserverConfigObservation]) -> Vec<NameserverConfigDifferenceField> {
+    let Some(baseline) = rows.first().map(|row| &row.values) else {
+        return Vec::new();
+    };
+    let mut differences = Vec::new();
+    macro_rules! difference {
+        ($field:ident, $variant:ident) => {
+            if rows.iter().any(|row| row.values.$field != baseline.$field) {
+                differences.push(NameserverConfigDifferenceField::$variant);
+            }
+        };
+    }
+    difference!(cluster_test, ClusterTest);
+    difference!(order_message_enable, OrderMessageEnable);
+    difference!(return_order_topic_config_to_broker, ReturnOrderTopicConfigToBroker);
+    difference!(client_request_thread_pool_nums, ClientRequestThreadPoolNums);
+    difference!(
+        client_request_thread_pool_queue_capacity,
+        ClientRequestThreadPoolQueueCapacity
+    );
+    difference!(scan_not_active_broker_interval_ms, ScanNotActiveBrokerIntervalMs);
+    difference!(unregister_broker_queue_capacity, UnregisterBrokerQueueCapacity);
+    difference!(support_acting_master, SupportActingMaster);
+    differences
+}
+
+fn observation_failure(
+    source: AdminQuerySource,
+    logical_target: &str,
+    error: InfrastructureObservationReadError,
+) -> AdminSourceFailure {
+    let code = match error.code() {
+        InfrastructureObservationReadErrorCode::SourceUnavailable => AdminQueryFailureCode::SourceUnavailable,
+        InfrastructureObservationReadErrorCode::Timeout => AdminQueryFailureCode::Timeout,
+        InfrastructureObservationReadErrorCode::PermissionDenied => AdminQueryFailureCode::PermissionDenied,
+        InfrastructureObservationReadErrorCode::NotFound => AdminQueryFailureCode::NotFound,
+        InfrastructureObservationReadErrorCode::RateLimited => AdminQueryFailureCode::RateLimited,
+        InfrastructureObservationReadErrorCode::InvalidResponse => AdminQueryFailureCode::InvalidResponse,
+    };
+    AdminSourceFailure::new(source, code, error.retryable(), logical_target)
+}
+
+fn invalid_failure(source: AdminQuerySource, logical_target: &str) -> AdminSourceFailure {
+    AdminSourceFailure::new(source, AdminQueryFailureCode::InvalidResponse, false, logical_target)
+}
+
+fn backend_error(operation: &'static str, error: RocketMQError) -> AdminError {
+    let view = error.boundary_view();
+    AdminError::backend_view(
+        operation,
+        "INFRASTRUCTURE_OBSERVATION_SOURCE_UNAVAILABLE",
+        "infrastructure observation source is unavailable",
+        None,
+        view.http().status.as_u16(),
+        view.is_retryable(),
+    )
+}
+
+fn safe_logical_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 100
+        && value.parse::<std::net::IpAddr>().is_err()
+        && value.parse::<std::net::SocketAddr>().is_err()
+        && !value.contains([':', '/', '\\', '@', '=', '&', '?'])
+        && !value.chars().any(char::is_control)
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+}
+
+#[cfg(test)]
+#[path = "infrastructure_observation/tests.rs"]
+mod tests;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/infrastructure_observation/tests.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/infrastructure_observation/tests.rs
@@ -1,0 +1,1234 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Mutex;
+
+use rocketmq_protocol::protocol::body::broker_replicas_info::ReplicaIdentity;
+use rocketmq_protocol::protocol::body::broker_replicas_info::ReplicasInfo;
+use rocketmq_protocol::protocol::body::ha_connection_runtime_info::HAConnectionRuntimeInfo;
+use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
+
+use super::*;
+
+const CLUSTER: &str = "cluster-a";
+const ADDRESS_A: &str = "broker-a.internal:10911";
+const ADDRESS_A_SLAVE: &str = "broker-a-slave.internal:10911";
+const ADDRESS_B: &str = "broker-b.internal:10911";
+const CONTROLLER_A: &str = "10.0.0.1:9878";
+const CONTROLLER_B: &str = "10.0.0.2:9878";
+
+type TopologyEntry<'a> = (&'a str, &'a str, &'a [(u64, &'a str)]);
+
+#[derive(Default)]
+struct FakeSource {
+    cluster_info: ClusterInfo,
+    ha: BTreeMap<String, ObservationResult<HARuntimeInfo>>,
+    sync: BTreeMap<String, ObservationResult<serde_json::Value>>,
+    metadata: BTreeMap<String, ObservationResult<GetMetaDataResponseHeader>>,
+    nameserver: BTreeMap<String, ObservationResult<HashMap<CheetahString, CheetahString>>>,
+    cluster_calls: Mutex<u32>,
+    ha_calls: Mutex<Vec<String>>,
+    sync_calls: Mutex<Vec<String>>,
+    metadata_calls: Mutex<Vec<String>>,
+    nameserver_calls: Mutex<Vec<String>>,
+}
+
+impl InfrastructureObservationSource for FakeSource {
+    async fn cluster_info(&self) -> Result<ClusterInfo, RocketMQError> {
+        *self.cluster_calls.lock().unwrap() += 1;
+        Ok(self.cluster_info.clone())
+    }
+
+    async fn ha_runtime(&self, endpoint: CheetahString) -> ObservationResult<HARuntimeInfo> {
+        self.ha_calls.lock().unwrap().push(endpoint.to_string());
+        self.ha
+            .get(endpoint.as_str())
+            .cloned()
+            .unwrap_or_else(|| Ok(master_runtime(Vec::new())))
+    }
+
+    async fn sync_state(
+        &self,
+        endpoint: CheetahString,
+        _broker_names: Vec<CheetahString>,
+    ) -> ObservationResult<BrokerReplicasInfo> {
+        self.sync_calls.lock().unwrap().push(endpoint.to_string());
+        self.sync
+            .get(endpoint.as_str())
+            .cloned()
+            .unwrap_or_else(|| Ok(serde_json::to_value(BrokerReplicasInfo::new()).unwrap()))
+            .and_then(|value| {
+                serde_json::from_value(value).map_err(|_| {
+                    InfrastructureObservationReadError::new(
+                        InfrastructureObservationReadErrorCode::InvalidResponse,
+                        false,
+                    )
+                })
+            })
+    }
+
+    async fn controller_metadata(&self, endpoint: CheetahString) -> ObservationResult<GetMetaDataResponseHeader> {
+        self.metadata_calls.lock().unwrap().push(endpoint.to_string());
+        self.metadata.get(endpoint.as_str()).cloned().unwrap_or_else(|| {
+            Ok(GetMetaDataResponseHeader {
+                controller_leader_address: Some("secret-leader.internal:9878".into()),
+                peers: Some("peer-a.internal:9878;peer-b.internal:9878".into()),
+                ..Default::default()
+            })
+        })
+    }
+
+    async fn nameserver_config(
+        &self,
+        endpoint: CheetahString,
+    ) -> ObservationResult<HashMap<CheetahString, CheetahString>> {
+        self.nameserver_calls.lock().unwrap().push(endpoint.to_string());
+        self.nameserver
+            .get(endpoint.as_str())
+            .cloned()
+            .unwrap_or_else(|| Ok(HashMap::new()))
+    }
+}
+
+#[tokio::test]
+async fn ha_uses_selected_cluster_embedded_identity_and_master_only() {
+    let mut cluster_info = topology(&[
+        (CLUSTER, "broker-a", &[(0, ADDRESS_A), (1, ADDRESS_A_SLAVE)]),
+        (CLUSTER, "broker-b", &[(0, ADDRESS_B)]),
+    ]);
+    cluster_info
+        .cluster_addr_table
+        .as_mut()
+        .unwrap()
+        .entry("other-cluster".into())
+        .or_default()
+        .insert("broker-a".into());
+    let source = FakeSource {
+        cluster_info,
+        ..Default::default()
+    };
+    let request = QueryHaStatusRequest::try_new(CLUSTER, ["broker-a".to_string()], false, Vec::new()).unwrap();
+    let result = query_ha_status_from(&source, &[], &request).await.unwrap();
+    assert_eq!(result.data.brokers.len(), 1);
+    assert_eq!(&*source.ha_calls.lock().unwrap(), &[ADDRESS_A]);
+
+    let mut mismatched = topology(&[(CLUSTER, "broker-a", &[(0, ADDRESS_A)])]);
+    mismatched
+        .broker_addr_table
+        .as_mut()
+        .unwrap()
+        .get_mut("broker-a")
+        .unwrap()
+        .set_cluster("other-cluster".into());
+    let source = FakeSource {
+        cluster_info: mismatched,
+        ..Default::default()
+    };
+    assert!(query_ha_status_from(&source, &[], &request).await.is_err());
+    assert!(source.ha_calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn ha_unknown_selector_and_target_caps_issue_no_observation_rpc() {
+    let source = FakeSource {
+        cluster_info: topology(&[(CLUSTER, "broker-a", &[(0, ADDRESS_A)])]),
+        ..Default::default()
+    };
+    let unknown = QueryHaStatusRequest::try_new(CLUSTER, ["broker-z".to_string()], false, Vec::new()).unwrap();
+    assert!(query_ha_status_from(&source, &[], &unknown).await.is_err());
+    assert!(source.ha_calls.lock().unwrap().is_empty());
+
+    let sixty_four = topology_owned(64);
+    assert_eq!(
+        resolve_ha_topology(&sixty_four, CLUSTER, &[]).unwrap().masters.len(),
+        MAX_HA_BROKER_TARGETS
+    );
+    let sixty_five = topology_owned(65);
+    assert!(resolve_ha_topology(&sixty_five, CLUSTER, &[]).is_err());
+
+    let large_cluster = topology_owned(256);
+    assert_eq!(
+        resolve_ha_topology(&large_cluster, CLUSTER, &["broker-00".to_string()])
+            .unwrap()
+            .masters
+            .len(),
+        1,
+        "a small selector must not inherit the full-cluster cap"
+    );
+
+    let exact_instances = topology_with_instances(MAX_BROKER_INSTANCES_PER_LOGICAL_BROKER);
+    assert_eq!(
+        resolve_ha_topology(&exact_instances, CLUSTER, &[])
+            .unwrap()
+            .masters
+            .len(),
+        1
+    );
+    let too_many_instances = topology_with_instances(MAX_BROKER_INSTANCES_PER_LOGICAL_BROKER + 1);
+    let topology = resolve_ha_topology(&too_many_instances, CLUSTER, &[]).unwrap();
+    assert!(topology.masters.is_empty());
+    assert_eq!(topology.failures.len(), 1);
+}
+
+#[test]
+fn ha_projection_enforces_connection_caps_identity_and_numeric_invariants() {
+    let (connections, identities) = valid_connections(MAX_HA_CONNECTIONS_PER_BROKER);
+    let runtime = master_runtime(connections.clone());
+    assert!(project_ha_runtime("broker-a", 0, MAX_HA_CONNECTIONS_PER_BROKER, runtime, &identities).is_some());
+
+    let (too_many, identities) = valid_connections(MAX_HA_CONNECTIONS_PER_BROKER + 1);
+    assert!(project_ha_runtime(
+        "broker-a",
+        0,
+        MAX_HA_CONNECTIONS_PER_BROKER,
+        master_runtime(too_many),
+        &identities
+    )
+    .is_none());
+
+    let invalid =
+        |mut connections: Vec<HAConnectionRuntimeInfo>,
+         mut identities: BTreeMap<String, Option<LogicalBrokerInstance>>,
+         mutation: fn(&mut HAConnectionRuntimeInfo, &mut BTreeMap<String, Option<LogicalBrokerInstance>>)| {
+            mutation(&mut connections[0], &mut identities);
+            project_ha_runtime(
+                "broker-a",
+                0,
+                MAX_HA_CONNECTIONS_PER_BROKER,
+                master_runtime(connections),
+                &identities,
+            )
+            .is_none()
+        };
+    let (connections, identities) = valid_connections(1);
+    assert!(invalid(connections.clone(), identities.clone(), |connection, _| {
+        connection.diff = -1
+    }));
+    assert!(invalid(connections.clone(), identities.clone(), |connection, _| {
+        connection.diff = 9
+    }));
+    assert!(invalid(connections.clone(), identities.clone(), |connection, _| {
+        connection.slave_ack_offset = 101
+    }));
+    assert!(invalid(connections.clone(), identities.clone(), |connection, _| {
+        connection.transfer_from_where = 101
+    }));
+    assert!(invalid(
+        connections.clone(),
+        identities.clone(),
+        |connection, identities| {
+            identities.insert(
+                connection.addr.clone(),
+                Some(LogicalBrokerInstance {
+                    broker_name: "other-broker".to_string(),
+                    broker_id: 1,
+                }),
+            );
+        }
+    ));
+    assert!(invalid(
+        connections.clone(),
+        identities.clone(),
+        |connection, identities| {
+            identities.insert(
+                connection.addr.clone(),
+                Some(LogicalBrokerInstance {
+                    broker_name: "broker-a".to_string(),
+                    broker_id: 0,
+                }),
+            );
+        }
+    ));
+
+    let mut duplicated = connections;
+    duplicated.push(duplicated[0].clone());
+    let mut runtime = master_runtime(duplicated);
+    runtime.in_sync_slave_nums = 2;
+    assert!(project_ha_runtime("broker-a", 0, MAX_HA_CONNECTIONS_PER_BROKER, runtime, &identities).is_none());
+    let mut runtime = master_runtime(valid_connections(1).0);
+    runtime.in_sync_slave_nums = 0;
+    assert!(project_ha_runtime(
+        "broker-a",
+        0,
+        MAX_HA_CONNECTIONS_PER_BROKER,
+        runtime,
+        &valid_connections(1).1
+    )
+    .is_none());
+    let (connections, identities) = valid_connections(1);
+    let mut disconnected_in_sync_member = master_runtime(connections);
+    disconnected_in_sync_member.in_sync_slave_nums = 2;
+    assert!(project_ha_runtime("broker-a", 0, 2, disconnected_in_sync_member.clone(), &identities).is_some());
+    assert!(project_ha_runtime("broker-a", 0, 1, disconnected_in_sync_member, &identities).is_none());
+    let (connections, identities) = valid_connections(1);
+    let mut runtime = master_runtime(connections.clone());
+    runtime.master_commit_log_max_offset = u64::MAX;
+    assert!(project_ha_runtime("broker-a", 0, MAX_HA_CONNECTIONS_PER_BROKER, runtime, &identities).is_none());
+    let mut runtime = master_runtime(connections.clone());
+    runtime.ha_connection_info[0].transferred_byte_in_second = u64::MAX;
+    assert!(project_ha_runtime("broker-a", 0, MAX_HA_CONNECTIONS_PER_BROKER, runtime, &identities).is_none());
+    let mut runtime = master_runtime(connections);
+    runtime.pending_group_transfer_request_count = u64::MAX;
+    assert!(project_ha_runtime("broker-a", 0, MAX_HA_CONNECTIONS_PER_BROKER, runtime, &identities).is_none());
+}
+
+#[tokio::test]
+async fn ha_address_reverse_lookup_failure_is_sanitized_partial_or_total() {
+    let connection = HAConnectionRuntimeInfo {
+        addr: "unmapped-secret.internal:10911".to_string(),
+        ..Default::default()
+    };
+    let source = FakeSource {
+        cluster_info: topology(&[(CLUSTER, "broker-a", &[(0, ADDRESS_A)])]),
+        ha: BTreeMap::from([(ADDRESS_A.to_string(), Ok(master_runtime(vec![connection.clone()])))]),
+        ..Default::default()
+    };
+    let request = QueryHaStatusRequest::try_new(CLUSTER, Vec::new(), false, Vec::new()).unwrap();
+    let error = query_ha_status_from(&source, &[], &request).await.unwrap_err();
+    assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+    assert!(!format!("{error:?}").contains("unmapped-secret"));
+
+    let source = FakeSource {
+        cluster_info: topology(&[
+            (CLUSTER, "broker-a", &[(0, ADDRESS_A)]),
+            (CLUSTER, "broker-b", &[(0, ADDRESS_B)]),
+        ]),
+        ha: BTreeMap::from([
+            (ADDRESS_A.to_string(), Ok(master_runtime(Vec::new()))),
+            (ADDRESS_B.to_string(), Ok(master_runtime(vec![connection]))),
+        ]),
+        ..Default::default()
+    };
+    let result = query_ha_status_from(&source, &[], &request).await.unwrap();
+    assert!(result.partial);
+    assert_eq!(result.data.brokers.len(), 1);
+    let wire = serde_json::to_string(&result).unwrap();
+    assert!(!wire.contains("unmapped-secret"));
+    assert!(!wire.contains(ADDRESS_A));
+}
+
+#[tokio::test]
+async fn ha_query_wide_row_budget_reserves_whole_sources_at_exact_and_plus_one() {
+    let exact_source = budget_ha_source(39);
+    let request = QueryHaStatusRequest::try_new(CLUSTER, Vec::new(), false, Vec::new()).unwrap();
+    let exact = query_ha_status_from(&exact_source, &[], &request).await.unwrap();
+    assert!(!exact.partial);
+    assert_eq!(ha_result_rows(&exact.data), MAX_INFRASTRUCTURE_QUERY_ROWS);
+    assert_eq!(exact.data.brokers.len(), 16);
+
+    let overflow_source = budget_ha_source(40);
+    let overflow = query_ha_status_from(&overflow_source, &[], &request).await.unwrap();
+    assert!(overflow.partial);
+    assert_eq!(
+        ha_result_rows(&overflow.data),
+        15 * MAX_BROKER_INSTANCES_PER_LOGICAL_BROKER
+    );
+    assert_eq!(
+        overflow.data.brokers.len(),
+        15,
+        "the overflowing source must append no partial rows"
+    );
+    assert_eq!(overflow.source_failures[0].logical_target(), "broker-15");
+
+    let total_source = oversized_sync_source(16, MAX_BROKER_INSTANCES_PER_LOGICAL_BROKER);
+    let controllers = [ControllerObservationTarget::new("controller-a", CONTROLLER_A)];
+    let request = QueryHaStatusRequest::try_new(CLUSTER, Vec::new(), true, Vec::new()).unwrap();
+    let error = query_ha_status_from(&total_source, &controllers, &request)
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Some("ADMIN_QUERY_ALL_SOURCES_FAILED"));
+    assert_eq!(total_source.sync_calls.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn maximum_ha_and_sync_shape_remains_bounded_and_whole_source_partial() {
+    let mut source = oversized_sync_source(MAX_SYNC_BROKERS, MAX_BROKER_INSTANCES_PER_LOGICAL_BROKER);
+    source
+        .ha
+        .values_mut()
+        .for_each(|runtime| *runtime = Ok(master_runtime(Vec::new())));
+    let sync = source.sync.remove(CONTROLLER_A).unwrap();
+    source.metadata.clear();
+    let controllers = (1..=MAX_CONTROLLER_TARGETS)
+        .map(|index| {
+            let endpoint = format!("10.2.0.{index}:9878");
+            source.sync.insert(endpoint.clone(), sync.clone());
+            source
+                .metadata
+                .insert(endpoint.clone(), Ok(controller_metadata(&endpoint, true, &[&endpoint])));
+            ControllerObservationTarget::new(format!("controller-{index:02}"), endpoint)
+        })
+        .collect::<Vec<_>>();
+    let request = QueryHaStatusRequest::try_new(CLUSTER, Vec::new(), true, Vec::new()).unwrap();
+    let result = query_ha_status_from(&source, &controllers, &request).await.unwrap();
+    assert!(result.partial);
+    assert_eq!(result.data.brokers.len(), MAX_SYNC_BROKERS);
+    assert!(result.data.controller_sync_states.is_empty());
+    assert!(ha_result_rows(&result.data) <= MAX_INFRASTRUCTURE_QUERY_ROWS);
+    assert_eq!(source.sync_calls.lock().unwrap().len(), MAX_CONTROLLER_TARGETS);
+}
+
+#[tokio::test]
+async fn sync_state_is_opt_in_alias_bounded_and_address_free() {
+    let state = valid_sync_state();
+    let source = FakeSource {
+        cluster_info: topology(&[(CLUSTER, "broker-a", &[(0, ADDRESS_A), (1, ADDRESS_A_SLAVE)])]),
+        sync: BTreeMap::from([(CONTROLLER_A.to_string(), Ok(serde_json::to_value(state).unwrap()))]),
+        metadata: BTreeMap::from([(
+            CONTROLLER_A.to_string(),
+            Ok(controller_metadata(CONTROLLER_A, true, &[CONTROLLER_A])),
+        )]),
+        ..Default::default()
+    };
+    let controllers = vec![ControllerObservationTarget::new("controller-a", CONTROLLER_A)];
+    let without = QueryHaStatusRequest::try_new(CLUSTER, Vec::new(), false, Vec::new()).unwrap();
+    query_ha_status_from(&source, &controllers, &without).await.unwrap();
+    assert!(source.sync_calls.lock().unwrap().is_empty());
+
+    let with = QueryHaStatusRequest::try_new(CLUSTER, Vec::new(), true, ["controller-a".to_string()]).unwrap();
+    let result = query_ha_status_from(&source, &controllers, &with).await.unwrap();
+    let sync = &result.data.controller_sync_states[0].brokers[0];
+    assert_eq!(sync.master_epoch, 7);
+    assert_eq!(sync.not_in_sync_replicas[0].broker_id, 1);
+    let wire = serde_json::to_string(&result).unwrap();
+    assert!(!wire.contains(ADDRESS_A));
+    assert!(!wire.contains(CONTROLLER_A));
+
+    let no_config = FakeSource {
+        cluster_info: source.cluster_info.clone(),
+        ..Default::default()
+    };
+    assert!(query_ha_status_from(&no_config, &[], &with).await.is_err());
+    assert!(no_config.ha_calls.lock().unwrap().is_empty());
+    assert!(no_config.sync_calls.lock().unwrap().is_empty());
+    assert_eq!(*no_config.cluster_calls.lock().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn sync_state_follows_only_a_uniquely_configured_leader_endpoint() {
+    let controllers = vec![
+        ControllerObservationTarget::new("controller-a", CONTROLLER_A),
+        ControllerObservationTarget::new("controller-b", CONTROLLER_B),
+    ];
+    let source = FakeSource {
+        cluster_info: topology(&[(CLUSTER, "broker-a", &[(0, ADDRESS_A), (1, ADDRESS_A_SLAVE)])]),
+        metadata: BTreeMap::from([(
+            CONTROLLER_B.to_string(),
+            Ok(controller_metadata(CONTROLLER_A, false, &[CONTROLLER_A, CONTROLLER_B])),
+        )]),
+        sync: BTreeMap::from([(
+            CONTROLLER_A.to_string(),
+            Ok(serde_json::to_value(valid_sync_state()).unwrap()),
+        )]),
+        ..Default::default()
+    };
+    let request = QueryHaStatusRequest::try_new(CLUSTER, Vec::new(), true, ["controller-b".to_string()]).unwrap();
+    let result = query_ha_status_from(&source, &controllers, &request).await.unwrap();
+    assert!(!result.partial);
+    assert_eq!(&*source.metadata_calls.lock().unwrap(), &[CONTROLLER_B]);
+    assert_eq!(&*source.sync_calls.lock().unwrap(), &[CONTROLLER_A]);
+
+    for advertised in ["private-other-cluster.internal:9878", "not-an-endpoint"] {
+        let source = FakeSource {
+            cluster_info: topology(&[(CLUSTER, "broker-a", &[(0, ADDRESS_A), (1, ADDRESS_A_SLAVE)])]),
+            metadata: BTreeMap::from([(
+                CONTROLLER_B.to_string(),
+                Ok(controller_metadata(advertised, false, &[advertised, CONTROLLER_B])),
+            )]),
+            ..Default::default()
+        };
+        let result = query_ha_status_from(&source, &controllers, &request).await.unwrap();
+        assert!(result.partial);
+        assert!(source.sync_calls.lock().unwrap().is_empty());
+        assert!(!serde_json::to_string(&result).unwrap().contains(advertised));
+    }
+
+    let ambiguous = vec![
+        ControllerObservationTarget::new("controller-a", "LEADER.internal:9878"),
+        ControllerObservationTarget::new("controller-c", "leader.INTERNAL:9878"),
+        ControllerObservationTarget::new("controller-b", CONTROLLER_B),
+    ];
+    let source = FakeSource {
+        cluster_info: topology(&[(CLUSTER, "broker-a", &[(0, ADDRESS_A), (1, ADDRESS_A_SLAVE)])]),
+        metadata: BTreeMap::from([(
+            CONTROLLER_B.to_string(),
+            Ok(controller_metadata(
+                "leader.internal:9878",
+                false,
+                &["leader.internal:9878", CONTROLLER_B],
+            )),
+        )]),
+        ..Default::default()
+    };
+    let result = query_ha_status_from(&source, &ambiguous, &request).await.unwrap();
+    assert!(result.partial);
+    assert!(source.sync_calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn sync_routing_rejects_incomplete_controller_metadata_before_second_rpc() {
+    let controllers = vec![
+        ControllerObservationTarget::new("controller-a", CONTROLLER_A),
+        ControllerObservationTarget::new("controller-b", CONTROLLER_B),
+    ];
+    let request = QueryHaStatusRequest::try_new(CLUSTER, Vec::new(), true, ["controller-b".to_string()]).unwrap();
+    let valid_peers = format!("{CONTROLLER_A};{CONTROLLER_B}");
+    let too_many_peers = (1..=MAX_CONTROLLER_PEERS + 1)
+        .map(|index| format!("10.1.0.{index}:9878"))
+        .collect::<Vec<_>>()
+        .join(";");
+    let headers = [
+        GetMetaDataResponseHeader {
+            peers: Some(valid_peers.clone().into()),
+            ..Default::default()
+        },
+        controller_metadata(CONTROLLER_A, true, &[CONTROLLER_A, CONTROLLER_B]),
+        GetMetaDataResponseHeader {
+            peers: Some(format!("{CONTROLLER_A},{CONTROLLER_B}").into()),
+            ..controller_metadata(CONTROLLER_A, false, &[CONTROLLER_A, CONTROLLER_B])
+        },
+        GetMetaDataResponseHeader {
+            peers: Some(format!("{CONTROLLER_A};{CONTROLLER_A}").into()),
+            ..controller_metadata(CONTROLLER_A, false, &[CONTROLLER_A, CONTROLLER_B])
+        },
+        GetMetaDataResponseHeader {
+            peers: Some(too_many_peers.into()),
+            ..controller_metadata(CONTROLLER_A, false, &[CONTROLLER_A, CONTROLLER_B])
+        },
+        GetMetaDataResponseHeader {
+            peers: Some(CONTROLLER_B.into()),
+            ..controller_metadata(CONTROLLER_A, false, &[CONTROLLER_A, CONTROLLER_B])
+        },
+        GetMetaDataResponseHeader {
+            last_log_index: Some(1),
+            committed_log_index: Some(2),
+            applied_log_index: Some(1),
+            ..controller_metadata(CONTROLLER_A, false, &[CONTROLLER_A, CONTROLLER_B])
+        },
+    ];
+    for header in headers {
+        let source = FakeSource {
+            cluster_info: topology(&[(CLUSTER, "broker-a", &[(0, ADDRESS_A)])]),
+            metadata: BTreeMap::from([(CONTROLLER_B.to_string(), Ok(header))]),
+            ..Default::default()
+        };
+        let result = query_ha_status_from(&source, &controllers, &request).await.unwrap();
+        assert!(result.partial);
+        assert!(source.sync_calls.lock().unwrap().is_empty());
+        let wire = serde_json::to_string(&result).unwrap();
+        assert!(!wire.contains(CONTROLLER_A));
+        assert!(!wire.contains(CONTROLLER_B));
+    }
+}
+
+#[test]
+fn sync_projection_requires_exact_complete_canonical_replica_sets() {
+    let topology = resolve_ha_topology(
+        &topology(&[(CLUSTER, "broker-a", &[(0, ADDRESS_A), (1, ADDRESS_A_SLAVE)])]),
+        CLUSTER,
+        &[],
+    )
+    .unwrap();
+    let selected = BTreeSet::from(["broker-a".to_string()]);
+    assert!(project_sync_state("controller-a", valid_sync_state(), &selected, &topology.identities).is_some());
+    assert!(project_sync_state(
+        "controller-a",
+        BrokerReplicasInfo::new(),
+        &selected,
+        &topology.identities
+    )
+    .is_none());
+
+    let mut extra = valid_sync_state();
+    extra.add_replica_info(
+        "broker-extra".into(),
+        ReplicasInfo::new(
+            0,
+            ADDRESS_A,
+            1,
+            1,
+            vec![ReplicaIdentity::new("broker-extra", 0, ADDRESS_A)],
+            Vec::new(),
+        ),
+    );
+    assert!(project_sync_state("controller-a", extra, &selected, &topology.identities).is_none());
+
+    for replicas in [
+        ReplicasInfo::new(
+            0,
+            ADDRESS_A,
+            0,
+            1,
+            vec![ReplicaIdentity::new("broker-a", 0, ADDRESS_A)],
+            Vec::new(),
+        ),
+        ReplicasInfo::new(
+            0,
+            ADDRESS_A,
+            1,
+            0,
+            vec![ReplicaIdentity::new("broker-a", 0, ADDRESS_A)],
+            Vec::new(),
+        ),
+        ReplicasInfo::new(
+            u64::MAX,
+            ADDRESS_A,
+            1,
+            1,
+            vec![ReplicaIdentity::new("broker-a", u64::MAX, ADDRESS_A)],
+            Vec::new(),
+        ),
+        ReplicasInfo::new(
+            0,
+            ADDRESS_A,
+            1,
+            1,
+            vec![ReplicaIdentity::new("other-broker", 0, ADDRESS_A)],
+            Vec::new(),
+        ),
+        ReplicasInfo::new(
+            0,
+            ADDRESS_A,
+            1,
+            1,
+            vec![ReplicaIdentity::new("broker-a", 1, ADDRESS_A_SLAVE)],
+            Vec::new(),
+        ),
+        ReplicasInfo::new(
+            0,
+            ADDRESS_A,
+            1,
+            1,
+            vec![ReplicaIdentity::new("broker-a", 0, ADDRESS_A)],
+            vec![ReplicaIdentity::new("broker-a", 0, ADDRESS_A)],
+        ),
+    ] {
+        assert!(project_sync_state(
+            "controller-a",
+            sync_state_from(replicas),
+            &selected,
+            &topology.identities
+        )
+        .is_none());
+    }
+
+    let (exact, identities) = bounded_sync_state(MAX_SYNC_REPLICAS_PER_BROKER);
+    assert!(project_sync_state("controller-a", exact, &selected, &identities).is_some());
+    let (overflow, identities) = bounded_sync_state(MAX_SYNC_REPLICAS_PER_BROKER + 1);
+    assert!(project_sync_state("controller-a", overflow, &selected, &identities).is_none());
+
+    let (exact, selected, identities) = bounded_sync_broker_table(MAX_SYNC_BROKERS);
+    assert!(project_sync_state("controller-a", exact, &selected, &identities).is_some());
+    let (overflow, selected, identities) = bounded_sync_broker_table(MAX_SYNC_BROKERS + 1);
+    assert!(project_sync_state("controller-a", overflow, &selected, &identities).is_none());
+}
+
+#[tokio::test]
+async fn controller_selection_metadata_projection_and_failures_are_closed() {
+    let controllers = vec![
+        ControllerObservationTarget::new("controller-b", CONTROLLER_B),
+        ControllerObservationTarget::new("controller-a", CONTROLLER_A),
+    ];
+    let source = FakeSource {
+        metadata: BTreeMap::from([
+            (
+                CONTROLLER_A.to_string(),
+                Ok(GetMetaDataResponseHeader {
+                    group: Some("group-a".into()),
+                    controller_leader_id: Some("1".into()),
+                    controller_leader_address: Some(CONTROLLER_A.into()),
+                    is_leader: Some(true),
+                    peers: Some(format!("{CONTROLLER_A};{CONTROLLER_B}").into()),
+                    last_log_index: Some(3),
+                    committed_log_index: Some(2),
+                    applied_log_index: Some(1),
+                }),
+            ),
+            (CONTROLLER_B.to_string(), Err(unavailable())),
+        ]),
+        ..Default::default()
+    };
+    let request = QueryControllerMetadataRequest::try_new(CLUSTER, Vec::new()).unwrap();
+    let result = query_controller_metadata_from(&source, &controllers, &request)
+        .await
+        .unwrap();
+    assert!(result.partial);
+    assert_eq!(result.data.controllers[0].peer_count, Some(2));
+    assert_eq!(result.data.controllers[0].last_log_index, Some(3));
+    let wire = serde_json::to_string(&result).unwrap();
+    assert!(!wire.contains("secret-leader"));
+    assert!(!wire.contains(CONTROLLER_A));
+
+    let unknown = QueryControllerMetadataRequest::try_new(CLUSTER, ["controller-z".to_string()]).unwrap();
+    let source = FakeSource::default();
+    assert!(query_controller_metadata_from(&source, &controllers, &unknown)
+        .await
+        .is_err());
+    assert!(source.metadata_calls.lock().unwrap().is_empty());
+
+    let total = QueryControllerMetadataRequest::try_new(CLUSTER, ["controller-b".to_string()]).unwrap();
+    assert!(
+        query_controller_metadata_from(&source_with_failure(), &controllers, &total)
+            .await
+            .is_err()
+    );
+}
+
+#[test]
+fn controller_metadata_validates_real_peer_syntax_optional_groups_and_log_progress() {
+    let valid = validate_controller_metadata(
+        CONTROLLER_A,
+        controller_metadata(CONTROLLER_A, true, &[CONTROLLER_A, CONTROLLER_B]),
+    )
+    .unwrap()
+    .into_observation("controller-a");
+    assert_eq!(valid.peer_count, Some(2));
+    assert!(validate_controller_metadata(CONTROLLER_A, GetMetaDataResponseHeader::default()).is_some());
+
+    let invalid_headers = [
+        GetMetaDataResponseHeader {
+            peers: Some(format!("{CONTROLLER_A},{CONTROLLER_B}").into()),
+            ..Default::default()
+        },
+        GetMetaDataResponseHeader {
+            peers: Some("[2001:0db8:0:0:0:0:0:1]:9878;[2001:db8::1]:9878".into()),
+            ..Default::default()
+        },
+        GetMetaDataResponseHeader {
+            controller_leader_id: Some("1".into()),
+            ..Default::default()
+        },
+        GetMetaDataResponseHeader {
+            last_log_index: Some(1),
+            committed_log_index: Some(2),
+            applied_log_index: Some(1),
+            ..Default::default()
+        },
+        GetMetaDataResponseHeader {
+            committed_log_index: Some(1),
+            ..Default::default()
+        },
+        GetMetaDataResponseHeader {
+            last_log_index: Some(u64::MAX),
+            ..Default::default()
+        },
+    ];
+    for header in invalid_headers {
+        assert!(validate_controller_metadata(CONTROLLER_A, header).is_none());
+    }
+
+    let exact = (1..=MAX_CONTROLLER_PEERS)
+        .map(|index| format!("10.0.1.{index}:9878"))
+        .collect::<Vec<_>>()
+        .join(";");
+    let exact = validate_controller_metadata(
+        CONTROLLER_A,
+        GetMetaDataResponseHeader {
+            peers: Some(exact.into()),
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .into_observation("controller-a");
+    assert_eq!(exact.peer_count, Some(MAX_CONTROLLER_PEERS));
+    let too_many = (1..=MAX_CONTROLLER_PEERS + 1)
+        .map(|index| format!("10.0.2.{index}:9878"))
+        .collect::<Vec<_>>()
+        .join(";");
+    assert!(validate_controller_metadata(
+        CONTROLLER_A,
+        GetMetaDataResponseHeader {
+            peers: Some(too_many.into()),
+            ..Default::default()
+        }
+    )
+    .is_none());
+    assert!(validate_controller_metadata(
+        CONTROLLER_A,
+        GetMetaDataResponseHeader {
+            peers: Some(";".repeat(MAX_CONTROLLER_PEERS_BYTES + 1).into()),
+            ..Default::default()
+        }
+    )
+    .is_none());
+}
+
+#[tokio::test]
+async fn nameserver_alias_allowlist_differences_and_failure_semantics_are_stable() {
+    let endpoints = parse_nameserver_endpoints("namesrv-b.internal:9876;namesrv-a.internal:9876").unwrap();
+    let source = FakeSource {
+        nameserver: BTreeMap::from([
+            (
+                "namesrv-a.internal:9876".to_string(),
+                Ok(HashMap::from([
+                    ("clusterTest".into(), "false".into()),
+                    ("clientRequestThreadPoolNums".into(), "8".into()),
+                    ("rocketmqHome".into(), "/private/path".into()),
+                    ("secretToken".into(), "do-not-return".into()),
+                ])),
+            ),
+            (
+                "namesrv-b.internal:9876".to_string(),
+                Ok(HashMap::from([
+                    ("clusterTest".into(), "true".into()),
+                    ("clientRequestThreadPoolNums".into(), "8".into()),
+                ])),
+            ),
+        ]),
+        ..Default::default()
+    };
+    let request = QueryNameserverConfigSummaryRequest::try_new(CLUSTER).unwrap();
+    let result = query_nameserver_config_summary_from(&source, &endpoints, &request)
+        .await
+        .unwrap();
+    assert_eq!(result.data.nameservers[0].nameserver_name, "nameserver-1");
+    assert_eq!(result.data.nameservers[1].nameserver_name, "nameserver-2");
+    assert_eq!(
+        result.data.inconsistent_fields,
+        [NameserverConfigDifferenceField::ClusterTest]
+    );
+    let wire = serde_json::to_string(&result).unwrap();
+    assert!(!wire.contains("private/path"));
+    assert!(!wire.contains("do-not-return"));
+    assert!(!wire.contains("namesrv-a.internal"));
+
+    let invalid = FakeSource {
+        nameserver: BTreeMap::from([(
+            "namesrv-a.internal:9876".to_string(),
+            Ok(HashMap::from([("clusterTest".into(), "not-a-bool".into())])),
+        )]),
+        ..Default::default()
+    };
+    let one = parse_nameserver_endpoints("namesrv-a.internal:9876").unwrap();
+    assert!(query_nameserver_config_summary_from(&invalid, &one, &request)
+        .await
+        .is_err());
+
+    let partial = FakeSource {
+        nameserver: BTreeMap::from([
+            ("namesrv-a.internal:9876".to_string(), Ok(HashMap::new())),
+            ("namesrv-b.internal:9876".to_string(), Err(unavailable())),
+        ]),
+        ..Default::default()
+    };
+    assert!(
+        query_nameserver_config_summary_from(&partial, &endpoints, &request)
+            .await
+            .unwrap()
+            .partial
+    );
+}
+
+#[test]
+fn nameserver_allowlist_matches_runtime_types_and_exact_ranges() {
+    for (key, valid, invalid) in [
+        (
+            "clientRequestThreadPoolNums",
+            vec!["1", "4096"],
+            vec!["-1", "0", "4097", "2147483648", "4294967296"],
+        ),
+        (
+            "clientRequestThreadPoolQueueCapacity",
+            vec!["1", "10000000"],
+            vec!["-1", "0", "10000001", "2147483648", "4294967296"],
+        ),
+        (
+            "unRegisterBrokerQueueCapacity",
+            vec!["1", "10000000"],
+            vec!["-1", "0", "10000001", "2147483648", "4294967296"],
+        ),
+        (
+            "scanNotActiveBrokerInterval",
+            vec!["1", "3600000"],
+            vec!["-1", "0", "3600001", "18446744073709551616"],
+        ),
+    ] {
+        for value in valid {
+            assert!(parse_nameserver_config(&HashMap::from([(key.into(), value.into())])).is_some());
+        }
+        for value in invalid {
+            assert!(parse_nameserver_config(&HashMap::from([(key.into(), value.into())])).is_none());
+        }
+    }
+    for key in [
+        "clusterTest",
+        "orderMessageEnable",
+        "returnOrderTopicConfigToBroker",
+        "supportActingMaster",
+    ] {
+        for value in ["true", "false"] {
+            assert!(parse_nameserver_config(&HashMap::from([(key.into(), value.into())])).is_some());
+        }
+        for value in ["TRUE", "1", " true", "false "] {
+            assert!(parse_nameserver_config(&HashMap::from([(key.into(), value.into())])).is_none());
+        }
+    }
+    let ignored = parse_nameserver_config(&HashMap::from([
+        ("rocketmqHome".into(), "/private/path".into()),
+        ("authToken".into(), "secret".into()),
+        ("version".into(), "future".into()),
+    ]))
+    .unwrap();
+    assert_eq!(ignored, NameserverConfigValues::default());
+}
+
+#[test]
+fn configured_target_caps_and_debug_redact_endpoints() {
+    let controllers = (0..MAX_CONTROLLER_TARGETS)
+        .map(|index| {
+            ControllerObservationTarget::new(format!("controller-{index}"), format!("c-{index}.internal:9878"))
+        })
+        .collect();
+    assert_eq!(
+        validate_controller_targets(controllers).unwrap().len(),
+        MAX_CONTROLLER_TARGETS
+    );
+    let overflow = (0..=MAX_CONTROLLER_TARGETS)
+        .map(|index| {
+            ControllerObservationTarget::new(format!("controller-{index}"), format!("c-{index}.internal:9878"))
+        })
+        .collect();
+    assert!(validate_controller_targets(overflow).is_err());
+    assert!(parse_nameserver_endpoints(
+        &(0..MAX_NAMESERVER_TARGETS)
+            .map(|index| format!("n-{index}.internal:9876"))
+            .collect::<Vec<_>>()
+            .join(";")
+    )
+    .is_ok());
+    assert!(parse_nameserver_endpoints(
+        &(0..=MAX_NAMESERVER_TARGETS)
+            .map(|index| format!("n-{index}.internal:9876"))
+            .collect::<Vec<_>>()
+            .join(";")
+    )
+    .is_err());
+    let debug = format!("{:?}", ControllerObservationTarget::new("controller-a", CONTROLLER_A));
+    assert!(!debug.contains(CONTROLLER_A));
+    let debug = format!(
+        "{:?}",
+        crate::core::admin::AdminBuilder::new().namesrv_addr("private-nameserver.internal:9876")
+    );
+    assert!(!debug.contains("private-nameserver"));
+}
+
+fn topology(entries: &[TopologyEntry<'_>]) -> ClusterInfo {
+    let mut broker_table = HashMap::new();
+    let mut cluster_table = HashMap::<CheetahString, std::collections::HashSet<CheetahString>>::new();
+    for (cluster, broker_name, endpoints) in entries {
+        let broker = BrokerData::new(
+            (*cluster).into(),
+            (*broker_name).into(),
+            endpoints
+                .iter()
+                .map(|(id, endpoint)| (*id, CheetahString::from(*endpoint)))
+                .collect(),
+            None,
+        );
+        broker_table.insert((*broker_name).into(), broker);
+        cluster_table
+            .entry((*cluster).into())
+            .or_default()
+            .insert((*broker_name).into());
+    }
+    ClusterInfo::new(Some(broker_table), Some(cluster_table))
+}
+
+fn topology_owned(count: usize) -> ClusterInfo {
+    let mut broker_table = HashMap::new();
+    let mut members = std::collections::HashSet::new();
+    for index in 0..count {
+        let name = format!("broker-{index:02}");
+        members.insert(CheetahString::from(name.clone()));
+        broker_table.insert(
+            CheetahString::from(name.clone()),
+            BrokerData::new(
+                CLUSTER.into(),
+                name.into(),
+                HashMap::from([(0, CheetahString::from(format!("b-{index}.internal:10911")))]),
+                None,
+            ),
+        );
+    }
+    ClusterInfo::new(Some(broker_table), Some(HashMap::from([(CLUSTER.into(), members)])))
+}
+
+fn topology_with_instances(count: usize) -> ClusterInfo {
+    let endpoints = (0..count)
+        .map(|index| {
+            (
+                u64::try_from(index).unwrap(),
+                CheetahString::from(format!("b-{index}.internal:10911")),
+            )
+        })
+        .collect();
+    ClusterInfo::new(
+        Some(HashMap::from([(
+            "broker-a".into(),
+            BrokerData::new(CLUSTER.into(), "broker-a".into(), endpoints, None),
+        )])),
+        Some(HashMap::from([(
+            CLUSTER.into(),
+            std::collections::HashSet::from(["broker-a".into()]),
+        )])),
+    )
+}
+
+fn budget_ha_source(last_connection_count: usize) -> FakeSource {
+    let mut broker_table = HashMap::new();
+    let mut members = std::collections::HashSet::new();
+    let mut ha = BTreeMap::new();
+    for broker_index in 0..16 {
+        let broker_name = format!("broker-{broker_index:02}");
+        let master = format!("budget-{broker_index}-0.internal:10911");
+        let connection_count = if broker_index == 15 {
+            last_connection_count
+        } else {
+            MAX_BROKER_INSTANCES_PER_LOGICAL_BROKER - 1
+        };
+        let mut addresses = HashMap::from([(0, CheetahString::from(master.clone()))]);
+        let mut connections = Vec::new();
+        for replica_index in 1..=connection_count {
+            let endpoint = format!("budget-{broker_index}-{replica_index}.internal:10911");
+            addresses.insert(u64::try_from(replica_index).unwrap(), endpoint.clone().into());
+            connections.push(HAConnectionRuntimeInfo {
+                addr: endpoint,
+                slave_ack_offset: 90,
+                diff: 10,
+                in_sync: true,
+                transferred_byte_in_second: 1,
+                transfer_from_where: 80,
+            });
+        }
+        members.insert(CheetahString::from(broker_name.clone()));
+        broker_table.insert(
+            CheetahString::from(broker_name.clone()),
+            BrokerData::new(CLUSTER.into(), broker_name.into(), addresses, None),
+        );
+        ha.insert(master, Ok(master_runtime(connections)));
+    }
+    FakeSource {
+        cluster_info: ClusterInfo::new(Some(broker_table), Some(HashMap::from([(CLUSTER.into(), members)]))),
+        ha,
+        ..Default::default()
+    }
+}
+
+fn oversized_sync_source(broker_count: usize, replica_count: usize) -> FakeSource {
+    let mut broker_table = HashMap::new();
+    let mut members = std::collections::HashSet::new();
+    let mut ha = BTreeMap::new();
+    let mut sync_state = BrokerReplicasInfo::new();
+    for broker_index in 0..broker_count {
+        let broker_name = format!("sync-budget-{broker_index:02}");
+        let mut addresses = HashMap::new();
+        let mut replicas = Vec::new();
+        for replica_index in 0..replica_count {
+            let broker_id = u64::try_from(replica_index).unwrap();
+            let endpoint = format!("sync-budget-{broker_index}-{replica_index}.internal:10911");
+            addresses.insert(broker_id, CheetahString::from(endpoint.clone()));
+            replicas.push(ReplicaIdentity::new(&broker_name, broker_id, endpoint));
+        }
+        let master = addresses.get(&0).unwrap().clone();
+        let mut invalid_runtime = master_runtime(Vec::new());
+        invalid_runtime.master = false;
+        ha.insert(master.to_string(), Ok(invalid_runtime));
+        members.insert(CheetahString::from(broker_name.clone()));
+        broker_table.insert(
+            CheetahString::from(broker_name.clone()),
+            BrokerData::new(CLUSTER.into(), broker_name.clone().into(), addresses, None),
+        );
+        sync_state.add_replica_info(
+            broker_name.clone().into(),
+            ReplicasInfo::new(0, master, 1, 1, replicas, Vec::new()),
+        );
+    }
+    FakeSource {
+        cluster_info: ClusterInfo::new(Some(broker_table), Some(HashMap::from([(CLUSTER.into(), members)]))),
+        ha,
+        sync: BTreeMap::from([(CONTROLLER_A.to_string(), Ok(serde_json::to_value(sync_state).unwrap()))]),
+        metadata: BTreeMap::from([(
+            CONTROLLER_A.to_string(),
+            Ok(controller_metadata(CONTROLLER_A, true, &[CONTROLLER_A])),
+        )]),
+        ..Default::default()
+    }
+}
+
+fn ha_result_rows(result: &QueryHaStatusResult) -> usize {
+    result
+        .brokers
+        .iter()
+        .fold(0usize, |rows, broker| rows + 1 + broker.connections.len())
+        + result
+            .controller_sync_states
+            .iter()
+            .map(controller_sync_state_rows)
+            .sum::<usize>()
+}
+
+fn valid_connections(
+    count: usize,
+) -> (
+    Vec<HAConnectionRuntimeInfo>,
+    BTreeMap<String, Option<LogicalBrokerInstance>>,
+) {
+    let mut connections = Vec::new();
+    let mut identities = BTreeMap::new();
+    for index in 0..count {
+        let endpoint = format!("replica-{index}.internal:10911");
+        connections.push(HAConnectionRuntimeInfo {
+            addr: endpoint.clone(),
+            slave_ack_offset: 90,
+            diff: 10,
+            in_sync: true,
+            transferred_byte_in_second: 1_000,
+            transfer_from_where: 80,
+        });
+        identities.insert(
+            endpoint,
+            Some(LogicalBrokerInstance {
+                broker_name: "broker-a".to_string(),
+                broker_id: u64::try_from(index + 1).unwrap(),
+            }),
+        );
+    }
+    (connections, identities)
+}
+
+fn master_runtime(connections: Vec<HAConnectionRuntimeInfo>) -> HARuntimeInfo {
+    let connections = connections
+        .into_iter()
+        .map(|mut connection| {
+            if connection.slave_ack_offset == 0 && connection.diff == 0 {
+                connection.slave_ack_offset = 100;
+            }
+            connection
+        })
+        .collect::<Vec<_>>();
+    HARuntimeInfo {
+        master: true,
+        master_commit_log_max_offset: 100,
+        in_sync_slave_nums: i32::try_from(connections.iter().filter(|connection| connection.in_sync).count()).unwrap(),
+        pending_group_transfer_request_count: 1,
+        pending_group_transfer_oldest_wait_millis: 2,
+        group_transfer_ack_notify_count: 3,
+        ha_connection_info: connections,
+        ..Default::default()
+    }
+}
+
+fn valid_sync_state() -> BrokerReplicasInfo {
+    let mut state = BrokerReplicasInfo::new();
+    state.add_replica_info(
+        "broker-a".into(),
+        ReplicasInfo::new(
+            0,
+            ADDRESS_A,
+            7,
+            9,
+            vec![ReplicaIdentity::new_with_alive("broker-a", 0, ADDRESS_A, true)],
+            vec![ReplicaIdentity::new_with_alive("broker-a", 1, ADDRESS_A_SLAVE, true)],
+        ),
+    );
+    state
+}
+
+fn sync_state_from(replicas: ReplicasInfo) -> BrokerReplicasInfo {
+    let mut state = BrokerReplicasInfo::new();
+    state.add_replica_info("broker-a".into(), replicas);
+    state
+}
+
+fn bounded_sync_state(count: usize) -> (BrokerReplicasInfo, BTreeMap<String, Option<LogicalBrokerInstance>>) {
+    let mut identities = BTreeMap::new();
+    let mut replicas = Vec::new();
+    for index in 0..count {
+        let broker_id = u64::try_from(index).unwrap();
+        let endpoint = format!("sync-{index}.internal:10911");
+        replicas.push(ReplicaIdentity::new("broker-a", broker_id, endpoint.clone()));
+        identities.insert(
+            endpoint,
+            Some(LogicalBrokerInstance {
+                broker_name: "broker-a".to_string(),
+                broker_id,
+            }),
+        );
+    }
+    let master_endpoint = "sync-0.internal:10911";
+    (
+        sync_state_from(ReplicasInfo::new(0, master_endpoint, 1, 1, replicas, Vec::new())),
+        identities,
+    )
+}
+
+fn bounded_sync_broker_table(
+    count: usize,
+) -> (
+    BrokerReplicasInfo,
+    BTreeSet<String>,
+    BTreeMap<String, Option<LogicalBrokerInstance>>,
+) {
+    let mut state = BrokerReplicasInfo::new();
+    let mut selected = BTreeSet::new();
+    let mut identities = BTreeMap::new();
+    for index in 0..count {
+        let broker_name = format!("broker-{index:02}");
+        let endpoint = format!("sync-broker-{index}.internal:10911");
+        selected.insert(broker_name.clone());
+        identities.insert(
+            endpoint.clone(),
+            Some(LogicalBrokerInstance {
+                broker_name: broker_name.clone(),
+                broker_id: 0,
+            }),
+        );
+        state.add_replica_info(
+            broker_name.clone().into(),
+            ReplicasInfo::new(
+                0,
+                endpoint.clone(),
+                1,
+                1,
+                vec![ReplicaIdentity::new(broker_name, 0, endpoint)],
+                Vec::new(),
+            ),
+        );
+    }
+    (state, selected, identities)
+}
+
+fn controller_metadata(leader_endpoint: &str, is_leader: bool, peers: &[&str]) -> GetMetaDataResponseHeader {
+    GetMetaDataResponseHeader {
+        controller_leader_id: Some("1".into()),
+        controller_leader_address: Some(leader_endpoint.into()),
+        is_leader: Some(is_leader),
+        peers: Some(peers.join(";").into()),
+        last_log_index: Some(3),
+        committed_log_index: Some(2),
+        applied_log_index: Some(1),
+        ..Default::default()
+    }
+}
+
+const fn unavailable() -> InfrastructureObservationReadError {
+    InfrastructureObservationReadError::new(InfrastructureObservationReadErrorCode::SourceUnavailable, true)
+}
+
+fn source_with_failure() -> FakeSource {
+    FakeSource {
+        metadata: BTreeMap::from([(CONTROLLER_B.to_string(), Err(unavailable()))]),
+        ..Default::default()
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/read.rs
@@ -85,6 +85,13 @@ use crate::core::consumer_observation::QueryConsumerGroupDetailsRequest;
 use crate::core::consumer_observation::QueryConsumerGroupDetailsResult;
 use crate::core::consumer_observation::QueryConsumerProgressRequest;
 use crate::core::consumer_observation::QueryConsumerProgressResult;
+use crate::core::infrastructure_observation::InfrastructureObservationQueryAdmin;
+use crate::core::infrastructure_observation::QueryControllerMetadataRequest;
+use crate::core::infrastructure_observation::QueryControllerMetadataResult;
+use crate::core::infrastructure_observation::QueryHaStatusRequest;
+use crate::core::infrastructure_observation::QueryHaStatusResult;
+use crate::core::infrastructure_observation::QueryNameserverConfigSummaryRequest;
+use crate::core::infrastructure_observation::QueryNameserverConfigSummaryResult;
 use crate::core::message::MessageMetadataQueryAdmin;
 use crate::core::message::MessageMetadataRequest;
 use crate::core::proxy::ProxyDrainPending;
@@ -122,11 +129,46 @@ pub use rocketmq_client_rust::ClientRuntime;
 pub use rocketmq_client_rust::ClientRuntimeConfig;
 pub use rocketmq_client_rust::TelemetryHandle;
 
+/// Configured logical Controller target used only inside the read adapter.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ControllerObservationTarget {
+    name: String,
+    endpoint: String,
+}
+
+impl ControllerObservationTarget {
+    pub fn new(name: impl Into<String>, endpoint: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            endpoint: endpoint.into(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+impl std::fmt::Debug for ControllerObservationTarget {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ControllerObservationTarget")
+            .field("name", &self.name)
+            .field("endpoint", &"[REDACTED]")
+            .finish()
+    }
+}
+
 #[derive(Clone)]
 pub struct ReadAdminBuilder {
     client_runtime: Arc<ClientRuntime>,
     config: crate::core::admin::AdminBuilder,
     credentials: Option<AdminCredentials>,
+    controller_targets: Vec<ControllerObservationTarget>,
 }
 
 impl ReadAdminBuilder {
@@ -135,6 +177,7 @@ impl ReadAdminBuilder {
             client_runtime,
             config: crate::core::admin::AdminBuilder::new(),
             credentials: None,
+            controller_targets: Vec::new(),
         }
     }
 
@@ -188,10 +231,17 @@ impl ReadAdminBuilder {
         self
     }
 
+    pub fn controller_targets(mut self, targets: Vec<ControllerObservationTarget>) -> Self {
+        self.controller_targets = targets;
+        self
+    }
+
     pub async fn build_and_start(self) -> AdminResult<ReadAdminSession> {
         let client_runtime = self.client_runtime;
         let config = self.config;
         let credentials = self.credentials;
+        let controller_targets =
+            crate::infrastructure_observation::validate_controller_targets(self.controller_targets)?;
         let clock = config.configured_clock();
         let now_millis = clock.now_millis();
         let admin_group = config
@@ -208,6 +258,9 @@ impl ReadAdminBuilder {
             ),
             None => DefaultMQAdminExt::with_admin_ext_group_and_timeout(client_runtime.clone(), admin_group, timeout),
         };
+        let nameserver_endpoints = crate::infrastructure_observation::parse_nameserver_endpoints(
+            config.configured_namesrv_addr().unwrap_or_default(),
+        )?;
         if let Some(namesrv_addr) = config.configured_namesrv_addr() {
             admin.set_namesrv_addr(namesrv_addr);
         }
@@ -230,6 +283,8 @@ impl ReadAdminBuilder {
             client_runtime,
             clock,
             closed: false,
+            controller_targets,
+            nameserver_endpoints,
         })
     }
 
@@ -245,6 +300,7 @@ impl std::fmt::Debug for ReadAdminBuilder {
             .field("client_runtime", &"explicit")
             .field("config", &self.config)
             .field("credentials", &self.credentials.as_ref().map(|_| "<redacted>"))
+            .field("controller_targets", &self.controller_targets)
             .finish()
     }
 }
@@ -265,6 +321,46 @@ pub struct ReadAdminSession {
     client_runtime: Arc<ClientRuntime>,
     clock: Arc<dyn Clock>,
     closed: bool,
+    controller_targets: Vec<ControllerObservationTarget>,
+    nameserver_endpoints: Vec<CheetahString>,
+}
+
+impl InfrastructureObservationQueryAdmin for ReadAdminSession {
+    fn query_ha_status<'a>(
+        &'a mut self,
+        request: &'a QueryHaStatusRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryHaStatusResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            crate::infrastructure_observation::query_ha_status(&self.inner, &self.controller_targets, request).await
+        })
+    }
+
+    fn query_controller_metadata<'a>(
+        &'a mut self,
+        request: &'a QueryControllerMetadataRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryControllerMetadataResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            crate::infrastructure_observation::query_controller_metadata(&self.inner, &self.controller_targets, request)
+                .await
+        })
+    }
+
+    fn query_nameserver_config_summary<'a>(
+        &'a mut self,
+        request: &'a QueryNameserverConfigSummaryRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryNameserverConfigSummaryResult>> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            crate::infrastructure_observation::query_nameserver_config_summary(
+                &self.inner,
+                &self.nameserver_endpoints,
+                request,
+            )
+            .await
+        })
+    }
 }
 
 impl ReadAdminSession {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/admin.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/admin.rs
@@ -60,7 +60,7 @@ impl std::fmt::Debug for AdminBuilder {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("AdminBuilder")
-            .field("namesrv_addr", &self.namesrv_addr)
+            .field("namesrv_addr", &self.namesrv_addr.as_ref().map(|_| "[REDACTED]"))
             .field("admin_group", &self.admin_group)
             .field("instance_name", &self.instance_name)
             .field("timeout_millis", &self.timeout_millis)

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/broker.rs
@@ -1043,6 +1043,25 @@ pub fn is_valid_remoting_endpoint(endpoint: &str) -> bool {
     !host.is_empty() && port.parse::<u16>().is_ok_and(|port| port != 0)
 }
 
+/// Returns the canonical ownership key for one valid remoting endpoint.
+///
+/// IP literals use [`std::net::SocketAddr`] canonical formatting. DNS hosts
+/// are lowercased and ports are normalized to their decimal representation.
+/// No caller should expose the returned value outside trusted target
+/// resolution code.
+#[must_use]
+pub fn canonical_remoting_endpoint(endpoint: &str) -> Option<String> {
+    if !is_valid_remoting_endpoint(endpoint) {
+        return None;
+    }
+    if let Ok(socket) = endpoint.parse::<std::net::SocketAddr>() {
+        return Some(socket.to_string());
+    }
+    let (host, port) = endpoint.rsplit_once(':')?;
+    let port = port.parse::<u16>().ok()?;
+    Some(format!("{}:{port}", host.to_ascii_lowercase()))
+}
+
 fn valid_remoting_host(host: &str) -> bool {
     if host.parse::<std::net::Ipv4Addr>().is_ok() {
         return true;
@@ -1498,6 +1517,14 @@ mod tests {
         ] {
             assert!(!is_valid_remoting_endpoint(invalid), "endpoint={invalid}");
         }
+        assert_eq!(
+            canonical_remoting_endpoint("Broker-A.INTERNAL:10911").as_deref(),
+            Some("broker-a.internal:10911")
+        );
+        assert_eq!(
+            canonical_remoting_endpoint("[2001:0db8:0:0:0:0:0:1]:10911").as_deref(),
+            Some("[2001:db8::1]:10911")
+        );
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/infrastructure_observation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/infrastructure_observation.rs
@@ -1,0 +1,346 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Closed, address-free infrastructure observation contracts.
+
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::core::error::required;
+use crate::core::query::AdminQueryResult;
+use crate::core::AdminError;
+use crate::core::AdminFuture;
+use crate::core::AdminResult;
+
+pub const MAX_HA_BROKER_TARGETS: usize = 64;
+pub const MAX_BROKER_INSTANCES_PER_LOGICAL_BROKER: usize = 64;
+pub const MAX_HA_CONNECTIONS_PER_BROKER: usize = 64;
+pub const MAX_SYNC_BROKERS: usize = 64;
+pub const MAX_SYNC_REPLICAS_PER_BROKER: usize = 64;
+pub const MAX_CONTROLLER_TARGETS: usize = 32;
+pub const MAX_CONTROLLER_PEERS: usize = 32;
+pub const MAX_NAMESERVER_TARGETS: usize = 16;
+pub const MAX_INFRASTRUCTURE_QUERY_ROWS: usize = 1_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryHaStatusRequest {
+    pub cluster: String,
+    pub broker_names: Vec<String>,
+    pub include_sync_state: bool,
+    pub controller_names: Vec<String>,
+}
+
+impl QueryHaStatusRequest {
+    pub fn try_new(
+        cluster: impl Into<String>,
+        broker_names: impl IntoIterator<Item = String>,
+        include_sync_state: bool,
+        controller_names: impl IntoIterator<Item = String>,
+    ) -> AdminResult<Self> {
+        let broker_names = normalize_broker_selectors(broker_names)?;
+        let controller_names = normalize_controller_selectors(controller_names)?;
+        if !include_sync_state && !controller_names.is_empty() {
+            return Err(AdminError::invalid_argument(
+                "controller_names",
+                "controller_names require include_sync_state=true",
+            ));
+        }
+        Ok(Self {
+            cluster: logical_identifier("cluster", required("cluster", cluster)?)?,
+            broker_names,
+            include_sync_state,
+            controller_names,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryControllerMetadataRequest {
+    pub cluster: String,
+    pub controller_names: Vec<String>,
+}
+
+impl QueryControllerMetadataRequest {
+    pub fn try_new(
+        cluster: impl Into<String>,
+        controller_names: impl IntoIterator<Item = String>,
+    ) -> AdminResult<Self> {
+        Ok(Self {
+            cluster: logical_identifier("cluster", required("cluster", cluster)?)?,
+            controller_names: normalize_controller_selectors(controller_names)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryNameserverConfigSummaryRequest {
+    pub cluster: String,
+}
+
+impl QueryNameserverConfigSummaryRequest {
+    pub fn try_new(cluster: impl Into<String>) -> AdminResult<Self> {
+        Ok(Self {
+            cluster: logical_identifier("cluster", required("cluster", cluster)?)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogicalBrokerInstance {
+    pub broker_name: String,
+    pub broker_id: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HaConnectionObservation {
+    pub replica: LogicalBrokerInstance,
+    pub slave_ack_offset: u64,
+    pub diff: i64,
+    pub in_sync: bool,
+    pub transferred_bytes_per_second: u64,
+    pub transfer_from_where: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrokerHaObservation {
+    pub broker_name: String,
+    pub broker_id: u64,
+    pub master_commit_log_max_offset: u64,
+    pub in_sync_slave_count: u32,
+    pub pending_group_transfer_request_count: u64,
+    pub pending_group_transfer_oldest_wait_millis: u64,
+    pub group_transfer_ack_notify_count: u64,
+    pub connections: Vec<HaConnectionObservation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrokerSyncStateObservation {
+    pub broker_name: String,
+    pub master_broker_id: u64,
+    pub master_epoch: i32,
+    pub sync_state_set_epoch: i32,
+    pub in_sync_replicas: Vec<LogicalBrokerInstance>,
+    pub not_in_sync_replicas: Vec<LogicalBrokerInstance>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControllerSyncStateObservation {
+    pub controller_name: String,
+    pub brokers: Vec<BrokerSyncStateObservation>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryHaStatusResult {
+    pub brokers: Vec<BrokerHaObservation>,
+    pub controller_sync_states: Vec<ControllerSyncStateObservation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControllerMetadataObservation {
+    pub controller_name: String,
+    pub group: Option<String>,
+    pub leader_id: Option<String>,
+    pub is_leader: Option<bool>,
+    pub peer_count: Option<usize>,
+    pub last_log_index: Option<u64>,
+    pub committed_log_index: Option<u64>,
+    pub applied_log_index: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryControllerMetadataResult {
+    pub controllers: Vec<ControllerMetadataObservation>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NameserverConfigValues {
+    pub cluster_test: Option<bool>,
+    pub order_message_enable: Option<bool>,
+    pub return_order_topic_config_to_broker: Option<bool>,
+    pub client_request_thread_pool_nums: Option<i32>,
+    pub client_request_thread_pool_queue_capacity: Option<i32>,
+    pub scan_not_active_broker_interval_ms: Option<u64>,
+    pub unregister_broker_queue_capacity: Option<i32>,
+    pub support_acting_master: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NameserverConfigObservation {
+    pub nameserver_name: String,
+    pub values: NameserverConfigValues,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NameserverConfigDifferenceField {
+    ClusterTest,
+    OrderMessageEnable,
+    ReturnOrderTopicConfigToBroker,
+    ClientRequestThreadPoolNums,
+    ClientRequestThreadPoolQueueCapacity,
+    ScanNotActiveBrokerIntervalMs,
+    UnregisterBrokerQueueCapacity,
+    SupportActingMaster,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryNameserverConfigSummaryResult {
+    pub nameservers: Vec<NameserverConfigObservation>,
+    pub inconsistent_fields: Vec<NameserverConfigDifferenceField>,
+}
+
+pub trait InfrastructureObservationQueryAdmin: Send {
+    fn query_ha_status<'a>(
+        &'a mut self,
+        request: &'a QueryHaStatusRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryHaStatusResult>>;
+
+    fn query_controller_metadata<'a>(
+        &'a mut self,
+        request: &'a QueryControllerMetadataRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryControllerMetadataResult>>;
+
+    fn query_nameserver_config_summary<'a>(
+        &'a mut self,
+        request: &'a QueryNameserverConfigSummaryRequest,
+    ) -> AdminFuture<'a, AdminQueryResult<QueryNameserverConfigSummaryResult>>;
+}
+
+fn normalize_broker_selectors(selectors: impl IntoIterator<Item = String>) -> AdminResult<Vec<String>> {
+    let selectors = selectors.into_iter().collect::<Vec<_>>();
+    if selectors.len() > MAX_HA_BROKER_TARGETS {
+        return Err(AdminError::invalid_argument(
+            "broker_names",
+            format!("must contain at most {MAX_HA_BROKER_TARGETS} logical Brokers"),
+        ));
+    }
+    let mut normalized = selectors
+        .into_iter()
+        .map(|selector| logical_identifier("broker_names", selector))
+        .collect::<AdminResult<Vec<_>>>()?;
+    normalized.sort();
+    normalized.dedup();
+    Ok(normalized)
+}
+
+fn normalize_controller_selectors(selectors: impl IntoIterator<Item = String>) -> AdminResult<Vec<String>> {
+    let selectors = selectors.into_iter().collect::<Vec<_>>();
+    if selectors.len() > MAX_CONTROLLER_TARGETS {
+        return Err(AdminError::invalid_argument(
+            "controller_names",
+            format!("must contain at most {MAX_CONTROLLER_TARGETS} logical Controllers"),
+        ));
+    }
+    let normalized = selectors
+        .into_iter()
+        .map(|selector| logical_identifier("controller_names", selector))
+        .collect::<AdminResult<Vec<_>>>()?;
+    let unique = normalized.iter().collect::<BTreeSet<_>>();
+    if unique.len() != normalized.len() {
+        return Err(AdminError::invalid_argument(
+            "controller_names",
+            "duplicate logical Controller aliases are not allowed",
+        ));
+    }
+    let mut normalized = normalized;
+    normalized.sort();
+    Ok(normalized)
+}
+
+fn logical_identifier(field: &'static str, value: impl Into<String>) -> AdminResult<String> {
+    let value = value.into();
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 100
+        || value.parse::<std::net::IpAddr>().is_ok()
+        || value.parse::<std::net::SocketAddr>().is_ok()
+        || value.contains([':', '/', '\\', '@', '=', '&', '?'])
+        || value.chars().any(char::is_control)
+        || !value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    {
+        Err(AdminError::invalid_argument(
+            field,
+            "must be a logical identifier of at most 100 bytes",
+        ))
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selector_contracts_are_bounded_and_relationship_checked() {
+        let request = QueryHaStatusRequest::try_new(
+            " cluster-a ",
+            ["broker-b".to_string(), "broker-a".to_string(), "broker-b".to_string()],
+            true,
+            ["controller-b".to_string(), "controller-a".to_string()],
+        )
+        .unwrap();
+        assert_eq!(request.broker_names, ["broker-a", "broker-b"]);
+        assert_eq!(request.controller_names, ["controller-a", "controller-b"]);
+        assert!(QueryHaStatusRequest::try_new("cluster-a", Vec::new(), false, ["controller-a".to_string()]).is_err());
+        assert!(QueryControllerMetadataRequest::try_new(
+            "cluster-a",
+            ["controller-a".to_string(), "controller-a".to_string()]
+        )
+        .is_err());
+        assert!(QueryControllerMetadataRequest::try_new(
+            "cluster-a",
+            (0..=MAX_CONTROLLER_TARGETS).map(|index| format!("controller-{index}"))
+        )
+        .is_err());
+        assert!(QueryHaStatusRequest::try_new(
+            "cluster-a",
+            (0..=MAX_HA_BROKER_TARGETS).map(|index| format!("broker-{index}")),
+            false,
+            Vec::new()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn nameserver_difference_fields_have_fixed_wire_order() {
+        let fields = [
+            NameserverConfigDifferenceField::ClusterTest,
+            NameserverConfigDifferenceField::OrderMessageEnable,
+            NameserverConfigDifferenceField::ReturnOrderTopicConfigToBroker,
+            NameserverConfigDifferenceField::ClientRequestThreadPoolNums,
+            NameserverConfigDifferenceField::ClientRequestThreadPoolQueueCapacity,
+            NameserverConfigDifferenceField::ScanNotActiveBrokerIntervalMs,
+            NameserverConfigDifferenceField::UnregisterBrokerQueueCapacity,
+            NameserverConfigDifferenceField::SupportActingMaster,
+        ];
+        assert_eq!(
+            serde_json::to_value(fields).unwrap(),
+            serde_json::json!([
+                "cluster_test",
+                "order_message_enable",
+                "return_order_topic_config_to_broker",
+                "client_request_thread_pool_nums",
+                "client_request_thread_pool_queue_capacity",
+                "scan_not_active_broker_interval_ms",
+                "unregister_broker_queue_capacity",
+                "support_acting_master"
+            ])
+        );
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/mod.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/mod.rs
@@ -32,6 +32,7 @@ pub mod consumer_workspace;
 pub mod dashboard;
 pub mod error;
 pub mod error_view;
+pub mod infrastructure_observation;
 pub mod lite;
 pub mod message;
 pub mod proxy;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/query.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/query.rs
@@ -45,6 +45,10 @@ pub enum AdminQuerySource {
     TopicStats,
     ConsumerGroupConfig,
     SubscriptionGroups,
+    BrokerHaRuntime,
+    ControllerSyncState,
+    ControllerMetadata,
+    NameserverConfig,
 }
 
 /// Stable, backend-independent failure classification.

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
@@ -36,6 +36,10 @@ mod exact_broker;
 mod read_queries;
 
 #[cfg(feature = "read-client-adapter")]
+#[path = "client_adapter/infrastructure_observation.rs"]
+mod infrastructure_observation;
+
+#[cfg(feature = "read-client-adapter")]
 #[path = "client_adapter/topic_observation.rs"]
 mod topic_observation;
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9951
- Fixes #9951

### Brief Description

This PR adds three typed, bounded infrastructure observation tools to the RocketMQ MCP read plane:

- `rocketmq_get_ha_status`
- `rocketmq_get_controller_metadata`
- `rocketmq_get_nameserver_config_summary`

It introduces a narrow `admin-read` client extension and closed Admin Core DTOs/adapters for HA runtime, Controller metadata and sync-state evidence, and allowlisted NameServer configuration. Broker, Controller, and NameServer endpoints remain internal to trusted target resolution; public results contain only logical names, typed values, deterministic partial-failure evidence, and bounded rows.

The MCP integration adds logical Controller configuration, read/diagnose permission routing, principal-isolated caching, timeout/cancellation/shutdown ownership, output row and byte enforcement, catalog and protocol contracts, and updated example configuration. The default and all-features tool catalogs now contain 24 and 29 tools respectively. Resources, ResourceTemplates, and Prompts remain unchanged at 7, 10, and 2.

### How Did You Test This Change?

The branch was rebased onto the latest `origin/main` before validation. `RUST_MIN_STACK` and `INSTA_UPDATE` were unset for every standalone MCP command, and no stack workaround was used.

- `cargo fmt -p rocketmq-client-rust -- --check`: passed.
- `cargo fmt -p rocketmq-admin-core -- --check`: passed.
- `cargo check -p rocketmq-client-rust --no-default-features --features admin-read`: passed.
- `cargo test -p rocketmq-admin-core --features read-client-adapter infrastructure_observation`: passed, 17 focused tests.
- `cargo test -p rocketmq-admin-core --features read-client-adapter`: passed, 121 unit tests and 10 integration tests.
- `cargo fmt -p rocketmq-mcp -- --check`: passed from the standalone MCP project.
- `cargo check --locked`: passed from the standalone MCP project.
- `python scripts/check_read_only_boundary.py`: passed.
- `cargo test --locked cache`: passed, 29 focused tests.
- `cargo test --locked output_policy`: passed, 7 focused tests.
- `cargo test --locked infrastructure`: passed, 46 focused tests.
- `cargo test --locked`: passed; the existing external-cluster E2E remained ignored because its required environment was not configured.
- `cargo test --locked --all-features`: passed; the same external-cluster E2E remained ignored.
- `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`: passed.
- `cargo doc --locked --no-deps`: passed.
- `cargo test --locked snapshot` and `cargo test --locked --all-features snapshot`: passed with no snapshot updates or `.snap.new` files.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed from the repository root.
- `git diff --check`: passed.

On Windows, the standalone `cargo fmt --all -- --check` command stops before formatting with `os error 206` because the expanded path set exceeds the platform filename limit. The package-scoped MCP format check above passed, as did all compilation, test, Clippy, documentation, boundary, and snapshot checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infrastructure diagnostic tools for broker HA status, controller metadata, and NameServer configuration summaries.
  * Added controller endpoint configuration and expanded permissions for read-only and diagnostic access.
  * Added bounded, validated infrastructure observations with clearer partial-result and source-failure reporting.

* **Bug Fixes**
  * Improved endpoint validation, duplicate detection, and configuration parsing.
  * Added cache memory limits to prevent oversized results.
  * Redacted sensitive endpoint and credential details from debug output and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->