### PR TITLE
[ISSUE #9963]♻️Consolidate remaining protocol header tests around observable contracts

### DIFF
--- a/rocketmq-protocol/src/protocol/header/controller/alter_sync_state_set_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/alter_sync_state_set_response_header.rs
@@ -61,10 +61,4 @@ mod tests {
         let header = <AlterSyncStateSetResponseHeader as FromMap>::from(&map).unwrap();
         assert_eq!(header.new_sync_state_set_epoch, 10);
     }
-
-    #[test]
-    fn alter_sync_state_set_response_header_default() {
-        let header = AlterSyncStateSetResponseHeader::default();
-        assert_eq!(header.new_sync_state_set_epoch, 0);
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/controller/apply_broker_id_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/apply_broker_id_request_header.rs
@@ -95,13 +95,4 @@ mod tests {
         assert_eq!(header.applied_broker_id, 9876543210);
         assert_eq!(header.register_check_code, "check_code_123");
     }
-
-    #[test]
-    fn apply_broker_id_request_header_default() {
-        let header = ApplyBrokerIdRequestHeader::default();
-        assert_eq!(header.cluster_name, "");
-        assert_eq!(header.broker_name, "");
-        assert_eq!(header.applied_broker_id, 0);
-        assert_eq!(header.register_check_code, "");
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/controller/apply_broker_id_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/apply_broker_id_response_header.rs
@@ -71,11 +71,4 @@ mod tests {
         );
         assert_eq!(header.broker_name, Some(CheetahString::from_static_str("test_broker")));
     }
-
-    #[test]
-    fn apply_broker_id_response_header_default() {
-        let header = ApplyBrokerIdResponseHeader::default();
-        assert_eq!(header.cluster_name, None);
-        assert_eq!(header.broker_name, None);
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/controller/clean_broker_data_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/clean_broker_data_request_header.rs
@@ -142,16 +142,6 @@ mod tests {
     }
 
     #[test]
-    fn clean_controller_broker_data_request_header_alias_matches_java_name() {
-        let header = CleanControllerBrokerDataRequestHeader {
-            broker_name: CheetahString::from_static_str("broker-a"),
-            ..Default::default()
-        };
-
-        assert_eq!(header.broker_name, "broker-a");
-    }
-
-    #[test]
     fn missing_invoke_time_uses_the_java_dynamic_default() {
         let before = rocketmq_model::time::current_millis();
         let map = HashMap::from([(
@@ -164,6 +154,19 @@ mod tests {
 
         assert!((before..=after).contains(&header.invoke_time));
         assert!(!header.clean_living_broker);
+    }
+
+    #[test]
+    fn clean_broker_data_request_header_default() {
+        let before = rocketmq_model::time::current_millis();
+        let header = CleanBrokerDataRequestHeader::default();
+        let after = rocketmq_model::time::current_millis();
+
+        assert!(header.cluster_name.is_none());
+        assert_eq!(header.broker_name, "");
+        assert!(header.broker_controller_ids_to_clean.is_none());
+        assert!(!header.clean_living_broker);
+        assert!((before..=after).contains(&header.invoke_time));
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header/controller/elect_master_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/elect_master_request_header.rs
@@ -88,16 +88,6 @@ mod tests {
     use crate::protocol::command_custom_header::FromMap;
 
     #[test]
-    fn elect_master_request_header_new() {
-        let header = ElectMasterRequestHeader::new("test_cluster", "test_broker", 123, true, 1234567890);
-        assert_eq!(header.cluster_name, "test_cluster");
-        assert_eq!(header.broker_name, "test_broker");
-        assert_eq!(header.broker_id, 123);
-        assert!(header.designate_elect);
-        assert_eq!(header.invoke_time, 1234567890);
-    }
-
-    #[test]
     fn elect_master_request_header_serializes_correctly() {
         let header = ElectMasterRequestHeader::new("test_cluster", "test_broker", 123, true, 1234567890);
         let map = header.to_map().unwrap();

--- a/rocketmq-protocol/src/protocol/header/controller/get_next_broker_id_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/get_next_broker_id_request_header.rs
@@ -71,11 +71,4 @@ mod tests {
         assert_eq!(header.cluster_name, "test_cluster");
         assert_eq!(header.broker_name, "test_broker");
     }
-
-    #[test]
-    fn get_next_broker_id_request_header_default() {
-        let header = GetNextBrokerIdRequestHeader::default();
-        assert_eq!(header.cluster_name, "");
-        assert_eq!(header.broker_name, "");
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/controller/get_next_broker_id_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/get_next_broker_id_response_header.rs
@@ -83,12 +83,4 @@ mod tests {
         assert_eq!(header.broker_name, Some(CheetahString::from_static_str("test_broker")));
         assert_eq!(header.next_broker_id, Some(12345));
     }
-
-    #[test]
-    fn get_next_broker_id_response_header_default() {
-        let header = GetNextBrokerIdResponseHeader::default();
-        assert_eq!(header.cluster_name, None);
-        assert_eq!(header.broker_name, None);
-        assert_eq!(header.next_broker_id, None);
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/controller/get_replica_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/get_replica_info_request_header.rs
@@ -59,10 +59,4 @@ mod tests {
         let header = <GetReplicaInfoRequestHeader as FromMap>::from(&map).unwrap();
         assert_eq!(header.broker_name, "test_broker");
     }
-
-    #[test]
-    fn get_replica_info_request_header_default() {
-        let header = GetReplicaInfoRequestHeader::default();
-        assert_eq!(header.broker_name, "");
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/controller/get_replica_info_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/get_replica_info_response_header.rs
@@ -78,12 +78,4 @@ mod tests {
         assert_eq!(header.master_address, Some("127.0.0.1:10911".to_string()));
         assert_eq!(header.master_epoch, Some(5));
     }
-
-    #[test]
-    fn get_replica_info_response_header_default() {
-        let header = GetReplicaInfoResponseHeader::default();
-        assert_eq!(header.master_broker_id, None);
-        assert_eq!(header.master_address, None);
-        assert_eq!(header.master_epoch, None);
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/controller/register_broker_to_controller_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/register_broker_to_controller_request_header.rs
@@ -106,14 +106,4 @@ mod tests {
         );
         assert_eq!(header.invoke_time, 1234567890);
     }
-
-    #[test]
-    fn register_broker_to_controller_request_header_default() {
-        let header = RegisterBrokerToControllerRequestHeader::default();
-        assert_eq!(header.cluster_name, None);
-        assert_eq!(header.broker_name, None);
-        assert_eq!(header.broker_id, None);
-        assert_eq!(header.broker_address, None);
-        assert_eq!(header.invoke_time, 0);
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/controller/register_broker_to_controller_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/controller/register_broker_to_controller_response_header.rs
@@ -116,15 +116,4 @@ mod tests {
         assert_eq!(header.master_epoch, Some(5));
         assert_eq!(header.sync_state_set_epoch, Some(10));
     }
-
-    #[test]
-    fn register_broker_to_controller_response_header_default() {
-        let header = RegisterBrokerToControllerResponseHeader::default();
-        assert_eq!(header.cluster_name, None);
-        assert_eq!(header.broker_name, None);
-        assert_eq!(header.master_broker_id, None);
-        assert_eq!(header.master_address, None);
-        assert_eq!(header.master_epoch, None);
-        assert_eq!(header.sync_state_set_epoch, None);
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/create_user_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/create_user_request_header.rs
@@ -47,41 +47,15 @@ mod tests {
     use crate::protocol::command_custom_header::FromMap;
 
     #[test]
-    fn create_user_request_header_new() {
-        let username = CheetahString::from_static_str("test_user");
-        let header = CreateUserRequestHeader::new(username.clone());
-
-        assert_eq!(header.username, username);
-    }
-
-    #[test]
-    fn create_user_request_header_default() {
-        let header = CreateUserRequestHeader::default();
-
-        assert!(header.username.is_empty());
-    }
-
-    #[test]
-    fn create_user_request_header_set_username() {
-        let mut header = CreateUserRequestHeader::default();
-        let username = CheetahString::from_static_str("admin");
-
-        header.set_username(username.clone());
-
-        assert_eq!(header.username, username);
-    }
-
-    #[test]
     fn create_user_request_header_serializes_correctly() {
-        let header = CreateUserRequestHeader {
-            username: CheetahString::from_static_str("test_admin"),
-        };
+        let mut header = CreateUserRequestHeader::new(CheetahString::from_static_str("test_admin"));
+        assert_eq!(header.username, "test_admin");
 
+        header.set_username(CheetahString::from_static_str("updated_admin"));
         let map = header.to_map().unwrap();
-
         assert_eq!(
             map.get(&CheetahString::from_static_str("username")).unwrap(),
-            "test_admin"
+            "updated_admin"
         );
     }
 

--- a/rocketmq-protocol/src/protocol/header/delete_acl_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/delete_acl_request_header.rs
@@ -85,63 +85,6 @@ mod tests {
     use crate::protocol::command_custom_header::FromMap;
 
     #[test]
-    fn delete_acl_request_header_new() {
-        let subject = CheetahString::from_static_str("user:alice");
-        let resource = Some(CheetahString::from_static_str("Topic:test-topic"));
-        let header = DeleteAclRequestHeader::new(subject.clone(), resource.clone());
-
-        assert_eq!(header.subject, subject);
-        assert!(header.policy_type.is_none());
-        assert_eq!(header.resource, resource);
-    }
-
-    #[test]
-    fn delete_acl_request_header_with_policy_type() {
-        let subject = CheetahString::from_static_str("user:alice");
-        let policy_type = Some(CheetahString::from_static_str("Default"));
-        let resource = Some(CheetahString::from_static_str("Topic:test-topic"));
-        let header = DeleteAclRequestHeader::with_policy_type(subject.clone(), policy_type.clone(), resource.clone());
-
-        assert_eq!(header.subject, subject);
-        assert_eq!(header.policy_type, policy_type);
-        assert_eq!(header.resource, resource);
-    }
-
-    #[test]
-    fn delete_acl_request_header_with_subject() {
-        let subject = CheetahString::from_static_str("user:bob");
-        let header = DeleteAclRequestHeader::with_subject(subject.clone());
-
-        assert_eq!(header.subject, subject);
-        assert!(header.resource.is_none());
-    }
-
-    #[test]
-    fn delete_acl_request_header_default() {
-        let header = DeleteAclRequestHeader::default();
-
-        assert!(header.subject.is_empty());
-        assert!(header.policy_type.is_none());
-        assert!(header.resource.is_none());
-    }
-
-    #[test]
-    fn delete_acl_request_header_set_methods() {
-        let mut header = DeleteAclRequestHeader::default();
-        let subject = CheetahString::from_static_str("user:charlie");
-        let policy_type = Some(CheetahString::from_static_str("Custom"));
-        let resource = Some(CheetahString::from_static_str("Group:consumer-group"));
-
-        header.set_subject(subject.clone());
-        header.set_policy_type(policy_type.clone());
-        header.set_resource(resource.clone());
-
-        assert_eq!(header.subject, subject);
-        assert_eq!(header.policy_type, policy_type);
-        assert_eq!(header.resource, resource);
-    }
-
-    #[test]
     fn delete_acl_request_header_serializes_correctly() {
         let header = DeleteAclRequestHeader::with_policy_type(
             CheetahString::from_static_str("user:alice"),
@@ -162,6 +105,31 @@ mod tests {
             map.get(&CheetahString::from_static_str("resource")),
             Some(&CheetahString::from_static_str("Topic:test"))
         );
+    }
+
+    #[test]
+    fn constructors_and_mutators_preserve_optional_wire_fields() {
+        let with_resource = DeleteAclRequestHeader::new(
+            CheetahString::from_static_str("user:alice"),
+            Some(CheetahString::from_static_str("Topic:test")),
+        );
+        assert_eq!(with_resource.subject, "user:alice");
+        assert!(with_resource.policy_type.is_none());
+        assert_eq!(with_resource.resource.as_deref(), Some("Topic:test"));
+
+        let mut header = DeleteAclRequestHeader::with_subject(CheetahString::from_static_str("user:before"));
+        assert_eq!(header.subject, "user:before");
+        assert!(header.policy_type.is_none());
+        assert!(header.resource.is_none());
+
+        header.set_subject(CheetahString::from_static_str("user:alice"));
+        header.set_policy_type(Some(CheetahString::from_static_str("Custom")));
+        header.set_resource(Some(CheetahString::from_static_str("Topic:test")));
+
+        let map = header.to_map().unwrap();
+        assert_eq!(map.get("subject").map(CheetahString::as_str), Some("user:alice"));
+        assert_eq!(map.get("policyType").map(CheetahString::as_str), Some("Custom"));
+        assert_eq!(map.get("resource").map(CheetahString::as_str), Some("Topic:test"));
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header/delete_user_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/delete_user_request_header.rs
@@ -47,41 +47,15 @@ mod tests {
     use crate::protocol::command_custom_header::FromMap;
 
     #[test]
-    fn delete_user_request_header_new() {
-        let username = CheetahString::from_static_str("test_user");
-        let header = DeleteUserRequestHeader::new(username.clone());
-
-        assert_eq!(header.username, username);
-    }
-
-    #[test]
-    fn delete_user_request_header_default() {
-        let header = DeleteUserRequestHeader::default();
-
-        assert!(header.username.is_empty());
-    }
-
-    #[test]
-    fn delete_user_request_header_set_username() {
-        let mut header = DeleteUserRequestHeader::default();
-        let username = CheetahString::from_static_str("admin");
-
-        header.set_username(username.clone());
-
-        assert_eq!(header.username, username);
-    }
-
-    #[test]
     fn delete_user_request_header_serializes_correctly() {
-        let header = DeleteUserRequestHeader {
-            username: CheetahString::from_static_str("test_admin"),
-        };
+        let mut header = DeleteUserRequestHeader::new(CheetahString::from_static_str("test_admin"));
+        assert_eq!(header.username, "test_admin");
 
+        header.set_username(CheetahString::from_static_str("updated_admin"));
         let map = header.to_map().unwrap();
-
         assert_eq!(
             map.get(&CheetahString::from_static_str("username")).unwrap(),
-            "test_admin"
+            "updated_admin"
         );
     }
 

--- a/rocketmq-protocol/src/protocol/header/end_transaction_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/end_transaction_request_header.rs
@@ -95,19 +95,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn end_transaction_request_header_default() {
-        let header = EndTransactionRequestHeader::default();
-        assert_eq!(header.topic, "");
-        assert_eq!(header.producer_group, "");
-        assert_eq!(header.tran_state_table_offset, 0);
-        assert_eq!(header.commit_log_offset, 0);
-        assert_eq!(header.commit_or_rollback, 0);
-        assert!(!header.from_transaction_check);
-        assert_eq!(header.msg_id, "");
-        assert!(header.transaction_id.is_none());
-    }
-
-    #[test]
     fn end_transaction_request_header_serialization() {
         let header = EndTransactionRequestHeader {
             topic: CheetahString::from("topic1"),
@@ -161,30 +148,6 @@ mod tests {
         assert!(header.from_transaction_check);
         assert_eq!(header.msg_id, "msg1");
         assert!(header.transaction_id.is_none());
-    }
-
-    #[test]
-    fn end_transaction_request_header_rpc_request_header() {
-        let header = EndTransactionRequestHeader {
-            topic: CheetahString::from("topic1"),
-            producer_group: CheetahString::from("group1"),
-            tran_state_table_offset: 123,
-            commit_log_offset: 456,
-            commit_or_rollback: 8,
-            from_transaction_check: true,
-            msg_id: CheetahString::from("msg1"),
-            transaction_id: Some(CheetahString::from("tran1")),
-            rpc_request_header: RpcRequestHeader {
-                namespace: Some(CheetahString::from("namespace1")),
-                namespaced: Some(true),
-                broker_name: Some(CheetahString::from("broker1")),
-                oneway: Some(false),
-            },
-        };
-        assert_eq!(header.rpc_request_header.namespace.as_ref().unwrap(), "namespace1");
-        assert!(header.rpc_request_header.namespaced.unwrap());
-        assert_eq!(header.rpc_request_header.broker_name.as_ref().unwrap(), "broker1");
-        assert!(!header.rpc_request_header.oneway.unwrap());
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header/export_rocksdb_config_to_json_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/export_rocksdb_config_to_json_request_header.rs
@@ -87,16 +87,4 @@ mod tests {
             ]
         );
     }
-
-    #[test]
-    fn export_rocksdb_config_to_json_request_header_alias_matches_java_name() {
-        let header = ExportRocksDBConfigToJsonRequestHeader {
-            config_type: CheetahString::from_static_str("topics"),
-        };
-
-        assert_eq!(
-            header.fetch_config_type().expect("config type should parse"),
-            vec![ExportRocksdbConfigType::Topics]
-        );
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/get_consume_stats_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_consume_stats_request_header.rs
@@ -73,31 +73,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn getters_and_setters() {
-        let mut header = GetConsumeStatsRequestHeader {
-            consumer_group: CheetahString::from("testGroup"),
-            topic: CheetahString::from("testTopic"),
-            topic_list: None,
-            topic_request_header: None,
-        };
-
-        assert_eq!(header.get_consumer_group(), "testGroup");
-        assert_eq!(header.get_topic(), "testTopic");
-
-        header.set_consumer_group(CheetahString::from("newGroup"));
-        header.set_topic(CheetahString::from("newTopic"));
-
-        assert_eq!(header.get_consumer_group(), "newGroup");
-        assert_eq!(header.get_topic(), "newTopic");
-    }
-    #[test]
     fn get_consume_stats_request_header_serde() {
-        let header = GetConsumeStatsRequestHeader {
-            consumer_group: CheetahString::from("testGroup"),
-            topic: CheetahString::from("testTopic"),
+        let mut header = GetConsumeStatsRequestHeader {
+            consumer_group: CheetahString::new(),
+            topic: CheetahString::new(),
             topic_list: None,
             topic_request_header: None,
         };
+        header.set_consumer_group(CheetahString::from("testGroup"));
+        header.set_topic(CheetahString::from("testTopic"));
 
         let json = serde_json::to_string(&header).unwrap();
 

--- a/rocketmq-protocol/src/protocol/header/get_consumer_connection_list_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_consumer_connection_list_request_header.rs
@@ -48,13 +48,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn getters_and_setters() {
+    fn serde_preserves_the_consumer_group() {
         let mut header = GetConsumerConnectionListRequestHeader {
-            consumer_group: CheetahString::from("group1"),
+            consumer_group: CheetahString::new(),
             rpc_request_header: None,
         };
-        assert_eq!(header.get_consumer_group(), "group1");
-        header.set_consumer_group(CheetahString::from("group2"));
-        assert_eq!(header.get_consumer_group(), "group2");
+        header.set_consumer_group(CheetahString::from("group-a"));
+
+        let json = serde_json::to_string(&header).unwrap();
+        assert_eq!(json, r#"{"consumerGroup":"group-a"}"#);
+
+        let decoded: GetConsumerConnectionListRequestHeader = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.get_consumer_group(), "group-a");
     }
 }

--- a/rocketmq-protocol/src/protocol/header/get_consumer_status_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_consumer_status_request_header.rs
@@ -61,37 +61,22 @@ mod tests {
     use crate::protocol::command_custom_header::FromMap;
 
     #[test]
-    fn get_consumer_status_request_header_default() {
-        let header = GetConsumerStatusRequestHeader::default();
-        assert_eq!(header.topic, "");
-        assert_eq!(header.group, "");
-        assert!(header.client_addr.is_none());
-        assert!(header.topic_request_header.is_none());
-    }
-
-    #[test]
-    fn get_consumer_status_request_header_new() {
-        let header = GetConsumerStatusRequestHeader::new(CheetahString::from("topic1"), CheetahString::from("group1"));
+    fn get_consumer_status_request_header_serialization() {
+        let mut header =
+            GetConsumerStatusRequestHeader::new(CheetahString::from("topic1"), CheetahString::from("group1"));
         assert_eq!(header.topic, "topic1");
         assert_eq!(header.group, "group1");
         assert!(header.client_addr.is_none());
         assert!(header.topic_request_header.is_none());
-    }
 
-    #[test]
-    fn get_consumer_status_request_header_serialization() {
-        let header = GetConsumerStatusRequestHeader {
-            topic: CheetahString::from("topic1"),
-            group: CheetahString::from("group1"),
-            client_addr: Some(CheetahString::from("127.0.0.1")),
-            topic_request_header: Some(TopicRequestHeader {
-                lo: Some(true),
-                rpc_request_header: Some(crate::rpc::rpc_request_header::RpcRequestHeader {
-                    broker_name: Some(CheetahString::from("broker")),
-                    ..Default::default()
-                }),
+        header.client_addr = Some(CheetahString::from("127.0.0.1"));
+        header.topic_request_header = Some(TopicRequestHeader {
+            lo: Some(true),
+            rpc_request_header: Some(crate::rpc::rpc_request_header::RpcRequestHeader {
+                broker_name: Some(CheetahString::from("broker")),
+                ..Default::default()
             }),
-        };
+        });
         let json = serde_json::to_string(&header).unwrap();
         assert!(json.contains("\"topic\":\"topic1\""));
         assert!(json.contains("\"group\":\"group1\""));

--- a/rocketmq-protocol/src/protocol/header/get_lite_client_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_lite_client_info_request_header.rs
@@ -72,15 +72,6 @@ mod tests {
     use crate::protocol::command_custom_header::FromMap;
 
     #[test]
-    fn get_lite_client_info_request_header_defaults_max_count() {
-        let header = GetLiteClientInfoRequestHeader::default();
-        assert_eq!(header.max_count, 1000);
-        assert!(header.parent_topic.is_none());
-        assert!(header.group.is_none());
-        assert!(header.client_id.is_none());
-    }
-
-    #[test]
     fn get_lite_client_info_request_header_serializes_to_map() {
         let header = GetLiteClientInfoRequestHeader {
             parent_topic: Some("parent".into()),
@@ -127,7 +118,13 @@ mod tests {
     }
 
     #[test]
-    fn missing_max_count_uses_java_default() {
+    fn default_paths_use_java_max_count() {
+        let default = GetLiteClientInfoRequestHeader::default();
+        assert!(default.parent_topic.is_none());
+        assert!(default.group.is_none());
+        assert!(default.client_id.is_none());
+        assert_eq!(default.max_count, 1000);
+
         let header = <GetLiteClientInfoRequestHeader as FromMap>::from(&HashMap::new()).unwrap();
         assert_eq!(header.max_count, 1000);
     }

--- a/rocketmq-protocol/src/protocol/header/get_max_offset_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_max_offset_response_header.rs
@@ -36,12 +36,6 @@ mod tests {
     use crate::protocol::command_custom_header::FromMap;
 
     #[test]
-    fn get_max_offset_response_header_default() {
-        let header = GetMaxOffsetResponseHeader::default();
-        assert_eq!(header.offset, 0);
-    }
-
-    #[test]
     fn get_max_offset_response_header_serialization() {
         let header = GetMaxOffsetResponseHeader { offset: 12345 };
         let json = serde_json::to_string(&header).unwrap();

--- a/rocketmq-protocol/src/protocol/header/get_min_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_min_offset_request_header.rs
@@ -135,14 +135,6 @@ mod tests {
     use crate::rpc::rpc_request_header::RpcRequestHeader;
 
     #[test]
-    fn get_min_offset_request_header_default() {
-        let header = GetMinOffsetRequestHeader::default();
-        assert_eq!(header.topic, "");
-        assert_eq!(header.queue_id, 0);
-        assert!(header.topic_request_header.is_none());
-    }
-
-    #[test]
     fn get_min_offset_request_header_trait_impl() {
         let mut header = GetMinOffsetRequestHeader::default();
 

--- a/rocketmq-protocol/src/protocol/header/get_producer_connection_list_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_producer_connection_list_request_header.rs
@@ -75,10 +75,4 @@ mod tests {
         let header: GetProducerConnectionListRequestHeader = serde_json::from_str(json).unwrap();
         assert_eq!(header.producer_group(), "test_group");
     }
-
-    #[test]
-    fn get_producer_connection_list_request_header_default() {
-        let header = GetProducerConnectionListRequestHeader::default();
-        assert_eq!(header.producer_group(), "");
-    }
 }

--- a/rocketmq-protocol/src/protocol/header/get_topic_config_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_topic_config_request_header.rs
@@ -140,10 +140,11 @@ mod tests {
 
     #[test]
     fn get_topic_config_request_header_serialization() {
-        let header = GetTopicConfigRequestHeader {
-            topic: CheetahString::from("topic1"),
+        let mut header = GetTopicConfigRequestHeader {
+            topic: CheetahString::new(),
             topic_request_header: None,
         };
+        header.set_topic(CheetahString::from("topic1"));
         let json = serde_json::to_string(&header).unwrap();
         assert!(json.contains("\"topic\":\"topic1\""));
     }
@@ -152,7 +153,7 @@ mod tests {
     fn get_topic_config_request_header_deserialization() {
         let json = r#"{"topic":"topic1"}"#;
         let header: GetTopicConfigRequestHeader = serde_json::from_str(json).unwrap();
-        assert_eq!(header.topic, "topic1");
+        assert_eq!(header.get_topic(), "topic1");
     }
 
     #[test]
@@ -161,16 +162,5 @@ mod tests {
         map.insert(CheetahString::from("topic"), CheetahString::from("topic1"));
         let header = <GetTopicConfigRequestHeader as FromMap>::from(&map).unwrap();
         assert_eq!(header.topic, "topic1");
-    }
-
-    #[test]
-    fn getters_and_setters() {
-        let mut header = GetTopicConfigRequestHeader {
-            topic: CheetahString::from("topic1"),
-            topic_request_header: None,
-        };
-        assert_eq!(header.get_topic(), "topic1");
-        header.set_topic(CheetahString::from("topic2"));
-        assert_eq!(header.get_topic(), "topic2");
     }
 }

--- a/rocketmq-protocol/src/protocol/header/get_user_request_headers.rs
+++ b/rocketmq-protocol/src/protocol/header/get_user_request_headers.rs
@@ -33,12 +33,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn get_user_request_header_default() {
-        let header = GetUserRequestHeader::default();
-        assert_eq!(header.username, CheetahString::default());
-    }
-
-    #[test]
     fn get_user_request_header_serialize() {
         let header = GetUserRequestHeader {
             username: CheetahString::from("value"),

--- a/rocketmq-protocol/src/protocol/header/list_acl_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/list_acl_request_header.rs
@@ -38,13 +38,6 @@ mod tests {
     use cheetah_string::CheetahString;
 
     #[test]
-    fn list_acl_request_header_default() {
-        let header: ListAclRequestHeader = Default::default();
-        assert_eq!(header.subject_filter, CheetahString::default());
-        assert_eq!(header.resource_filter, CheetahString::default());
-    }
-
-    #[test]
     fn list_acl_request_header_serialize() {
         let header = ListAclRequestHeader {
             subject_filter: CheetahString::from("subjectFilterValue"),
@@ -69,16 +62,5 @@ mod tests {
 
         assert_eq!(header.subject_filter, CheetahString::from("subjectFilterValue"));
         assert_eq!(header.resource_filter, CheetahString::from("resourceFilterValue"));
-    }
-
-    #[test]
-    fn list_acls_request_header_alias_matches_java_name() {
-        let header = ListAclsRequestHeader {
-            subject_filter: CheetahString::from("subject"),
-            resource_filter: CheetahString::from("resource"),
-        };
-
-        assert_eq!(header.subject_filter, "subject");
-        assert_eq!(header.resource_filter, "resource");
     }
 }

--- a/rocketmq-protocol/src/protocol/header/list_users_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/list_users_request_header.rs
@@ -33,12 +33,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn list_users_request_header_default() {
-        let body = ListUsersRequestHeader::default();
-        assert_eq!(body.filter, "");
-    }
-
-    #[test]
     fn list_users_request_header_serialize_deserialize() {
         let body = ListUsersRequestHeader { filter: "test".into() };
         let serialized = serde_json::to_string(&body).unwrap();

--- a/rocketmq-protocol/src/protocol/header/lock_batch_mq_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/lock_batch_mq_request_header.rs
@@ -36,12 +36,6 @@ mod tests {
     use cheetah_string::CheetahString;
 
     #[test]
-    fn lock_batch_mq_request_header_default() {
-        let header: LockBatchMqRequestHeader = Default::default();
-        assert!(header.rpc_request_header.is_none());
-    }
-
-    #[test]
     fn lock_batch_mq_request_header_serialize() {
         let header: LockBatchMqRequestHeader = LockBatchMqRequestHeader {
             rpc_request_header: Some(RpcRequestHeader::new(

--- a/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/message_operation_header/send_message_response_header.rs
@@ -132,61 +132,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn send_message_response_header_new_and_default() {
-        let header = SendMessageResponseHeader::new(
-            CheetahString::from("msg123"),
-            1,
-            100,
-            Some(CheetahString::from("tx456")),
-            Some(CheetahString::from("batch789")),
-            Some(CheetahString::from("recall-handle")),
-        );
-
-        assert_eq!(header.msg_id(), "msg123");
-        assert_eq!(header.queue_id(), 1);
-        assert_eq!(header.queue_offset(), 100);
-        assert_eq!(header.transaction_id(), Some("tx456"));
-        assert_eq!(header.batch_uniq_id(), Some("batch789"));
-        assert_eq!(header.recall_handle(), Some("recall-handle"));
-
-        let header = SendMessageResponseHeader::default();
-
-        assert_eq!(header.msg_id(), "");
-        assert_eq!(header.queue_id(), 0);
-        assert_eq!(header.queue_offset(), 0);
-        assert_eq!(header.transaction_id(), None);
-        assert_eq!(header.batch_uniq_id(), None);
-        assert_eq!(header.recall_handle(), None);
-    }
-
-    #[test]
-    fn send_message_response_header_setters_and_getters() {
-        let mut header = SendMessageResponseHeader::default();
-        header.set_msg_id("newMsgId");
-        header.set_queue_id(2);
-        header.set_queue_offset(200);
-        header.set_transaction_id(Some(CheetahString::from("newTxId")));
-        header.set_batch_uniq_id(Some(CheetahString::from("newBatchId")));
-        header.set_recall_handle(Some(CheetahString::from("recall-123")));
-
-        assert_eq!(header.msg_id(), "newMsgId");
-        assert_eq!(header.queue_id(), 2);
-        assert_eq!(header.queue_offset(), 200);
-        assert_eq!(header.transaction_id(), Some("newTxId"));
-        assert_eq!(header.batch_uniq_id(), Some("newBatchId"));
-        assert_eq!(header.recall_handle(), Some("recall-123"));
-    }
-
-    #[test]
     fn send_message_response_header_serialization_and_deserialization() {
-        let header = SendMessageResponseHeader::new(
-            CheetahString::from("msg123"),
-            1,
-            100,
-            Some(CheetahString::from("tx456")),
-            Some(CheetahString::from("batch789")),
-            Some(CheetahString::from("recall-handle")),
-        );
+        let mut header = SendMessageResponseHeader::default();
+        header.set_msg_id("msg123");
+        header.set_queue_id(1);
+        header.set_queue_offset(100);
+        header.set_transaction_id(Some(CheetahString::from("tx456")));
+        header.set_batch_uniq_id(Some(CheetahString::from("batch789")));
+        header.set_recall_handle(Some(CheetahString::from("recall-handle")));
 
         let json = serde_json::to_string(&header).unwrap();
         assert_eq!(
@@ -214,6 +167,12 @@ mod tests {
             Some(CheetahString::from("batch789")),
             Some(CheetahString::from("recall-handle")),
         );
+        assert_eq!(header.msg_id(), "msg123");
+        assert_eq!(header.queue_id(), 1);
+        assert_eq!(header.queue_offset(), 100);
+        assert_eq!(header.transaction_id(), Some("tx456"));
+        assert_eq!(header.batch_uniq_id(), Some("batch789"));
+        assert_eq!(header.recall_handle(), Some("recall-handle"));
 
         let mut out = bytes::BytesMut::new();
         FastCodesHeader::encode_fast(&mut header, &mut out);

--- a/rocketmq-protocol/src/protocol/header/namesrv/broker_request.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/broker_request.rs
@@ -124,18 +124,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_creates_instance_with_correct_values() {
-        let header = GetBrokerMemberGroupRequestHeader::new("testCluster", "testBroker");
-        assert_eq!(header.cluster_name, CheetahString::from("testCluster"));
-        assert_eq!(header.broker_name, CheetahString::from("testBroker"));
-    }
-
-    #[test]
     fn unregister_broker_request_header_display() {
         let header = UnRegisterBrokerRequestHeader::new("name", "addr", "cluster", 1);
         let display = format!("{}", header);
         let expected =
             "UnRegisterBrokerRequestHeader { brokerName: name, brokerAddr: addr, clusterName: cluster, brokerId: 1 }";
         assert_eq!(display, expected);
+    }
+
+    #[test]
+    fn get_broker_member_group_request_uses_java_wire_names() {
+        let header = GetBrokerMemberGroupRequestHeader::new("cluster-a", "broker-a");
+
+        assert_eq!(
+            serde_json::to_string(&header).unwrap(),
+            r#"{"clusterName":"cluster-a","brokerName":"broker-a"}"#
+        );
     }
 }

--- a/rocketmq-protocol/src/protocol/header/namesrv/brokerid_change_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/brokerid_change_request_header.rs
@@ -60,43 +60,32 @@ impl NotifyMinBrokerIdChangeRequestHeader {
 
 #[cfg(test)]
 mod tests {
-    use cheetah_string::CheetahString;
-
     use super::*;
 
     #[test]
-    fn new_creates_instance_with_all_fields() {
+    fn serde_preserves_the_broker_change_wire_fields() {
         let header = NotifyMinBrokerIdChangeRequestHeader::new(
             Some(1),
-            Some(CheetahString::from("broker1")),
-            Some(CheetahString::from("addr1")),
-            Some(CheetahString::from("addr2")),
-            Some(CheetahString::from("addr3")),
+            Some(CheetahString::from("broker-a")),
+            Some(CheetahString::from("127.0.0.1:10911")),
+            Some(CheetahString::from("127.0.0.2:10911")),
+            Some(CheetahString::from("127.0.0.1:10912")),
         );
-        assert_eq!(header.min_broker_id, Some(1));
-        assert_eq!(header.broker_name.as_deref(), Some("broker1"));
-        assert_eq!(header.min_broker_addr.as_deref(), Some("addr1"));
-        assert_eq!(header.offline_broker_addr.as_deref(), Some("addr2"));
-        assert_eq!(header.ha_broker_addr.as_deref(), Some("addr3"));
-    }
 
-    #[test]
-    fn new_creates_instance_with_none_fields() {
-        let header = NotifyMinBrokerIdChangeRequestHeader::new(None, None, None, None, None);
-        assert_eq!(header.min_broker_id, None);
-        assert_eq!(header.broker_name, None);
-        assert_eq!(header.min_broker_addr, None);
-        assert_eq!(header.offline_broker_addr, None);
-        assert_eq!(header.ha_broker_addr, None);
-    }
+        let json = serde_json::to_string(&header).unwrap();
+        let decoded: NotifyMinBrokerIdChangeRequestHeader = serde_json::from_str(&json).unwrap();
 
-    #[test]
-    fn default_creates_instance_with_none_fields() {
-        let header: NotifyMinBrokerIdChangeRequestHeader = Default::default();
-        assert_eq!(header.min_broker_id, None);
-        assert_eq!(header.broker_name, None);
-        assert_eq!(header.min_broker_addr, None);
-        assert_eq!(header.offline_broker_addr, None);
-        assert_eq!(header.ha_broker_addr, None);
+        assert_eq!(decoded.min_broker_id, Some(1));
+        assert_eq!(decoded.broker_name.as_deref(), Some("broker-a"));
+        assert_eq!(decoded.min_broker_addr.as_deref(), Some("127.0.0.1:10911"));
+        assert_eq!(decoded.offline_broker_addr.as_deref(), Some("127.0.0.2:10911"));
+        assert_eq!(decoded.ha_broker_addr.as_deref(), Some("127.0.0.1:10912"));
+
+        let empty = NotifyMinBrokerIdChangeRequestHeader::new(None, None, None, None, None);
+        assert!(empty.min_broker_id.is_none());
+        assert!(empty.broker_name.is_none());
+        assert!(empty.min_broker_addr.is_none());
+        assert!(empty.offline_broker_addr.is_none());
+        assert!(empty.ha_broker_addr.is_none());
     }
 }

--- a/rocketmq-protocol/src/protocol/header/namesrv/config_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/config_header.rs
@@ -38,12 +38,6 @@ mod tests {
     use crate::protocol::remoting_command::RemotingCommand;
 
     #[test]
-    fn for_probe_sets_probe_only_flag() {
-        let header = GetNamesrvConfigRequestHeader::for_probe();
-        assert_eq!(header.probe_only, Some(true));
-    }
-
-    #[test]
     fn request_command_encodes_probe_only_header() {
         let mut command = RemotingCommand::create_request_command(
             RequestCode::GetNamesrvConfig,

--- a/rocketmq-protocol/src/protocol/header/namesrv/kv_config_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/kv_config_header.rs
@@ -138,14 +138,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn put_kv_config_request_header_new() {
-        let header = PutKVConfigRequestHeader::new("namespace1", "key1", "value1");
-        assert_eq!(header.namespace, CheetahString::from("namespace1"));
-        assert_eq!(header.key, CheetahString::from("key1"));
-        assert_eq!(header.value, CheetahString::from("value1"));
-    }
-
-    #[test]
     fn put_kv_config_request_header_serialization() {
         let header = PutKVConfigRequestHeader::new("namespace1", "key1", "value1");
         let serialized = serde_json::to_string(&header).unwrap();
@@ -165,13 +157,6 @@ mod tests {
     }
 
     #[test]
-    fn get_kv_config_request_header_new() {
-        let header = GetKVConfigRequestHeader::new("namespace1", "key1");
-        assert_eq!(header.namespace, CheetahString::from("namespace1"));
-        assert_eq!(header.key, CheetahString::from("key1"));
-    }
-
-    #[test]
     fn get_kv_config_request_header_serialization() {
         let header = GetKVConfigRequestHeader::new("namespace1", "key1");
         let serialized = serde_json::to_string(&header).unwrap();
@@ -184,12 +169,6 @@ mod tests {
         let deserialized: GetKVConfigRequestHeader = serde_json::from_str(json).unwrap();
         assert_eq!(deserialized.namespace, CheetahString::from("namespace1"));
         assert_eq!(deserialized.key, CheetahString::from("key1"));
-    }
-
-    #[test]
-    fn get_kv_config_response_header_new() {
-        let header = GetKVConfigResponseHeader::new(Some(CheetahString::from("value1")));
-        assert_eq!(header.value, Some(CheetahString::from("value1")));
     }
 
     #[test]
@@ -207,13 +186,6 @@ mod tests {
     }
 
     #[test]
-    fn delete_kv_config_request_header_new() {
-        let header = DeleteKVConfigRequestHeader::new("namespace1", "key1");
-        assert_eq!(header.namespace, CheetahString::from("namespace1"));
-        assert_eq!(header.key, CheetahString::from("key1"));
-    }
-
-    #[test]
     fn delete_kv_config_request_header_serialization() {
         let header = DeleteKVConfigRequestHeader::new("namespace1", "key1");
         let serialized = serde_json::to_string(&header).unwrap();
@@ -226,12 +198,6 @@ mod tests {
         let deserialized: DeleteKVConfigRequestHeader = serde_json::from_str(json).unwrap();
         assert_eq!(deserialized.namespace, CheetahString::from("namespace1"));
         assert_eq!(deserialized.key, CheetahString::from("key1"));
-    }
-
-    #[test]
-    fn get_kv_list_by_namespace_request_header_new() {
-        let header = GetKVListByNamespaceRequestHeader::new("namespace1");
-        assert_eq!(header.namespace, CheetahString::from("namespace1"));
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header/namesrv/perm_broker_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/perm_broker_header.rs
@@ -102,26 +102,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn wipe_write_perm_of_broker_request_header_new() {
-        let header = WipeWritePermOfBrokerRequestHeader::new("broker1");
-        assert_eq!(header.broker_name, CheetahString::from("broker1"));
-    }
+    fn permission_headers_use_java_wire_names() {
+        let wipe_request = WipeWritePermOfBrokerRequestHeader::new("broker-a");
+        let wipe_response = WipeWritePermOfBrokerResponseHeader::new(3);
+        let add_request = AddWritePermOfBrokerRequestHeader::new("broker-b");
+        let add_response = AddWritePermOfBrokerResponseHeader::new(5);
 
-    #[test]
-    fn wipe_write_perm_of_broker_response_header_new_and_getters() {
-        let header = WipeWritePermOfBrokerResponseHeader::new(10);
-        assert_eq!(header.get_wipe_topic_count(), 10);
-    }
+        assert_eq!(
+            serde_json::to_string(&wipe_request).unwrap(),
+            r#"{"brokerName":"broker-a"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&wipe_response).unwrap(),
+            r#"{"wipeTopicCount":3}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&add_request).unwrap(),
+            r#"{"brokerName":"broker-b"}"#
+        );
+        assert_eq!(serde_json::to_string(&add_response).unwrap(), r#"{"addTopicCount":5}"#);
 
-    #[test]
-    fn add_write_perm_of_broker_request_header_new() {
-        let header = AddWritePermOfBrokerRequestHeader::new("broker1");
-        assert_eq!(header.broker_name, CheetahString::from("broker1"));
-    }
-
-    #[test]
-    fn add_write_perm_of_broker_response_header_new_and_getters() {
-        let header = AddWritePermOfBrokerResponseHeader::new(20);
-        assert_eq!(header.get_add_topic_count(), 20);
+        let wipe_response: WipeWritePermOfBrokerResponseHeader =
+            serde_json::from_str(r#"{"wipeTopicCount":3}"#).unwrap();
+        let add_response: AddWritePermOfBrokerResponseHeader = serde_json::from_str(r#"{"addTopicCount":5}"#).unwrap();
+        assert_eq!(wipe_response.get_wipe_topic_count(), 3);
+        assert_eq!(add_response.get_add_topic_count(), 5);
     }
 }

--- a/rocketmq-protocol/src/protocol/header/namesrv/query_data_version_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/query_data_version_header.rs
@@ -80,15 +80,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn query_data_version_request_header_new() {
-        let header = QueryDataVersionRequestHeader::new("broker1", "127.0.0.1", "cluster1", 1);
-        assert_eq!(header.broker_name, CheetahString::from("broker1"));
-        assert_eq!(header.broker_addr, CheetahString::from("127.0.0.1"));
-        assert_eq!(header.cluster_name, CheetahString::from("cluster1"));
-        assert_eq!(header.broker_id, 1);
-    }
-
-    #[test]
     fn query_data_version_request_header_serialization() {
         let header = QueryDataVersionRequestHeader::new("broker1", "127.0.0.1", "cluster1", 1);
         let serialized = serde_json::to_string(&header).unwrap();
@@ -106,12 +97,6 @@ mod tests {
         assert_eq!(deserialized.broker_addr, CheetahString::from("127.0.0.1"));
         assert_eq!(deserialized.cluster_name, CheetahString::from("cluster1"));
         assert_eq!(deserialized.broker_id, 1);
-    }
-
-    #[test]
-    fn query_data_version_response_header_new() {
-        let header = QueryDataVersionResponseHeader::new(true);
-        assert!(header.changed);
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header/namesrv/register_broker_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/register_broker_header.rs
@@ -138,30 +138,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn register_broker_request_header_new() {
-        let header = RegisterBrokerRequestHeader::new(
-            CheetahString::from("broker1"),
-            CheetahString::from("127.0.0.1"),
-            CheetahString::from("cluster1"),
-            CheetahString::from("127.0.0.2"),
-            1,
-            Some(3000),
-            Some(true),
-            true,
-            12345,
-        );
-        assert_eq!(header.broker_name, CheetahString::from("broker1"));
-        assert_eq!(header.broker_addr, CheetahString::from("127.0.0.1"));
-        assert_eq!(header.cluster_name, CheetahString::from("cluster1"));
-        assert_eq!(header.ha_server_addr, CheetahString::from("127.0.0.2"));
-        assert_eq!(header.broker_id, 1);
-        assert_eq!(header.heartbeat_timeout_millis, Some(3000));
-        assert_eq!(header.enable_acting_master, Some(true));
-        assert!(header.compressed);
-        assert_eq!(header.body_crc32, 12345);
-    }
-
-    #[test]
     fn register_broker_request_header_serialization() {
         let header = RegisterBrokerRequestHeader::new(
             CheetahString::from("broker1"),
@@ -209,16 +185,6 @@ mod tests {
         assert_eq!(deserialized.enable_acting_master, None);
         assert!(deserialized.compressed);
         assert_eq!(deserialized.body_crc32, 12345);
-    }
-
-    #[test]
-    fn register_broker_response_header_new() {
-        let header = RegisterBrokerResponseHeader::new(
-            Some(CheetahString::from("127.0.0.2")),
-            Some(CheetahString::from("127.0.0.3")),
-        );
-        assert_eq!(header.ha_server_addr, Some(CheetahString::from("127.0.0.2")));
-        assert_eq!(header.master_addr, Some(CheetahString::from("127.0.0.3")));
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header/namesrv/topic_operation_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/topic_operation_header.rs
@@ -106,13 +106,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn delete_topic_from_namesrv_request_header_new() {
-        let header = DeleteTopicFromNamesrvRequestHeader::new("topic1", Some("cluster1"));
-        assert_eq!(header.topic, CheetahString::from("topic1"));
-        assert_eq!(header.cluster_name, Some(CheetahString::from("cluster1")));
-    }
-
-    #[test]
     fn delete_topic_from_namesrv_request_header_serialization() {
         let header = DeleteTopicFromNamesrvRequestHeader::new("topic1", Some("cluster1"));
         let serialized = serde_json::to_string(&header).unwrap();
@@ -128,23 +121,10 @@ mod tests {
     }
 
     #[test]
-    fn register_topic_request_header_new() {
-        let header = RegisterTopicRequestHeader::new("topic1");
-        assert_eq!(header.topic, CheetahString::from("topic1"));
-        assert!(header.topic_request.is_none());
-    }
-
-    #[test]
     fn register_topic_request_header_serialization() {
         let header = RegisterTopicRequestHeader::new("topic1");
         let serialized = serde_json::to_string(&header).unwrap();
         assert_eq!(serialized, r#"{"topic":"topic1"}"#);
-    }
-
-    #[test]
-    fn get_topics_by_cluster_request_header_new() {
-        let header = GetTopicsByClusterRequestHeader::new("cluster1");
-        assert_eq!(header.cluster, CheetahString::from("cluster1"));
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header/notification_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/notification_request_header.rs
@@ -106,30 +106,6 @@ mod tests {
     }
 
     #[test]
-    fn test_notification_request_header_default_order() {
-        let header = NotificationRequestHeader {
-            consumer_group: CheetahString::from("consumer_group_1"),
-            topic: CheetahString::from("test_topic"),
-            queue_id: 10,
-            poll_time: 1234567890,
-            born_time: 1234567891,
-            order: false, // Defaults to false
-            attempt_id: None,
-            exp_type: None,
-            exp: None,
-            is_lite_consumer: false,
-            client_id: None,
-            topic_request_header: None,
-        };
-
-        let serialized = serde_json::to_string(&header).expect("Failed to serialize header");
-
-        let deserialized: NotificationRequestHeader =
-            serde_json::from_str(&serialized).expect("Failed to deserialize header");
-        assert_eq!(header.queue_id, deserialized.queue_id);
-    }
-
-    #[test]
     fn notification_v3_defaults_and_required_fields_match_the_wire_contract() {
         let mut fields = HeaderMap::from([
             ("consumerGroup".into(), "group-a".into()),

--- a/rocketmq-protocol/src/protocol/header/notification_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/notification_response_header.rs
@@ -36,17 +36,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn notification_response_header_initializes_java_fields() {
-        let header = NotificationResponseHeader {
-            has_msg: true,
-            polling_full: true,
-        };
-
-        assert!(header.has_msg);
-        assert!(header.polling_full);
-    }
-
-    #[test]
     fn notification_response_header_serializes_java_camel_case_fields() {
         let header = NotificationResponseHeader {
             has_msg: true,
@@ -77,14 +66,6 @@ mod tests {
         let header: NotificationResponseHeader = serde_json::from_str(json).unwrap();
 
         assert!(header.has_msg);
-        assert!(!header.polling_full);
-    }
-
-    #[test]
-    fn notification_response_header_default_is_empty() {
-        let header = NotificationResponseHeader::default();
-
-        assert!(!header.has_msg);
         assert!(!header.polling_full);
     }
 }

--- a/rocketmq-protocol/src/protocol/header/polling_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/polling_info_request_header.rs
@@ -199,49 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn topic_request_header_trait_set_and_get_lo() {
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: Some(TopicRequestHeader::default()),
-        };
-
-        header.set_lo(Some(true));
-        assert_eq!(header.lo(), Some(true));
-
-        header.set_lo(Some(false));
-        assert_eq!(header.lo(), Some(false));
-
-        header.set_lo(None);
-        assert_eq!(header.lo(), None);
-
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: None,
-        };
-
-        header.set_lo(Some(true));
-        assert_eq!(header.lo(), None);
-    }
-
-    #[test]
-    fn topic_request_header_trait_set_and_get_topic() {
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: None,
-        };
-
-        header.set_topic(CheetahString::from_static_str("new_topic"));
-        assert_eq!(header.topic(), "new_topic");
-    }
-
-    #[test]
-    fn topic_request_header_trait_set_and_get_broker_name() {
+    fn topic_request_header_trait_forwards_fields() {
         let mut header = PollingInfoRequestHeader {
             consumer_group: CheetahString::from_static_str("test_group"),
             topic: CheetahString::from_static_str("test_topic"),
@@ -252,120 +210,58 @@ mod tests {
             }),
         };
 
+        header.set_topic(CheetahString::from_static_str("new_topic"));
+        header.set_queue_id(10);
+        header.set_lo(Some(true));
         header.set_broker_name(CheetahString::from_static_str("new_broker"));
+        header.set_namespace(CheetahString::from_static_str("new_namespace"));
+        header.set_namespaced(true);
+        header.set_oneway(false);
+
+        assert_eq!(header.topic(), "new_topic");
+        assert_eq!(header.queue_id(), 10);
+        assert_eq!(header.lo(), Some(true));
         assert_eq!(
             header.broker_name(),
             Some(&CheetahString::from_static_str("new_broker"))
         );
-
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: None,
-        };
-
-        header.set_broker_name(CheetahString::from_static_str("new_broker"));
-        assert_eq!(header.broker_name(), None);
-    }
-
-    #[test]
-    fn topic_request_header_trait_set_and_get_namespace() {
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: Some(TopicRequestHeader {
-                lo: None,
-                rpc: Some(RpcRequestHeader::default()),
-            }),
-        };
-
-        header.set_namespace(CheetahString::from_static_str("new_namespace"));
         assert_eq!(header.namespace(), Some("new_namespace"));
-
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: None,
-        };
-
-        header.set_namespace(CheetahString::from_static_str("new_namespace"));
-        assert_eq!(header.namespace(), None);
-    }
-
-    #[test]
-    fn topic_request_header_trait_set_and_get_namespaced() {
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: Some(TopicRequestHeader {
-                lo: None,
-                rpc: Some(RpcRequestHeader::default()),
-            }),
-        };
-
-        header.set_namespaced(true);
         assert_eq!(header.namespaced(), Some(true));
-
-        header.set_namespaced(false);
-        assert_eq!(header.namespaced(), Some(false));
-
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: None,
-        };
-
-        header.set_namespaced(true);
-        assert_eq!(header.namespaced(), None);
-    }
-
-    #[test]
-    fn topic_request_header_trait_set_and_get_oneway() {
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: Some(TopicRequestHeader {
-                lo: None,
-                rpc: Some(RpcRequestHeader::default()),
-            }),
-        };
-
-        header.set_oneway(true);
-        assert_eq!(header.oneway(), Some(true));
-
-        header.set_oneway(false);
         assert_eq!(header.oneway(), Some(false));
-
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: None,
-        };
-
-        header.set_oneway(true);
-        assert_eq!(header.oneway(), None);
-    }
-
-    #[test]
-    fn topic_request_header_trait_set_and_get_queue_id() {
-        let mut header = PollingInfoRequestHeader {
-            consumer_group: CheetahString::from_static_str("test_group"),
-            topic: CheetahString::from_static_str("test_topic"),
-            queue_id: 0,
-            topic_request_header: None,
-        };
-
-        header.set_queue_id(10);
-        assert_eq!(header.queue_id(), 10);
 
         header.set_queue_id(-1);
         assert_eq!(header.queue_id(), -1);
+
+        header.set_lo(Some(false));
+        assert_eq!(header.lo(), Some(false));
+        header.set_lo(None);
+        assert_eq!(header.lo(), None);
+
+        header.set_namespaced(false);
+        assert_eq!(header.namespaced(), Some(false));
+        header.set_oneway(true);
+        assert_eq!(header.oneway(), Some(true));
+    }
+
+    #[test]
+    fn topic_request_header_trait_ignores_nested_setters_without_envelope() {
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: None,
+        };
+
+        header.set_lo(Some(true));
+        header.set_broker_name(CheetahString::from_static_str("new_broker"));
+        header.set_namespace(CheetahString::from_static_str("new_namespace"));
+        header.set_namespaced(true);
+        header.set_oneway(true);
+
+        assert_eq!(header.lo(), None);
+        assert_eq!(header.broker_name(), None);
+        assert_eq!(header.namespace(), None);
+        assert_eq!(header.namespaced(), None);
+        assert_eq!(header.oneway(), None);
     }
 }

--- a/rocketmq-protocol/src/protocol/header/query_consumer_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_consumer_offset_request_header.rs
@@ -152,26 +152,6 @@ mod tests {
     use crate::rpc::rpc_request_header::RpcRequestHeader;
 
     #[test]
-    fn query_consumer_offset_request_header_default() {
-        let header = QueryConsumerOffsetRequestHeader::default();
-        assert_eq!(header.consumer_group, "");
-        assert_eq!(header.topic, "");
-        assert_eq!(header.queue_id, 0);
-        assert!(header.set_zero_if_not_found.is_none());
-        assert!(header.topic_request_header.is_none());
-    }
-
-    #[test]
-    fn query_consumer_offset_request_header_new() {
-        let header = QueryConsumerOffsetRequestHeader::new("group", "topic", 1);
-        assert_eq!(header.consumer_group, "group");
-        assert_eq!(header.topic, "topic");
-        assert_eq!(header.queue_id, 1);
-        assert!(header.set_zero_if_not_found.is_none());
-        assert!(header.topic_request_header.is_none());
-    }
-
-    #[test]
     fn query_consumer_offset_request_header_trait_impl() {
         let mut header = QueryConsumerOffsetRequestHeader::default();
 
@@ -206,16 +186,18 @@ mod tests {
 
     #[test]
     fn query_consumer_offset_request_header_serialization() {
-        let header = QueryConsumerOffsetRequestHeader {
-            consumer_group: CheetahString::from("group"),
-            topic: CheetahString::from("topic"),
-            queue_id: 1,
-            set_zero_if_not_found: Some(true),
-            topic_request_header: Some(TopicRequestHeader {
-                lo: Some(true),
-                ..Default::default()
-            }),
-        };
+        let mut header = QueryConsumerOffsetRequestHeader::new("group", "topic", 1);
+        assert_eq!(header.consumer_group, "group");
+        assert_eq!(header.topic, "topic");
+        assert_eq!(header.queue_id, 1);
+        assert!(header.set_zero_if_not_found.is_none());
+        assert!(header.topic_request_header.is_none());
+
+        header.set_zero_if_not_found = Some(true);
+        header.topic_request_header = Some(TopicRequestHeader {
+            lo: Some(true),
+            ..Default::default()
+        });
         let json = serde_json::to_string(&header).unwrap();
         assert!(json.contains("\"consumerGroup\":\"group\""));
         assert!(json.contains("\"topic\":\"topic\""));

--- a/rocketmq-protocol/src/protocol/header/query_consumer_offset_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_consumer_offset_response_header.rs
@@ -36,12 +36,6 @@ mod tests {
     use crate::protocol::command_custom_header::FromMap;
 
     #[test]
-    fn query_consumer_offset_response_header_default() {
-        let header = QueryConsumerOffsetResponseHeader::default();
-        assert!(header.offset.is_none());
-    }
-
-    #[test]
     fn query_consumer_offset_response_header_serialization() {
         let header = QueryConsumerOffsetResponseHeader { offset: Some(12345) };
         let json = serde_json::to_string(&header).unwrap();

--- a/rocketmq-protocol/src/protocol/header/query_topics_by_consumer_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_topics_by_consumer_request_header.rs
@@ -59,27 +59,18 @@ mod tests {
     use crate::protocol::command_custom_header::FromMap;
 
     #[test]
-    fn constructor_and_accessors_manage_the_group() {
-        let mut header = QueryTopicsByConsumerRequestHeader::new("before");
-
-        assert_eq!(header.get_group(), "before");
+    fn serde_flattens_the_java_rpc_keys() {
+        let mut header = QueryTopicsByConsumerRequestHeader::new("initial-group");
+        assert_eq!(header.get_group(), "initial-group");
         assert!(header.rpc_request_header.is_none());
 
-        header.set_group(CheetahString::from("after"));
-        assert_eq!(header.get_group(), "after");
-    }
-
-    #[test]
-    fn serde_flattens_the_java_rpc_keys() {
-        let header = QueryTopicsByConsumerRequestHeader {
-            group: CheetahString::from("group-a"),
-            rpc_request_header: Some(RpcRequestHeader {
-                namespace: Some(CheetahString::from("namespace-a")),
-                namespaced: Some(true),
-                broker_name: None,
-                oneway: None,
-            }),
-        };
+        header.set_group(CheetahString::from("group-a"));
+        header.rpc_request_header = Some(RpcRequestHeader {
+            namespace: Some(CheetahString::from("namespace-a")),
+            namespaced: Some(true),
+            broker_name: None,
+            oneway: None,
+        });
         let value = serde_json::to_value(&header).unwrap();
 
         assert_eq!(
@@ -94,7 +85,7 @@ mod tests {
         );
 
         let decoded: QueryTopicsByConsumerRequestHeader = serde_json::from_value(value).unwrap();
-        assert_eq!(decoded.group, "group-a");
+        assert_eq!(decoded.get_group(), "group-a");
         assert_eq!(
             decoded.rpc_request_header.unwrap().namespace.as_deref(),
             Some("namespace-a")

--- a/rocketmq-protocol/src/protocol/header/recall_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/recall_message_request_header.rs
@@ -133,37 +133,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_new_with_producer_group() {
-        let header = RecallMessageRequestHeader::new("TestTopic", "handle123", Some("ProducerGroup1"));
-
-        assert_eq!(header.topic(), &CheetahString::from("TestTopic"));
-        assert_eq!(header.recall_handle(), &CheetahString::from("handle123"));
-        assert_eq!(header.producer_group(), Some(&CheetahString::from("ProducerGroup1")));
-    }
-
-    #[test]
-    fn test_new_without_producer_group() {
-        let header = RecallMessageRequestHeader::new("TestTopic", "handle123", None::<&str>);
-
-        assert_eq!(header.topic(), &CheetahString::from("TestTopic"));
-        assert_eq!(header.recall_handle(), &CheetahString::from("handle123"));
-        assert_eq!(header.producer_group(), None);
-    }
-
-    #[test]
-    fn test_setters() {
-        let mut header = RecallMessageRequestHeader::default();
-
-        header.set_topic("NewTopic");
-        header.set_recall_handle("newHandle");
-        header.set_producer_group("NewGroup");
-
-        assert_eq!(header.topic(), &CheetahString::from("NewTopic"));
-        assert_eq!(header.recall_handle(), &CheetahString::from("newHandle"));
-        assert_eq!(header.producer_group(), Some(&CheetahString::from("NewGroup")));
-    }
-
-    #[test]
     fn test_display() {
         let header = RecallMessageRequestHeader::new("TestTopic", "handle123", Some("Group1"));
         let display = format!("{}", header);
@@ -175,7 +144,12 @@ mod tests {
 
     #[test]
     fn test_serialization() {
-        let header = RecallMessageRequestHeader::new("TestTopic", "handle123", Some("ProducerGroup1"));
+        let mut header = RecallMessageRequestHeader::new("initial-topic", "initial-handle", None::<&str>);
+        assert!(header.producer_group().is_none());
+
+        header.set_topic("TestTopic");
+        header.set_recall_handle("handle123");
+        header.set_producer_group("ProducerGroup1");
 
         let json = serde_json::to_string(&header).unwrap();
         assert!(json.contains("\"topic\":\"TestTopic\""));

--- a/rocketmq-protocol/src/protocol/header/recall_message_response_header.rs
+++ b/rocketmq-protocol/src/protocol/header/recall_message_response_header.rs
@@ -58,18 +58,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_with_msg_id() {
-        let mut body = RecallMessageResponseHeader::new("some_message");
-        assert_eq!(body.msg_id(), &CheetahString::from("some_message"));
-
-        body.set_msg_id("some_new_message");
-        assert_eq!(body.msg_id(), &CheetahString::from("some_new_message"));
-
+    fn display_includes_message_id() {
+        let mut body = RecallMessageResponseHeader::new("initial_message");
+        body.set_msg_id("some_message");
         let display_output = format!("{}", body);
-        assert_eq!(
-            display_output,
-            "RecallMessageResponseHeader { msg_id: some_new_message }"
-        );
+        assert_eq!(display_output, "RecallMessageResponseHeader { msg_id: some_message }");
     }
     #[test]
     fn recall_message_serialisation() {

--- a/rocketmq-protocol/src/protocol/header/unlock_batch_mq_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/unlock_batch_mq_request_header.rs
@@ -74,27 +74,6 @@ mod tests {
     }
 
     #[test]
-    fn test_default_values() {
-        let header = UnlockBatchMqRequestHeader::default();
-        assert!(header.rpc_request_header.is_none());
-    }
-
-    #[test]
-    fn test_rpc_request_header_new() {
-        let ns = Some("ns".into());
-        let namespaced = Some(false);
-        let broker = Some("b1".into());
-        let oneway = Some(true);
-
-        let header = RpcRequestHeader::new(ns.clone(), namespaced, broker.clone(), oneway);
-
-        assert_eq!(header.namespace, ns);
-        assert_eq!(header.namespaced, namespaced);
-        assert_eq!(header.broker_name, broker);
-        assert_eq!(header.oneway, oneway);
-    }
-
-    #[test]
     fn test_partial_fields_deserialization() {
         let json = r#"{"brokerName": "only_broker"}"#;
         let decoded: UnlockBatchMqRequestHeader = serde_json::from_str(json).unwrap();

--- a/rocketmq-protocol/src/protocol/header/update_user_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/update_user_request_header.rs
@@ -41,21 +41,9 @@ mod tests {
     use crate::protocol::command_custom_header::{CommandCustomHeader, FromMap};
 
     #[test]
-    fn set_username_replaces_the_current_value() {
-        let mut header = UpdateUserRequestHeader {
-            username: CheetahString::from("before"),
-        };
-
-        header.set_username(CheetahString::from("after"));
-
-        assert_eq!(header.username, "after");
-    }
-
-    #[test]
     fn serde_and_v3_codec_preserve_the_username() {
-        let header = UpdateUserRequestHeader {
-            username: CheetahString::from("user-a"),
-        };
+        let mut header = UpdateUserRequestHeader::default();
+        header.set_username(CheetahString::from("user-a"));
         let json = serde_json::to_string(&header).unwrap();
         let map = header.to_map().unwrap();
 

--- a/rocketmq-protocol/src/protocol/header/view_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/view_message_request_header.rs
@@ -27,32 +27,3 @@ pub struct ViewMessageRequestHeader {
     #[header(required)]
     pub offset: i64,
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_view_message_request_header_with_none_topic() {
-        let header = ViewMessageRequestHeader {
-            topic: None,
-            offset: 100,
-        };
-
-        assert!(header.topic.is_none());
-        assert_eq!(header.offset, 100);
-    }
-
-    #[test]
-    fn test_view_message_request_header_with_topic_value() {
-        let topic_name = CheetahString::from("test_topic");
-        let header = ViewMessageRequestHeader {
-            topic: Some(topic_name.clone()),
-            offset: 200,
-        };
-
-        assert!(header.topic.is_some());
-        assert_eq!(header.topic.unwrap(), topic_name);
-        assert_eq!(header.offset, 200);
-    }
-}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9963 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated protocol-header tests around serialization, deserialization, wire-format compatibility, and accessor behavior.
  * Removed redundant constructor, default-value, alias, and standalone getter/setter tests.
  * Added coverage for default initialization and nested field forwarding in selected request headers.
  * Preserved and strengthened validation of Java-compatible camelCase encoding and round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->