### PR TITLE
[ISSUE #9985]🐛Resend full Heartbeat V2 subscriptions after broker subChange

### DIFF
--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -2055,33 +2055,56 @@ impl MQClientInstance {
             heartbeat_data_with_sub.clone()
         };
 
-        // Send heartbeat and get result with V2 support info
-        let (result, support_v2) = self
-            .send_heartbeat_to_broker_inner(id, broker_name, addr, &heartbeat_data)
-            .await;
+        let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() else {
+            warn!(
+                "send heart beat to broker[{} {} {}] skipped because mq_client_api_impl is None",
+                broker_name, id, addr
+            );
+            return false;
+        };
 
-        if result {
-            if let Some(support_v2) = support_v2 {
-                if support_v2 {
-                    // Update V2 support set
+        match mq_client_api_impl
+            .send_heartbeat_v2(addr, &heartbeat_data, self.client_config.mq_client_api_timeout)
+            .await
+        {
+            Ok(result) => {
+                self.broker_version_table
+                    .entry(broker_name.clone())
+                    .or_default()
+                    .insert(addr.clone(), result.version());
+                let times = self
+                    .send_heartbeat_times_total
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if times % 20 == 0 {
+                    info!("send heart beat to broker[{} {} {}] success", broker_name, id, addr);
+                }
+                if !result.is_support_v2() {
+                    self.broker_support_v2_heartbeat_set.remove(addr);
+                    self.broker_heartbeat_fingerprint_table.remove(addr);
+                    warn!("Broker {} does not support HeartbeatV2, downgrading to V1", addr);
+                } else {
                     self.broker_support_v2_heartbeat_set.insert(addr.clone(), ());
-
-                    // Update fingerprint cache only when sending full data
-                    if !should_send_minimal {
+                    if result.is_sub_change() {
+                        self.broker_heartbeat_fingerprint_table.remove(addr);
+                    } else if !should_send_minimal {
                         self.broker_heartbeat_fingerprint_table
                             .insert(addr.clone(), current_fingerprint);
                     }
-                } else {
-                    // Broker doesn't support V2, remove from set and clear fingerprint
-                    self.broker_support_v2_heartbeat_set.remove(addr);
-                    self.broker_heartbeat_fingerprint_table.remove(addr);
-
-                    warn!("Broker {} does not support HeartbeatV2, downgrading to V1", addr);
                 }
+                true
+            }
+            Err(_) => {
+                if self.is_broker_in_name_server(addr) {
+                    warn!("send heart beat to broker[{} {} {}] failed", broker_name, id, addr);
+                } else {
+                    warn!(
+                        "send heart beat to broker[{} {} {}] exception, because the broker not up, forget it",
+                        broker_name, id, addr
+                    );
+                }
+                false
             }
         }
-
-        result
     }
 
     async fn send_heartbeat_to_broker_inner(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9985 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker heartbeat handling for environments that support the newer heartbeat protocol.
  * Broker version and protocol-support status are now tracked more accurately.
  * Enhanced heartbeat failure reporting, including clearer warnings for brokers reached through name-server routing.
  * Improved handling when the client API is unavailable, preventing heartbeat attempts from proceeding incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->