### PR TITLE
[ISSUE #9971]🚀Add Topic and Consumer Group upsert tools to RocketMQ MCP control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,7 @@ docs
 !rocketmq-ai/rocketmq-sre/docs/**
 !rocketmq-ai/rocketmq-mcp/docs/
 !rocketmq-ai/rocketmq-mcp/docs/**
+!rocketmq-ai/rocketmq-mcp-control/docs/
+!rocketmq-ai/rocketmq-mcp-control/docs/**
 !rocketmq-dashboard/rocketmq-dashboard-web/docs/
 !rocketmq-dashboard/rocketmq-dashboard-web/docs/**

--- a/rocketmq-ai/rocketmq-mcp-control/AGENTS.md
+++ b/rocketmq-ai/rocketmq-mcp-control/AGENTS.md
@@ -10,11 +10,19 @@ This file applies to `rocketmq-ai/rocketmq-mcp-control/`.
 - HTTPS Streamable MCP with RS256 OAuth/JWKS is the only transport and authentication mode.
 - The default feature set must not depend on RocketMQ Admin or client mutation adapters.
 - `write-tools` may enable only `rocketmq-admin-core/mutation-client-adapter`; it must never enable a read or full adapter.
-- Keep the production operation catalog empty until separately reviewed write operations and schemas exist.
+- The only reviewed production tools are `rocketmq_upsert_topic` and
+  `rocketmq_upsert_consumer_group`. Keep offset reset, broker configuration, consumer request mode, delete,
+  skip, resend, and any free-form mutation outside this project until separately reviewed.
 - OAuth and closed operation/cluster authorization must complete before mutation argument parsing. A durable
   `started` audit record must then complete before session creation or RPC.
 - Do not add stdio, CLI, shell, subprocess, free-form RPC, arbitrary Admin commands, or stdout protocol output.
 - Audit and public data must exclude credentials, tokens, network addresses, raw backend errors, message bodies, and client identities.
+- Each upsert accepts only 1--64 explicit broker names. Validate the full selected-cluster topology before
+  target state RPC, keep plans sealed to one Admin session, and preserve exact-target post-read verification.
+- Targeted Topic upserts must treat the complete order-Topic KV as a sealed no-write guard. Never merge, put,
+  or delete that global KV from the targeted path; reject any selected entry that is not already exact.
+- Request-key reuse is bounded and process-local; every invocation, including followers and cache hits, keeps
+  its own durable audit pair.
 - Prefer native async trait methods where object safety is not required; do not add `async_trait`.
 
 ## Mandatory validation

--- a/rocketmq-ai/rocketmq-mcp-control/README.md
+++ b/rocketmq-ai/rocketmq-mcp-control/README.md
@@ -1,8 +1,9 @@
 # RocketMQ MCP Control
 
-`rocketmq-mcp-control` is an isolated, deny-by-default foundation for future supervised RocketMQ mutations. It is
-a standalone Cargo project and is not part of the root workspace. This delivery deliberately registers no
-production mutation tools and performs no RocketMQ mutation.
+`rocketmq-mcp-control` is an isolated, deny-by-default server for supervised RocketMQ mutations. It is a
+standalone Cargo project and is not part of the root workspace. The reviewed `write-tools` surface contains
+exactly `rocketmq_upsert_topic` and `rocketmq_upsert_consumer_group`; the default build contains neither Admin
+Core nor production mutation tools.
 
 ## Security boundary
 
@@ -21,8 +22,7 @@ production mutation tools and performs no RocketMQ mutation.
 The fixed capability Resource is `rocketmq-control://capabilities`. Its independent compile-time,
 runtime-enabled, and registered-operation fields make availability explicit. `mutation_supported` becomes true
 only when `write-tools` is compiled, runtime mutation policy is enabled, and at least one reviewed production
-operation is registered. The last condition is false in this foundation, so `tools/list` is empty in every build
-and runtime combination.
+operation is registered. Resource templates and prompts remain empty.
 
 ## Feature boundary
 
@@ -30,11 +30,13 @@ and runtime combination.
 |---|---|---:|---:|---:|
 | default | none | off or on | 0 | false |
 | `write-tools` | mutation-only adapter | off | 0 | false |
-| `write-tools` | mutation-only adapter | on | 0 | false |
+| `write-tools` | mutation-only adapter | on, future-only allowlist | 0 | false |
+| `write-tools` | mutation-only adapter | on, one reviewed operation | 1 | true |
+| `write-tools` | mutation-only adapter | on, both reviewed operations | 2 | true |
 
 The optional feature enables only `rocketmq-admin-core/mutation-client-adapter`, whose client dependency enables
-only `admin-mutation`. It does not enable read or full Admin adapters. Future operations require separate schema,
-authorization, adapter, and review work; this project does not define speculative schemas for them.
+only `admin-mutation`. It does not enable read or full Admin adapters. Offset reset, broker configuration,
+consumer request mode, delete, skip, resend, CLI, shell, and free-form RPC remain outside this delivery.
 
 ## Configuration
 
@@ -45,15 +47,53 @@ URLs must use canonical public HTTPS hostnames. The listener rejects wildcard bi
 startup; changing `mutations_enabled` or either allowlist, including an emergency disable, requires a process
 restart.
 
+The private cluster registry maps a logical alias to a NameServer endpoint, TLS policy, and optional environment
+variable names for credentials. Inline credentials are rejected. Registry values and resolved credentials have
+redacted debug behavior and never enter MCP responses or audit records. Every server-allowed cluster for one of
+the two registered operations must have a registry entry.
+
 [`conf/permissions.example.toml`](conf/permissions.example.toml) documents the closed operation and cluster
 claim vocabulary for an authorization server. It is an identity-provider example, not a local authorization
 bypass.
 
-The only accepted operation identifiers are `topic_upsert`, `consumer_group_upsert`,
+The closed policy vocabulary remains `topic_upsert`, `consumer_group_upsert`,
 `consumer_offset_reset`, `broker_config_patch`, and `consumer_request_mode`. Common request arguments reject
 unknown fields. Omitted `dry_run` uses the configured default and omitted `confirm` is false. Dry-run requests may
 omit `reason` and `request_key`; execution requires `confirm = true` and a 5–256 byte safe reason. A request key is
 optional and, when present, is a bounded safe identifier.
+
+Both registered tools accept 1–64 unique logical broker names. Admin Core validates the complete selected
+cluster membership, embedded broker identity, master presence, and endpoint uniqueness before reading any
+target state. Only selected masters are processed, in broker-name order. Requests use complete Topic or Consumer
+Group replacements and closed message-type/numeric bounds. The Consumer Group validator reuses Admin Core's
+single canonical protected-group classifier, including RocketMQ defaults, tools/scheduler/filter/monitor groups,
+ONS groups, transaction/system prefixes, and the heartbeat syncer group. System names, addresses, inline
+secrets, and unknown fields are rejected before audit or session creation; Admin constructors repeat the same
+check as defense in depth.
+
+Each result uses `rocketmq-mcp-mutation.v1`, returns the closed `topic_upsert` or `consumer_group_upsert`
+operation, and has an operation-specific top-level `target`: `topic` or `consumer_group` plus sorted `brokers`.
+Top-level `before`, `requested`, and post-read `after` preserve the complete aggregate state; broker-sorted
+`targets` retain per-target persistence, verification, and failure evidence rather than replacing that aggregate
+contract. Schema version and operation are single-value enums in each tool output schema. Conflict, partial, and
+failed outcomes set MCP `isError=true` while retaining the structured result. An unchanged success is `applied`
+with `changed=false`; there is no separate no-op status. Responses never include addresses, credential
+references, OAuth subjects, reasons, request keys, or raw backend errors.
+
+Targeted Topic upserts never update or delete the NameServer-wide order-Topic KV. Before any broker state read,
+the server reads and strictly parses the complete KV: selected ordered entries must already equal the requested
+queue count, while selected unordered entries must already be absent. The sealed value is checked again before
+broker CAS and after it. A pre-change is a zero-broker-write conflict; a post-change preserves broker-applied
+truth and returns `order_reconciliation_failed` as a partial result. Unselected and other-cluster KV entries are
+never rewritten.
+
+Optional request keys use an in-process 10-minute, 4096-entry singleflight/result cache scoped by principal,
+operation, cluster, sorted target set, and canonical payload. Matching followers and cache hits open no Admin
+session and perform no RocketMQ RPC, but every invocation writes its own started/terminal audit pair. Reusing a
+key with a different payload is rejected. If all 4096 slots are in flight, a new explicit key is rejected before
+audit or session creation; an unkeyed request may still run uncached. A follower's cancellation or timeout ends
+only that invocation and its audit pair—the leader continues and its result remains cacheable. The cache makes no
+cross-restart guarantee.
 
 ## Reliable audit and session ordering
 
@@ -71,7 +111,7 @@ record is accepted only for a matching active invocation from the same live trai
 terminal attempt can become durable. Unknown, cross-trail, and duplicate terminal attempts fail closed; a failed
 terminal write leaves the invocation active while poisoning subsequent audit operations.
 
-A future registered implementation must follow this order:
+Each registered tool follows this order:
 
 1. authenticate and authorize scope/operation/cluster;
 2. parse the common bounded arguments;

--- a/rocketmq-ai/rocketmq-mcp-control/conf/mcp-control.example.toml
+++ b/rocketmq-ai/rocketmq-mcp-control/conf/mcp-control.example.toml
@@ -22,6 +22,16 @@ allowed_operations = []
 allowed_clusters = []
 operation_timeout_seconds = 24
 
+# A private logical cluster registry is required before either reviewed operation can be allowlisted.
+# Credential values are read from these environment variables only when a session is opened.
+[[clusters]]
+name = "production-a"
+namesrv_addr = "nameserver.example.test:9876"
+use_tls = true
+access_key_env = "ROCKETMQ_CONTROL_ACCESS_KEY"
+secret_key_env = "ROCKETMQ_CONTROL_SECRET_KEY"
+# security_token_env = "ROCKETMQ_CONTROL_SECURITY_TOKEN"
+
 [audit]
 path = "var/audit/rocketmq-mcp-control.jsonl"
 capacity = 4096

--- a/rocketmq-ai/rocketmq-mcp-control/conf/permissions.example.toml
+++ b/rocketmq-ai/rocketmq-mcp-control/conf/permissions.example.toml
@@ -7,8 +7,5 @@ scope = ["rocketmq:write"]
 rocketmq_operations = [
   "topic_upsert",
   "consumer_group_upsert",
-  "consumer_offset_reset",
-  "broker_config_patch",
-  "consumer_request_mode",
 ]
 rocketmq_clusters = ["production-a"]

--- a/rocketmq-ai/rocketmq-mcp-control/docs/operations-runbook.md
+++ b/rocketmq-ai/rocketmq-mcp-control/docs/operations-runbook.md
@@ -1,0 +1,53 @@
+# RocketMQ MCP Control operations runbook
+
+## Prepare and enable
+
+1. Build the standalone project with `write-tools`; the default build intentionally has no Admin dependency or
+   mutation tools.
+2. Configure TLS and the canonical HTTPS public origin, remote RS256 OAuth issuer/JWKS/audience, and the durable
+   JSONL audit path.
+3. Add a private cluster-registry entry for each logical cluster. Reference credentials only through protected
+   environment-variable names; inline credentials are rejected.
+4. Configure `mutations_enabled=true` and allowlist only `topic_upsert`, `consumer_group_upsert`, or both, plus
+   their logical clusters. The identity provider must issue matching closed claims and `rocketmq:write`.
+5. Restart the process. Configuration and emergency-disable changes are startup-time controls and do not hot
+   reload.
+
+Verify authenticated `tools/list`: a principal can see zero, one, or two tools according to the intersection.
+The capability Resource must report compile/runtime/registered state consistent with that catalog. Resource
+templates and prompts remain empty.
+
+## Safe operating sequence
+
+Start with dry-run and inspect the operation-specific top-level `target`, aggregate `before` and `requested`,
+then the broker-sorted per-target evidence. For execution, preserve the same complete replacement and target
+set, set `dry_run=false` and `confirm=true`, and provide a safe operator reason. Inspect aggregate `after` as
+well as each target's persistence/verification evidence. Use a request key when retry or concurrent delivery is
+possible. Do not change the payload for a reused key.
+
+The server persists `started` before opening an Admin session. One lifecycle-owned supervisor then opens one
+mutation-only session, performs targeted preflight, optionally executes the sealed conditional plan, performs a
+targeted post-read, awaits exactly one bounded shutdown, and persists a terminal record. A caller disconnect,
+timeout, cancellation, or contained adapter panic does not abandon an acquired session.
+
+Interpret results conservatively:
+
+- `planned` and `applied` are non-error statuses; unchanged success is `applied` with `changed=false`;
+- `conflict` means the conditional expected state no longer matched and is not retried;
+- `partial` retains per-target applied/persistence/verification truth and requires operator review;
+- `failed` may still contain an applied target whose persistence or post-read verification failed;
+- `order_reconciliation_failed` means the sealed NameServer-wide order value changed after broker CAS; the
+  targeted path never tries to repair that global value and preserves the broker-applied truth.
+
+Never infer success from HTTP delivery alone; consume the closed structured result and `isError` value.
+
+## Failure and emergency handling
+
+If audit `started` is unavailable, the operation opens no session and performs no RocketMQ RPC. Treat audit
+poison, shutdown failure, persistence failure, or verification failure as fail-closed and investigate the
+durable audit plus RocketMQ state using separately authorized operational systems. Audit records deliberately
+contain no credentials, endpoints, principals, request reasons/keys, or backend error text.
+
+To stop new mutations, set `mutations_enabled=false` and restart. Removing an operation or cluster from the
+server allowlist also requires restart. Keep the service unavailable until incomplete or partial targets are
+reconciled explicitly; the control server never retries conflicts or invents compensating mutations.

--- a/rocketmq-ai/rocketmq-mcp-control/docs/tool-reference.md
+++ b/rocketmq-ai/rocketmq-mcp-control/docs/tool-reference.md
@@ -1,0 +1,64 @@
+# Reviewed mutation tool reference
+
+The `write-tools` build exposes at most two production tools. A tool is listed only when compile-time support,
+runtime mutation enablement, the server operation/cluster allowlists, a configured logical cluster, and the
+authenticated principal's `rocketmq:write` scope plus operation/cluster claims all intersect. Authorization is
+completed before the tool-specific JSON schema is parsed.
+
+Both tools use input schema version `rocketmq-mcp-control.arguments.v1`. Unknown fields are rejected. The
+`cluster` is a closed logical alias; it is never a NameServer or broker address. `broker_names` contains 1--64
+unique logical masters and is validated against the complete selected-cluster topology before a target state
+RPC. Omitted `dry_run` uses the server default, and omitted `confirm` is false. Execution requires
+`dry_run=false`, `confirm=true`, and a safe 5--256 byte `reason`. An optional `request_key` is an 8--64 byte safe
+identifier.
+
+## `rocketmq_upsert_topic`
+
+The request identifies one non-system Topic and supplies a complete replacement:
+
+- `read_queue_nums` and `write_queue_nums`: integers from 1 through 127;
+- `perm`: a RocketMQ permission value from 1 through 7 that grants read or write;
+- `order`: whether ordered-topic configuration is required;
+- `message_type`: one of `NORMAL`, `FIFO`, `DELAY`, `TRANSACTION`, or `UNSPECIFIED`.
+
+The same sealed Admin session performs targeted preflight, optional conditional replacement, and targeted
+post-read. The targeted path never writes or deletes the global order-Topic KV. Its complete value must already
+represent each selected target (`order=true` means the entry equals `write_queue_nums`; `order=false` means the
+entry is absent), and the sealed value is rechecked before and after broker CAS. A pre-change conflicts before
+broker mutation; a post-change returns `order_reconciliation_failed` and partial while preserving applied broker
+truth. Entries for unselected brokers or other clusters are never merged, replaced, or removed.
+
+## `rocketmq_upsert_consumer_group`
+
+The request identifies one non-system Consumer Group and supplies every replacement field:
+
+- `consume_enable`, `consume_from_min_enable`, `consume_broadcast_enable`, and
+  `consume_message_orderly`;
+- `retry_queue_nums`, `retry_max_times`, `broker_id`, and `which_broker_when_consume_slowly`;
+- `notify_consumer_ids_changed_enable`, `group_sys_flag`, and `consume_timeout_minute`.
+
+The operation uses the same exact-target preflight, conditional replacement, post-read, and session-seal rules
+as the Topic tool. It rejects the complete canonical RocketMQ protected Consumer Group set through the same
+Admin Core classifier used by Admin request constructors, before audit or session creation.
+
+## Result contract
+
+Every successful tool invocation returns `rocketmq-mcp-mutation.v1` structured content. Each tool schema fixes
+the schema version and operation to one value. The operation-specific top-level `target` contains `topic` or
+`consumer_group` and sorted `brokers`; top-level `before`, `requested`, and post-read `after` preserve the full
+aggregate state required by the mutation contract. Broker-name-sorted `targets` additionally retain per-target
+persistence, verification, and failure evidence and do not replace the aggregate fields. An unchanged success
+uses `status=applied` with `changed=false`; `noop` is not part of the status vocabulary.
+`partial`, `conflict`, and `failed` set MCP `isError=true` while preserving structured target truth. Output never
+contains endpoints, credential references or values, OAuth subjects, reasons, request keys, or raw backend
+errors.
+
+## Request-key semantics
+
+A request key is scoped to principal, operation, logical cluster, sorted target set, and canonical payload.
+Matching calls share a process-local singleflight or reuse its result for 10 minutes; the bounded cache holds at
+most 4096 entries and includes partial or failed results. A key reused with different content is rejected. Every
+call, including a follower or cache hit, still receives its own durable started/terminal audit pair. When all
+4096 entries are in flight, a new explicit key is rejected before audit/session/RPC; unkeyed calls may run
+uncached. A follower cancellation or timeout does not cancel or evict the leader. No behavior is promised across
+process restart.

--- a/rocketmq-ai/rocketmq-mcp-control/examples/README.md
+++ b/rocketmq-ai/rocketmq-mcp-control/examples/README.md
@@ -18,5 +18,8 @@ On a Unix shell:
 ROCKETMQ_MCP_CONTROL_CONFIG="$(pwd)/conf/mcp-control.example.toml" cargo run --locked
 ```
 
-The example intentionally leaves `mutations_enabled = false` and both allowlists empty. Enabling `write-tools`
-does not register a tool or make mutation supported in this foundation.
+The example intentionally leaves `mutations_enabled = false` and both allowlists empty. It also demonstrates a
+private logical cluster registry whose credential values come only from environment variables. The default
+build never links Admin Core. To make reviewed tools discoverable, compile with `--features write-tools`, enable
+the runtime policy, and intersect one or both of `topic_upsert` and `consumer_group_upsert` plus the logical
+cluster in both the server policy and authenticated claims. Any other operation remains unavailable.

--- a/rocketmq-ai/rocketmq-mcp-control/scripts/check_control_boundary.py
+++ b/rocketmq-ai/rocketmq-mcp-control/scripts/check_control_boundary.py
@@ -91,7 +91,8 @@ for forbidden in ("admin-read", "admin-full"):
     if forbidden in client_features:
         fail(f"write-tools enabled forbidden client feature {forbidden}")
 
-source = "\n".join(path.read_text(encoding="utf-8") for path in sorted((PROJECT / "src").glob("**/*.rs")))
+source_paths = sorted((PROJECT / "src").glob("**/*.rs"))
+source = "\n".join(path.read_text(encoding="utf-8") for path in source_paths)
 for forbidden in (
     "transport-io",
     "std::process",
@@ -105,8 +106,42 @@ for forbidden in (
     if forbidden in source:
         fail(f"production source contains prohibited surface {forbidden}")
 
-if "registered_operations(&self) -> u32 {\n        0" not in source:
-    fail("foundation catalog is not visibly empty")
+# Dedicated test modules and inline `mod tests` bodies are excluded from the production lifecycle scan.
+production_units = []
+for path in source_paths:
+    if path.name == "tests.rs":
+        continue
+    unit = path.read_text(encoding="utf-8")
+    unit = unit.split("#[cfg(test)]\nmod tests", maxsplit=1)[0]
+    production_units.append(unit)
+production_source = "\n".join(production_units)
+for forbidden in (
+    "tokio::spawn",
+    "spawn_blocking",
+    "std::thread",
+    "JoinSet",
+    "tokio::runtime::Runtime::new",
+    "tokio::runtime::Runtime::block_on",
+):
+    if forbidden in production_source:
+        fail(f"production source contains unmanaged lifecycle surface {forbidden}")
+if "spawn_service(\"mcp-control-upsert-supervisor\"" not in production_source:
+    fail("reviewed tool execution is not visibly owned by the injected task group")
+
+for required in ("rocketmq_upsert_topic", "rocketmq_upsert_consumer_group"):
+    if required not in source:
+        fail(f"reviewed write catalog is missing {required}")
+
+for forbidden in (
+    "rocketmq_reset_consumer_offset",
+    "rocketmq_patch_broker_config",
+    "rocketmq_set_consumer_request_mode",
+    "rocketmq_delete_",
+    "rocketmq_skip_",
+    "rocketmq_resend_",
+):
+    if forbidden in source:
+        fail(f"production source contains unreviewed tool {forbidden}")
 
 run_query_contract([sys.executable, "scripts/check_read_only_boundary.py"])
 for arguments in (

--- a/rocketmq-ai/rocketmq-mcp-control/src/catalog.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/catalog.rs
@@ -12,21 +12,169 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rmcp::model::ListToolsResult;
+use std::collections::BTreeSet;
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct OperationCatalog;
+use rmcp::model::ListToolsResult;
+use rmcp::model::Tool;
+use rmcp::model::ToolAnnotations;
+
+use crate::config::MutationPolicyConfig;
+use crate::model::ControlOperation;
+use crate::tools::ConsumerGroupMutationToolResponse;
+use crate::tools::TopicMutationToolResponse;
+use crate::tools::UpsertConsumerGroupArgs;
+use crate::tools::UpsertTopicArgs;
+use crate::tools::UPSERT_CONSUMER_GROUP_TOOL;
+use crate::tools::UPSERT_TOPIC_TOOL;
+
+#[derive(Debug, Clone, Default)]
+pub struct OperationCatalog {
+    operations: BTreeSet<ControlOperation>,
+}
 
 impl OperationCatalog {
-    pub const fn registered_operations(&self) -> u32 {
-        0
+    pub fn from_policy(policy: &MutationPolicyConfig) -> Self {
+        #[cfg(feature = "write-tools")]
+        let mut operations = BTreeSet::new();
+        #[cfg(not(feature = "write-tools"))]
+        let operations = BTreeSet::new();
+        #[cfg(feature = "write-tools")]
+        if policy.mutations_enabled {
+            for operation in &policy.allowed_operations {
+                if matches!(
+                    operation,
+                    ControlOperation::TopicUpsert | ControlOperation::ConsumerGroupUpsert
+                ) {
+                    operations.insert(*operation);
+                }
+            }
+        }
+        #[cfg(not(feature = "write-tools"))]
+        let _ = policy;
+        Self { operations }
+    }
+
+    pub fn registered_operations(&self) -> u32 {
+        u32::try_from(self.operations.len()).unwrap_or(u32::MAX)
     }
 
     pub fn list_tools(&self) -> ListToolsResult {
-        ListToolsResult::default()
+        ListToolsResult::with_all_items(self.operations.iter().copied().filter_map(tool_definition).collect())
     }
 
-    pub const fn is_registered(&self, _operation: crate::model::ControlOperation) -> bool {
-        false
+    pub fn list_tools_for(&self, allowed: impl Fn(ControlOperation) -> bool) -> ListToolsResult {
+        ListToolsResult::with_all_items(
+            self.operations
+                .iter()
+                .copied()
+                .filter(|operation| allowed(*operation))
+                .filter_map(tool_definition)
+                .collect(),
+        )
+    }
+
+    pub fn is_registered(&self, operation: ControlOperation) -> bool {
+        self.operations.contains(&operation)
+    }
+}
+
+fn tool_definition(operation: ControlOperation) -> Option<Tool> {
+    let annotations = ToolAnnotations::with_title(match operation {
+        ControlOperation::TopicUpsert => "Upsert RocketMQ topic",
+        ControlOperation::ConsumerGroupUpsert => "Upsert RocketMQ consumer group",
+        _ => "Unavailable RocketMQ mutation",
+    })
+    .read_only(false)
+    .destructive(true)
+    .idempotent(true)
+    .open_world(true);
+    match operation {
+        ControlOperation::TopicUpsert => Some(
+            Tool::new(
+                UPSERT_TOPIC_TOOL,
+                "Dry-run or conditionally replace a complete Topic configuration on selected cluster masters.",
+                std::sync::Arc::new(Default::default()),
+            )
+            .with_title("Upsert RocketMQ topic")
+            .with_input_schema::<UpsertTopicArgs>()
+            .with_output_schema::<TopicMutationToolResponse>()
+            .with_annotations(annotations),
+        ),
+        ControlOperation::ConsumerGroupUpsert => Some(
+            Tool::new(
+                UPSERT_CONSUMER_GROUP_TOOL,
+                "Dry-run or conditionally replace a complete Consumer Group configuration on selected cluster masters.",
+                std::sync::Arc::new(Default::default()),
+            )
+            .with_title("Upsert RocketMQ consumer group")
+            .with_input_schema::<UpsertConsumerGroupArgs>()
+            .with_output_schema::<ConsumerGroupMutationToolResponse>()
+            .with_annotations(annotations),
+        ),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy(enabled: bool, operations: Vec<ControlOperation>) -> MutationPolicyConfig {
+        MutationPolicyConfig {
+            mutations_enabled: enabled,
+            dry_run: true,
+            allowed_operations: operations,
+            allowed_clusters: Vec::new(),
+            operation_timeout_seconds: 12,
+        }
+    }
+
+    #[test]
+    fn catalog_is_policy_derived_and_registers_only_stage_b_operations() {
+        assert_eq!(
+            OperationCatalog::from_policy(&policy(false, vec![ControlOperation::TopicUpsert])).registered_operations(),
+            0
+        );
+        let future_only = OperationCatalog::from_policy(&policy(
+            true,
+            vec![
+                ControlOperation::ConsumerOffsetReset,
+                ControlOperation::BrokerConfigPatch,
+                ControlOperation::ConsumerRequestMode,
+            ],
+        ));
+        assert_eq!(future_only.registered_operations(), 0);
+
+        #[cfg(feature = "write-tools")]
+        {
+            let one = OperationCatalog::from_policy(&policy(true, vec![ControlOperation::TopicUpsert]));
+            assert_eq!(one.registered_operations(), 1);
+            let two = OperationCatalog::from_policy(&policy(
+                true,
+                vec![ControlOperation::TopicUpsert, ControlOperation::ConsumerGroupUpsert],
+            ));
+            assert_eq!(two.registered_operations(), 2);
+            for tool in two.list_tools().tools {
+                assert_eq!(
+                    tool.input_schema.get("additionalProperties"),
+                    Some(&serde_json::json!(false))
+                );
+                let annotations = tool.annotations.unwrap();
+                assert_eq!(annotations.read_only_hint, Some(false));
+                assert_eq!(annotations.destructive_hint, Some(true));
+                assert_eq!(annotations.idempotent_hint, Some(true));
+                assert_eq!(annotations.open_world_hint, Some(true));
+            }
+        }
+    }
+
+    #[cfg(feature = "write-tools")]
+    #[test]
+    fn reviewed_tool_schema_snapshot() {
+        let catalog = OperationCatalog::from_policy(&policy(
+            true,
+            vec![ControlOperation::TopicUpsert, ControlOperation::ConsumerGroupUpsert],
+        ));
+        insta::assert_json_snapshot!("control_reviewed_tool_schemas", catalog.list_tools().tools);
     }
 }

--- a/rocketmq-ai/rocketmq-mcp-control/src/config.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/config.rs
@@ -32,6 +32,8 @@ pub struct ControlConfig {
     pub oauth: OAuthConfig,
     #[serde(default)]
     pub mutations: MutationPolicyConfig,
+    #[serde(default)]
+    pub(crate) clusters: Vec<MutationClusterConfig>,
     pub audit: AuditConfig,
 }
 
@@ -58,7 +60,121 @@ impl ControlConfig {
         self.server.validate()?;
         self.oauth.validate()?;
         self.mutations.validate()?;
+        validate_cluster_registry(&self.clusters)?;
+        if self.mutations.mutations_enabled
+            && self.mutations.allowed_operations.iter().any(|operation| {
+                matches!(
+                    operation,
+                    ControlOperation::TopicUpsert | ControlOperation::ConsumerGroupUpsert
+                )
+            })
+        {
+            let configured = self
+                .clusters
+                .iter()
+                .map(|cluster| &cluster.name)
+                .collect::<BTreeSet<_>>();
+            if self
+                .mutations
+                .allowed_clusters
+                .iter()
+                .any(|cluster| !configured.contains(cluster))
+            {
+                return Err(ControlError::invalid_config());
+            }
+        }
         self.audit.validate()
+    }
+
+    #[cfg(feature = "write-tools")]
+    pub(crate) fn mutation_clusters(&self) -> &[MutationClusterConfig] {
+        &self.clusters
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct MutationClusterConfig {
+    name: ClusterName,
+    namesrv_addr: String,
+    #[serde(default)]
+    use_tls: bool,
+    #[serde(default)]
+    access_key_env: Option<String>,
+    #[serde(default)]
+    secret_key_env: Option<String>,
+    #[serde(default)]
+    security_token_env: Option<String>,
+}
+
+#[cfg(feature = "write-tools")]
+impl MutationClusterConfig {
+    pub(crate) fn name(&self) -> &ClusterName {
+        &self.name
+    }
+
+    pub(crate) fn namesrv_addr(&self) -> &str {
+        &self.namesrv_addr
+    }
+
+    pub(crate) const fn use_tls(&self) -> bool {
+        self.use_tls
+    }
+
+    pub(crate) fn credential_envs(&self) -> (Option<&str>, Option<&str>, Option<&str>) {
+        (
+            self.access_key_env.as_deref(),
+            self.secret_key_env.as_deref(),
+            self.security_token_env.as_deref(),
+        )
+    }
+}
+
+fn validate_cluster_registry(clusters: &[MutationClusterConfig]) -> Result<(), ControlError> {
+    let mut names = BTreeSet::new();
+    for cluster in clusters {
+        if !names.insert(cluster.name.clone())
+            || !valid_namesrv_addr(&cluster.namesrv_addr)
+            || !valid_credential_env_pair(cluster)
+        {
+            return Err(ControlError::invalid_config());
+        }
+    }
+    Ok(())
+}
+
+fn valid_namesrv_addr(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 1024
+        && value.split(';').all(|endpoint| {
+            let Some((host, port)) = endpoint.rsplit_once(':') else {
+                return false;
+            };
+            !host.is_empty()
+                && host.len() <= 253
+                && host
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'[' | b']' | b':'))
+                && port.parse::<u16>().is_ok_and(|port| port != 0)
+        })
+}
+
+fn valid_credential_env_pair(cluster: &MutationClusterConfig) -> bool {
+    let valid_env = |value: &str| {
+        (1..=128).contains(&value.len())
+            && value
+                .bytes()
+                .enumerate()
+                .all(|(index, byte)| byte == b'_' || byte.is_ascii_uppercase() || (index > 0 && byte.is_ascii_digit()))
+    };
+    match (&cluster.access_key_env, &cluster.secret_key_env) {
+        (None, None) => cluster.security_token_env.is_none(),
+        (Some(access), Some(secret)) => {
+            valid_env(access)
+                && valid_env(secret)
+                && cluster.security_token_env.as_deref().map(valid_env).unwrap_or(true)
+        }
+        _ => false,
     }
 }
 
@@ -338,6 +454,7 @@ mod tests {
                 jwks_ca_path: None,
             },
             mutations: MutationPolicyConfig::default(),
+            clusters: Vec::new(),
             audit: AuditConfig {
                 path: "audit.jsonl".to_string(),
                 capacity: 64,
@@ -415,5 +532,32 @@ mod tests {
         assert_eq!(rendered, "ControlConfig { redacted: true }");
         assert!(!rendered.contains("127.0.0.1"));
         assert!(!rendered.contains("issuer.example.test"));
+    }
+
+    #[test]
+    fn mutation_cluster_registry_is_closed_and_required_for_registered_operations() {
+        let cluster = MutationClusterConfig {
+            name: ClusterName::try_new("cluster-a").unwrap(),
+            namesrv_addr: "namesrv.example.test:9876".to_owned(),
+            use_tls: true,
+            access_key_env: Some("ROCKETMQ_ACCESS_KEY".to_owned()),
+            secret_key_env: Some("ROCKETMQ_SECRET_KEY".to_owned()),
+            security_token_env: Some("ROCKETMQ_SECURITY_TOKEN".to_owned()),
+        };
+        let mut config = valid_config();
+        config.mutations.mutations_enabled = true;
+        config.mutations.allowed_operations = vec![ControlOperation::TopicUpsert];
+        config.mutations.allowed_clusters = vec![ClusterName::try_new("cluster-a").unwrap()];
+        assert!(config.validate().is_err());
+        config.clusters.push(cluster.clone());
+        assert!(config.validate().is_ok());
+        config.clusters.push(cluster);
+        assert!(config.validate().is_err());
+
+        let inline_secret = format!(
+            "{}\n[[clusters]]\nname='cluster-a'\nnamesrv_addr='namesrv.example.test:9876'\naccess_key='secret'\n",
+            include_str!("../conf/mcp-control.example.toml")
+        );
+        assert!(toml::from_str::<ControlConfig>(&inline_secret).is_err());
     }
 }

--- a/rocketmq-ai/rocketmq-mcp-control/src/guard.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/guard.rs
@@ -84,6 +84,26 @@ impl MutationGuard {
         arguments.validate()?;
         Ok(arguments)
     }
+
+    pub const fn default_dry_run(&self) -> bool {
+        self.default_dry_run
+    }
+
+    pub fn allows_discovery(
+        &self,
+        principal: &Principal,
+        operation: ControlOperation,
+        configured_clusters: &BTreeSet<ClusterName>,
+    ) -> bool {
+        self.runtime_enabled
+            && principal.scopes.contains(REQUIRED_WRITE_SCOPE)
+            && principal.allowed_operations.contains(&operation)
+            && self.allowed_operations.contains(&operation)
+            && principal
+                .allowed_clusters
+                .iter()
+                .any(|cluster| self.allowed_clusters.contains(cluster) && configured_clusters.contains(cluster))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -134,7 +154,7 @@ mod tests {
     fn scope_and_intersections_are_checked_before_availability() {
         let guard = MutationGuard::new(&policy(true));
         let denied = guard
-            .authorize_raw(&principal(&[]), "unknown", "bad.cluster", &OperationCatalog)
+            .authorize_raw(&principal(&[]), "unknown", "bad.cluster", &OperationCatalog::default())
             .unwrap_err();
         assert_eq!(denied.code(), crate::error::ControlErrorCode::PermissionDenied);
 
@@ -143,7 +163,7 @@ mod tests {
                 &principal(&[REQUIRED_WRITE_SCOPE]),
                 "topic_upsert",
                 "cluster-a",
-                &OperationCatalog,
+                &OperationCatalog::default(),
             )
             .unwrap_err();
         assert_eq!(unavailable.code(), crate::error::ControlErrorCode::OperationUnavailable);
@@ -157,7 +177,7 @@ mod tests {
                 &principal(&[REQUIRED_WRITE_SCOPE]),
                 "topic_upsert",
                 "cluster-a",
-                &OperationCatalog,
+                &OperationCatalog::default(),
             )
             .unwrap_err();
         assert_eq!(error.code(), crate::error::ControlErrorCode::OperationUnavailable);
@@ -176,7 +196,12 @@ mod tests {
         let expected = ControlError::permission_denied().envelope();
         for _raw in malformed {
             let denied = guard
-                .authorize_raw(&principal(&[]), "topic_upsert", "cluster-a", &OperationCatalog)
+                .authorize_raw(
+                    &principal(&[]),
+                    "topic_upsert",
+                    "cluster-a",
+                    &OperationCatalog::default(),
+                )
                 .unwrap_err();
             assert_eq!(denied.envelope(), expected);
         }
@@ -186,7 +211,7 @@ mod tests {
                 &principal(&[REQUIRED_WRITE_SCOPE]),
                 "topic_upsert",
                 "cluster-a",
-                &OperationCatalog,
+                &OperationCatalog::default(),
             )
             .unwrap_err();
         assert_eq!(unavailable.code(), crate::error::ControlErrorCode::OperationUnavailable);

--- a/rocketmq-ai/rocketmq-mcp-control/src/lib.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/lib.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Isolated, deny-by-default foundation for supervised RocketMQ mutations.
+//! Isolated, deny-by-default supervised RocketMQ Topic and Consumer Group upserts.
 //!
 //! Authentication test seams are intentionally not public API:
 //!
 //! ```compile_fail
 //! use rocketmq_mcp_control::auth::AuthState;
 //! ```
+
+#![recursion_limit = "256"]
 
 pub mod audit;
 mod auth;
@@ -29,6 +31,9 @@ pub mod guard;
 pub mod model;
 pub mod server;
 pub mod session;
+#[cfg(feature = "write-tools")]
+mod tool_runtime;
+pub mod tools;
 pub mod transport;
 pub mod workflow;
 

--- a/rocketmq-ai/rocketmq-mcp-control/src/main.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/main.rs
@@ -48,8 +48,8 @@ async fn run(
     service_context: rocketmq_runtime::ChildServiceContext,
 ) -> Result<(), ControlError> {
     let sink = JsonlAuditSink::open(&config.audit.path, config.audit.capacity, config.audit.max_record_bytes).await?;
-    let _audit = AuditTrail::resume(Arc::new(sink)).await?;
-    transport::serve(config, service_context, async {
+    let audit = AuditTrail::resume(Arc::new(sink)).await?;
+    transport::serve(config, service_context, audit, async {
         if rocketmq_runtime::wait_for_signal_result().await.is_err() {
             tracing::warn!("control termination signal observation failed");
         }

--- a/rocketmq-ai/rocketmq-mcp-control/src/server.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/server.rs
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeSet;
+#[cfg(feature = "write-tools")]
+use std::sync::Arc;
+
+use rmcp::model::CallToolRequestParams;
+use rmcp::model::CallToolResponse;
+use rmcp::model::CallToolResult;
+use rmcp::model::ContentBlock;
 use rmcp::model::Implementation;
 use rmcp::model::InitializeRequestParams;
 use rmcp::model::InitializeResult;
@@ -32,26 +40,109 @@ use rmcp::RoleServer;
 use rmcp::ServerHandler;
 
 use crate::catalog::OperationCatalog;
+use crate::guard::MutationGuard;
+use crate::model::ClusterName;
 use crate::model::ControlCapabilities;
+use crate::model::ControlOperation;
+use crate::model::Principal;
+use crate::tools::UPSERT_CONSUMER_GROUP_TOOL;
+use crate::tools::UPSERT_TOPIC_TOOL;
 
 pub const CAPABILITY_RESOURCE_URI: &str = "rocketmq-control://capabilities";
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ControlServer {
     catalog: OperationCatalog,
     capabilities: ControlCapabilities,
+    guard: MutationGuard,
+    configured_clusters: BTreeSet<ClusterName>,
+    #[cfg(feature = "write-tools")]
+    tool_runtime: Option<Arc<crate::tool_runtime::ToolRuntime>>,
     #[cfg(test)]
     response_delay: Option<std::time::Duration>,
 }
 
 impl ControlServer {
     pub fn new(mutations_runtime_enabled: bool) -> Self {
-        let catalog = OperationCatalog;
+        let policy = crate::config::MutationPolicyConfig {
+            mutations_enabled: mutations_runtime_enabled,
+            ..Default::default()
+        };
+        let catalog = OperationCatalog::from_policy(&policy);
         let capabilities = ControlCapabilities::from_catalog(mutations_runtime_enabled, &catalog);
         Self {
             catalog,
             capabilities,
+            guard: MutationGuard::new(&policy),
+            configured_clusters: BTreeSet::new(),
+            #[cfg(feature = "write-tools")]
+            tool_runtime: None,
             #[cfg(test)]
+            response_delay: None,
+        }
+    }
+
+    #[cfg(feature = "write-tools")]
+    pub(crate) fn from_config(
+        config: &crate::config::ControlConfig,
+        audit: crate::audit::AuditTrail,
+        service_context: rocketmq_runtime::ChildServiceContext,
+    ) -> Result<Self, crate::error::ControlError> {
+        let catalog = OperationCatalog::from_policy(&config.mutations);
+        let capabilities = ControlCapabilities::from_catalog(config.mutations.mutations_enabled, &catalog);
+        let guard = MutationGuard::new(&config.mutations);
+        let configured_clusters = config
+            .mutation_clusters()
+            .iter()
+            .map(|cluster| cluster.name().clone())
+            .collect();
+        let tool_runtime = if catalog.registered_operations() == 0 {
+            None
+        } else {
+            let factory = Arc::new(crate::tool_runtime::AdminUpsertFactory::new(
+                service_context.component("admin-factory"),
+                config.mutation_clusters(),
+            )?);
+            Some(Arc::new(crate::tool_runtime::ToolRuntime::new(
+                audit,
+                factory,
+                std::time::Duration::from_secs(config.mutations.operation_timeout_seconds),
+                service_context.task_group().clone(),
+            )))
+        };
+        Ok(Self {
+            catalog,
+            capabilities,
+            guard,
+            configured_clusters,
+            tool_runtime,
+            #[cfg(test)]
+            response_delay: None,
+        })
+    }
+
+    #[cfg(all(test, feature = "write-tools"))]
+    pub(crate) fn with_test_factory(
+        policy: &crate::config::MutationPolicyConfig,
+        configured_clusters: BTreeSet<ClusterName>,
+        audit: crate::audit::AuditTrail,
+        factory: Arc<dyn crate::tool_runtime::UpsertSessionFactory>,
+        owner: rocketmq_runtime::TaskGroup,
+    ) -> Self {
+        let catalog = OperationCatalog::from_policy(policy);
+        let capabilities = ControlCapabilities::from_catalog(policy.mutations_enabled, &catalog);
+        let tool_runtime = crate::tool_runtime::ToolRuntime::new(
+            audit,
+            factory,
+            std::time::Duration::from_secs(policy.operation_timeout_seconds),
+            owner,
+        );
+        Self {
+            catalog,
+            capabilities,
+            guard: MutationGuard::new(policy),
+            configured_clusters,
+            tool_runtime: Some(Arc::new(tool_runtime)),
             response_delay: None,
         }
     }
@@ -64,10 +155,27 @@ impl ControlServer {
         self.catalog.list_tools()
     }
 
+    fn tools_list_for(&self, principal: &Principal) -> ListToolsResult {
+        self.catalog.list_tools_for(|operation| {
+            self.guard
+                .allows_discovery(principal, operation, &self.configured_clusters)
+        })
+    }
+
     #[cfg(test)]
     pub(crate) fn with_response_delay(mut self, delay: std::time::Duration) -> Self {
         self.response_delay = Some(delay);
         self
+    }
+}
+
+impl std::fmt::Debug for ControlServer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ControlServer")
+            .field("capabilities", &self.capabilities)
+            .field("configured_cluster_count", &self.configured_clusters.len())
+            .finish()
     }
 }
 
@@ -76,7 +184,9 @@ impl ServerHandler for ControlServer {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().enable_resources().build())
             .with_server_info(Implementation::new("rocketmq-mcp-control", env!("CARGO_PKG_VERSION")))
             .with_protocol_version(ProtocolVersion::V_2025_11_25)
-            .with_instructions("Isolated RocketMQ control foundation. No production mutation tools are registered.")
+            .with_instructions(
+                "Isolated RocketMQ control server. Reviewed Topic and Consumer Group upserts are available only when compile-time, runtime, server-policy, and principal authorization all intersect.",
+            )
     }
 
     async fn initialize(
@@ -94,13 +204,95 @@ impl ServerHandler for ControlServer {
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
         #[cfg(test)]
         if let Some(delay) = self.response_delay {
             tokio::time::sleep(delay).await;
         }
-        Ok(self.tools_list())
+        let principal = principal_from_context(&context)?;
+        Ok(self.tools_list_for(&principal))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        let principal = principal_from_context(&context)?;
+        let raw = request
+            .arguments
+            .clone()
+            .map(serde_json::Value::Object)
+            .unwrap_or(serde_json::Value::Null);
+        let cluster = raw
+            .as_object()
+            .and_then(|object| object.get("cluster"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        let (operation_name, operation) = match request.name.as_ref() {
+            UPSERT_TOPIC_TOOL => (
+                ControlOperation::TopicUpsert.as_str(),
+                Some(ControlOperation::TopicUpsert),
+            ),
+            UPSERT_CONSUMER_GROUP_TOOL => (
+                ControlOperation::ConsumerGroupUpsert.as_str(),
+                Some(ControlOperation::ConsumerGroupUpsert),
+            ),
+            _ => ("unknown", None),
+        };
+        let authorized = match self
+            .guard
+            .authorize_raw(&principal, operation_name, cluster, &self.catalog)
+        {
+            Ok(authorized) => authorized,
+            Err(error) => return Ok(tool_error(error).into()),
+        };
+        #[cfg(not(feature = "write-tools"))]
+        {
+            let _ = (authorized, operation, context);
+            return Ok(tool_error(crate::error::ControlError::operation_unavailable()).into());
+        }
+        #[cfg(feature = "write-tools")]
+        {
+            let dry_run_omitted = raw.as_object().is_some_and(|object| !object.contains_key("dry_run"));
+            let upsert = match operation {
+                Some(ControlOperation::TopicUpsert) => {
+                    let mut args: crate::tools::UpsertTopicArgs = match serde_json::from_value(raw) {
+                        Ok(args) => args,
+                        Err(_) => return Ok(tool_error(crate::error::ControlError::invalid_arguments()).into()),
+                    };
+                    if let Err(error) = args.validate(self.guard.default_dry_run(), dry_run_omitted) {
+                        return Ok(tool_error(error).into());
+                    }
+                    args.dry_run = args.effective_dry_run(self.guard.default_dry_run(), dry_run_omitted);
+                    crate::tool_runtime::UpsertRequest::Topic(args)
+                }
+                Some(ControlOperation::ConsumerGroupUpsert) => {
+                    let mut args: crate::tools::UpsertConsumerGroupArgs = match serde_json::from_value(raw) {
+                        Ok(args) => args,
+                        Err(_) => return Ok(tool_error(crate::error::ControlError::invalid_arguments()).into()),
+                    };
+                    if let Err(error) = args.validate(self.guard.default_dry_run(), dry_run_omitted) {
+                        return Ok(tool_error(error).into());
+                    }
+                    args.dry_run = args.effective_dry_run(self.guard.default_dry_run(), dry_run_omitted);
+                    crate::tool_runtime::UpsertRequest::ConsumerGroup(args)
+                }
+                _ => return Ok(tool_error(crate::error::ControlError::permission_denied()).into()),
+            };
+            let Some(runtime) = &self.tool_runtime else {
+                return Ok(tool_error(crate::error::ControlError::operation_unavailable()).into());
+            };
+            let result = runtime
+                .execute(&principal, &authorized, upsert, context.ct.clone())
+                .await;
+            Ok(match result {
+                Ok(response) => tool_response(response),
+                Err(error) => tool_error(error),
+            }
+            .into())
+        }
     }
 
     async fn list_resources(
@@ -134,12 +326,47 @@ impl ServerHandler for ControlServer {
     }
 }
 
+fn principal_from_context(context: &RequestContext<RoleServer>) -> Result<Principal, ErrorData> {
+    let parts = context
+        .extensions
+        .get::<axum::http::request::Parts>()
+        .ok_or_else(|| ErrorData::invalid_request("authenticated request context is unavailable", None))?;
+    parts
+        .extensions
+        .get::<Principal>()
+        .cloned()
+        .ok_or_else(|| ErrorData::invalid_request("authenticated request context is unavailable", None))
+}
+
+#[cfg(feature = "write-tools")]
+fn tool_response(response: crate::tool_runtime::UpsertResponse) -> CallToolResult {
+    let structured = serde_json::to_value(&response).unwrap_or_else(|_| {
+        serde_json::to_value(crate::error::ControlError::execution_failed().envelope()).unwrap_or_default()
+    });
+    let text = serde_json::to_string(&structured).unwrap_or_else(|_| "mutation response unavailable".to_owned());
+    let mut result = if response.is_error() {
+        CallToolResult::error(vec![ContentBlock::text(text)])
+    } else {
+        CallToolResult::success(vec![ContentBlock::text(text)])
+    };
+    result.structured_content = Some(structured);
+    result
+}
+
+fn tool_error(error: crate::error::ControlError) -> CallToolResult {
+    let structured = serde_json::to_value(error.envelope()).unwrap_or_default();
+    let text = serde_json::to_string(&structured).unwrap_or_else(|_| "mutation failed".to_owned());
+    let mut result = CallToolResult::error(vec![ContentBlock::text(text)]);
+    result.structured_content = Some(structured);
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn all_foundation_modes_keep_tools_list_empty() {
+    fn constructors_without_reviewed_policy_keep_tools_list_empty() {
         for runtime_enabled in [false, true] {
             let server = ControlServer::new(runtime_enabled);
             assert!(server.tools_list().tools.is_empty());

--- a/rocketmq-ai/rocketmq-mcp-control/src/snapshots/rocketmq_mcp_control__catalog__tests__control_reviewed_tool_schemas.snap
+++ b/rocketmq-ai/rocketmq-mcp-control/src/snapshots/rocketmq_mcp_control__catalog__tests__control_reviewed_tool_schemas.snap
@@ -1,0 +1,896 @@
+---
+source: src/catalog.rs
+expression: catalog.list_tools().tools
+---
+[
+  {
+    "name": "rocketmq_upsert_topic",
+    "title": "Upsert RocketMQ topic",
+    "description": "Dry-run or conditionally replace a complete Topic configuration on selected cluster masters.",
+    "inputSchema": {
+      "$defs": {
+        "TopicMessageType": {
+          "enum": [
+            "NORMAL",
+            "FIFO",
+            "DELAY",
+            "TRANSACTION",
+            "UNSPECIFIED"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_names": {
+          "items": {
+            "maxLength": 127,
+            "minLength": 1,
+            "pattern": "^[%|a-zA-Z0-9_-]+$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "type": "array"
+        },
+        "cluster": {
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "confirm": {
+          "default": false,
+          "type": "boolean"
+        },
+        "dry_run": {
+          "default": true,
+          "type": "boolean"
+        },
+        "message_type": {
+          "$ref": "#/$defs/TopicMessageType"
+        },
+        "order": {
+          "type": "boolean"
+        },
+        "perm": {
+          "format": "uint32",
+          "maximum": 7,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "read_queue_nums": {
+          "format": "uint32",
+          "maximum": 127,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "reason": {
+          "default": null,
+          "maxLength": 256,
+          "minLength": 5,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_key": {
+          "default": null,
+          "maxLength": 64,
+          "minLength": 8,
+          "pattern": "^[a-zA-Z0-9._:-]+$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "pattern": "^rocketmq-mcp-control\\.arguments\\.v1$",
+          "type": "string"
+        },
+        "topic": {
+          "maxLength": 127,
+          "minLength": 1,
+          "pattern": "^[%|a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "write_queue_nums": {
+          "format": "uint32",
+          "maximum": 127,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "schema_version",
+        "cluster",
+        "topic",
+        "broker_names",
+        "read_queue_nums",
+        "write_queue_nums",
+        "perm",
+        "order",
+        "message_type"
+      ],
+      "type": "object"
+    },
+    "outputSchema": {
+      "$defs": {
+        "FailureCode": {
+          "enum": [
+            "conflict",
+            "invalid_data",
+            "unavailable",
+            "persistence_failed",
+            "verification_failed",
+            "order_reconciliation_failed"
+          ],
+          "type": "string"
+        },
+        "LogicalMutationTarget": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "broker_name"
+          ],
+          "type": "object"
+        },
+        "MutationMode": {
+          "enum": [
+            "dry_run",
+            "execute"
+          ],
+          "type": "string"
+        },
+        "MutationResultSchemaVersion": {
+          "const": "rocketmq-mcp-mutation.v1",
+          "type": "string"
+        },
+        "MutationStatus": {
+          "enum": [
+            "planned",
+            "applied",
+            "partial",
+            "conflict",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "MutationTarget": {
+          "additionalProperties": false,
+          "properties": {
+            "after": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VisibleState"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "applied": {
+              "type": "boolean"
+            },
+            "before": {
+              "$ref": "#/$defs/VisibleState"
+            },
+            "changed": {
+              "type": "boolean"
+            },
+            "failure": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/FailureCode"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "persistence": {
+              "$ref": "#/$defs/PersistenceState"
+            },
+            "requested": {
+              "$ref": "#/$defs/TopicReplacement"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "target": {
+              "$ref": "#/$defs/LogicalMutationTarget"
+            },
+            "verification": {
+              "$ref": "#/$defs/VerificationState"
+            }
+          },
+          "required": [
+            "target",
+            "before",
+            "requested",
+            "applied",
+            "changed",
+            "persistence",
+            "verification",
+            "retryable"
+          ],
+          "type": "object"
+        },
+        "PersistenceState": {
+          "enum": [
+            "not_required",
+            "persisted",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "TopicMessageType": {
+          "enum": [
+            "NORMAL",
+            "FIFO",
+            "DELAY",
+            "TRANSACTION",
+            "UNSPECIFIED"
+          ],
+          "type": "string"
+        },
+        "TopicMutationResource": {
+          "additionalProperties": false,
+          "properties": {
+            "brokers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "brokers"
+          ],
+          "type": "object"
+        },
+        "TopicReplacement": {
+          "additionalProperties": false,
+          "properties": {
+            "message_type": {
+              "$ref": "#/$defs/TopicMessageType"
+            },
+            "order": {
+              "type": "boolean"
+            },
+            "perm": {
+              "format": "uint32",
+              "maximum": 7,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "read_queue_nums": {
+              "format": "uint32",
+              "maximum": 127,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "write_queue_nums": {
+              "format": "uint32",
+              "maximum": 127,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "read_queue_nums",
+            "write_queue_nums",
+            "perm",
+            "order",
+            "message_type"
+          ],
+          "type": "object"
+        },
+        "TopicUpsertOperation": {
+          "const": "topic_upsert",
+          "type": "string"
+        },
+        "VerificationState": {
+          "enum": [
+            "not_performed",
+            "verified",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "VisibleState": {
+          "oneOf": [
+            {
+              "properties": {
+                "kind": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "const": "absent",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "const": "present",
+                  "type": "string"
+                },
+                "value": {
+                  "$ref": "#/$defs/TopicReplacement"
+                },
+                "version": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "kind",
+                "version",
+                "value"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "additionalProperties": {
+            "$ref": "#/$defs/VisibleState"
+          },
+          "type": "object"
+        },
+        "before": {
+          "additionalProperties": {
+            "$ref": "#/$defs/VisibleState"
+          },
+          "type": "object"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "mode": {
+          "$ref": "#/$defs/MutationMode"
+        },
+        "operation": {
+          "$ref": "#/$defs/TopicUpsertOperation"
+        },
+        "requested": {
+          "$ref": "#/$defs/TopicReplacement"
+        },
+        "schema_version": {
+          "$ref": "#/$defs/MutationResultSchemaVersion"
+        },
+        "status": {
+          "$ref": "#/$defs/MutationStatus"
+        },
+        "target": {
+          "$ref": "#/$defs/TopicMutationResource"
+        },
+        "targets": {
+          "items": {
+            "$ref": "#/$defs/MutationTarget"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "operation",
+        "cluster",
+        "mode",
+        "status",
+        "target",
+        "before",
+        "requested",
+        "after",
+        "targets",
+        "warnings"
+      ],
+      "type": "object"
+    },
+    "annotations": {
+      "title": "Upsert RocketMQ topic",
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "rocketmq_upsert_consumer_group",
+    "title": "Upsert RocketMQ consumer group",
+    "description": "Dry-run or conditionally replace a complete Consumer Group configuration on selected cluster masters.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_id": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "broker_names": {
+          "items": {
+            "maxLength": 127,
+            "minLength": 1,
+            "pattern": "^[%|a-zA-Z0-9_-]+$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "type": "array"
+        },
+        "cluster": {
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "confirm": {
+          "default": false,
+          "type": "boolean"
+        },
+        "consume_broadcast_enable": {
+          "type": "boolean"
+        },
+        "consume_enable": {
+          "type": "boolean"
+        },
+        "consume_from_min_enable": {
+          "type": "boolean"
+        },
+        "consume_message_orderly": {
+          "type": "boolean"
+        },
+        "consume_timeout_minute": {
+          "format": "int32",
+          "maximum": 10080,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "consumer_group": {
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[%|a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "dry_run": {
+          "default": true,
+          "type": "boolean"
+        },
+        "group_sys_flag": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "notify_consumer_ids_changed_enable": {
+          "type": "boolean"
+        },
+        "reason": {
+          "default": null,
+          "maxLength": 256,
+          "minLength": 5,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_key": {
+          "default": null,
+          "maxLength": 64,
+          "minLength": 8,
+          "pattern": "^[a-zA-Z0-9._:-]+$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "retry_max_times": {
+          "format": "int32",
+          "maximum": 10000,
+          "minimum": -1,
+          "type": "integer"
+        },
+        "retry_queue_nums": {
+          "format": "int32",
+          "maximum": 127,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "schema_version": {
+          "pattern": "^rocketmq-mcp-control\\.arguments\\.v1$",
+          "type": "string"
+        },
+        "which_broker_when_consume_slowly": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "schema_version",
+        "cluster",
+        "consumer_group",
+        "broker_names",
+        "consume_enable",
+        "consume_from_min_enable",
+        "consume_broadcast_enable",
+        "consume_message_orderly",
+        "retry_queue_nums",
+        "retry_max_times",
+        "broker_id",
+        "which_broker_when_consume_slowly",
+        "notify_consumer_ids_changed_enable",
+        "group_sys_flag",
+        "consume_timeout_minute"
+      ],
+      "type": "object"
+    },
+    "outputSchema": {
+      "$defs": {
+        "ConsumerGroupMutationResource": {
+          "additionalProperties": false,
+          "properties": {
+            "brokers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "consumer_group": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "consumer_group",
+            "brokers"
+          ],
+          "type": "object"
+        },
+        "ConsumerGroupReplacement": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "consume_broadcast_enable": {
+              "type": "boolean"
+            },
+            "consume_enable": {
+              "type": "boolean"
+            },
+            "consume_from_min_enable": {
+              "type": "boolean"
+            },
+            "consume_message_orderly": {
+              "type": "boolean"
+            },
+            "consume_timeout_minute": {
+              "format": "int32",
+              "maximum": 10080,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "group_sys_flag": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "notify_consumer_ids_changed_enable": {
+              "type": "boolean"
+            },
+            "retry_max_times": {
+              "format": "int32",
+              "maximum": 10000,
+              "minimum": -1,
+              "type": "integer"
+            },
+            "retry_queue_nums": {
+              "format": "int32",
+              "maximum": 127,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "which_broker_when_consume_slowly": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "consume_enable",
+            "consume_from_min_enable",
+            "consume_broadcast_enable",
+            "consume_message_orderly",
+            "retry_queue_nums",
+            "retry_max_times",
+            "broker_id",
+            "which_broker_when_consume_slowly",
+            "notify_consumer_ids_changed_enable",
+            "group_sys_flag",
+            "consume_timeout_minute"
+          ],
+          "type": "object"
+        },
+        "ConsumerGroupUpsertOperation": {
+          "const": "consumer_group_upsert",
+          "type": "string"
+        },
+        "FailureCode": {
+          "enum": [
+            "conflict",
+            "invalid_data",
+            "unavailable",
+            "persistence_failed",
+            "verification_failed",
+            "order_reconciliation_failed"
+          ],
+          "type": "string"
+        },
+        "LogicalMutationTarget": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "broker_name"
+          ],
+          "type": "object"
+        },
+        "MutationMode": {
+          "enum": [
+            "dry_run",
+            "execute"
+          ],
+          "type": "string"
+        },
+        "MutationResultSchemaVersion": {
+          "const": "rocketmq-mcp-mutation.v1",
+          "type": "string"
+        },
+        "MutationStatus": {
+          "enum": [
+            "planned",
+            "applied",
+            "partial",
+            "conflict",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "MutationTarget": {
+          "additionalProperties": false,
+          "properties": {
+            "after": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/VisibleState"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "applied": {
+              "type": "boolean"
+            },
+            "before": {
+              "$ref": "#/$defs/VisibleState"
+            },
+            "changed": {
+              "type": "boolean"
+            },
+            "failure": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/FailureCode"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "persistence": {
+              "$ref": "#/$defs/PersistenceState"
+            },
+            "requested": {
+              "$ref": "#/$defs/ConsumerGroupReplacement"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "target": {
+              "$ref": "#/$defs/LogicalMutationTarget"
+            },
+            "verification": {
+              "$ref": "#/$defs/VerificationState"
+            }
+          },
+          "required": [
+            "target",
+            "before",
+            "requested",
+            "applied",
+            "changed",
+            "persistence",
+            "verification",
+            "retryable"
+          ],
+          "type": "object"
+        },
+        "PersistenceState": {
+          "enum": [
+            "not_required",
+            "persisted",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "VerificationState": {
+          "enum": [
+            "not_performed",
+            "verified",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "VisibleState": {
+          "oneOf": [
+            {
+              "properties": {
+                "kind": {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "const": "absent",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "const": "present",
+                  "type": "string"
+                },
+                "value": {
+                  "$ref": "#/$defs/ConsumerGroupReplacement"
+                },
+                "version": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "kind",
+                "version",
+                "value"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "additionalProperties": {
+            "$ref": "#/$defs/VisibleState"
+          },
+          "type": "object"
+        },
+        "before": {
+          "additionalProperties": {
+            "$ref": "#/$defs/VisibleState"
+          },
+          "type": "object"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "mode": {
+          "$ref": "#/$defs/MutationMode"
+        },
+        "operation": {
+          "$ref": "#/$defs/ConsumerGroupUpsertOperation"
+        },
+        "requested": {
+          "$ref": "#/$defs/ConsumerGroupReplacement"
+        },
+        "schema_version": {
+          "$ref": "#/$defs/MutationResultSchemaVersion"
+        },
+        "status": {
+          "$ref": "#/$defs/MutationStatus"
+        },
+        "target": {
+          "$ref": "#/$defs/ConsumerGroupMutationResource"
+        },
+        "targets": {
+          "items": {
+            "$ref": "#/$defs/MutationTarget"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "operation",
+        "cluster",
+        "mode",
+        "status",
+        "target",
+        "before",
+        "requested",
+        "after",
+        "targets",
+        "warnings"
+      ],
+      "type": "object"
+    },
+    "annotations": {
+      "title": "Upsert RocketMQ consumer group",
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true
+    }
+  }
+]

--- a/rocketmq-ai/rocketmq-mcp-control/src/snapshots/rocketmq_mcp_control__tools__tests__control_mutation_response.snap
+++ b/rocketmq-ai/rocketmq-mcp-control/src/snapshots/rocketmq_mcp_control__tools__tests__control_mutation_response.snap
@@ -1,0 +1,79 @@
+---
+source: src/tools.rs
+expression: response
+---
+{
+  "schema_version": "rocketmq-mcp-mutation.v1",
+  "operation": "topic_upsert",
+  "cluster": "cluster-a",
+  "mode": "execute",
+  "status": "partial",
+  "target": {
+    "topic": "orders",
+    "brokers": [
+      "broker-a"
+    ]
+  },
+  "before": {
+    "broker-a": {
+      "kind": "absent"
+    }
+  },
+  "requested": {
+    "read_queue_nums": 8,
+    "write_queue_nums": 8,
+    "perm": 6,
+    "order": false,
+    "message_type": "NORMAL"
+  },
+  "after": {
+    "broker-a": {
+      "kind": "present",
+      "version": 1,
+      "value": {
+        "read_queue_nums": 8,
+        "write_queue_nums": 8,
+        "perm": 6,
+        "order": false,
+        "message_type": "NORMAL"
+      }
+    }
+  },
+  "targets": [
+    {
+      "target": {
+        "broker_name": "broker-a"
+      },
+      "before": {
+        "kind": "absent"
+      },
+      "requested": {
+        "read_queue_nums": 8,
+        "write_queue_nums": 8,
+        "perm": 6,
+        "order": false,
+        "message_type": "NORMAL"
+      },
+      "after": {
+        "kind": "present",
+        "version": 1,
+        "value": {
+          "read_queue_nums": 8,
+          "write_queue_nums": 8,
+          "perm": 6,
+          "order": false,
+          "message_type": "NORMAL"
+        }
+      },
+      "applied": true,
+      "changed": true,
+      "persistence": "persisted",
+      "verification": "verified",
+      "failure": "order_reconciliation_failed",
+      "retryable": false
+    }
+  ],
+  "warnings": [
+    "topic order configuration was not reconciled"
+  ]
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime.rs
@@ -1,0 +1,703 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "write-tools")]
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_admin_core::core::supervised_mutation as admin;
+use rocketmq_runtime::TaskGroup;
+use serde::Serialize;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::audit::AuditTrail;
+use crate::error::ControlError;
+use crate::guard::AuthorizedMutation;
+use crate::model::ClusterName;
+use crate::model::ControlOperation;
+use crate::model::Principal;
+use crate::tools;
+
+const IDEMPOTENCY_TTL: Duration = Duration::from_secs(10 * 60);
+const IDEMPOTENCY_CAPACITY: usize = 4096;
+const SESSION_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub(crate) type RuntimeFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+#[derive(Clone)]
+pub(crate) enum UpsertRequest {
+    Topic(tools::UpsertTopicArgs),
+    ConsumerGroup(tools::UpsertConsumerGroupArgs),
+}
+
+impl UpsertRequest {
+    fn operation(&self) -> ControlOperation {
+        match self {
+            Self::Topic(_) => ControlOperation::TopicUpsert,
+            Self::ConsumerGroup(_) => ControlOperation::ConsumerGroupUpsert,
+        }
+    }
+
+    fn dry_run(&self) -> bool {
+        match self {
+            Self::Topic(args) => args.dry_run,
+            Self::ConsumerGroup(args) => args.dry_run,
+        }
+    }
+
+    fn request_key(&self) -> Option<&str> {
+        match self {
+            Self::Topic(args) => args.request_key.as_deref(),
+            Self::ConsumerGroup(args) => args.request_key.as_deref(),
+        }
+    }
+
+    fn target_names(&self) -> &[String] {
+        match self {
+            Self::Topic(args) => &args.broker_names,
+            Self::ConsumerGroup(args) => &args.broker_names,
+        }
+    }
+
+    fn canonical_payload(&self) -> Result<String, ControlError> {
+        let mut canonical = self.clone();
+        match &mut canonical {
+            Self::Topic(args) => args.broker_names.sort(),
+            Self::ConsumerGroup(args) => args.broker_names.sort(),
+        }
+        serde_json::to_string(&canonical).map_err(|_| ControlError::invalid_arguments())
+    }
+}
+
+impl Serialize for UpsertRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Topic(args) => args.serialize(serializer),
+            Self::ConsumerGroup(args) => args.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub(crate) enum UpsertResponse {
+    Topic(tools::TopicMutationToolResponse),
+    ConsumerGroup(tools::ConsumerGroupMutationToolResponse),
+}
+
+impl UpsertResponse {
+    pub(crate) fn is_error(&self) -> bool {
+        match self {
+            Self::Topic(response) => response.is_error(),
+            Self::ConsumerGroup(response) => response.is_error(),
+        }
+    }
+
+    fn audit_error(&self) -> Option<crate::error::ControlErrorCode> {
+        let status = match self {
+            Self::Topic(response) => response.status,
+            Self::ConsumerGroup(response) => response.status,
+        };
+        match status {
+            tools::MutationStatus::Conflict => Some(crate::error::ControlErrorCode::Conflict),
+            tools::MutationStatus::Partial | tools::MutationStatus::Failed => {
+                Some(crate::error::ControlErrorCode::ExecutionFailed)
+            }
+            tools::MutationStatus::Planned | tools::MutationStatus::Applied => None,
+        }
+    }
+}
+
+pub(crate) trait UpsertSession: Send {
+    fn run<'a>(&'a mut self, request: UpsertRequest) -> RuntimeFuture<'a, Result<UpsertResponse, ControlError>>;
+    fn shutdown(&mut self) -> RuntimeFuture<'_, Result<(), ControlError>>;
+}
+
+pub(crate) trait UpsertSessionFactory: Send + Sync {
+    fn open<'a>(&'a self, cluster: &'a ClusterName) -> RuntimeFuture<'a, Result<Box<dyn UpsertSession>, ControlError>>;
+}
+
+#[derive(Clone)]
+pub(crate) struct ToolRuntime {
+    audit: AuditTrail,
+    factory: Arc<dyn UpsertSessionFactory>,
+    operation_timeout: Duration,
+    owner: TaskGroup,
+    idempotency: Arc<Mutex<IdempotencyState>>,
+}
+
+impl ToolRuntime {
+    pub(crate) fn new(
+        audit: AuditTrail,
+        factory: Arc<dyn UpsertSessionFactory>,
+        operation_timeout: Duration,
+        owner: TaskGroup,
+    ) -> Self {
+        Self {
+            audit,
+            factory,
+            operation_timeout,
+            owner,
+            idempotency: Arc::new(Mutex::new(IdempotencyState::default())),
+        }
+    }
+
+    pub(crate) async fn execute(
+        &self,
+        principal: &Principal,
+        authorized: &AuthorizedMutation,
+        request: UpsertRequest,
+        cancellation: CancellationToken,
+    ) -> Result<UpsertResponse, ControlError> {
+        let cluster = authorized.cluster().clone();
+        let identity = IdempotencyIdentity::from_request(principal, &cluster, &request)?;
+        let admission =
+            match idempotency::admit_cache(&self.idempotency, identity.key.as_ref(), &identity.payload).await {
+                Ok(admission) => admission,
+                Err(idempotency::AdmissionError::Capacity) => return Err(ControlError::operation_unavailable()),
+                Err(idempotency::AdmissionError::Collision) => {
+                    let invocation = self
+                        .audit
+                        .start(authorized.operation(), authorized.cluster(), request.dry_run())
+                        .await?;
+                    let error = ControlError::invalid_arguments();
+                    self.audit.terminal(&invocation, Some(error.code())).await?;
+                    return Err(error);
+                }
+            };
+        let is_leader = matches!(&admission, idempotency::CacheAdmission::Leader);
+        let invocation = match self
+            .audit
+            .start(authorized.operation(), authorized.cluster(), request.dry_run())
+            .await
+        {
+            Ok(invocation) => invocation,
+            Err(error) => {
+                if is_leader {
+                    idempotency::abort_cache_reservation(&self.idempotency, &identity, error.clone()).await;
+                }
+                return Err(error);
+            }
+        };
+        let (sender, receiver) = oneshot::channel();
+        let audit = self.audit.clone();
+        let factory = self.factory.clone();
+        let operation_timeout = self.operation_timeout;
+        let owner_cancellation = self.owner.cancellation_token();
+        let cache = self.idempotency.clone();
+        let cleanup_identity = identity.clone();
+        let task_invocation = invocation.clone();
+        let spawn = self.owner.spawn_service("mcp-control-upsert-supervisor", async move {
+            let result = execute_admitted(
+                cache,
+                identity,
+                admission,
+                factory,
+                cluster,
+                request,
+                operation_timeout,
+                cancellation,
+                owner_cancellation,
+            )
+            .await;
+            let error_code = match &result {
+                Ok(response) => response.audit_error(),
+                Err(error) => Some(error.code()),
+            };
+            let terminal = audit.terminal(&task_invocation, error_code).await;
+            let delivered = terminal.map_or_else(Err, |_| result);
+            let _ = sender.send(delivered);
+        });
+        if spawn.is_err() {
+            let error = ControlError::execution_failed();
+            if is_leader {
+                idempotency::abort_cache_reservation(&self.idempotency, &cleanup_identity, error.clone()).await;
+            }
+            self.audit.terminal(&invocation, Some(error.code())).await?;
+            return Err(error);
+        }
+        receiver.await.map_err(|_| ControlError::audit_unavailable())?
+    }
+}
+
+pub(crate) mod admin_session;
+mod execution;
+mod idempotency;
+
+pub(crate) use admin_session::AdminUpsertFactory;
+use idempotency::execute_admitted;
+use idempotency::IdempotencyIdentity;
+use idempotency::IdempotencyState;
+
+fn topic_before(
+    args: &tools::UpsertTopicArgs,
+    targets: Vec<admin::MetadataPreflightTarget<admin::TopicReplacement>>,
+) -> BTreeMap<String, tools::VisibleState<tools::TopicReplacement>> {
+    let mut states = args
+        .broker_names
+        .iter()
+        .cloned()
+        .map(|broker| (broker, tools::VisibleState::Unknown))
+        .collect::<BTreeMap<_, _>>();
+    for target in targets {
+        states.insert(target.broker_name, topic_visible_state(target.state, target.current));
+    }
+    states
+}
+
+fn group_before(
+    args: &tools::UpsertConsumerGroupArgs,
+    targets: Vec<admin::MetadataPreflightTarget<admin::SubscriptionGroupReplacement>>,
+) -> BTreeMap<String, tools::VisibleState<tools::ConsumerGroupReplacement>> {
+    let mut states = args
+        .broker_names
+        .iter()
+        .cloned()
+        .map(|broker| (broker, tools::VisibleState::Unknown))
+        .collect::<BTreeMap<_, _>>();
+    for target in targets {
+        states.insert(target.broker_name, group_visible_state(target.state, target.current));
+    }
+    states
+}
+
+fn topic_dry_run(
+    args: &tools::UpsertTopicArgs,
+    before: BTreeMap<String, tools::VisibleState<tools::TopicReplacement>>,
+    failures: &[admin::MutationTargetFailure],
+) -> tools::TopicMutationToolResponse {
+    let failures = failure_map(failures);
+    let aggregate_before = before.clone();
+    let targets: Vec<_> = before
+        .into_iter()
+        .map(|(broker_name, before)| {
+            let failure = failures.get(&broker_name).copied();
+            tools::MutationTarget {
+                target: tools::LogicalMutationTarget { broker_name },
+                before,
+                requested: args.replacement.clone(),
+                after: None,
+                applied: false,
+                changed: false,
+                persistence: tools::PersistenceState::NotRequired,
+                verification: tools::VerificationState::NotPerformed,
+                failure: failure.map(|(code, _)| code),
+                retryable: failure.is_some_and(|(_, retryable)| retryable),
+            }
+        })
+        .collect();
+    let status = dry_run_status(targets.len(), failures.len());
+    topic_response(
+        args,
+        tools::MutationMode::DryRun,
+        status,
+        aggregate_before,
+        None,
+        targets,
+        Vec::new(),
+    )
+}
+
+fn group_dry_run(
+    args: &tools::UpsertConsumerGroupArgs,
+    before: BTreeMap<String, tools::VisibleState<tools::ConsumerGroupReplacement>>,
+    failures: &[admin::MutationTargetFailure],
+) -> tools::ConsumerGroupMutationToolResponse {
+    let failures = failure_map(failures);
+    let aggregate_before = before.clone();
+    let targets: Vec<_> = before
+        .into_iter()
+        .map(|(broker_name, before)| {
+            let failure = failures.get(&broker_name).copied();
+            tools::MutationTarget {
+                target: tools::LogicalMutationTarget { broker_name },
+                before,
+                requested: args.replacement.clone(),
+                after: None,
+                applied: false,
+                changed: false,
+                persistence: tools::PersistenceState::NotRequired,
+                verification: tools::VerificationState::NotPerformed,
+                failure: failure.map(|(code, _)| code),
+                retryable: failure.is_some_and(|(_, retryable)| retryable),
+            }
+        })
+        .collect();
+    let status = dry_run_status(targets.len(), failures.len());
+    group_response(
+        args,
+        tools::MutationMode::DryRun,
+        status,
+        aggregate_before,
+        None,
+        targets,
+        Vec::new(),
+    )
+}
+
+fn topic_executed(
+    args: &tools::UpsertTopicArgs,
+    before: BTreeMap<String, tools::VisibleState<tools::TopicReplacement>>,
+    outcome: admin::MetadataMutationOutcome,
+    observed: Option<Vec<admin::MetadataPreflightTarget<admin::TopicReplacement>>>,
+) -> tools::TopicMutationToolResponse {
+    let aggregate_before = before.clone();
+    let after = observed.map(|targets| topic_before(args, targets));
+    let outcomes = outcome
+        .targets
+        .into_iter()
+        .map(|target| (target.broker_name.clone(), target))
+        .collect::<BTreeMap<_, _>>();
+    let failures = failure_map(&outcome.failures);
+    let targets = build_executed_targets(
+        before,
+        after.clone().unwrap_or_default(),
+        outcomes,
+        failures,
+        args.replacement.clone(),
+    );
+    let mut warnings = Vec::new();
+    if outcome.order_reconciled == Some(false) {
+        warnings.push("topic order configuration was not reconciled".to_owned());
+    }
+    let mut status = execution_status(&targets);
+    if !warnings.is_empty() && status == tools::MutationStatus::Applied {
+        status = tools::MutationStatus::Partial;
+    }
+    topic_response(
+        args,
+        tools::MutationMode::Execute,
+        status,
+        aggregate_before,
+        after,
+        targets,
+        warnings,
+    )
+}
+
+fn group_executed(
+    args: &tools::UpsertConsumerGroupArgs,
+    before: BTreeMap<String, tools::VisibleState<tools::ConsumerGroupReplacement>>,
+    outcome: admin::MetadataMutationOutcome,
+    observed: Option<Vec<admin::MetadataPreflightTarget<admin::SubscriptionGroupReplacement>>>,
+) -> tools::ConsumerGroupMutationToolResponse {
+    let aggregate_before = before.clone();
+    let after = observed.map(|targets| group_before(args, targets));
+    let outcomes = outcome
+        .targets
+        .into_iter()
+        .map(|target| (target.broker_name.clone(), target))
+        .collect::<BTreeMap<_, _>>();
+    let failures = failure_map(&outcome.failures);
+    let targets = build_executed_targets(
+        before,
+        after.clone().unwrap_or_default(),
+        outcomes,
+        failures,
+        args.replacement.clone(),
+    );
+    let status = execution_status(&targets);
+    group_response(
+        args,
+        tools::MutationMode::Execute,
+        status,
+        aggregate_before,
+        after,
+        targets,
+        Vec::new(),
+    )
+}
+
+fn build_executed_targets<T: Clone + PartialEq>(
+    before: BTreeMap<String, tools::VisibleState<T>>,
+    after: BTreeMap<String, tools::VisibleState<T>>,
+    mut outcomes: BTreeMap<String, admin::MetadataMutationTargetOutcome>,
+    failures: BTreeMap<String, (tools::FailureCode, bool)>,
+    requested: T,
+) -> Vec<tools::MutationTarget<T>> {
+    before
+        .into_iter()
+        .map(|(broker_name, before)| {
+            let outcome = outcomes.remove(&broker_name);
+            let applied = outcome.as_ref().is_some_and(|target| target.applied);
+            let observed_matches = matches!(
+                after.get(&broker_name),
+                Some(tools::VisibleState::Present { value, .. }) if value == &requested
+            );
+            let failure = outcome
+                .as_ref()
+                .and_then(|target| target.failure.map(map_failure))
+                .or_else(|| failures.get(&broker_name).map(|(code, _)| *code))
+                .or_else(|| (applied && !observed_matches).then_some(tools::FailureCode::VerificationFailed));
+            tools::MutationTarget {
+                target: tools::LogicalMutationTarget {
+                    broker_name: broker_name.clone(),
+                },
+                before,
+                requested: requested.clone(),
+                after: after.get(&broker_name).cloned(),
+                applied,
+                changed: outcome.as_ref().is_some_and(|target| target.changed),
+                persistence: outcome
+                    .as_ref()
+                    .map(|target| map_persistence(target.persistence))
+                    .unwrap_or(tools::PersistenceState::NotRequired),
+                verification: if applied {
+                    if observed_matches {
+                        tools::VerificationState::Verified
+                    } else {
+                        tools::VerificationState::Failed
+                    }
+                } else {
+                    outcome
+                        .as_ref()
+                        .map(|target| map_verification(target.verification))
+                        .unwrap_or(tools::VerificationState::Failed)
+                },
+                failure,
+                retryable: outcome.as_ref().is_some_and(|target| target.retryable)
+                    || failures.get(&broker_name).is_some_and(|(_, retryable)| *retryable),
+            }
+        })
+        .collect()
+}
+
+fn execution_status<T>(targets: &[tools::MutationTarget<T>]) -> tools::MutationStatus {
+    let succeeded = targets.iter().filter(|target| target.failure.is_none()).count();
+    let failed = targets.len().saturating_sub(succeeded);
+    if failed == 0 {
+        tools::MutationStatus::Applied
+    } else if succeeded > 0 {
+        tools::MutationStatus::Partial
+    } else if targets
+        .iter()
+        .all(|target| target.failure == Some(tools::FailureCode::Conflict))
+    {
+        tools::MutationStatus::Conflict
+    } else {
+        tools::MutationStatus::Failed
+    }
+}
+
+fn dry_run_status(target_count: usize, failure_count: usize) -> tools::MutationStatus {
+    let succeeded = target_count.saturating_sub(failure_count);
+    if failure_count == 0 {
+        tools::MutationStatus::Planned
+    } else if succeeded == 0 {
+        tools::MutationStatus::Failed
+    } else {
+        tools::MutationStatus::Partial
+    }
+}
+
+fn topic_response(
+    args: &tools::UpsertTopicArgs,
+    mode: tools::MutationMode,
+    status: tools::MutationStatus,
+    before: BTreeMap<String, tools::VisibleState<tools::TopicReplacement>>,
+    after: Option<BTreeMap<String, tools::VisibleState<tools::TopicReplacement>>>,
+    targets: Vec<tools::MutationTarget<tools::TopicReplacement>>,
+    warnings: Vec<String>,
+) -> tools::TopicMutationToolResponse {
+    let mut brokers = args.broker_names.clone();
+    brokers.sort();
+    tools::MutationToolResponse {
+        schema_version: tools::MutationResultSchemaVersion::V1,
+        operation: tools::TopicUpsertOperation::TopicUpsert,
+        cluster: args.cluster.clone(),
+        mode,
+        status,
+        target: tools::TopicMutationResource {
+            topic: args.topic.clone(),
+            brokers,
+        },
+        before,
+        requested: args.replacement.clone(),
+        after,
+        targets,
+        warnings,
+    }
+}
+
+fn group_response(
+    args: &tools::UpsertConsumerGroupArgs,
+    mode: tools::MutationMode,
+    status: tools::MutationStatus,
+    before: BTreeMap<String, tools::VisibleState<tools::ConsumerGroupReplacement>>,
+    after: Option<BTreeMap<String, tools::VisibleState<tools::ConsumerGroupReplacement>>>,
+    targets: Vec<tools::MutationTarget<tools::ConsumerGroupReplacement>>,
+    warnings: Vec<String>,
+) -> tools::ConsumerGroupMutationToolResponse {
+    let mut brokers = args.broker_names.clone();
+    brokers.sort();
+    tools::MutationToolResponse {
+        schema_version: tools::MutationResultSchemaVersion::V1,
+        operation: tools::ConsumerGroupUpsertOperation::ConsumerGroupUpsert,
+        cluster: args.cluster.clone(),
+        mode,
+        status,
+        target: tools::ConsumerGroupMutationResource {
+            consumer_group: args.consumer_group.clone(),
+            brokers,
+        },
+        before,
+        requested: args.replacement.clone(),
+        after,
+        targets,
+        warnings,
+    }
+}
+
+fn topic_visible_state(
+    state: admin::ExpectedState,
+    current: Option<admin::TopicReplacement>,
+) -> tools::VisibleState<tools::TopicReplacement> {
+    match (state, current) {
+        (admin::ExpectedState::Absent, None) => tools::VisibleState::Absent,
+        (admin::ExpectedState::Present { version }, Some(value)) => tools::VisibleState::Present {
+            version,
+            value: map_topic_from_admin(value),
+        },
+        _ => tools::VisibleState::Unknown,
+    }
+}
+
+fn group_visible_state(
+    state: admin::ExpectedState,
+    current: Option<admin::SubscriptionGroupReplacement>,
+) -> tools::VisibleState<tools::ConsumerGroupReplacement> {
+    match (state, current) {
+        (admin::ExpectedState::Absent, None) => tools::VisibleState::Absent,
+        (admin::ExpectedState::Present { version }, Some(value)) => tools::VisibleState::Present {
+            version,
+            value: map_group_from_admin(value),
+        },
+        _ => tools::VisibleState::Unknown,
+    }
+}
+
+fn failure_map(failures: &[admin::MutationTargetFailure]) -> BTreeMap<String, (tools::FailureCode, bool)> {
+    failures
+        .iter()
+        .map(|failure| {
+            (
+                failure.broker_name.clone(),
+                (map_failure(failure.code), failure.retryable),
+            )
+        })
+        .collect()
+}
+
+fn map_failure(code: admin::MutationFailureCode) -> tools::FailureCode {
+    match code {
+        admin::MutationFailureCode::Conflict => tools::FailureCode::Conflict,
+        admin::MutationFailureCode::InvalidData => tools::FailureCode::InvalidData,
+        admin::MutationFailureCode::Unavailable => tools::FailureCode::Unavailable,
+        admin::MutationFailureCode::PersistenceFailed => tools::FailureCode::PersistenceFailed,
+        admin::MutationFailureCode::VerificationFailed => tools::FailureCode::VerificationFailed,
+        admin::MutationFailureCode::OrderReconciliationFailed => tools::FailureCode::OrderReconciliationFailed,
+    }
+}
+
+fn map_persistence(state: admin::MutationPersistenceState) -> tools::PersistenceState {
+    match state {
+        admin::MutationPersistenceState::NotRequired => tools::PersistenceState::NotRequired,
+        admin::MutationPersistenceState::Persisted => tools::PersistenceState::Persisted,
+        admin::MutationPersistenceState::Failed => tools::PersistenceState::Failed,
+    }
+}
+
+fn map_verification(state: admin::MutationVerificationState) -> tools::VerificationState {
+    match state {
+        admin::MutationVerificationState::NotPerformed => tools::VerificationState::NotPerformed,
+        admin::MutationVerificationState::Verified => tools::VerificationState::Verified,
+        admin::MutationVerificationState::Failed => tools::VerificationState::Failed,
+    }
+}
+
+fn map_topic_to_admin(value: &tools::TopicReplacement) -> admin::TopicReplacement {
+    admin::TopicReplacement {
+        read_queue_nums: value.read_queue_nums,
+        write_queue_nums: value.write_queue_nums,
+        perm: value.perm,
+        order: value.order,
+        message_type: match value.message_type {
+            tools::TopicMessageType::Normal => admin::TopicMessageType::Normal,
+            tools::TopicMessageType::Fifo => admin::TopicMessageType::Fifo,
+            tools::TopicMessageType::Delay => admin::TopicMessageType::Delay,
+            tools::TopicMessageType::Transaction => admin::TopicMessageType::Transaction,
+            tools::TopicMessageType::Unspecified => admin::TopicMessageType::Unspecified,
+        },
+    }
+}
+
+fn map_topic_from_admin(value: admin::TopicReplacement) -> tools::TopicReplacement {
+    tools::TopicReplacement {
+        read_queue_nums: value.read_queue_nums,
+        write_queue_nums: value.write_queue_nums,
+        perm: value.perm,
+        order: value.order,
+        message_type: match value.message_type {
+            admin::TopicMessageType::Normal => tools::TopicMessageType::Normal,
+            admin::TopicMessageType::Fifo => tools::TopicMessageType::Fifo,
+            admin::TopicMessageType::Delay => tools::TopicMessageType::Delay,
+            admin::TopicMessageType::Transaction => tools::TopicMessageType::Transaction,
+            admin::TopicMessageType::Unspecified => tools::TopicMessageType::Unspecified,
+        },
+    }
+}
+
+fn map_group_to_admin(value: &tools::ConsumerGroupReplacement) -> admin::SubscriptionGroupReplacement {
+    admin::SubscriptionGroupReplacement {
+        consume_enable: value.consume_enable,
+        consume_from_min_enable: value.consume_from_min_enable,
+        consume_broadcast_enable: value.consume_broadcast_enable,
+        consume_message_orderly: value.consume_message_orderly,
+        retry_queue_nums: value.retry_queue_nums,
+        retry_max_times: value.retry_max_times,
+        broker_id: value.broker_id,
+        which_broker_when_consume_slowly: value.which_broker_when_consume_slowly,
+        notify_consumer_ids_changed_enable: value.notify_consumer_ids_changed_enable,
+        group_sys_flag: value.group_sys_flag,
+        consume_timeout_minute: value.consume_timeout_minute,
+    }
+}
+
+fn map_group_from_admin(value: admin::SubscriptionGroupReplacement) -> tools::ConsumerGroupReplacement {
+    tools::ConsumerGroupReplacement {
+        consume_enable: value.consume_enable,
+        consume_from_min_enable: value.consume_from_min_enable,
+        consume_broadcast_enable: value.consume_broadcast_enable,
+        consume_message_orderly: value.consume_message_orderly,
+        retry_queue_nums: value.retry_queue_nums,
+        retry_max_times: value.retry_max_times,
+        broker_id: value.broker_id,
+        which_broker_when_consume_slowly: value.which_broker_when_consume_slowly,
+        notify_consumer_ids_changed_enable: value.notify_consumer_ids_changed_enable,
+        group_sys_flag: value.group_sys_flag,
+        consume_timeout_minute: value.consume_timeout_minute,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/admin_session.rs
@@ -1,0 +1,294 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use rocketmq_admin_core::core::supervised_mutation as admin;
+use rocketmq_admin_core::core::supervised_mutation::SupervisedMutationAdmin;
+use rocketmq_admin_core::mutation_client_adapter::MutationAdminBuilder;
+use rocketmq_admin_core::mutation_client_adapter::MutationAdminSession;
+
+use super::group_before;
+use super::group_dry_run;
+use super::group_executed;
+use super::map_group_to_admin;
+use super::map_topic_to_admin;
+use super::topic_before;
+use super::topic_dry_run;
+use super::topic_executed;
+use super::RuntimeFuture;
+use super::UpsertRequest;
+use super::UpsertResponse;
+use super::UpsertSession;
+use super::UpsertSessionFactory;
+use crate::config::MutationClusterConfig;
+use crate::error::ControlError;
+use crate::model::ClusterName;
+use crate::tools;
+
+pub(crate) trait SupervisedUpsertBackend: Send {
+    type TopicPlan: Send;
+    type GroupPlan: Send;
+
+    fn preflight_topic<'a>(
+        &'a mut self,
+        request: &'a admin::TopicMutationPreflightRequest,
+        broker_names: &'a [String],
+    ) -> RuntimeFuture<'a, Result<Self::TopicPlan, ControlError>>;
+
+    fn topic_targets(plan: &Self::TopicPlan) -> Vec<admin::MetadataPreflightTarget<admin::TopicReplacement>>;
+
+    fn topic_failures(plan: &Self::TopicPlan) -> &[admin::MutationTargetFailure];
+
+    fn execute_topic<'a>(
+        &'a mut self,
+        plan: &'a Self::TopicPlan,
+    ) -> RuntimeFuture<'a, Result<admin::MetadataMutationOutcome, ControlError>>;
+
+    fn preflight_group<'a>(
+        &'a mut self,
+        request: &'a admin::SubscriptionGroupMutationPreflightRequest,
+        broker_names: &'a [String],
+    ) -> RuntimeFuture<'a, Result<Self::GroupPlan, ControlError>>;
+
+    fn group_targets(
+        plan: &Self::GroupPlan,
+    ) -> Vec<admin::MetadataPreflightTarget<admin::SubscriptionGroupReplacement>>;
+
+    fn group_failures(plan: &Self::GroupPlan) -> &[admin::MutationTargetFailure];
+
+    fn execute_group<'a>(
+        &'a mut self,
+        plan: &'a Self::GroupPlan,
+    ) -> RuntimeFuture<'a, Result<admin::MetadataMutationOutcome, ControlError>>;
+
+    fn shutdown(&mut self) -> RuntimeFuture<'_, Result<(), ControlError>>;
+}
+
+impl SupervisedUpsertBackend for MutationAdminSession {
+    type TopicPlan = admin::TopicMutationPlan;
+    type GroupPlan = admin::SubscriptionGroupMutationPlan;
+
+    fn preflight_topic<'a>(
+        &'a mut self,
+        request: &'a admin::TopicMutationPreflightRequest,
+        broker_names: &'a [String],
+    ) -> RuntimeFuture<'a, Result<Self::TopicPlan, ControlError>> {
+        Box::pin(async move {
+            self.preflight_topic_targets(request, broker_names)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
+    fn topic_targets(plan: &Self::TopicPlan) -> Vec<admin::MetadataPreflightTarget<admin::TopicReplacement>> {
+        plan.preflight_targets()
+    }
+
+    fn topic_failures(plan: &Self::TopicPlan) -> &[admin::MutationTargetFailure] {
+        plan.failures()
+    }
+
+    fn execute_topic<'a>(
+        &'a mut self,
+        plan: &'a Self::TopicPlan,
+    ) -> RuntimeFuture<'a, Result<admin::MetadataMutationOutcome, ControlError>> {
+        Box::pin(async move {
+            SupervisedMutationAdmin::execute_topic(self, plan)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
+    fn preflight_group<'a>(
+        &'a mut self,
+        request: &'a admin::SubscriptionGroupMutationPreflightRequest,
+        broker_names: &'a [String],
+    ) -> RuntimeFuture<'a, Result<Self::GroupPlan, ControlError>> {
+        Box::pin(async move {
+            self.preflight_subscription_group_targets(request, broker_names)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
+    fn group_targets(
+        plan: &Self::GroupPlan,
+    ) -> Vec<admin::MetadataPreflightTarget<admin::SubscriptionGroupReplacement>> {
+        plan.preflight_targets()
+    }
+
+    fn group_failures(plan: &Self::GroupPlan) -> &[admin::MutationTargetFailure] {
+        plan.failures()
+    }
+
+    fn execute_group<'a>(
+        &'a mut self,
+        plan: &'a Self::GroupPlan,
+    ) -> RuntimeFuture<'a, Result<admin::MetadataMutationOutcome, ControlError>> {
+        Box::pin(async move {
+            self.execute_subscription_group(plan)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
+    fn shutdown(&mut self) -> RuntimeFuture<'_, Result<(), ControlError>> {
+        Box::pin(async move {
+            MutationAdminSession::shutdown(self).await;
+            Ok(())
+        })
+    }
+}
+
+pub(crate) struct AdminUpsertSession<B> {
+    backend: B,
+}
+
+impl<B> AdminUpsertSession<B> {
+    pub(crate) const fn new(backend: B) -> Self {
+        Self { backend }
+    }
+}
+
+impl<B> UpsertSession for AdminUpsertSession<B>
+where
+    B: SupervisedUpsertBackend,
+{
+    fn run<'a>(&'a mut self, request: UpsertRequest) -> RuntimeFuture<'a, Result<UpsertResponse, ControlError>> {
+        Box::pin(async move {
+            match request {
+                UpsertRequest::Topic(args) => run_topic(&mut self.backend, args).await.map(UpsertResponse::Topic),
+                UpsertRequest::ConsumerGroup(args) => run_group(&mut self.backend, args)
+                    .await
+                    .map(UpsertResponse::ConsumerGroup),
+            }
+        })
+    }
+
+    fn shutdown(&mut self) -> RuntimeFuture<'_, Result<(), ControlError>> {
+        self.backend.shutdown()
+    }
+}
+
+async fn run_topic<B: SupervisedUpsertBackend>(
+    backend: &mut B,
+    args: tools::UpsertTopicArgs,
+) -> Result<tools::TopicMutationToolResponse, ControlError> {
+    let request = admin::TopicMutationPreflightRequest {
+        cluster: args.cluster.clone(),
+        topic: args.topic.clone(),
+        replacement: map_topic_to_admin(&args.replacement),
+    };
+    let plan = backend.preflight_topic(&request, &args.broker_names).await?;
+    let before = topic_before(&args, B::topic_targets(&plan));
+    if args.dry_run {
+        return Ok(topic_dry_run(&args, before, B::topic_failures(&plan)));
+    }
+    let outcome = backend.execute_topic(&plan).await?;
+    let observed = backend
+        .preflight_topic(&request, &args.broker_names)
+        .await
+        .ok()
+        .map(|plan| B::topic_targets(&plan));
+    Ok(topic_executed(&args, before, outcome, observed))
+}
+
+async fn run_group<B: SupervisedUpsertBackend>(
+    backend: &mut B,
+    args: tools::UpsertConsumerGroupArgs,
+) -> Result<tools::ConsumerGroupMutationToolResponse, ControlError> {
+    let request = admin::SubscriptionGroupMutationPreflightRequest {
+        cluster: args.cluster.clone(),
+        consumer_group: args.consumer_group.clone(),
+        replacement: map_group_to_admin(&args.replacement),
+    };
+    let plan = backend.preflight_group(&request, &args.broker_names).await?;
+    let before = group_before(&args, B::group_targets(&plan));
+    if args.dry_run {
+        return Ok(group_dry_run(&args, before, B::group_failures(&plan)));
+    }
+    let outcome = backend.execute_group(&plan).await?;
+    let observed = backend
+        .preflight_group(&request, &args.broker_names)
+        .await
+        .ok()
+        .map(|plan| B::group_targets(&plan));
+    Ok(group_executed(&args, before, outcome, observed))
+}
+
+pub(crate) struct AdminUpsertFactory {
+    runtime: Arc<rocketmq_admin_core::mutation_client_adapter::ClientRuntime>,
+    clusters: BTreeMap<ClusterName, MutationClusterConfig>,
+    sequence: AtomicU64,
+}
+
+impl AdminUpsertFactory {
+    pub(crate) fn new(
+        service_context: rocketmq_runtime::ChildServiceContext,
+        clusters: &[MutationClusterConfig],
+    ) -> Result<Self, ControlError> {
+        let runtime = rocketmq_admin_core::mutation_client_adapter::create_mutation_client_runtime(
+            service_context.component("mutation-client"),
+        )
+        .map_err(|_| ControlError::invalid_config())?;
+        Ok(Self {
+            runtime,
+            clusters: clusters
+                .iter()
+                .cloned()
+                .map(|cluster| (cluster.name().clone(), cluster))
+                .collect(),
+            sequence: AtomicU64::new(0),
+        })
+    }
+}
+
+impl UpsertSessionFactory for AdminUpsertFactory {
+    fn open<'a>(&'a self, cluster: &'a ClusterName) -> RuntimeFuture<'a, Result<Box<dyn UpsertSession>, ControlError>> {
+        Box::pin(async move {
+            let config = self
+                .clusters
+                .get(cluster)
+                .ok_or_else(ControlError::operation_unavailable)?;
+            let sequence = self.sequence.fetch_add(1, Ordering::Relaxed);
+            let identity = format!("mcp-control-{sequence}");
+            let mut builder = MutationAdminBuilder::new(self.runtime.clone())
+                .namesrv_addr(config.namesrv_addr())
+                .use_tls(config.use_tls())
+                .admin_group(identity.clone())
+                .instance_name(identity);
+            let (access_env, secret_env, token_env) = config.credential_envs();
+            if let (Some(access_env), Some(secret_env)) = (access_env, secret_env) {
+                let access = std::env::var(access_env).map_err(|_| ControlError::invalid_config())?;
+                let secret = std::env::var(secret_env).map_err(|_| ControlError::invalid_config())?;
+                let token = token_env
+                    .map(std::env::var)
+                    .transpose()
+                    .map_err(|_| ControlError::invalid_config())?;
+                let credentials = rocketmq_admin_core::core::security::AdminCredentials::try_new(access, secret, token)
+                    .map_err(|_| ControlError::invalid_config())?;
+                builder = builder.credentials(credentials);
+            }
+            let admin = builder
+                .build_and_start()
+                .await
+                .map_err(|_| ControlError::execution_failed())?;
+            Ok(Box::new(AdminUpsertSession::new(admin)) as Box<dyn UpsertSession>)
+        })
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/execution.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/execution.rs
@@ -1,0 +1,72 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::FutureExt;
+use tokio_util::sync::CancellationToken;
+
+use super::UpsertRequest;
+use super::UpsertResponse;
+use super::UpsertSessionFactory;
+use super::SESSION_SHUTDOWN_TIMEOUT;
+use crate::error::ControlError;
+use crate::model::ClusterName;
+
+pub(super) async fn supervise_session(
+    factory: Arc<dyn UpsertSessionFactory>,
+    cluster: ClusterName,
+    request: UpsertRequest,
+    timeout: Duration,
+    request_cancellation: CancellationToken,
+    owner_cancellation: CancellationToken,
+) -> Result<UpsertResponse, ControlError> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let opened = tokio::time::timeout_at(deadline, AssertUnwindSafe(factory.open(&cluster)).catch_unwind());
+    tokio::pin!(opened);
+    let opened = tokio::select! {
+        biased;
+        result = &mut opened => result,
+        _ = request_cancellation.cancelled() => return Err(ControlError::cancelled()),
+        _ = owner_cancellation.cancelled() => return Err(ControlError::cancelled()),
+    };
+    let mut session = match opened {
+        Ok(Ok(Ok(session))) => session,
+        Ok(Ok(Err(error))) => return Err(error),
+        Ok(Err(_)) => return Err(ControlError::execution_failed()),
+        Err(_) => return Err(ControlError::timeout()),
+    };
+    let run = tokio::select! {
+        biased;
+        _ = request_cancellation.cancelled() => Err(ControlError::cancelled()),
+        _ = owner_cancellation.cancelled() => Err(ControlError::cancelled()),
+        result = tokio::time::timeout_at(deadline, AssertUnwindSafe(session.run(request)).catch_unwind()) => {
+            match result {
+                Ok(Ok(result)) => result,
+                Ok(Err(_)) => Err(ControlError::execution_failed()),
+                Err(_) => Err(ControlError::timeout()),
+            }
+        }
+    };
+    let shutdown = tokio::time::timeout(
+        SESSION_SHUTDOWN_TIMEOUT,
+        AssertUnwindSafe(session.shutdown()).catch_unwind(),
+    )
+    .await;
+    match shutdown {
+        Ok(Ok(Ok(()))) => run,
+        _ => Err(ControlError::shutdown_failed()),
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/idempotency.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/idempotency.rs
@@ -1,0 +1,268 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use super::execution::supervise_session;
+use super::UpsertRequest;
+use super::UpsertResponse;
+use super::UpsertSessionFactory;
+use super::IDEMPOTENCY_CAPACITY;
+use super::IDEMPOTENCY_TTL;
+use crate::error::ControlError;
+use crate::model::ClusterName;
+use crate::model::ControlOperation;
+use crate::model::Principal;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub(super) struct IdempotencyKey {
+    pub(super) principal: String,
+    pub(super) operation: ControlOperation,
+    pub(super) cluster: ClusterName,
+    pub(super) targets: Vec<String>,
+    pub(super) request_key: String,
+}
+
+#[derive(Clone)]
+pub(super) struct IdempotencyIdentity {
+    pub(super) key: Option<IdempotencyKey>,
+    pub(super) payload: String,
+}
+
+impl IdempotencyIdentity {
+    pub(super) fn from_request(
+        principal: &Principal,
+        cluster: &ClusterName,
+        request: &UpsertRequest,
+    ) -> Result<Self, ControlError> {
+        let mut targets = request.target_names().to_vec();
+        targets.sort();
+        let key = request.request_key().map(|request_key| IdempotencyKey {
+            principal: principal.subject.clone(),
+            operation: request.operation(),
+            cluster: cluster.clone(),
+            targets,
+            request_key: request_key.to_owned(),
+        });
+        Ok(Self {
+            key,
+            payload: request.canonical_payload()?,
+        })
+    }
+}
+
+#[derive(Default)]
+pub(super) struct IdempotencyState {
+    pub(super) entries: BTreeMap<IdempotencyKey, IdempotencyEntry>,
+    sequence: u64,
+}
+
+pub(super) enum IdempotencyEntry {
+    InFlight {
+        payload: String,
+        followers: Vec<oneshot::Sender<Result<UpsertResponse, ControlError>>>,
+    },
+    Completed {
+        payload: String,
+        result: Box<Result<UpsertResponse, ControlError>>,
+        expires_at: tokio::time::Instant,
+        sequence: u64,
+    },
+}
+
+pub(super) enum CacheAdmission {
+    Leader,
+    Follower(oneshot::Receiver<Result<UpsertResponse, ControlError>>),
+    Hit(Box<Result<UpsertResponse, ControlError>>),
+    Uncached,
+}
+
+#[derive(Debug)]
+pub(super) enum AdmissionError {
+    Collision,
+    Capacity,
+}
+
+pub(super) async fn execute_admitted(
+    cache: Arc<Mutex<IdempotencyState>>,
+    identity: IdempotencyIdentity,
+    admission: CacheAdmission,
+    factory: Arc<dyn UpsertSessionFactory>,
+    cluster: ClusterName,
+    request: UpsertRequest,
+    timeout: Duration,
+    request_cancellation: CancellationToken,
+    owner_cancellation: CancellationToken,
+) -> Result<UpsertResponse, ControlError> {
+    let Some(key) = identity.key else {
+        return supervise_session(
+            factory,
+            cluster,
+            request,
+            timeout,
+            request_cancellation,
+            owner_cancellation,
+        )
+        .await;
+    };
+    match admission {
+        CacheAdmission::Follower(receiver) => {
+            let deadline = tokio::time::Instant::now() + timeout;
+            tokio::select! {
+                biased;
+                _ = request_cancellation.cancelled() => Err(ControlError::cancelled()),
+                _ = owner_cancellation.cancelled() => Err(ControlError::cancelled()),
+                _ = tokio::time::sleep_until(deadline) => Err(ControlError::timeout()),
+                result = receiver => result.map_err(|_| ControlError::execution_failed())?,
+            }
+        }
+        CacheAdmission::Hit(result) => *result,
+        CacheAdmission::Uncached => {
+            supervise_session(
+                factory,
+                cluster,
+                request,
+                timeout,
+                request_cancellation,
+                owner_cancellation,
+            )
+            .await
+        }
+        CacheAdmission::Leader => {
+            let result = supervise_session(
+                factory,
+                cluster,
+                request,
+                timeout,
+                request_cancellation,
+                owner_cancellation,
+            )
+            .await;
+            complete_cache(&cache, key, identity.payload, result.clone()).await;
+            result
+        }
+    }
+}
+
+pub(super) async fn admit_cache(
+    cache: &Mutex<IdempotencyState>,
+    key: Option<&IdempotencyKey>,
+    payload: &str,
+) -> Result<CacheAdmission, AdmissionError> {
+    let Some(key) = key else {
+        return Ok(CacheAdmission::Uncached);
+    };
+    let mut state = cache.lock().await;
+    let now = tokio::time::Instant::now();
+    state
+        .entries
+        .retain(|_, entry| !matches!(entry, IdempotencyEntry::Completed { expires_at, .. } if *expires_at <= now));
+    if let Some(entry) = state.entries.get_mut(key) {
+        return match entry {
+            IdempotencyEntry::InFlight {
+                payload: recorded,
+                followers,
+            } if recorded == payload => {
+                let (sender, receiver) = oneshot::channel();
+                followers.push(sender);
+                Ok(CacheAdmission::Follower(receiver))
+            }
+            IdempotencyEntry::Completed {
+                payload: recorded,
+                result,
+                ..
+            } if recorded == payload => Ok(CacheAdmission::Hit(result.clone())),
+            _ => Err(AdmissionError::Collision),
+        };
+    }
+    while state.entries.len() >= IDEMPOTENCY_CAPACITY {
+        let oldest = state
+            .entries
+            .iter()
+            .filter_map(|(key, entry)| match entry {
+                IdempotencyEntry::Completed { sequence, .. } => Some((key.clone(), *sequence)),
+                IdempotencyEntry::InFlight { .. } => None,
+            })
+            .min_by_key(|(_, sequence)| *sequence)
+            .map(|(key, _)| key);
+        let Some(oldest) = oldest else {
+            return Err(AdmissionError::Capacity);
+        };
+        state.entries.remove(&oldest);
+    }
+    state.entries.insert(
+        key.clone(),
+        IdempotencyEntry::InFlight {
+            payload: payload.to_owned(),
+            followers: Vec::new(),
+        },
+    );
+    Ok(CacheAdmission::Leader)
+}
+
+pub(super) async fn abort_cache_reservation(
+    cache: &Mutex<IdempotencyState>,
+    identity: &IdempotencyIdentity,
+    error: ControlError,
+) {
+    let Some(key) = &identity.key else {
+        return;
+    };
+    let mut state = cache.lock().await;
+    let followers = match state.entries.remove(key) {
+        Some(IdempotencyEntry::InFlight { followers, .. }) => followers,
+        Some(entry) => {
+            state.entries.insert(key.clone(), entry);
+            Vec::new()
+        }
+        None => Vec::new(),
+    };
+    drop(state);
+    for follower in followers {
+        let _ = follower.send(Err(error.clone()));
+    }
+}
+
+pub(super) async fn complete_cache(
+    cache: &Mutex<IdempotencyState>,
+    key: IdempotencyKey,
+    payload: String,
+    result: Result<UpsertResponse, ControlError>,
+) {
+    let mut state = cache.lock().await;
+    let followers = match state.entries.remove(&key) {
+        Some(IdempotencyEntry::InFlight { followers, .. }) => followers,
+        _ => Vec::new(),
+    };
+    state.sequence = state.sequence.saturating_add(1);
+    let sequence = state.sequence;
+    state.entries.insert(
+        key,
+        IdempotencyEntry::Completed {
+            payload,
+            result: Box::new(result.clone()),
+            expires_at: tokio::time::Instant::now() + IDEMPOTENCY_TTL,
+            sequence,
+        },
+    );
+    drop(state);
+    for follower in followers {
+        let _ = follower.send(result.clone());
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/tests.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/tests.rs
@@ -1,0 +1,793 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::idempotency::admit_cache;
+use super::idempotency::complete_cache;
+use super::idempotency::CacheAdmission;
+use super::idempotency::IdempotencyKey;
+use super::*;
+use std::collections::BTreeSet;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use crate::audit::MemoryAuditSink;
+use crate::audit::ReliableAuditSink;
+use crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION;
+
+#[derive(Clone, Copy)]
+enum Behavior {
+    Success,
+    Partial,
+    Block,
+    Panic,
+}
+
+#[derive(Default)]
+struct Counters {
+    opens: AtomicUsize,
+    runs: AtomicUsize,
+    shutdowns: AtomicUsize,
+}
+
+struct FakeFactory {
+    behavior: Behavior,
+    counters: Arc<Counters>,
+    gate: Arc<tokio::sync::Notify>,
+}
+
+impl UpsertSessionFactory for FakeFactory {
+    fn open<'a>(
+        &'a self,
+        _cluster: &'a ClusterName,
+    ) -> RuntimeFuture<'a, Result<Box<dyn UpsertSession>, ControlError>> {
+        Box::pin(async move {
+            self.counters.opens.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::new(FakeSession {
+                behavior: self.behavior,
+                counters: self.counters.clone(),
+                gate: self.gate.clone(),
+            }) as Box<dyn UpsertSession>)
+        })
+    }
+}
+
+struct FakeSession {
+    behavior: Behavior,
+    counters: Arc<Counters>,
+    gate: Arc<tokio::sync::Notify>,
+}
+
+impl UpsertSession for FakeSession {
+    fn run<'a>(&'a mut self, request: UpsertRequest) -> RuntimeFuture<'a, Result<UpsertResponse, ControlError>> {
+        Box::pin(async move {
+            self.counters.runs.fetch_add(1, Ordering::SeqCst);
+            match self.behavior {
+                Behavior::Block => self.gate.notified().await,
+                Behavior::Panic => panic!("synthetic adapter panic"),
+                Behavior::Success | Behavior::Partial => {}
+            }
+            let UpsertRequest::Topic(args) = request else {
+                return Err(ControlError::execution_failed());
+            };
+            let status = if matches!(self.behavior, Behavior::Partial) {
+                tools::MutationStatus::Partial
+            } else {
+                tools::MutationStatus::Applied
+            };
+            Ok(UpsertResponse::Topic(topic_response(
+                &args,
+                if args.dry_run {
+                    tools::MutationMode::DryRun
+                } else {
+                    tools::MutationMode::Execute
+                },
+                status,
+                BTreeMap::new(),
+                None,
+                Vec::new(),
+                Vec::new(),
+            )))
+        })
+    }
+
+    fn shutdown(&mut self) -> RuntimeFuture<'_, Result<(), ControlError>> {
+        Box::pin(async move {
+            self.counters.shutdowns.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+    }
+}
+
+fn request(key: Option<&str>) -> UpsertRequest {
+    UpsertRequest::Topic(tools::UpsertTopicArgs {
+        schema_version: MUTATION_ARGUMENTS_SCHEMA_VERSION.to_owned(),
+        cluster: "cluster-a".to_owned(),
+        topic: "orders".to_owned(),
+        broker_names: vec!["broker-b".to_owned(), "broker-a".to_owned()],
+        replacement: tools::TopicReplacement {
+            read_queue_nums: 8,
+            write_queue_nums: 8,
+            perm: 6,
+            order: false,
+            message_type: tools::TopicMessageType::Normal,
+        },
+        dry_run: false,
+        confirm: true,
+        reason: Some("planned operation".to_owned()),
+        request_key: key.map(ToOwned::to_owned),
+    })
+}
+
+fn principal(subject: &str) -> Principal {
+    Principal {
+        subject: subject.to_owned(),
+        scopes: BTreeSet::from(["rocketmq:write".to_owned()]),
+        allowed_operations: BTreeSet::from([ControlOperation::TopicUpsert]),
+        allowed_clusters: BTreeSet::from([ClusterName::try_new("cluster-a").unwrap()]),
+    }
+}
+
+fn runtime(
+    behavior: Behavior,
+    timeout: Duration,
+) -> (
+    ToolRuntime,
+    Arc<Counters>,
+    Arc<MemoryAuditSink>,
+    Arc<tokio::sync::Notify>,
+) {
+    let counters = Arc::new(Counters::default());
+    let sink = Arc::new(MemoryAuditSink::new(32, 4096));
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let context = rocketmq_runtime::RuntimeContext::from_current("control-upsert-test");
+    let owner = context.service_context("control-upsert-test").task_group().clone();
+    (
+        ToolRuntime::new(
+            AuditTrail::new(sink.clone()),
+            Arc::new(FakeFactory {
+                behavior,
+                counters: counters.clone(),
+                gate: gate.clone(),
+            }),
+            timeout,
+            owner,
+        ),
+        counters,
+        sink,
+        gate,
+    )
+}
+
+fn authorized() -> AuthorizedMutation {
+    AuthorizedMutation::synthetic(
+        ControlOperation::TopicUpsert,
+        ClusterName::try_new("cluster-a").unwrap(),
+    )
+}
+
+#[tokio::test]
+async fn completed_and_partial_results_are_cached_with_per_invocation_audit() {
+    for behavior in [Behavior::Success, Behavior::Partial] {
+        let (runtime, counters, sink, _) = runtime(behavior, Duration::from_secs(1));
+        let first = runtime
+            .execute(
+                &principal("alice"),
+                &authorized(),
+                request(Some("request-1234")),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        let second = runtime
+            .execute(
+                &principal("alice"),
+                &authorized(),
+                request(Some("request-1234")),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.is_error(), matches!(behavior, Behavior::Partial));
+        assert_eq!(second.is_error(), first.is_error());
+        assert_eq!(counters.opens.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.runs.load(Ordering::SeqCst), 1);
+        assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(sink.records().await.unwrap().len(), 4);
+    }
+}
+
+#[tokio::test]
+async fn request_key_collision_and_principal_isolation_are_fail_closed() {
+    let (runtime, counters, _, _) = runtime(Behavior::Success, Duration::from_secs(1));
+    runtime
+        .execute(
+            &principal("alice"),
+            &authorized(),
+            request(Some("request-1234")),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let mut changed = request(Some("request-1234"));
+    let UpsertRequest::Topic(args) = &mut changed else {
+        unreachable!();
+    };
+    args.replacement.write_queue_nums = 9;
+    assert_eq!(
+        runtime
+            .execute(&principal("alice"), &authorized(), changed, CancellationToken::new())
+            .await
+            .unwrap_err()
+            .code(),
+        crate::error::ControlErrorCode::InvalidArguments
+    );
+    runtime
+        .execute(
+            &principal("bob"),
+            &authorized(),
+            request(Some("request-1234")),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(counters.opens.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn concurrent_followers_share_one_session_and_adapter_panics_still_shutdown() {
+    let (blocked_runtime, counters, _, gate) = runtime(Behavior::Block, Duration::from_secs(1));
+    let first = tokio::spawn({
+        let runtime = blocked_runtime.clone();
+        async move {
+            runtime
+                .execute(
+                    &principal("alice"),
+                    &authorized(),
+                    request(Some("request-1234")),
+                    CancellationToken::new(),
+                )
+                .await
+        }
+    });
+    while counters.runs.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+    let second = tokio::spawn({
+        let runtime = blocked_runtime.clone();
+        async move {
+            runtime
+                .execute(
+                    &principal("alice"),
+                    &authorized(),
+                    request(Some("request-1234")),
+                    CancellationToken::new(),
+                )
+                .await
+        }
+    });
+    tokio::task::yield_now().await;
+    gate.notify_waiters();
+    first.await.unwrap().unwrap();
+    second.await.unwrap().unwrap();
+    assert_eq!(counters.opens.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+
+    let (runtime, counters, _, _) = runtime(Behavior::Panic, Duration::from_secs(1));
+    assert_eq!(
+        runtime
+            .execute(
+                &principal("alice"),
+                &authorized(),
+                request(None),
+                CancellationToken::new()
+            )
+            .await
+            .unwrap_err()
+            .code(),
+        crate::error::ControlErrorCode::ExecutionFailed
+    );
+    assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn cancelling_a_follower_does_not_cancel_or_evict_the_leader() {
+    let (runtime, counters, sink, gate) = runtime(Behavior::Block, Duration::from_secs(2));
+    let leader = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .execute(
+                    &principal("alice"),
+                    &authorized(),
+                    request(Some("request-1234")),
+                    CancellationToken::new(),
+                )
+                .await
+        }
+    });
+    while counters.runs.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+
+    let cancellation = CancellationToken::new();
+    let follower = tokio::spawn({
+        let runtime = runtime.clone();
+        let cancellation = cancellation.clone();
+        async move {
+            runtime
+                .execute(
+                    &principal("alice"),
+                    &authorized(),
+                    request(Some("request-1234")),
+                    cancellation,
+                )
+                .await
+        }
+    });
+    while sink.records().await.unwrap().len() < 2 {
+        tokio::task::yield_now().await;
+    }
+    cancellation.cancel();
+    assert_eq!(
+        follower.await.unwrap().unwrap_err().code(),
+        crate::error::ControlErrorCode::Cancelled
+    );
+    assert_eq!(counters.opens.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 0);
+
+    gate.notify_waiters();
+    leader.await.unwrap().unwrap();
+    assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    runtime
+        .execute(
+            &principal("alice"),
+            &authorized(),
+            request(Some("request-1234")),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(counters.opens.load(Ordering::SeqCst), 1);
+    assert_eq!(sink.records().await.unwrap().len(), 6);
+}
+
+#[tokio::test(start_paused = true)]
+async fn timing_out_a_follower_does_not_cancel_or_evict_the_leader() {
+    let (runtime, counters, sink, gate) = runtime(Behavior::Block, Duration::from_secs(2));
+    let leader = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .execute(
+                    &principal("alice"),
+                    &authorized(),
+                    request(Some("request-1234")),
+                    CancellationToken::new(),
+                )
+                .await
+        }
+    });
+    while counters.runs.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+
+    let mut follower_runtime = runtime.clone();
+    follower_runtime.operation_timeout = Duration::from_millis(5);
+    let follower = tokio::spawn(async move {
+        follower_runtime
+            .execute(
+                &principal("alice"),
+                &authorized(),
+                request(Some("request-1234")),
+                CancellationToken::new(),
+            )
+            .await
+    });
+    while sink.records().await.unwrap().len() < 2 {
+        tokio::task::yield_now().await;
+    }
+    tokio::time::advance(Duration::from_millis(6)).await;
+    assert_eq!(
+        follower.await.unwrap().unwrap_err().code(),
+        crate::error::ControlErrorCode::Timeout
+    );
+    assert_eq!(counters.opens.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 0);
+
+    gate.notify_waiters();
+    leader.await.unwrap().unwrap();
+    runtime
+        .execute(
+            &principal("alice"),
+            &authorized(),
+            request(Some("request-1234")),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(counters.opens.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    assert_eq!(sink.records().await.unwrap().len(), 6);
+}
+
+#[tokio::test]
+async fn explicit_key_capacity_rejection_is_stable_before_audit_or_session() {
+    let (runtime, counters, sink, _) = runtime(Behavior::Success, Duration::from_secs(1));
+    for index in 0..IDEMPOTENCY_CAPACITY {
+        let key = IdempotencyKey {
+            principal: "blocked".to_owned(),
+            operation: ControlOperation::TopicUpsert,
+            cluster: ClusterName::try_new("cluster-a").unwrap(),
+            targets: vec!["broker-a".to_owned()],
+            request_key: format!("blocked-{index:08}"),
+        };
+        assert!(matches!(
+            admit_cache(&runtime.idempotency, Some(&key), "blocked").await.unwrap(),
+            CacheAdmission::Leader
+        ));
+    }
+
+    let principal = principal("alice");
+    let authorized = authorized();
+    let first = runtime.execute(
+        &principal,
+        &authorized,
+        request(Some("request-4097")),
+        CancellationToken::new(),
+    );
+    let second = runtime.execute(
+        &principal,
+        &authorized,
+        request(Some("request-4097")),
+        CancellationToken::new(),
+    );
+    let (first, second) = tokio::join!(first, second);
+    for result in [first, second] {
+        assert_eq!(
+            result.unwrap_err().code(),
+            crate::error::ControlErrorCode::OperationUnavailable
+        );
+    }
+    assert_eq!(runtime.idempotency.lock().await.entries.len(), IDEMPOTENCY_CAPACITY);
+    assert_eq!(counters.opens.load(Ordering::SeqCst), 0);
+    assert!(sink.records().await.unwrap().is_empty());
+}
+
+#[tokio::test(start_paused = true)]
+async fn idempotency_ttl_expires_and_capacity_evicts_oldest_completed_entry() {
+    let (runtime, counters, _, _) = runtime(Behavior::Success, Duration::from_secs(1));
+    runtime
+        .execute(
+            &principal("alice"),
+            &authorized(),
+            request(Some("request-1234")),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    tokio::time::advance(IDEMPOTENCY_TTL + Duration::from_millis(1)).await;
+    runtime
+        .execute(
+            &principal("alice"),
+            &authorized(),
+            request(Some("request-1234")),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(counters.opens.load(Ordering::SeqCst), 2);
+
+    let cache = Mutex::new(IdempotencyState::default());
+    let UpsertRequest::Topic(sample_args) = request(None) else {
+        unreachable!();
+    };
+    let result = Ok(UpsertResponse::Topic(topic_response(
+        &sample_args,
+        tools::MutationMode::DryRun,
+        tools::MutationStatus::Planned,
+        BTreeMap::new(),
+        None,
+        Vec::new(),
+        Vec::new(),
+    )));
+    for index in 0..=IDEMPOTENCY_CAPACITY {
+        let key = IdempotencyKey {
+            principal: "alice".to_owned(),
+            operation: ControlOperation::TopicUpsert,
+            cluster: ClusterName::try_new("cluster-a").unwrap(),
+            targets: vec!["broker-a".to_owned()],
+            request_key: format!("request-{index:08}"),
+        };
+        assert!(matches!(
+            admit_cache(&cache, Some(&key), "payload").await.unwrap(),
+            CacheAdmission::Leader
+        ));
+        complete_cache(&cache, key, "payload".to_owned(), result.clone()).await;
+    }
+    let state = cache.lock().await;
+    assert_eq!(state.entries.len(), IDEMPOTENCY_CAPACITY);
+    assert!(!state.entries.keys().any(|key| key.request_key == "request-00000000"));
+}
+
+#[tokio::test]
+async fn cancellation_timeout_and_caller_drop_preserve_shutdown_and_terminal_audit() {
+    let (cancel_runtime, counters, sink, _) = runtime(Behavior::Block, Duration::from_secs(1));
+    let cancellation = CancellationToken::new();
+    let task = tokio::spawn({
+        let runtime = cancel_runtime.clone();
+        let task_cancellation = cancellation.clone();
+        async move {
+            runtime
+                .execute(&principal("alice"), &authorized(), request(None), task_cancellation)
+                .await
+        }
+    });
+    while counters.runs.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+    cancellation.cancel();
+    assert_eq!(
+        task.await.unwrap().unwrap_err().code(),
+        crate::error::ControlErrorCode::Cancelled
+    );
+    assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+    assert_eq!(sink.records().await.unwrap().len(), 2);
+
+    let (timeout_runtime, counters, _, _) = runtime(Behavior::Block, Duration::from_millis(5));
+    assert_eq!(
+        timeout_runtime
+            .execute(
+                &principal("alice"),
+                &authorized(),
+                request(None),
+                CancellationToken::new()
+            )
+            .await
+            .unwrap_err()
+            .code(),
+        crate::error::ControlErrorCode::Timeout
+    );
+    assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+
+    let (runtime, counters, sink, gate) = runtime(Behavior::Block, Duration::from_secs(1));
+    let caller = tokio::spawn({
+        let runtime = runtime.clone();
+        async move {
+            runtime
+                .execute(
+                    &principal("alice"),
+                    &authorized(),
+                    request(None),
+                    CancellationToken::new(),
+                )
+                .await
+        }
+    });
+    while counters.runs.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+    caller.abort();
+    gate.notify_waiters();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while counters.shutdowns.load(Ordering::SeqCst) == 0 || sink.records().await.unwrap().len() < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(counters.shutdowns.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn failed_postread_preserves_applied_and_persisted_target_truth() {
+    let UpsertRequest::Topic(args) = request(None) else {
+        unreachable!();
+    };
+    let before = BTreeMap::from([("broker-a".to_owned(), tools::VisibleState::Absent)]);
+    let outcome = admin::MetadataMutationOutcome {
+        targets: vec![admin::MetadataMutationTargetOutcome {
+            broker_name: "broker-a".to_owned(),
+            expected_state: admin::ExpectedState::Absent,
+            resulting_state: Some(admin::ExpectedState::Present { version: 1 }),
+            applied: true,
+            changed: true,
+            persistence: admin::MutationPersistenceState::Persisted,
+            verification: admin::MutationVerificationState::NotPerformed,
+            failure: None,
+            retryable: false,
+        }],
+        failures: Vec::new(),
+        order_reconciled: Some(true),
+    };
+    let response = topic_executed(&args, before, outcome, None);
+    assert_eq!(response.status, tools::MutationStatus::Failed);
+    assert!(response.is_error());
+    assert_eq!(response.targets[0].after, None);
+    assert!(response.targets[0].applied);
+    assert!(response.targets[0].changed);
+    assert_eq!(response.targets[0].persistence, tools::PersistenceState::Persisted);
+    assert_eq!(response.targets[0].verification, tools::VerificationState::Failed);
+    assert_eq!(
+        response.targets[0].failure,
+        Some(tools::FailureCode::VerificationFailed)
+    );
+}
+
+#[test]
+fn topic_and_group_dry_runs_report_all_mixed_and_zero_success() {
+    let UpsertRequest::Topic(topic_args) = request(None) else {
+        unreachable!();
+    };
+    let group_args = tools::UpsertConsumerGroupArgs {
+        schema_version: MUTATION_ARGUMENTS_SCHEMA_VERSION.to_owned(),
+        cluster: "cluster-a".to_owned(),
+        consumer_group: "orders_consumers".to_owned(),
+        broker_names: vec!["broker-a".to_owned(), "broker-b".to_owned()],
+        replacement: tools::ConsumerGroupReplacement {
+            consume_enable: true,
+            consume_from_min_enable: false,
+            consume_broadcast_enable: false,
+            consume_message_orderly: false,
+            retry_queue_nums: 1,
+            retry_max_times: 16,
+            broker_id: 0,
+            which_broker_when_consume_slowly: 1,
+            notify_consumer_ids_changed_enable: true,
+            group_sys_flag: 0,
+            consume_timeout_minute: 15,
+        },
+        dry_run: true,
+        confirm: false,
+        reason: None,
+        request_key: None,
+    };
+    let topic_before = BTreeMap::from([
+        ("broker-a".to_owned(), tools::VisibleState::Absent),
+        ("broker-b".to_owned(), tools::VisibleState::Absent),
+    ]);
+    let group_before = BTreeMap::from([
+        ("broker-a".to_owned(), tools::VisibleState::Absent),
+        ("broker-b".to_owned(), tools::VisibleState::Absent),
+    ]);
+    let failure = |broker_name: &str| admin::MutationTargetFailure {
+        broker_name: broker_name.to_owned(),
+        queue_id: None,
+        code: admin::MutationFailureCode::Unavailable,
+        retryable: true,
+    };
+    for (failures, expected) in [
+        (Vec::new(), tools::MutationStatus::Planned),
+        (vec![failure("broker-a")], tools::MutationStatus::Partial),
+        (
+            vec![failure("broker-a"), failure("broker-b")],
+            tools::MutationStatus::Failed,
+        ),
+    ] {
+        assert_eq!(
+            topic_dry_run(&topic_args, topic_before.clone(), &failures).status,
+            expected
+        );
+        assert_eq!(
+            group_dry_run(&group_args, group_before.clone(), &failures).status,
+            expected
+        );
+    }
+}
+
+#[test]
+fn response_mapping_preserves_unchanged_conflict_partial_and_persistence_states() {
+    let replacement = tools::TopicReplacement {
+        read_queue_nums: 8,
+        write_queue_nums: 8,
+        perm: 6,
+        order: false,
+        message_type: tools::TopicMessageType::Normal,
+    };
+    let state = tools::VisibleState::Present {
+        version: 2,
+        value: replacement.clone(),
+    };
+    let mapped = |outcomes: Vec<admin::MetadataMutationTargetOutcome>, brokers: &[&str]| {
+        let before = brokers
+            .iter()
+            .map(|broker| ((*broker).to_owned(), state.clone()))
+            .collect();
+        let after = brokers
+            .iter()
+            .map(|broker| ((*broker).to_owned(), state.clone()))
+            .collect();
+        let outcomes = outcomes
+            .into_iter()
+            .map(|outcome| (outcome.broker_name.clone(), outcome))
+            .collect();
+        let targets = build_executed_targets(before, after, outcomes, BTreeMap::new(), replacement.clone());
+        (execution_status(&targets), targets)
+    };
+    let outcome =
+        |broker: &str,
+         applied: bool,
+         changed: bool,
+         persistence: admin::MutationPersistenceState,
+         failure: Option<admin::MutationFailureCode>| admin::MetadataMutationTargetOutcome {
+            broker_name: broker.to_owned(),
+            expected_state: admin::ExpectedState::Present { version: 1 },
+            resulting_state: Some(admin::ExpectedState::Present { version: 2 }),
+            applied,
+            changed,
+            persistence,
+            verification: admin::MutationVerificationState::NotPerformed,
+            failure,
+            retryable: false,
+        };
+
+    let (status, targets) = mapped(
+        vec![outcome(
+            "broker-a",
+            true,
+            false,
+            admin::MutationPersistenceState::NotRequired,
+            None,
+        )],
+        &["broker-a"],
+    );
+    assert_eq!(status, tools::MutationStatus::Applied);
+    assert_eq!(targets[0].verification, tools::VerificationState::Verified);
+
+    let (status, _) = mapped(
+        vec![outcome(
+            "broker-a",
+            false,
+            false,
+            admin::MutationPersistenceState::NotRequired,
+            Some(admin::MutationFailureCode::Conflict),
+        )],
+        &["broker-a"],
+    );
+    assert_eq!(status, tools::MutationStatus::Conflict);
+
+    let (status, targets) = mapped(
+        vec![outcome(
+            "broker-a",
+            true,
+            true,
+            admin::MutationPersistenceState::Failed,
+            Some(admin::MutationFailureCode::PersistenceFailed),
+        )],
+        &["broker-a"],
+    );
+    assert_eq!(status, tools::MutationStatus::Failed);
+    assert_eq!(targets[0].persistence, tools::PersistenceState::Failed);
+
+    let (status, targets) = mapped(
+        vec![
+            outcome("broker-a", true, true, admin::MutationPersistenceState::Persisted, None),
+            outcome(
+                "broker-b",
+                false,
+                false,
+                admin::MutationPersistenceState::NotRequired,
+                Some(admin::MutationFailureCode::Conflict),
+            ),
+        ],
+        &["broker-b", "broker-a"],
+    );
+    assert_eq!(status, tools::MutationStatus::Partial);
+    assert_eq!(
+        targets
+            .iter()
+            .map(|target| target.target.broker_name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["broker-a", "broker-b"]
+    );
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tools.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tools.rs
@@ -1,0 +1,778 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::error::ControlError;
+use crate::model::MutationArguments;
+
+pub const MUTATION_RESULT_SCHEMA_VERSION: &str = "rocketmq-mcp-mutation.v1";
+pub const UPSERT_TOPIC_TOOL: &str = "rocketmq_upsert_topic";
+pub const UPSERT_CONSUMER_GROUP_TOOL: &str = "rocketmq_upsert_consumer_group";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum MutationResultSchemaVersion {
+    #[serde(rename = "rocketmq-mcp-mutation.v1")]
+    V1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum TopicUpsertOperation {
+    #[serde(rename = "topic_upsert")]
+    TopicUpsert,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ConsumerGroupUpsertOperation {
+    #[serde(rename = "consumer_group_upsert")]
+    ConsumerGroupUpsert,
+}
+
+macro_rules! const_string_schema {
+    ($type:ty, $name:literal, $value:literal) => {
+        impl JsonSchema for $type {
+            fn schema_name() -> Cow<'static, str> {
+                $name.into()
+            }
+
+            fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                schemars::json_schema!({"type": "string", "const": $value})
+            }
+        }
+    };
+}
+
+const_string_schema!(
+    MutationResultSchemaVersion,
+    "MutationResultSchemaVersion",
+    "rocketmq-mcp-mutation.v1"
+);
+const_string_schema!(TopicUpsertOperation, "TopicUpsertOperation", "topic_upsert");
+const_string_schema!(
+    ConsumerGroupUpsertOperation,
+    "ConsumerGroupUpsertOperation",
+    "consumer_group_upsert"
+);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TopicMessageType {
+    Normal,
+    Fifo,
+    Delay,
+    Transaction,
+    Unspecified,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TopicReplacement {
+    #[schemars(range(min = 1, max = 127))]
+    pub read_queue_nums: u32,
+    #[schemars(range(min = 1, max = 127))]
+    pub write_queue_nums: u32,
+    #[schemars(range(min = 1, max = 7))]
+    pub perm: u32,
+    pub order: bool,
+    pub message_type: TopicMessageType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ConsumerGroupReplacement {
+    pub consume_enable: bool,
+    pub consume_from_min_enable: bool,
+    pub consume_broadcast_enable: bool,
+    pub consume_message_orderly: bool,
+    #[schemars(range(min = 0, max = 127))]
+    pub retry_queue_nums: i32,
+    #[schemars(range(min = -1, max = 10_000))]
+    pub retry_max_times: i32,
+    pub broker_id: u64,
+    pub which_broker_when_consume_slowly: u64,
+    pub notify_consumer_ids_changed_enable: bool,
+    pub group_sys_flag: i32,
+    #[schemars(range(min = 1, max = 10_080))]
+    pub consume_timeout_minute: i32,
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UpsertTopicArgs {
+    #[schemars(regex(pattern = "^rocketmq-mcp-control\\.arguments\\.v1$"))]
+    pub schema_version: String,
+    #[schemars(length(min = 1, max = 64), regex(pattern = "^[a-zA-Z0-9_-]+$"))]
+    pub cluster: String,
+    #[schemars(length(min = 1, max = 127), regex(pattern = "^[%|a-zA-Z0-9_-]+$"))]
+    pub topic: String,
+    #[schemars(
+        length(min = 1, max = 64),
+        inner(length(min = 1, max = 127), regex(pattern = "^[%|a-zA-Z0-9_-]+$"))
+    )]
+    pub broker_names: Vec<String>,
+    #[serde(flatten)]
+    pub replacement: TopicReplacement,
+    #[serde(default = "default_dry_run")]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub confirm: bool,
+    #[serde(default)]
+    #[schemars(length(min = 5, max = 256))]
+    pub reason: Option<String>,
+    #[serde(default)]
+    #[schemars(length(min = 8, max = 64), regex(pattern = "^[a-zA-Z0-9._:-]+$"))]
+    pub request_key: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UpsertConsumerGroupArgs {
+    #[schemars(regex(pattern = "^rocketmq-mcp-control\\.arguments\\.v1$"))]
+    pub schema_version: String,
+    #[schemars(length(min = 1, max = 64), regex(pattern = "^[a-zA-Z0-9_-]+$"))]
+    pub cluster: String,
+    #[schemars(length(min = 1, max = 255), regex(pattern = "^[%|a-zA-Z0-9_-]+$"))]
+    pub consumer_group: String,
+    #[schemars(
+        length(min = 1, max = 64),
+        inner(length(min = 1, max = 127), regex(pattern = "^[%|a-zA-Z0-9_-]+$"))
+    )]
+    pub broker_names: Vec<String>,
+    #[serde(flatten)]
+    pub replacement: ConsumerGroupReplacement,
+    #[serde(default = "default_dry_run")]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub confirm: bool,
+    #[serde(default)]
+    #[schemars(length(min = 5, max = 256))]
+    pub reason: Option<String>,
+    #[serde(default)]
+    #[schemars(length(min = 8, max = 64), regex(pattern = "^[a-zA-Z0-9._:-]+$"))]
+    pub request_key: Option<String>,
+}
+
+impl std::fmt::Debug for UpsertTopicArgs {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("UpsertTopicArgs")
+            .field("schema_version", &self.schema_version)
+            .field("broker_count", &self.broker_names.len())
+            .field("dry_run", &self.dry_run)
+            .field("confirm", &self.confirm)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for UpsertConsumerGroupArgs {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("UpsertConsumerGroupArgs")
+            .field("schema_version", &self.schema_version)
+            .field("broker_count", &self.broker_names.len())
+            .field("dry_run", &self.dry_run)
+            .field("confirm", &self.confirm)
+            .finish_non_exhaustive()
+    }
+}
+
+impl UpsertTopicArgs {
+    pub fn validate(&self, configured_default_dry_run: bool, dry_run_omitted: bool) -> Result<(), ControlError> {
+        validate_common(
+            &self.schema_version,
+            if dry_run_omitted {
+                configured_default_dry_run
+            } else {
+                self.dry_run
+            },
+            self.confirm,
+            self.reason.as_deref(),
+            self.request_key.as_deref(),
+        )?;
+        validate_target_set(&self.broker_names)?;
+        validate_user_name(&self.topic, NameKind::Topic)?;
+        if !(1..=127).contains(&self.replacement.read_queue_nums)
+            || !(1..=127).contains(&self.replacement.write_queue_nums)
+            || !(1..=7).contains(&self.replacement.perm)
+            || self.replacement.perm & 0b110 == 0
+        {
+            return Err(ControlError::invalid_arguments());
+        }
+        Ok(())
+    }
+
+    pub fn effective_dry_run(&self, configured_default: bool, omitted: bool) -> bool {
+        if omitted {
+            configured_default
+        } else {
+            self.dry_run
+        }
+    }
+}
+
+impl UpsertConsumerGroupArgs {
+    pub fn validate(&self, configured_default_dry_run: bool, dry_run_omitted: bool) -> Result<(), ControlError> {
+        validate_common(
+            &self.schema_version,
+            if dry_run_omitted {
+                configured_default_dry_run
+            } else {
+                self.dry_run
+            },
+            self.confirm,
+            self.reason.as_deref(),
+            self.request_key.as_deref(),
+        )?;
+        validate_target_set(&self.broker_names)?;
+        validate_user_name(&self.consumer_group, NameKind::ConsumerGroup)?;
+        #[cfg(feature = "write-tools")]
+        if rocketmq_admin_core::core::consumer::is_protected_consumer_group(&self.consumer_group) {
+            return Err(ControlError::invalid_arguments());
+        }
+        if self.replacement.retry_queue_nums < 0
+            || self.replacement.retry_queue_nums > 127
+            || self.replacement.retry_max_times < -1
+            || self.replacement.retry_max_times > 10_000
+            || self.replacement.consume_timeout_minute <= 0
+            || self.replacement.consume_timeout_minute > 10_080
+        {
+            return Err(ControlError::invalid_arguments());
+        }
+        Ok(())
+    }
+
+    pub fn effective_dry_run(&self, configured_default: bool, omitted: bool) -> bool {
+        if omitted {
+            configured_default
+        } else {
+            self.dry_run
+        }
+    }
+}
+
+fn validate_common(
+    schema_version: &str,
+    dry_run: bool,
+    confirm: bool,
+    reason: Option<&str>,
+    request_key: Option<&str>,
+) -> Result<(), ControlError> {
+    MutationArguments {
+        schema_version: schema_version.to_owned(),
+        dry_run,
+        confirm,
+        reason: reason.map(ToOwned::to_owned),
+        request_key: request_key.map(ToOwned::to_owned),
+    }
+    .validate()
+}
+
+fn validate_target_set(broker_names: &[String]) -> Result<(), ControlError> {
+    if !(1..=64).contains(&broker_names.len()) {
+        return Err(ControlError::invalid_arguments());
+    }
+    let mut canonical = broker_names.to_vec();
+    canonical.sort();
+    if canonical.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(ControlError::invalid_arguments());
+    }
+    for broker in broker_names {
+        validate_user_name(broker, NameKind::Broker)?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum NameKind {
+    Topic,
+    ConsumerGroup,
+    Broker,
+}
+
+fn validate_user_name(value: &str, kind: NameKind) -> Result<(), ControlError> {
+    let max = if matches!(kind, NameKind::ConsumerGroup) {
+        255
+    } else {
+        127
+    };
+    let valid = !value.is_empty()
+        && value.len() <= max
+        && !contains_encoded_octet(value)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'%' | b'|' | b'-' | b'_'));
+    let system = match kind {
+        NameKind::Topic => {
+            value.starts_with("%RETRY%")
+                || value.starts_with("%DLQ%")
+                || value.starts_with("rmq_sys_")
+                || matches!(
+                    value,
+                    "TBW102"
+                        | "SCHEDULE_TOPIC_XXXX"
+                        | "BenchmarkTest"
+                        | "RMQ_SYS_TRANS_HALF_TOPIC"
+                        | "RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC"
+                        | "RMQ_SYS_TRACE_TOPIC"
+                        | "RMQ_SYS_TRANS_OP_HALF_TOPIC"
+                        | "RMQ_SYS_ROCKSDB_TRANS_OP_HALF_TOPIC"
+                        | "TRANS_CHECK_MAX_TIME_TOPIC"
+                        | "SELF_TEST_TOPIC"
+                        | "OFFSET_MOVED_EVENT"
+                        | "CHECKPOINT_TOPIC"
+                )
+        }
+        NameKind::ConsumerGroup => false,
+        NameKind::Broker => false,
+    };
+    if !valid || system {
+        return Err(ControlError::invalid_arguments());
+    }
+    Ok(())
+}
+
+fn contains_encoded_octet(value: &str) -> bool {
+    value
+        .as_bytes()
+        .windows(3)
+        .any(|window| window[0] == b'%' && window[1].is_ascii_hexdigit() && window[2].is_ascii_hexdigit())
+}
+
+const fn default_dry_run() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationMode {
+    DryRun,
+    Execute,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationStatus {
+    Planned,
+    Applied,
+    Partial,
+    Conflict,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PersistenceState {
+    NotRequired,
+    Persisted,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationState {
+    NotPerformed,
+    Verified,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureCode {
+    Conflict,
+    InvalidData,
+    Unavailable,
+    PersistenceFailed,
+    VerificationFailed,
+    OrderReconciliationFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum VisibleState<T> {
+    Unknown,
+    Absent,
+    Present { version: u64, value: T },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LogicalMutationTarget {
+    pub broker_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TopicMutationResource {
+    pub topic: String,
+    pub brokers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ConsumerGroupMutationResource {
+    pub consumer_group: String,
+    pub brokers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MutationTarget<T> {
+    pub target: LogicalMutationTarget,
+    pub before: VisibleState<T>,
+    pub requested: T,
+    pub after: Option<VisibleState<T>>,
+    pub applied: bool,
+    pub changed: bool,
+    pub persistence: PersistenceState,
+    pub verification: VerificationState,
+    pub failure: Option<FailureCode>,
+    pub retryable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MutationToolResponse<O, R, T> {
+    pub schema_version: MutationResultSchemaVersion,
+    pub operation: O,
+    pub cluster: String,
+    pub mode: MutationMode,
+    pub status: MutationStatus,
+    pub target: R,
+    pub before: BTreeMap<String, VisibleState<T>>,
+    pub requested: T,
+    #[schemars(required)]
+    pub after: Option<BTreeMap<String, VisibleState<T>>>,
+    pub targets: Vec<MutationTarget<T>>,
+    pub warnings: Vec<String>,
+}
+
+pub type TopicMutationToolResponse =
+    MutationToolResponse<TopicUpsertOperation, TopicMutationResource, TopicReplacement>;
+pub type ConsumerGroupMutationToolResponse =
+    MutationToolResponse<ConsumerGroupUpsertOperation, ConsumerGroupMutationResource, ConsumerGroupReplacement>;
+
+impl<O, R, T> MutationToolResponse<O, R, T> {
+    pub fn is_error(&self) -> bool {
+        matches!(
+            self.status,
+            MutationStatus::Partial | MutationStatus::Conflict | MutationStatus::Failed
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION;
+
+    #[test]
+    fn topic_schema_and_names_are_closed() {
+        let valid = serde_json::json!({
+            "schema_version": MUTATION_ARGUMENTS_SCHEMA_VERSION,
+            "cluster": "cluster-a",
+            "topic": "orders_v1",
+            "broker_names": ["broker-b", "broker-a"],
+            "read_queue_nums": 8,
+            "write_queue_nums": 8,
+            "perm": 6,
+            "order": false,
+            "message_type": "NORMAL"
+        });
+        let args: UpsertTopicArgs = serde_json::from_value(valid.clone()).unwrap();
+        args.validate(true, true).unwrap();
+        for topic in ["a".repeat(127), "orders|v1".to_owned()] {
+            let mut case = valid.clone();
+            case["topic"] = serde_json::json!(topic);
+            serde_json::from_value::<UpsertTopicArgs>(case)
+                .unwrap()
+                .validate(true, true)
+                .unwrap();
+        }
+        for (field, value) in [
+            ("topic", serde_json::json!("10.0.0.1")),
+            ("topic", serde_json::json!("%RETRY%orders")),
+            ("topic", serde_json::json!("token=secret")),
+            ("topic", serde_json::json!("a".repeat(128))),
+            ("topic", serde_json::json!("10%2e0%2e0%2e1")),
+            ("topic", serde_json::json!("token%3dsecret")),
+            ("broker_names", serde_json::json!([])),
+            ("broker_names", serde_json::json!(["broker-a", "broker-a"])),
+            ("read_queue_nums", serde_json::json!(0)),
+            ("message_type", serde_json::json!("OTHER")),
+        ] {
+            let mut case = valid.clone();
+            case[field] = value;
+            let rejected = serde_json::from_value::<UpsertTopicArgs>(case)
+                .map_err(|_| ControlError::invalid_arguments())
+                .and_then(|args| args.validate(true, true));
+            assert!(rejected.is_err(), "accepted {field}");
+        }
+        for system in [
+            "TBW102",
+            "SCHEDULE_TOPIC_XXXX",
+            "BenchmarkTest",
+            "RMQ_SYS_TRANS_HALF_TOPIC",
+            "RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC",
+            "RMQ_SYS_TRACE_TOPIC",
+            "RMQ_SYS_TRANS_OP_HALF_TOPIC",
+            "RMQ_SYS_ROCKSDB_TRANS_OP_HALF_TOPIC",
+            "TRANS_CHECK_MAX_TIME_TOPIC",
+            "SELF_TEST_TOPIC",
+            "OFFSET_MOVED_EVENT",
+            "CHECKPOINT_TOPIC",
+            "rmq_sys_internal",
+            "%DLQ%orders",
+        ] {
+            let mut case = valid.clone();
+            case["topic"] = serde_json::json!(system);
+            assert!(serde_json::from_value::<UpsertTopicArgs>(case)
+                .unwrap()
+                .validate(true, true)
+                .is_err());
+        }
+        let mut sixty_four = valid.clone();
+        sixty_four["broker_names"] =
+            serde_json::json!((0..64).map(|index| format!("broker-{index:02}")).collect::<Vec<_>>());
+        serde_json::from_value::<UpsertTopicArgs>(sixty_four.clone())
+            .unwrap()
+            .validate(true, true)
+            .unwrap();
+        sixty_four["broker_names"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!("broker-64"));
+        assert!(serde_json::from_value::<UpsertTopicArgs>(sixty_four)
+            .unwrap()
+            .validate(true, true)
+            .is_err());
+        let mut unknown = valid;
+        unknown["unknown"] = serde_json::json!(true);
+        assert!(serde_json::from_value::<UpsertTopicArgs>(unknown).is_err());
+    }
+
+    #[test]
+    fn consumer_group_schema_and_execution_arguments_are_closed() {
+        let valid = serde_json::json!({
+            "schema_version": MUTATION_ARGUMENTS_SCHEMA_VERSION,
+            "cluster": "cluster-a",
+            "consumer_group": "orders_consumers",
+            "broker_names": ["broker-b", "broker-a"],
+            "consume_enable": true,
+            "consume_from_min_enable": false,
+            "consume_broadcast_enable": false,
+            "consume_message_orderly": false,
+            "retry_queue_nums": 1,
+            "retry_max_times": 16,
+            "broker_id": 0,
+            "which_broker_when_consume_slowly": 1,
+            "notify_consumer_ids_changed_enable": true,
+            "group_sys_flag": 0,
+            "consume_timeout_minute": 15
+        });
+        let args: UpsertConsumerGroupArgs = serde_json::from_value(valid.clone()).unwrap();
+        args.validate(true, true).unwrap();
+
+        #[cfg(feature = "write-tools")]
+        for protected in [
+            "DEFAULT_CONSUMER",
+            "TOOLS_CONSUMER",
+            "SCHEDULE_CONSUMER",
+            "FILTERSRV_CONSUMER",
+            "__MONITOR_CONSUMER",
+            "SELF_TEST_C_GROUP",
+            "CID_ONS-HTTP-PROXY",
+            "CID_ONSAPI_PULL",
+            "CID_ONSAPI_PERMISSION",
+            "CID_ONSAPI_OWNER",
+            "CID_RMQ_SYS_TRANS",
+            "CID_RMQ_SYS_INTERNAL",
+            "CID_DefaultHeartBeatSyncerTopic",
+            "%SYS%INTERNAL",
+        ] {
+            let mut case = valid.clone();
+            case["consumer_group"] = serde_json::json!(protected);
+            assert_eq!(
+                serde_json::from_value::<UpsertConsumerGroupArgs>(case)
+                    .unwrap()
+                    .validate(true, true)
+                    .unwrap_err()
+                    .code(),
+                crate::error::ControlErrorCode::InvalidArguments
+            );
+        }
+
+        for (field, value) in [
+            ("consumer_group", serde_json::json!("broker.example.test:10911")),
+            ("broker_names", serde_json::json!(["broker-a", "broker-a"])),
+            ("retry_queue_nums", serde_json::json!(-1)),
+            ("retry_max_times", serde_json::json!(-2)),
+            ("consume_timeout_minute", serde_json::json!(0)),
+        ] {
+            let mut case = valid.clone();
+            case[field] = value;
+            let rejected = serde_json::from_value::<UpsertConsumerGroupArgs>(case)
+                .map_err(|_| ControlError::invalid_arguments())
+                .and_then(|args| args.validate(true, true));
+            assert!(rejected.is_err(), "accepted {field}");
+        }
+
+        let mut execute = valid.clone();
+        execute["dry_run"] = serde_json::json!(false);
+        let args: UpsertConsumerGroupArgs = serde_json::from_value(execute.clone()).unwrap();
+        assert!(args.validate(true, false).is_err());
+        execute["confirm"] = serde_json::json!(true);
+        execute["reason"] = serde_json::json!("approved group replacement");
+        serde_json::from_value::<UpsertConsumerGroupArgs>(execute)
+            .unwrap()
+            .validate(true, false)
+            .unwrap();
+    }
+
+    #[test]
+    fn mutation_argument_debug_omits_identifiers_reason_and_request_key() {
+        let topic: UpsertTopicArgs = serde_json::from_value(serde_json::json!({
+            "schema_version": MUTATION_ARGUMENTS_SCHEMA_VERSION,
+            "cluster": "cluster-sensitive",
+            "topic": "secret-topic",
+            "broker_names": ["secret-broker"],
+            "read_queue_nums": 8,
+            "write_queue_nums": 8,
+            "perm": 6,
+            "order": false,
+            "message_type": "NORMAL",
+            "dry_run": false,
+            "confirm": true,
+            "reason": "sensitive approval reason",
+            "request_key": "sensitive-key"
+        }))
+        .unwrap();
+        let rendered = format!("{topic:?}");
+        for sensitive in [
+            "cluster-sensitive",
+            "secret-topic",
+            "secret-broker",
+            "sensitive approval reason",
+            "sensitive-key",
+        ] {
+            assert!(!rendered.contains(sensitive));
+        }
+        assert!(rendered.contains("broker_count: 1"));
+
+        let group: UpsertConsumerGroupArgs = serde_json::from_value(serde_json::json!({
+            "schema_version": MUTATION_ARGUMENTS_SCHEMA_VERSION,
+            "cluster": "cluster-private",
+            "consumer_group": "private-consumers",
+            "broker_names": ["private-broker"],
+            "consume_enable": true,
+            "consume_from_min_enable": false,
+            "consume_broadcast_enable": false,
+            "consume_message_orderly": false,
+            "retry_queue_nums": 1,
+            "retry_max_times": 16,
+            "broker_id": 0,
+            "which_broker_when_consume_slowly": 1,
+            "notify_consumer_ids_changed_enable": true,
+            "group_sys_flag": 0,
+            "consume_timeout_minute": 15,
+            "dry_run": false,
+            "confirm": true,
+            "reason": "private approval reason",
+            "request_key": "private-key"
+        }))
+        .unwrap();
+        let rendered = format!("{group:?}");
+        for sensitive in [
+            "cluster-private",
+            "private-consumers",
+            "private-broker",
+            "private approval reason",
+            "private-key",
+        ] {
+            assert!(!rendered.contains(sensitive));
+        }
+        assert!(rendered.contains("broker_count: 1"));
+    }
+
+    #[test]
+    fn stable_response_snapshot_exposes_only_logical_mutation_state() {
+        let response = MutationToolResponse {
+            schema_version: MutationResultSchemaVersion::V1,
+            operation: TopicUpsertOperation::TopicUpsert,
+            cluster: "cluster-a".to_owned(),
+            mode: MutationMode::Execute,
+            status: MutationStatus::Partial,
+            target: TopicMutationResource {
+                topic: "orders".to_owned(),
+                brokers: vec!["broker-a".to_owned()],
+            },
+            before: BTreeMap::from([("broker-a".to_owned(), VisibleState::Absent)]),
+            requested: TopicReplacement {
+                read_queue_nums: 8,
+                write_queue_nums: 8,
+                perm: 6,
+                order: false,
+                message_type: TopicMessageType::Normal,
+            },
+            after: Some(BTreeMap::from([(
+                "broker-a".to_owned(),
+                VisibleState::Present {
+                    version: 1,
+                    value: TopicReplacement {
+                        read_queue_nums: 8,
+                        write_queue_nums: 8,
+                        perm: 6,
+                        order: false,
+                        message_type: TopicMessageType::Normal,
+                    },
+                },
+            )])),
+            targets: vec![MutationTarget {
+                target: LogicalMutationTarget {
+                    broker_name: "broker-a".to_owned(),
+                },
+                before: VisibleState::Absent,
+                requested: TopicReplacement {
+                    read_queue_nums: 8,
+                    write_queue_nums: 8,
+                    perm: 6,
+                    order: false,
+                    message_type: TopicMessageType::Normal,
+                },
+                after: Some(VisibleState::Present {
+                    version: 1,
+                    value: TopicReplacement {
+                        read_queue_nums: 8,
+                        write_queue_nums: 8,
+                        perm: 6,
+                        order: false,
+                        message_type: TopicMessageType::Normal,
+                    },
+                }),
+                applied: true,
+                changed: true,
+                persistence: PersistenceState::Persisted,
+                verification: VerificationState::Verified,
+                failure: Some(FailureCode::OrderReconciliationFailed),
+                retryable: false,
+            }],
+            warnings: vec!["topic order configuration was not reconciled".to_owned()],
+        };
+        insta::assert_json_snapshot!("control_mutation_response", response);
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/transport.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport.rs
@@ -55,6 +55,7 @@ pub const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 pub async fn serve<F>(
     config: ControlConfig,
     service_context: ChildServiceContext,
+    audit: crate::audit::AuditTrail,
     shutdown: F,
 ) -> Result<(), ControlError>
 where
@@ -81,7 +82,13 @@ where
         .map_err(|_| ControlError::invalid_config())?;
     let listener = HttpsListener { tcp, tls };
     let cancellation = CancellationToken::new();
-    let server = ControlServer::new(config.mutations.mutations_enabled);
+    #[cfg(feature = "write-tools")]
+    let server = ControlServer::from_config(&config, audit, service_context.component("mutation-tools"))?;
+    #[cfg(not(feature = "write-tools"))]
+    let server = {
+        let _ = (audit, &service_context);
+        ControlServer::new(config.mutations.mutations_enabled)
+    };
     let router = build_router_with_auth(&config, server, cancellation.clone(), auth);
 
     tracing::info!("rocketmq-mcp-control authenticated HTTPS transport is ready");
@@ -272,6 +279,10 @@ mod tests {
     use tracing_subscriber::fmt::MakeWriter;
 
     use super::*;
+    #[cfg(feature = "write-tools")]
+    use crate::audit::MemoryAuditSink;
+    #[cfg(feature = "write-tools")]
+    use crate::audit::ReliableAuditSink;
     use crate::auth::AuthError;
     use crate::config::AuditConfig;
     use crate::config::MutationPolicyConfig;
@@ -344,6 +355,7 @@ mod tests {
                 jwks_ca_path: None,
             },
             mutations: MutationPolicyConfig::default(),
+            clusters: Vec::new(),
             audit: AuditConfig {
                 path: "audit.jsonl".to_string(),
                 capacity: 64,
@@ -353,6 +365,10 @@ mod tests {
     }
 
     fn token(scope: &str) -> String {
+        token_with_claims(scope, Vec::new(), Vec::new())
+    }
+
+    fn token_with_claims(scope: &str, operations: Vec<&str>, clusters: Vec<&str>) -> String {
         let mut header = Header::new(Algorithm::RS256);
         header.kid = Some("test-key".to_string());
         encode(
@@ -363,12 +379,294 @@ mod tests {
                 aud: "rocketmq-mcp-control",
                 exp: 4_102_444_800,
                 scope,
-                rocketmq_operations: vec![],
-                rocketmq_clusters: vec![],
+                rocketmq_operations: operations,
+                rocketmq_clusters: clusters,
             },
             &EncodingKey::from_rsa_pem(include_bytes!("../tests/fixtures/oauth-private-key.pem")).unwrap(),
         )
         .unwrap()
+    }
+
+    #[cfg(feature = "write-tools")]
+    #[derive(Default)]
+    struct ProtocolCounters {
+        opens: std::sync::atomic::AtomicUsize,
+        preflights: std::sync::atomic::AtomicUsize,
+        executes: std::sync::atomic::AtomicUsize,
+        shutdowns: std::sync::atomic::AtomicUsize,
+    }
+
+    #[cfg(feature = "write-tools")]
+    struct ProtocolFactory {
+        counters: Arc<ProtocolCounters>,
+    }
+
+    #[cfg(feature = "write-tools")]
+    impl crate::tool_runtime::UpsertSessionFactory for ProtocolFactory {
+        fn open<'a>(
+            &'a self,
+            _cluster: &'a crate::model::ClusterName,
+        ) -> crate::tool_runtime::RuntimeFuture<'a, Result<Box<dyn crate::tool_runtime::UpsertSession>, ControlError>>
+        {
+            Box::pin(async move {
+                self.counters.opens.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(Box::new(crate::tool_runtime::admin_session::AdminUpsertSession::new(
+                    ProtocolBackend {
+                        counters: self.counters.clone(),
+                        topic_executed: false,
+                        group_executed: false,
+                    },
+                )) as Box<dyn crate::tool_runtime::UpsertSession>)
+            })
+        }
+    }
+
+    #[cfg(feature = "write-tools")]
+    struct ProtocolTopicPlan {
+        targets: Vec<
+            rocketmq_admin_core::core::supervised_mutation::MetadataPreflightTarget<
+                rocketmq_admin_core::core::supervised_mutation::TopicReplacement,
+            >,
+        >,
+        failures: Vec<rocketmq_admin_core::core::supervised_mutation::MutationTargetFailure>,
+    }
+
+    #[cfg(feature = "write-tools")]
+    struct ProtocolGroupPlan {
+        targets: Vec<
+            rocketmq_admin_core::core::supervised_mutation::MetadataPreflightTarget<
+                rocketmq_admin_core::core::supervised_mutation::SubscriptionGroupReplacement,
+            >,
+        >,
+        failures: Vec<rocketmq_admin_core::core::supervised_mutation::MutationTargetFailure>,
+    }
+
+    #[cfg(feature = "write-tools")]
+    struct ProtocolBackend {
+        counters: Arc<ProtocolCounters>,
+        topic_executed: bool,
+        group_executed: bool,
+    }
+
+    #[cfg(feature = "write-tools")]
+    impl crate::tool_runtime::admin_session::SupervisedUpsertBackend for ProtocolBackend {
+        type TopicPlan = ProtocolTopicPlan;
+        type GroupPlan = ProtocolGroupPlan;
+
+        fn preflight_topic<'a>(
+            &'a mut self,
+            request: &'a rocketmq_admin_core::core::supervised_mutation::TopicMutationPreflightRequest,
+            broker_names: &'a [String],
+        ) -> crate::tool_runtime::RuntimeFuture<'a, Result<Self::TopicPlan, ControlError>> {
+            Box::pin(async move {
+                use rocketmq_admin_core::core::supervised_mutation::ExpectedState;
+                use rocketmq_admin_core::core::supervised_mutation::MetadataPreflightTarget;
+                self.counters
+                    .preflights
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(ProtocolTopicPlan {
+                    targets: broker_names
+                        .iter()
+                        .cloned()
+                        .map(|broker_name| MetadataPreflightTarget {
+                            broker_name,
+                            state: if self.topic_executed {
+                                ExpectedState::Present { version: 1 }
+                            } else {
+                                ExpectedState::Absent
+                            },
+                            current: self.topic_executed.then(|| request.replacement.clone()),
+                        })
+                        .collect(),
+                    failures: Vec::new(),
+                })
+            })
+        }
+
+        fn topic_targets(
+            plan: &Self::TopicPlan,
+        ) -> Vec<
+            rocketmq_admin_core::core::supervised_mutation::MetadataPreflightTarget<
+                rocketmq_admin_core::core::supervised_mutation::TopicReplacement,
+            >,
+        > {
+            plan.targets.clone()
+        }
+
+        fn topic_failures(
+            plan: &Self::TopicPlan,
+        ) -> &[rocketmq_admin_core::core::supervised_mutation::MutationTargetFailure] {
+            &plan.failures
+        }
+
+        fn execute_topic<'a>(
+            &'a mut self,
+            plan: &'a Self::TopicPlan,
+        ) -> crate::tool_runtime::RuntimeFuture<
+            'a,
+            Result<rocketmq_admin_core::core::supervised_mutation::MetadataMutationOutcome, ControlError>,
+        > {
+            Box::pin(async move {
+                use rocketmq_admin_core::core::supervised_mutation::ExpectedState;
+                use rocketmq_admin_core::core::supervised_mutation::MetadataMutationOutcome;
+                use rocketmq_admin_core::core::supervised_mutation::MetadataMutationTargetOutcome;
+                use rocketmq_admin_core::core::supervised_mutation::MutationPersistenceState;
+                use rocketmq_admin_core::core::supervised_mutation::MutationVerificationState;
+                self.counters.executes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                self.topic_executed = true;
+                Ok(MetadataMutationOutcome {
+                    targets: plan
+                        .targets
+                        .iter()
+                        .map(|target| MetadataMutationTargetOutcome {
+                            broker_name: target.broker_name.clone(),
+                            expected_state: target.state,
+                            resulting_state: Some(ExpectedState::Present { version: 1 }),
+                            applied: true,
+                            changed: true,
+                            persistence: MutationPersistenceState::Persisted,
+                            verification: MutationVerificationState::Verified,
+                            failure: None,
+                            retryable: false,
+                        })
+                        .collect(),
+                    failures: Vec::new(),
+                    order_reconciled: Some(true),
+                })
+            })
+        }
+
+        fn preflight_group<'a>(
+            &'a mut self,
+            request: &'a rocketmq_admin_core::core::supervised_mutation::SubscriptionGroupMutationPreflightRequest,
+            broker_names: &'a [String],
+        ) -> crate::tool_runtime::RuntimeFuture<'a, Result<Self::GroupPlan, ControlError>> {
+            Box::pin(async move {
+                use rocketmq_admin_core::core::supervised_mutation::ExpectedState;
+                use rocketmq_admin_core::core::supervised_mutation::MetadataPreflightTarget;
+                self.counters
+                    .preflights
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(ProtocolGroupPlan {
+                    targets: broker_names
+                        .iter()
+                        .cloned()
+                        .map(|broker_name| MetadataPreflightTarget {
+                            broker_name,
+                            state: if self.group_executed {
+                                ExpectedState::Present { version: 1 }
+                            } else {
+                                ExpectedState::Absent
+                            },
+                            current: self.group_executed.then(|| request.replacement.clone()),
+                        })
+                        .collect(),
+                    failures: Vec::new(),
+                })
+            })
+        }
+
+        fn group_targets(
+            plan: &Self::GroupPlan,
+        ) -> Vec<
+            rocketmq_admin_core::core::supervised_mutation::MetadataPreflightTarget<
+                rocketmq_admin_core::core::supervised_mutation::SubscriptionGroupReplacement,
+            >,
+        > {
+            plan.targets.clone()
+        }
+
+        fn group_failures(
+            plan: &Self::GroupPlan,
+        ) -> &[rocketmq_admin_core::core::supervised_mutation::MutationTargetFailure] {
+            &plan.failures
+        }
+
+        fn execute_group<'a>(
+            &'a mut self,
+            plan: &'a Self::GroupPlan,
+        ) -> crate::tool_runtime::RuntimeFuture<
+            'a,
+            Result<rocketmq_admin_core::core::supervised_mutation::MetadataMutationOutcome, ControlError>,
+        > {
+            Box::pin(async move {
+                use rocketmq_admin_core::core::supervised_mutation::ExpectedState;
+                use rocketmq_admin_core::core::supervised_mutation::MetadataMutationOutcome;
+                use rocketmq_admin_core::core::supervised_mutation::MetadataMutationTargetOutcome;
+                use rocketmq_admin_core::core::supervised_mutation::MutationPersistenceState;
+                use rocketmq_admin_core::core::supervised_mutation::MutationVerificationState;
+                self.counters.executes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                self.group_executed = true;
+                Ok(MetadataMutationOutcome {
+                    targets: plan
+                        .targets
+                        .iter()
+                        .map(|target| MetadataMutationTargetOutcome {
+                            broker_name: target.broker_name.clone(),
+                            expected_state: target.state,
+                            resulting_state: Some(ExpectedState::Present { version: 1 }),
+                            applied: true,
+                            changed: true,
+                            persistence: MutationPersistenceState::Persisted,
+                            verification: MutationVerificationState::Verified,
+                            failure: None,
+                            retryable: false,
+                        })
+                        .collect(),
+                    failures: Vec::new(),
+                    order_reconciled: None,
+                })
+            })
+        }
+
+        fn shutdown(&mut self) -> crate::tool_runtime::RuntimeFuture<'_, Result<(), ControlError>> {
+            Box::pin(async move {
+                self.counters
+                    .shutdowns
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            })
+        }
+    }
+
+    #[cfg(feature = "write-tools")]
+    async fn write_router() -> (Router, Arc<ProtocolCounters>, Arc<MemoryAuditSink>) {
+        use crate::audit::AuditTrail;
+        use crate::model::ClusterName;
+        use crate::model::ControlOperation;
+
+        let mut config = config();
+        config.mutations = MutationPolicyConfig {
+            mutations_enabled: true,
+            dry_run: true,
+            allowed_operations: vec![ControlOperation::TopicUpsert, ControlOperation::ConsumerGroupUpsert],
+            allowed_clusters: vec![ClusterName::try_new("cluster-a").unwrap()],
+            operation_timeout_seconds: 2,
+        };
+        let runtime = rocketmq_runtime::RuntimeContext::from_current("control-protocol-write-test");
+        let owner = runtime
+            .service_context("control-protocol-write-test")
+            .task_group()
+            .clone();
+        let counters = Arc::new(ProtocolCounters::default());
+        let sink = Arc::new(MemoryAuditSink::new(64, 4096));
+        let server = ControlServer::with_test_factory(
+            &config.mutations,
+            std::collections::BTreeSet::from([ClusterName::try_new("cluster-a").unwrap()]),
+            AuditTrail::new(sink.clone()),
+            Arc::new(ProtocolFactory {
+                counters: counters.clone(),
+            }),
+            owner,
+        );
+        let auth = AuthState::from_source(&config.oauth, resource_metadata_url(&config), StaticSource)
+            .await
+            .unwrap();
+        (
+            build_router_with_auth(&config, server, CancellationToken::new(), auth),
+            counters,
+            sink,
+        )
     }
 
     async fn router() -> Router {
@@ -396,6 +694,128 @@ mod tests {
             builder = builder.header(AUTHORIZATION, format!("Bearer {token}"));
         }
         builder.body(body).unwrap()
+    }
+
+    #[cfg(feature = "write-tools")]
+    fn topic_arguments(topic: &str, broker_names: Vec<String>) -> serde_json::Value {
+        serde_json::json!({
+            "schema_version": crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION,
+            "cluster": "cluster-a",
+            "topic": topic,
+            "broker_names": broker_names,
+            "read_queue_nums": 8,
+            "write_queue_nums": 8,
+            "perm": 6,
+            "order": false,
+            "message_type": "NORMAL"
+        })
+    }
+
+    #[cfg(feature = "write-tools")]
+    fn consumer_group_arguments(consumer_group: &str, broker_names: Vec<String>) -> serde_json::Value {
+        serde_json::json!({
+            "schema_version": crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION,
+            "cluster": "cluster-a",
+            "consumer_group": consumer_group,
+            "broker_names": broker_names,
+            "consume_enable": true,
+            "consume_from_min_enable": false,
+            "consume_broadcast_enable": false,
+            "consume_message_orderly": false,
+            "retry_queue_nums": 1,
+            "retry_max_times": 16,
+            "broker_id": 0,
+            "which_broker_when_consume_slowly": 1,
+            "notify_consumer_ids_changed_enable": true,
+            "group_sys_flag": 0,
+            "consume_timeout_minute": 15
+        })
+    }
+
+    #[cfg(feature = "write-tools")]
+    async fn authenticated_tool_call(
+        router: &Router,
+        token: &str,
+        id: usize,
+        tool: &str,
+        arguments: serde_json::Value,
+    ) -> serde_json::Value {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments}
+        });
+        let response = router
+            .clone()
+            .oneshot(request("/mcp", Body::from(body.to_string()), Some(token)))
+            .await
+            .unwrap();
+        let bytes = to_bytes(response.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[cfg(feature = "write-tools")]
+    fn expected_upsert_response(
+        operation: &str,
+        resource_field: &str,
+        resource_name: &str,
+        requested: serde_json::Value,
+        execute: bool,
+    ) -> serde_json::Value {
+        let brokers = ["broker-a", "broker-b"];
+        let before = brokers
+            .into_iter()
+            .map(|broker| (broker.to_owned(), serde_json::json!({"kind": "absent"})))
+            .collect::<serde_json::Map<_, _>>();
+        let after = execute.then(|| {
+            brokers
+                .into_iter()
+                .map(|broker| {
+                    (
+                        broker.to_owned(),
+                        serde_json::json!({"kind": "present", "version": 1, "value": requested}),
+                    )
+                })
+                .collect::<serde_json::Map<_, _>>()
+        });
+        let targets = brokers
+            .into_iter()
+            .map(|broker| {
+                serde_json::json!({
+                    "target": {"broker_name": broker},
+                    "before": {"kind": "absent"},
+                    "requested": requested,
+                    "after": execute.then(|| serde_json::json!({
+                        "kind": "present",
+                        "version": 1,
+                        "value": requested
+                    })),
+                    "applied": execute,
+                    "changed": execute,
+                    "persistence": if execute { "persisted" } else { "not_required" },
+                    "verification": if execute { "verified" } else { "not_performed" },
+                    "failure": null,
+                    "retryable": false
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut target = serde_json::Map::new();
+        target.insert(resource_field.to_owned(), serde_json::json!(resource_name));
+        target.insert("brokers".to_owned(), serde_json::json!(brokers));
+        serde_json::json!({
+            "schema_version": crate::tools::MUTATION_RESULT_SCHEMA_VERSION,
+            "operation": operation,
+            "cluster": "cluster-a",
+            "mode": if execute { "execute" } else { "dry_run" },
+            "status": if execute { "applied" } else { "planned" },
+            "target": target,
+            "before": before,
+            "requested": requested,
+            "after": after,
+            "targets": targets,
+            "warnings": []
+        })
     }
 
     #[tokio::test]
@@ -478,6 +898,462 @@ mod tests {
         let body = to_bytes(tools.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(value["result"]["tools"], serde_json::json!([]));
+    }
+
+    #[cfg(feature = "write-tools")]
+    #[tokio::test]
+    async fn authenticated_tool_discovery_and_call_enforce_claims_before_schema() {
+        let (router, counters, _sink) = write_router().await;
+        let both = token_with_claims(
+            REQUIRED_WRITE_SCOPE,
+            vec!["topic_upsert", "consumer_group_upsert"],
+            vec!["cluster-a"],
+        );
+        let tools = router
+            .clone()
+            .oneshot(request(
+                "/mcp",
+                Body::from(r#"{"jsonrpc":"2.0","id":20,"method":"tools/list","params":{}}"#),
+                Some(&both),
+            ))
+            .await
+            .unwrap();
+        let body = to_bytes(tools.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        let listed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(listed["result"]["tools"].as_array().unwrap().len(), 2);
+        for tool in listed["result"]["tools"].as_array().unwrap() {
+            assert_eq!(tool["annotations"]["readOnlyHint"], false);
+            assert_eq!(tool["annotations"]["destructiveHint"], true);
+            assert_eq!(tool["annotations"]["idempotentHint"], true);
+            assert_eq!(tool["annotations"]["openWorldHint"], true);
+        }
+
+        let topic_only = token_with_claims(REQUIRED_WRITE_SCOPE, vec!["topic_upsert"], vec!["cluster-a"]);
+        let one = router
+            .clone()
+            .oneshot(request(
+                "/mcp",
+                Body::from(r#"{"jsonrpc":"2.0","id":23,"method":"tools/list","params":{}}"#),
+                Some(&topic_only),
+            ))
+            .await
+            .unwrap();
+        let one_body = to_bytes(one.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        let one_value: serde_json::Value = serde_json::from_slice(&one_body).unwrap();
+        assert_eq!(one_value["result"]["tools"].as_array().unwrap().len(), 1);
+        let no_cluster = token_with_claims(
+            REQUIRED_WRITE_SCOPE,
+            vec!["topic_upsert", "consumer_group_upsert"],
+            vec!["cluster-b"],
+        );
+        let zero = router
+            .clone()
+            .oneshot(request(
+                "/mcp",
+                Body::from(r#"{"jsonrpc":"2.0","id":24,"method":"tools/list","params":{}}"#),
+                Some(&no_cluster),
+            ))
+            .await
+            .unwrap();
+        let zero_body = to_bytes(zero.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        let zero_value: serde_json::Value = serde_json::from_slice(&zero_body).unwrap();
+        assert_eq!(zero_value["result"]["tools"].as_array().unwrap().len(), 0);
+
+        let denied = token_with_claims(REQUIRED_WRITE_SCOPE, Vec::new(), vec!["cluster-a"]);
+        let denied_call = router
+            .clone()
+            .oneshot(request(
+                "/mcp",
+                Body::from(r#"{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{"name":"rocketmq_upsert_topic","arguments":{"cluster":"cluster-a","unknown":true}}}"#),
+                Some(&denied),
+            ))
+            .await
+            .unwrap();
+        let denied_body = to_bytes(denied_call.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        let denied_value: serde_json::Value = serde_json::from_slice(&denied_body).unwrap();
+        assert_eq!(denied_value["result"]["structuredContent"]["code"], "permission_denied");
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 0);
+
+        let denied_envelope = denied_value["result"]["structuredContent"].clone();
+        for (index, arguments) in [
+            serde_json::json!({}),
+            serde_json::json!({"cluster": null}),
+            serde_json::json!({"cluster": 7}),
+            serde_json::json!({"cluster": ""}),
+            serde_json::json!({"cluster": "cluster-a", "unknown": true}),
+            serde_json::json!({"cluster": "cluster-a", "topic": null}),
+            serde_json::json!({"cluster": "cluster-a", "topic": "x".repeat(512)}),
+            serde_json::json!({"cluster": "cluster-a", "topic": "orders\nignore"}),
+            serde_json::json!({"cluster": "cluster-a", "topic": "<tool>ignore</tool>"}),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 30 + index,
+                "method": "tools/call",
+                "params": {
+                    "name": crate::tools::UPSERT_TOPIC_TOOL,
+                    "arguments": arguments,
+                }
+            });
+            let response = router
+                .clone()
+                .oneshot(request("/mcp", Body::from(body.to_string()), Some(&denied)))
+                .await
+                .unwrap();
+            let body = to_bytes(response.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(value["result"]["structuredContent"], denied_envelope);
+        }
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 0);
+
+        let call = router
+            .clone()
+            .oneshot(request(
+                "/mcp",
+                Body::from(format!(
+                    r#"{{"jsonrpc":"2.0","id":22,"method":"tools/call","params":{{"name":"rocketmq_upsert_topic","arguments":{{"schema_version":"{}","cluster":"cluster-a","topic":"orders","broker_names":["broker-a"],"read_queue_nums":8,"write_queue_nums":8,"perm":6,"order":false,"message_type":"NORMAL"}}}}}}"#,
+                    crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION
+                )),
+                Some(&both),
+            ))
+            .await
+            .unwrap();
+        let call_body = to_bytes(call.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&call_body).unwrap();
+        assert_eq!(value["result"]["isError"], false);
+        assert_eq!(
+            value["result"]["structuredContent"]["schema_version"],
+            crate::tools::MUTATION_RESULT_SCHEMA_VERSION
+        );
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        let group_call = router
+            .clone()
+            .oneshot(request(
+                "/mcp",
+                Body::from(format!(
+                    r#"{{"jsonrpc":"2.0","id":25,"method":"tools/call","params":{{"name":"rocketmq_upsert_consumer_group","arguments":{{"schema_version":"{}","cluster":"cluster-a","consumer_group":"orders_consumers","broker_names":["broker-a"],"consume_enable":true,"consume_from_min_enable":false,"consume_broadcast_enable":false,"consume_message_orderly":false,"retry_queue_nums":1,"retry_max_times":16,"broker_id":0,"which_broker_when_consume_slowly":1,"notify_consumer_ids_changed_enable":true,"group_sys_flag":0,"consume_timeout_minute":15}}}}}}"#,
+                    crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION
+                )),
+                Some(&both),
+            ))
+            .await
+            .unwrap();
+        let group_body = to_bytes(group_call.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        let group_value: serde_json::Value = serde_json::from_slice(&group_body).unwrap();
+        assert_eq!(group_value["result"]["isError"], false);
+        assert_eq!(
+            group_value["result"]["structuredContent"]["operation"],
+            "consumer_group_upsert"
+        );
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(counters.preflights.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(counters.executes.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(counters.shutdowns.load(std::sync::atomic::Ordering::SeqCst), 2);
+
+        let execute_topic = router
+            .clone()
+            .oneshot(request(
+                "/mcp",
+                Body::from(format!(
+                    r#"{{"jsonrpc":"2.0","id":26,"method":"tools/call","params":{{"name":"rocketmq_upsert_topic","arguments":{{"schema_version":"{}","cluster":"cluster-a","topic":"orders","broker_names":["broker-a"],"read_queue_nums":8,"write_queue_nums":8,"perm":6,"order":false,"message_type":"NORMAL","dry_run":false,"confirm":true,"reason":"approved rollout"}}}}}}"#,
+                    crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION
+                )),
+                Some(&both),
+            ))
+            .await
+            .unwrap();
+        let execute_topic_body = to_bytes(execute_topic.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        let execute_topic_value: serde_json::Value = serde_json::from_slice(&execute_topic_body).unwrap();
+        assert_eq!(execute_topic_value["result"]["isError"], false);
+        assert_eq!(execute_topic_value["result"]["structuredContent"]["status"], "applied");
+        assert_eq!(
+            execute_topic_value["result"]["structuredContent"]["targets"][0]["target"]["broker_name"],
+            "broker-a"
+        );
+
+        let execute_group = router
+            .oneshot(request(
+                "/mcp",
+                Body::from(format!(
+                    r#"{{"jsonrpc":"2.0","id":27,"method":"tools/call","params":{{"name":"rocketmq_upsert_consumer_group","arguments":{{"schema_version":"{}","cluster":"cluster-a","consumer_group":"orders_consumers","broker_names":["broker-a"],"consume_enable":true,"consume_from_min_enable":false,"consume_broadcast_enable":false,"consume_message_orderly":false,"retry_queue_nums":1,"retry_max_times":16,"broker_id":0,"which_broker_when_consume_slowly":1,"notify_consumer_ids_changed_enable":true,"group_sys_flag":0,"consume_timeout_minute":15,"dry_run":false,"confirm":true,"reason":"approved rollout"}}}}}}"#,
+                    crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION
+                )),
+                Some(&both),
+            ))
+            .await
+            .unwrap();
+        let execute_group_body = to_bytes(execute_group.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        let execute_group_value: serde_json::Value = serde_json::from_slice(&execute_group_body).unwrap();
+        assert_eq!(execute_group_value["result"]["isError"], false);
+        assert_eq!(execute_group_value["result"]["structuredContent"]["status"], "applied");
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 4);
+        assert_eq!(counters.preflights.load(std::sync::atomic::Ordering::SeqCst), 6);
+        assert_eq!(counters.executes.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(std::sync::atomic::Ordering::SeqCst), 4);
+    }
+
+    #[cfg(feature = "write-tools")]
+    #[tokio::test]
+    async fn authenticated_upserts_preserve_complete_contract_for_dry_run_execute_and_cache_hit() {
+        let (router, counters, sink) = write_router().await;
+        let token = token_with_claims(
+            REQUIRED_WRITE_SCOPE,
+            vec!["topic_upsert", "consumer_group_upsert"],
+            vec!["cluster-a"],
+        );
+
+        let topic_requested = serde_json::json!({
+            "read_queue_nums": 8,
+            "write_queue_nums": 8,
+            "perm": 6,
+            "order": false,
+            "message_type": "NORMAL"
+        });
+        let topic_dry_arguments = topic_arguments("orders", vec!["broker-b".to_owned(), "broker-a".to_owned()]);
+        let topic_dry = authenticated_tool_call(
+            &router,
+            &token,
+            300,
+            crate::tools::UPSERT_TOPIC_TOOL,
+            topic_dry_arguments.clone(),
+        )
+        .await;
+        assert_eq!(
+            topic_dry["result"]["structuredContent"],
+            expected_upsert_response("topic_upsert", "topic", "orders", topic_requested.clone(), false)
+        );
+        let mut topic_execute_arguments = topic_dry_arguments;
+        let topic_object = topic_execute_arguments.as_object_mut().unwrap();
+        topic_object.insert("dry_run".to_owned(), serde_json::json!(false));
+        topic_object.insert("confirm".to_owned(), serde_json::json!(true));
+        topic_object.insert("reason".to_owned(), serde_json::json!("approved topic rollout"));
+        topic_object.insert("request_key".to_owned(), serde_json::json!("topic-request-0001"));
+        let topic_execute = authenticated_tool_call(
+            &router,
+            &token,
+            301,
+            crate::tools::UPSERT_TOPIC_TOOL,
+            topic_execute_arguments.clone(),
+        )
+        .await;
+        let expected_topic_execute = expected_upsert_response("topic_upsert", "topic", "orders", topic_requested, true);
+        assert_eq!(topic_execute["result"]["structuredContent"], expected_topic_execute);
+        let topic_cache_hit = authenticated_tool_call(
+            &router,
+            &token,
+            302,
+            crate::tools::UPSERT_TOPIC_TOOL,
+            topic_execute_arguments,
+        )
+        .await;
+        assert_eq!(topic_cache_hit["result"]["structuredContent"], expected_topic_execute);
+
+        let group_requested = serde_json::json!({
+            "consume_enable": true,
+            "consume_from_min_enable": false,
+            "consume_broadcast_enable": false,
+            "consume_message_orderly": false,
+            "retry_queue_nums": 1,
+            "retry_max_times": 16,
+            "broker_id": 0,
+            "which_broker_when_consume_slowly": 1,
+            "notify_consumer_ids_changed_enable": true,
+            "group_sys_flag": 0,
+            "consume_timeout_minute": 15
+        });
+        let group_dry_arguments =
+            consumer_group_arguments("orders_consumers", vec!["broker-b".to_owned(), "broker-a".to_owned()]);
+        let group_dry = authenticated_tool_call(
+            &router,
+            &token,
+            303,
+            crate::tools::UPSERT_CONSUMER_GROUP_TOOL,
+            group_dry_arguments.clone(),
+        )
+        .await;
+        assert_eq!(
+            group_dry["result"]["structuredContent"],
+            expected_upsert_response(
+                "consumer_group_upsert",
+                "consumer_group",
+                "orders_consumers",
+                group_requested.clone(),
+                false,
+            )
+        );
+        let mut group_execute_arguments = group_dry_arguments;
+        let group_object = group_execute_arguments.as_object_mut().unwrap();
+        group_object.insert("dry_run".to_owned(), serde_json::json!(false));
+        group_object.insert("confirm".to_owned(), serde_json::json!(true));
+        group_object.insert("reason".to_owned(), serde_json::json!("approved group rollout"));
+        group_object.insert("request_key".to_owned(), serde_json::json!("group-request-0001"));
+        let group_execute = authenticated_tool_call(
+            &router,
+            &token,
+            304,
+            crate::tools::UPSERT_CONSUMER_GROUP_TOOL,
+            group_execute_arguments.clone(),
+        )
+        .await;
+        let expected_group_execute = expected_upsert_response(
+            "consumer_group_upsert",
+            "consumer_group",
+            "orders_consumers",
+            group_requested,
+            true,
+        );
+        assert_eq!(group_execute["result"]["structuredContent"], expected_group_execute);
+        let group_cache_hit = authenticated_tool_call(
+            &router,
+            &token,
+            305,
+            crate::tools::UPSERT_CONSUMER_GROUP_TOOL,
+            group_execute_arguments,
+        )
+        .await;
+        assert_eq!(group_cache_hit["result"]["structuredContent"], expected_group_execute);
+
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 4);
+        assert_eq!(counters.preflights.load(std::sync::atomic::Ordering::SeqCst), 6);
+        assert_eq!(counters.executes.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(counters.shutdowns.load(std::sync::atomic::Ordering::SeqCst), 4);
+        assert_eq!(sink.records().await.unwrap().len(), 12);
+    }
+
+    #[cfg(feature = "write-tools")]
+    #[tokio::test]
+    async fn authenticated_closed_name_and_target_limits_run_before_audit_and_session() {
+        let (router, counters, sink) = write_router().await;
+        let token = token_with_claims(REQUIRED_WRITE_SCOPE, vec!["topic_upsert"], vec!["cluster-a"]);
+        let system_topics = [
+            "TBW102",
+            "SCHEDULE_TOPIC_XXXX",
+            "BenchmarkTest",
+            "RMQ_SYS_TRANS_HALF_TOPIC",
+            "RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC",
+            "RMQ_SYS_TRACE_TOPIC",
+            "RMQ_SYS_TRANS_OP_HALF_TOPIC",
+            "RMQ_SYS_ROCKSDB_TRANS_OP_HALF_TOPIC",
+            "TRANS_CHECK_MAX_TIME_TOPIC",
+            "SELF_TEST_TOPIC",
+            "OFFSET_MOVED_EVENT",
+            "CHECKPOINT_TOPIC",
+        ];
+        let mut invalid = system_topics
+            .into_iter()
+            .map(|topic| topic_arguments(topic, vec!["broker-a".to_owned()]))
+            .collect::<Vec<_>>();
+        invalid.extend([
+            topic_arguments(&"a".repeat(128), vec!["broker-a".to_owned()]),
+            topic_arguments("10.0.0.1", vec!["broker-a".to_owned()]),
+            topic_arguments("10%2e0%2e0%2e1", vec!["broker-a".to_owned()]),
+            topic_arguments("token=secret", vec!["broker-a".to_owned()]),
+            topic_arguments("token%3dsecret", vec!["broker-a".to_owned()]),
+            topic_arguments("orders", vec!["broker-a".to_owned(), "broker-a".to_owned()]),
+            topic_arguments("orders", vec!["10.0.0.1".to_owned()]),
+            topic_arguments("orders", vec!["token%3dsecret".to_owned()]),
+            topic_arguments("orders", (0..65).map(|index| format!("broker-{index:02}")).collect()),
+        ]);
+        for (index, arguments) in invalid.into_iter().enumerate() {
+            let body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 100 + index,
+                "method": "tools/call",
+                "params": {"name": crate::tools::UPSERT_TOPIC_TOOL, "arguments": arguments}
+            });
+            let response = router
+                .clone()
+                .oneshot(request("/mcp", Body::from(body.to_string()), Some(&token)))
+                .await
+                .unwrap();
+            let bytes = to_bytes(response.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(
+                value["result"]["structuredContent"]["code"], "invalid_arguments",
+                "case {index}"
+            );
+        }
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(counters.preflights.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(counters.executes.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(sink.records().await.unwrap().is_empty());
+
+        let group_token = token_with_claims(REQUIRED_WRITE_SCOPE, vec!["consumer_group_upsert"], vec!["cluster-a"]);
+        for (index, consumer_group) in [
+            "DEFAULT_CONSUMER",
+            "TOOLS_CONSUMER",
+            "SCHEDULE_CONSUMER",
+            "FILTERSRV_CONSUMER",
+            "__MONITOR_CONSUMER",
+            "SELF_TEST_C_GROUP",
+            "CID_ONS-HTTP-PROXY",
+            "CID_ONSAPI_PULL",
+            "CID_ONSAPI_PERMISSION",
+            "CID_ONSAPI_OWNER",
+            "CID_RMQ_SYS_TRANS",
+            "CID_RMQ_SYS_INTERNAL",
+            "CID_DefaultHeartBeatSyncerTopic",
+            "%SYS%INTERNAL",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 150 + index,
+                "method": "tools/call",
+                "params": {
+                    "name": crate::tools::UPSERT_CONSUMER_GROUP_TOOL,
+                    "arguments": consumer_group_arguments(consumer_group, vec!["broker-a".to_owned()])
+                }
+            });
+            let response = router
+                .clone()
+                .oneshot(request("/mcp", Body::from(body.to_string()), Some(&group_token)))
+                .await
+                .unwrap();
+            let bytes = to_bytes(response.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(
+                value["result"]["structuredContent"]["code"], "invalid_arguments",
+                "protected group case {index}"
+            );
+        }
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(counters.preflights.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(counters.executes.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(sink.records().await.unwrap().is_empty());
+
+        for (index, arguments) in [
+            topic_arguments(&"a".repeat(127), vec!["broker-a".to_owned()]),
+            topic_arguments("orders", (0..64).map(|item| format!("broker-{item:02}")).collect()),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 200 + index,
+                "method": "tools/call",
+                "params": {"name": crate::tools::UPSERT_TOPIC_TOOL, "arguments": arguments}
+            });
+            let response = router
+                .clone()
+                .oneshot(request("/mcp", Body::from(body.to_string()), Some(&token)))
+                .await
+                .unwrap();
+            let bytes = to_bytes(response.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(value["result"]["isError"], false);
+        }
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(counters.executes.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(counters.shutdowns.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(sink.records().await.unwrap().len(), 4);
     }
 
     #[tokio::test(start_paused = true)]

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl/mutation_api.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl/mutation_api.rs
@@ -1350,6 +1350,19 @@ impl MQAdminMutationExt for DefaultMQAdminExtImpl {
         .await
     }
 
+    async fn mutation_order_topic_config(
+        &self,
+        topic: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<Option<CheetahString>> {
+        self.mq_client_api()?
+            .get_kvconfig_value(
+                CheetahString::from_static_str(NAMESPACE_ORDER_TOPIC_CONFIG),
+                topic,
+                self.remoting_timeout_millis()?,
+            )
+            .await
+    }
+
     async fn delete_order_topic_config(&self, topic: CheetahString) -> rocketmq_error::RocketMQResult<()> {
         self.mq_client_api()?
             .delete_kvconfig_value(
@@ -1447,6 +1460,8 @@ mod detailed_offset_tests {
     use rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats;
     use rocketmq_protocol::protocol::admin::offset_wrapper::OffsetWrapper;
     use rocketmq_protocol::protocol::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
+    use rocketmq_protocol::protocol::header::namesrv::kv_config_header::GetKVConfigRequestHeader;
+    use rocketmq_protocol::protocol::header::namesrv::kv_config_header::GetKVConfigResponseHeader;
     use rocketmq_protocol::protocol::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
     use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
     use rocketmq_protocol::RemotingCommand;
@@ -1468,6 +1483,7 @@ mod detailed_offset_tests {
     struct ScriptedRequestLedger {
         responses: Mutex<HashMap<i32, VecDeque<RemotingCommand>>>,
         counts: Mutex<HashMap<i32, usize>>,
+        kv_reads: Mutex<Vec<(String, String)>>,
     }
 
     impl ScriptedRequestLedger {
@@ -1483,6 +1499,10 @@ mod detailed_offset_tests {
         fn snapshot(&self) -> HashMap<i32, usize> {
             self.counts.lock().expect("request counts").clone()
         }
+
+        fn kv_reads(&self) -> Vec<(String, String)> {
+            self.kv_reads.lock().expect("KV reads").clone()
+        }
     }
 
     impl SessionProcessor for ScriptedRequestLedger {
@@ -1491,6 +1511,13 @@ mod detailed_offset_tests {
             request: RemotingCommand,
         ) -> Pin<Box<dyn Future<Output = rocketmq_error::RocketMQResult<RemotingCommand>> + Send + '_>> {
             Box::pin(async move {
+                if request.code() == RequestCode::GetKvConfig.to_i32() {
+                    let header = request.decode_command_custom_header::<GetKVConfigRequestHeader>()?;
+                    self.kv_reads
+                        .lock()
+                        .expect("KV reads")
+                        .push((header.namespace.to_string(), header.key.to_string()));
+                }
                 *self
                     .counts
                     .lock()
@@ -1656,6 +1683,53 @@ mod detailed_offset_tests {
         );
         response.make_custom_header_to_net();
         response
+    }
+
+    #[tokio::test]
+    async fn production_admin_reads_the_exact_order_topic_value_without_merging() {
+        let harness = ProductionAdminHarness::new("order-topic-exact-read-test").await;
+        harness
+            .client_instance
+            .get_mq_client_api_impl()
+            .expect("client API")
+            .update_name_server_address_list_sync(harness.broker_addr.as_str());
+        let exact = "broker-a:8;broker-z:4";
+        let mut found = RemotingCommand::create_response_command_with_code_and_header(
+            ResponseCode::Success,
+            GetKVConfigResponseHeader::new(Some(exact.into())),
+        );
+        found.make_custom_header_to_net();
+        harness.ledger.push(RequestCode::GetKvConfig, found);
+        let before = harness.ledger.snapshot();
+        let value =
+            MQAdminMutationExt::mutation_order_topic_config(&harness.admin, CheetahString::from_static_str("orders"))
+                .await
+                .expect("exact order Topic read");
+        assert_eq!(value.as_deref(), Some(exact));
+        let after = harness.ledger.snapshot();
+        assert_request_delta(&before, &after, &[(RequestCode::GetKvConfig, 1)]);
+        assert_eq!(
+            harness.ledger.kv_reads(),
+            vec![(NAMESPACE_ORDER_TOPIC_CONFIG.to_owned(), "orders".to_owned())]
+        );
+
+        harness.ledger.push(
+            RequestCode::GetKvConfig,
+            RemotingCommand::create_response_command_with_code(ResponseCode::QueryNotFound),
+        );
+        let missing =
+            MQAdminMutationExt::mutation_order_topic_config(&harness.admin, CheetahString::from_static_str("missing"))
+                .await
+                .expect("missing exact order Topic read");
+        assert_eq!(missing, None);
+        assert_eq!(
+            harness.ledger.kv_reads(),
+            vec![
+                (NAMESPACE_ORDER_TOPIC_CONFIG.to_owned(), "orders".to_owned()),
+                (NAMESPACE_ORDER_TOPIC_CONFIG.to_owned(), "missing".to_owned()),
+            ]
+        );
+        harness.shutdown().await;
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/admin/mq_admin_mutation_ext.rs
+++ b/rocketmq-client/src/admin/mq_admin_mutation_ext.rs
@@ -676,6 +676,17 @@ pub trait MQAdminMutationExt: Send {
         cluster_wide: bool,
     ) -> rocketmq_error::RocketMQResult<()>;
 
+    /// Reads the exact NameServer-wide order-topic value used by a supervised mutation guard.
+    async fn mutation_order_topic_config(
+        &self,
+        topic: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<Option<CheetahString>> {
+        let _ = topic;
+        Err(rocketmq_error::RocketMQError::illegal_argument(
+            "order Topic mutation preflight is not implemented by this admin client",
+        ))
+    }
+
     /// Deletes the global order-topic entry after an unordered update or a
     /// complete Topic deletion.
     async fn delete_order_topic_config(&self, topic: CheetahString) -> rocketmq_error::RocketMQResult<()> {
@@ -1124,6 +1135,13 @@ impl MQAdminMutationExt for DefaultMQAdminExt {
         cluster_wide: bool,
     ) -> rocketmq_error::RocketMQResult<()> {
         MQAdminMutationExt::upsert_order_topic_config(self.inner(), topic, value, cluster_wide).await
+    }
+
+    async fn mutation_order_topic_config(
+        &self,
+        topic: CheetahString,
+    ) -> rocketmq_error::RocketMQResult<Option<CheetahString>> {
+        MQAdminMutationExt::mutation_order_topic_config(self.inner(), topic).await
     }
 
     async fn delete_order_topic_config(&self, topic: CheetahString) -> rocketmq_error::RocketMQResult<()> {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
@@ -713,7 +713,7 @@ fn first_address(value: Option<&str>) -> Option<CheetahString> {
 }
 
 fn classify_consumer_group(group: &str, meta: &ConsumerGroupMeta) -> String {
-    if is_system_consumer_group(group) {
+    if is_protected_consumer_group(group) {
         "SYSTEM".to_string()
     } else if !meta.orderly_flags.is_empty() && meta.orderly_flags.iter().all(|flag| *flag) {
         "FIFO".to_string()
@@ -722,8 +722,8 @@ fn classify_consumer_group(group: &str, meta: &ConsumerGroupMeta) -> String {
     }
 }
 
-fn is_system_consumer_group(group: &str) -> bool {
-    consumer::is_system_consumer_group(group)
+fn is_protected_consumer_group(group: &str) -> bool {
+    consumer::is_protected_consumer_group(group)
 }
 
 fn collect_master_broker_targets(cluster_info: &ClusterInfo) -> Vec<(String, CheetahString)> {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/workspace.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/workspace.rs
@@ -71,7 +71,7 @@ impl ConsumerWorkspaceAdmin for AdminSession {
             let mut failures = discovery.failures;
             let mut items = Vec::with_capacity(discovery.groups.len());
             for (group, meta) in &discovery.groups {
-                if request.skip_system_groups && crate::core::consumer::is_system_consumer_group(group) {
+                if request.skip_system_groups && crate::core::consumer::is_protected_consumer_group(group) {
                     continue;
                 }
                 let connection = observe_group_connection(&self.inner, group, forwarded_address.clone()).await;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/dashboard.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/dashboard.rs
@@ -42,7 +42,7 @@ use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::subscription::subscription_group_config::validate_subscription_group_name;
 
 use crate::client_adapter::lifecycle::AdminSession;
-use crate::core::consumer::is_system_consumer_group;
+use crate::core::consumer::is_protected_consumer_group;
 use crate::core::dashboard;
 use crate::core::AdminError;
 use crate::core::AdminFuture;
@@ -332,7 +332,7 @@ impl dashboard::DashboardAdmin for AdminSession {
         Box::pin(async move {
             self.ensure_open()?;
             let group = group.trim();
-            if group.is_empty() || group.starts_with("%SYS%") || is_system_consumer_group(group) {
+            if group.is_empty() || is_protected_consumer_group(group) {
                 return Err(AdminError::invalid_argument(
                     "consumerGroup",
                     "System consumer groups cannot be inspected for deletion.",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/mutation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/mutation.rs
@@ -1754,6 +1754,60 @@ fn master_targets_by_cluster_name(
     Ok(targets)
 }
 
+/// Creates the isolated client runtime used by mutation-only applications.
+///
+/// This constructor keeps telemetry and the concrete client dependency behind
+/// the mutation adapter boundary.
+///
+/// # Errors
+///
+/// Returns an administration error when the bounded client runtime cannot be
+/// initialized from the supplied lifecycle context.
+pub fn create_mutation_client_runtime(
+    service_context: rocketmq_runtime::ChildServiceContext,
+) -> AdminResult<Arc<ClientRuntime>> {
+    ClientRuntime::try_new(
+        service_context,
+        ClientRuntimeConfig::default(),
+        rocketmq_observability::TelemetryHandle::noop(),
+    )
+    .map_err(|_| AdminError::backend("mutation_client_runtime", "client runtime initialization failed"))
+}
+
+fn select_metadata_targets(
+    all_targets: Vec<(String, CheetahString)>,
+    selected_broker_names: Option<&[String]>,
+) -> AdminResult<Vec<(String, CheetahString)>> {
+    let Some(selected_broker_names) = selected_broker_names else {
+        return Ok(all_targets);
+    };
+    if selected_broker_names.is_empty() || selected_broker_names.len() > MAX_METADATA_MUTATION_TARGETS {
+        return Err(AdminError::invalid_argument(
+            "brokerNames",
+            format!("must contain between 1 and {MAX_METADATA_MUTATION_TARGETS} broker names"),
+        ));
+    }
+    let selected = selected_broker_names.iter().collect::<HashSet<_>>();
+    if selected.len() != selected_broker_names.len() {
+        return Err(AdminError::invalid_argument(
+            "brokerNames",
+            "must not contain duplicates",
+        ));
+    }
+    let mut targets = all_targets
+        .into_iter()
+        .filter(|(broker_name, _)| selected.contains(broker_name))
+        .collect::<Vec<_>>();
+    if targets.len() != selected.len() {
+        return Err(AdminError::invalid_argument(
+            "brokerNames",
+            "contains a broker outside the selected cluster master topology",
+        ));
+    }
+    targets.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(targets)
+}
+
 fn build_order_conf(broker_names: &HashSet<String>, write_queue_nums: u32) -> String {
     let mut broker_names = broker_names.iter().cloned().collect::<Vec<_>>();
     broker_names.sort();

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/mutation/supervised.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/mutation/supervised.rs
@@ -15,6 +15,8 @@
 //! Supervised, preflight-bound mutation adapter operations.
 
 use super::*;
+use std::collections::BTreeMap;
+
 impl SupervisedMutationAdmin for MutationAdminSession {
     fn preflight_topic<'a>(
         &'a mut self,
@@ -23,6 +25,18 @@ impl SupervisedMutationAdmin for MutationAdminSession {
         Box::pin(async move {
             self.inner.ensure_open()?;
             preflight_topic_with_admin(&self.inner.inner, Arc::clone(&self.plan_seal), request).await
+        })
+    }
+
+    fn preflight_topic_targets<'a>(
+        &'a mut self,
+        request: &'a TopicMutationPreflightRequest,
+        broker_names: &'a [String],
+    ) -> AdminFuture<'a, TopicMutationPlan> {
+        Box::pin(async move {
+            self.inner.ensure_open()?;
+            preflight_topic_targets_with_admin(&self.inner.inner, Arc::clone(&self.plan_seal), request, broker_names)
+                .await
         })
     }
 
@@ -40,6 +54,23 @@ impl SupervisedMutationAdmin for MutationAdminSession {
         Box::pin(async move {
             self.inner.ensure_open()?;
             preflight_subscription_group_with_admin(&self.inner.inner, Arc::clone(&self.plan_seal), request).await
+        })
+    }
+
+    fn preflight_subscription_group_targets<'a>(
+        &'a mut self,
+        request: &'a SubscriptionGroupMutationPreflightRequest,
+        broker_names: &'a [String],
+    ) -> AdminFuture<'a, SubscriptionGroupMutationPlan> {
+        Box::pin(async move {
+            self.inner.ensure_open()?;
+            preflight_subscription_group_targets_with_admin(
+                &self.inner.inner,
+                Arc::clone(&self.plan_seal),
+                request,
+                broker_names,
+            )
+            .await
         })
     }
 
@@ -178,6 +209,24 @@ async fn preflight_topic_with_admin<A: MQAdminMutationExt + ?Sized>(
     seal: Arc<MutationPlanSeal>,
     request: &TopicMutationPreflightRequest,
 ) -> AdminResult<TopicMutationPlan> {
+    preflight_topic_with_targets(admin, seal, request, None).await
+}
+
+async fn preflight_topic_targets_with_admin<A: MQAdminMutationExt + ?Sized>(
+    admin: &A,
+    seal: Arc<MutationPlanSeal>,
+    request: &TopicMutationPreflightRequest,
+    broker_names: &[String],
+) -> AdminResult<TopicMutationPlan> {
+    preflight_topic_with_targets(admin, seal, request, Some(broker_names)).await
+}
+
+async fn preflight_topic_with_targets<A: MQAdminMutationExt + ?Sized>(
+    admin: &A,
+    seal: Arc<MutationPlanSeal>,
+    request: &TopicMutationPreflightRequest,
+    broker_names: Option<&[String]>,
+) -> AdminResult<TopicMutationPlan> {
     let cluster = require_non_empty("cluster", &request.cluster)?.to_owned();
     let topic = validate_supervised_topic(&request.topic)?;
     validate_topic_replacement(&request.replacement)?;
@@ -187,7 +236,24 @@ async fn preflight_topic_with_admin<A: MQAdminMutationExt + ?Sized>(
         .map_err(|error| backend_error("mutation_cluster_info", error))?;
     let mut targets = Vec::new();
     let mut failures = Vec::new();
-    for (broker_name, broker_addr) in master_targets_by_cluster_name(&cluster_info, &cluster)? {
+    let master_targets = master_targets_by_cluster_name(&cluster_info, &cluster)?;
+    let master_targets = select_metadata_targets(master_targets, broker_names)?;
+    let targeted_order_guard = if broker_names.is_some() {
+        let current = admin
+            .mutation_order_topic_config(topic.clone().into())
+            .await
+            .map_err(|error| backend_error("mutation_order_topic_config", error))?;
+        let expected = parse_order_topic_config(current.as_deref())?;
+        validate_targeted_order_state(
+            &expected,
+            master_targets.iter().map(|(broker_name, _)| broker_name.as_str()),
+            &request.replacement,
+        )?;
+        Some(TargetedTopicOrderGuard { expected })
+    } else {
+        None
+    };
+    for (broker_name, broker_addr) in master_targets {
         match admin
             .mutation_topic_config_state(broker_addr.clone(), topic.clone().into())
             .await
@@ -208,6 +274,7 @@ async fn preflight_topic_with_admin<A: MQAdminMutationExt + ?Sized>(
         replacement: request.replacement.clone(),
         targets,
         failures,
+        targeted_order_guard,
     })
 }
 
@@ -217,6 +284,16 @@ async fn execute_topic_checked<A: MQAdminMutationExt + ?Sized>(
     plan: &TopicMutationPlan,
 ) -> AdminResult<MetadataMutationOutcome> {
     ensure_same_plan_seal(session_seal, &plan.seal)?;
+    if let Some(guard) = &plan.targeted_order_guard {
+        let current = admin
+            .mutation_order_topic_config(plan.topic.as_str().into())
+            .await
+            .map_err(|error| backend_error("mutation_order_topic_config", error))?;
+        let current = parse_order_topic_config(current.as_deref())?;
+        if current != guard.expected {
+            return Ok(targeted_order_conflict(plan));
+        }
+    }
     let mut outcome = MetadataMutationOutcome {
         failures: plan.failures.clone(),
         ..MetadataMutationOutcome::default()
@@ -270,6 +347,28 @@ async fn execute_topic_checked<A: MQAdminMutationExt + ?Sized>(
             Err(error) => outcome.targets.push(metadata_client_failure(target, &error)),
         }
     }
+    if let Some(guard) = &plan.targeted_order_guard {
+        let postread = admin
+            .mutation_order_topic_config(plan.topic.as_str().into())
+            .await
+            .ok()
+            .and_then(|current| parse_order_topic_config(current.as_deref()).ok());
+        if postread.as_ref() == Some(&guard.expected) {
+            outcome.order_reconciled = Some(true);
+        } else {
+            outcome.order_reconciled = Some(false);
+            for target in &plan.targets {
+                outcome.failures.push(MutationTargetFailure {
+                    broker_name: target.broker_name.clone(),
+                    queue_id: None,
+                    code: MutationFailureCode::OrderReconciliationFailed,
+                    retryable: false,
+                });
+            }
+        }
+        return Ok(outcome);
+    }
+
     let all_applied = !plan.targets.is_empty()
         && outcome.failures.is_empty()
         && outcome.targets.iter().all(|target| {
@@ -312,10 +411,121 @@ async fn execute_topic_checked<A: MQAdminMutationExt + ?Sized>(
     Ok(outcome)
 }
 
+fn parse_order_topic_config(value: Option<&str>) -> AdminResult<Option<BTreeMap<String, u32>>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_empty() {
+        return Err(AdminError::invalid_argument("orderTopicConfig", "must not be empty"));
+    }
+    let mut entries = BTreeMap::new();
+    for entry in value.split(';') {
+        let Some((broker_name, queues)) = entry.split_once(':') else {
+            return Err(AdminError::invalid_argument(
+                "orderTopicConfig",
+                "contains a malformed broker entry",
+            ));
+        };
+        if broker_name.is_empty()
+            || broker_name.len() > 127
+            || !broker_name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'%' | b'|' | b'-' | b'_'))
+            || broker_name
+                .as_bytes()
+                .windows(3)
+                .any(|window| window[0] == b'%' && window[1].is_ascii_hexdigit() && window[2].is_ascii_hexdigit())
+            || queues.is_empty()
+            || (queues.len() > 1 && queues.starts_with('0'))
+        {
+            return Err(AdminError::invalid_argument(
+                "orderTopicConfig",
+                "contains a non-canonical broker entry",
+            ));
+        }
+        let queues = queues
+            .parse::<u32>()
+            .ok()
+            .filter(|queues| *queues > 0)
+            .ok_or_else(|| AdminError::invalid_argument("orderTopicConfig", "contains an invalid queue count"))?;
+        if entries.insert(broker_name.to_owned(), queues).is_some() {
+            return Err(AdminError::invalid_argument(
+                "orderTopicConfig",
+                "contains a duplicate broker entry",
+            ));
+        }
+    }
+    Ok(Some(entries))
+}
+
+fn validate_targeted_order_state<'a>(
+    expected: &Option<BTreeMap<String, u32>>,
+    selected_brokers: impl Iterator<Item = &'a str>,
+    replacement: &TopicReplacement,
+) -> AdminResult<()> {
+    let entries = expected.as_ref();
+    let compatible = if replacement.order {
+        selected_brokers
+            .into_iter()
+            .all(|broker| entries.and_then(|entries| entries.get(broker)) == Some(&replacement.write_queue_nums))
+    } else {
+        selected_brokers
+            .into_iter()
+            .all(|broker| entries.is_none_or(|entries| !entries.contains_key(broker)))
+    };
+    if !compatible {
+        return Err(AdminError::invalid_argument(
+            "orderTopicConfig",
+            "targeted mutation would require a NameServer-wide order configuration write",
+        ));
+    }
+    Ok(())
+}
+
+fn targeted_order_conflict(plan: &TopicMutationPlan) -> MetadataMutationOutcome {
+    MetadataMutationOutcome {
+        targets: plan
+            .targets
+            .iter()
+            .map(|target| MetadataMutationTargetOutcome {
+                broker_name: target.broker_name.clone(),
+                expected_state: target.state,
+                resulting_state: None,
+                applied: false,
+                changed: false,
+                persistence: MutationPersistenceState::NotRequired,
+                verification: MutationVerificationState::NotPerformed,
+                failure: Some(MutationFailureCode::Conflict),
+                retryable: false,
+            })
+            .collect(),
+        failures: Vec::new(),
+        order_reconciled: Some(false),
+    }
+}
+
 async fn preflight_subscription_group_with_admin<A: MQAdminMutationExt + ?Sized>(
     admin: &A,
     seal: Arc<MutationPlanSeal>,
     request: &SubscriptionGroupMutationPreflightRequest,
+) -> AdminResult<SubscriptionGroupMutationPlan> {
+    preflight_subscription_group_with_targets(admin, seal, request, None).await
+}
+
+async fn preflight_subscription_group_targets_with_admin<A: MQAdminMutationExt + ?Sized>(
+    admin: &A,
+    seal: Arc<MutationPlanSeal>,
+    request: &SubscriptionGroupMutationPreflightRequest,
+    broker_names: &[String],
+) -> AdminResult<SubscriptionGroupMutationPlan> {
+    preflight_subscription_group_with_targets(admin, seal, request, Some(broker_names)).await
+}
+
+async fn preflight_subscription_group_with_targets<A: MQAdminMutationExt + ?Sized>(
+    admin: &A,
+    seal: Arc<MutationPlanSeal>,
+    request: &SubscriptionGroupMutationPreflightRequest,
+    broker_names: Option<&[String]>,
 ) -> AdminResult<SubscriptionGroupMutationPlan> {
     let cluster = require_non_empty("cluster", &request.cluster)?.to_owned();
     let group = validate_supervised_group(&request.consumer_group)?;
@@ -326,7 +536,9 @@ async fn preflight_subscription_group_with_admin<A: MQAdminMutationExt + ?Sized>
         .map_err(|error| backend_error("mutation_cluster_info", error))?;
     let mut targets = Vec::new();
     let mut failures = Vec::new();
-    for (broker_name, broker_addr) in master_targets_by_cluster_name(&cluster_info, &cluster)? {
+    let master_targets = master_targets_by_cluster_name(&cluster_info, &cluster)?;
+    let master_targets = select_metadata_targets(master_targets, broker_names)?;
+    for (broker_name, broker_addr) in master_targets {
         match admin
             .mutation_subscription_group_config_state(broker_addr.clone(), group.clone().into())
             .await
@@ -865,7 +1077,7 @@ fn validate_supervised_group(group: &str) -> AdminResult<String> {
     let group = require_non_empty("consumerGroup", group)?;
     rocketmq_protocol::protocol::subscription::subscription_group_config::validate_subscription_group_name(group)
         .map_err(|error| AdminError::invalid_argument("consumerGroup", error.to_string()))?;
-    if rocketmq_model::common::mix_all::is_sys_consumer_group(group) {
+    if crate::core::consumer::is_protected_consumer_group(group) {
         return Err(AdminError::invalid_argument(
             "consumerGroup",
             "must not be a system consumer group",
@@ -1132,6 +1344,9 @@ mod tests {
         group_writes: AtomicUsize,
         group_persistence: Mutex<ClientMutationPersistenceState>,
         group_dirty: AtomicBool,
+        order_config: Mutex<Option<CheetahString>>,
+        order_after_topic_write: Mutex<Option<CheetahString>>,
+        order_reads: AtomicUsize,
         order_writes: AtomicUsize,
     }
 
@@ -1215,6 +1430,9 @@ mod tests {
                 group_writes: AtomicUsize::new(0),
                 group_persistence: Mutex::new(ClientMutationPersistenceState::Persisted),
                 group_dirty: AtomicBool::new(false),
+                order_config: Mutex::new(None),
+                order_after_topic_write: Mutex::new(None),
+                order_reads: AtomicUsize::new(0),
                 order_writes: AtomicUsize::new(0),
             }
         }
@@ -1432,6 +1650,14 @@ mod tests {
             Ok(())
         }
 
+        async fn mutation_order_topic_config(
+            &self,
+            _topic: CheetahString,
+        ) -> rocketmq_error::RocketMQResult<Option<CheetahString>> {
+            self.order_reads.fetch_add(1, Ordering::SeqCst);
+            Ok(self.order_config.lock().expect("order config").clone())
+        }
+
         async fn delete_order_topic_config(&self, _topic: CheetahString) -> rocketmq_error::RocketMQResult<()> {
             self.order_writes.fetch_add(1, Ordering::SeqCst);
             Ok(())
@@ -1555,6 +1781,14 @@ mod tests {
             };
             if persistence == ClientMutationPersistenceState::Failed {
                 self.topic_dirty.store(true, Ordering::SeqCst);
+            }
+            if let Some(order) = self
+                .order_after_topic_write
+                .lock()
+                .expect("order after Topic write")
+                .take()
+            {
+                *self.order_config.lock().expect("order config") = Some(order);
             }
             Ok(rocketmq_client_rust::MutationStateCasOutcome {
                 applied: true,
@@ -1895,6 +2129,223 @@ mod tests {
         );
         assert!(calls.iter().all(|(_, endpoint)| endpoint == "10.0.0.1:10911"));
         assert!(calls.iter().all(|(_, endpoint)| endpoint != "10.0.0.1:10912"));
+    }
+
+    #[tokio::test]
+    async fn targeted_metadata_preflight_is_sorted_and_rejects_invalid_selection_before_state_rpc() {
+        let fake = CountingMutationAdmin::with_queue_counts(&[1, 1, 1]);
+        let seal = Arc::new(MutationPlanSeal);
+        let topic_request = TopicMutationPreflightRequest {
+            cluster: "cluster-a".to_owned(),
+            topic: "orders".to_owned(),
+            replacement: TopicReplacement {
+                read_queue_nums: 1,
+                write_queue_nums: 1,
+                perm: 6,
+                order: false,
+                message_type: TopicMessageType::Normal,
+            },
+        };
+        let group_request = SubscriptionGroupMutationPreflightRequest {
+            cluster: "cluster-a".to_owned(),
+            consumer_group: "orders-consumer".to_owned(),
+            replacement: SubscriptionGroupReplacement {
+                consume_enable: true,
+                consume_from_min_enable: false,
+                consume_broadcast_enable: false,
+                consume_message_orderly: false,
+                retry_queue_nums: 1,
+                retry_max_times: 16,
+                broker_id: 0,
+                which_broker_when_consume_slowly: 1,
+                notify_consumer_ids_changed_enable: true,
+                group_sys_flag: 0,
+                consume_timeout_minute: 15,
+            },
+        };
+
+        let topic_plan = preflight_topic_targets_with_admin(
+            &fake,
+            Arc::clone(&seal),
+            &topic_request,
+            &["broker-2".to_owned(), "broker-0".to_owned()],
+        )
+        .await
+        .expect("targeted topic preflight");
+        assert_eq!(
+            topic_plan
+                .preflight_targets()
+                .into_iter()
+                .map(|target| target.broker_name)
+                .collect::<Vec<_>>(),
+            ["broker-0", "broker-2"]
+        );
+        assert_eq!(fake.topic_reads.load(Ordering::SeqCst), 2);
+
+        let group_plan = preflight_subscription_group_targets_with_admin(
+            &fake,
+            Arc::clone(&seal),
+            &group_request,
+            &["broker-1".to_owned()],
+        )
+        .await
+        .expect("targeted group preflight");
+        assert_eq!(group_plan.preflight_targets()[0].broker_name, "broker-1");
+        assert_eq!(fake.group_reads.load(Ordering::SeqCst), 1);
+
+        for invalid in [
+            Vec::new(),
+            vec!["broker-0".to_owned(), "broker-0".to_owned()],
+            vec!["broker-unknown".to_owned()],
+            (0..=MAX_METADATA_MUTATION_TARGETS)
+                .map(|index| format!("broker-{index}"))
+                .collect(),
+        ] {
+            let topic_reads = fake.topic_reads.load(Ordering::SeqCst);
+            let order_reads = fake.order_reads.load(Ordering::SeqCst);
+            assert!(
+                preflight_topic_targets_with_admin(&fake, Arc::clone(&seal), &topic_request, &invalid,)
+                    .await
+                    .is_err()
+            );
+            assert_eq!(fake.topic_reads.load(Ordering::SeqCst), topic_reads);
+            assert_eq!(fake.order_reads.load(Ordering::SeqCst), order_reads);
+        }
+
+        let mut corrupt = CountingMutationAdmin::with_queue_counts(&[1, 1]);
+        corrupt
+            .cluster_info
+            .broker_addr_table
+            .as_mut()
+            .expect("broker table")
+            .insert(
+                CheetahString::from("broker-1"),
+                broker("cluster-a", "broker-1", [(MASTER_ID, "10.0.0.1:10911")]),
+            );
+        assert!(preflight_topic_targets_with_admin(
+            &corrupt,
+            Arc::clone(&seal),
+            &topic_request,
+            &["broker-0".to_owned()],
+        )
+        .await
+        .is_err());
+        assert_eq!(corrupt.topic_reads.load(Ordering::SeqCst), 0);
+        assert_eq!(corrupt.order_reads.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn targeted_topic_order_guard_never_writes_global_kv_and_detects_pre_and_post_races() {
+        let request = |order| TopicMutationPreflightRequest {
+            cluster: "cluster-a".to_owned(),
+            topic: "orders".to_owned(),
+            replacement: TopicReplacement {
+                read_queue_nums: 1,
+                write_queue_nums: 1,
+                perm: 6,
+                order,
+                message_type: TopicMessageType::Normal,
+            },
+        };
+        let selected = ["broker-0".to_owned()];
+        let seal = Arc::new(MutationPlanSeal);
+
+        let mut unordered = CountingMutationAdmin::with_queue_counts(&[1, 1]);
+        unordered
+            .cluster_info
+            .broker_addr_table
+            .as_mut()
+            .expect("broker table")
+            .insert(
+                CheetahString::from_static_str("broker-other"),
+                broker("cluster-b", "broker-other", [(MASTER_ID, "10.0.1.1:10911")]),
+            );
+        unordered
+            .cluster_info
+            .cluster_addr_table
+            .as_mut()
+            .expect("cluster table")
+            .insert(
+                CheetahString::from_static_str("cluster-b"),
+                HashSet::from([CheetahString::from_static_str("broker-other")]),
+            );
+        *unordered.order_config.lock().expect("order config") = Some("broker-other:7;broker-1:9".into());
+        let plan = preflight_topic_targets_with_admin(&unordered, Arc::clone(&seal), &request(false), &selected)
+            .await
+            .expect("unchanged unordered subset");
+        let outcome = execute_topic_checked(&unordered, &seal, &plan)
+            .await
+            .expect("guarded execute");
+        assert_eq!(outcome.order_reconciled, Some(true));
+        assert_eq!(unordered.topic_writes.load(Ordering::SeqCst), 1);
+        assert_eq!(unordered.order_writes.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            unordered.order_config.lock().expect("order config").as_deref(),
+            Some("broker-other:7;broker-1:9")
+        );
+
+        let ordered = CountingMutationAdmin::with_queue_counts(&[1, 1]);
+        *ordered.order_config.lock().expect("order config") = Some("broker-1:9;broker-0:1".into());
+        let plan = preflight_topic_targets_with_admin(&ordered, Arc::clone(&seal), &request(true), &selected)
+            .await
+            .expect("unchanged ordered subset");
+        let outcome = execute_topic_checked(&ordered, &seal, &plan)
+            .await
+            .expect("guarded execute");
+        assert_eq!(outcome.order_reconciled, Some(true));
+        assert_eq!(ordered.order_writes.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            ordered.order_config.lock().expect("order config").as_deref(),
+            Some("broker-1:9;broker-0:1")
+        );
+
+        for invalid in [
+            "broker-0:1;broker-0:1",
+            "broker-0:not-a-number",
+            "broker-0:01",
+            "broker-0:1;",
+            "broker%2d0:1",
+        ] {
+            let fake = CountingMutationAdmin::with_queue_counts(&[1, 1]);
+            *fake.order_config.lock().expect("order config") = Some(invalid.into());
+            assert!(
+                preflight_topic_targets_with_admin(&fake, Arc::clone(&seal), &request(true), &selected)
+                    .await
+                    .is_err()
+            );
+            assert_eq!(fake.topic_reads.load(Ordering::SeqCst), 0);
+            assert_eq!(fake.topic_writes.load(Ordering::SeqCst), 0);
+            assert_eq!(fake.order_writes.load(Ordering::SeqCst), 0);
+        }
+
+        let prechange = CountingMutationAdmin::with_queue_counts(&[1, 1]);
+        let plan = preflight_topic_targets_with_admin(&prechange, Arc::clone(&seal), &request(false), &selected)
+            .await
+            .expect("initial order guard");
+        *prechange.order_config.lock().expect("order config") = Some("broker-0:1".into());
+        let outcome = execute_topic_checked(&prechange, &seal, &plan)
+            .await
+            .expect("conflict outcome");
+        assert_eq!(outcome.targets[0].failure, Some(MutationFailureCode::Conflict));
+        assert_eq!(prechange.topic_writes.load(Ordering::SeqCst), 0);
+        assert_eq!(prechange.order_writes.load(Ordering::SeqCst), 0);
+
+        let postchange = CountingMutationAdmin::with_queue_counts(&[1, 1]);
+        let plan = preflight_topic_targets_with_admin(&postchange, Arc::clone(&seal), &request(false), &selected)
+            .await
+            .expect("initial order guard");
+        *postchange
+            .order_after_topic_write
+            .lock()
+            .expect("order after Topic write") = Some("broker-0:1".into());
+        let outcome = execute_topic_checked(&postchange, &seal, &plan)
+            .await
+            .expect("partial outcome");
+        assert_eq!(outcome.order_reconciled, Some(false));
+        assert_eq!(outcome.failures[0].code, MutationFailureCode::OrderReconciliationFailed);
+        assert!(outcome.targets[0].applied);
+        assert_eq!(postchange.topic_writes.load(Ordering::SeqCst), 1);
+        assert_eq!(postchange.order_writes.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
@@ -496,18 +496,7 @@ pub struct DashboardConsumerUpsertRequest {
     pub consume_timeout_minute: i32,
 }
 
-const CID_RMQ_SYS_PREFIX: &str = "CID_RMQ_SYS_";
-const SYSTEM_CONSUMER_GROUPS: &[&str] = &[
-    "TOOLS_CONSUMER",
-    "FILTERSRV_CONSUMER",
-    "SELF_TEST_C_GROUP",
-    "CID_ONS-HTTP-PROXY",
-    "CID_ONSAPI_PULL",
-    "CID_ONSAPI_PERMISSION",
-    "CID_ONSAPI_OWNER",
-    "CID_RMQ_SYS_TRANS",
-    "CID_DefaultHeartBeatSyncerTopic",
-];
+const DEFAULT_HEARTBEAT_SYNCER_CONSUMER_GROUP: &str = "CID_DefaultHeartBeatSyncerTopic";
 
 /// Validated create-or-update request for a complete multi-broker workflow.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -833,7 +822,7 @@ where
 
 fn validate_batch_consumer_group(value: impl Into<String>) -> AdminResult<String> {
     let value = required("consumerGroup", value)?;
-    if value.starts_with("%SYS%") || is_system_consumer_group(&value) {
+    if is_protected_consumer_group(&value) {
         return Err(crate::core::AdminError::invalid_argument(
             "consumerGroup",
             "System consumer groups cannot be mutated.",
@@ -866,8 +855,14 @@ fn validate_batch_consumer_limits(request: &DashboardConsumerUpsertRequest) -> A
     Ok(())
 }
 
-pub(crate) fn is_system_consumer_group(group: &str) -> bool {
-    group.starts_with(CID_RMQ_SYS_PREFIX) || SYSTEM_CONSUMER_GROUPS.contains(&group)
+/// Returns whether a consumer group is reserved for RocketMQ infrastructure.
+///
+/// Mutation callers must apply this classifier before opening an admin session.
+/// Admin request constructors apply it again as defense in depth.
+pub fn is_protected_consumer_group(group: &str) -> bool {
+    rocketmq_model::common::mix_all::is_sys_consumer_group_for_no_cold_read_limit(group)
+        || group == DEFAULT_HEARTBEAT_SYNCER_CONSUMER_GROUP
+        || group.starts_with("%SYS%")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1434,6 +1429,47 @@ pub(crate) mod batch_test_support {
 mod tests {
     use super::*;
     use crate::core::AdminFuture;
+
+    #[test]
+    fn protected_consumer_group_classifier_covers_canonical_system_groups() {
+        let protected = [
+            "DEFAULT_CONSUMER",
+            "TOOLS_CONSUMER",
+            "SCHEDULE_CONSUMER",
+            "FILTERSRV_CONSUMER",
+            "__MONITOR_CONSUMER",
+            "SELF_TEST_C_GROUP",
+            "CID_ONS-HTTP-PROXY",
+            "CID_ONSAPI_PULL",
+            "CID_ONSAPI_PERMISSION",
+            "CID_ONSAPI_OWNER",
+            "CID_RMQ_SYS_TRANS",
+            "CID_RMQ_SYS_INTERNAL",
+            "CID_DefaultHeartBeatSyncerTopic",
+            "%SYS%INTERNAL",
+        ];
+        for group in protected {
+            assert!(is_protected_consumer_group(group), "accepted {group}");
+            let request = DashboardConsumerUpsertRequest {
+                cluster_name_list: Vec::new(),
+                broker_name_list: vec!["broker-a".to_owned()],
+                consumer_group: group.to_owned(),
+                consume_enable: true,
+                consume_from_min_enable: false,
+                consume_broadcast_enable: false,
+                consume_message_orderly: false,
+                retry_queue_nums: 1,
+                retry_max_times: 16,
+                broker_id: 0,
+                which_broker_when_consume_slowly: 1,
+                notify_consumer_ids_changed_enable: true,
+                group_sys_flag: 0,
+                consume_timeout_minute: 15,
+            };
+            assert!(ConsumerBatchUpsertRequest::try_new(request).is_err());
+        }
+        assert!(!is_protected_consumer_group("orders_consumers"));
+    }
 
     struct ExistingConsumerAdmin;
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/supervised_mutation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/supervised_mutation.rs
@@ -14,6 +14,7 @@
 
 //! Closed, presentation-independent contracts for supervised mutations.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use serde::de::Error as _;
@@ -26,6 +27,7 @@ use crate::core::AdminFuture;
 use crate::core::AdminResult;
 
 pub const MAX_OFFSET_RESET_TARGETS: usize = 1_000;
+pub const MAX_METADATA_MUTATION_TARGETS: usize = 64;
 
 /// Private session identity carried by plans so they cannot cross an admin-session boundary.
 pub(crate) struct MutationPlanSeal;
@@ -119,6 +121,7 @@ pub enum MutationFailureCode {
     Unavailable,
     PersistenceFailed,
     VerificationFailed,
+    OrderReconciliationFailed,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -164,6 +167,11 @@ pub(crate) struct ResolvedMetadataTarget<T> {
     pub(crate) current: Option<T>,
 }
 
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct TargetedTopicOrderGuard {
+    pub(crate) expected: Option<BTreeMap<String, u32>>,
+}
+
 #[derive(Clone)]
 pub struct TopicMutationPlan {
     pub(crate) seal: Arc<MutationPlanSeal>,
@@ -172,6 +180,7 @@ pub struct TopicMutationPlan {
     pub(crate) replacement: TopicReplacement,
     pub(crate) targets: Vec<ResolvedMetadataTarget<TopicReplacement>>,
     pub(crate) failures: Vec<MutationTargetFailure>,
+    pub(crate) targeted_order_guard: Option<TargetedTopicOrderGuard>,
 }
 
 impl std::fmt::Debug for TopicMutationPlan {
@@ -184,6 +193,7 @@ impl std::fmt::Debug for TopicMutationPlan {
             .field("replacement", &self.replacement)
             .field("targets", &self.preflight_targets())
             .field("failures", &self.failures)
+            .field("targeted_order_guarded", &self.targeted_order_guard.is_some())
             .finish()
     }
 }
@@ -584,12 +594,47 @@ pub trait SupervisedMutationAdmin: Send {
         request: &'a TopicMutationPreflightRequest,
     ) -> AdminFuture<'a, TopicMutationPlan>;
 
+    /// Preflights a topic replacement against only the named brokers in the
+    /// selected cluster. Implementations must validate the complete selected
+    /// cluster topology before issuing any target state request.
+    fn preflight_topic_targets<'a>(
+        &'a mut self,
+        request: &'a TopicMutationPreflightRequest,
+        broker_names: &'a [String],
+    ) -> AdminFuture<'a, TopicMutationPlan> {
+        let _ = (request, broker_names);
+        Box::pin(async move {
+            Err(AdminError::backend(
+                "preflight_topic_targets",
+                "targeted supervised topic preflight is unavailable",
+            ))
+        })
+    }
+
     fn execute_topic<'a>(&'a mut self, plan: &'a TopicMutationPlan) -> AdminFuture<'a, MetadataMutationOutcome>;
 
     fn preflight_subscription_group<'a>(
         &'a mut self,
         request: &'a SubscriptionGroupMutationPreflightRequest,
     ) -> AdminFuture<'a, SubscriptionGroupMutationPlan>;
+
+    /// Preflights a subscription-group replacement against only the named
+    /// brokers in the selected cluster. Implementations must validate the
+    /// complete selected cluster topology before issuing any target state
+    /// request.
+    fn preflight_subscription_group_targets<'a>(
+        &'a mut self,
+        request: &'a SubscriptionGroupMutationPreflightRequest,
+        broker_names: &'a [String],
+    ) -> AdminFuture<'a, SubscriptionGroupMutationPlan> {
+        let _ = (request, broker_names);
+        Box::pin(async move {
+            Err(AdminError::backend(
+                "preflight_subscription_group_targets",
+                "targeted supervised subscription-group preflight is unavailable",
+            ))
+        })
+    }
 
     fn execute_subscription_group<'a>(
         &'a mut self,


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9971
- Fixes #9971

### Brief Description

Adds exactly two reviewed write operations to the isolated RocketMQ MCP control server: `rocketmq_upsert_topic` and `rocketmq_upsert_consumer_group`.

- Keeps the default and runtime-disabled catalogs empty while registering both operations only behind `write-tools` and explicit runtime policy.
- Uses closed, bounded schemas, exact selected-cluster master targets, full-state preflight, sealed one-session execution, compare-and-swap conflict handling, and exact-target post-read verification.
- Preserves mutation-only dependency closure, authorization before argument parsing, durable per-invocation audit records, owned shutdown, sanitized logical output, and bounded request-key deduplication.
- Adds targeted Admin/client compatibility wiring, no-update contract snapshots, boundary enforcement, operator documentation, and focused regression coverage. Stage C operations remain deferred.

### How Did You Test This Change?

- [x] Control package formatting, locked default/write checks and tests, Query snapshot boundary, strict all-feature Clippy, and documentation.
- [x] Control default profile: 55 unit tests, 1 dependency-boundary test, and 2 doctests.
- [x] Control write profile: 70 unit tests, 1 dependency-boundary test, and 2 doctests.
- [x] Admin Core targeted preflight/order-guard/protected-group tests, mutation-client-adapter full tests, package formatting, and all-feature strict Clippy.
- [x] Client mutation-only check, production loopback exact order-topic read, legacy implementer compatibility, package formatting, and all-feature strict Clippy.
- [x] AGENTS routing validation, root workspace strict Clippy, affected standalone consumer profiles, and `git diff --check`.
- [x] No `.snap.new`, Cargo/lock, Query production, wire, Stage C tool, or implementation-plan changes.

The Windows all-project formatter retains its `os error 206` baseline while every affected package-scoped format check passes. Root strict Clippy retains the unrelated `rocketmq-store` test-module ordering baseline. The unchanged SRE suite reproduced three capability-document failures after 255 passing and 54 ignored tests, while its formatting, check, strict Clippy, docs, and boundary scripts passed. The unchanged Web backend reproduced its Windows query-depth baseline in Clippy and all-targets build. Narrow mutation-only Admin/client test-target combinations also retain their unchanged feature-test baselines; the required all-feature and focused compatibility profiles pass.
