### PR TITLE
Contribution link is 404, found overview page in offical site. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ We welcome contributions from the community! Whether you're fixing bugs, adding 
 - Ensure CI passes before submitting PR
 - Use meaningful commit messages
 
-For detailed guidelines, please read our [Contribution Guide](https://rocketmqrust.com/docs/contribute-guide/).
+For detailed guidelines, please read our [Contribution Guide](https://rocketmqrust.com/docs/contributing/overview).
 
 ### Repository Activity
 


### PR DESCRIPTION


### Which Issue(s) This PR Fixes(Closes)
close #9978.

### Brief Description
Contribution guide page wasn't working. it's 404 page. update it to the right page, I guess `overview page` is the right one.

### How Did You Test This Change?
Don't need tests. just a normal page update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Contribution Guidelines link to point to the new contribution documentation URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->