### PR TITLE
[ISSUE #10008]🐛Install native dependencies for nightly property suites

### DIFF
--- a/.github/workflows/architecture-nightly-evidence.yml
+++ b/.github/workflows/architecture-nightly-evidence.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
+      - name: Install native build dependencies
+        run: >-
+          sudo apt-get update &&
+          sudo apt-get install -y
+          clang llvm libclang-dev cmake make ninja-build pkg-config protobuf-compiler
+
       - name: Use repository Rust 1.95 toolchain
         run: rustup show active-toolchain
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10008 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of nightly architecture validation by ensuring required native build tools are available during automated checks.
  * No user-facing features or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->