### PR TITLE
[ISSUE #9994]🐛Add the conditional consumer offset header to codec contract registries

### DIFF
--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -641,6 +641,7 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<rocketmq_protocol::protocol::header::namesrv::config_header::GetNamesrvConfigRequestHeader>(),
         register::<rocketmq_protocol::protocol::header::update_broker_config_request_header::UpdateBrokerConfigRequestHeader>(),
         register::<rocketmq_protocol::protocol::header::update_broker_config_response_header::UpdateBrokerConfigResponseHeader>(),
+        register::<rocketmq_protocol::protocol::header::update_consumer_offset_conditional_header::UpdateConsumerOffsetConditionalHeader>(),
         register::<rocketmq_protocol::protocol::header::update_global_white_addrs_config_request_header::UpdateGlobalWhiteAddrsConfigRequestHeader>(),
         register_value(
             &rocketmq_protocol::protocol::header::update_subscription_group_config_cas_request_header::UpdateSubscriptionGroupConfigCasRequestHeader {

--- a/scripts/request-header-codec/extension-allowlist.json
+++ b/scripts/request-header-codec/extension-allowlist.json
@@ -54,6 +54,7 @@
     "rocketmq_protocol::protocol::header::maintenance_request_header::MaintenanceRequestHeader",
     "rocketmq_protocol::protocol::header::update_broker_config_request_header::UpdateBrokerConfigRequestHeader",
     "rocketmq_protocol::protocol::header::update_broker_config_response_header::UpdateBrokerConfigResponseHeader",
+    "rocketmq_protocol::protocol::header::update_consumer_offset_conditional_header::UpdateConsumerOffsetConditionalHeader",
     "rocketmq_protocol::protocol::header::update_global_white_addrs_config_request_header::UpdateGlobalWhiteAddrsConfigRequestHeader",
     "rocketmq_protocol::protocol::header::update_subscription_group_config_cas_request_header::UpdateSubscriptionGroupConfigCasRequestHeader",
     "rocketmq_protocol::protocol::header::update_subscription_group_config_cas_response_header::UpdateSubscriptionGroupConfigCasResponseHeader",

--- a/scripts/request-header-codec/header-class-map.json
+++ b/scripts/request-header-codec/header-class-map.json
@@ -4,11 +4,11 @@
   "javaCommit": "2daf0e2ca91a1592d18235d43e5d709d1c35d15f",
   "generatedBy": "scripts/request-header-codec/generate_header_class_map.py",
   "historicalDeriveCount": 150,
-  "currentDeriveCount": 151,
+  "currentDeriveCount": 152,
   "manualHeaderCount": 1,
-  "entryCount": 152,
+  "entryCount": 153,
   "mappedCount": 143,
-  "rustOnlyExtensionCount": 9,
+  "rustOnlyExtensionCount": 10,
   "entries": [
     {
       "rustTypeId": "rocketmq_protocol::protocol::header::ack_message_request_header::AckMessageRequestHeader",
@@ -2146,6 +2146,22 @@
       "javaFast": false,
       "status": "rust-only-extension",
       "reason": "Rust compare-and-set broker configuration response extension"
+    },
+    {
+      "rustTypeId": "rocketmq_protocol::protocol::header::update_consumer_offset_conditional_header::UpdateConsumerOffsetConditionalHeader",
+      "rustType": "UpdateConsumerOffsetConditionalHeader",
+      "rustAliases": [],
+      "rustSource": "rocketmq-protocol/src/protocol/header/update_consumer_offset_conditional_header.rs",
+      "javaClass": null,
+      "javaSource": null,
+      "direction": "request",
+      "requestCodes": [
+        "UPDATE_CONSUMER_OFFSET_CONDITIONAL"
+      ],
+      "exactName": false,
+      "javaFast": false,
+      "status": "rust-only-extension",
+      "reason": "Rust conditional consumer offset update extension"
     },
     {
       "rustTypeId": "rocketmq_protocol::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader",

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -5,13 +5,13 @@
   "javaCommit": "2daf0e2ca91a1592d18235d43e5d709d1c35d15f",
   "generatedBy": "scripts/request-header-codec/migrate.py inventory",
   "summary": {
-    "entryCount": 152,
+    "entryCount": 153,
     "mappedCount": 143,
-    "rustOnlyExtensionCount": 9,
+    "rustOnlyExtensionCount": 10,
     "v2Count": 0,
-    "v3Count": 152,
+    "v3Count": 153,
     "pendingCount": 0,
-    "migratedCount": 152
+    "migratedCount": 153
   },
   "baseline": {
     "v2TypeIds": [
@@ -312,6 +312,7 @@
       "rocketmq_protocol::protocol::header::update_acl_request_header::UpdateAclRequestHeader",
       "rocketmq_protocol::protocol::header::update_broker_config_request_header::UpdateBrokerConfigRequestHeader",
       "rocketmq_protocol::protocol::header::update_broker_config_response_header::UpdateBrokerConfigResponseHeader",
+      "rocketmq_protocol::protocol::header::update_consumer_offset_conditional_header::UpdateConsumerOffsetConditionalHeader",
       "rocketmq_protocol::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetResponseHeader",
       "rocketmq_protocol::protocol::header::update_global_white_addrs_config_request_header::UpdateGlobalWhiteAddrsConfigRequestHeader",
@@ -3495,6 +3496,32 @@
         "classification": "rust-extension-safe",
         "owner": "rocketmq-rust protocol maintainers",
         "reason": "Rust compare-and-set broker configuration response extension",
+        "reviewBy": "2027-08-01"
+      }
+    },
+    {
+      "rustTypeId": "rocketmq_protocol::protocol::header::update_consumer_offset_conditional_header::UpdateConsumerOffsetConditionalHeader",
+      "rustType": "UpdateConsumerOffsetConditionalHeader",
+      "rustSource": "rocketmq-protocol/src/protocol/header/update_consumer_offset_conditional_header.rs",
+      "javaClass": null,
+      "requestCodes": [
+        "UPDATE_CONSUMER_OFFSET_CONDITIONAL"
+      ],
+      "baselineCodec": "absent",
+      "v2AtBaseline": false,
+      "legacyV2Exception": null,
+      "currentCodec": "v3",
+      "flattenDepth": 0,
+      "flattenTypeIds": [],
+      "fastCodec": false,
+      "risk": "tier2",
+      "wave": "A",
+      "owner": "remoting",
+      "status": "migrated",
+      "extensionDecision": {
+        "classification": "rust-extension-safe",
+        "owner": "rocketmq-rust protocol maintainers",
+        "reason": "Rust conditional consumer offset update extension",
         "reviewBy": "2027-08-01"
       }
     },

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -56,17 +56,17 @@ class MigrationGuardTests(unittest.TestCase):
             self.manifest,
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
-        self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 152)
+        self.assertEqual(len(self.headers), 153)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 153)
         self.assertEqual(
             {
-                "entryCount": 152,
+                "entryCount": 153,
                 "mappedCount": 143,
-                "rustOnlyExtensionCount": 9,
+                "rustOnlyExtensionCount": 10,
                 "v2Count": 0,
-                "v3Count": 152,
+                "v3Count": 153,
                 "pendingCount": 0,
-                "migratedCount": 152,
+                "migratedCount": 153,
             },
             self.manifest["summary"],
         )
@@ -81,7 +81,7 @@ class MigrationGuardTests(unittest.TestCase):
         self.assertEqual(0, result)
         self.assertEqual(
             "request-header migration guard passed: "
-            "152 registered, 152 V3, 0 V2, 0 pending, 0 production legacy derive uses\n",
+            "153 registered, 153 V3, 0 V2, 0 pending, 0 production legacy derive uses\n",
             output.getvalue(),
         )
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9994 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protocol support for conditional consumer-offset update requests in the RocketMQ Rust client.

* **Compatibility**
  * Registered the request type for V3 codec validation and migration tracking, improving interoperability with supported protocol contracts.

* **Tests**
  * Updated codec and migration checks to cover the expanded request-header registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->