### PR TITLE
[ISSUE #10001]🐛Update stale mapped-write Miri test references

### DIFF
--- a/.github/workflows/architecture-nightly-evidence.yml
+++ b/.github/workflows/architecture-nightly-evidence.yml
@@ -127,7 +127,7 @@ jobs:
           cargo +nightly-2026-07-05 miri setup
           cargo +nightly-2026-07-05 miri test \
             -p rocketmq-store-local \
-            --test mapped_write_lease_miri \
+            --lib mapped_file::write_lease_miri_tests \
             2>&1 | tee target/architecture-evidence/miri/test-output.txt
 
       - name: Upload Miri evidence

--- a/scripts/tests/test_m06_store_local_contract.py
+++ b/scripts/tests/test_m06_store_local_contract.py
@@ -31,9 +31,9 @@ class StoreLocalContractTests(unittest.TestCase):
             "rocketmq-store-local/tests/storage_layout_golden.rs",
             "rocketmq-store-local/tests/consume_queue_record.rs",
             "rocketmq-store-local/tests/index_codec.rs",
-            "rocketmq-store-local/tests/mapped_write_lease.rs",
+            "rocketmq-store-local/src/mapped_file/write_lease_scenarios.rs",
             "rocketmq-store-local/tests/mapped_write_lease_loom.rs",
-            "rocketmq-store-local/tests/mapped_write_lease_miri.rs",
+            "rocketmq-store-local/src/mapped_file/write_lease_miri_tests.rs",
             "rocketmq-store-local/tests/commit_log_recovery_orchestration.rs",
         ):
             self.assertTrue((ROOT / relative).is_file(), relative)


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10001 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated automated coverage for mapped-file write lease and ownership behavior.
  - Nightly validation now runs the relevant library-level checks and continues producing evidence for these scenarios.
  - Contract checks were aligned with the current test coverage to ensure expected persistence and lease semantics remain verified.

- **Chores**
  - Improved consistency between automated test discovery and nightly validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->