### PR TITLE
[ISSUE #9980]🚀Add Offset Reset, Broker Config Patch, and Request Mode tools to RocketMQ MCP control

### DIFF
--- a/rocketmq-ai/rocketmq-mcp-control/AGENTS.md
+++ b/rocketmq-ai/rocketmq-mcp-control/AGENTS.md
@@ -10,15 +10,17 @@ This file applies to `rocketmq-ai/rocketmq-mcp-control/`.
 - HTTPS Streamable MCP with RS256 OAuth/JWKS is the only transport and authentication mode.
 - The default feature set must not depend on RocketMQ Admin or client mutation adapters.
 - `write-tools` may enable only `rocketmq-admin-core/mutation-client-adapter`; it must never enable a read or full adapter.
-- The only reviewed production tools are `rocketmq_upsert_topic` and
-  `rocketmq_upsert_consumer_group`. Keep offset reset, broker configuration, consumer request mode, delete,
-  skip, resend, and any free-form mutation outside this project until separately reviewed.
+- The reviewed production tools are `rocketmq_upsert_topic`,
+  `rocketmq_upsert_consumer_group`, `rocketmq_reset_consumer_offset`,
+  `rocketmq_patch_broker_config`, and `rocketmq_set_consumer_request_mode`.
+  Keep delete, skip, resend, and any free-form mutation outside this project
+  until separately reviewed.
 - OAuth and closed operation/cluster authorization must complete before mutation argument parsing. A durable
   `started` audit record must then complete before session creation or RPC.
 - Do not add stdio, CLI, shell, subprocess, free-form RPC, arbitrary Admin commands, or stdout protocol output.
 - Audit and public data must exclude credentials, tokens, network addresses, raw backend errors, message bodies, and client identities.
-- Each upsert accepts only 1--64 explicit broker names. Validate the full selected-cluster topology before
-  target state RPC, keep plans sealed to one Admin session, and preserve exact-target post-read verification.
+- Each upsert accepts only 1--64 explicit broker names. All operations validate the full selected-cluster topology
+  before target state RPC, keep plans sealed to one Admin session, and preserve exact-target post-read verification.
 - Targeted Topic upserts must treat the complete order-Topic KV as a sealed no-write guard. Never merge, put,
   or delete that global KV from the targeted path; reject any selected entry that is not already exact.
 - Request-key reuse is bounded and process-local; every invocation, including followers and cache hits, keeps

--- a/rocketmq-ai/rocketmq-mcp-control/Cargo.lock
+++ b/rocketmq-ai/rocketmq-mcp-control/Cargo.lock
@@ -2590,6 +2590,7 @@ version = "1.0.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "chrono",
  "futures-util",
  "insta",
  "jsonwebtoken",

--- a/rocketmq-ai/rocketmq-mcp-control/Cargo.toml
+++ b/rocketmq-ai/rocketmq-mcp-control/Cargo.toml
@@ -40,6 +40,7 @@ rocketmq-admin-core = { version = "1.0.0", path = "../../rocketmq-tools/rocketmq
 
 axum = "0.8"
 base64 = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 futures-util = "0.3"
 jsonwebtoken = { version = "11.0", default-features = false, features = ["aws_lc_rs", "use_pem"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }

--- a/rocketmq-ai/rocketmq-mcp-control/README.md
+++ b/rocketmq-ai/rocketmq-mcp-control/README.md
@@ -2,8 +2,8 @@
 
 `rocketmq-mcp-control` is an isolated, deny-by-default server for supervised RocketMQ mutations. It is a
 standalone Cargo project and is not part of the root workspace. The reviewed `write-tools` surface contains
-exactly `rocketmq_upsert_topic` and `rocketmq_upsert_consumer_group`; the default build contains neither Admin
-Core nor production mutation tools.
+exactly five typed tools: Topic and Consumer Group upsert, consumer offset reset, Broker configuration patch,
+and consumer request mode. The default build contains neither Admin Core nor production mutation tools.
 
 ## Security boundary
 
@@ -30,13 +30,13 @@ operation is registered. Resource templates and prompts remain empty.
 |---|---|---:|---:|---:|
 | default | none | off or on | 0 | false |
 | `write-tools` | mutation-only adapter | off | 0 | false |
-| `write-tools` | mutation-only adapter | on, future-only allowlist | 0 | false |
+| `write-tools` | mutation-only adapter | on, empty allowlist | 0 | false |
 | `write-tools` | mutation-only adapter | on, one reviewed operation | 1 | true |
-| `write-tools` | mutation-only adapter | on, both reviewed operations | 2 | true |
+| `write-tools` | mutation-only adapter | on, all reviewed operations | 5 | true |
 
 The optional feature enables only `rocketmq-admin-core/mutation-client-adapter`, whose client dependency enables
-only `admin-mutation`. It does not enable read or full Admin adapters. Offset reset, broker configuration,
-consumer request mode, delete, skip, resend, CLI, shell, and free-form RPC remain outside this delivery.
+only `admin-mutation`. It does not enable read or full Admin adapters. Delete, skip, resend, CLI, shell, and
+free-form RPC remain outside this delivery.
 
 ## Configuration
 
@@ -49,8 +49,8 @@ restart.
 
 The private cluster registry maps a logical alias to a NameServer endpoint, TLS policy, and optional environment
 variable names for credentials. Inline credentials are rejected. Registry values and resolved credentials have
-redacted debug behavior and never enter MCP responses or audit records. Every server-allowed cluster for one of
-the two registered operations must have a registry entry.
+redacted debug behavior and never enter MCP responses or audit records. Every server-allowed cluster for a
+registered operation must have a registry entry.
 
 [`conf/permissions.example.toml`](conf/permissions.example.toml) documents the closed operation and cluster
 claim vocabulary for an authorization server. It is an identity-provider example, not a local authorization
@@ -62,17 +62,17 @@ unknown fields. Omitted `dry_run` uses the configured default and omitted `confi
 omit `reason` and `request_key`; execution requires `confirm = true` and a 5–256 byte safe reason. A request key is
 optional and, when present, is a bounded safe identifier.
 
-Both registered tools accept 1–64 unique logical broker names. Admin Core validates the complete selected
-cluster membership, embedded broker identity, master presence, and endpoint uniqueness before reading any
-target state. Only selected masters are processed, in broker-name order. Requests use complete Topic or Consumer
-Group replacements and closed message-type/numeric bounds. The Consumer Group validator reuses Admin Core's
+The upsert tools accept 1–64 unique logical broker names. All five tools validate the complete selected cluster
+membership, embedded broker identity, master presence, and endpoint uniqueness before reading target state.
+Offset and request-mode operations use every validated master; Broker patch uses exactly one named master.
+Requests use closed typed fields and bounds. The Consumer Group validator reuses Admin Core's
 single canonical protected-group classifier, including RocketMQ defaults, tools/scheduler/filter/monitor groups,
 ONS groups, transaction/system prefixes, and the heartbeat syncer group. System names, addresses, inline
 secrets, and unknown fields are rejected before audit or session creation; Admin constructors repeat the same
 check as defense in depth.
 
-Each result uses `rocketmq-mcp-mutation.v1`, returns the closed `topic_upsert` or `consumer_group_upsert`
-operation, and has an operation-specific top-level `target`: `topic` or `consumer_group` plus sorted `brokers`.
+Each result uses `rocketmq-mcp-mutation.v1`, returns one of the five closed operations, and has an
+operation-specific logical top-level `target`.
 Top-level `before`, `requested`, and post-read `after` preserve the complete aggregate state; broker-sorted
 `targets` retain per-target persistence, verification, and failure evidence rather than replacing that aggregate
 contract. Schema version and operation are single-value enums in each tool output schema. Conflict, partial, and

--- a/rocketmq-ai/rocketmq-mcp-control/conf/mcp-control.example.toml
+++ b/rocketmq-ai/rocketmq-mcp-control/conf/mcp-control.example.toml
@@ -18,11 +18,13 @@ jwks_url = "https://identity.example.test/.well-known/jwks.json"
 [mutations]
 mutations_enabled = false
 dry_run = true
+# Closed values: topic_upsert, consumer_group_upsert, consumer_offset_reset, broker_config_patch,
+# consumer_request_mode. Keep the allowlist empty until the matching OAuth claims and cluster are ready.
 allowed_operations = []
 allowed_clusters = []
 operation_timeout_seconds = 24
 
-# A private logical cluster registry is required before either reviewed operation can be allowlisted.
+# A private logical cluster registry is required before any reviewed operation can be allowlisted.
 # Credential values are read from these environment variables only when a session is opened.
 [[clusters]]
 name = "production-a"

--- a/rocketmq-ai/rocketmq-mcp-control/conf/permissions.example.toml
+++ b/rocketmq-ai/rocketmq-mcp-control/conf/permissions.example.toml
@@ -7,5 +7,8 @@ scope = ["rocketmq:write"]
 rocketmq_operations = [
   "topic_upsert",
   "consumer_group_upsert",
+  "consumer_offset_reset",
+  "broker_config_patch",
+  "consumer_request_mode",
 ]
 rocketmq_clusters = ["production-a"]

--- a/rocketmq-ai/rocketmq-mcp-control/docs/operations-runbook.md
+++ b/rocketmq-ai/rocketmq-mcp-control/docs/operations-runbook.md
@@ -8,12 +8,13 @@
    JSONL audit path.
 3. Add a private cluster-registry entry for each logical cluster. Reference credentials only through protected
    environment-variable names; inline credentials are rejected.
-4. Configure `mutations_enabled=true` and allowlist only `topic_upsert`, `consumer_group_upsert`, or both, plus
+4. Configure `mutations_enabled=true` and allowlist only the required subset of `topic_upsert`,
+   `consumer_group_upsert`, `consumer_offset_reset`, `broker_config_patch`, and `consumer_request_mode`, plus
    their logical clusters. The identity provider must issue matching closed claims and `rocketmq:write`.
 5. Restart the process. Configuration and emergency-disable changes are startup-time controls and do not hot
    reload.
 
-Verify authenticated `tools/list`: a principal can see zero, one, or two tools according to the intersection.
+Verify authenticated `tools/list`: a principal can see zero through five tools according to the intersection.
 The capability Resource must report compile/runtime/registered state consistent with that catalog. Resource
 templates and prompts remain empty.
 

--- a/rocketmq-ai/rocketmq-mcp-control/docs/tool-reference.md
+++ b/rocketmq-ai/rocketmq-mcp-control/docs/tool-reference.md
@@ -1,11 +1,11 @@
 # Reviewed mutation tool reference
 
-The `write-tools` build exposes at most two production tools. A tool is listed only when compile-time support,
+The `write-tools` build exposes at most five production tools. A tool is listed only when compile-time support,
 runtime mutation enablement, the server operation/cluster allowlists, a configured logical cluster, and the
 authenticated principal's `rocketmq:write` scope plus operation/cluster claims all intersect. Authorization is
 completed before the tool-specific JSON schema is parsed.
 
-Both tools use input schema version `rocketmq-mcp-control.arguments.v1`. Unknown fields are rejected. The
+All five tools use input schema version `rocketmq-mcp-control.arguments.v1`. Unknown fields are rejected. The
 `cluster` is a closed logical alias; it is never a NameServer or broker address. `broker_names` contains 1--64
 unique logical masters and is validated against the complete selected-cluster topology before a target state
 RPC. Omitted `dry_run` uses the server default, and omitted `confirm` is false. Execution requires
@@ -41,17 +41,84 @@ The operation uses the same exact-target preflight, conditional replacement, pos
 as the Topic tool. It rejects the complete canonical RocketMQ protected Consumer Group set through the same
 Admin Core classifier used by Admin request constructors, before audit or session creation.
 
+## `rocketmq_reset_consumer_offset`
+
+The request identifies one non-system Topic and Consumer Group, a timezone-qualified RFC3339 `timestamp`, and
+`force`. Preflight resolves every validated cluster master and seals at most 1,000 unique Broker/queue targets.
+Dry-run returns each queue's current offset, planned offset, and delta. Execute performs one exact expected-offset
+CAS per changed queue without retry or route re-resolution, then re-reads that queue. A Broker preview failure is
+retained as a target with `queue_id=null`; it is never hidden by successful queues. Without `force`, a reset does
+not move an uninitialized or existing offset forward; with `force`, the timestamp-derived offset is used.
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "topic": "orders",
+  "consumer_group": "orders-consumer",
+  "timestamp": "2026-08-30T08:00:00+08:00",
+  "force": false,
+  "dry_run": true
+}
+```
+
+## `rocketmq_patch_broker_config`
+
+The request identifies exactly one logical `broker_name`. Its nested `properties` object rejects unknown keys and
+must contain at least one of `autoCreateTopicEnable`, `autoCreateSubscriptionGroup`, `brokerPermission`,
+`defaultTopicQueueNums`, `messageIndexEnable`, or `traceTopicEnable`. Boolean strings must be canonical lowercase;
+explicit `null` and empty strings are rejected; permissions are 1--7 with read or write, and queue count is
+1--128. Admin Core validates the complete selected
+cluster topology before reading only that Broker. Execute performs one generation CAS with no retry and re-reads
+the complete six-field projection on the same sealed endpoint. Post-read failure keeps `applied=true` and returns
+a failed result.
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "broker_name": "broker-a",
+  "properties": {
+    "brokerPermission": "6",
+    "traceTopicEnable": "true"
+  },
+  "dry_run": true
+}
+```
+
+## `rocketmq_set_consumer_request_mode`
+
+The request identifies a non-system Topic and Consumer Group, `mode=pull|pop`, a non-negative
+`pop_share_queue_num`, and `timeout_millis` from 1 through 24,000. Every validated master must have the Topic and
+Consumer Group before its current request mode is accepted into the sealed plan. Execute forwards the request
+timeout to the conditional Client RPC, performs no conflict retry, and precisely re-reads each applied target.
+Endpoints remain internal.
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "topic": "orders",
+  "consumer_group": "orders-consumer",
+  "mode": "pop",
+  "pop_share_queue_num": 4,
+  "timeout_millis": 12000,
+  "dry_run": true
+}
+```
+
 ## Result contract
 
 Every successful tool invocation returns `rocketmq-mcp-mutation.v1` structured content. Each tool schema fixes
-the schema version and operation to one value. The operation-specific top-level `target` contains `topic` or
-`consumer_group` and sorted `brokers`; top-level `before`, `requested`, and post-read `after` preserve the full
+the schema version and operation to one value. The operation-specific top-level `target` contains only logical
+resource names and sorted brokers; top-level `before`, `requested`, and post-read `after` preserve the full
 aggregate state required by the mutation contract. Broker-name-sorted `targets` additionally retain per-target
 persistence, verification, and failure evidence and do not replace the aggregate fields. An unchanged success
 uses `status=applied` with `changed=false`; `noop` is not part of the status vocabulary.
 `partial`, `conflict`, and `failed` set MCP `isError=true` while preserving structured target truth. Output never
 contains endpoints, credential references or values, OAuth subjects, reasons, request keys, or raw backend
-errors.
+errors. Operation-specific post-read fields are required in the schema but nullable: a missing observation is
+represented by JSON `null`, never by omitting the field.
 
 ## Request-key semantics
 

--- a/rocketmq-ai/rocketmq-mcp-control/examples/README.md
+++ b/rocketmq-ai/rocketmq-mcp-control/examples/README.md
@@ -21,5 +21,10 @@ ROCKETMQ_MCP_CONTROL_CONFIG="$(pwd)/conf/mcp-control.example.toml" cargo run --l
 The example intentionally leaves `mutations_enabled = false` and both allowlists empty. It also demonstrates a
 private logical cluster registry whose credential values come only from environment variables. The default
 build never links Admin Core. To make reviewed tools discoverable, compile with `--features write-tools`, enable
-the runtime policy, and intersect one or both of `topic_upsert` and `consumer_group_upsert` plus the logical
-cluster in both the server policy and authenticated claims. Any other operation remains unavailable.
+the runtime policy, and intersect the required subset of `topic_upsert`, `consumer_group_upsert`,
+`consumer_offset_reset`, `broker_config_patch`, and `consumer_request_mode` plus the logical cluster in both the
+server policy and authenticated claims. Delete, skip, resend, and free-form operations remain unavailable.
+
+[`stage-c-dry-run-requests.json`](stage-c-dry-run-requests.json) contains closed, safe dry-run argument examples
+for the three Stage C tools. Send one named object's value as the MCP tool arguments; do not send the enclosing
+example object itself.

--- a/rocketmq-ai/rocketmq-mcp-control/examples/stage-c-dry-run-requests.json
+++ b/rocketmq-ai/rocketmq-mcp-control/examples/stage-c-dry-run-requests.json
@@ -1,0 +1,31 @@
+{
+  "rocketmq_reset_consumer_offset": {
+    "schema_version": "rocketmq-mcp-control.arguments.v1",
+    "cluster": "production-a",
+    "topic": "orders",
+    "consumer_group": "orders-consumer",
+    "timestamp": "2026-08-30T08:00:00+08:00",
+    "force": false,
+    "dry_run": true
+  },
+  "rocketmq_patch_broker_config": {
+    "schema_version": "rocketmq-mcp-control.arguments.v1",
+    "cluster": "production-a",
+    "broker_name": "broker-a",
+    "properties": {
+      "brokerPermission": "6",
+      "traceTopicEnable": "true"
+    },
+    "dry_run": true
+  },
+  "rocketmq_set_consumer_request_mode": {
+    "schema_version": "rocketmq-mcp-control.arguments.v1",
+    "cluster": "production-a",
+    "topic": "orders",
+    "consumer_group": "orders-consumer",
+    "mode": "pop",
+    "pop_share_queue_num": 4,
+    "timeout_millis": 12000,
+    "dry_run": true
+  }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/scripts/check_control_boundary.py
+++ b/rocketmq-ai/rocketmq-mcp-control/scripts/check_control_boundary.py
@@ -125,17 +125,20 @@ for forbidden in (
 ):
     if forbidden in production_source:
         fail(f"production source contains unmanaged lifecycle surface {forbidden}")
-if "spawn_service(\"mcp-control-upsert-supervisor\"" not in production_source:
+if "spawn_service(\"mcp-control-mutation-supervisor\"" not in production_source:
     fail("reviewed tool execution is not visibly owned by the injected task group")
 
-for required in ("rocketmq_upsert_topic", "rocketmq_upsert_consumer_group"):
+for required in (
+    "rocketmq_upsert_topic",
+    "rocketmq_upsert_consumer_group",
+    "rocketmq_reset_consumer_offset",
+    "rocketmq_patch_broker_config",
+    "rocketmq_set_consumer_request_mode",
+):
     if required not in source:
         fail(f"reviewed write catalog is missing {required}")
 
 for forbidden in (
-    "rocketmq_reset_consumer_offset",
-    "rocketmq_patch_broker_config",
-    "rocketmq_set_consumer_request_mode",
     "rocketmq_delete_",
     "rocketmq_skip_",
     "rocketmq_resend_",

--- a/rocketmq-ai/rocketmq-mcp-control/src/catalog.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/catalog.rs
@@ -20,10 +20,19 @@ use rmcp::model::ToolAnnotations;
 
 use crate::config::MutationPolicyConfig;
 use crate::model::ControlOperation;
+use crate::tools::BrokerConfigMutationToolResponse;
 use crate::tools::ConsumerGroupMutationToolResponse;
+use crate::tools::OffsetMutationToolResponse;
+use crate::tools::PatchBrokerConfigArgs;
+use crate::tools::RequestModeMutationToolResponse;
+use crate::tools::ResetConsumerOffsetArgs;
+use crate::tools::SetConsumerRequestModeArgs;
 use crate::tools::TopicMutationToolResponse;
 use crate::tools::UpsertConsumerGroupArgs;
 use crate::tools::UpsertTopicArgs;
+use crate::tools::PATCH_BROKER_CONFIG_TOOL;
+use crate::tools::RESET_CONSUMER_OFFSET_TOOL;
+use crate::tools::SET_CONSUMER_REQUEST_MODE_TOOL;
 use crate::tools::UPSERT_CONSUMER_GROUP_TOOL;
 use crate::tools::UPSERT_TOPIC_TOOL;
 
@@ -41,12 +50,7 @@ impl OperationCatalog {
         #[cfg(feature = "write-tools")]
         if policy.mutations_enabled {
             for operation in &policy.allowed_operations {
-                if matches!(
-                    operation,
-                    ControlOperation::TopicUpsert | ControlOperation::ConsumerGroupUpsert
-                ) {
-                    operations.insert(*operation);
-                }
+                operations.insert(*operation);
             }
         }
         #[cfg(not(feature = "write-tools"))]
@@ -82,7 +86,9 @@ fn tool_definition(operation: ControlOperation) -> Option<Tool> {
     let annotations = ToolAnnotations::with_title(match operation {
         ControlOperation::TopicUpsert => "Upsert RocketMQ topic",
         ControlOperation::ConsumerGroupUpsert => "Upsert RocketMQ consumer group",
-        _ => "Unavailable RocketMQ mutation",
+        ControlOperation::ConsumerOffsetReset => "Reset RocketMQ consumer offset",
+        ControlOperation::BrokerConfigPatch => "Patch RocketMQ Broker configuration",
+        ControlOperation::ConsumerRequestMode => "Set RocketMQ consumer request mode",
     })
     .read_only(false)
     .destructive(true)
@@ -111,7 +117,39 @@ fn tool_definition(operation: ControlOperation) -> Option<Tool> {
             .with_output_schema::<ConsumerGroupMutationToolResponse>()
             .with_annotations(annotations),
         ),
-        _ => None,
+        ControlOperation::ConsumerOffsetReset => Some(
+            Tool::new(
+                RESET_CONSUMER_OFFSET_TOOL,
+                "Dry-run or conditionally reset exact consumer queue offsets from a sealed RFC3339 preview.",
+                std::sync::Arc::new(Default::default()),
+            )
+            .with_title("Reset RocketMQ consumer offset")
+            .with_input_schema::<ResetConsumerOffsetArgs>()
+            .with_output_schema::<OffsetMutationToolResponse>()
+            .with_annotations(annotations),
+        ),
+        ControlOperation::BrokerConfigPatch => Some(
+            Tool::new(
+                PATCH_BROKER_CONFIG_TOOL,
+                "Dry-run or generation-conditionally patch six allowlisted settings on one logical Broker.",
+                std::sync::Arc::new(Default::default()),
+            )
+            .with_title("Patch RocketMQ Broker configuration")
+            .with_input_schema::<PatchBrokerConfigArgs>()
+            .with_output_schema::<BrokerConfigMutationToolResponse>()
+            .with_annotations(annotations),
+        ),
+        ControlOperation::ConsumerRequestMode => Some(
+            Tool::new(
+                SET_CONSUMER_REQUEST_MODE_TOOL,
+                "Dry-run or conditionally set pull/pop request mode on validated cluster masters.",
+                std::sync::Arc::new(Default::default()),
+            )
+            .with_title("Set RocketMQ consumer request mode")
+            .with_input_schema::<SetConsumerRequestModeArgs>()
+            .with_output_schema::<RequestModeMutationToolResponse>()
+            .with_annotations(annotations),
+        ),
     }
 }
 
@@ -130,12 +168,12 @@ mod tests {
     }
 
     #[test]
-    fn catalog_is_policy_derived_and_registers_only_stage_b_operations() {
+    fn catalog_is_policy_derived_and_registers_all_reviewed_operations() {
         assert_eq!(
             OperationCatalog::from_policy(&policy(false, vec![ControlOperation::TopicUpsert])).registered_operations(),
             0
         );
-        let future_only = OperationCatalog::from_policy(&policy(
+        let stage_c = OperationCatalog::from_policy(&policy(
             true,
             vec![
                 ControlOperation::ConsumerOffsetReset,
@@ -143,7 +181,10 @@ mod tests {
                 ControlOperation::ConsumerRequestMode,
             ],
         ));
-        assert_eq!(future_only.registered_operations(), 0);
+        #[cfg(feature = "write-tools")]
+        assert_eq!(stage_c.registered_operations(), 3);
+        #[cfg(not(feature = "write-tools"))]
+        assert_eq!(stage_c.registered_operations(), 0);
 
         #[cfg(feature = "write-tools")]
         {
@@ -165,6 +206,17 @@ mod tests {
                 assert_eq!(annotations.idempotent_hint, Some(true));
                 assert_eq!(annotations.open_world_hint, Some(true));
             }
+            let all = OperationCatalog::from_policy(&policy(
+                true,
+                vec![
+                    ControlOperation::TopicUpsert,
+                    ControlOperation::ConsumerGroupUpsert,
+                    ControlOperation::ConsumerOffsetReset,
+                    ControlOperation::BrokerConfigPatch,
+                    ControlOperation::ConsumerRequestMode,
+                ],
+            ));
+            assert_eq!(all.registered_operations(), 5);
         }
     }
 
@@ -173,7 +225,13 @@ mod tests {
     fn reviewed_tool_schema_snapshot() {
         let catalog = OperationCatalog::from_policy(&policy(
             true,
-            vec![ControlOperation::TopicUpsert, ControlOperation::ConsumerGroupUpsert],
+            vec![
+                ControlOperation::TopicUpsert,
+                ControlOperation::ConsumerGroupUpsert,
+                ControlOperation::ConsumerOffsetReset,
+                ControlOperation::BrokerConfigPatch,
+                ControlOperation::ConsumerRequestMode,
+            ],
         ));
         insta::assert_json_snapshot!("control_reviewed_tool_schemas", catalog.list_tools().tools);
     }

--- a/rocketmq-ai/rocketmq-mcp-control/src/config.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/config.rs
@@ -61,14 +61,7 @@ impl ControlConfig {
         self.oauth.validate()?;
         self.mutations.validate()?;
         validate_cluster_registry(&self.clusters)?;
-        if self.mutations.mutations_enabled
-            && self.mutations.allowed_operations.iter().any(|operation| {
-                matches!(
-                    operation,
-                    ControlOperation::TopicUpsert | ControlOperation::ConsumerGroupUpsert
-                )
-            })
-        {
+        if self.mutations.mutations_enabled && !self.mutations.allowed_operations.is_empty() {
             let configured = self
                 .clusters
                 .iter()

--- a/rocketmq-ai/rocketmq-mcp-control/src/server.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/server.rs
@@ -45,6 +45,9 @@ use crate::model::ClusterName;
 use crate::model::ControlCapabilities;
 use crate::model::ControlOperation;
 use crate::model::Principal;
+use crate::tools::PATCH_BROKER_CONFIG_TOOL;
+use crate::tools::RESET_CONSUMER_OFFSET_TOOL;
+use crate::tools::SET_CONSUMER_REQUEST_MODE_TOOL;
 use crate::tools::UPSERT_CONSUMER_GROUP_TOOL;
 use crate::tools::UPSERT_TOPIC_TOOL;
 
@@ -99,7 +102,7 @@ impl ControlServer {
         let tool_runtime = if catalog.registered_operations() == 0 {
             None
         } else {
-            let factory = Arc::new(crate::tool_runtime::AdminUpsertFactory::new(
+            let factory = Arc::new(crate::tool_runtime::AdminMutationToolFactory::new(
                 service_context.component("admin-factory"),
                 config.mutation_clusters(),
             )?);
@@ -126,7 +129,7 @@ impl ControlServer {
         policy: &crate::config::MutationPolicyConfig,
         configured_clusters: BTreeSet<ClusterName>,
         audit: crate::audit::AuditTrail,
-        factory: Arc<dyn crate::tool_runtime::UpsertSessionFactory>,
+        factory: Arc<dyn crate::tool_runtime::MutationToolSessionFactory>,
         owner: rocketmq_runtime::TaskGroup,
     ) -> Self {
         let catalog = OperationCatalog::from_policy(policy);
@@ -185,7 +188,7 @@ impl ServerHandler for ControlServer {
             .with_server_info(Implementation::new("rocketmq-mcp-control", env!("CARGO_PKG_VERSION")))
             .with_protocol_version(ProtocolVersion::V_2025_11_25)
             .with_instructions(
-                "Isolated RocketMQ control server. Reviewed Topic and Consumer Group upserts are available only when compile-time, runtime, server-policy, and principal authorization all intersect.",
+                "Isolated RocketMQ control server. Five reviewed typed mutations are available only when compile-time, runtime, server-policy, and principal authorization all intersect.",
             )
     }
 
@@ -239,6 +242,18 @@ impl ServerHandler for ControlServer {
                 ControlOperation::ConsumerGroupUpsert.as_str(),
                 Some(ControlOperation::ConsumerGroupUpsert),
             ),
+            RESET_CONSUMER_OFFSET_TOOL => (
+                ControlOperation::ConsumerOffsetReset.as_str(),
+                Some(ControlOperation::ConsumerOffsetReset),
+            ),
+            PATCH_BROKER_CONFIG_TOOL => (
+                ControlOperation::BrokerConfigPatch.as_str(),
+                Some(ControlOperation::BrokerConfigPatch),
+            ),
+            SET_CONSUMER_REQUEST_MODE_TOOL => (
+                ControlOperation::ConsumerRequestMode.as_str(),
+                Some(ControlOperation::ConsumerRequestMode),
+            ),
             _ => ("unknown", None),
         };
         let authorized = match self
@@ -256,7 +271,7 @@ impl ServerHandler for ControlServer {
         #[cfg(feature = "write-tools")]
         {
             let dry_run_omitted = raw.as_object().is_some_and(|object| !object.contains_key("dry_run"));
-            let upsert = match operation {
+            let mutation = match operation {
                 Some(ControlOperation::TopicUpsert) => {
                     let mut args: crate::tools::UpsertTopicArgs = match serde_json::from_value(raw) {
                         Ok(args) => args,
@@ -266,7 +281,7 @@ impl ServerHandler for ControlServer {
                         return Ok(tool_error(error).into());
                     }
                     args.dry_run = args.effective_dry_run(self.guard.default_dry_run(), dry_run_omitted);
-                    crate::tool_runtime::UpsertRequest::Topic(args)
+                    crate::tool_runtime::MutationToolRequest::Topic(args)
                 }
                 Some(ControlOperation::ConsumerGroupUpsert) => {
                     let mut args: crate::tools::UpsertConsumerGroupArgs = match serde_json::from_value(raw) {
@@ -277,7 +292,40 @@ impl ServerHandler for ControlServer {
                         return Ok(tool_error(error).into());
                     }
                     args.dry_run = args.effective_dry_run(self.guard.default_dry_run(), dry_run_omitted);
-                    crate::tool_runtime::UpsertRequest::ConsumerGroup(args)
+                    crate::tool_runtime::MutationToolRequest::ConsumerGroup(args)
+                }
+                Some(ControlOperation::ConsumerOffsetReset) => {
+                    let mut args: crate::tools::ResetConsumerOffsetArgs = match serde_json::from_value(raw) {
+                        Ok(args) => args,
+                        Err(_) => return Ok(tool_error(crate::error::ControlError::invalid_arguments()).into()),
+                    };
+                    if args.validate(self.guard.default_dry_run(), dry_run_omitted).is_err() {
+                        return Ok(tool_error(crate::error::ControlError::invalid_arguments()).into());
+                    }
+                    args.dry_run = args.effective_dry_run(self.guard.default_dry_run(), dry_run_omitted);
+                    crate::tool_runtime::MutationToolRequest::ConsumerOffset(args)
+                }
+                Some(ControlOperation::BrokerConfigPatch) => {
+                    let mut args: crate::tools::PatchBrokerConfigArgs = match serde_json::from_value(raw) {
+                        Ok(args) => args,
+                        Err(_) => return Ok(tool_error(crate::error::ControlError::invalid_arguments()).into()),
+                    };
+                    if args.validate(self.guard.default_dry_run(), dry_run_omitted).is_err() {
+                        return Ok(tool_error(crate::error::ControlError::invalid_arguments()).into());
+                    }
+                    args.dry_run = args.effective_dry_run(self.guard.default_dry_run(), dry_run_omitted);
+                    crate::tool_runtime::MutationToolRequest::BrokerConfig(args)
+                }
+                Some(ControlOperation::ConsumerRequestMode) => {
+                    let mut args: crate::tools::SetConsumerRequestModeArgs = match serde_json::from_value(raw) {
+                        Ok(args) => args,
+                        Err(_) => return Ok(tool_error(crate::error::ControlError::invalid_arguments()).into()),
+                    };
+                    if let Err(error) = args.validate(self.guard.default_dry_run(), dry_run_omitted) {
+                        return Ok(tool_error(error).into());
+                    }
+                    args.dry_run = args.effective_dry_run(self.guard.default_dry_run(), dry_run_omitted);
+                    crate::tool_runtime::MutationToolRequest::ConsumerRequestMode(args)
                 }
                 _ => return Ok(tool_error(crate::error::ControlError::permission_denied()).into()),
             };
@@ -285,7 +333,7 @@ impl ServerHandler for ControlServer {
                 return Ok(tool_error(crate::error::ControlError::operation_unavailable()).into());
             };
             let result = runtime
-                .execute(&principal, &authorized, upsert, context.ct.clone())
+                .execute(&principal, &authorized, mutation, context.ct.clone())
                 .await;
             Ok(match result {
                 Ok(response) => tool_response(response),
@@ -339,7 +387,7 @@ fn principal_from_context(context: &RequestContext<RoleServer>) -> Result<Princi
 }
 
 #[cfg(feature = "write-tools")]
-fn tool_response(response: crate::tool_runtime::UpsertResponse) -> CallToolResult {
+fn tool_response(response: crate::tool_runtime::MutationToolResponse) -> CallToolResult {
     let structured = serde_json::to_value(&response).unwrap_or_else(|_| {
         serde_json::to_value(crate::error::ControlError::execution_failed().envelope()).unwrap_or_default()
     });

--- a/rocketmq-ai/rocketmq-mcp-control/src/snapshots/rocketmq_mcp_control__catalog__tests__control_reviewed_tool_schemas.snap
+++ b/rocketmq-ai/rocketmq-mcp-control/src/snapshots/rocketmq_mcp_control__catalog__tests__control_reviewed_tool_schemas.snap
@@ -892,5 +892,1138 @@ expression: catalog.list_tools().tools
       "idempotentHint": true,
       "openWorldHint": true
     }
+  },
+  {
+    "name": "rocketmq_reset_consumer_offset",
+    "title": "Reset RocketMQ consumer offset",
+    "description": "Dry-run or conditionally reset exact consumer queue offsets from a sealed RFC3339 preview.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "confirm": {
+          "default": false,
+          "type": "boolean"
+        },
+        "consumer_group": {
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[%|a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "dry_run": {
+          "default": true,
+          "type": "boolean"
+        },
+        "force": {
+          "default": false,
+          "type": "boolean"
+        },
+        "reason": {
+          "default": null,
+          "maxLength": 256,
+          "minLength": 5,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_key": {
+          "default": null,
+          "maxLength": 64,
+          "minLength": 8,
+          "pattern": "^[a-zA-Z0-9._:-]+$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "pattern": "^rocketmq-mcp-control\\.arguments\\.v1$",
+          "type": "string"
+        },
+        "timestamp": {
+          "maxLength": 40,
+          "minLength": 20,
+          "type": "string"
+        },
+        "topic": {
+          "maxLength": 127,
+          "minLength": 1,
+          "pattern": "^[%|a-zA-Z0-9_-]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "cluster",
+        "topic",
+        "consumer_group",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "outputSchema": {
+      "$defs": {
+        "ConsumerOffsetResetOperation": {
+          "const": "consumer_offset_reset",
+          "type": "string"
+        },
+        "FailureCode": {
+          "enum": [
+            "conflict",
+            "invalid_data",
+            "unavailable",
+            "persistence_failed",
+            "verification_failed",
+            "order_reconciliation_failed"
+          ],
+          "type": "string"
+        },
+        "MutationMode": {
+          "enum": [
+            "dry_run",
+            "execute"
+          ],
+          "type": "string"
+        },
+        "MutationResultSchemaVersion": {
+          "const": "rocketmq-mcp-mutation.v1",
+          "type": "string"
+        },
+        "MutationStatus": {
+          "enum": [
+            "planned",
+            "applied",
+            "partial",
+            "conflict",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "OffsetMutationTarget": {
+          "additionalProperties": false,
+          "properties": {
+            "after": {
+              "anyOf": [
+                {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "applied": {
+              "type": "boolean"
+            },
+            "before": {
+              "anyOf": [
+                {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "changed": {
+              "type": "boolean"
+            },
+            "delta": {
+              "anyOf": [
+                {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "failure": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/FailureCode"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "planned": {
+              "anyOf": [
+                {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "queue_id": {
+              "anyOf": [
+                {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "broker_name",
+            "queue_id",
+            "before",
+            "planned",
+            "delta",
+            "after",
+            "applied",
+            "changed",
+            "failure",
+            "retryable"
+          ],
+          "type": "object"
+        },
+        "OffsetQueueState": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            },
+            "offset": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "queue_id": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "broker_name",
+            "queue_id",
+            "offset"
+          ],
+          "type": "object"
+        },
+        "OffsetRequested": {
+          "additionalProperties": false,
+          "properties": {
+            "force": {
+              "type": "boolean"
+            },
+            "timestamp": {
+              "type": "string"
+            },
+            "timestamp_millis": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "timestamp",
+            "timestamp_millis",
+            "force"
+          ],
+          "type": "object"
+        },
+        "OffsetResetResource": {
+          "additionalProperties": false,
+          "properties": {
+            "brokers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "consumer_group": {
+              "type": "string"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "consumer_group",
+            "brokers"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/OffsetQueueState"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "before": {
+          "items": {
+            "$ref": "#/$defs/OffsetQueueState"
+          },
+          "type": "array"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "mode": {
+          "$ref": "#/$defs/MutationMode"
+        },
+        "operation": {
+          "$ref": "#/$defs/ConsumerOffsetResetOperation"
+        },
+        "requested": {
+          "$ref": "#/$defs/OffsetRequested"
+        },
+        "schema_version": {
+          "$ref": "#/$defs/MutationResultSchemaVersion"
+        },
+        "status": {
+          "$ref": "#/$defs/MutationStatus"
+        },
+        "target": {
+          "$ref": "#/$defs/OffsetResetResource"
+        },
+        "targets": {
+          "items": {
+            "$ref": "#/$defs/OffsetMutationTarget"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "operation",
+        "cluster",
+        "mode",
+        "status",
+        "target",
+        "before",
+        "requested",
+        "after",
+        "targets",
+        "warnings"
+      ],
+      "type": "object"
+    },
+    "annotations": {
+      "title": "Reset RocketMQ consumer offset",
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "rocketmq_patch_broker_config",
+    "title": "Patch RocketMQ Broker configuration",
+    "description": "Dry-run or generation-conditionally patch six allowlisted settings on one logical Broker.",
+    "inputSchema": {
+      "$defs": {
+        "BrokerConfigProperties": {
+          "additionalProperties": false,
+          "properties": {
+            "autoCreateSubscriptionGroup": {
+              "default": null,
+              "type": "string"
+            },
+            "autoCreateTopicEnable": {
+              "default": null,
+              "type": "string"
+            },
+            "brokerPermission": {
+              "default": null,
+              "type": "string"
+            },
+            "defaultTopicQueueNums": {
+              "default": null,
+              "type": "string"
+            },
+            "messageIndexEnable": {
+              "default": null,
+              "type": "string"
+            },
+            "traceTopicEnable": {
+              "default": null,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "broker_name": {
+          "maxLength": 127,
+          "minLength": 1,
+          "pattern": "^[%|a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "cluster": {
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "confirm": {
+          "default": false,
+          "type": "boolean"
+        },
+        "dry_run": {
+          "default": true,
+          "type": "boolean"
+        },
+        "properties": {
+          "$ref": "#/$defs/BrokerConfigProperties"
+        },
+        "reason": {
+          "default": null,
+          "maxLength": 256,
+          "minLength": 5,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_key": {
+          "default": null,
+          "maxLength": 64,
+          "minLength": 8,
+          "pattern": "^[a-zA-Z0-9._:-]+$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "pattern": "^rocketmq-mcp-control\\.arguments\\.v1$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "cluster",
+        "broker_name",
+        "properties"
+      ],
+      "type": "object"
+    },
+    "outputSchema": {
+      "$defs": {
+        "BrokerConfigMutationTarget": {
+          "additionalProperties": false,
+          "properties": {
+            "after": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BrokerConfigState"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "applied": {
+              "type": "boolean"
+            },
+            "before": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BrokerConfigState"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "changed": {
+              "type": "boolean"
+            },
+            "failure": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/FailureCode"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "persistence": {
+              "$ref": "#/$defs/PersistenceState"
+            },
+            "requested": {
+              "$ref": "#/$defs/BrokerConfigPatch"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "verification": {
+              "$ref": "#/$defs/VerificationState"
+            }
+          },
+          "required": [
+            "broker_name",
+            "before",
+            "requested",
+            "after",
+            "applied",
+            "changed",
+            "persistence",
+            "verification",
+            "failure",
+            "retryable"
+          ],
+          "type": "object"
+        },
+        "BrokerConfigPatch": {
+          "additionalProperties": false,
+          "properties": {
+            "autoCreateSubscriptionGroup": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "autoCreateTopicEnable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "brokerPermission": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "defaultTopicQueueNums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "messageIndexEnable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "traceTopicEnable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "BrokerConfigPatchOperation": {
+          "const": "broker_config_patch",
+          "type": "string"
+        },
+        "BrokerConfigResource": {
+          "additionalProperties": false,
+          "properties": {
+            "broker_name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "broker_name"
+          ],
+          "type": "object"
+        },
+        "BrokerConfigState": {
+          "additionalProperties": false,
+          "properties": {
+            "autoCreateSubscriptionGroup": {
+              "type": "boolean"
+            },
+            "autoCreateTopicEnable": {
+              "type": "boolean"
+            },
+            "brokerPermission": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "defaultTopicQueueNums": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "generation": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "messageIndexEnable": {
+              "type": "boolean"
+            },
+            "traceTopicEnable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "generation",
+            "autoCreateTopicEnable",
+            "autoCreateSubscriptionGroup",
+            "brokerPermission",
+            "defaultTopicQueueNums",
+            "messageIndexEnable",
+            "traceTopicEnable"
+          ],
+          "type": "object"
+        },
+        "FailureCode": {
+          "enum": [
+            "conflict",
+            "invalid_data",
+            "unavailable",
+            "persistence_failed",
+            "verification_failed",
+            "order_reconciliation_failed"
+          ],
+          "type": "string"
+        },
+        "MutationMode": {
+          "enum": [
+            "dry_run",
+            "execute"
+          ],
+          "type": "string"
+        },
+        "MutationResultSchemaVersion": {
+          "const": "rocketmq-mcp-mutation.v1",
+          "type": "string"
+        },
+        "MutationStatus": {
+          "enum": [
+            "planned",
+            "applied",
+            "partial",
+            "conflict",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "PersistenceState": {
+          "enum": [
+            "not_required",
+            "persisted",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "VerificationState": {
+          "enum": [
+            "not_performed",
+            "verified",
+            "failed"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/BrokerConfigState"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "before": {
+          "additionalProperties": {
+            "$ref": "#/$defs/BrokerConfigState"
+          },
+          "type": "object"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "mode": {
+          "$ref": "#/$defs/MutationMode"
+        },
+        "operation": {
+          "$ref": "#/$defs/BrokerConfigPatchOperation"
+        },
+        "requested": {
+          "$ref": "#/$defs/BrokerConfigPatch"
+        },
+        "schema_version": {
+          "$ref": "#/$defs/MutationResultSchemaVersion"
+        },
+        "status": {
+          "$ref": "#/$defs/MutationStatus"
+        },
+        "target": {
+          "$ref": "#/$defs/BrokerConfigResource"
+        },
+        "targets": {
+          "items": {
+            "$ref": "#/$defs/BrokerConfigMutationTarget"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "operation",
+        "cluster",
+        "mode",
+        "status",
+        "target",
+        "before",
+        "requested",
+        "after",
+        "targets",
+        "warnings"
+      ],
+      "type": "object"
+    },
+    "annotations": {
+      "title": "Patch RocketMQ Broker configuration",
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "rocketmq_set_consumer_request_mode",
+    "title": "Set RocketMQ consumer request mode",
+    "description": "Dry-run or conditionally set pull/pop request mode on validated cluster masters.",
+    "inputSchema": {
+      "$defs": {
+        "ConsumerRequestMode": {
+          "enum": [
+            "pull",
+            "pop"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "maxLength": 64,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "confirm": {
+          "default": false,
+          "type": "boolean"
+        },
+        "consumer_group": {
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[%|a-zA-Z0-9_-]+$",
+          "type": "string"
+        },
+        "dry_run": {
+          "default": true,
+          "type": "boolean"
+        },
+        "mode": {
+          "$ref": "#/$defs/ConsumerRequestMode"
+        },
+        "pop_share_queue_num": {
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "reason": {
+          "default": null,
+          "maxLength": 256,
+          "minLength": 5,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_key": {
+          "default": null,
+          "maxLength": 64,
+          "minLength": 8,
+          "pattern": "^[a-zA-Z0-9._:-]+$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "pattern": "^rocketmq-mcp-control\\.arguments\\.v1$",
+          "type": "string"
+        },
+        "timeout_millis": {
+          "format": "uint64",
+          "maximum": 24000,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "topic": {
+          "maxLength": 127,
+          "minLength": 1,
+          "pattern": "^[%|a-zA-Z0-9_-]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "cluster",
+        "topic",
+        "consumer_group",
+        "mode",
+        "pop_share_queue_num",
+        "timeout_millis"
+      ],
+      "type": "object"
+    },
+    "outputSchema": {
+      "$defs": {
+        "ConsumerRequestMode": {
+          "enum": [
+            "pull",
+            "pop"
+          ],
+          "type": "string"
+        },
+        "ConsumerRequestModeOperation": {
+          "const": "consumer_request_mode",
+          "type": "string"
+        },
+        "FailureCode": {
+          "enum": [
+            "conflict",
+            "invalid_data",
+            "unavailable",
+            "persistence_failed",
+            "verification_failed",
+            "order_reconciliation_failed"
+          ],
+          "type": "string"
+        },
+        "MutationMode": {
+          "enum": [
+            "dry_run",
+            "execute"
+          ],
+          "type": "string"
+        },
+        "MutationResultSchemaVersion": {
+          "const": "rocketmq-mcp-mutation.v1",
+          "type": "string"
+        },
+        "MutationStatus": {
+          "enum": [
+            "planned",
+            "applied",
+            "partial",
+            "conflict",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "PersistenceState": {
+          "enum": [
+            "not_required",
+            "persisted",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "RequestModeMutationTarget": {
+          "additionalProperties": false,
+          "properties": {
+            "after": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RequestModeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "applied": {
+              "type": "boolean"
+            },
+            "before": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RequestModeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "broker_name": {
+              "type": "string"
+            },
+            "changed": {
+              "type": "boolean"
+            },
+            "failure": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/FailureCode"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "persistence": {
+              "$ref": "#/$defs/PersistenceState"
+            },
+            "requested": {
+              "$ref": "#/$defs/RequestModeValue"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "verification": {
+              "$ref": "#/$defs/VerificationState"
+            }
+          },
+          "required": [
+            "broker_name",
+            "before",
+            "requested",
+            "after",
+            "applied",
+            "changed",
+            "persistence",
+            "verification",
+            "failure",
+            "retryable"
+          ],
+          "type": "object"
+        },
+        "RequestModeRequested": {
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "$ref": "#/$defs/ConsumerRequestMode"
+            },
+            "pop_share_queue_num": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "timeout_millis": {
+              "format": "uint64",
+              "maximum": 24000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "mode",
+            "pop_share_queue_num",
+            "timeout_millis"
+          ],
+          "type": "object"
+        },
+        "RequestModeResource": {
+          "additionalProperties": false,
+          "properties": {
+            "brokers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "consumer_group": {
+              "type": "string"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "topic",
+            "consumer_group",
+            "brokers"
+          ],
+          "type": "object"
+        },
+        "RequestModeValue": {
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "$ref": "#/$defs/ConsumerRequestMode"
+            },
+            "pop_share_queue_num": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "mode",
+            "pop_share_queue_num"
+          ],
+          "type": "object"
+        },
+        "VerificationState": {
+          "enum": [
+            "not_performed",
+            "verified",
+            "failed"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/RequestModeValue"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "before": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/RequestModeValue"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": "object"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "mode": {
+          "$ref": "#/$defs/MutationMode"
+        },
+        "operation": {
+          "$ref": "#/$defs/ConsumerRequestModeOperation"
+        },
+        "requested": {
+          "$ref": "#/$defs/RequestModeRequested"
+        },
+        "schema_version": {
+          "$ref": "#/$defs/MutationResultSchemaVersion"
+        },
+        "status": {
+          "$ref": "#/$defs/MutationStatus"
+        },
+        "target": {
+          "$ref": "#/$defs/RequestModeResource"
+        },
+        "targets": {
+          "items": {
+            "$ref": "#/$defs/RequestModeMutationTarget"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "operation",
+        "cluster",
+        "mode",
+        "status",
+        "target",
+        "before",
+        "requested",
+        "after",
+        "targets",
+        "warnings"
+      ],
+      "type": "object"
+    },
+    "annotations": {
+      "title": "Set RocketMQ consumer request mode",
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true
+    }
   }
 ]

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime.rs
@@ -42,16 +42,22 @@ const SESSION_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 pub(crate) type RuntimeFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 #[derive(Clone)]
-pub(crate) enum UpsertRequest {
+pub(crate) enum MutationToolRequest {
     Topic(tools::UpsertTopicArgs),
     ConsumerGroup(tools::UpsertConsumerGroupArgs),
+    ConsumerOffset(tools::ResetConsumerOffsetArgs),
+    BrokerConfig(tools::PatchBrokerConfigArgs),
+    ConsumerRequestMode(tools::SetConsumerRequestModeArgs),
 }
 
-impl UpsertRequest {
+impl MutationToolRequest {
     fn operation(&self) -> ControlOperation {
         match self {
             Self::Topic(_) => ControlOperation::TopicUpsert,
             Self::ConsumerGroup(_) => ControlOperation::ConsumerGroupUpsert,
+            Self::ConsumerOffset(_) => ControlOperation::ConsumerOffsetReset,
+            Self::BrokerConfig(_) => ControlOperation::BrokerConfigPatch,
+            Self::ConsumerRequestMode(_) => ControlOperation::ConsumerRequestMode,
         }
     }
 
@@ -59,6 +65,9 @@ impl UpsertRequest {
         match self {
             Self::Topic(args) => args.dry_run,
             Self::ConsumerGroup(args) => args.dry_run,
+            Self::ConsumerOffset(args) => args.dry_run,
+            Self::BrokerConfig(args) => args.dry_run,
+            Self::ConsumerRequestMode(args) => args.dry_run,
         }
     }
 
@@ -66,13 +75,19 @@ impl UpsertRequest {
         match self {
             Self::Topic(args) => args.request_key.as_deref(),
             Self::ConsumerGroup(args) => args.request_key.as_deref(),
+            Self::ConsumerOffset(args) => args.request_key.as_deref(),
+            Self::BrokerConfig(args) => args.request_key.as_deref(),
+            Self::ConsumerRequestMode(args) => args.request_key.as_deref(),
         }
     }
 
-    fn target_names(&self) -> &[String] {
+    fn target_names(&self) -> Vec<String> {
         match self {
-            Self::Topic(args) => &args.broker_names,
-            Self::ConsumerGroup(args) => &args.broker_names,
+            Self::Topic(args) => args.broker_names.clone(),
+            Self::ConsumerGroup(args) => args.broker_names.clone(),
+            Self::ConsumerOffset(args) => vec![args.topic.clone(), args.consumer_group.clone()],
+            Self::BrokerConfig(args) => vec![args.broker_name.clone()],
+            Self::ConsumerRequestMode(args) => vec![args.topic.clone(), args.consumer_group.clone()],
         }
     }
 
@@ -81,12 +96,13 @@ impl UpsertRequest {
         match &mut canonical {
             Self::Topic(args) => args.broker_names.sort(),
             Self::ConsumerGroup(args) => args.broker_names.sort(),
+            Self::ConsumerOffset(_) | Self::BrokerConfig(_) | Self::ConsumerRequestMode(_) => {}
         }
         serde_json::to_string(&canonical).map_err(|_| ControlError::invalid_arguments())
     }
 }
 
-impl Serialize for UpsertRequest {
+impl Serialize for MutationToolRequest {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -94,22 +110,31 @@ impl Serialize for UpsertRequest {
         match self {
             Self::Topic(args) => args.serialize(serializer),
             Self::ConsumerGroup(args) => args.serialize(serializer),
+            Self::ConsumerOffset(args) => args.serialize(serializer),
+            Self::BrokerConfig(args) => args.serialize(serializer),
+            Self::ConsumerRequestMode(args) => args.serialize(serializer),
         }
     }
 }
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
-pub(crate) enum UpsertResponse {
+pub(crate) enum MutationToolResponse {
     Topic(tools::TopicMutationToolResponse),
     ConsumerGroup(tools::ConsumerGroupMutationToolResponse),
+    ConsumerOffset(tools::OffsetMutationToolResponse),
+    BrokerConfig(tools::BrokerConfigMutationToolResponse),
+    ConsumerRequestMode(tools::RequestModeMutationToolResponse),
 }
 
-impl UpsertResponse {
+impl MutationToolResponse {
     pub(crate) fn is_error(&self) -> bool {
         match self {
             Self::Topic(response) => response.is_error(),
             Self::ConsumerGroup(response) => response.is_error(),
+            Self::ConsumerOffset(response) => response.is_error(),
+            Self::BrokerConfig(response) => response.is_error(),
+            Self::ConsumerRequestMode(response) => response.is_error(),
         }
     }
 
@@ -117,6 +142,9 @@ impl UpsertResponse {
         let status = match self {
             Self::Topic(response) => response.status,
             Self::ConsumerGroup(response) => response.status,
+            Self::ConsumerOffset(response) => response.status,
+            Self::BrokerConfig(response) => response.status,
+            Self::ConsumerRequestMode(response) => response.status,
         };
         match status {
             tools::MutationStatus::Conflict => Some(crate::error::ControlErrorCode::Conflict),
@@ -128,19 +156,25 @@ impl UpsertResponse {
     }
 }
 
-pub(crate) trait UpsertSession: Send {
-    fn run<'a>(&'a mut self, request: UpsertRequest) -> RuntimeFuture<'a, Result<UpsertResponse, ControlError>>;
+pub(crate) trait MutationToolSession: Send {
+    fn run<'a>(
+        &'a mut self,
+        request: MutationToolRequest,
+    ) -> RuntimeFuture<'a, Result<MutationToolResponse, ControlError>>;
     fn shutdown(&mut self) -> RuntimeFuture<'_, Result<(), ControlError>>;
 }
 
-pub(crate) trait UpsertSessionFactory: Send + Sync {
-    fn open<'a>(&'a self, cluster: &'a ClusterName) -> RuntimeFuture<'a, Result<Box<dyn UpsertSession>, ControlError>>;
+pub(crate) trait MutationToolSessionFactory: Send + Sync {
+    fn open<'a>(
+        &'a self,
+        cluster: &'a ClusterName,
+    ) -> RuntimeFuture<'a, Result<Box<dyn MutationToolSession>, ControlError>>;
 }
 
 #[derive(Clone)]
 pub(crate) struct ToolRuntime {
     audit: AuditTrail,
-    factory: Arc<dyn UpsertSessionFactory>,
+    factory: Arc<dyn MutationToolSessionFactory>,
     operation_timeout: Duration,
     owner: TaskGroup,
     idempotency: Arc<Mutex<IdempotencyState>>,
@@ -149,7 +183,7 @@ pub(crate) struct ToolRuntime {
 impl ToolRuntime {
     pub(crate) fn new(
         audit: AuditTrail,
-        factory: Arc<dyn UpsertSessionFactory>,
+        factory: Arc<dyn MutationToolSessionFactory>,
         operation_timeout: Duration,
         owner: TaskGroup,
     ) -> Self {
@@ -166,9 +200,9 @@ impl ToolRuntime {
         &self,
         principal: &Principal,
         authorized: &AuthorizedMutation,
-        request: UpsertRequest,
+        request: MutationToolRequest,
         cancellation: CancellationToken,
-    ) -> Result<UpsertResponse, ControlError> {
+    ) -> Result<MutationToolResponse, ControlError> {
         let cluster = authorized.cluster().clone();
         let identity = IdempotencyIdentity::from_request(principal, &cluster, &request)?;
         let admission =
@@ -207,7 +241,7 @@ impl ToolRuntime {
         let cache = self.idempotency.clone();
         let cleanup_identity = identity.clone();
         let task_invocation = invocation.clone();
-        let spawn = self.owner.spawn_service("mcp-control-upsert-supervisor", async move {
+        let spawn = self.owner.spawn_service("mcp-control-mutation-supervisor", async move {
             let result = execute_admitted(
                 cache,
                 identity,
@@ -243,11 +277,21 @@ impl ToolRuntime {
 pub(crate) mod admin_session;
 mod execution;
 mod idempotency;
+mod remaining;
 
-pub(crate) use admin_session::AdminUpsertFactory;
+pub(crate) use admin_session::AdminMutationToolFactory;
 use idempotency::execute_admitted;
 use idempotency::IdempotencyIdentity;
 use idempotency::IdempotencyState;
+
+#[cfg(test)]
+pub(crate) use MutationToolRequest as UpsertRequest;
+#[cfg(test)]
+pub(crate) use MutationToolResponse as UpsertResponse;
+#[cfg(test)]
+pub(crate) use MutationToolSession as UpsertSession;
+#[cfg(test)]
+pub(crate) use MutationToolSessionFactory as UpsertSessionFactory;
 
 fn topic_before(
     args: &tools::UpsertTopicArgs,

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/admin_session.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/admin_session.rs
@@ -30,19 +30,22 @@ use super::map_topic_to_admin;
 use super::topic_before;
 use super::topic_dry_run;
 use super::topic_executed;
+use super::MutationToolRequest;
+use super::MutationToolResponse;
+use super::MutationToolSession;
+use super::MutationToolSessionFactory;
 use super::RuntimeFuture;
-use super::UpsertRequest;
-use super::UpsertResponse;
-use super::UpsertSession;
-use super::UpsertSessionFactory;
 use crate::config::MutationClusterConfig;
 use crate::error::ControlError;
 use crate::model::ClusterName;
 use crate::tools;
 
-pub(crate) trait SupervisedUpsertBackend: Send {
+pub(crate) trait SupervisedMutationBackend: Send {
     type TopicPlan: Send;
     type GroupPlan: Send;
+    type OffsetPlan: Send;
+    type BrokerPlan: Send;
+    type RequestModePlan: Send;
 
     fn preflight_topic<'a>(
         &'a mut self,
@@ -76,12 +79,60 @@ pub(crate) trait SupervisedUpsertBackend: Send {
         plan: &'a Self::GroupPlan,
     ) -> RuntimeFuture<'a, Result<admin::MetadataMutationOutcome, ControlError>>;
 
+    fn preview_offset<'a>(
+        &'a mut self,
+        request: &'a admin::OffsetResetPreviewRequest,
+    ) -> RuntimeFuture<'a, Result<Self::OffsetPlan, ControlError>>;
+
+    fn offset_rows(plan: &Self::OffsetPlan) -> Vec<admin::OffsetResetPreviewRow>;
+
+    fn offset_failures(plan: &Self::OffsetPlan) -> &[admin::MutationTargetFailure];
+
+    fn execute_offset<'a>(
+        &'a mut self,
+        plan: &'a Self::OffsetPlan,
+    ) -> RuntimeFuture<'a, Result<admin::OffsetResetOutcome, ControlError>>;
+
+    fn preflight_broker<'a>(
+        &'a mut self,
+        cluster: &'a str,
+        broker_name: &'a str,
+    ) -> RuntimeFuture<'a, Result<Self::BrokerPlan, ControlError>>;
+
+    fn broker_targets(plan: &Self::BrokerPlan) -> Vec<admin::BrokerMutationConfigTarget>;
+
+    fn broker_failures(plan: &Self::BrokerPlan) -> &[admin::MutationTargetFailure];
+
+    fn execute_broker<'a>(
+        &'a mut self,
+        plan: &'a Self::BrokerPlan,
+        patch: admin::BrokerMutationConfigPatch,
+    ) -> RuntimeFuture<'a, Result<admin::BrokerMutationConfigOutcome, ControlError>>;
+
+    fn preflight_request_mode<'a>(
+        &'a mut self,
+        request: &'a admin::RequestModePreflightRequest,
+    ) -> RuntimeFuture<'a, Result<Self::RequestModePlan, ControlError>>;
+
+    fn request_mode_targets(plan: &Self::RequestModePlan) -> Vec<(String, Option<admin::RequestModeValue>)>;
+
+    fn request_mode_failures(plan: &Self::RequestModePlan) -> &[admin::MutationTargetFailure];
+
+    fn execute_request_mode<'a>(
+        &'a mut self,
+        plan: &'a Self::RequestModePlan,
+        timeout_millis: u64,
+    ) -> RuntimeFuture<'a, Result<admin::RequestModeMutationOutcome, ControlError>>;
+
     fn shutdown(&mut self) -> RuntimeFuture<'_, Result<(), ControlError>>;
 }
 
-impl SupervisedUpsertBackend for MutationAdminSession {
+impl SupervisedMutationBackend for MutationAdminSession {
     type TopicPlan = admin::TopicMutationPlan;
     type GroupPlan = admin::SubscriptionGroupMutationPlan;
+    type OffsetPlan = admin::OffsetResetPlan;
+    type BrokerPlan = admin::BrokerMutationConfigPlan;
+    type RequestModePlan = admin::RequestModeMutationPlan;
 
     fn preflight_topic<'a>(
         &'a mut self,
@@ -147,6 +198,99 @@ impl SupervisedUpsertBackend for MutationAdminSession {
         })
     }
 
+    fn preview_offset<'a>(
+        &'a mut self,
+        request: &'a admin::OffsetResetPreviewRequest,
+    ) -> RuntimeFuture<'a, Result<Self::OffsetPlan, ControlError>> {
+        Box::pin(async move {
+            self.preview_offset_reset(request)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
+    fn offset_rows(plan: &Self::OffsetPlan) -> Vec<admin::OffsetResetPreviewRow> {
+        plan.rows()
+    }
+
+    fn offset_failures(plan: &Self::OffsetPlan) -> &[admin::MutationTargetFailure] {
+        plan.failures()
+    }
+
+    fn execute_offset<'a>(
+        &'a mut self,
+        plan: &'a Self::OffsetPlan,
+    ) -> RuntimeFuture<'a, Result<admin::OffsetResetOutcome, ControlError>> {
+        Box::pin(async move {
+            self.execute_offset_reset(plan)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
+    fn preflight_broker<'a>(
+        &'a mut self,
+        cluster: &'a str,
+        broker_name: &'a str,
+    ) -> RuntimeFuture<'a, Result<Self::BrokerPlan, ControlError>> {
+        Box::pin(async move {
+            self.preflight_broker_config_target(cluster, broker_name)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
+    fn broker_targets(plan: &Self::BrokerPlan) -> Vec<admin::BrokerMutationConfigTarget> {
+        plan.targets()
+    }
+
+    fn broker_failures(plan: &Self::BrokerPlan) -> &[admin::MutationTargetFailure] {
+        plan.failures()
+    }
+
+    fn execute_broker<'a>(
+        &'a mut self,
+        plan: &'a Self::BrokerPlan,
+        patch: admin::BrokerMutationConfigPatch,
+    ) -> RuntimeFuture<'a, Result<admin::BrokerMutationConfigOutcome, ControlError>> {
+        Box::pin(async move {
+            self.execute_broker_config_patch_verified(plan, patch)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
+    fn preflight_request_mode<'a>(
+        &'a mut self,
+        request: &'a admin::RequestModePreflightRequest,
+    ) -> RuntimeFuture<'a, Result<Self::RequestModePlan, ControlError>> {
+        Box::pin(async move {
+            SupervisedMutationAdmin::preflight_request_mode(self, request)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
+    fn request_mode_targets(plan: &Self::RequestModePlan) -> Vec<(String, Option<admin::RequestModeValue>)> {
+        plan.targets()
+    }
+
+    fn request_mode_failures(plan: &Self::RequestModePlan) -> &[admin::MutationTargetFailure] {
+        plan.failures()
+    }
+
+    fn execute_request_mode<'a>(
+        &'a mut self,
+        plan: &'a Self::RequestModePlan,
+        timeout_millis: u64,
+    ) -> RuntimeFuture<'a, Result<admin::RequestModeMutationOutcome, ControlError>> {
+        Box::pin(async move {
+            SupervisedMutationAdmin::execute_request_mode_with_timeout(self, plan, timeout_millis)
+                .await
+                .map_err(|_| ControlError::execution_failed())
+        })
+    }
+
     fn shutdown(&mut self) -> RuntimeFuture<'_, Result<(), ControlError>> {
         Box::pin(async move {
             MutationAdminSession::shutdown(self).await;
@@ -155,27 +299,43 @@ impl SupervisedUpsertBackend for MutationAdminSession {
     }
 }
 
-pub(crate) struct AdminUpsertSession<B> {
+pub(crate) struct AdminMutationToolSession<B> {
     backend: B,
 }
 
-impl<B> AdminUpsertSession<B> {
+impl<B> AdminMutationToolSession<B> {
     pub(crate) const fn new(backend: B) -> Self {
         Self { backend }
     }
 }
 
-impl<B> UpsertSession for AdminUpsertSession<B>
+impl<B> MutationToolSession for AdminMutationToolSession<B>
 where
-    B: SupervisedUpsertBackend,
+    B: SupervisedMutationBackend,
 {
-    fn run<'a>(&'a mut self, request: UpsertRequest) -> RuntimeFuture<'a, Result<UpsertResponse, ControlError>> {
+    fn run<'a>(
+        &'a mut self,
+        request: MutationToolRequest,
+    ) -> RuntimeFuture<'a, Result<MutationToolResponse, ControlError>> {
         Box::pin(async move {
             match request {
-                UpsertRequest::Topic(args) => run_topic(&mut self.backend, args).await.map(UpsertResponse::Topic),
-                UpsertRequest::ConsumerGroup(args) => run_group(&mut self.backend, args)
+                MutationToolRequest::Topic(args) => run_topic(&mut self.backend, args)
                     .await
-                    .map(UpsertResponse::ConsumerGroup),
+                    .map(MutationToolResponse::Topic),
+                MutationToolRequest::ConsumerGroup(args) => run_group(&mut self.backend, args)
+                    .await
+                    .map(MutationToolResponse::ConsumerGroup),
+                MutationToolRequest::ConsumerOffset(args) => super::remaining::run_offset(&mut self.backend, args)
+                    .await
+                    .map(MutationToolResponse::ConsumerOffset),
+                MutationToolRequest::BrokerConfig(args) => super::remaining::run_broker(&mut self.backend, args)
+                    .await
+                    .map(MutationToolResponse::BrokerConfig),
+                MutationToolRequest::ConsumerRequestMode(args) => {
+                    super::remaining::run_request_mode(&mut self.backend, args)
+                        .await
+                        .map(MutationToolResponse::ConsumerRequestMode)
+                }
             }
         })
     }
@@ -185,7 +345,7 @@ where
     }
 }
 
-async fn run_topic<B: SupervisedUpsertBackend>(
+async fn run_topic<B: SupervisedMutationBackend>(
     backend: &mut B,
     args: tools::UpsertTopicArgs,
 ) -> Result<tools::TopicMutationToolResponse, ControlError> {
@@ -208,7 +368,7 @@ async fn run_topic<B: SupervisedUpsertBackend>(
     Ok(topic_executed(&args, before, outcome, observed))
 }
 
-async fn run_group<B: SupervisedUpsertBackend>(
+async fn run_group<B: SupervisedMutationBackend>(
     backend: &mut B,
     args: tools::UpsertConsumerGroupArgs,
 ) -> Result<tools::ConsumerGroupMutationToolResponse, ControlError> {
@@ -231,13 +391,13 @@ async fn run_group<B: SupervisedUpsertBackend>(
     Ok(group_executed(&args, before, outcome, observed))
 }
 
-pub(crate) struct AdminUpsertFactory {
+pub(crate) struct AdminMutationToolFactory {
     runtime: Arc<rocketmq_admin_core::mutation_client_adapter::ClientRuntime>,
     clusters: BTreeMap<ClusterName, MutationClusterConfig>,
     sequence: AtomicU64,
 }
 
-impl AdminUpsertFactory {
+impl AdminMutationToolFactory {
     pub(crate) fn new(
         service_context: rocketmq_runtime::ChildServiceContext,
         clusters: &[MutationClusterConfig],
@@ -258,8 +418,11 @@ impl AdminUpsertFactory {
     }
 }
 
-impl UpsertSessionFactory for AdminUpsertFactory {
-    fn open<'a>(&'a self, cluster: &'a ClusterName) -> RuntimeFuture<'a, Result<Box<dyn UpsertSession>, ControlError>> {
+impl MutationToolSessionFactory for AdminMutationToolFactory {
+    fn open<'a>(
+        &'a self,
+        cluster: &'a ClusterName,
+    ) -> RuntimeFuture<'a, Result<Box<dyn MutationToolSession>, ControlError>> {
         Box::pin(async move {
             let config = self
                 .clusters
@@ -288,7 +451,11 @@ impl UpsertSessionFactory for AdminUpsertFactory {
                 .build_and_start()
                 .await
                 .map_err(|_| ControlError::execution_failed())?;
-            Ok(Box::new(AdminUpsertSession::new(admin)) as Box<dyn UpsertSession>)
+            Ok(Box::new(AdminMutationToolSession::new(admin)) as Box<dyn MutationToolSession>)
         })
     }
 }
+
+#[cfg(test)]
+#[path = "admin_session/tests.rs"]
+mod tests;

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/admin_session/tests.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/admin_session/tests.rs
@@ -1,0 +1,703 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use super::*;
+
+#[derive(Default)]
+struct Evidence {
+    offset_executes: AtomicUsize,
+    offset_verification_failure: AtomicBool,
+    broker_executes: AtomicUsize,
+    request_mode_executes: AtomicUsize,
+    request_mode_verification_failure: AtomicBool,
+    request_mode_mixed_postread: AtomicBool,
+    request_mode_timeout: AtomicU64,
+    shutdowns: AtomicUsize,
+}
+
+struct OffsetPlan {
+    rows: Vec<admin::OffsetResetPreviewRow>,
+    failures: Vec<admin::MutationTargetFailure>,
+}
+
+struct BrokerPlan {
+    targets: Vec<admin::BrokerMutationConfigTarget>,
+    failures: Vec<admin::MutationTargetFailure>,
+}
+
+struct RequestModePlan {
+    targets: Vec<(String, Option<admin::RequestModeValue>)>,
+    failures: Vec<admin::MutationTargetFailure>,
+}
+
+struct ProductionPathBackend {
+    evidence: Arc<Evidence>,
+}
+
+fn unused<T: Send>() -> RuntimeFuture<'static, Result<T, ControlError>> {
+    Box::pin(async { Err(ControlError::operation_unavailable()) })
+}
+
+impl SupervisedMutationBackend for ProductionPathBackend {
+    type TopicPlan = ();
+    type GroupPlan = ();
+    type OffsetPlan = OffsetPlan;
+    type BrokerPlan = BrokerPlan;
+    type RequestModePlan = RequestModePlan;
+
+    fn preflight_topic<'a>(
+        &'a mut self,
+        _request: &'a admin::TopicMutationPreflightRequest,
+        _broker_names: &'a [String],
+    ) -> RuntimeFuture<'a, Result<Self::TopicPlan, ControlError>> {
+        unused()
+    }
+
+    fn topic_targets(_plan: &Self::TopicPlan) -> Vec<admin::MetadataPreflightTarget<admin::TopicReplacement>> {
+        Vec::new()
+    }
+
+    fn topic_failures(_plan: &Self::TopicPlan) -> &[admin::MutationTargetFailure] {
+        &[]
+    }
+
+    fn execute_topic<'a>(
+        &'a mut self,
+        _plan: &'a Self::TopicPlan,
+    ) -> RuntimeFuture<'a, Result<admin::MetadataMutationOutcome, ControlError>> {
+        unused()
+    }
+
+    fn preflight_group<'a>(
+        &'a mut self,
+        _request: &'a admin::SubscriptionGroupMutationPreflightRequest,
+        _broker_names: &'a [String],
+    ) -> RuntimeFuture<'a, Result<Self::GroupPlan, ControlError>> {
+        unused()
+    }
+
+    fn group_targets(
+        _plan: &Self::GroupPlan,
+    ) -> Vec<admin::MetadataPreflightTarget<admin::SubscriptionGroupReplacement>> {
+        Vec::new()
+    }
+
+    fn group_failures(_plan: &Self::GroupPlan) -> &[admin::MutationTargetFailure] {
+        &[]
+    }
+
+    fn execute_group<'a>(
+        &'a mut self,
+        _plan: &'a Self::GroupPlan,
+    ) -> RuntimeFuture<'a, Result<admin::MetadataMutationOutcome, ControlError>> {
+        unused()
+    }
+
+    fn preview_offset<'a>(
+        &'a mut self,
+        _request: &'a admin::OffsetResetPreviewRequest,
+    ) -> RuntimeFuture<'a, Result<Self::OffsetPlan, ControlError>> {
+        Box::pin(async {
+            Ok(OffsetPlan {
+                rows: vec![admin::OffsetResetPreviewRow {
+                    broker_name: "broker-a".to_owned(),
+                    queue_id: 0,
+                    current_offset: 9,
+                    planned_offset: 4,
+                    delta: -5,
+                    changed: true,
+                }],
+                failures: vec![admin::MutationTargetFailure {
+                    broker_name: "broker-0-preview-failed".to_owned(),
+                    queue_id: None,
+                    code: admin::MutationFailureCode::Unavailable,
+                    retryable: true,
+                }],
+            })
+        })
+    }
+
+    fn offset_rows(plan: &Self::OffsetPlan) -> Vec<admin::OffsetResetPreviewRow> {
+        plan.rows.clone()
+    }
+
+    fn offset_failures(plan: &Self::OffsetPlan) -> &[admin::MutationTargetFailure] {
+        &plan.failures
+    }
+
+    fn execute_offset<'a>(
+        &'a mut self,
+        _plan: &'a Self::OffsetPlan,
+    ) -> RuntimeFuture<'a, Result<admin::OffsetResetOutcome, ControlError>> {
+        self.evidence.offset_executes.fetch_add(1, Ordering::SeqCst);
+        let verification_failure = self.evidence.offset_verification_failure.load(Ordering::SeqCst);
+        Box::pin(async move {
+            Ok(admin::OffsetResetOutcome {
+                targets: vec![admin::OffsetResetTargetOutcome {
+                    broker_name: "broker-a".to_owned(),
+                    queue_id: 0,
+                    expected_offset: 9,
+                    planned_offset: 4,
+                    observed_offset: (!verification_failure).then_some(4),
+                    applied: true,
+                    changed: true,
+                    failure: verification_failure.then_some(admin::MutationFailureCode::VerificationFailed),
+                    retryable: verification_failure,
+                }],
+                failures: vec![admin::MutationTargetFailure {
+                    broker_name: "broker-0-preview-failed".to_owned(),
+                    queue_id: None,
+                    code: admin::MutationFailureCode::Unavailable,
+                    retryable: true,
+                }],
+            })
+        })
+    }
+
+    fn preflight_broker<'a>(
+        &'a mut self,
+        _cluster: &'a str,
+        broker_name: &'a str,
+    ) -> RuntimeFuture<'a, Result<Self::BrokerPlan, ControlError>> {
+        let broker_name = broker_name.to_owned();
+        Box::pin(async move {
+            Ok(BrokerPlan {
+                targets: vec![admin::BrokerMutationConfigTarget {
+                    broker_name,
+                    state: admin::BrokerMutationConfigState {
+                        generation: 7,
+                        auto_create_topic_enable: true,
+                        auto_create_subscription_group: true,
+                        broker_permission: 6,
+                        default_topic_queue_nums: 8,
+                        message_index_enable: true,
+                        trace_topic_enable: false,
+                    },
+                }],
+                failures: Vec::new(),
+            })
+        })
+    }
+
+    fn broker_targets(plan: &Self::BrokerPlan) -> Vec<admin::BrokerMutationConfigTarget> {
+        plan.targets.clone()
+    }
+
+    fn broker_failures(plan: &Self::BrokerPlan) -> &[admin::MutationTargetFailure] {
+        &plan.failures
+    }
+
+    fn execute_broker<'a>(
+        &'a mut self,
+        _plan: &'a Self::BrokerPlan,
+        patch: admin::BrokerMutationConfigPatch,
+    ) -> RuntimeFuture<'a, Result<admin::BrokerMutationConfigOutcome, ControlError>> {
+        self.evidence.broker_executes.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move {
+            assert_eq!(patch.trace_topic_enable, Some(true));
+            Ok(admin::BrokerMutationConfigOutcome {
+                targets: vec![admin::BrokerMutationConfigTargetOutcome {
+                    broker_name: "broker-a".to_owned(),
+                    before: admin::BrokerMutationConfigState {
+                        generation: 7,
+                        auto_create_topic_enable: true,
+                        auto_create_subscription_group: true,
+                        broker_permission: 6,
+                        default_topic_queue_nums: 8,
+                        message_index_enable: true,
+                        trace_topic_enable: false,
+                    },
+                    after: None,
+                    applied: true,
+                    changed: true,
+                    persistence: admin::MutationPersistenceState::Persisted,
+                    verification: admin::MutationVerificationState::Failed,
+                    failure: Some(admin::MutationFailureCode::VerificationFailed),
+                    retryable: true,
+                }],
+                failures: Vec::new(),
+            })
+        })
+    }
+
+    fn preflight_request_mode<'a>(
+        &'a mut self,
+        request: &'a admin::RequestModePreflightRequest,
+    ) -> RuntimeFuture<'a, Result<Self::RequestModePlan, ControlError>> {
+        let replacement = request.replacement;
+        let mixed_postread = self.evidence.request_mode_mixed_postread.load(Ordering::SeqCst);
+        Box::pin(async move {
+            assert_eq!(replacement.mode, admin::RequestMode::Pop);
+            let mut targets = vec![(
+                "broker-a".to_owned(),
+                Some(admin::RequestModeValue {
+                    mode: admin::RequestMode::Pull,
+                    pop_share_queue_num: 0,
+                }),
+            )];
+            if mixed_postread {
+                targets.insert(
+                    0,
+                    (
+                        "broker-b".to_owned(),
+                        Some(admin::RequestModeValue {
+                            mode: admin::RequestMode::Pull,
+                            pop_share_queue_num: 0,
+                        }),
+                    ),
+                );
+            }
+            Ok(RequestModePlan {
+                targets,
+                failures: Vec::new(),
+            })
+        })
+    }
+
+    fn request_mode_targets(plan: &Self::RequestModePlan) -> Vec<(String, Option<admin::RequestModeValue>)> {
+        plan.targets.clone()
+    }
+
+    fn request_mode_failures(plan: &Self::RequestModePlan) -> &[admin::MutationTargetFailure] {
+        &plan.failures
+    }
+
+    fn execute_request_mode<'a>(
+        &'a mut self,
+        _plan: &'a Self::RequestModePlan,
+        timeout_millis: u64,
+    ) -> RuntimeFuture<'a, Result<admin::RequestModeMutationOutcome, ControlError>> {
+        self.evidence.request_mode_executes.fetch_add(1, Ordering::SeqCst);
+        self.evidence
+            .request_mode_timeout
+            .store(timeout_millis, Ordering::SeqCst);
+        let verification_failure = self.evidence.request_mode_verification_failure.load(Ordering::SeqCst);
+        let mixed_postread = self.evidence.request_mode_mixed_postread.load(Ordering::SeqCst);
+        Box::pin(async move {
+            let successful = admin::RequestModeTargetOutcome {
+                broker_name: "broker-a".to_owned(),
+                expected: Some(admin::RequestModeValue {
+                    mode: admin::RequestMode::Pull,
+                    pop_share_queue_num: 0,
+                }),
+                current: Some(admin::RequestModeValue {
+                    mode: admin::RequestMode::Pop,
+                    pop_share_queue_num: 4,
+                }),
+                applied: true,
+                changed: true,
+                persistence: admin::MutationPersistenceState::Persisted,
+                verification: admin::MutationVerificationState::Verified,
+                failure: None,
+                retryable: false,
+            };
+            if mixed_postread {
+                return Ok(admin::RequestModeMutationOutcome {
+                    targets: vec![
+                        admin::RequestModeTargetOutcome {
+                            broker_name: "broker-b".to_owned(),
+                            expected: Some(admin::RequestModeValue {
+                                mode: admin::RequestMode::Pull,
+                                pop_share_queue_num: 0,
+                            }),
+                            current: None,
+                            applied: true,
+                            changed: true,
+                            persistence: admin::MutationPersistenceState::Persisted,
+                            verification: admin::MutationVerificationState::Failed,
+                            failure: Some(admin::MutationFailureCode::VerificationFailed),
+                            retryable: true,
+                        },
+                        successful,
+                    ],
+                    failures: Vec::new(),
+                });
+            }
+            Ok(admin::RequestModeMutationOutcome {
+                targets: vec![if verification_failure {
+                    admin::RequestModeTargetOutcome {
+                        current: None,
+                        verification: admin::MutationVerificationState::Failed,
+                        failure: Some(admin::MutationFailureCode::VerificationFailed),
+                        retryable: true,
+                        ..successful
+                    }
+                } else {
+                    successful
+                }],
+                failures: Vec::new(),
+            })
+        })
+    }
+
+    fn shutdown(&mut self) -> RuntimeFuture<'_, Result<(), ControlError>> {
+        self.evidence.shutdowns.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(()) })
+    }
+}
+
+fn common() -> (String, String, bool, bool, Option<String>, Option<String>) {
+    (
+        crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION.to_owned(),
+        "cluster-a".to_owned(),
+        false,
+        true,
+        Some("approved operation".to_owned()),
+        None,
+    )
+}
+
+#[tokio::test]
+async fn production_session_orchestrates_all_stage_c_operations_and_preserves_truth() {
+    let evidence = Arc::new(Evidence::default());
+    let mut session = AdminMutationToolSession::new(ProductionPathBackend {
+        evidence: Arc::clone(&evidence),
+    });
+    let (schema_version, cluster, dry_run, confirm, reason, request_key) = common();
+    let offset = session
+        .run(MutationToolRequest::ConsumerOffset(tools::ResetConsumerOffsetArgs {
+            schema_version,
+            cluster,
+            topic: "orders".to_owned(),
+            consumer_group: "orders-consumer".to_owned(),
+            timestamp: "2026-08-30T08:00:00+08:00".to_owned(),
+            force: false,
+            dry_run,
+            confirm,
+            reason,
+            request_key,
+        }))
+        .await
+        .expect("offset through production session");
+    let MutationToolResponse::ConsumerOffset(offset) = offset else {
+        panic!("unexpected response variant");
+    };
+    assert_eq!(offset.status, tools::MutationStatus::Partial);
+    assert_eq!(offset.targets.len(), 2);
+    assert!(offset.targets.iter().any(|target| {
+        target.broker_name == "broker-0-preview-failed"
+            && target.queue_id.is_none()
+            && target.failure == Some(tools::FailureCode::Unavailable)
+    }));
+    assert_eq!(offset.targets[0].broker_name, "broker-0-preview-failed");
+    assert_eq!(
+        offset
+            .targets
+            .iter()
+            .find(|target| target.queue_id == Some(0))
+            .and_then(|target| target.after),
+        Some(4)
+    );
+
+    let (schema_version, cluster, dry_run, confirm, reason, request_key) = common();
+    let broker = session
+        .run(MutationToolRequest::BrokerConfig(tools::PatchBrokerConfigArgs {
+            schema_version,
+            cluster,
+            broker_name: "broker-a".to_owned(),
+            properties: tools::BrokerConfigProperties {
+                trace_topic_enable: Some("true".to_owned()),
+                ..tools::BrokerConfigProperties::default()
+            },
+            dry_run,
+            confirm,
+            reason,
+            request_key,
+        }))
+        .await
+        .expect("broker through production session");
+    let MutationToolResponse::BrokerConfig(broker) = broker else {
+        panic!("unexpected response variant");
+    };
+    assert_eq!(broker.status, tools::MutationStatus::Failed);
+    assert!(broker.after.is_none());
+    assert!(broker.targets[0].applied);
+    assert!(broker.targets[0].after.is_none());
+    assert_eq!(broker.targets[0].failure, Some(tools::FailureCode::VerificationFailed));
+
+    let (schema_version, cluster, dry_run, confirm, reason, request_key) = common();
+    let request_mode = session
+        .run(MutationToolRequest::ConsumerRequestMode(
+            tools::SetConsumerRequestModeArgs {
+                schema_version,
+                cluster,
+                topic: "orders".to_owned(),
+                consumer_group: "orders-consumer".to_owned(),
+                mode: tools::ConsumerRequestMode::Pop,
+                pop_share_queue_num: 4,
+                timeout_millis: 12_345,
+                dry_run,
+                confirm,
+                reason,
+                request_key,
+            },
+        ))
+        .await
+        .expect("request mode through production session");
+    let MutationToolResponse::ConsumerRequestMode(request_mode) = request_mode else {
+        panic!("unexpected response variant");
+    };
+    assert_eq!(request_mode.status, tools::MutationStatus::Applied);
+    assert_eq!(
+        request_mode.targets[0].after.expect("postread").mode,
+        tools::ConsumerRequestMode::Pop
+    );
+    assert_eq!(evidence.offset_executes.load(Ordering::SeqCst), 1);
+    assert_eq!(evidence.broker_executes.load(Ordering::SeqCst), 1);
+    assert_eq!(evidence.request_mode_executes.load(Ordering::SeqCst), 1);
+    assert_eq!(evidence.request_mode_timeout.load(Ordering::SeqCst), 12_345);
+
+    session.shutdown().await.expect("session shutdown");
+    assert_eq!(evidence.shutdowns.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn production_session_maps_stage_c_postread_errors_as_verification_failures() {
+    let evidence = Arc::new(Evidence::default());
+    evidence.offset_verification_failure.store(true, Ordering::SeqCst);
+    evidence.request_mode_verification_failure.store(true, Ordering::SeqCst);
+    let mut session = AdminMutationToolSession::new(ProductionPathBackend {
+        evidence: Arc::clone(&evidence),
+    });
+
+    let (schema_version, cluster, dry_run, confirm, reason, request_key) = common();
+    let offset = session
+        .run(MutationToolRequest::ConsumerOffset(tools::ResetConsumerOffsetArgs {
+            schema_version,
+            cluster,
+            topic: "orders".to_owned(),
+            consumer_group: "orders-consumer".to_owned(),
+            timestamp: "2026-08-30T08:00:00+08:00".to_owned(),
+            force: false,
+            dry_run,
+            confirm,
+            reason,
+            request_key,
+        }))
+        .await
+        .expect("offset through production session");
+    let MutationToolResponse::ConsumerOffset(offset) = offset else {
+        panic!("unexpected response variant");
+    };
+    let offset_target = offset
+        .targets
+        .iter()
+        .find(|target| target.queue_id == Some(0))
+        .expect("offset queue target");
+    assert!(offset_target.applied);
+    assert!(offset_target.changed);
+    assert_eq!(offset_target.after, None);
+    assert_eq!(offset_target.failure, Some(tools::FailureCode::VerificationFailed));
+    assert!(offset_target.retryable);
+    assert!(offset.after.is_none());
+
+    let (schema_version, cluster, dry_run, confirm, reason, request_key) = common();
+    let request_mode = session
+        .run(MutationToolRequest::ConsumerRequestMode(
+            tools::SetConsumerRequestModeArgs {
+                schema_version,
+                cluster,
+                topic: "orders".to_owned(),
+                consumer_group: "orders-consumer".to_owned(),
+                mode: tools::ConsumerRequestMode::Pop,
+                pop_share_queue_num: 4,
+                timeout_millis: 12_345,
+                dry_run,
+                confirm,
+                reason,
+                request_key,
+            },
+        ))
+        .await
+        .expect("request mode through production session");
+    let MutationToolResponse::ConsumerRequestMode(request_mode) = request_mode else {
+        panic!("unexpected response variant");
+    };
+    let request_target = &request_mode.targets[0];
+    assert!(request_target.applied);
+    assert!(request_target.changed);
+    assert_eq!(request_target.after, None);
+    assert_eq!(request_target.verification, tools::VerificationState::Failed);
+    assert_eq!(request_target.failure, Some(tools::FailureCode::VerificationFailed));
+    assert!(request_target.retryable);
+    assert!(request_mode.after.is_none());
+
+    session.shutdown().await.expect("session shutdown");
+    assert_eq!(evidence.shutdowns.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn production_session_preserves_sorted_mixed_request_mode_postread_truth() {
+    let evidence = Arc::new(Evidence::default());
+    evidence.request_mode_mixed_postread.store(true, Ordering::SeqCst);
+    let mut session = AdminMutationToolSession::new(ProductionPathBackend {
+        evidence: Arc::clone(&evidence),
+    });
+    let (schema_version, cluster, dry_run, confirm, reason, request_key) = common();
+    let response = session
+        .run(MutationToolRequest::ConsumerRequestMode(
+            tools::SetConsumerRequestModeArgs {
+                schema_version,
+                cluster,
+                topic: "orders".to_owned(),
+                consumer_group: "orders-consumer".to_owned(),
+                mode: tools::ConsumerRequestMode::Pop,
+                pop_share_queue_num: 4,
+                timeout_millis: 12_345,
+                dry_run,
+                confirm,
+                reason,
+                request_key,
+            },
+        ))
+        .await
+        .expect("mixed request mode through production session");
+    let MutationToolResponse::ConsumerRequestMode(response) = response else {
+        panic!("unexpected response variant");
+    };
+
+    assert_eq!(response.status, tools::MutationStatus::Partial);
+    assert_eq!(response.targets.len(), 2);
+    assert_eq!(
+        response
+            .targets
+            .iter()
+            .map(|target| target.broker_name.as_str())
+            .collect::<Vec<_>>(),
+        ["broker-a", "broker-b"]
+    );
+    let successful = &response.targets[0];
+    assert!(successful.applied);
+    assert!(successful.changed);
+    assert_eq!(successful.verification, tools::VerificationState::Verified);
+    assert_eq!(successful.failure, None);
+    assert!(!successful.retryable);
+    assert_eq!(
+        successful.after.expect("successful postread").mode,
+        tools::ConsumerRequestMode::Pop
+    );
+    let failed = &response.targets[1];
+    assert!(failed.applied);
+    assert!(failed.changed);
+    assert_eq!(failed.after, None);
+    assert_eq!(failed.verification, tools::VerificationState::Failed);
+    assert_eq!(failed.failure, Some(tools::FailureCode::VerificationFailed));
+    assert!(failed.retryable);
+
+    let after = response.after.expect("at least one broker has postread truth");
+    assert_eq!(
+        after.keys().map(String::as_str).collect::<Vec<_>>(),
+        ["broker-a", "broker-b"]
+    );
+    assert_eq!(
+        after.get("broker-a").and_then(|value| *value),
+        Some(tools::RequestModeValue {
+            mode: tools::ConsumerRequestMode::Pop,
+            pop_share_queue_num: 4,
+        })
+    );
+    assert_eq!(after.get("broker-b"), Some(&None));
+    assert_eq!(evidence.request_mode_executes.load(Ordering::SeqCst), 1);
+    assert_eq!(evidence.request_mode_timeout.load(Ordering::SeqCst), 12_345);
+
+    session.shutdown().await.expect("session shutdown");
+    assert_eq!(evidence.shutdowns.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn production_session_dry_runs_all_stage_c_operations_without_execute() {
+    let evidence = Arc::new(Evidence::default());
+    let mut session = AdminMutationToolSession::new(ProductionPathBackend {
+        evidence: Arc::clone(&evidence),
+    });
+    let (schema_version, cluster, _, confirm, reason, request_key) = common();
+    let offset = session
+        .run(MutationToolRequest::ConsumerOffset(tools::ResetConsumerOffsetArgs {
+            schema_version,
+            cluster,
+            topic: "orders".to_owned(),
+            consumer_group: "orders-consumer".to_owned(),
+            timestamp: "2026-08-30T08:00:00+08:00".to_owned(),
+            force: false,
+            dry_run: true,
+            confirm,
+            reason,
+            request_key,
+        }))
+        .await
+        .expect("offset dry run through production session");
+    let MutationToolResponse::ConsumerOffset(offset) = offset else {
+        panic!("unexpected response variant");
+    };
+    assert_eq!(offset.mode, tools::MutationMode::DryRun);
+    assert_eq!(offset.status, tools::MutationStatus::Partial);
+
+    let (schema_version, cluster, _, confirm, reason, request_key) = common();
+    let broker = session
+        .run(MutationToolRequest::BrokerConfig(tools::PatchBrokerConfigArgs {
+            schema_version,
+            cluster,
+            broker_name: "broker-a".to_owned(),
+            properties: tools::BrokerConfigProperties {
+                trace_topic_enable: Some("true".to_owned()),
+                ..tools::BrokerConfigProperties::default()
+            },
+            dry_run: true,
+            confirm,
+            reason,
+            request_key,
+        }))
+        .await
+        .expect("broker dry run through production session");
+    let MutationToolResponse::BrokerConfig(broker) = broker else {
+        panic!("unexpected response variant");
+    };
+    assert_eq!(broker.mode, tools::MutationMode::DryRun);
+    assert_eq!(broker.status, tools::MutationStatus::Planned);
+
+    let (schema_version, cluster, _, confirm, reason, request_key) = common();
+    let request_mode = session
+        .run(MutationToolRequest::ConsumerRequestMode(
+            tools::SetConsumerRequestModeArgs {
+                schema_version,
+                cluster,
+                topic: "orders".to_owned(),
+                consumer_group: "orders-consumer".to_owned(),
+                mode: tools::ConsumerRequestMode::Pop,
+                pop_share_queue_num: 4,
+                timeout_millis: 12_345,
+                dry_run: true,
+                confirm,
+                reason,
+                request_key,
+            },
+        ))
+        .await
+        .expect("request mode dry run through production session");
+    let MutationToolResponse::ConsumerRequestMode(request_mode) = request_mode else {
+        panic!("unexpected response variant");
+    };
+    assert_eq!(request_mode.mode, tools::MutationMode::DryRun);
+    assert_eq!(request_mode.status, tools::MutationStatus::Planned);
+    assert_eq!(evidence.offset_executes.load(Ordering::SeqCst), 0);
+    assert_eq!(evidence.broker_executes.load(Ordering::SeqCst), 0);
+    assert_eq!(evidence.request_mode_executes.load(Ordering::SeqCst), 0);
+    assert_eq!(evidence.request_mode_timeout.load(Ordering::SeqCst), 0);
+
+    session.shutdown().await.expect("session shutdown");
+    assert_eq!(evidence.shutdowns.load(Ordering::SeqCst), 1);
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/execution.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/execution.rs
@@ -18,21 +18,21 @@ use std::time::Duration;
 use futures_util::FutureExt;
 use tokio_util::sync::CancellationToken;
 
-use super::UpsertRequest;
-use super::UpsertResponse;
-use super::UpsertSessionFactory;
+use super::MutationToolRequest;
+use super::MutationToolResponse;
+use super::MutationToolSessionFactory;
 use super::SESSION_SHUTDOWN_TIMEOUT;
 use crate::error::ControlError;
 use crate::model::ClusterName;
 
 pub(super) async fn supervise_session(
-    factory: Arc<dyn UpsertSessionFactory>,
+    factory: Arc<dyn MutationToolSessionFactory>,
     cluster: ClusterName,
-    request: UpsertRequest,
+    request: MutationToolRequest,
     timeout: Duration,
     request_cancellation: CancellationToken,
     owner_cancellation: CancellationToken,
-) -> Result<UpsertResponse, ControlError> {
+) -> Result<MutationToolResponse, ControlError> {
     let deadline = tokio::time::Instant::now() + timeout;
     let opened = tokio::time::timeout_at(deadline, AssertUnwindSafe(factory.open(&cluster)).catch_unwind());
     tokio::pin!(opened);

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/idempotency.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/idempotency.rs
@@ -20,9 +20,9 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use super::execution::supervise_session;
-use super::UpsertRequest;
-use super::UpsertResponse;
-use super::UpsertSessionFactory;
+use super::MutationToolRequest;
+use super::MutationToolResponse;
+use super::MutationToolSessionFactory;
 use super::IDEMPOTENCY_CAPACITY;
 use super::IDEMPOTENCY_TTL;
 use crate::error::ControlError;
@@ -49,9 +49,9 @@ impl IdempotencyIdentity {
     pub(super) fn from_request(
         principal: &Principal,
         cluster: &ClusterName,
-        request: &UpsertRequest,
+        request: &MutationToolRequest,
     ) -> Result<Self, ControlError> {
-        let mut targets = request.target_names().to_vec();
+        let mut targets = request.target_names();
         targets.sort();
         let key = request.request_key().map(|request_key| IdempotencyKey {
             principal: principal.subject.clone(),
@@ -76,11 +76,11 @@ pub(super) struct IdempotencyState {
 pub(super) enum IdempotencyEntry {
     InFlight {
         payload: String,
-        followers: Vec<oneshot::Sender<Result<UpsertResponse, ControlError>>>,
+        followers: Vec<oneshot::Sender<Result<MutationToolResponse, ControlError>>>,
     },
     Completed {
         payload: String,
-        result: Box<Result<UpsertResponse, ControlError>>,
+        result: Box<Result<MutationToolResponse, ControlError>>,
         expires_at: tokio::time::Instant,
         sequence: u64,
     },
@@ -88,8 +88,8 @@ pub(super) enum IdempotencyEntry {
 
 pub(super) enum CacheAdmission {
     Leader,
-    Follower(oneshot::Receiver<Result<UpsertResponse, ControlError>>),
-    Hit(Box<Result<UpsertResponse, ControlError>>),
+    Follower(oneshot::Receiver<Result<MutationToolResponse, ControlError>>),
+    Hit(Box<Result<MutationToolResponse, ControlError>>),
     Uncached,
 }
 
@@ -103,13 +103,13 @@ pub(super) async fn execute_admitted(
     cache: Arc<Mutex<IdempotencyState>>,
     identity: IdempotencyIdentity,
     admission: CacheAdmission,
-    factory: Arc<dyn UpsertSessionFactory>,
+    factory: Arc<dyn MutationToolSessionFactory>,
     cluster: ClusterName,
-    request: UpsertRequest,
+    request: MutationToolRequest,
     timeout: Duration,
     request_cancellation: CancellationToken,
     owner_cancellation: CancellationToken,
-) -> Result<UpsertResponse, ControlError> {
+) -> Result<MutationToolResponse, ControlError> {
     let Some(key) = identity.key else {
         return supervise_session(
             factory,
@@ -243,7 +243,7 @@ pub(super) async fn complete_cache(
     cache: &Mutex<IdempotencyState>,
     key: IdempotencyKey,
     payload: String,
-    result: Result<UpsertResponse, ControlError>,
+    result: Result<MutationToolResponse, ControlError>,
 ) {
     let mut state = cache.lock().await;
     let followers = match state.entries.remove(&key) {

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/remaining.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/remaining.rs
@@ -1,0 +1,120 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_admin_core::core::supervised_mutation as admin;
+
+use crate::tools;
+
+#[path = "remaining/broker.rs"]
+mod broker;
+#[path = "remaining/offset.rs"]
+mod offset;
+#[path = "remaining/request_mode.rs"]
+mod request_mode;
+
+pub(super) use broker::run_broker;
+pub(super) use offset::run_offset;
+pub(super) use request_mode::run_request_mode;
+
+fn dry_status(success_count: usize, failure_count: usize) -> tools::MutationStatus {
+    if failure_count == 0 {
+        tools::MutationStatus::Planned
+    } else if success_count == 0 {
+        tools::MutationStatus::Failed
+    } else {
+        tools::MutationStatus::Partial
+    }
+}
+
+fn status_from_failures(failures: impl Iterator<Item = Option<tools::FailureCode>>) -> tools::MutationStatus {
+    let failures = failures.collect::<Vec<_>>();
+    let succeeded = failures.iter().filter(|failure| failure.is_none()).count();
+    if succeeded == failures.len() {
+        tools::MutationStatus::Applied
+    } else if succeeded > 0 {
+        tools::MutationStatus::Partial
+    } else if !failures.is_empty()
+        && failures
+            .iter()
+            .all(|failure| *failure == Some(tools::FailureCode::Conflict))
+    {
+        tools::MutationStatus::Conflict
+    } else {
+        tools::MutationStatus::Failed
+    }
+}
+
+fn map_broker_state(state: admin::BrokerMutationConfigState) -> tools::BrokerConfigState {
+    tools::BrokerConfigState {
+        generation: state.generation,
+        auto_create_topic_enable: state.auto_create_topic_enable,
+        auto_create_subscription_group: state.auto_create_subscription_group,
+        broker_permission: state.broker_permission,
+        default_topic_queue_nums: state.default_topic_queue_nums,
+        message_index_enable: state.message_index_enable,
+        trace_topic_enable: state.trace_topic_enable,
+    }
+}
+
+fn map_broker_patch(patch: tools::BrokerConfigPatch) -> admin::BrokerMutationConfigPatch {
+    admin::BrokerMutationConfigPatch {
+        auto_create_topic_enable: patch.auto_create_topic_enable,
+        auto_create_subscription_group: patch.auto_create_subscription_group,
+        broker_permission: patch.broker_permission,
+        default_topic_queue_nums: patch.default_topic_queue_nums,
+        message_index_enable: patch.message_index_enable,
+        trace_topic_enable: patch.trace_topic_enable,
+    }
+}
+
+fn broker_patch_changes(state: tools::BrokerConfigState, patch: tools::BrokerConfigPatch) -> bool {
+    patch
+        .auto_create_topic_enable
+        .is_some_and(|value| value != state.auto_create_topic_enable)
+        || patch
+            .auto_create_subscription_group
+            .is_some_and(|value| value != state.auto_create_subscription_group)
+        || patch
+            .broker_permission
+            .is_some_and(|value| value != state.broker_permission)
+        || patch
+            .default_topic_queue_nums
+            .is_some_and(|value| value != state.default_topic_queue_nums)
+        || patch
+            .message_index_enable
+            .is_some_and(|value| value != state.message_index_enable)
+        || patch
+            .trace_topic_enable
+            .is_some_and(|value| value != state.trace_topic_enable)
+}
+
+fn map_request_mode(value: tools::RequestModeValue) -> admin::RequestModeValue {
+    admin::RequestModeValue {
+        mode: match value.mode {
+            tools::ConsumerRequestMode::Pull => admin::RequestMode::Pull,
+            tools::ConsumerRequestMode::Pop => admin::RequestMode::Pop,
+        },
+        pop_share_queue_num: value.pop_share_queue_num,
+    }
+}
+
+fn map_request_mode_from_admin(value: admin::RequestModeValue) -> tools::RequestModeValue {
+    tools::RequestModeValue {
+        mode: match value.mode {
+            admin::RequestMode::Pull => tools::ConsumerRequestMode::Pull,
+            admin::RequestMode::Pop => tools::ConsumerRequestMode::Pop,
+        },
+        pop_share_queue_num: value.pop_share_queue_num,
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/remaining/broker.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/remaining/broker.rs
@@ -1,0 +1,170 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use rocketmq_admin_core::core::supervised_mutation as admin;
+
+use super::{broker_patch_changes, dry_status, map_broker_patch, map_broker_state, status_from_failures};
+use crate::error::ControlError;
+use crate::tool_runtime::admin_session::SupervisedMutationBackend;
+use crate::tool_runtime::{map_failure, map_persistence, map_verification};
+use crate::tools;
+
+pub(crate) async fn run_broker<B: SupervisedMutationBackend>(
+    backend: &mut B,
+    args: tools::PatchBrokerConfigArgs,
+) -> Result<tools::BrokerConfigMutationToolResponse, ControlError> {
+    let patch = args.properties.typed()?;
+    let admin_patch = map_broker_patch(patch);
+    let plan = backend.preflight_broker(&args.cluster, &args.broker_name).await?;
+    let targets = B::broker_targets(&plan);
+    let failures = B::broker_failures(&plan).to_vec();
+    if args.dry_run {
+        return Ok(broker_dry_run(&args, patch, targets, failures));
+    }
+    let before = targets;
+    let outcome = backend.execute_broker(&plan, admin_patch).await?;
+    Ok(broker_executed(&args, patch, before, outcome))
+}
+
+fn broker_dry_run(
+    args: &tools::PatchBrokerConfigArgs,
+    patch: tools::BrokerConfigPatch,
+    targets: Vec<admin::BrokerMutationConfigTarget>,
+    failures: Vec<admin::MutationTargetFailure>,
+) -> tools::BrokerConfigMutationToolResponse {
+    let before: BTreeMap<String, tools::BrokerConfigState> = targets
+        .iter()
+        .map(|target| (target.broker_name.clone(), map_broker_state(target.state)))
+        .collect();
+    let mut result_targets = targets
+        .into_iter()
+        .map(|target| tools::BrokerConfigMutationTarget {
+            broker_name: target.broker_name,
+            before: Some(map_broker_state(target.state)),
+            requested: patch,
+            after: None,
+            applied: false,
+            changed: broker_patch_changes(map_broker_state(target.state), patch),
+            persistence: tools::PersistenceState::NotRequired,
+            verification: tools::VerificationState::NotPerformed,
+            failure: None,
+            retryable: false,
+        })
+        .collect::<Vec<_>>();
+    result_targets.extend(failures.iter().map(|failure| tools::BrokerConfigMutationTarget {
+        broker_name: failure.broker_name.clone(),
+        before: None,
+        requested: patch,
+        after: None,
+        applied: false,
+        changed: false,
+        persistence: tools::PersistenceState::NotRequired,
+        verification: tools::VerificationState::NotPerformed,
+        failure: Some(map_failure(failure.code)),
+        retryable: failure.retryable,
+    }));
+    result_targets.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    broker_response(
+        args,
+        patch,
+        dry_status(before.len(), failures.len()),
+        before,
+        None,
+        result_targets,
+    )
+}
+
+fn broker_executed(
+    args: &tools::PatchBrokerConfigArgs,
+    patch: tools::BrokerConfigPatch,
+    before_targets: Vec<admin::BrokerMutationConfigTarget>,
+    outcome: admin::BrokerMutationConfigOutcome,
+) -> tools::BrokerConfigMutationToolResponse {
+    let before = before_targets
+        .into_iter()
+        .map(|target| (target.broker_name, map_broker_state(target.state)))
+        .collect::<BTreeMap<_, _>>();
+    let mut targets = outcome
+        .targets
+        .into_iter()
+        .map(|target| tools::BrokerConfigMutationTarget {
+            broker_name: target.broker_name,
+            before: Some(map_broker_state(target.before)),
+            requested: patch,
+            after: target.after.map(map_broker_state),
+            applied: target.applied,
+            changed: target.changed,
+            persistence: map_persistence(target.persistence),
+            verification: map_verification(target.verification),
+            failure: target.failure.map(map_failure),
+            retryable: target.retryable,
+        })
+        .collect::<Vec<_>>();
+    targets.extend(
+        outcome
+            .failures
+            .iter()
+            .map(|failure| tools::BrokerConfigMutationTarget {
+                broker_name: failure.broker_name.clone(),
+                before: None,
+                requested: patch,
+                after: None,
+                applied: false,
+                changed: false,
+                persistence: tools::PersistenceState::NotRequired,
+                verification: tools::VerificationState::NotPerformed,
+                failure: Some(map_failure(failure.code)),
+                retryable: failure.retryable,
+            }),
+    );
+    targets.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    let after = targets
+        .iter()
+        .filter_map(|target| target.after.map(|state| (target.broker_name.clone(), state)))
+        .collect::<BTreeMap<_, _>>();
+    let after = (!after.is_empty()).then_some(after);
+    let status = status_from_failures(targets.iter().map(|target| target.failure));
+    broker_response(args, patch, status, before, after, targets)
+}
+
+fn broker_response(
+    args: &tools::PatchBrokerConfigArgs,
+    patch: tools::BrokerConfigPatch,
+    status: tools::MutationStatus,
+    before: BTreeMap<String, tools::BrokerConfigState>,
+    after: Option<BTreeMap<String, tools::BrokerConfigState>>,
+    targets: Vec<tools::BrokerConfigMutationTarget>,
+) -> tools::BrokerConfigMutationToolResponse {
+    tools::BrokerConfigMutationToolResponse {
+        schema_version: tools::MutationResultSchemaVersion::V1,
+        operation: tools::BrokerConfigPatchOperation::BrokerConfigPatch,
+        cluster: args.cluster.clone(),
+        mode: if args.dry_run {
+            tools::MutationMode::DryRun
+        } else {
+            tools::MutationMode::Execute
+        },
+        status,
+        target: tools::BrokerConfigResource {
+            broker_name: args.broker_name.clone(),
+        },
+        before,
+        requested: patch,
+        after,
+        targets,
+        warnings: Vec::new(),
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/remaining/offset.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/remaining/offset.rs
@@ -1,0 +1,187 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rocketmq_admin_core::core::supervised_mutation as admin;
+
+use super::dry_status;
+use super::status_from_failures;
+use crate::error::ControlError;
+use crate::tool_runtime::admin_session::SupervisedMutationBackend;
+use crate::tool_runtime::map_failure;
+use crate::tools;
+
+pub(crate) async fn run_offset<B: SupervisedMutationBackend>(
+    backend: &mut B,
+    args: tools::ResetConsumerOffsetArgs,
+) -> Result<tools::OffsetMutationToolResponse, ControlError> {
+    let timestamp_millis = args.validate(true, false)?;
+    let request = admin::OffsetResetPreviewRequest {
+        cluster: args.cluster.clone(),
+        topic: args.topic.clone(),
+        consumer_group: args.consumer_group.clone(),
+        timestamp: timestamp_millis,
+        force: args.force,
+    };
+    let plan = backend.preview_offset(&request).await?;
+    let rows = B::offset_rows(&plan);
+    let failures = B::offset_failures(&plan).to_vec();
+    if args.dry_run {
+        return Ok(offset_dry_run(&args, timestamp_millis, rows, failures));
+    }
+    let before = rows.clone();
+    let outcome = backend.execute_offset(&plan).await?;
+    Ok(offset_executed(&args, timestamp_millis, before, outcome))
+}
+
+fn offset_dry_run(
+    args: &tools::ResetConsumerOffsetArgs,
+    timestamp_millis: i64,
+    rows: Vec<admin::OffsetResetPreviewRow>,
+    failures: Vec<admin::MutationTargetFailure>,
+) -> tools::OffsetMutationToolResponse {
+    let before = rows.iter().map(offset_before).collect::<Vec<_>>();
+    let mut targets = rows
+        .iter()
+        .map(|row| tools::OffsetMutationTarget {
+            broker_name: row.broker_name.clone(),
+            queue_id: Some(row.queue_id),
+            before: Some(row.current_offset),
+            planned: Some(row.planned_offset),
+            delta: Some(row.delta),
+            after: None,
+            applied: false,
+            changed: row.changed,
+            failure: None,
+            retryable: false,
+        })
+        .collect::<Vec<_>>();
+    targets.extend(failures.iter().map(offset_failure_target));
+    sort_offset_targets(&mut targets);
+    let status = dry_status(rows.len(), failures.len());
+    offset_response(args, timestamp_millis, status, before, None, targets)
+}
+
+fn offset_executed(
+    args: &tools::ResetConsumerOffsetArgs,
+    timestamp_millis: i64,
+    before_rows: Vec<admin::OffsetResetPreviewRow>,
+    outcome: admin::OffsetResetOutcome,
+) -> tools::OffsetMutationToolResponse {
+    let before = before_rows.iter().map(offset_before).collect::<Vec<_>>();
+    let deltas = before_rows
+        .iter()
+        .map(|row| ((row.broker_name.clone(), row.queue_id), row.delta))
+        .collect::<BTreeMap<_, _>>();
+    let mut targets = outcome
+        .targets
+        .into_iter()
+        .map(|target| tools::OffsetMutationTarget {
+            broker_name: target.broker_name.clone(),
+            queue_id: Some(target.queue_id),
+            before: Some(target.expected_offset),
+            planned: Some(target.planned_offset),
+            delta: deltas.get(&(target.broker_name.clone(), target.queue_id)).copied(),
+            after: target.observed_offset,
+            applied: target.applied,
+            changed: target.changed,
+            failure: target.failure.map(map_failure),
+            retryable: target.retryable,
+        })
+        .collect::<Vec<_>>();
+    targets.extend(outcome.failures.iter().map(offset_failure_target));
+    sort_offset_targets(&mut targets);
+    let after = targets
+        .iter()
+        .filter_map(|target| {
+            Some(tools::OffsetQueueState {
+                broker_name: target.broker_name.clone(),
+                queue_id: target.queue_id?,
+                offset: target.after?,
+            })
+        })
+        .collect::<Vec<_>>();
+    let after = (!after.is_empty()).then_some(after);
+    let status = status_from_failures(targets.iter().map(|target| target.failure));
+    offset_response(args, timestamp_millis, status, before, after, targets)
+}
+
+fn offset_response(
+    args: &tools::ResetConsumerOffsetArgs,
+    timestamp_millis: i64,
+    status: tools::MutationStatus,
+    before: Vec<tools::OffsetQueueState>,
+    after: Option<Vec<tools::OffsetQueueState>>,
+    targets: Vec<tools::OffsetMutationTarget>,
+) -> tools::OffsetMutationToolResponse {
+    let brokers = targets
+        .iter()
+        .map(|target| target.broker_name.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    tools::OffsetMutationToolResponse {
+        schema_version: tools::MutationResultSchemaVersion::V1,
+        operation: tools::ConsumerOffsetResetOperation::ConsumerOffsetReset,
+        cluster: args.cluster.clone(),
+        mode: if args.dry_run {
+            tools::MutationMode::DryRun
+        } else {
+            tools::MutationMode::Execute
+        },
+        status,
+        target: tools::OffsetResetResource {
+            topic: args.topic.clone(),
+            consumer_group: args.consumer_group.clone(),
+            brokers,
+        },
+        before,
+        requested: tools::OffsetRequested {
+            timestamp: args.timestamp.clone(),
+            timestamp_millis,
+            force: args.force,
+        },
+        after,
+        targets,
+        warnings: Vec::new(),
+    }
+}
+
+fn sort_offset_targets(targets: &mut [tools::OffsetMutationTarget]) {
+    targets.sort_by(|left, right| (&left.broker_name, left.queue_id).cmp(&(&right.broker_name, right.queue_id)));
+}
+
+fn offset_before(row: &admin::OffsetResetPreviewRow) -> tools::OffsetQueueState {
+    tools::OffsetQueueState {
+        broker_name: row.broker_name.clone(),
+        queue_id: row.queue_id,
+        offset: row.current_offset,
+    }
+}
+
+fn offset_failure_target(failure: &admin::MutationTargetFailure) -> tools::OffsetMutationTarget {
+    tools::OffsetMutationTarget {
+        broker_name: failure.broker_name.clone(),
+        queue_id: failure.queue_id,
+        before: None,
+        planned: None,
+        delta: None,
+        after: None,
+        applied: false,
+        changed: false,
+        failure: Some(map_failure(failure.code)),
+        retryable: failure.retryable,
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/remaining/request_mode.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/remaining/request_mode.rs
@@ -1,0 +1,189 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rocketmq_admin_core::core::supervised_mutation as admin;
+
+use super::{dry_status, map_request_mode, map_request_mode_from_admin, status_from_failures};
+use crate::error::ControlError;
+use crate::tool_runtime::admin_session::SupervisedMutationBackend;
+use crate::tool_runtime::{map_failure, map_persistence, map_verification};
+use crate::tools;
+
+pub(crate) async fn run_request_mode<B: SupervisedMutationBackend>(
+    backend: &mut B,
+    args: tools::SetConsumerRequestModeArgs,
+) -> Result<tools::RequestModeMutationToolResponse, ControlError> {
+    let replacement = tools::RequestModeValue {
+        mode: args.mode,
+        pop_share_queue_num: args.pop_share_queue_num,
+    };
+    let request = admin::RequestModePreflightRequest {
+        cluster: args.cluster.clone(),
+        topic: args.topic.clone(),
+        consumer_group: args.consumer_group.clone(),
+        replacement: map_request_mode(replacement),
+    };
+    let plan = backend.preflight_request_mode(&request).await?;
+    let targets = B::request_mode_targets(&plan);
+    let failures = B::request_mode_failures(&plan).to_vec();
+    if args.dry_run {
+        return Ok(request_mode_dry_run(&args, replacement, targets, failures));
+    }
+    let before = targets;
+    let outcome = backend.execute_request_mode(&plan, args.timeout_millis).await?;
+    Ok(request_mode_executed(&args, replacement, before, outcome))
+}
+
+fn request_mode_dry_run(
+    args: &tools::SetConsumerRequestModeArgs,
+    requested: tools::RequestModeValue,
+    targets: Vec<(String, Option<admin::RequestModeValue>)>,
+    failures: Vec<admin::MutationTargetFailure>,
+) -> tools::RequestModeMutationToolResponse {
+    let before: BTreeMap<String, Option<tools::RequestModeValue>> = targets
+        .iter()
+        .map(|(broker, value)| (broker.clone(), value.map(map_request_mode_from_admin)))
+        .collect();
+    let mut result_targets = targets
+        .into_iter()
+        .map(|(broker_name, current)| {
+            let current = current.map(map_request_mode_from_admin);
+            tools::RequestModeMutationTarget {
+                broker_name,
+                before: current,
+                requested,
+                after: None,
+                applied: false,
+                changed: current != Some(requested),
+                persistence: tools::PersistenceState::NotRequired,
+                verification: tools::VerificationState::NotPerformed,
+                failure: None,
+                retryable: false,
+            }
+        })
+        .collect::<Vec<_>>();
+    result_targets.extend(failures.iter().map(|failure| tools::RequestModeMutationTarget {
+        broker_name: failure.broker_name.clone(),
+        before: None,
+        requested,
+        after: None,
+        applied: false,
+        changed: false,
+        persistence: tools::PersistenceState::NotRequired,
+        verification: tools::VerificationState::NotPerformed,
+        failure: Some(map_failure(failure.code)),
+        retryable: failure.retryable,
+    }));
+    result_targets.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    request_mode_response(
+        args,
+        requested,
+        dry_status(before.len(), failures.len()),
+        before,
+        None,
+        result_targets,
+    )
+}
+
+fn request_mode_executed(
+    args: &tools::SetConsumerRequestModeArgs,
+    requested: tools::RequestModeValue,
+    before_targets: Vec<(String, Option<admin::RequestModeValue>)>,
+    outcome: admin::RequestModeMutationOutcome,
+) -> tools::RequestModeMutationToolResponse {
+    let before = before_targets
+        .into_iter()
+        .map(|(broker, current)| (broker, current.map(map_request_mode_from_admin)))
+        .collect::<BTreeMap<_, _>>();
+    let mut targets = outcome
+        .targets
+        .into_iter()
+        .map(|target| tools::RequestModeMutationTarget {
+            broker_name: target.broker_name,
+            before: target.expected.map(map_request_mode_from_admin),
+            requested,
+            after: target.current.map(map_request_mode_from_admin),
+            applied: target.applied,
+            changed: target.changed,
+            persistence: map_persistence(target.persistence),
+            verification: map_verification(target.verification),
+            failure: target.failure.map(map_failure),
+            retryable: target.retryable,
+        })
+        .collect::<Vec<_>>();
+    targets.extend(outcome.failures.iter().map(|failure| tools::RequestModeMutationTarget {
+        broker_name: failure.broker_name.clone(),
+        before: None,
+        requested,
+        after: None,
+        applied: false,
+        changed: false,
+        persistence: tools::PersistenceState::NotRequired,
+        verification: tools::VerificationState::NotPerformed,
+        failure: Some(map_failure(failure.code)),
+        retryable: failure.retryable,
+    }));
+    targets.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    let after = targets.iter().any(|target| target.after.is_some()).then(|| {
+        targets
+            .iter()
+            .map(|target| (target.broker_name.clone(), target.after))
+            .collect()
+    });
+    let status = status_from_failures(targets.iter().map(|target| target.failure));
+    request_mode_response(args, requested, status, before, after, targets)
+}
+
+fn request_mode_response(
+    args: &tools::SetConsumerRequestModeArgs,
+    requested: tools::RequestModeValue,
+    status: tools::MutationStatus,
+    before: BTreeMap<String, Option<tools::RequestModeValue>>,
+    after: Option<BTreeMap<String, Option<tools::RequestModeValue>>>,
+    targets: Vec<tools::RequestModeMutationTarget>,
+) -> tools::RequestModeMutationToolResponse {
+    let brokers = targets
+        .iter()
+        .map(|target| target.broker_name.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    tools::RequestModeMutationToolResponse {
+        schema_version: tools::MutationResultSchemaVersion::V1,
+        operation: tools::ConsumerRequestModeOperation::ConsumerRequestMode,
+        cluster: args.cluster.clone(),
+        mode: if args.dry_run {
+            tools::MutationMode::DryRun
+        } else {
+            tools::MutationMode::Execute
+        },
+        status,
+        target: tools::RequestModeResource {
+            topic: args.topic.clone(),
+            consumer_group: args.consumer_group.clone(),
+            brokers,
+        },
+        before,
+        requested: tools::RequestModeRequested {
+            mode: requested.mode,
+            pop_share_queue_num: requested.pop_share_queue_num,
+            timeout_millis: args.timeout_millis,
+        },
+        after,
+        targets,
+        warnings: Vec::new(),
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/tests.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tool_runtime/tests.rs
@@ -15,6 +15,7 @@
 use super::idempotency::admit_cache;
 use super::idempotency::complete_cache;
 use super::idempotency::CacheAdmission;
+use super::idempotency::IdempotencyIdentity;
 use super::idempotency::IdempotencyKey;
 use super::*;
 use std::collections::BTreeSet;
@@ -136,6 +137,90 @@ fn principal(subject: &str) -> Principal {
         allowed_operations: BTreeSet::from([ControlOperation::TopicUpsert]),
         allowed_clusters: BTreeSet::from([ClusterName::try_new("cluster-a").unwrap()]),
     }
+}
+
+#[test]
+fn stage_c_idempotency_identity_covers_operation_resource_and_full_payload() {
+    let principal = principal("alice");
+    let cluster = ClusterName::try_new("cluster-a").unwrap();
+    let common = || {
+        (
+            MUTATION_ARGUMENTS_SCHEMA_VERSION.to_owned(),
+            "cluster-a".to_owned(),
+            Some("planned operation".to_owned()),
+            Some("request-1234".to_owned()),
+        )
+    };
+
+    let (schema_version, cluster_name, reason, request_key) = common();
+    let offset = MutationToolRequest::ConsumerOffset(tools::ResetConsumerOffsetArgs {
+        schema_version,
+        cluster: cluster_name,
+        topic: "orders".to_owned(),
+        consumer_group: "workers".to_owned(),
+        timestamp: "2026-08-30T00:00:00Z".to_owned(),
+        force: false,
+        dry_run: false,
+        confirm: true,
+        reason,
+        request_key,
+    });
+    let offset_identity = IdempotencyIdentity::from_request(&principal, &cluster, &offset).unwrap();
+    let offset_key = offset_identity.key.as_ref().expect("explicit offset key");
+    assert_eq!(offset_key.operation, ControlOperation::ConsumerOffsetReset);
+    assert_eq!(offset_key.targets, ["orders", "workers"]);
+
+    let (schema_version, cluster_name, reason, request_key) = common();
+    let broker = MutationToolRequest::BrokerConfig(tools::PatchBrokerConfigArgs {
+        schema_version,
+        cluster: cluster_name,
+        broker_name: "broker-a".to_owned(),
+        properties: tools::BrokerConfigProperties {
+            trace_topic_enable: Some("true".to_owned()),
+            ..tools::BrokerConfigProperties::default()
+        },
+        dry_run: false,
+        confirm: true,
+        reason,
+        request_key,
+    });
+    let broker_identity = IdempotencyIdentity::from_request(&principal, &cluster, &broker).unwrap();
+    let broker_key = broker_identity.key.as_ref().expect("explicit broker key");
+    assert_eq!(broker_key.operation, ControlOperation::BrokerConfigPatch);
+    assert_eq!(broker_key.targets, ["broker-a"]);
+
+    let (schema_version, cluster_name, reason, request_key) = common();
+    let request_mode = MutationToolRequest::ConsumerRequestMode(tools::SetConsumerRequestModeArgs {
+        schema_version,
+        cluster: cluster_name,
+        topic: "orders".to_owned(),
+        consumer_group: "workers".to_owned(),
+        mode: tools::ConsumerRequestMode::Pop,
+        pop_share_queue_num: 4,
+        timeout_millis: 12_000,
+        dry_run: false,
+        confirm: true,
+        reason,
+        request_key,
+    });
+    let request_mode_identity = IdempotencyIdentity::from_request(&principal, &cluster, &request_mode).unwrap();
+    let request_mode_key = request_mode_identity.key.as_ref().expect("explicit request-mode key");
+    assert_eq!(request_mode_key.operation, ControlOperation::ConsumerRequestMode);
+    assert_eq!(request_mode_key.targets, ["orders", "workers"]);
+
+    assert_ne!(offset_identity.payload, broker_identity.payload);
+    assert_ne!(broker_identity.payload, request_mode_identity.payload);
+    let mut changed_timeout = request_mode.clone();
+    let MutationToolRequest::ConsumerRequestMode(args) = &mut changed_timeout else {
+        unreachable!();
+    };
+    args.timeout_millis += 1;
+    assert_ne!(
+        request_mode_identity.payload,
+        IdempotencyIdentity::from_request(&principal, &cluster, &changed_timeout)
+            .unwrap()
+            .payload
+    );
 }
 
 fn runtime(

--- a/rocketmq-ai/rocketmq-mcp-control/src/tools.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tools.rs
@@ -22,6 +22,10 @@ use serde::Serialize;
 use crate::error::ControlError;
 use crate::model::MutationArguments;
 
+#[path = "tools/remaining.rs"]
+mod remaining;
+pub use remaining::*;
+
 pub const MUTATION_RESULT_SCHEMA_VERSION: &str = "rocketmq-mcp-mutation.v1";
 pub const UPSERT_TOPIC_TOOL: &str = "rocketmq_upsert_topic";
 pub const UPSERT_CONSUMER_GROUP_TOOL: &str = "rocketmq_upsert_consumer_group";
@@ -266,7 +270,7 @@ impl UpsertConsumerGroupArgs {
     }
 }
 
-fn validate_common(
+pub(super) fn validate_common(
     schema_version: &str,
     dry_run: bool,
     confirm: bool,
@@ -299,13 +303,13 @@ fn validate_target_set(broker_names: &[String]) -> Result<(), ControlError> {
 }
 
 #[derive(Clone, Copy)]
-enum NameKind {
+pub(super) enum NameKind {
     Topic,
     ConsumerGroup,
     Broker,
 }
 
-fn validate_user_name(value: &str, kind: NameKind) -> Result<(), ControlError> {
+pub(super) fn validate_user_name(value: &str, kind: NameKind) -> Result<(), ControlError> {
     let max = if matches!(kind, NameKind::ConsumerGroup) {
         255
     } else {
@@ -354,7 +358,7 @@ fn contains_encoded_octet(value: &str) -> bool {
         .any(|window| window[0] == b'%' && window[1].is_ascii_hexdigit() && window[2].is_ascii_hexdigit())
 }
 
-const fn default_dry_run() -> bool {
+pub(super) const fn default_dry_run() -> bool {
     true
 }
 

--- a/rocketmq-ai/rocketmq-mcp-control/src/tools/remaining.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tools/remaining.rs
@@ -1,0 +1,62 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::{JsonSchema, Schema, SchemaGenerator};
+
+use super::validate_user_name;
+use super::NameKind;
+use crate::error::ControlError;
+
+macro_rules! operation_schema {
+    ($type:ty, $name:literal, $value:literal) => {
+        impl schemars::JsonSchema for $type {
+            fn schema_name() -> std::borrow::Cow<'static, str> {
+                $name.into()
+            }
+
+            fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                schemars::json_schema!({"type": "string", "const": $value})
+            }
+        }
+    };
+}
+
+#[path = "remaining/broker.rs"]
+mod broker;
+#[path = "remaining/offset.rs"]
+mod offset;
+#[path = "remaining/request_mode.rs"]
+mod request_mode;
+
+pub use broker::*;
+pub use offset::*;
+pub use request_mode::*;
+
+fn nullable_schema<T: JsonSchema>(generator: &mut SchemaGenerator) -> Schema {
+    schemars::json_schema!({
+        "anyOf": [
+            generator.subschema_for::<T>(),
+            { "type": "null" }
+        ]
+    })
+}
+
+fn validate_consumer_group(group: &str) -> Result<(), ControlError> {
+    validate_user_name(group, NameKind::ConsumerGroup)?;
+    #[cfg(feature = "write-tools")]
+    if rocketmq_admin_core::core::consumer::is_protected_consumer_group(group) {
+        return Err(ControlError::invalid_arguments());
+    }
+    Ok(())
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tools/remaining/broker.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tools/remaining/broker.rs
@@ -1,0 +1,298 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use schemars::{JsonSchema, Schema, SchemaGenerator};
+use serde::{Deserialize, Deserializer, Serialize};
+
+use super::super::{
+    default_dry_run, validate_common, validate_user_name, FailureCode, MutationMode, MutationResultSchemaVersion,
+    MutationStatus, NameKind, PersistenceState, VerificationState,
+};
+use super::nullable_schema;
+use crate::error::ControlError;
+
+pub const PATCH_BROKER_CONFIG_TOOL: &str = "rocketmq_patch_broker_config";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum BrokerConfigPatchOperation {
+    #[serde(rename = "broker_config_patch")]
+    BrokerConfigPatch,
+}
+
+operation_schema!(
+    BrokerConfigPatchOperation,
+    "BrokerConfigPatchOperation",
+    "broker_config_patch"
+);
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct BrokerConfigProperties {
+    #[serde(default, deserialize_with = "deserialize_present_string")]
+    #[schemars(schema_with = "string_schema")]
+    pub auto_create_topic_enable: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_present_string")]
+    #[schemars(schema_with = "string_schema")]
+    pub auto_create_subscription_group: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_present_string")]
+    #[schemars(schema_with = "string_schema")]
+    pub broker_permission: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_present_string")]
+    #[schemars(schema_with = "string_schema")]
+    pub default_topic_queue_nums: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_present_string")]
+    #[schemars(schema_with = "string_schema")]
+    pub message_index_enable: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_present_string")]
+    #[schemars(schema_with = "string_schema")]
+    pub trace_topic_enable: Option<String>,
+}
+
+fn deserialize_present_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Some)
+}
+
+fn string_schema(_generator: &mut SchemaGenerator) -> Schema {
+    schemars::json_schema!({"type": "string"})
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PatchBrokerConfigArgs {
+    #[schemars(regex(pattern = "^rocketmq-mcp-control\\.arguments\\.v1$"))]
+    pub schema_version: String,
+    #[schemars(length(min = 1, max = 64), regex(pattern = "^[a-zA-Z0-9_-]+$"))]
+    pub cluster: String,
+    #[schemars(length(min = 1, max = 127), regex(pattern = "^[%|a-zA-Z0-9_-]+$"))]
+    pub broker_name: String,
+    pub properties: BrokerConfigProperties,
+    #[serde(default = "default_dry_run")]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub confirm: bool,
+    #[serde(default)]
+    #[schemars(length(min = 5, max = 256))]
+    pub reason: Option<String>,
+    #[serde(default)]
+    #[schemars(length(min = 8, max = 64), regex(pattern = "^[a-zA-Z0-9._:-]+$"))]
+    pub request_key: Option<String>,
+}
+
+impl std::fmt::Debug for PatchBrokerConfigArgs {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PatchBrokerConfigArgs")
+            .field("schema_version", &self.schema_version)
+            .field("property_count", &self.properties.count())
+            .field("dry_run", &self.dry_run)
+            .field("confirm", &self.confirm)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BrokerConfigProperties {
+    fn count(&self) -> usize {
+        [
+            self.auto_create_topic_enable.is_some(),
+            self.auto_create_subscription_group.is_some(),
+            self.broker_permission.is_some(),
+            self.default_topic_queue_nums.is_some(),
+            self.message_index_enable.is_some(),
+            self.trace_topic_enable.is_some(),
+        ]
+        .into_iter()
+        .filter(|present| *present)
+        .count()
+    }
+
+    pub fn typed(&self) -> Result<BrokerConfigPatch, ControlError> {
+        if self.count() == 0 {
+            return Err(ControlError::invalid_arguments());
+        }
+        Ok(BrokerConfigPatch {
+            auto_create_topic_enable: parse_bool(self.auto_create_topic_enable.as_deref())?,
+            auto_create_subscription_group: parse_bool(self.auto_create_subscription_group.as_deref())?,
+            broker_permission: parse_u32(self.broker_permission.as_deref(), 1, 7)?
+                .map(|value| {
+                    if value & 0b110 == 0 {
+                        Err(ControlError::invalid_arguments())
+                    } else {
+                        Ok(value)
+                    }
+                })
+                .transpose()?,
+            default_topic_queue_nums: parse_u32(self.default_topic_queue_nums.as_deref(), 1, 128)?,
+            message_index_enable: parse_bool(self.message_index_enable.as_deref())?,
+            trace_topic_enable: parse_bool(self.trace_topic_enable.as_deref())?,
+        })
+    }
+}
+
+impl PatchBrokerConfigArgs {
+    pub fn validate(&self, configured_default: bool, omitted: bool) -> Result<BrokerConfigPatch, ControlError> {
+        validate_common(
+            &self.schema_version,
+            self.effective_dry_run(configured_default, omitted),
+            self.confirm,
+            self.reason.as_deref(),
+            self.request_key.as_deref(),
+        )?;
+        validate_user_name(&self.broker_name, NameKind::Broker)?;
+        self.properties.typed()
+    }
+
+    pub fn effective_dry_run(&self, configured_default: bool, omitted: bool) -> bool {
+        if omitted {
+            configured_default
+        } else {
+            self.dry_run
+        }
+    }
+}
+
+fn parse_bool(value: Option<&str>) -> Result<Option<bool>, ControlError> {
+    value
+        .map(|value| match value {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            _ => Err(ControlError::invalid_arguments()),
+        })
+        .transpose()
+}
+
+fn parse_u32(value: Option<&str>, min: u32, max: u32) -> Result<Option<u32>, ControlError> {
+    value
+        .map(|value| {
+            let parsed = value.parse::<u32>().map_err(|_| ControlError::invalid_arguments())?;
+            if !(min..=max).contains(&parsed) || parsed.to_string() != value {
+                return Err(ControlError::invalid_arguments());
+            }
+            Ok(parsed)
+        })
+        .transpose()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct BrokerConfigState {
+    pub generation: u64,
+    pub auto_create_topic_enable: bool,
+    pub auto_create_subscription_group: bool,
+    pub broker_permission: u32,
+    pub default_topic_queue_nums: u32,
+    pub message_index_enable: bool,
+    pub trace_topic_enable: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct BrokerConfigPatch {
+    pub auto_create_topic_enable: Option<bool>,
+    pub auto_create_subscription_group: Option<bool>,
+    pub broker_permission: Option<u32>,
+    pub default_topic_queue_nums: Option<u32>,
+    pub message_index_enable: Option<bool>,
+    pub trace_topic_enable: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BrokerConfigResource {
+    pub broker_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BrokerConfigMutationTarget {
+    pub broker_name: String,
+    #[schemars(required, schema_with = "nullable_schema::<BrokerConfigState>")]
+    pub before: Option<BrokerConfigState>,
+    pub requested: BrokerConfigPatch,
+    #[schemars(required, schema_with = "nullable_schema::<BrokerConfigState>")]
+    pub after: Option<BrokerConfigState>,
+    pub applied: bool,
+    pub changed: bool,
+    pub persistence: PersistenceState,
+    pub verification: VerificationState,
+    #[schemars(required, schema_with = "nullable_schema::<FailureCode>")]
+    pub failure: Option<FailureCode>,
+    pub retryable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BrokerConfigMutationToolResponse {
+    pub schema_version: MutationResultSchemaVersion,
+    pub operation: BrokerConfigPatchOperation,
+    pub cluster: String,
+    pub mode: MutationMode,
+    pub status: MutationStatus,
+    pub target: BrokerConfigResource,
+    pub before: BTreeMap<String, BrokerConfigState>,
+    pub requested: BrokerConfigPatch,
+    #[schemars(required, schema_with = "nullable_schema::<BTreeMap<String, BrokerConfigState>>")]
+    pub after: Option<BTreeMap<String, BrokerConfigState>>,
+    pub targets: Vec<BrokerConfigMutationTarget>,
+    pub warnings: Vec<String>,
+}
+
+impl BrokerConfigMutationToolResponse {
+    pub fn is_error(&self) -> bool {
+        matches!(
+            self.status,
+            MutationStatus::Partial | MutationStatus::Conflict | MutationStatus::Failed
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION;
+
+    #[test]
+    fn broker_properties_are_closed_and_canonical() {
+        let value = serde_json::json!({
+            "schema_version": MUTATION_ARGUMENTS_SCHEMA_VERSION,
+            "cluster": "cluster-a",
+            "broker_name": "broker-a",
+            "properties": {"brokerPermission":"6","traceTopicEnable":"false"},
+            "dry_run": true,
+            "confirm": false
+        });
+        let args: PatchBrokerConfigArgs = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(args.validate(true, false).unwrap().broker_permission, Some(6));
+        for properties in [
+            serde_json::json!({}),
+            serde_json::json!({"brokerPermission":"0"}),
+            serde_json::json!({"brokerPermission":"06"}),
+            serde_json::json!({"traceTopicEnable":"False"}),
+            serde_json::json!({"traceTopicEnable":null}),
+            serde_json::json!({"brokerPermission":"6","traceTopicEnable":null}),
+            serde_json::json!({"unknown":"true"}),
+        ] {
+            let mut case = value.clone();
+            case["properties"] = properties;
+            let rejected = serde_json::from_value::<PatchBrokerConfigArgs>(case)
+                .map_err(|_| ControlError::invalid_arguments())
+                .and_then(|args| args.validate(true, false));
+            assert!(rejected.is_err());
+        }
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tools/remaining/offset.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tools/remaining/offset.rs
@@ -1,0 +1,209 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chrono::DateTime;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::super::{
+    default_dry_run, validate_common, validate_user_name, FailureCode, MutationMode, MutationResultSchemaVersion,
+    MutationStatus, NameKind,
+};
+use super::nullable_schema;
+use super::validate_consumer_group;
+use crate::error::ControlError;
+
+pub const RESET_CONSUMER_OFFSET_TOOL: &str = "rocketmq_reset_consumer_offset";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ConsumerOffsetResetOperation {
+    #[serde(rename = "consumer_offset_reset")]
+    ConsumerOffsetReset,
+}
+
+operation_schema!(
+    ConsumerOffsetResetOperation,
+    "ConsumerOffsetResetOperation",
+    "consumer_offset_reset"
+);
+
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResetConsumerOffsetArgs {
+    #[schemars(regex(pattern = "^rocketmq-mcp-control\\.arguments\\.v1$"))]
+    pub schema_version: String,
+    #[schemars(length(min = 1, max = 64), regex(pattern = "^[a-zA-Z0-9_-]+$"))]
+    pub cluster: String,
+    #[schemars(length(min = 1, max = 127), regex(pattern = "^[%|a-zA-Z0-9_-]+$"))]
+    pub topic: String,
+    #[schemars(length(min = 1, max = 255), regex(pattern = "^[%|a-zA-Z0-9_-]+$"))]
+    pub consumer_group: String,
+    #[schemars(length(min = 20, max = 40))]
+    pub timestamp: String,
+    #[serde(default)]
+    pub force: bool,
+    #[serde(default = "default_dry_run")]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub confirm: bool,
+    #[serde(default)]
+    #[schemars(length(min = 5, max = 256))]
+    pub reason: Option<String>,
+    #[serde(default)]
+    #[schemars(length(min = 8, max = 64), regex(pattern = "^[a-zA-Z0-9._:-]+$"))]
+    pub request_key: Option<String>,
+}
+
+impl std::fmt::Debug for ResetConsumerOffsetArgs {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ResetConsumerOffsetArgs")
+            .field("schema_version", &self.schema_version)
+            .field("dry_run", &self.dry_run)
+            .field("confirm", &self.confirm)
+            .field("force", &self.force)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResetConsumerOffsetArgs {
+    pub fn validate(&self, configured_default: bool, omitted: bool) -> Result<i64, ControlError> {
+        validate_common(
+            &self.schema_version,
+            self.effective_dry_run(configured_default, omitted),
+            self.confirm,
+            self.reason.as_deref(),
+            self.request_key.as_deref(),
+        )?;
+        validate_user_name(&self.topic, NameKind::Topic)?;
+        validate_consumer_group(&self.consumer_group)?;
+        let timestamp = DateTime::parse_from_rfc3339(&self.timestamp)
+            .map_err(|_| ControlError::invalid_arguments())?
+            .timestamp_millis();
+        if timestamp < 0 {
+            return Err(ControlError::invalid_arguments());
+        }
+        Ok(timestamp)
+    }
+
+    pub fn effective_dry_run(&self, configured_default: bool, omitted: bool) -> bool {
+        if omitted {
+            configured_default
+        } else {
+            self.dry_run
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OffsetResetResource {
+    pub topic: String,
+    pub consumer_group: String,
+    pub brokers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OffsetRequested {
+    pub timestamp: String,
+    pub timestamp_millis: i64,
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OffsetQueueState {
+    pub broker_name: String,
+    pub queue_id: i32,
+    pub offset: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OffsetMutationTarget {
+    pub broker_name: String,
+    #[schemars(required, schema_with = "nullable_schema::<i32>")]
+    pub queue_id: Option<i32>,
+    #[schemars(required, schema_with = "nullable_schema::<i64>")]
+    pub before: Option<i64>,
+    #[schemars(required, schema_with = "nullable_schema::<i64>")]
+    pub planned: Option<i64>,
+    #[schemars(required, schema_with = "nullable_schema::<i64>")]
+    pub delta: Option<i64>,
+    #[schemars(required, schema_with = "nullable_schema::<i64>")]
+    pub after: Option<i64>,
+    pub applied: bool,
+    pub changed: bool,
+    #[schemars(required, schema_with = "nullable_schema::<FailureCode>")]
+    pub failure: Option<FailureCode>,
+    pub retryable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OffsetMutationToolResponse {
+    pub schema_version: MutationResultSchemaVersion,
+    pub operation: ConsumerOffsetResetOperation,
+    pub cluster: String,
+    pub mode: MutationMode,
+    pub status: MutationStatus,
+    pub target: OffsetResetResource,
+    pub before: Vec<OffsetQueueState>,
+    pub requested: OffsetRequested,
+    #[schemars(required, schema_with = "nullable_schema::<Vec<OffsetQueueState>>")]
+    pub after: Option<Vec<OffsetQueueState>>,
+    pub targets: Vec<OffsetMutationTarget>,
+    pub warnings: Vec<String>,
+}
+
+impl OffsetMutationToolResponse {
+    pub fn is_error(&self) -> bool {
+        matches!(
+            self.status,
+            MutationStatus::Partial | MutationStatus::Conflict | MutationStatus::Failed
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION;
+
+    #[test]
+    fn offset_timestamp_and_names_are_closed() {
+        let mut value = serde_json::json!({
+            "schema_version": MUTATION_ARGUMENTS_SCHEMA_VERSION,
+            "cluster": "cluster-a",
+            "topic": "orders",
+            "consumer_group": "workers",
+            "timestamp": "2026-08-30T08:00:00+08:00",
+            "dry_run": true,
+            "confirm": false
+        });
+        let args: ResetConsumerOffsetArgs = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(args.validate(true, false).unwrap(), 1_788_048_000_000);
+        for invalid in ["2026-08-30T08:00:00", "1969-12-31T23:59:59Z", "not-a-time"] {
+            let mut case = value.clone();
+            case["timestamp"] = serde_json::json!(invalid);
+            assert!(serde_json::from_value::<ResetConsumerOffsetArgs>(case)
+                .unwrap()
+                .validate(true, false)
+                .is_err());
+        }
+        value["unknown"] = serde_json::json!(true);
+        assert!(serde_json::from_value::<ResetConsumerOffsetArgs>(value).is_err());
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/tools/remaining/request_mode.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/tools/remaining/request_mode.rs
@@ -1,0 +1,216 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::super::{
+    default_dry_run, validate_common, validate_user_name, FailureCode, MutationMode, MutationResultSchemaVersion,
+    MutationStatus, NameKind, PersistenceState, VerificationState,
+};
+use super::nullable_schema;
+use super::validate_consumer_group;
+use crate::error::ControlError;
+
+pub const SET_CONSUMER_REQUEST_MODE_TOOL: &str = "rocketmq_set_consumer_request_mode";
+pub const MAX_REQUEST_MODE_TIMEOUT_MILLIS: u64 = 24_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ConsumerRequestModeOperation {
+    #[serde(rename = "consumer_request_mode")]
+    ConsumerRequestMode,
+}
+
+operation_schema!(
+    ConsumerRequestModeOperation,
+    "ConsumerRequestModeOperation",
+    "consumer_request_mode"
+);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerRequestMode {
+    Pull,
+    Pop,
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SetConsumerRequestModeArgs {
+    #[schemars(regex(pattern = "^rocketmq-mcp-control\\.arguments\\.v1$"))]
+    pub schema_version: String,
+    #[schemars(length(min = 1, max = 64), regex(pattern = "^[a-zA-Z0-9_-]+$"))]
+    pub cluster: String,
+    #[schemars(length(min = 1, max = 127), regex(pattern = "^[%|a-zA-Z0-9_-]+$"))]
+    pub topic: String,
+    #[schemars(length(min = 1, max = 255), regex(pattern = "^[%|a-zA-Z0-9_-]+$"))]
+    pub consumer_group: String,
+    pub mode: ConsumerRequestMode,
+    #[schemars(range(min = 0))]
+    pub pop_share_queue_num: i32,
+    #[schemars(range(min = 1, max = 24000))]
+    pub timeout_millis: u64,
+    #[serde(default = "default_dry_run")]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub confirm: bool,
+    #[serde(default)]
+    #[schemars(length(min = 5, max = 256))]
+    pub reason: Option<String>,
+    #[serde(default)]
+    #[schemars(length(min = 8, max = 64), regex(pattern = "^[a-zA-Z0-9._:-]+$"))]
+    pub request_key: Option<String>,
+}
+
+impl std::fmt::Debug for SetConsumerRequestModeArgs {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SetConsumerRequestModeArgs")
+            .field("schema_version", &self.schema_version)
+            .field("mode", &self.mode)
+            .field("pop_share_queue_num", &self.pop_share_queue_num)
+            .field("timeout_millis", &self.timeout_millis)
+            .field("dry_run", &self.dry_run)
+            .field("confirm", &self.confirm)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SetConsumerRequestModeArgs {
+    pub fn validate(&self, configured_default: bool, omitted: bool) -> Result<(), ControlError> {
+        validate_common(
+            &self.schema_version,
+            self.effective_dry_run(configured_default, omitted),
+            self.confirm,
+            self.reason.as_deref(),
+            self.request_key.as_deref(),
+        )?;
+        validate_user_name(&self.topic, NameKind::Topic)?;
+        validate_consumer_group(&self.consumer_group)?;
+        if self.pop_share_queue_num < 0 || !(1..=MAX_REQUEST_MODE_TIMEOUT_MILLIS).contains(&self.timeout_millis) {
+            return Err(ControlError::invalid_arguments());
+        }
+        Ok(())
+    }
+
+    pub fn effective_dry_run(&self, configured_default: bool, omitted: bool) -> bool {
+        if omitted {
+            configured_default
+        } else {
+            self.dry_run
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RequestModeValue {
+    pub mode: ConsumerRequestMode,
+    pub pop_share_queue_num: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RequestModeRequested {
+    pub mode: ConsumerRequestMode,
+    pub pop_share_queue_num: i32,
+    #[schemars(range(min = 1, max = 24000))]
+    pub timeout_millis: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RequestModeResource {
+    pub topic: String,
+    pub consumer_group: String,
+    pub brokers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RequestModeMutationTarget {
+    pub broker_name: String,
+    #[schemars(required, schema_with = "nullable_schema::<RequestModeValue>")]
+    pub before: Option<RequestModeValue>,
+    pub requested: RequestModeValue,
+    #[schemars(required, schema_with = "nullable_schema::<RequestModeValue>")]
+    pub after: Option<RequestModeValue>,
+    pub applied: bool,
+    pub changed: bool,
+    pub persistence: PersistenceState,
+    pub verification: VerificationState,
+    #[schemars(required, schema_with = "nullable_schema::<FailureCode>")]
+    pub failure: Option<FailureCode>,
+    pub retryable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RequestModeMutationToolResponse {
+    pub schema_version: MutationResultSchemaVersion,
+    pub operation: ConsumerRequestModeOperation,
+    pub cluster: String,
+    pub mode: MutationMode,
+    pub status: MutationStatus,
+    pub target: RequestModeResource,
+    pub before: BTreeMap<String, Option<RequestModeValue>>,
+    pub requested: RequestModeRequested,
+    #[schemars(
+        required,
+        schema_with = "nullable_schema::<BTreeMap<String, Option<RequestModeValue>>>"
+    )]
+    pub after: Option<BTreeMap<String, Option<RequestModeValue>>>,
+    pub targets: Vec<RequestModeMutationTarget>,
+    pub warnings: Vec<String>,
+}
+
+impl RequestModeMutationToolResponse {
+    pub fn is_error(&self) -> bool {
+        matches!(
+            self.status,
+            MutationStatus::Partial | MutationStatus::Conflict | MutationStatus::Failed
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION;
+
+    #[test]
+    fn request_mode_bounds_and_debug_are_closed() {
+        let mut value = serde_json::json!({
+            "schema_version": MUTATION_ARGUMENTS_SCHEMA_VERSION,
+            "cluster": "cluster-a",
+            "topic": "orders",
+            "consumer_group": "workers",
+            "mode": "pop",
+            "pop_share_queue_num": 4,
+            "timeout_millis": 24000,
+            "dry_run": true,
+            "confirm": false
+        });
+        let args: SetConsumerRequestModeArgs = serde_json::from_value(value.clone()).unwrap();
+        args.validate(true, false).unwrap();
+        assert!(!format!("{args:?}").contains("orders"));
+        value["timeout_millis"] = serde_json::json!(24_001);
+        assert!(serde_json::from_value::<SetConsumerRequestModeArgs>(value)
+            .unwrap()
+            .validate(true, false)
+            .is_err());
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/transport.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport.rs
@@ -410,13 +410,15 @@ mod tests {
         {
             Box::pin(async move {
                 self.counters.opens.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                Ok(Box::new(crate::tool_runtime::admin_session::AdminUpsertSession::new(
-                    ProtocolBackend {
-                        counters: self.counters.clone(),
-                        topic_executed: false,
-                        group_executed: false,
-                    },
-                )) as Box<dyn crate::tool_runtime::UpsertSession>)
+                Ok(
+                    Box::new(crate::tool_runtime::admin_session::AdminMutationToolSession::new(
+                        ProtocolBackend {
+                            counters: self.counters.clone(),
+                            topic_executed: false,
+                            group_executed: false,
+                        },
+                    )) as Box<dyn crate::tool_runtime::UpsertSession>,
+                )
             })
         }
     }
@@ -449,9 +451,12 @@ mod tests {
     }
 
     #[cfg(feature = "write-tools")]
-    impl crate::tool_runtime::admin_session::SupervisedUpsertBackend for ProtocolBackend {
+    impl crate::tool_runtime::admin_session::SupervisedMutationBackend for ProtocolBackend {
         type TopicPlan = ProtocolTopicPlan;
         type GroupPlan = ProtocolGroupPlan;
+        type OffsetPlan = ();
+        type BrokerPlan = ();
+        type RequestModePlan = ();
 
         fn preflight_topic<'a>(
             &'a mut self,
@@ -619,6 +624,99 @@ mod tests {
             })
         }
 
+        fn preview_offset<'a>(
+            &'a mut self,
+            _request: &'a rocketmq_admin_core::core::supervised_mutation::OffsetResetPreviewRequest,
+        ) -> crate::tool_runtime::RuntimeFuture<'a, Result<Self::OffsetPlan, ControlError>> {
+            Box::pin(async { Err(ControlError::operation_unavailable()) })
+        }
+
+        fn offset_rows(
+            _plan: &Self::OffsetPlan,
+        ) -> Vec<rocketmq_admin_core::core::supervised_mutation::OffsetResetPreviewRow> {
+            Vec::new()
+        }
+
+        fn offset_failures(
+            _plan: &Self::OffsetPlan,
+        ) -> &[rocketmq_admin_core::core::supervised_mutation::MutationTargetFailure] {
+            &[]
+        }
+
+        fn execute_offset<'a>(
+            &'a mut self,
+            _plan: &'a Self::OffsetPlan,
+        ) -> crate::tool_runtime::RuntimeFuture<
+            'a,
+            Result<rocketmq_admin_core::core::supervised_mutation::OffsetResetOutcome, ControlError>,
+        > {
+            Box::pin(async { Err(ControlError::operation_unavailable()) })
+        }
+
+        fn preflight_broker<'a>(
+            &'a mut self,
+            _cluster: &'a str,
+            _broker_name: &'a str,
+        ) -> crate::tool_runtime::RuntimeFuture<'a, Result<Self::BrokerPlan, ControlError>> {
+            Box::pin(async { Err(ControlError::operation_unavailable()) })
+        }
+
+        fn broker_targets(
+            _plan: &Self::BrokerPlan,
+        ) -> Vec<rocketmq_admin_core::core::supervised_mutation::BrokerMutationConfigTarget> {
+            Vec::new()
+        }
+
+        fn broker_failures(
+            _plan: &Self::BrokerPlan,
+        ) -> &[rocketmq_admin_core::core::supervised_mutation::MutationTargetFailure] {
+            &[]
+        }
+
+        fn execute_broker<'a>(
+            &'a mut self,
+            _plan: &'a Self::BrokerPlan,
+            _patch: rocketmq_admin_core::core::supervised_mutation::BrokerMutationConfigPatch,
+        ) -> crate::tool_runtime::RuntimeFuture<
+            'a,
+            Result<rocketmq_admin_core::core::supervised_mutation::BrokerMutationConfigOutcome, ControlError>,
+        > {
+            Box::pin(async { Err(ControlError::operation_unavailable()) })
+        }
+
+        fn preflight_request_mode<'a>(
+            &'a mut self,
+            _request: &'a rocketmq_admin_core::core::supervised_mutation::RequestModePreflightRequest,
+        ) -> crate::tool_runtime::RuntimeFuture<'a, Result<Self::RequestModePlan, ControlError>> {
+            Box::pin(async { Err(ControlError::operation_unavailable()) })
+        }
+
+        fn request_mode_targets(
+            _plan: &Self::RequestModePlan,
+        ) -> Vec<(
+            String,
+            Option<rocketmq_admin_core::core::supervised_mutation::RequestModeValue>,
+        )> {
+            Vec::new()
+        }
+
+        fn request_mode_failures(
+            _plan: &Self::RequestModePlan,
+        ) -> &[rocketmq_admin_core::core::supervised_mutation::MutationTargetFailure] {
+            &[]
+        }
+
+        fn execute_request_mode<'a>(
+            &'a mut self,
+            _plan: &'a Self::RequestModePlan,
+            _timeout_millis: u64,
+        ) -> crate::tool_runtime::RuntimeFuture<
+            'a,
+            Result<rocketmq_admin_core::core::supervised_mutation::RequestModeMutationOutcome, ControlError>,
+        > {
+            Box::pin(async { Err(ControlError::operation_unavailable()) })
+        }
+
         fn shutdown(&mut self) -> crate::tool_runtime::RuntimeFuture<'_, Result<(), ControlError>> {
             Box::pin(async move {
                 self.counters
@@ -639,7 +737,13 @@ mod tests {
         config.mutations = MutationPolicyConfig {
             mutations_enabled: true,
             dry_run: true,
-            allowed_operations: vec![ControlOperation::TopicUpsert, ControlOperation::ConsumerGroupUpsert],
+            allowed_operations: vec![
+                ControlOperation::TopicUpsert,
+                ControlOperation::ConsumerGroupUpsert,
+                ControlOperation::ConsumerOffsetReset,
+                ControlOperation::BrokerConfigPatch,
+                ControlOperation::ConsumerRequestMode,
+            ],
             allowed_clusters: vec![ClusterName::try_new("cluster-a").unwrap()],
             operation_timeout_seconds: 2,
         };
@@ -904,6 +1008,43 @@ mod tests {
     #[tokio::test]
     async fn authenticated_tool_discovery_and_call_enforce_claims_before_schema() {
         let (router, counters, _sink) = write_router().await;
+        let all = token_with_claims(
+            REQUIRED_WRITE_SCOPE,
+            vec![
+                "topic_upsert",
+                "consumer_group_upsert",
+                "consumer_offset_reset",
+                "broker_config_patch",
+                "consumer_request_mode",
+            ],
+            vec!["cluster-a"],
+        );
+        let tools = router
+            .clone()
+            .oneshot(request(
+                "/mcp",
+                Body::from(r#"{"jsonrpc":"2.0","id":19,"method":"tools/list","params":{}}"#),
+                Some(&all),
+            ))
+            .await
+            .unwrap();
+        let body = to_bytes(tools.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+        let listed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            listed["result"]["tools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|tool| tool["name"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec![
+                "rocketmq_upsert_topic",
+                "rocketmq_upsert_consumer_group",
+                "rocketmq_reset_consumer_offset",
+                "rocketmq_patch_broker_config",
+                "rocketmq_set_consumer_request_mode",
+            ]
+        );
         let both = token_with_claims(
             REQUIRED_WRITE_SCOPE,
             vec!["topic_upsert", "consumer_group_upsert"],
@@ -1354,6 +1495,184 @@ mod tests {
         assert_eq!(counters.executes.load(std::sync::atomic::Ordering::SeqCst), 0);
         assert_eq!(counters.shutdowns.load(std::sync::atomic::Ordering::SeqCst), 2);
         assert_eq!(sink.records().await.unwrap().len(), 4);
+    }
+
+    #[cfg(feature = "write-tools")]
+    #[tokio::test]
+    async fn stage_c_authorization_and_validation_precede_audit_session_and_backend() {
+        let (router, counters, sink) = write_router().await;
+        let denied = token_with_claims(REQUIRED_WRITE_SCOPE, Vec::new(), vec!["cluster-a"]);
+        for (index, tool) in [
+            crate::tools::RESET_CONSUMER_OFFSET_TOOL,
+            crate::tools::PATCH_BROKER_CONFIG_TOOL,
+            crate::tools::SET_CONSUMER_REQUEST_MODE_TOOL,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 300 + index,
+                "method": "tools/call",
+                "params": {
+                    "name": tool,
+                    "arguments": {"cluster": "cluster-a", "unknown": true}
+                }
+            });
+            let response = router
+                .clone()
+                .oneshot(request("/mcp", Body::from(body.to_string()), Some(&denied)))
+                .await
+                .unwrap();
+            let body = to_bytes(response.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(value["result"]["structuredContent"]["code"], "permission_denied");
+        }
+
+        let allowed = token_with_claims(
+            REQUIRED_WRITE_SCOPE,
+            vec!["consumer_offset_reset", "broker_config_patch", "consumer_request_mode"],
+            vec!["cluster-a"],
+        );
+        let schema = crate::model::MUTATION_ARGUMENTS_SCHEMA_VERSION;
+        let invalid = [
+            (
+                crate::tools::RESET_CONSUMER_OFFSET_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "topic": "orders",
+                    "consumer_group": "workers",
+                    "timestamp": "2026-08-30T08:00:00",
+                }),
+            ),
+            (
+                crate::tools::RESET_CONSUMER_OFFSET_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "topic": "RMQ_SYS_TRACE_TOPIC",
+                    "consumer_group": "workers",
+                    "timestamp": "2026-08-30T00:00:00Z",
+                }),
+            ),
+            (
+                crate::tools::RESET_CONSUMER_OFFSET_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "topic": "orders",
+                    "consumer_group": "CID_RMQ_SYS_TRANS",
+                    "timestamp": "2026-08-30T00:00:00Z",
+                }),
+            ),
+            (
+                crate::tools::RESET_CONSUMER_OFFSET_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "topic": "orders%2fhidden",
+                    "consumer_group": "workers",
+                    "timestamp": "2026-08-30T00:00:00Z",
+                }),
+            ),
+            (
+                crate::tools::PATCH_BROKER_CONFIG_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "broker_name": "broker-a",
+                    "properties": {},
+                }),
+            ),
+            (
+                crate::tools::PATCH_BROKER_CONFIG_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "broker_name": "broker-a",
+                    "properties": {"brokerPermission": "06"},
+                }),
+            ),
+            (
+                crate::tools::PATCH_BROKER_CONFIG_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "broker_name": "broker-a",
+                    "properties": {"unknown": "true"},
+                }),
+            ),
+            (
+                crate::tools::PATCH_BROKER_CONFIG_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "broker_name": "broker-a",
+                    "properties": {"traceTopicEnable": null},
+                }),
+            ),
+            (
+                crate::tools::SET_CONSUMER_REQUEST_MODE_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "topic": "orders",
+                    "consumer_group": "workers",
+                    "mode": "pop",
+                    "pop_share_queue_num": 1,
+                    "timeout_millis": 0,
+                }),
+            ),
+            (
+                crate::tools::SET_CONSUMER_REQUEST_MODE_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "topic": "orders",
+                    "consumer_group": "workers",
+                    "mode": "pop",
+                    "pop_share_queue_num": 1,
+                    "timeout_millis": 24001,
+                }),
+            ),
+            (
+                crate::tools::SET_CONSUMER_REQUEST_MODE_TOOL,
+                serde_json::json!({
+                    "schema_version": schema,
+                    "cluster": "cluster-a",
+                    "topic": "TBW102",
+                    "consumer_group": "workers",
+                    "mode": "pull",
+                    "pop_share_queue_num": 0,
+                    "timeout_millis": 12000,
+                }),
+            ),
+        ];
+        for (index, (tool, arguments)) in invalid.into_iter().enumerate() {
+            let body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 320 + index,
+                "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments}
+            });
+            let response = router
+                .clone()
+                .oneshot(request("/mcp", Body::from(body.to_string()), Some(&allowed)))
+                .await
+                .unwrap();
+            let body = to_bytes(response.into_body(), MAX_HTTP_BODY_BYTES).await.unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(
+                value["result"]["structuredContent"]["code"], "invalid_arguments",
+                "case {index}"
+            );
+        }
+        assert_eq!(counters.opens.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(counters.preflights.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(counters.executes.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(counters.shutdowns.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(sink.records().await.unwrap().is_empty());
     }
 
     #[tokio::test(start_paused = true)]

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl/mutation_api.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl/mutation_api.rs
@@ -870,6 +870,32 @@ impl MQAdminMutationExt for DefaultMQAdminExtImpl {
             .await
     }
 
+    async fn replace_message_request_mode_if_current_with_timeout(
+        &self,
+        broker_addr: CheetahString,
+        topic: CheetahString,
+        consumer_group: CheetahString,
+        expected: MutationExpectedMessageRequestMode,
+        replacement: MutationMessageRequestMode,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<MutationMessageRequestModeOutcome> {
+        if timeout_millis == 0 || timeout_millis > 24_000 {
+            return Err(RocketMQError::illegal_argument(
+                "request-mode timeoutMillis must be between 1 and 24000",
+            ));
+        }
+        self.mq_client_api()?
+            .replace_message_request_mode_if_current(
+                &broker_addr,
+                topic,
+                consumer_group,
+                expected,
+                replacement,
+                timeout_millis,
+            )
+            .await
+    }
+
     async fn set_broker_log_filter_ttl(
         &self,
         broker_addr: CheetahString,
@@ -1459,11 +1485,15 @@ mod detailed_offset_tests {
     use rocketmq_protocol::code::request_code::RequestCode;
     use rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats;
     use rocketmq_protocol::protocol::admin::offset_wrapper::OffsetWrapper;
+    use rocketmq_protocol::protocol::body::supervised_mutation::MessageRequestModeMutationResultBody;
+    use rocketmq_protocol::protocol::body::supervised_mutation::MutationPersistenceState;
+    use rocketmq_protocol::protocol::body::supervised_mutation::SupervisedMessageRequestMode;
     use rocketmq_protocol::protocol::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
     use rocketmq_protocol::protocol::header::namesrv::kv_config_header::GetKVConfigRequestHeader;
     use rocketmq_protocol::protocol::header::namesrv::kv_config_header::GetKVConfigResponseHeader;
     use rocketmq_protocol::protocol::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
     use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
+    use rocketmq_protocol::protocol::RemotingSerializable;
     use rocketmq_protocol::RemotingCommand;
     use rocketmq_runtime::RuntimeContext;
     use rocketmq_runtime::ShutdownDeadline;
@@ -1473,6 +1503,7 @@ mod detailed_offset_tests {
     use rocketmq_transport::test_support::SessionTransportServer;
     use rocketmq_transport::test_support::SessionTransportServerConfig;
 
+    use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
     use crate::base::client_config::ClientConfig;
     use crate::factory::mq_client_instance::MQClientInstance;
     use crate::runtime::test_client_runtime;
@@ -1482,6 +1513,7 @@ mod detailed_offset_tests {
     #[derive(Default)]
     struct ScriptedRequestLedger {
         responses: Mutex<HashMap<i32, VecDeque<RemotingCommand>>>,
+        delays: Mutex<HashMap<i32, VecDeque<Duration>>>,
         counts: Mutex<HashMap<i32, usize>>,
         kv_reads: Mutex<Vec<(String, String)>>,
     }
@@ -1494,6 +1526,16 @@ mod detailed_offset_tests {
                 .entry(code.to_i32())
                 .or_default()
                 .push_back(response);
+        }
+
+        fn push_delayed(&self, code: RequestCode, delay: Duration, response: RemotingCommand) {
+            self.push(code, response);
+            self.delays
+                .lock()
+                .expect("scripted delays")
+                .entry(code.to_i32())
+                .or_default()
+                .push_back(delay);
         }
 
         fn snapshot(&self) -> HashMap<i32, usize> {
@@ -1524,6 +1566,15 @@ mod detailed_offset_tests {
                     .expect("request counts")
                     .entry(request.code())
                     .or_default() += 1;
+                let delay = self
+                    .delays
+                    .lock()
+                    .expect("scripted delays")
+                    .get_mut(&request.code())
+                    .and_then(VecDeque::pop_front);
+                if let Some(delay) = delay {
+                    tokio::time::sleep(delay).await;
+                }
                 let response = self
                     .responses
                     .lock()
@@ -1540,6 +1591,7 @@ mod detailed_offset_tests {
 
     struct ProductionAdminHarness {
         admin: DefaultMQAdminExtImpl,
+        facade: DefaultMQAdminExt,
         broker_addr: CheetahString,
         client_instance: Arc<MQClientInstance>,
         client_runtime: Arc<crate::runtime::ClientRuntime>,
@@ -1591,9 +1643,17 @@ mod detailed_offset_tests {
                 CheetahString::from_string(format!("{scope}-admin")),
             );
             admin.client_instance = Some(Arc::clone(&client_instance));
+            let mut facade = DefaultMQAdminExt::with_admin_ext_group_and_timeout(
+                Arc::clone(&client_runtime),
+                format!("{scope}-facade"),
+                Duration::from_secs(5),
+            );
+            facade.client_config_mut().set_vip_channel_enabled(false);
+            facade.inner_mut().client_instance = Some(Arc::clone(&client_instance));
 
             Self {
                 admin,
+                facade,
                 broker_addr,
                 client_instance,
                 client_runtime,
@@ -1606,13 +1666,14 @@ mod detailed_offset_tests {
         async fn shutdown(self) {
             let Self {
                 admin,
+                facade,
                 client_instance,
                 client_runtime,
                 server,
                 server_runtime,
                 ..
             } = self;
-            drop(admin);
+            drop((admin, facade));
             client_instance.shutdown().await;
             client_runtime
                 .shutdown()
@@ -1683,6 +1744,112 @@ mod detailed_offset_tests {
         );
         response.make_custom_header_to_net();
         response
+    }
+
+    fn request_mode_success_response() -> RemotingCommand {
+        RemotingCommand::create_success_response_command().set_body(
+            MessageRequestModeMutationResultBody {
+                applied: true,
+                changed: true,
+                current: Some(SupervisedMessageRequestMode {
+                    mode: "POP".to_owned(),
+                    pop_share_queue_num: 4,
+                }),
+                persistence: MutationPersistenceState::Persisted,
+            }
+            .encode()
+            .expect("request-mode response body"),
+        )
+    }
+
+    #[tokio::test]
+    async fn production_request_mode_uses_the_exact_caller_timeout_on_loopback() {
+        let harness = ProductionAdminHarness::new("request-mode-exact-timeout-test").await;
+        harness.ledger.push_delayed(
+            RequestCode::SetMessageRequestModeCas,
+            Duration::from_millis(50),
+            request_mode_success_response(),
+        );
+        let replacement = MutationMessageRequestMode {
+            mode: MessageRequestMode::Pop,
+            pop_share_queue_num: 4,
+        };
+        MQAdminMutationExt::replace_message_request_mode_if_current_with_timeout(
+            &harness.admin,
+            harness.broker_addr.clone(),
+            CheetahString::from_static_str("orders"),
+            CheetahString::from_static_str("orders-consumer"),
+            MutationExpectedMessageRequestMode::Absent,
+            replacement,
+            1,
+        )
+        .await
+        .expect_err("one millisecond caller timeout must reach remoting");
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        harness
+            .ledger
+            .push(RequestCode::SetMessageRequestModeCas, request_mode_success_response());
+        let outcome = MQAdminMutationExt::replace_message_request_mode_if_current_with_timeout(
+            &harness.admin,
+            harness.broker_addr.clone(),
+            CheetahString::from_static_str("orders"),
+            CheetahString::from_static_str("orders-consumer"),
+            MutationExpectedMessageRequestMode::Absent,
+            replacement,
+            24_000,
+        )
+        .await
+        .expect("bounded caller timeout should permit immediate response");
+        assert!(outcome.applied);
+        assert!(outcome.changed);
+        assert_eq!(outcome.current, Some(replacement));
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn public_admin_facade_delegates_the_exact_request_mode_timeout_on_loopback() {
+        let harness = ProductionAdminHarness::new("request-mode-facade-timeout-test").await;
+        harness.ledger.push_delayed(
+            RequestCode::SetMessageRequestModeCas,
+            Duration::from_millis(50),
+            request_mode_success_response(),
+        );
+        let replacement = MutationMessageRequestMode {
+            mode: MessageRequestMode::Pop,
+            pop_share_queue_num: 4,
+        };
+        MQAdminMutationExt::replace_message_request_mode_if_current_with_timeout(
+            &harness.facade,
+            harness.broker_addr.clone(),
+            CheetahString::from_static_str("orders"),
+            CheetahString::from_static_str("orders-consumer"),
+            MutationExpectedMessageRequestMode::Absent,
+            replacement,
+            1,
+        )
+        .await
+        .expect_err("the public facade must forward the one millisecond timeout");
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        harness
+            .ledger
+            .push(RequestCode::SetMessageRequestModeCas, request_mode_success_response());
+        let outcome = MQAdminMutationExt::replace_message_request_mode_if_current_with_timeout(
+            &harness.facade,
+            harness.broker_addr.clone(),
+            CheetahString::from_static_str("orders"),
+            CheetahString::from_static_str("orders-consumer"),
+            MutationExpectedMessageRequestMode::Absent,
+            replacement,
+            24_000,
+        )
+        .await
+        .expect("the public facade must forward the bounded caller timeout");
+        assert!(outcome.applied);
+        assert!(outcome.changed);
+        assert_eq!(outcome.current, Some(replacement));
+        harness.shutdown().await;
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/admin/mq_admin_mutation_ext.rs
+++ b/rocketmq-client/src/admin/mq_admin_mutation_ext.rs
@@ -482,6 +482,34 @@ pub trait MQAdminMutationExt: Send {
         ))
     }
 
+    /// Conditionally replaces one exact Topic/group request-mode entry using
+    /// the caller's bounded request timeout.
+    ///
+    /// The default deliberately fails closed so existing trait implementers
+    /// remain source compatible without silently ignoring the requested
+    /// timeout.
+    async fn replace_message_request_mode_if_current_with_timeout(
+        &self,
+        broker_addr: CheetahString,
+        topic: CheetahString,
+        consumer_group: CheetahString,
+        expected: MutationExpectedMessageRequestMode,
+        replacement: MutationMessageRequestMode,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<MutationMessageRequestModeOutcome> {
+        let _ = (
+            broker_addr,
+            topic,
+            consumer_group,
+            expected,
+            replacement,
+            timeout_millis,
+        );
+        Err(rocketmq_error::RocketMQError::illegal_argument(
+            "timeout-aware conditional request-mode mutation is not implemented by this admin client",
+        ))
+    }
+
     /// Applies one bounded Broker logger override with an automatic TTL.
     ///
     /// Implementations must reject arbitrary filter expressions. `logger`
@@ -913,6 +941,27 @@ impl MQAdminMutationExt for DefaultMQAdminExt {
             consumer_group,
             expected,
             replacement,
+        )
+        .await
+    }
+
+    async fn replace_message_request_mode_if_current_with_timeout(
+        &self,
+        broker_addr: CheetahString,
+        topic: CheetahString,
+        consumer_group: CheetahString,
+        expected: MutationExpectedMessageRequestMode,
+        replacement: MutationMessageRequestMode,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<MutationMessageRequestModeOutcome> {
+        MQAdminMutationExt::replace_message_request_mode_if_current_with_timeout(
+            self.inner(),
+            broker_addr,
+            topic,
+            consumer_group,
+            expected,
+            replacement,
+            timeout_millis,
         )
         .await
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/lifecycle.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/lifecycle.rs
@@ -121,7 +121,7 @@ pub struct AdminSession {
 }
 
 impl AdminSession {
-    #[cfg(feature = "client-adapter")]
+    #[cfg(any(feature = "client-adapter", test))]
     pub(crate) fn from_started(inner: DefaultMQAdminExt, clock: Arc<dyn Clock>) -> Self {
         let client_runtime = inner.client_runtime();
         Self {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/mutation/supervised.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/mutation/supervised.rs
@@ -108,6 +108,23 @@ impl SupervisedMutationAdmin for MutationAdminSession {
         })
     }
 
+    fn preflight_broker_config_target<'a>(
+        &'a mut self,
+        cluster: &'a str,
+        broker_name: &'a str,
+    ) -> AdminFuture<'a, BrokerMutationConfigPlan> {
+        Box::pin(async move {
+            self.inner.ensure_open()?;
+            preflight_broker_config_target_with_admin(
+                &self.inner.inner,
+                Arc::clone(&self.plan_seal),
+                cluster,
+                broker_name,
+            )
+            .await
+        })
+    }
+
     fn execute_broker_config_patch<'a>(
         &'a mut self,
         plan: &'a BrokerMutationConfigPlan,
@@ -183,6 +200,17 @@ impl SupervisedMutationAdmin for MutationAdminSession {
         })
     }
 
+    fn execute_broker_config_patch_verified<'a>(
+        &'a mut self,
+        plan: &'a BrokerMutationConfigPlan,
+        patch: BrokerMutationConfigPatch,
+    ) -> AdminFuture<'a, BrokerMutationConfigOutcome> {
+        Box::pin(async move {
+            self.inner.ensure_open()?;
+            execute_broker_config_patch_verified_with_admin(&self.inner.inner, &self.plan_seal, plan, patch).await
+        })
+    }
+
     fn preflight_request_mode<'a>(
         &'a mut self,
         request: &'a RequestModePreflightRequest,
@@ -200,6 +228,23 @@ impl SupervisedMutationAdmin for MutationAdminSession {
         Box::pin(async move {
             self.inner.ensure_open()?;
             execute_request_mode_checked(&self.inner.inner, &self.plan_seal, plan).await
+        })
+    }
+
+    fn execute_request_mode_with_timeout<'a>(
+        &'a mut self,
+        plan: &'a RequestModeMutationPlan,
+        timeout_millis: u64,
+    ) -> AdminFuture<'a, RequestModeMutationOutcome> {
+        Box::pin(async move {
+            self.inner.ensure_open()?;
+            if !(1..=24_000).contains(&timeout_millis) {
+                return Err(AdminError::invalid_argument(
+                    "timeoutMillis",
+                    "must be between 1 and 24000",
+                ));
+            }
+            execute_request_mode_checked_with_timeout(&self.inner.inner, &self.plan_seal, plan, timeout_millis).await
         })
     }
 }
@@ -644,6 +689,56 @@ async fn preflight_request_mode_with_admin<A: MQAdminMutationExt + ?Sized>(
     let mut targets = Vec::new();
     let mut failures = Vec::new();
     for (broker_name, broker_addr) in master_targets_by_cluster_name(&cluster_info, &cluster)? {
+        let topic_state = match admin
+            .mutation_topic_config_state(broker_addr.clone(), topic.clone().into())
+            .await
+        {
+            Ok(state) => state,
+            Err(error) => {
+                failures.push(client_failure(broker_name, None, &error));
+                continue;
+            }
+        };
+        if !matches!(
+            topic_state,
+            rocketmq_client_rust::MutationTopicConfigState {
+                state: ClientExpectedState::Present { .. },
+                config: Some(_),
+            }
+        ) {
+            failures.push(MutationTargetFailure {
+                broker_name,
+                queue_id: None,
+                code: MutationFailureCode::InvalidData,
+                retryable: false,
+            });
+            continue;
+        }
+        let group_state = match admin
+            .mutation_subscription_group_config_state(broker_addr.clone(), group.clone().into())
+            .await
+        {
+            Ok(state) => state,
+            Err(error) => {
+                failures.push(client_failure(broker_name, None, &error));
+                continue;
+            }
+        };
+        if !matches!(
+            group_state,
+            rocketmq_client_rust::MutationSubscriptionGroupConfigState {
+                state: ClientExpectedState::Present { .. },
+                config: Some(_),
+            }
+        ) {
+            failures.push(MutationTargetFailure {
+                broker_name,
+                queue_id: None,
+                code: MutationFailureCode::InvalidData,
+                retryable: false,
+            });
+            continue;
+        }
         match admin
             .mutation_message_request_mode(broker_addr.clone(), topic.clone().into(), group.clone().into())
             .await
@@ -693,10 +788,140 @@ async fn preflight_broker_config_with_admin<A: MQAdminMutationExt + ?Sized>(
     })
 }
 
+async fn preflight_broker_config_target_with_admin<A: MQAdminMutationExt + ?Sized>(
+    admin: &A,
+    seal: Arc<MutationPlanSeal>,
+    cluster: &str,
+    broker_name: &str,
+) -> AdminResult<BrokerMutationConfigPlan> {
+    let cluster = require_non_empty("cluster", cluster)?.to_owned();
+    let broker_name = require_non_empty("brokerName", broker_name)?.to_owned();
+    let cluster_info = admin
+        .mutation_cluster_info()
+        .await
+        .map_err(|error| backend_error("mutation_cluster_info", error))?;
+    let all_targets = master_targets_by_cluster_name(&cluster_info, &cluster)?;
+    let selected = vec![broker_name];
+    let selected_targets = select_metadata_targets(all_targets, Some(&selected))?;
+    let mut targets = Vec::with_capacity(1);
+    let mut failures = Vec::new();
+    for (broker_name, broker_addr) in selected_targets {
+        match admin.broker_mutation_config_state(broker_addr.clone()).await {
+            Ok(state) => targets.push((broker_name, broker_addr.to_string(), map_client_broker_state(state))),
+            Err(error) => failures.push(client_failure(broker_name, None, &error)),
+        }
+    }
+    Ok(BrokerMutationConfigPlan {
+        seal,
+        cluster,
+        targets,
+        failures,
+    })
+}
+
+async fn execute_broker_config_patch_verified_with_admin<A: MQAdminMutationExt + ?Sized>(
+    admin: &A,
+    session_seal: &Arc<MutationPlanSeal>,
+    plan: &BrokerMutationConfigPlan,
+    patch: BrokerMutationConfigPatch,
+) -> AdminResult<BrokerMutationConfigOutcome> {
+    ensure_same_plan_seal(session_seal, &plan.seal)?;
+    let properties = broker_patch_properties(patch)?;
+    let mut outcome = BrokerMutationConfigOutcome {
+        failures: plan.failures.clone(),
+        ..BrokerMutationConfigOutcome::default()
+    };
+    for (broker_name, broker_addr, before) in &plan.targets {
+        let planned_changed = broker_patch_changes(*before, patch);
+        match admin
+            .patch_broker_config_if_generation(broker_addr.as_str().into(), before.generation, properties.clone())
+            .await
+        {
+            Ok(ClientBrokerConfigPatchOutcome::Applied { .. }) => {
+                match admin.broker_mutation_config_state(broker_addr.as_str().into()).await {
+                    Ok(observed) => {
+                        let observed = map_client_broker_state(observed);
+                        let verified = broker_patch_matches(observed, patch);
+                        outcome.targets.push(BrokerMutationConfigTargetOutcome {
+                            broker_name: broker_name.clone(),
+                            before: *before,
+                            after: Some(observed),
+                            applied: true,
+                            changed: planned_changed,
+                            persistence: MutationPersistenceState::Persisted,
+                            verification: if verified {
+                                MutationVerificationState::Verified
+                            } else {
+                                MutationVerificationState::Failed
+                            },
+                            failure: (!verified).then_some(MutationFailureCode::VerificationFailed),
+                            retryable: false,
+                        });
+                    }
+                    Err(error) => outcome.targets.push(BrokerMutationConfigTargetOutcome {
+                        broker_name: broker_name.clone(),
+                        before: *before,
+                        after: None,
+                        applied: true,
+                        changed: planned_changed,
+                        persistence: MutationPersistenceState::Persisted,
+                        verification: MutationVerificationState::Failed,
+                        failure: Some(MutationFailureCode::VerificationFailed),
+                        retryable: error.boundary_view().is_retryable(),
+                    }),
+                }
+            }
+            Ok(ClientBrokerConfigPatchOutcome::GenerationConflict { .. }) => {
+                outcome.targets.push(BrokerMutationConfigTargetOutcome {
+                    broker_name: broker_name.clone(),
+                    before: *before,
+                    after: None,
+                    applied: false,
+                    changed: false,
+                    persistence: MutationPersistenceState::NotRequired,
+                    verification: MutationVerificationState::NotPerformed,
+                    failure: Some(MutationFailureCode::Conflict),
+                    retryable: false,
+                });
+            }
+            Err(error) => outcome.targets.push(BrokerMutationConfigTargetOutcome {
+                broker_name: broker_name.clone(),
+                before: *before,
+                after: None,
+                applied: false,
+                changed: false,
+                persistence: MutationPersistenceState::NotRequired,
+                verification: MutationVerificationState::NotPerformed,
+                failure: Some(MutationFailureCode::Unavailable),
+                retryable: error.boundary_view().is_retryable(),
+            }),
+        }
+    }
+    Ok(outcome)
+}
+
 async fn execute_request_mode_checked<A: MQAdminMutationExt + ?Sized>(
     admin: &A,
     session_seal: &Arc<MutationPlanSeal>,
     plan: &RequestModeMutationPlan,
+) -> AdminResult<RequestModeMutationOutcome> {
+    execute_request_mode_checked_inner(admin, session_seal, plan, None).await
+}
+
+async fn execute_request_mode_checked_with_timeout<A: MQAdminMutationExt + ?Sized>(
+    admin: &A,
+    session_seal: &Arc<MutationPlanSeal>,
+    plan: &RequestModeMutationPlan,
+    timeout_millis: u64,
+) -> AdminResult<RequestModeMutationOutcome> {
+    execute_request_mode_checked_inner(admin, session_seal, plan, Some(timeout_millis)).await
+}
+
+async fn execute_request_mode_checked_inner<A: MQAdminMutationExt + ?Sized>(
+    admin: &A,
+    session_seal: &Arc<MutationPlanSeal>,
+    plan: &RequestModeMutationPlan,
+    timeout_millis: Option<u64>,
 ) -> AdminResult<RequestModeMutationOutcome> {
     ensure_same_plan_seal(session_seal, &plan.seal)?;
     let mut outcome = RequestModeMutationOutcome {
@@ -707,16 +932,30 @@ async fn execute_request_mode_checked<A: MQAdminMutationExt + ?Sized>(
         let expected = current.map_or(ClientExpectedMessageRequestMode::Absent, |value| {
             ClientExpectedMessageRequestMode::Present(map_request_mode_to_client(value))
         });
-        match admin
-            .replace_message_request_mode_if_current(
-                broker_addr.as_str().into(),
-                plan.topic.as_str().into(),
-                plan.consumer_group.as_str().into(),
-                expected,
-                map_request_mode_to_client(plan.replacement),
-            )
-            .await
-        {
+        let replacement = map_request_mode_to_client(plan.replacement);
+        let result = if let Some(timeout_millis) = timeout_millis {
+            admin
+                .replace_message_request_mode_if_current_with_timeout(
+                    broker_addr.as_str().into(),
+                    plan.topic.as_str().into(),
+                    plan.consumer_group.as_str().into(),
+                    expected,
+                    replacement,
+                    timeout_millis,
+                )
+                .await
+        } else {
+            admin
+                .replace_message_request_mode_if_current(
+                    broker_addr.as_str().into(),
+                    plan.topic.as_str().into(),
+                    plan.consumer_group.as_str().into(),
+                    expected,
+                    replacement,
+                )
+                .await
+        };
+        match result {
             Ok(result) if result.applied || result.persistence == ClientMutationPersistenceState::Failed => {
                 let observed = admin
                     .mutation_message_request_mode(
@@ -742,7 +981,7 @@ async fn execute_request_mode_checked<A: MQAdminMutationExt + ?Sized>(
                         )
                     }
                     Err(error) => (
-                        result.current.map(map_client_request_mode),
+                        None,
                         MutationVerificationState::Failed,
                         true,
                         error.boundary_view().is_retryable(),
@@ -996,7 +1235,7 @@ async fn execute_offset_reset_with_admin<A: MQAdminMutationExt + ?Sized>(
                         observed_offset: None,
                         applied: true,
                         changed: true,
-                        failure: Some(MutationFailureCode::Unavailable),
+                        failure: Some(MutationFailureCode::VerificationFailed),
                         retryable: error.boundary_view().is_retryable(),
                     }),
                 }
@@ -1312,6 +1551,31 @@ fn broker_patch_properties(patch: BrokerMutationConfigPatch) -> AdminResult<Hash
     Ok(properties)
 }
 
+fn broker_patch_matches(state: BrokerMutationConfigState, patch: BrokerMutationConfigPatch) -> bool {
+    patch
+        .auto_create_topic_enable
+        .is_none_or(|value| state.auto_create_topic_enable == value)
+        && patch
+            .auto_create_subscription_group
+            .is_none_or(|value| state.auto_create_subscription_group == value)
+        && patch
+            .broker_permission
+            .is_none_or(|value| state.broker_permission == value)
+        && patch
+            .default_topic_queue_nums
+            .is_none_or(|value| state.default_topic_queue_nums == value)
+        && patch
+            .message_index_enable
+            .is_none_or(|value| state.message_index_enable == value)
+        && patch
+            .trace_topic_enable
+            .is_none_or(|value| state.trace_topic_enable == value)
+}
+
+fn broker_patch_changes(state: BrokerMutationConfigState, patch: BrokerMutationConfigPatch) -> bool {
+    !broker_patch_matches(state, patch)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1319,6 +1583,9 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
     use std::sync::Mutex;
+    use std::time::Duration;
+
+    use rocketmq_runtime::RuntimeContext;
 
     struct CountingMutationAdmin {
         cluster_info: ClusterInfo,
@@ -1328,10 +1595,18 @@ mod tests {
         preview_calls: AtomicUsize,
         reset_calls: AtomicUsize,
         verify_calls: AtomicUsize,
+        offset_fail_postread: AtomicBool,
         endpoint_calls: Mutex<Vec<(&'static str, String)>>,
+        broker_state: Mutex<ClientBrokerMutationConfigState>,
+        broker_reads: AtomicUsize,
+        broker_writes: AtomicUsize,
+        broker_conflict: AtomicBool,
+        broker_fail_postread: AtomicBool,
         request_mode: Mutex<Option<ClientMessageRequestMode>>,
         request_mode_reads: AtomicUsize,
         request_mode_writes: AtomicUsize,
+        request_mode_fail_postread: AtomicBool,
+        request_mode_timeouts: Mutex<Vec<u64>>,
         request_mode_persistence: Mutex<ClientMutationPersistenceState>,
         request_mode_dirty: AtomicBool,
         topic_state: Mutex<rocketmq_client_rust::MutationTopicConfigState>,
@@ -1408,10 +1683,26 @@ mod tests {
                 preview_calls: AtomicUsize::new(0),
                 reset_calls: AtomicUsize::new(0),
                 verify_calls: AtomicUsize::new(0),
+                offset_fail_postread: AtomicBool::new(false),
                 endpoint_calls: Mutex::new(Vec::new()),
+                broker_state: Mutex::new(ClientBrokerMutationConfigState {
+                    generation: 1,
+                    auto_create_topic_enable: true,
+                    auto_create_subscription_group: true,
+                    broker_permission: 6,
+                    default_topic_queue_nums: 8,
+                    message_index_enable: true,
+                    trace_topic_enable: false,
+                }),
+                broker_reads: AtomicUsize::new(0),
+                broker_writes: AtomicUsize::new(0),
+                broker_conflict: AtomicBool::new(false),
+                broker_fail_postread: AtomicBool::new(false),
                 request_mode: Mutex::new(None),
                 request_mode_reads: AtomicUsize::new(0),
                 request_mode_writes: AtomicUsize::new(0),
+                request_mode_fail_postread: AtomicBool::new(false),
+                request_mode_timeouts: Mutex::new(Vec::new()),
                 request_mode_persistence: Mutex::new(ClientMutationPersistenceState::Persisted),
                 request_mode_dirty: AtomicBool::new(false),
                 topic_state: Mutex::new(rocketmq_client_rust::MutationTopicConfigState {
@@ -1447,6 +1738,36 @@ mod tests {
                 .expect("endpoint calls")
                 .push((operation, broker_addr.to_string()));
         }
+
+        fn enable_request_mode_target(&self) {
+            *self.topic_state.lock().expect("topic state") = rocketmq_client_rust::MutationTopicConfigState {
+                state: ClientExpectedState::Present { version: 1 },
+                config: Some(map_topic_replacement_to_client(&TopicReplacement {
+                    read_queue_nums: 1,
+                    write_queue_nums: 1,
+                    perm: 6,
+                    order: false,
+                    message_type: TopicMessageType::Normal,
+                })),
+            };
+            *self.group_state.lock().expect("group state") =
+                rocketmq_client_rust::MutationSubscriptionGroupConfigState {
+                    state: ClientExpectedState::Present { version: 1 },
+                    config: Some(map_group_replacement_to_client(&SubscriptionGroupReplacement {
+                        consume_enable: true,
+                        consume_from_min_enable: false,
+                        consume_broadcast_enable: false,
+                        consume_message_orderly: false,
+                        retry_queue_nums: 1,
+                        retry_max_times: 16,
+                        broker_id: 0,
+                        which_broker_when_consume_slowly: 1,
+                        notify_consumer_ids_changed_enable: true,
+                        group_sys_flag: 0,
+                        consume_timeout_minute: 15,
+                    })),
+                };
+        }
     }
 
     fn unsupported<T>() -> rocketmq_error::RocketMQResult<T> {
@@ -1478,11 +1799,44 @@ mod tests {
 
         async fn patch_broker_config_if_generation(
             &self,
-            _broker_addr: CheetahString,
-            _expected_generation: u64,
-            _properties: HashMap<CheetahString, CheetahString>,
+            broker_addr: CheetahString,
+            expected_generation: u64,
+            properties: HashMap<CheetahString, CheetahString>,
         ) -> rocketmq_error::RocketMQResult<ClientBrokerConfigPatchOutcome> {
-            unsupported()
+            self.record_endpoint("broker_write", &broker_addr);
+            self.broker_writes.fetch_add(1, Ordering::SeqCst);
+            let mut state = self.broker_state.lock().expect("broker state");
+            if self.broker_conflict.load(Ordering::SeqCst) || state.generation != expected_generation {
+                return Ok(ClientBrokerConfigPatchOutcome::GenerationConflict {
+                    expected_generation,
+                    actual_generation: state.generation,
+                });
+            }
+            for (key, value) in properties {
+                match key.as_str() {
+                    "autoCreateTopicEnable" => state.auto_create_topic_enable = value == "true",
+                    "autoCreateSubscriptionGroup" => state.auto_create_subscription_group = value == "true",
+                    "brokerPermission" => {
+                        state.broker_permission = value
+                            .parse()
+                            .map_err(|_| RocketMQError::illegal_argument("invalid test broker permission"))?;
+                    }
+                    "defaultTopicQueueNums" => {
+                        state.default_topic_queue_nums = value
+                            .parse()
+                            .map_err(|_| RocketMQError::illegal_argument("invalid test queue count"))?;
+                    }
+                    "messageIndexEnable" => state.message_index_enable = value == "true",
+                    "traceTopicEnable" => state.trace_topic_enable = value == "true",
+                    _ => return unsupported(),
+                }
+            }
+            let previous_generation = state.generation;
+            state.generation += 1;
+            Ok(ClientBrokerConfigPatchOutcome::Applied {
+                previous_generation,
+                generation: state.generation,
+            })
         }
 
         async fn patch_topic_config_if_version(
@@ -1722,6 +2076,12 @@ mod tests {
             queue_id: i32,
         ) -> rocketmq_error::RocketMQResult<i64> {
             self.verify_calls.fetch_add(1, Ordering::SeqCst);
+            if self.offset_fail_postread.load(Ordering::SeqCst) && self.reset_calls.load(Ordering::SeqCst) > 0 {
+                return Err(RocketMQError::network_connection_failed(
+                    "test-broker",
+                    "test offset postread failure",
+                ));
+            }
             self.offsets
                 .lock()
                 .expect("offsets")
@@ -1863,15 +2223,11 @@ mod tests {
             broker_addr: CheetahString,
         ) -> rocketmq_error::RocketMQResult<ClientBrokerMutationConfigState> {
             self.record_endpoint("broker", &broker_addr);
-            Ok(ClientBrokerMutationConfigState {
-                generation: 1,
-                auto_create_topic_enable: true,
-                auto_create_subscription_group: true,
-                broker_permission: 6,
-                default_topic_queue_nums: 8,
-                message_index_enable: true,
-                trace_topic_enable: false,
-            })
+            self.broker_reads.fetch_add(1, Ordering::SeqCst);
+            if self.broker_fail_postread.load(Ordering::SeqCst) && self.broker_writes.load(Ordering::SeqCst) > 0 {
+                return Err(RocketMQError::illegal_argument("test postread failure"));
+            }
+            Ok(*self.broker_state.lock().expect("broker state"))
         }
 
         async fn mutation_message_request_mode(
@@ -1882,6 +2238,14 @@ mod tests {
         ) -> rocketmq_error::RocketMQResult<Option<ClientMessageRequestMode>> {
             self.record_endpoint("request_mode", &broker_addr);
             self.request_mode_reads.fetch_add(1, Ordering::SeqCst);
+            if self.request_mode_fail_postread.load(Ordering::SeqCst)
+                && self.request_mode_writes.load(Ordering::SeqCst) > 0
+            {
+                return Err(RocketMQError::network_connection_failed(
+                    "test-broker",
+                    "test request-mode postread failure",
+                ));
+            }
             Ok(*self.request_mode.lock().expect("request mode"))
         }
 
@@ -1932,6 +2296,23 @@ mod tests {
                 current: *current,
                 persistence,
             })
+        }
+
+        async fn replace_message_request_mode_if_current_with_timeout(
+            &self,
+            broker_addr: CheetahString,
+            topic: CheetahString,
+            consumer_group: CheetahString,
+            expected: ClientExpectedMessageRequestMode,
+            replacement: ClientMessageRequestMode,
+            timeout_millis: u64,
+        ) -> rocketmq_error::RocketMQResult<rocketmq_client_rust::MutationMessageRequestModeOutcome> {
+            self.request_mode_timeouts
+                .lock()
+                .expect("request mode timeouts")
+                .push(timeout_millis);
+            self.replace_message_request_mode_if_current(broker_addr, topic, consumer_group, expected, replacement)
+                .await
         }
     }
 
@@ -2058,6 +2439,7 @@ mod tests {
     #[tokio::test]
     async fn production_preflights_use_only_selected_cluster_master_endpoints() {
         let fake = CountingMutationAdmin::new(1);
+        fake.enable_request_mode_target();
         let seal = Arc::new(MutationPlanSeal);
         preflight_topic_with_admin(
             &fake,
@@ -2122,7 +2504,7 @@ mod tests {
         .expect("request-mode preflight");
 
         let calls = fake.endpoint_calls.lock().expect("endpoint calls");
-        assert_eq!(calls.len(), 5);
+        assert_eq!(calls.len(), 7);
         assert_eq!(
             calls.iter().map(|(operation, _)| *operation).collect::<HashSet<_>>(),
             HashSet::from(["topic", "group", "offset", "broker", "request_mode"])
@@ -2374,6 +2756,114 @@ mod tests {
         assert!(broker_patch_properties(BrokerMutationConfigPatch::default()).is_err());
     }
 
+    #[tokio::test]
+    async fn targeted_broker_patch_seals_one_validated_master_and_verifies_full_state() {
+        let fake = CountingMutationAdmin::with_queue_counts(&[1, 1]);
+        let seal = Arc::new(MutationPlanSeal);
+        let plan = preflight_broker_config_target_with_admin(&fake, Arc::clone(&seal), "cluster-a", "broker-1")
+            .await
+            .expect("targeted broker preflight");
+        assert_eq!(plan.targets()[0].broker_name, "broker-1");
+        assert_eq!(fake.broker_reads.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            fake.endpoint_calls.lock().expect("endpoint calls").as_slice(),
+            [("broker", "10.0.0.2:10911".to_owned())]
+        );
+
+        let patch = BrokerMutationConfigPatch {
+            auto_create_topic_enable: Some(false),
+            auto_create_subscription_group: Some(false),
+            broker_permission: Some(4),
+            default_topic_queue_nums: Some(16),
+            message_index_enable: Some(false),
+            trace_topic_enable: Some(true),
+        };
+        let outcome = execute_broker_config_patch_verified_with_admin(&fake, &seal, &plan, patch)
+            .await
+            .expect("verified broker patch");
+        assert_eq!(outcome.targets.len(), 1);
+        let target = &outcome.targets[0];
+        assert!(target.applied);
+        assert!(target.changed);
+        assert_eq!(target.verification, MutationVerificationState::Verified);
+        assert_eq!(target.after.expect("postread").generation, 2);
+        assert_eq!(target.after.expect("postread").broker_permission, 4);
+        assert_eq!(fake.broker_writes.load(Ordering::SeqCst), 1);
+        assert_eq!(fake.broker_reads.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            fake.endpoint_calls.lock().expect("endpoint calls").as_slice(),
+            [
+                ("broker", "10.0.0.2:10911".to_owned()),
+                ("broker_write", "10.0.0.2:10911".to_owned()),
+                ("broker", "10.0.0.2:10911".to_owned()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn targeted_broker_patch_never_retries_conflict_and_retains_applied_postread_failure() {
+        let conflict = CountingMutationAdmin::new(1);
+        let seal = Arc::new(MutationPlanSeal);
+        let plan = preflight_broker_config_target_with_admin(&conflict, Arc::clone(&seal), "cluster-a", "broker-0")
+            .await
+            .expect("broker preflight");
+        conflict.broker_conflict.store(true, Ordering::SeqCst);
+        let patch = BrokerMutationConfigPatch {
+            trace_topic_enable: Some(true),
+            ..BrokerMutationConfigPatch::default()
+        };
+        let outcome = execute_broker_config_patch_verified_with_admin(&conflict, &seal, &plan, patch)
+            .await
+            .expect("conflict outcome");
+        assert_eq!(conflict.broker_writes.load(Ordering::SeqCst), 1);
+        assert_eq!(conflict.broker_reads.load(Ordering::SeqCst), 1);
+        assert_eq!(outcome.targets[0].failure, Some(MutationFailureCode::Conflict));
+        assert!(!outcome.targets[0].applied);
+
+        let postread = CountingMutationAdmin::new(1);
+        let seal = Arc::new(MutationPlanSeal);
+        let plan = preflight_broker_config_target_with_admin(&postread, Arc::clone(&seal), "cluster-a", "broker-0")
+            .await
+            .expect("broker preflight");
+        postread.broker_fail_postread.store(true, Ordering::SeqCst);
+        let outcome = execute_broker_config_patch_verified_with_admin(&postread, &seal, &plan, patch)
+            .await
+            .expect("postread outcome");
+        assert_eq!(postread.broker_writes.load(Ordering::SeqCst), 1);
+        assert_eq!(postread.broker_reads.load(Ordering::SeqCst), 2);
+        assert!(outcome.targets[0].applied);
+        assert_eq!(outcome.targets[0].after, None);
+        assert_eq!(outcome.targets[0].verification, MutationVerificationState::Failed);
+        assert_eq!(
+            outcome.targets[0].failure,
+            Some(MutationFailureCode::VerificationFailed)
+        );
+    }
+
+    #[tokio::test]
+    async fn targeted_broker_preflight_validates_full_topology_before_state_read() {
+        let mut corrupt = CountingMutationAdmin::with_queue_counts(&[1, 1]);
+        corrupt
+            .cluster_info
+            .broker_addr_table
+            .as_mut()
+            .expect("broker table")
+            .insert(
+                CheetahString::from("broker-1"),
+                broker("cluster-a", "broker-1", [(MASTER_ID, "10.0.0.1:10911")]),
+            );
+        assert!(preflight_broker_config_target_with_admin(
+            &corrupt,
+            Arc::new(MutationPlanSeal),
+            "cluster-a",
+            "broker-0",
+        )
+        .await
+        .is_err());
+        assert_eq!(corrupt.broker_reads.load(Ordering::SeqCst), 0);
+        assert_eq!(corrupt.broker_writes.load(Ordering::SeqCst), 0);
+    }
+
     #[test]
     fn partial_failures_expose_only_logical_identity() {
         let error = RocketMQError::illegal_argument("backend at 10.0.0.9:10911 with accessKey=secret");
@@ -2443,6 +2933,27 @@ mod tests {
             .await
             .expect("force execute");
         assert!(outcome.targets[0].changed);
+        assert_eq!(fake.reset_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fake.verify_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn production_offset_postread_error_preserves_applied_truth_as_verification_failure() {
+        let fake = CountingMutationAdmin::new(1);
+        fake.offset_fail_postread.store(true, Ordering::SeqCst);
+        let seal = Arc::new(MutationPlanSeal);
+        let plan = preview_offset_reset_with_admin(&fake, Arc::clone(&seal), &offset_request(true))
+            .await
+            .expect("offset preflight");
+        let outcome = execute_offset_reset_checked(&fake, &seal, &plan)
+            .await
+            .expect("offset execute");
+        let target = &outcome.targets[0];
+        assert!(target.applied);
+        assert!(target.changed);
+        assert_eq!(target.observed_offset, None);
+        assert_eq!(target.failure, Some(MutationFailureCode::VerificationFailed));
+        assert!(target.retryable);
         assert_eq!(fake.reset_calls.load(Ordering::SeqCst), 1);
         assert_eq!(fake.verify_calls.load(Ordering::SeqCst), 1);
     }
@@ -2541,6 +3052,7 @@ mod tests {
     #[tokio::test]
     async fn production_request_mode_workflow_checks_current_cas_and_verifies_once() {
         let fake = CountingMutationAdmin::new(1);
+        fake.enable_request_mode_target();
         let seal = Arc::new(MutationPlanSeal);
         let request = RequestModePreflightRequest {
             cluster: "cluster-a".to_owned(),
@@ -2566,8 +3078,175 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn production_request_mode_postread_error_never_uses_cas_current_as_after() {
+        let fake = CountingMutationAdmin::new(1);
+        fake.enable_request_mode_target();
+        fake.request_mode_fail_postread.store(true, Ordering::SeqCst);
+        let seal = Arc::new(MutationPlanSeal);
+        let request = RequestModePreflightRequest {
+            cluster: "cluster-a".to_owned(),
+            topic: "orders".to_owned(),
+            consumer_group: "orders-consumer".to_owned(),
+            replacement: RequestModeValue {
+                mode: RequestMode::Pop,
+                pop_share_queue_num: 4,
+            },
+        };
+        let plan = preflight_request_mode_with_admin(&fake, Arc::clone(&seal), &request)
+            .await
+            .expect("request-mode preflight");
+        let outcome = execute_request_mode_checked_with_timeout(&fake, &seal, &plan, 12_345)
+            .await
+            .expect("request-mode execute");
+        let target = &outcome.targets[0];
+        assert!(target.applied);
+        assert!(target.changed);
+        assert_eq!(target.current, None);
+        assert_eq!(target.persistence, MutationPersistenceState::Persisted);
+        assert_eq!(target.verification, MutationVerificationState::Failed);
+        assert_eq!(target.failure, Some(MutationFailureCode::VerificationFailed));
+        assert!(target.retryable);
+        assert_eq!(fake.request_mode_writes.load(Ordering::SeqCst), 1);
+        assert_eq!(fake.request_mode_reads.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn production_request_mode_preflight_requires_topic_and_group_before_mode_query() {
+        let fake = CountingMutationAdmin::new(1);
+        let request = RequestModePreflightRequest {
+            cluster: "cluster-a".to_owned(),
+            topic: "orders".to_owned(),
+            consumer_group: "orders-consumer".to_owned(),
+            replacement: RequestModeValue {
+                mode: RequestMode::Pull,
+                pop_share_queue_num: 0,
+            },
+        };
+        let plan = preflight_request_mode_with_admin(&fake, Arc::new(MutationPlanSeal), &request)
+            .await
+            .expect("missing topic is a target failure");
+        assert!(plan.targets().is_empty());
+        assert_eq!(plan.failures()[0].code, MutationFailureCode::InvalidData);
+        assert_eq!(fake.topic_reads.load(Ordering::SeqCst), 1);
+        assert_eq!(fake.group_reads.load(Ordering::SeqCst), 0);
+        assert_eq!(fake.request_mode_reads.load(Ordering::SeqCst), 0);
+
+        *fake.topic_state.lock().expect("topic state") = rocketmq_client_rust::MutationTopicConfigState {
+            state: ClientExpectedState::Present { version: 1 },
+            config: Some(map_topic_replacement_to_client(&TopicReplacement {
+                read_queue_nums: 1,
+                write_queue_nums: 1,
+                perm: 6,
+                order: false,
+                message_type: TopicMessageType::Normal,
+            })),
+        };
+        let plan = preflight_request_mode_with_admin(&fake, Arc::new(MutationPlanSeal), &request)
+            .await
+            .expect("missing group is a target failure");
+        assert!(plan.targets().is_empty());
+        assert_eq!(plan.failures()[0].code, MutationFailureCode::InvalidData);
+        assert_eq!(fake.group_reads.load(Ordering::SeqCst), 1);
+        assert_eq!(fake.request_mode_reads.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn production_request_mode_timeout_is_forwarded_exactly() {
+        let fake = CountingMutationAdmin::new(1);
+        fake.enable_request_mode_target();
+        let seal = Arc::new(MutationPlanSeal);
+        let request = RequestModePreflightRequest {
+            cluster: "cluster-a".to_owned(),
+            topic: "orders".to_owned(),
+            consumer_group: "orders-consumer".to_owned(),
+            replacement: RequestModeValue {
+                mode: RequestMode::Pop,
+                pop_share_queue_num: 3,
+            },
+        };
+        let plan = preflight_request_mode_with_admin(&fake, Arc::clone(&seal), &request)
+            .await
+            .expect("request-mode preflight");
+        let outcome = execute_request_mode_checked_with_timeout(&fake, &seal, &plan, 12_345)
+            .await
+            .expect("timeout-aware request-mode execute");
+        assert!(outcome.targets[0].applied);
+        assert_eq!(
+            fake.request_mode_timeouts
+                .lock()
+                .expect("request mode timeouts")
+                .as_slice(),
+            [12_345]
+        );
+    }
+
+    #[tokio::test]
+    async fn mutation_admin_session_uses_the_real_facade_timeout_dispatch() {
+        let runtime_context = RuntimeContext::from_current("mutation-session-facade-dispatch-test");
+        let client_runtime =
+            create_mutation_client_runtime(runtime_context.service_context("client")).expect("client runtime");
+        let facade = rocketmq_client_rust::DefaultMQAdminExt::new(Arc::clone(&client_runtime));
+        let inner = crate::client_adapter::lifecycle::AdminSession::from_started(
+            facade,
+            Arc::new(crate::core::clock::SystemClock),
+        );
+        let mut session = MutationAdminSession {
+            inner,
+            plan_seal: Arc::new(MutationPlanSeal),
+        };
+        let plan = RequestModeMutationPlan {
+            seal: Arc::clone(&session.plan_seal),
+            cluster: "cluster-a".to_owned(),
+            topic: "orders".to_owned(),
+            consumer_group: "orders-consumer".to_owned(),
+            replacement: RequestModeValue {
+                mode: RequestMode::Pop,
+                pop_share_queue_num: 4,
+            },
+            targets: vec![("broker-a".to_owned(), "127.0.0.1:10911".to_owned(), None)],
+            failures: Vec::new(),
+        };
+        let outcome = SupervisedMutationAdmin::execute_request_mode_with_timeout(&mut session, &plan, 12_345)
+            .await
+            .expect("the real mutation session maps facade failures into a typed target outcome");
+        assert_eq!(outcome.targets.len(), 1);
+        assert!(!outcome.targets[0].applied);
+        assert_eq!(outcome.targets[0].failure, Some(MutationFailureCode::Unavailable));
+
+        let error = MQAdminMutationExt::replace_message_request_mode_if_current_with_timeout(
+            &session.inner.inner,
+            "127.0.0.1:10911".into(),
+            "orders".into(),
+            "orders-consumer".into(),
+            ClientExpectedMessageRequestMode::Absent,
+            ClientMessageRequestMode {
+                mode: rocketmq_model::common::message::message_enum::MessageRequestMode::Pop,
+                pop_share_queue_num: 4,
+            },
+            12_345,
+        )
+        .await
+        .expect_err("an unstarted real facade must reach its concrete inner implementation");
+        assert!(matches!(error, RocketMQError::ClientNotStarted));
+
+        session.shutdown().await;
+        drop(session);
+        client_runtime
+            .shutdown()
+            .await
+            .assert_no_task_leak()
+            .expect("client runtime tasks drained");
+        runtime_context
+            .shutdown_tasks(Duration::from_secs(5))
+            .await
+            .assert_no_task_leak()
+            .expect("runtime tasks drained");
+    }
+
+    #[tokio::test]
     async fn production_request_mode_persistence_failure_retains_applied_truth_and_rereads_once() {
         let fake = CountingMutationAdmin::new(1);
+        fake.enable_request_mode_target();
         *fake.request_mode_persistence.lock().expect("persistence") = ClientMutationPersistenceState::Failed;
         let seal = Arc::new(MutationPlanSeal);
         let request = RequestModePreflightRequest {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/supervised_mutation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/supervised_mutation.rs
@@ -456,6 +456,25 @@ pub struct BrokerMutationConfigPlan {
     pub(crate) failures: Vec<MutationTargetFailure>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BrokerMutationConfigTargetOutcome {
+    pub broker_name: String,
+    pub before: BrokerMutationConfigState,
+    pub after: Option<BrokerMutationConfigState>,
+    pub applied: bool,
+    pub changed: bool,
+    pub persistence: MutationPersistenceState,
+    pub verification: MutationVerificationState,
+    pub failure: Option<MutationFailureCode>,
+    pub retryable: bool,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BrokerMutationConfigOutcome {
+    pub targets: Vec<BrokerMutationConfigTargetOutcome>,
+    pub failures: Vec<MutationTargetFailure>,
+}
+
 impl BrokerMutationConfigPlan {
     pub fn targets(&self) -> Vec<BrokerMutationConfigTarget> {
         self.targets
@@ -650,11 +669,43 @@ pub trait SupervisedMutationAdmin: Send {
 
     fn preflight_broker_config<'a>(&'a mut self, cluster: &'a str) -> AdminFuture<'a, BrokerMutationConfigPlan>;
 
+    /// Preflights one logical Broker after validating the complete selected
+    /// cluster topology. The default fails closed for source compatibility.
+    fn preflight_broker_config_target<'a>(
+        &'a mut self,
+        cluster: &'a str,
+        broker_name: &'a str,
+    ) -> AdminFuture<'a, BrokerMutationConfigPlan> {
+        let _ = (cluster, broker_name);
+        Box::pin(async move {
+            Err(AdminError::backend(
+                "preflight_broker_config_target",
+                "targeted supervised Broker preflight is unavailable",
+            ))
+        })
+    }
+
     fn execute_broker_config_patch<'a>(
         &'a mut self,
         plan: &'a BrokerMutationConfigPlan,
         patch: BrokerMutationConfigPatch,
     ) -> AdminFuture<'a, MetadataMutationOutcome>;
+
+    /// Executes and verifies one sealed Broker patch without re-resolving or
+    /// expanding the target. The default fails closed for source compatibility.
+    fn execute_broker_config_patch_verified<'a>(
+        &'a mut self,
+        plan: &'a BrokerMutationConfigPlan,
+        patch: BrokerMutationConfigPatch,
+    ) -> AdminFuture<'a, BrokerMutationConfigOutcome> {
+        let _ = (plan, patch);
+        Box::pin(async move {
+            Err(AdminError::backend(
+                "execute_broker_config_patch_verified",
+                "verified supervised Broker patch is unavailable",
+            ))
+        })
+    }
 
     fn preflight_request_mode<'a>(
         &'a mut self,
@@ -665,6 +716,22 @@ pub trait SupervisedMutationAdmin: Send {
         &'a mut self,
         plan: &'a RequestModeMutationPlan,
     ) -> AdminFuture<'a, RequestModeMutationOutcome>;
+
+    /// Executes the sealed request-mode plan with the caller's bounded wire
+    /// timeout. The default fails closed rather than ignoring the value.
+    fn execute_request_mode_with_timeout<'a>(
+        &'a mut self,
+        plan: &'a RequestModeMutationPlan,
+        timeout_millis: u64,
+    ) -> AdminFuture<'a, RequestModeMutationOutcome> {
+        let _ = (plan, timeout_millis);
+        Box::pin(async move {
+            Err(AdminError::backend(
+                "execute_request_mode_with_timeout",
+                "timeout-aware supervised request-mode execution is unavailable",
+            ))
+        })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #9980
- Fixes #9980

### Brief Description

- Registers exactly `reset_consumer_offset`, `patch_broker_config`, and `set_consumer_request_mode` behind the `write-tools` feature while keeping the default and runtime-disabled catalogs empty.
- Adds typed MCP contracts and the smallest additive Admin and Client seams for per-queue offset evidence, allowlisted single-Broker patches with generation conflicts, and bounded conditional request-mode updates.
- Reuses validation-before-RPC, request-key singleflight, durable audit, cancellation, owned shutdown, dry-run, partial-truth, and output-redaction guarantees.
- Updates snapshots, configuration examples, reference documentation, the operations runbook, dry-run examples, and boundary checks.

### How Did You Test This Change?

- [x] Control default and `write-tools` locked checks and tests passed.
- [x] Control all-feature Clippy, documentation, package formatting, and boundary validation passed; the boundary validator also passed all four Query no-update profiles.
- [x] Admin mutation-client focused tests passed 25/25 and the full mutation-client library passed 86/86; production-library Clippy and package formatting passed.
- [x] Client mutation-only library check, exact-timeout loopback tests, legacy facade compatibility test, default library tests (1094/1094), mutation-library Clippy, and package formatting passed.
- [x] Query default and all-feature tests, checks, Streamable HTTP Clippy, documentation, package formatting, and read-only boundary validation passed.
- [x] Routing validation, GPUI validation (including 166 tests), Tauri backend Clippy, Example Clippy, and all corresponding package formatting checks passed.
- [x] `git diff --check` passed with no `.snap.new` files or Query, Protocol, Broker, or CLI drift.
- [ ] Root all-feature Clippy retains the pre-existing `rocketmq-store/src/factory.rs:95` `items_after_test_module` baseline; focused Broker all-feature Clippy passes.
- [ ] Admin all-target mutation Clippy retains three pre-existing test-helper `dead_code` warnings; production-library Clippy passes.
- [ ] SRE all-feature tests retain three pre-existing capability-registry failures reporting `unknown=["mcp"]`; SRE check, Clippy, documentation, formatting, source-layout, and execution-boundary validation pass.
- [ ] Web backend Clippy and build retain the pre-existing recursion-depth overflow at `src/main.rs:51`; package formatting passes.
- [ ] Workspace-wide standalone formatting is affected by Windows OS error 206; exact package formatting checks pass.
- [ ] Live-cluster end-to-end validation is intentionally outside this PR and deferred to Plan07.
