### PR TITLE
[ISSUE #9974]🐛Fix rocketmq-broker clippy collapsible_if error

### DIFF
--- a/rocketmq-broker/src/broker/broker_control_plane.rs
+++ b/rocketmq-broker/src/broker/broker_control_plane.rs
@@ -308,10 +308,8 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
 
         self.escape_policy.update_controller_role(role, outcome.master_epoch);
         self.role_state.set_isolated(false);
-        if outcome.should_register_to_namesrv {
-            if self.registration.register().await.is_err() {
-                tracing::warn!("failed to register broker after controller role transition");
-            }
+        if outcome.should_register_to_namesrv && self.registration.register().await.is_err() {
+            tracing::warn!("failed to register broker after controller role transition");
         }
         Ok(true)
     }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9974

### Brief Description

Collapses the nested `if` in `BrokerControlPlane` (rocketmq-broker/src/broker/broker_control_plane.rs:311) into a single `if` with `&&`, exactly as the `clippy::collapsible_if` suggestion in the issue proposes. Short-circuit evaluation keeps the semantics identical: `self.registration.register().await` still only runs when `outcome.should_register_to_namesrv` is true.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check` passes
- `cargo clippy -p rocketmq-broker --all-targets -- -D warnings` passes (previously failed with the `collapsible_if` error from the issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved broker role-change behavior while simplifying nameserver registration failure handling.
  * Registration failures continue to generate a warning without interrupting role-change processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->