### PR TITLE
[ISSUE #10004]🧪Add isolated real-cluster E2E coverage for RocketMQ MCP control

### DIFF
--- a/rocketmq-ai/rocketmq-mcp-control/scripts/check_control_boundary.py
+++ b/rocketmq-ai/rocketmq-mcp-control/scripts/check_control_boundary.py
@@ -93,6 +93,24 @@ for forbidden in ("admin-read", "admin-full"):
 
 source_paths = sorted((PROJECT / "src").glob("**/*.rs"))
 source = "\n".join(path.read_text(encoding="utf-8") for path in source_paths)
+
+
+def is_test_only_source(path: pathlib.Path) -> bool:
+    relative = path.relative_to(PROJECT / "src")
+    return path.name == "tests.rs" or relative.parts[:2] == ("transport", "real_cluster_e2e")
+
+
+# Dedicated test source may own explicit E2E process orchestration. It must not
+# weaken the production transport and mutation dependency boundary below.
+production_units = []
+for path in source_paths:
+    if is_test_only_source(path):
+        continue
+    unit = path.read_text(encoding="utf-8")
+    unit = unit.split("#[cfg(test)]\nmod tests", maxsplit=1)[0]
+    production_units.append(unit)
+production_source = "\n".join(production_units)
+
 for forbidden in (
     "transport-io",
     "std::process",
@@ -103,18 +121,9 @@ for forbidden in (
     "read_client_adapter",
     "ReadOnlyQuery",
 ):
-    if forbidden in source:
+    if forbidden in production_source:
         fail(f"production source contains prohibited surface {forbidden}")
 
-# Dedicated test modules and inline `mod tests` bodies are excluded from the production lifecycle scan.
-production_units = []
-for path in source_paths:
-    if path.name == "tests.rs":
-        continue
-    unit = path.read_text(encoding="utf-8")
-    unit = unit.split("#[cfg(test)]\nmod tests", maxsplit=1)[0]
-    production_units.append(unit)
-production_source = "\n".join(production_units)
 for forbidden in (
     "tokio::spawn",
     "spawn_blocking",

--- a/rocketmq-ai/rocketmq-mcp-control/scripts/run_real_cluster_e2e.ps1
+++ b/rocketmq-ai/rocketmq-mcp-control/scripts/run_real_cluster_e2e.ps1
@@ -1,0 +1,97 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+param(
+    [Alias("h")]
+    [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($Help) {
+    @"
+Runs the ignored RocketMQ MCP Control real-cluster E2E test.
+
+The runner builds the repository's Rust NameServer and Broker binaries, starts
+them only through the test harness on dynamically reserved loopback ports, and
+runs the TLS Streamable HTTP mutation scenario serially. The harness owns and
+reaps its child processes and removes its unique temporary resource root.
+
+Usage:
+  .\scripts\run_real_cluster_e2e.ps1
+  .\scripts\run_real_cluster_e2e.ps1 -Help
+"@ | Write-Host
+    exit 0
+}
+
+$projectRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")).Path
+$repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..\..")).Path
+$repositoryManifest = Join-Path $repositoryRoot "Cargo.toml"
+$controlManifest = Join-Path $projectRoot "Cargo.toml"
+$testName = "transport::real_cluster_e2e::real_cluster_tls_mcp_mutations_restore_and_reap_every_owned_resource"
+
+Write-Host "Building the owned Rust NameServer and Broker test processes..."
+& cargo build --locked --manifest-path $repositoryManifest -p rocketmq-namesrv --bin rocketmq-namesrv-rust
+if ($LASTEXITCODE -ne 0) {
+    throw "NameServer build failed with exit code $LASTEXITCODE"
+}
+& cargo build --locked --manifest-path $repositoryManifest -p rocketmq-broker --bin rocketmq-broker-rust
+if ($LASTEXITCODE -ne 0) {
+    throw "Broker build failed with exit code $LASTEXITCODE"
+}
+
+$metadataText = & cargo metadata --locked --manifest-path $repositoryManifest --format-version 1 --no-deps
+if ($LASTEXITCODE -ne 0) {
+    throw "Cargo metadata failed with exit code $LASTEXITCODE"
+}
+$targetDirectory = ($metadataText | ConvertFrom-Json).target_directory
+$executableSuffix = if ($IsWindows) { ".exe" } else { "" }
+$debugDirectory = Join-Path $targetDirectory "debug"
+$namesrvBinary = Join-Path $debugDirectory "rocketmq-namesrv-rust$executableSuffix"
+$brokerBinary = Join-Path $debugDirectory "rocketmq-broker-rust$executableSuffix"
+foreach ($binary in @($namesrvBinary, $brokerBinary)) {
+    if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) {
+        throw "Expected built test process was not found: $binary"
+    }
+}
+
+$ownedEnvironment = @(
+    "INSTA_UPDATE",
+    "RUST_MIN_STACK",
+    "ROCKETMQ_MCP_CONTROL_REAL_CLUSTER_E2E",
+    "ROCKETMQ_MCP_CONTROL_E2E_NAMESRV_BIN",
+    "ROCKETMQ_MCP_CONTROL_E2E_BROKER_BIN"
+)
+$priorEnvironment = @{}
+foreach ($name in $ownedEnvironment) {
+    $priorEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+}
+
+try {
+    $env:INSTA_UPDATE = "no"
+    Remove-Item Env:RUST_MIN_STACK -ErrorAction SilentlyContinue
+    $env:ROCKETMQ_MCP_CONTROL_REAL_CLUSTER_E2E = "1"
+    $env:ROCKETMQ_MCP_CONTROL_E2E_NAMESRV_BIN = $namesrvBinary
+    $env:ROCKETMQ_MCP_CONTROL_E2E_BROKER_BIN = $brokerBinary
+
+    Write-Host "Running the ignored real-cluster E2E test serially..."
+    & cargo test --locked --manifest-path $controlManifest --features write-tools --lib $testName -- --ignored --exact --test-threads=1 --nocapture
+    if ($LASTEXITCODE -ne 0) {
+        throw "Real-cluster E2E test failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    foreach ($name in $ownedEnvironment) {
+        $value = $priorEnvironment[$name]
+        if ($null -eq $value) {
+            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+        }
+        else {
+            Set-Item "Env:$name" $value
+        }
+    }
+}
+
+Write-Host "Real-cluster E2E test completed; owned resources were restored and reaped."

--- a/rocketmq-ai/rocketmq-mcp-control/src/transport.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport.rs
@@ -66,6 +66,20 @@ where
     let auth = AuthState::<HttpJwksSource>::initialize(&config.oauth, metadata_url)
         .await
         .map_err(|_| ControlError::invalid_config())?;
+    serve_authenticated(config, service_context, audit, shutdown, auth).await
+}
+
+async fn serve_authenticated<F, S>(
+    config: ControlConfig,
+    service_context: ChildServiceContext,
+    audit: crate::audit::AuditTrail,
+    shutdown: F,
+    auth: AuthState<S>,
+) -> Result<(), ControlError>
+where
+    F: FutureShutdown,
+    S: JwksSource + 'static,
+{
     let tls = TlsServerRuntime::initialize_with_service_context(tls_config(&config), &service_context)
         .await
         .map_err(|_| ControlError::invalid_config())?;
@@ -2113,3 +2127,6 @@ mod tests {
     #[cfg(feature = "write-tools")]
     include!("transport/acceptance_matrix.rs");
 }
+
+#[cfg(all(test, feature = "write-tools"))]
+mod real_cluster_e2e;

--- a/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/mod.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/mod.rs
@@ -1,0 +1,113 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod process;
+mod protocol;
+mod scenario;
+
+use std::fmt;
+
+const E2E_OPT_IN_ENV: &str = "ROCKETMQ_MCP_CONTROL_REAL_CLUSTER_E2E";
+const NAMESRV_BIN_ENV: &str = "ROCKETMQ_MCP_CONTROL_E2E_NAMESRV_BIN";
+const BROKER_BIN_ENV: &str = "ROCKETMQ_MCP_CONTROL_E2E_BROKER_BIN";
+const MESSAGE_BODY: &str = "isolated-e2e-payload";
+const EXPECTED_CALLS: usize = 22;
+const EXPECTED_AUDIT_RECORDS: usize = 44;
+const _: [(); EXPECTED_AUDIT_RECORDS] = [(); EXPECTED_CALLS * 2];
+
+type E2eResult<T> = Result<T, E2eError>;
+
+#[derive(Debug)]
+struct E2eError(String);
+
+impl E2eError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for E2eError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for E2eError {}
+
+trait E2eContext<T> {
+    fn e2e(self, context: &str) -> E2eResult<T>;
+}
+
+impl<T, E> E2eContext<T> for Result<T, E>
+where
+    E: fmt::Display,
+{
+    fn e2e(self, context: &str) -> E2eResult<T> {
+        self.map_err(|error| E2eError::new(format!("{context}: {error}")))
+    }
+}
+
+fn ensure(condition: bool, message: impl Into<String>) -> E2eResult<()> {
+    if condition {
+        Ok(())
+    } else {
+        Err(E2eError::new(message))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "explicit opt-in: run scripts/run_real_cluster_e2e.ps1"]
+async fn real_cluster_tls_mcp_mutations_restore_and_reap_every_owned_resource() {
+    if std::env::var(E2E_OPT_IN_ENV).as_deref() != Ok("1") {
+        panic!("set {E2E_OPT_IN_ENV}=1 through scripts/run_real_cluster_e2e.ps1");
+    }
+
+    let mut harness = match scenario::E2eHarness::start().await {
+        Ok(harness) => harness,
+        Err(error) => panic!("real-cluster E2E setup failed: {error}"),
+    };
+    let scenario_result = harness.exercise().await;
+    let scenario_diagnostics = scenario_result
+        .as_ref()
+        .err()
+        .map(|_| harness.sanitized_process_diagnostics());
+    let cleanup_result = harness.cleanup().await;
+    match (scenario_result, cleanup_result) {
+        (Ok(()), Ok(evidence)) => {
+            assert!(evidence.cluster_root_removed, "ephemeral cluster root was not removed");
+            assert!(evidence.children_reaped, "an owned child process was not reaped");
+            assert!(evidence.broker_config_restored, "Broker configuration was not restored");
+            assert!(
+                evidence.consumer_request_mode_restored,
+                "Consumer request mode was not restored"
+            );
+            let repeated = harness
+                .cleanup()
+                .await
+                .unwrap_or_else(|error| panic!("idempotent cleanup repeat failed: {error}"));
+            assert_eq!(repeated, evidence, "cleanup repeat changed its evidence");
+        }
+        (Err(scenario), Ok(_)) => panic!(
+            "real-cluster E2E scenario failed after successful cleanup: {scenario}; {}",
+            scenario_diagnostics.as_deref().unwrap_or("diagnostics unavailable")
+        ),
+        (Ok(()), Err(cleanup)) => panic!("real-cluster E2E cleanup failed: {cleanup}"),
+        (Err(scenario), Err(cleanup)) => {
+            panic!(
+                "real-cluster E2E scenario failed: {scenario}; cleanup also failed: {cleanup}; {}",
+                scenario_diagnostics.as_deref().unwrap_or("diagnostics unavailable")
+            )
+        }
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/process.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/process.rs
@@ -1,0 +1,628 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Reverse;
+use std::fs::File;
+use std::io::Read;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use std::net::TcpListener;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Child;
+use std::process::Command;
+use std::process::Stdio;
+use std::time::Duration;
+use std::time::Instant;
+
+use super::E2eContext;
+use super::E2eError;
+use super::E2eResult;
+use super::BROKER_BIN_ENV;
+use super::MESSAGE_BODY;
+use super::NAMESRV_BIN_ENV;
+
+const LOOPBACK: Ipv4Addr = Ipv4Addr::LOCALHOST;
+const READINESS_TIMEOUT: Duration = Duration::from_secs(45);
+const STOP_TIMEOUT: Duration = Duration::from_secs(8);
+const DROP_REAP_TIMEOUT: Duration = Duration::from_secs(2);
+const DROP_REAP_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const DIAGNOSTIC_BYTES: u64 = 8 * 1024;
+const BROKER_THREAD_STACK_BYTES: usize = 16 * 1024 * 1024;
+
+pub(super) struct PortSet {
+    pub namesrv: ReservedPort,
+    pub namesrv_health: ReservedPort,
+    pub broker: ReservedPort,
+    pub broker_fast: ReservedPort,
+    pub broker_ha: ReservedPort,
+    pub broker_health: ReservedPort,
+    pub control_https: ReservedPort,
+}
+
+impl PortSet {
+    pub fn allocate() -> E2eResult<Self> {
+        let (broker, broker_fast) = reserve_broker_pair()?;
+        Ok(Self {
+            namesrv: ReservedPort::allocate()?,
+            namesrv_health: ReservedPort::allocate()?,
+            broker,
+            broker_fast,
+            broker_ha: ReservedPort::allocate()?,
+            broker_health: ReservedPort::allocate()?,
+            control_https: ReservedPort::allocate()?,
+        })
+    }
+}
+
+pub(super) struct ReservedPort {
+    listener: Option<TcpListener>,
+    port: u16,
+}
+
+impl ReservedPort {
+    fn allocate() -> E2eResult<Self> {
+        let listener = TcpListener::bind(SocketAddr::from((LOOPBACK, 0))).e2e("reserve loopback port")?;
+        let port = listener.local_addr().e2e("inspect reserved loopback port")?.port();
+        Ok(Self {
+            listener: Some(listener),
+            port,
+        })
+    }
+
+    pub const fn value(&self) -> u16 {
+        self.port
+    }
+
+    pub fn release(&mut self) {
+        self.listener.take();
+    }
+}
+
+fn reserve_broker_pair() -> E2eResult<(ReservedPort, ReservedPort)> {
+    for _ in 0..128 {
+        let main = ReservedPort::allocate()?;
+        let port = main.value();
+        if port <= 1026 {
+            continue;
+        }
+        let fast_port = port - 2;
+        if let Ok(listener) = TcpListener::bind(SocketAddr::from((LOOPBACK, fast_port))) {
+            return Ok((
+                main,
+                ReservedPort {
+                    listener: Some(listener),
+                    port: fast_port,
+                },
+            ));
+        }
+    }
+    Err(E2eError::new(
+        "could not reserve the Broker remoting and fast-remoting port pair",
+    ))
+}
+
+pub(super) struct ClusterProcesses {
+    root: PathBuf,
+    namesrv_bin: PathBuf,
+    broker_bin: PathBuf,
+    namesrv_config: PathBuf,
+    broker_config: PathBuf,
+    namesrv_health: u16,
+    broker_health: u16,
+    redactions: Vec<String>,
+    namesrv: Option<OwnedChild>,
+    broker: Option<OwnedChild>,
+}
+
+impl ClusterProcesses {
+    pub fn new(root: &Path, ports: &PortSet, namesrv_config: PathBuf, broker_config: PathBuf) -> E2eResult<Self> {
+        let namesrv_bin = required_binary(NAMESRV_BIN_ENV)?;
+        let broker_bin = required_binary(BROKER_BIN_ENV)?;
+        let mut redactions = vec![
+            "127.0.0.1".to_owned(),
+            MESSAGE_BODY.to_owned(),
+            ports.namesrv.value().to_string(),
+            ports.namesrv_health.value().to_string(),
+            ports.broker.value().to_string(),
+            ports.broker_fast.value().to_string(),
+            ports.broker_ha.value().to_string(),
+            ports.broker_health.value().to_string(),
+            ports.control_https.value().to_string(),
+        ];
+        for path in [
+            root,
+            namesrv_bin.as_path(),
+            broker_bin.as_path(),
+            namesrv_config.as_path(),
+            broker_config.as_path(),
+        ] {
+            push_path_redactions(&mut redactions, path);
+        }
+        if let Ok(current_dir) = std::env::current_dir() {
+            for path in current_dir.ancestors().take(3) {
+                push_path_redactions(&mut redactions, path);
+            }
+        }
+        redactions.sort_by_key(|value| Reverse(value.len()));
+        redactions.dedup();
+        Ok(Self {
+            root: root.to_path_buf(),
+            namesrv_bin,
+            broker_bin,
+            namesrv_config,
+            broker_config,
+            namesrv_health: ports.namesrv_health.value(),
+            broker_health: ports.broker_health.value(),
+            redactions,
+            namesrv: None,
+            broker: None,
+        })
+    }
+
+    pub async fn start_namesrv(&mut self, ports: &mut PortSet) -> E2eResult<()> {
+        ports.namesrv.release();
+        ports.namesrv_health.release();
+        let config = self.namesrv_config.as_os_str();
+        let child = OwnedChild::spawn(
+            "NameServer",
+            &self.namesrv_bin,
+            ["--configFile".as_ref(), config],
+            self.namesrv_health,
+            &self.root,
+            &self.redactions,
+        )?;
+        self.namesrv = Some(child);
+        self.wait_ready("NameServer", self.namesrv_health).await
+    }
+
+    pub async fn start_broker(&mut self, ports: &mut PortSet) -> E2eResult<()> {
+        ports.broker.release();
+        ports.broker_fast.release();
+        ports.broker_ha.release();
+        ports.broker_health.release();
+        self.spawn_broker()?;
+        self.wait_ready("Broker", self.broker_health).await
+    }
+
+    pub async fn restart_broker(&mut self) -> E2eResult<()> {
+        self.stop_broker().await?;
+        self.spawn_broker()?;
+        self.wait_ready("Broker", self.broker_health).await
+    }
+
+    pub async fn ensure_broker_running(&mut self) -> E2eResult<()> {
+        let running = match self.broker.as_mut() {
+            Some(child) => child.try_wait()?.is_none(),
+            None => false,
+        };
+        if running {
+            self.wait_ready("Broker", self.broker_health).await
+        } else {
+            self.broker.take();
+            self.spawn_broker()?;
+            self.wait_ready("Broker", self.broker_health).await
+        }
+    }
+
+    fn spawn_broker(&mut self) -> E2eResult<()> {
+        let config = self.broker_config.as_os_str();
+        let child = OwnedChild::spawn(
+            "Broker",
+            &self.broker_bin,
+            ["--configFile".as_ref(), config],
+            self.broker_health,
+            &self.root,
+            &self.redactions,
+        )?;
+        self.broker = Some(child);
+        Ok(())
+    }
+
+    pub async fn stop_broker(&mut self) -> E2eResult<()> {
+        stop_owned_child(&mut self.broker).await
+    }
+
+    pub async fn stop_all(&mut self) -> E2eResult<()> {
+        let broker = self.stop_broker().await;
+        let namesrv = stop_owned_child(&mut self.namesrv).await;
+        broker.and(namesrv)
+    }
+
+    pub fn all_reaped(&self) -> bool {
+        self.namesrv.is_none() && self.broker.is_none()
+    }
+
+    pub fn sanitized_diagnostics(&self) -> String {
+        let namesrv = self.namesrv.as_ref().map_or_else(
+            || "NameServer=<not-owned>".to_owned(),
+            |child| child.sanitized_diagnostics(),
+        );
+        let broker = self.broker.as_ref().map_or_else(
+            || "Broker=<not-owned>".to_owned(),
+            |child| child.sanitized_diagnostics(),
+        );
+        format!("NameServer[{namesrv}] Broker[{broker}]")
+    }
+
+    async fn wait_ready(&mut self, label: &str, port: u16) -> E2eResult<()> {
+        let deadline = tokio::time::Instant::now() + READINESS_TIMEOUT;
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_millis(400))
+            .timeout(Duration::from_millis(800))
+            .no_proxy()
+            .build()
+            .e2e("build readiness client")?;
+        loop {
+            let child = if label == "Broker" {
+                self.broker.as_mut()
+            } else {
+                self.namesrv.as_mut()
+            }
+            .ok_or_else(|| E2eError::new(format!("{label} ownership is missing")))?;
+            if let Some(status) = child.try_wait()? {
+                return Err(E2eError::new(format!(
+                    "{label} exited before readiness ({status}); {}",
+                    child.sanitized_diagnostics()
+                )));
+            }
+            let response = client.get(format!("http://127.0.0.1:{port}/readyz")).send().await;
+            if response.is_ok_and(|response| response.status().is_success()) {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(E2eError::new(format!(
+                    "{label} readiness deadline expired; {}",
+                    child.sanitized_diagnostics()
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+}
+
+async fn stop_owned_child(child: &mut Option<OwnedChild>) -> E2eResult<()> {
+    if let Some(owned) = child.as_mut() {
+        owned.stop().await?;
+    }
+    child.take();
+    Ok(())
+}
+
+struct OwnedChild {
+    label: &'static str,
+    child: Child,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+    redactions: Vec<String>,
+    reaped: bool,
+}
+
+impl OwnedChild {
+    fn spawn<I, S>(
+        label: &'static str,
+        executable: &Path,
+        args: I,
+        health_port: u16,
+        root: &Path,
+        redactions: &[String],
+    ) -> E2eResult<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        let stdout_path = root.join(format!("{}.stdout.log", label.to_ascii_lowercase()));
+        let stderr_path = root.join(format!("{}.stderr.log", label.to_ascii_lowercase()));
+        let stdout = File::create(&stdout_path).e2e("create child stdout capture")?;
+        let stderr = File::create(&stderr_path).e2e("create child stderr capture")?;
+        let mut command = Command::new(executable);
+        command
+            .args(args)
+            .env("ROCKETMQ_HOME", root)
+            .env("ROCKETMQ_HEALTH_BIND_ADDR", format!("127.0.0.1:{health_port}"))
+            .env("ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS", "5")
+            .env("ROCKETMQ_SECURITY_PROFILE", "development-insecure-loopback")
+            .env("RUST_LOG", "warn")
+            .env_remove("NAMESRV_ADDR")
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr));
+        if label == "Broker" {
+            command.env("RUST_MIN_STACK", BROKER_THREAD_STACK_BYTES.to_string());
+        }
+        let child = command.spawn().e2e(&format!("spawn {label}"))?;
+        Ok(Self {
+            label,
+            child,
+            stdout_path,
+            stderr_path,
+            redactions: redactions.to_vec(),
+            reaped: false,
+        })
+    }
+
+    fn try_wait(&mut self) -> E2eResult<Option<std::process::ExitStatus>> {
+        let status = self.child.try_wait().e2e(&format!("inspect {} child", self.label))?;
+        if status.is_some() {
+            self.reaped = true;
+        }
+        Ok(status)
+    }
+
+    async fn stop(&mut self) -> E2eResult<()> {
+        if self.reaped {
+            return Ok(());
+        }
+        if self.try_wait()?.is_none() {
+            if let Err(error) = self.child.kill() {
+                if self.try_wait()?.is_none() {
+                    return Err(E2eError::new(format!(
+                        "terminate {} child: {error}; {}",
+                        self.label,
+                        self.sanitized_diagnostics()
+                    )));
+                }
+                return Ok(());
+            }
+        }
+        let deadline = tokio::time::Instant::now() + STOP_TIMEOUT;
+        loop {
+            if self.try_wait()?.is_some() {
+                self.reaped = true;
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(E2eError::new(format!(
+                    "{} did not exit before the reap deadline; {}",
+                    self.label,
+                    self.sanitized_diagnostics()
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    fn force_reap(&mut self) -> E2eResult<()> {
+        if self.reaped {
+            return Ok(());
+        }
+        if self.try_wait()?.is_some() {
+            return Ok(());
+        }
+        if let Err(error) = self.child.kill() {
+            if self.try_wait()?.is_none() {
+                return Err(E2eError::new(format!(
+                    "terminate {} child during fallback reap: {error}; {}",
+                    self.label,
+                    self.sanitized_diagnostics()
+                )));
+            }
+            return Ok(());
+        }
+        let deadline = Instant::now() + DROP_REAP_TIMEOUT;
+        loop {
+            if self.try_wait()?.is_some() {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(E2eError::new(format!(
+                    "{} did not exit before the fallback reap deadline; {}",
+                    self.label,
+                    self.sanitized_diagnostics()
+                )));
+            }
+            std::thread::sleep(DROP_REAP_POLL_INTERVAL);
+        }
+    }
+
+    fn sanitized_diagnostics(&self) -> String {
+        format!(
+            "stdout={} stderr={}",
+            sanitize_diagnostic(&tail(&self.stdout_path), &self.redactions),
+            sanitize_diagnostic(&tail(&self.stderr_path), &self.redactions)
+        )
+    }
+}
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        let _ = self.force_reap();
+    }
+}
+
+fn required_binary(environment: &str) -> E2eResult<PathBuf> {
+    let path = std::env::var_os(environment)
+        .map(PathBuf::from)
+        .ok_or_else(|| E2eError::new(format!("{environment} is required")))?;
+    if !path.is_file() {
+        return Err(E2eError::new(format!(
+            "{environment} does not identify a built executable"
+        )));
+    }
+    Ok(path)
+}
+
+fn tail(path: &Path) -> String {
+    let Ok(mut file) = File::open(path) else {
+        return "<unavailable>".to_owned();
+    };
+    let length = file.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+    if length > DIAGNOSTIC_BYTES {
+        use std::io::Seek;
+        let _ = file.seek(std::io::SeekFrom::Start(length - DIAGNOSTIC_BYTES));
+    }
+    let mut text = String::new();
+    let _ = file.read_to_string(&mut text);
+    text
+}
+
+fn push_path_redactions(redactions: &mut Vec<String>, path: &Path) {
+    let native = path.to_string_lossy().into_owned();
+    if !native.is_empty() {
+        redactions.push(native.replace('\\', "/"));
+        redactions.push(native);
+    }
+}
+
+fn sanitize_diagnostic(input: &str, redactions: &[String]) -> String {
+    let mut diagnostic = strip_terminal_sequences(input)
+        .chars()
+        .map(|character| {
+            if character == '\r' || character == '\n' || character == '\t' {
+                ' '
+            } else if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    for sensitive in redactions {
+        if !sensitive.is_empty() {
+            let escaped = json_escaped_string_contents(sensitive);
+            if !escaped.is_empty() {
+                diagnostic = diagnostic.replace(&escaped, "<redacted>");
+            }
+            diagnostic = diagnostic.replace(sensitive, "<redacted>");
+        }
+    }
+    diagnostic
+}
+
+fn json_escaped_string_contents(value: &str) -> String {
+    serde_json::to_string(value)
+        .ok()
+        .and_then(|encoded| {
+            encoded
+                .strip_prefix('"')
+                .and_then(|text| text.strip_suffix('"'))
+                .map(str::to_owned)
+        })
+        .unwrap_or_default()
+}
+
+fn strip_terminal_sequences(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut characters = input.chars().peekable();
+    while let Some(character) = characters.next() {
+        if character != '\u{1b}' {
+            output.push(character);
+            continue;
+        }
+        match characters.next() {
+            Some('[') => {
+                for next in characters.by_ref() {
+                    if ('@'..='~').contains(&next) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                let mut escaped = false;
+                for next in characters.by_ref() {
+                    if next == '\u{7}' || (escaped && next == '\\') {
+                        break;
+                    }
+                    escaped = next == '\u{1b}';
+                }
+            }
+            Some(_) | None => {}
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+    use std::process::Stdio;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use super::sanitize_diagnostic;
+    use super::OwnedChild;
+    use super::DROP_REAP_TIMEOUT;
+
+    const REAP_HELPER_ENV: &str = "ROCKETMQ_MCP_CONTROL_REAP_HELPER";
+    const REAP_HELPER_TEST: &str = "transport::real_cluster_e2e::process::tests::owned_child_reap_helper";
+
+    #[test]
+    fn owned_child_reap_helper() {
+        if std::env::var(REAP_HELPER_ENV).as_deref() == Ok("1") {
+            loop {
+                std::thread::park();
+            }
+        }
+    }
+
+    #[test]
+    fn force_reap_is_bounded_and_reports_reaped_only_after_exit() {
+        let root = tempfile::tempdir().expect("create child-reap test root");
+        let child = Command::new(std::env::current_exe().expect("locate current test executable"))
+            .args(["--exact", REAP_HELPER_TEST])
+            .env(REAP_HELPER_ENV, "1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn owned child-reap helper");
+        let mut owned = OwnedChild {
+            label: "reap-test",
+            child,
+            stdout_path: root.path().join("stdout.log"),
+            stderr_path: root.path().join("stderr.log"),
+            redactions: Vec::new(),
+            reaped: false,
+        };
+
+        let started = Instant::now();
+        owned.force_reap().expect("reap helper within its deadline");
+
+        assert!(started.elapsed() <= DROP_REAP_TIMEOUT + Duration::from_secs(1));
+        assert!(owned.reaped);
+        assert!(owned.try_wait().expect("inspect reaped helper").is_some());
+    }
+
+    #[test]
+    fn diagnostics_remove_terminal_sequences_paths_and_endpoints() {
+        let redactions = vec![
+            r"D:\owned\cluster".to_owned(),
+            "127.0.0.1".to_owned(),
+            "43210".to_owned(),
+            "message-payload".to_owned(),
+        ];
+        let diagnostic = sanitize_diagnostic(
+            "\u{1b}[31mfailed\u{1b}[0m at D:\\owned\\cluster\\broker on 127.0.0.1:43210 message-payload\n",
+            &redactions,
+        );
+
+        assert_eq!(
+            diagnostic,
+            "failed at <redacted>\\broker on <redacted>:<redacted> <redacted> "
+        );
+        assert!(!diagnostic.contains('\u{1b}'));
+    }
+
+    #[test]
+    fn diagnostics_redact_json_escaped_windows_paths() {
+        const WINDOWS_PATH: &str = r"D:\owned\cluster";
+        let diagnostic = sanitize_diagnostic(
+            r#"child={"diagnostic_path":"D:\\owned\\cluster\\broker"}"#,
+            &[WINDOWS_PATH.to_owned()],
+        );
+
+        assert_eq!(diagnostic, r#"child={"diagnostic_path":"<redacted>\\broker"}"#);
+        assert!(!diagnostic.contains("owned"));
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/protocol.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/protocol.rs
@@ -1,0 +1,736 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use jsonwebtoken::Algorithm;
+use jsonwebtoken::EncodingKey;
+use jsonwebtoken::Header;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::super::resource_metadata_url;
+use super::super::serve_authenticated;
+use super::E2eContext;
+use super::E2eError;
+use super::E2eResult;
+use crate::audit::AuditTrail;
+use crate::audit::JsonlAuditSink;
+use crate::auth::AuthError;
+use crate::auth::AuthState;
+use crate::auth::JwksSource;
+use crate::config::ControlConfig;
+
+const PUBLIC_HOST: &str = "control.example.test";
+const PUBLIC_ORIGIN: &str = "https://control.example.test";
+const ISSUER: &str = "https://issuer.example.test";
+const AUDIENCE: &str = "rocketmq-mcp-control";
+const SESSION_HEADER: &str = "mcp-session-id";
+const PROTOCOL_VERSION: &str = "2025-11-25";
+const EXPECTED_TOOL_NAMES: [&str; 5] = [
+    "rocketmq_patch_broker_config",
+    "rocketmq_reset_consumer_offset",
+    "rocketmq_set_consumer_request_mode",
+    "rocketmq_upsert_consumer_group",
+    "rocketmq_upsert_topic",
+];
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const SERVER_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+const RSA_N: &str = "yRE6rHuNR0QbHO3H3Kt2pOKGVhQqGZXInOduQNxXzuKlvQTLUTv4l4sggh5_CYYi_cvI-SXVT9kPWSKXxJXBXd_4LkvcPuUakBoAkfh-eiFVMh2VrUyWyj3MFl0HTVF9KwRXLAcwkREiS3npThHRyIxuy0ZMeZfxVL5arMhw1SRELB8HoGfG_AtH89BIE9jDBHZ9dLelK9a184zAf8LwoPLxvJb3Il5nncqPcSfKDDodMFBIMc4lQzDKL5gvmiXLXB1AGLm8KBjfE8s3L5xqi-yUod-j8MtvIj812dkS4QMiRVN_by2h3ZY8LYVGrqZXZTcgn2ujn8uKjXLZVD5TdQ";
+const OAUTH_PRIVATE_KEY: &[u8] = include_bytes!("../../../tests/fixtures/oauth-private-key.pem");
+
+pub(super) struct GeneratedTlsMaterial {
+    pub certificate_path: String,
+    pub private_key_path: String,
+    pub private_key_markers: Vec<String>,
+}
+
+#[derive(Clone)]
+pub(super) struct StaticJwks;
+
+impl JwksSource for StaticJwks {
+    fn fetch(&self) -> impl Future<Output = Result<Vec<u8>, AuthError>> + Send {
+        async {
+            serde_json::to_vec(&serde_json::json!({"keys": [{
+                "kty": "RSA",
+                "kid": "e2e-key",
+                "alg": "RS256",
+                "use": "sig",
+                "key_ops": ["verify"],
+                "n": RSA_N,
+                "e": "AQAB"
+            }]}))
+            .map_err(|_| AuthError::Unavailable)
+        }
+    }
+}
+
+pub(super) struct ControlInstance {
+    cancellation: CancellationToken,
+    task: Option<JoinHandle<Result<(), crate::error::ControlError>>>,
+    runtime: rocketmq_runtime::RuntimeContext,
+}
+
+impl ControlInstance {
+    pub async fn start(config_path: &Path) -> E2eResult<(Self, McpClient)> {
+        let config = ControlConfig::load(config_path).e2e("load E2E control configuration")?;
+        let port = config
+            .server
+            .bind
+            .parse::<SocketAddr>()
+            .e2e("parse E2E control bind")?
+            .port();
+        let certificate = tokio::fs::read(&config.server.tls.cert_path)
+            .await
+            .e2e("read E2E control certificate")?;
+        let audit_sink = JsonlAuditSink::open(&config.audit.path, config.audit.capacity, config.audit.max_record_bytes)
+            .await
+            .e2e("open E2E audit sink")?;
+        let audit = AuditTrail::resume(Arc::new(audit_sink))
+            .await
+            .e2e("recover E2E audit trail")?;
+        let auth = AuthState::from_source(&config.oauth, resource_metadata_url(&config), StaticJwks)
+            .await
+            .e2e("initialize local static RS256 verifier")?;
+        let runtime = rocketmq_runtime::RuntimeContext::from_current("mcp-control-real-cluster-e2e");
+        let context = runtime.service_context("control-server");
+        let cancellation = CancellationToken::new();
+        let shutdown = cancellation.clone();
+        let task =
+            tokio::spawn(
+                async move { serve_authenticated(config, context, audit, shutdown.cancelled_owned(), auth).await },
+            );
+        let mut instance = Self {
+            cancellation,
+            task: Some(task),
+            runtime,
+        };
+        match McpClient::connect(port, &certificate).await {
+            Ok(client) => Ok((instance, client)),
+            Err(error) => {
+                let cleanup = instance.stop().await;
+                match cleanup {
+                    Ok(()) => Err(error),
+                    Err(cleanup) => Err(E2eError::new(format!(
+                        "{error}; control startup cleanup failed: {cleanup}"
+                    ))),
+                }
+            }
+        }
+    }
+
+    pub async fn stop(&mut self) -> E2eResult<()> {
+        self.cancellation.cancel();
+        let task_result = match self.task.take() {
+            Some(mut task) => match tokio::time::timeout(SERVER_STOP_TIMEOUT, &mut task).await {
+                Ok(joined) => joined
+                    .e2e("join control server task")?
+                    .e2e("control server returned an error"),
+                Err(_) => {
+                    task.abort();
+                    let _ = task.await;
+                    Err(E2eError::new("control server stop deadline expired"))
+                }
+            },
+            None => Ok(()),
+        };
+        let report = self.runtime.shutdown_tasks(SERVER_STOP_TIMEOUT).await;
+        let runtime_result = report.assert_no_task_leak().map_err(E2eError::new);
+        task_result.and(runtime_result)
+    }
+}
+
+impl Drop for ControlInstance {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+        let _ = self.runtime.shutdown_tasks_now();
+    }
+}
+
+#[derive(Serialize)]
+struct Claims<'a> {
+    iss: &'a str,
+    aud: &'a str,
+    sub: &'a str,
+    exp: u64,
+    nbf: u64,
+    scope: &'a str,
+    rocketmq_operations: Vec<&'a str>,
+    rocketmq_clusters: Vec<&'a str>,
+}
+
+pub(super) struct McpClient {
+    client: reqwest::Client,
+    token: String,
+    session: Option<String>,
+    endpoint: String,
+    raw_responses: Vec<String>,
+}
+
+impl McpClient {
+    async fn connect(port: u16, certificate_pem: &[u8]) -> E2eResult<Self> {
+        let certificate = reqwest::Certificate::from_pem(certificate_pem).e2e("parse E2E root certificate")?;
+        let client = reqwest::Client::builder()
+            .https_only(true)
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(2))
+            .timeout(REQUEST_TIMEOUT)
+            .add_root_certificate(certificate)
+            .resolve(PUBLIC_HOST, SocketAddr::from((Ipv4Addr::LOCALHOST, port)))
+            .build()
+            .e2e("build E2E TLS client")?;
+        let token = token()?;
+        let endpoint = format!("{PUBLIC_ORIGIN}/mcp");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            let response = send_json(
+                &client,
+                &token,
+                &endpoint,
+                None,
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "clientInfo": {"name": "real-cluster-e2e", "version": "1.0"}
+                    }
+                }),
+            )
+            .await;
+            if let Ok((_status, headers, body)) = response {
+                let session = session_id_from_initialize(&headers)?;
+                let value: Value = serde_json::from_str(&body).e2e("decode initialize response")?;
+                validate_json_rpc_response(&value, 1)?;
+                super::ensure(
+                    value["result"]["protocolVersion"] == PROTOCOL_VERSION,
+                    "initialize response did not negotiate the requested protocol version",
+                )?;
+                let mut mcp = Self {
+                    client,
+                    token,
+                    session,
+                    endpoint,
+                    raw_responses: vec![body],
+                };
+                mcp.initialized().await?;
+                mcp.assert_five_tools().await?;
+                return Ok(mcp);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(E2eError::new(
+                    "control TLS endpoint did not become ready before its deadline",
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    async fn initialized(&mut self) -> E2eResult<()> {
+        let (status, _headers, body) = send_json(
+            &self.client,
+            &self.token,
+            &self.endpoint,
+            self.session.as_deref(),
+            serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized"}),
+        )
+        .await?;
+        super::ensure(
+            status == StatusCode::ACCEPTED,
+            "initialized notification did not return HTTP 202",
+        )?;
+        self.raw_responses.push(body);
+        Ok(())
+    }
+
+    async fn assert_five_tools(&mut self) -> E2eResult<()> {
+        let response = self.request(2, "tools/list", serde_json::json!({})).await?;
+        let tools = response["result"]["tools"]
+            .as_array()
+            .ok_or_else(|| E2eError::new("tools/list response omitted its array"))?;
+        let mut names = tools
+            .iter()
+            .map(|tool| {
+                tool["name"]
+                    .as_str()
+                    .ok_or_else(|| E2eError::new("tools/list entry omitted its name"))
+            })
+            .collect::<E2eResult<Vec<_>>>()?;
+        names.sort_unstable();
+        super::ensure(
+            names.as_slice() == EXPECTED_TOOL_NAMES,
+            "tools/list did not expose exactly the five reviewed mutation tools",
+        )
+    }
+
+    pub async fn call(&mut self, id: u64, tool: &str, arguments: Value) -> E2eResult<Value> {
+        let response = self
+            .request(
+                id,
+                "tools/call",
+                serde_json::json!({"name": tool, "arguments": arguments}),
+            )
+            .await?;
+        if response.get("error").is_some() {
+            return Err(E2eError::new("MCP tools/call returned a JSON-RPC error"));
+        }
+        let text = tool_response_text(&response, false)?;
+        serde_json::from_str(text).e2e("decode typed mutation response")
+    }
+
+    pub async fn call_expect_error(&mut self, id: u64, tool: &str, arguments: Value) -> E2eResult<Value> {
+        let response = self
+            .request(
+                id,
+                "tools/call",
+                serde_json::json!({"name": tool, "arguments": arguments}),
+            )
+            .await?;
+        super::ensure(
+            response.get("error").is_none(),
+            "MCP tools/call failure used a JSON-RPC error instead of a tool result",
+        )?;
+        let text = tool_response_text(&response, true)?;
+        serde_json::from_str(text).e2e("decode stable MCP tool error envelope")
+    }
+
+    async fn request(&mut self, id: u64, method: &str, params: Value) -> E2eResult<Value> {
+        let (_status, _headers, body) = send_json(
+            &self.client,
+            &self.token,
+            &self.endpoint,
+            self.session.as_deref(),
+            serde_json::json!({"jsonrpc":"2.0","id":id,"method":method,"params":params}),
+        )
+        .await?;
+        let value = serde_json::from_str(&body).e2e("decode MCP JSON response")?;
+        validate_json_rpc_response(&value, id)?;
+        self.raw_responses.push(body);
+        Ok(value)
+    }
+
+    pub fn assert_public_surfaces_redacted(&self, operator: &str, reason: &str, extra: &[String]) -> E2eResult<()> {
+        let oauth_private_key = String::from_utf8_lossy(OAUTH_PRIVATE_KEY);
+        let mut sensitive_markers = vec![operator, reason, self.token.as_str(), RSA_N];
+        sensitive_markers.extend(private_key_markers(oauth_private_key.as_ref()));
+        sensitive_markers.extend(extra.iter().map(String::as_str));
+        for response in &self.raw_responses {
+            for sensitive in &sensitive_markers {
+                if sensitive.is_empty() {
+                    continue;
+                }
+                super::ensure(
+                    !response_contains_sensitive(response, sensitive),
+                    "a public MCP response exposed private operator, reason, token, key, endpoint, or raw backend data",
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn private_key_markers(private_key: &str) -> Vec<&str> {
+    let mut markers = Vec::with_capacity(private_key.lines().count() + 1);
+    if !private_key.is_empty() {
+        markers.push(private_key);
+    }
+    markers.extend(private_key.lines().map(str::trim).filter(|line| !line.is_empty()));
+    markers
+}
+
+fn response_contains_sensitive(response: &str, sensitive: &str) -> bool {
+    if response.contains(sensitive) {
+        return true;
+    }
+    let escaped = json_escaped_string_contents(sensitive);
+    if !escaped.is_empty() && response.contains(&escaped) {
+        return true;
+    }
+    serde_json::from_str::<Value>(response)
+        .is_ok_and(|value| json_value_contains_sensitive(&value, sensitive, &escaped, 0))
+}
+
+fn json_value_contains_sensitive(value: &Value, sensitive: &str, escaped: &str, depth: usize) -> bool {
+    match value {
+        Value::String(text) => {
+            text.contains(sensitive)
+                || (!escaped.is_empty() && text.contains(escaped))
+                || (depth < 2
+                    && serde_json::from_str::<Value>(text)
+                        .is_ok_and(|nested| json_value_contains_sensitive(&nested, sensitive, escaped, depth + 1)))
+        }
+        Value::Array(values) => values
+            .iter()
+            .any(|value| json_value_contains_sensitive(value, sensitive, escaped, depth)),
+        Value::Object(values) => values
+            .values()
+            .any(|value| json_value_contains_sensitive(value, sensitive, escaped, depth)),
+        Value::Null | Value::Bool(_) | Value::Number(_) => false,
+    }
+}
+
+fn json_escaped_string_contents(value: &str) -> String {
+    serde_json::to_string(value)
+        .ok()
+        .and_then(|encoded| {
+            encoded
+                .strip_prefix('"')
+                .and_then(|text| text.strip_suffix('"'))
+                .map(str::to_owned)
+        })
+        .unwrap_or_default()
+}
+
+fn session_id_from_initialize(headers: &HeaderMap) -> E2eResult<Option<String>> {
+    let Some(value) = headers.get(SESSION_HEADER) else {
+        return Ok(None);
+    };
+    let bytes = value.as_bytes();
+    super::ensure(
+        !bytes.is_empty() && bytes.iter().all(|byte| (0x21..=0x7e).contains(byte)),
+        "initialize response returned an invalid MCP session id",
+    )?;
+    std::str::from_utf8(bytes)
+        .map(str::to_owned)
+        .map(Some)
+        .map_err(|_| E2eError::new("initialize response returned an invalid MCP session id"))
+}
+
+fn validate_json_rpc_response(response: &Value, request_id: u64) -> E2eResult<()> {
+    super::ensure(
+        response["jsonrpc"] == "2.0",
+        "MCP response omitted the JSON-RPC 2.0 marker",
+    )?;
+    super::ensure(
+        response["id"].as_u64() == Some(request_id),
+        "MCP response id did not match its request",
+    )?;
+    super::ensure(
+        response.get("result").is_some() ^ response.get("error").is_some(),
+        "MCP response did not contain exactly one of result or error",
+    )
+}
+
+fn tool_response_text(response: &Value, expected_error: bool) -> E2eResult<&str> {
+    let result = response["result"]
+        .as_object()
+        .ok_or_else(|| E2eError::new("MCP tools/call response omitted its result object"))?;
+    let is_error = match result.get("isError") {
+        None => false,
+        Some(Value::Bool(is_error)) => *is_error,
+        Some(_) => return Err(E2eError::new("MCP tools/call result used an invalid isError value")),
+    };
+    super::ensure(
+        is_error == expected_error,
+        "MCP tools/call result error semantics did not match the invocation outcome",
+    )?;
+    let content = result
+        .get("content")
+        .and_then(Value::as_array)
+        .ok_or_else(|| E2eError::new("MCP tools/call result omitted its content array"))?;
+    super::ensure(
+        content.len() == 1 && content[0]["type"] == "text",
+        "MCP tools/call result did not contain exactly one text content item",
+    )?;
+    content[0]["text"]
+        .as_str()
+        .ok_or_else(|| E2eError::new("MCP tools/call text content omitted its string value"))
+}
+
+async fn send_json(
+    client: &reqwest::Client,
+    token: &str,
+    endpoint: &str,
+    session: Option<&str>,
+    body: Value,
+) -> E2eResult<(StatusCode, HeaderMap, String)> {
+    let response = build_json_request(client, token, endpoint, session, body)
+        .send()
+        .await
+        .e2e("send TLS Streamable HTTP request")?;
+    let status = response.status();
+    let headers = response.headers().clone();
+    let text = response.text().await.e2e("read TLS Streamable HTTP response")?;
+    if !status.is_success() {
+        return Err(E2eError::new(format!(
+            "TLS Streamable HTTP request returned status {status}"
+        )));
+    }
+    Ok((status, headers, text))
+}
+
+fn build_json_request(
+    client: &reqwest::Client,
+    token: &str,
+    endpoint: &str,
+    session: Option<&str>,
+    body: Value,
+) -> reqwest::RequestBuilder {
+    let mut request = client
+        .post(endpoint)
+        .header("authorization", format!("Bearer {token}"))
+        .header("origin", PUBLIC_ORIGIN)
+        .header("accept", "application/json, text/event-stream")
+        .header("content-type", "application/json")
+        .header("mcp-protocol-version", PROTOCOL_VERSION)
+        .json(&body);
+    if let Some(session) = session {
+        request = request.header(SESSION_HEADER, session);
+    }
+    request
+}
+
+fn token() -> E2eResult<String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .e2e("read token clock")?
+        .as_secs();
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some("e2e-key".to_owned());
+    jsonwebtoken::encode(
+        &header,
+        &Claims {
+            iss: ISSUER,
+            aud: AUDIENCE,
+            sub: "e2e.operator@example.test",
+            exp: now + 3600,
+            nbf: now.saturating_sub(1),
+            scope: "rocketmq:write",
+            rocketmq_operations: vec![
+                "topic_upsert",
+                "consumer_group_upsert",
+                "consumer_offset_reset",
+                "broker_config_patch",
+                "consumer_request_mode",
+            ],
+            rocketmq_clusters: vec!["E2eCluster"],
+        },
+        &EncodingKey::from_rsa_pem(OAUTH_PRIVATE_KEY).e2e("load test-only RS256 key")?,
+    )
+    .e2e("sign test-only RS256 token")
+}
+
+pub(super) fn write_tls_material(root: &Path) -> E2eResult<GeneratedTlsMaterial> {
+    let rcgen::CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec![PUBLIC_HOST.to_owned()]).e2e("generate E2E TLS identity")?;
+    let cert_path = root.join("control-cert.pem");
+    let key_path = root.join("control-key.pem");
+    let private_key = signing_key.serialize_pem();
+    let private_key_markers = private_key_markers(&private_key)
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+    std::fs::write(&cert_path, cert.pem()).e2e("write E2E TLS certificate")?;
+    std::fs::write(&key_path, private_key).e2e("write E2E TLS private key")?;
+    Ok(GeneratedTlsMaterial {
+        certificate_path: path_for_toml(&cert_path),
+        private_key_path: path_for_toml(&key_path),
+        private_key_markers,
+    })
+}
+
+pub(super) fn path_for_toml(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+pub(super) const fn operator() -> &'static str {
+    "e2e.operator@example.test"
+}
+
+pub(super) const fn reason() -> &'static str {
+    "verify isolated E2E #10004"
+}
+
+pub(super) const fn public_host() -> &'static str {
+    PUBLIC_HOST
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::HeaderValue;
+
+    use super::build_json_request;
+    use super::private_key_markers;
+    use super::response_contains_sensitive;
+    use super::session_id_from_initialize;
+    use super::tool_response_text;
+    use super::validate_json_rpc_response;
+    use super::write_tls_material;
+    use super::HeaderMap;
+    use super::OAUTH_PRIVATE_KEY;
+    use super::RSA_N;
+    use super::SESSION_HEADER;
+
+    const TEST_WINDOWS_PATH: &str = r"D:\owned\cluster";
+    const TEST_PEM_BODY: &str = "c3RhYmxlLXByaXZhdGUta2V5LWJvZHktbWFya2Vy";
+    const TEST_MULTILINE_PEM: &str =
+        "-----BEGIN PRIVATE KEY-----\nc3RhYmxlLXByaXZhdGUta2V5LWJvZHktbWFya2Vy\n-----END PRIVATE KEY-----\n";
+
+    #[test]
+    fn initialize_accepts_stateless_or_visible_ascii_session_ids_and_rejects_invalid_values() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(
+            session_id_from_initialize(&headers).expect("stateless initialize response must be accepted"),
+            None
+        );
+
+        headers.insert(SESSION_HEADER, HeaderValue::from_static(""));
+        assert!(session_id_from_initialize(&headers).is_err());
+
+        headers.insert(SESSION_HEADER, HeaderValue::from_static(" "));
+        assert!(session_id_from_initialize(&headers).is_err());
+
+        headers.insert(
+            SESSION_HEADER,
+            HeaderValue::from_bytes(b"opaque-session\x80").expect("construct obs-text header fixture"),
+        );
+        assert!(session_id_from_initialize(&headers).is_err());
+
+        headers.insert(SESSION_HEADER, HeaderValue::from_static("owned-session_123~"));
+        assert_eq!(
+            session_id_from_initialize(&headers).expect("visible ASCII session must be accepted"),
+            Some("owned-session_123~".to_owned())
+        );
+    }
+
+    #[test]
+    fn request_builder_echoes_session_header_if_and_only_if_initialize_supplied_one() {
+        let client = reqwest::Client::new();
+        let stateless = build_json_request(
+            &client,
+            "test-token",
+            "https://control.example.test/mcp",
+            None,
+            serde_json::json!({"jsonrpc":"2.0","id":1,"method":"tools/list"}),
+        )
+        .build()
+        .expect("build stateless MCP request");
+        assert!(stateless.headers().get(SESSION_HEADER).is_none());
+
+        let stateful = build_json_request(
+            &client,
+            "test-token",
+            "https://control.example.test/mcp",
+            Some("owned-session_123~"),
+            serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/list"}),
+        )
+        .build()
+        .expect("build MCP request with server-provided session");
+        assert_eq!(
+            stateful.headers().get(SESSION_HEADER).map(HeaderValue::as_bytes),
+            Some(b"owned-session_123~".as_slice())
+        );
+    }
+
+    #[test]
+    fn json_rpc_ids_and_tool_content_semantics_are_strict() {
+        let success = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 17,
+            "result": {"content": [{"type": "text", "text": "{}"}], "isError": false}
+        });
+        assert!(validate_json_rpc_response(&success, 17).is_ok());
+        assert_eq!(
+            tool_response_text(&success, false).expect("accept success tool content"),
+            "{}"
+        );
+        assert!(validate_json_rpc_response(&success, 18).is_err());
+
+        let failure = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 18,
+            "result": {"content": [{"type": "text", "text": "{}"}], "isError": true}
+        });
+        assert!(validate_json_rpc_response(&failure, 18).is_ok());
+        assert!(tool_response_text(&failure, true).is_ok());
+        assert!(tool_response_text(&failure, false).is_err());
+    }
+
+    #[test]
+    fn response_redaction_detects_nested_json_escaped_paths_and_pem_material() {
+        let tool_text = serde_json::to_string(&serde_json::json!({
+            "diagnostic_path": TEST_WINDOWS_PATH,
+            "private_key": TEST_MULTILINE_PEM,
+        }))
+        .expect("encode nested tool response");
+        let response = serde_json::to_string(&serde_json::json!({
+            "result": {"content": [{"type": "text", "text": tool_text}]}
+        }))
+        .expect("encode MCP response");
+
+        assert!(!response.contains(TEST_WINDOWS_PATH));
+        assert!(!response.contains(TEST_MULTILINE_PEM));
+        assert!(response_contains_sensitive(&response, TEST_WINDOWS_PATH));
+        assert!(response_contains_sensitive(&response, TEST_MULTILINE_PEM));
+        assert!(private_key_markers(TEST_MULTILINE_PEM)
+            .into_iter()
+            .any(|marker| marker == TEST_PEM_BODY && response_contains_sensitive(&response, marker)));
+    }
+
+    #[test]
+    fn generated_tls_private_key_markers_match_the_written_server_key_and_are_scanned() {
+        let root = tempfile::tempdir().expect("create TLS marker test root");
+        let material = write_tls_material(root.path()).expect("generate TLS marker test material");
+        let written_key = std::fs::read_to_string(root.path().join("control-key.pem"))
+            .expect("read generated TLS private key fixture");
+        let written_markers = private_key_markers(&written_key)
+            .into_iter()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+
+        assert!(
+            material.private_key_markers == written_markers,
+            "retained TLS private-key markers differed from the key file loaded by Control"
+        );
+        let oauth_private_key = String::from_utf8_lossy(OAUTH_PRIVATE_KEY);
+        let has_server_only_body_marker = material.private_key_markers.iter().any(|marker| {
+            !marker.starts_with("-----")
+                && marker.len() >= 32
+                && !oauth_private_key.contains(marker)
+                && !RSA_N.contains(marker)
+        });
+        assert!(
+            has_server_only_body_marker,
+            "generated TLS key did not retain a body marker distinct from OAuth material"
+        );
+        let response = serde_json::to_string(&serde_json::json!({
+            "result": {"content": [{"type": "text", "text": written_key}]}
+        }))
+        .expect("encode simulated TLS private-key leak");
+        assert!(
+            material
+                .private_key_markers
+                .iter()
+                .any(|marker| response_contains_sensitive(&response, marker)),
+            "generated TLS private-key leak was not detected"
+        );
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/scenario.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/scenario.rs
@@ -1,0 +1,1533 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use chrono::SecondsFormat;
+use chrono::Utc;
+use rocketmq_admin_core::core::consumer::ConsumerMutationAdmin;
+use rocketmq_admin_core::core::consumer::DeleteSubscriptionGroupsRequest;
+use rocketmq_admin_core::core::supervised_mutation::BrokerMutationConfigState;
+use rocketmq_admin_core::core::supervised_mutation::RequestMode;
+use rocketmq_admin_core::core::supervised_mutation::RequestModePreflightRequest;
+use rocketmq_admin_core::core::supervised_mutation::RequestModeValue;
+use rocketmq_admin_core::core::supervised_mutation::SupervisedMutationAdmin;
+use rocketmq_admin_core::core::supervised_mutation::TopicMessageType;
+use rocketmq_admin_core::core::supervised_mutation::TopicMutationPreflightRequest;
+use rocketmq_admin_core::core::supervised_mutation::TopicReplacement;
+use rocketmq_admin_core::core::topic::DeleteTopicAdminRequest;
+use rocketmq_admin_core::core::topic::ResetTopicConsumerOffsetRequest;
+use rocketmq_admin_core::core::topic::TopicMutationAdmin;
+use rocketmq_admin_core::core::topic::TopicSendRequest;
+use rocketmq_admin_core::core::AdminError;
+use rocketmq_admin_core::mutation_client_adapter::MutationAdminBuilder;
+use rocketmq_admin_core::mutation_client_adapter::MutationAdminSession;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::ensure;
+use super::process::ClusterProcesses;
+use super::process::PortSet;
+use super::protocol;
+use super::protocol::ControlInstance;
+use super::protocol::McpClient;
+use super::E2eContext;
+use super::E2eError;
+use super::E2eResult;
+use super::EXPECTED_AUDIT_RECORDS;
+use super::EXPECTED_CALLS;
+use super::MESSAGE_BODY;
+use crate::audit::AuditEvent;
+use crate::audit::AuditMode;
+use crate::audit::AuditRecord;
+use crate::audit::AuditResult;
+use crate::audit::AuditSchemaVersion;
+use crate::error::ControlErrorCode;
+use crate::model::ControlOperation;
+use crate::tools::PATCH_BROKER_CONFIG_TOOL;
+use crate::tools::RESET_CONSUMER_OFFSET_TOOL;
+use crate::tools::SET_CONSUMER_REQUEST_MODE_TOOL;
+use crate::tools::UPSERT_CONSUMER_GROUP_TOOL;
+use crate::tools::UPSERT_TOPIC_TOOL;
+
+const CLUSTER: &str = "E2eCluster";
+const BROKER_CLUSTER: &str = CLUSTER;
+const BROKER: &str = "e2e-broker";
+const ARGUMENT_SCHEMA: &str = "rocketmq-mcp-control.arguments.v1";
+const REGISTRATION_TIMEOUT: Duration = Duration::from_secs(45);
+const FIXTURE_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct CleanupEvidence {
+    pub cluster_root_removed: bool,
+    pub children_reaped: bool,
+    pub broker_config_restored: bool,
+    pub consumer_request_mode_restored: bool,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct ExpectedAudit {
+    operation: ControlOperation,
+    mode: AuditMode,
+    result: AuditResult,
+    error_code: Option<ControlErrorCode>,
+}
+
+struct ControlConfigMaterial {
+    path: PathBuf,
+    tls_private_key_markers: Vec<String>,
+}
+
+pub(super) struct E2eHarness {
+    temp: Option<TempDir>,
+    root: PathBuf,
+    ports: PortSet,
+    cluster: ClusterProcesses,
+    control_config: PathBuf,
+    tls_private_key_markers: Vec<String>,
+    audit_path: PathBuf,
+    control: Option<ControlInstance>,
+    mcp: Option<McpClient>,
+    fixture: Option<FixtureAdmin>,
+    topic: String,
+    group: String,
+    next_request_id: u64,
+    expected_audit: Vec<ExpectedAudit>,
+    original_broker_state: Option<BrokerMutationConfigState>,
+    broker_change_generation: Option<u64>,
+    broker_repeat_generation: Option<u64>,
+    broker_restore_generation: Option<u64>,
+    broker_restart_generation: Option<u64>,
+    broker_patch_touched: bool,
+    request_mode_baseline: Option<RequestModeValue>,
+    request_mode_touched: bool,
+    topic_created: bool,
+    group_created: bool,
+    cleanup_outcome: Option<Result<CleanupEvidence, String>>,
+}
+
+impl E2eHarness {
+    pub fn sanitized_process_diagnostics(&self) -> String {
+        self.cluster.sanitized_diagnostics()
+    }
+
+    pub async fn start() -> E2eResult<Self> {
+        let temp = tempfile::Builder::new()
+            .prefix("rocketmq-mcp-control-e2e-")
+            .tempdir()
+            .e2e("create isolated E2E root")?;
+        let root = temp.path().to_path_buf();
+        let mut ports = PortSet::allocate()?;
+        let run_id = unique_id()?;
+        let topic = format!("McpE2eTopic_{run_id}");
+        let group = format!("McpE2eGroup_{run_id}");
+        let namesrv_config = write_namesrv_config(&root, &ports)?;
+        let broker_config = write_broker_config(&root, &ports)?;
+        let audit_path = root.join("control-audit.jsonl");
+        let ControlConfigMaterial {
+            path: control_config,
+            tls_private_key_markers,
+        } = write_control_config(&root, &ports, &audit_path)?;
+        let mut cluster = ClusterProcesses::new(&root, &ports, namesrv_config, broker_config)?;
+        cluster.start_namesrv(&mut ports).await?;
+        cluster.start_broker(&mut ports).await?;
+        let mut fixture = FixtureAdmin::start(ports.namesrv.value(), ports.broker.value()).await?;
+        if let Err(error) = fixture.wait_for_broker(&topic).await {
+            let diagnostics = cluster.sanitized_diagnostics();
+            let fixture_cleanup_failed = fixture.shutdown().await.is_err();
+            let cluster_cleanup_failed = cluster.stop_all().await.is_err();
+            return Err(E2eError::new(format!(
+                "{error}; {diagnostics}; fixture_cleanup_failed={fixture_cleanup_failed}; \
+                 cluster_cleanup_failed={cluster_cleanup_failed}"
+            )));
+        }
+        ports.control_https.release();
+        let (control, mcp) = match ControlInstance::start(&control_config).await {
+            Ok(started) => started,
+            Err(error) => {
+                let fixture_cleanup_failed = fixture.shutdown().await.is_err();
+                let cluster_cleanup_failed = cluster.stop_all().await.is_err();
+                return Err(E2eError::new(format!(
+                    "{error}; fixture_cleanup_failed={fixture_cleanup_failed}; \
+                     cluster_cleanup_failed={cluster_cleanup_failed}"
+                )));
+            }
+        };
+        Ok(Self {
+            temp: Some(temp),
+            root,
+            ports,
+            cluster,
+            control: Some(control),
+            mcp: Some(mcp),
+            fixture: Some(fixture),
+            control_config,
+            tls_private_key_markers,
+            audit_path,
+            topic,
+            group,
+            next_request_id: 10,
+            expected_audit: Vec::new(),
+            original_broker_state: None,
+            broker_change_generation: None,
+            broker_repeat_generation: None,
+            broker_restore_generation: None,
+            broker_restart_generation: None,
+            broker_patch_touched: false,
+            request_mode_baseline: None,
+            request_mode_touched: false,
+            topic_created: false,
+            group_created: false,
+            cleanup_outcome: None,
+        })
+    }
+
+    pub async fn exercise(&mut self) -> E2eResult<()> {
+        self.exercise_topic().await?;
+        self.exercise_group().await?;
+        self.exercise_offset().await?;
+        self.exercise_broker_config().await?;
+        self.exercise_request_mode().await?;
+        self.exercise_broker_outage().await?;
+        self.restart_control_and_prove_audit_recovery().await?;
+        Ok(())
+    }
+
+    async fn exercise_topic(&mut self) -> E2eResult<()> {
+        let dry = self
+            .invoke(
+                UPSERT_TOPIC_TOOL,
+                topic_args(&self.topic, true, "topic-dry-0001"),
+                ControlOperation::TopicUpsert,
+                AuditMode::DryRun,
+                AuditResult::Planned,
+            )
+            .await?;
+        ensure(
+            dry["status"] == "planned",
+            format!(
+                "Topic dry-run status={} error_code={} stable_code={} stable_message={} target_failures={:?}",
+                dry["status"],
+                dry["error_code"],
+                dry["code"],
+                dry["message"],
+                dry["targets"].as_array().map(|targets| targets
+                    .iter()
+                    .map(|target| target["failure"].clone())
+                    .collect::<Vec<_>>())
+            ),
+        )?;
+        ensure(
+            dry["before"][BROKER]["kind"] == "absent",
+            "Topic pre-state was not absent",
+        )?;
+        ensure(dry["after"].is_null(), "Topic dry-run exposed a post-state")?;
+
+        let applied = self
+            .invoke(
+                UPSERT_TOPIC_TOOL,
+                topic_args(&self.topic, false, "topic-exec-0001"),
+                ControlOperation::TopicUpsert,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        self.topic_created = true;
+        ensure(applied["status"] == "applied", "Topic execute was not applied")?;
+        ensure(
+            applied["before"] == dry["before"],
+            "Topic execute pre-state differed from its dry-run pre-state",
+        )?;
+        ensure(
+            applied["after"][BROKER]["kind"] == "present",
+            "Topic execute did not verify a present post-state",
+        )?;
+        ensure(
+            applied["after"][BROKER]["value"] == applied["requested"],
+            "Topic execute did not verify the exact requested post-state",
+        )?;
+
+        let repeat = self
+            .invoke(
+                UPSERT_TOPIC_TOOL,
+                topic_args(&self.topic, false, "topic-repeat-01"),
+                ControlOperation::TopicUpsert,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        ensure(repeat["status"] == "applied", "Topic repeat was not stable")?;
+        ensure(
+            repeat["before"] == repeat["after"],
+            "Topic idempotent repeat changed the resulting state",
+        )
+    }
+
+    async fn exercise_group(&mut self) -> E2eResult<()> {
+        let dry = self
+            .invoke(
+                UPSERT_CONSUMER_GROUP_TOOL,
+                group_args(&self.group, true, "group-dry-0001"),
+                ControlOperation::ConsumerGroupUpsert,
+                AuditMode::DryRun,
+                AuditResult::Planned,
+            )
+            .await?;
+        ensure(dry["status"] == "planned", "Consumer Group dry-run was not planned")?;
+        ensure(
+            dry["before"][BROKER]["kind"] == "absent",
+            "Consumer Group pre-state was not absent",
+        )?;
+        ensure(dry["after"].is_null(), "Consumer Group dry-run exposed a post-state")?;
+
+        let applied = self
+            .invoke(
+                UPSERT_CONSUMER_GROUP_TOOL,
+                group_args(&self.group, false, "group-exec-0001"),
+                ControlOperation::ConsumerGroupUpsert,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        self.group_created = true;
+        ensure(applied["status"] == "applied", "Consumer Group execute was not applied")?;
+        ensure(
+            applied["before"] == dry["before"],
+            "Consumer Group execute pre-state differed from its dry-run pre-state",
+        )?;
+        ensure(
+            applied["after"][BROKER]["kind"] == "present",
+            "Consumer Group execute did not verify its exact post-state",
+        )?;
+        ensure(
+            applied["after"][BROKER]["value"] == applied["requested"],
+            "Consumer Group execute did not verify the exact requested values",
+        )?;
+
+        let repeat = self
+            .invoke(
+                UPSERT_CONSUMER_GROUP_TOOL,
+                group_args(&self.group, false, "group-repeat-01"),
+                ControlOperation::ConsumerGroupUpsert,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        ensure(
+            repeat["before"] == repeat["after"],
+            "Consumer Group idempotent repeat changed the resulting state",
+        )
+    }
+
+    async fn exercise_offset(&mut self) -> E2eResult<()> {
+        let reset_time = current_millis()?;
+        let topic = self.topic.clone();
+        let group = self.group.clone();
+        self.fixture_mut()?.publish_and_seed_progress(&topic, &group).await?;
+        let initial = self
+            .fixture_mut()?
+            .offset_rows(&topic, &group, reset_time as i64)
+            .await?;
+        ensure(
+            initial.iter().any(|(_, current, planned)| current > planned),
+            "fixture did not create observable Consumer Group progress",
+        )?;
+        let timestamp = millis_timestamp(reset_time)?;
+        let dry = self
+            .invoke(
+                RESET_CONSUMER_OFFSET_TOOL,
+                offset_args(&self.topic, &self.group, &timestamp, true, "offset-dry-001"),
+                ControlOperation::ConsumerOffsetReset,
+                AuditMode::DryRun,
+                AuditResult::Planned,
+            )
+            .await?;
+        ensure(dry["status"] == "planned", "Offset Reset dry-run was not planned")?;
+        let before = dry["before"].clone();
+        let after_dry = self
+            .fixture_mut()?
+            .offset_rows(&topic, &group, reset_time as i64)
+            .await?;
+        ensure(initial == after_dry, "Offset Reset dry-run changed Consumer offsets")?;
+
+        let applied = self
+            .invoke(
+                RESET_CONSUMER_OFFSET_TOOL,
+                offset_args(&self.topic, &self.group, &timestamp, false, "offset-exec-001"),
+                ControlOperation::ConsumerOffsetReset,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        ensure(applied["status"] == "applied", "Offset Reset execute was not applied")?;
+        ensure(
+            applied["before"] == before,
+            "Offset Reset before-state drifted after dry-run",
+        )?;
+        ensure(
+            applied["targets"].as_array().is_some_and(|targets| {
+                !targets.is_empty() && targets.iter().all(|target| target["after"] == target["planned"])
+            }),
+            "Offset Reset did not verify every queue post-state",
+        )?;
+        let observed = self
+            .fixture_mut()?
+            .offset_rows(&topic, &group, reset_time as i64)
+            .await?;
+        ensure(
+            !observed.is_empty() && observed.iter().all(|(_, current, planned)| current == planned),
+            "typed fixture did not observe every reset queue at its planned offset",
+        )?;
+
+        let repeat = self
+            .invoke(
+                RESET_CONSUMER_OFFSET_TOOL,
+                offset_args(&self.topic, &self.group, &timestamp, false, "offset-repeat-1"),
+                ControlOperation::ConsumerOffsetReset,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        ensure(repeat["status"] == "applied", "Offset Reset repeat was not stable")?;
+        ensure(
+            repeat["targets"]
+                .as_array()
+                .is_some_and(|targets| targets.iter().all(|target| target["changed"] == false)),
+            "Offset Reset repeat was not idempotent",
+        )
+    }
+
+    async fn exercise_broker_config(&mut self) -> E2eResult<()> {
+        let original = self
+            .fixture
+            .as_mut()
+            .ok_or_else(|| E2eError::new("fixture Admin is unavailable"))?
+            .broker_state()
+            .await?;
+        self.original_broker_state = Some(original);
+        let desired = !original.trace_topic_enable;
+        let dry = self
+            .invoke(
+                PATCH_BROKER_CONFIG_TOOL,
+                broker_args(desired, true, "broker-dry-0001"),
+                ControlOperation::BrokerConfigPatch,
+                AuditMode::DryRun,
+                AuditResult::Planned,
+            )
+            .await?;
+        ensure(
+            dry["before"][BROKER] == broker_state_json(original),
+            "Broker dry-run did not expose the complete original allowlisted state",
+        )?;
+        ensure(dry["after"].is_null(), "Broker dry-run exposed a post-state")?;
+        let after_dry = self.fixture_mut()?.broker_state().await?;
+        ensure(
+            after_dry == original,
+            "Broker dry-run changed the configuration or generation",
+        )?;
+
+        let applied = self
+            .invoke(
+                PATCH_BROKER_CONFIG_TOOL,
+                broker_args(desired, false, "broker-exec-0001"),
+                ControlOperation::BrokerConfigPatch,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        self.broker_patch_touched = true;
+        ensure(
+            applied["before"][BROKER] == broker_state_json(original),
+            "Broker execute pre-state differed from its dry-run pre-state",
+        )?;
+        ensure(
+            applied["after"][BROKER]["traceTopicEnable"] == desired,
+            format!(
+                "Broker patch result did not verify the changed property: status={} error_code={} before={} after={} target={}",
+                applied["status"],
+                applied["error_code"],
+                applied["before"][BROKER]["traceTopicEnable"],
+                applied["after"][BROKER]["traceTopicEnable"],
+                applied["targets"].as_array().and_then(|targets| targets.first()).cloned().unwrap_or(Value::Null),
+            ),
+        )?;
+        let applied_generation = broker_generation(&applied, "after")?;
+        ensure(
+            applied_generation > original.generation,
+            "Broker patch generation did not advance",
+        )?;
+        let applied_target = single_broker_target(&applied)?;
+        ensure(
+            applied_target["changed"] == true && applied_target["applied"] == true,
+            "Broker patch did not report a changed, applied target",
+        )?;
+        self.broker_change_generation = Some(applied_generation);
+        let mut expected = original;
+        expected.trace_topic_enable = desired;
+        expected.generation = applied_generation;
+        ensure(
+            applied["after"][BROKER] == broker_state_json(expected),
+            "Broker patch response did not preserve all six allowlisted fields",
+        )?;
+        let observed = self.fixture_mut()?.broker_state().await?;
+        ensure(
+            observed == expected,
+            "typed fixture did not observe the exact Broker configuration patch",
+        )?;
+
+        let repeat = self
+            .invoke(
+                PATCH_BROKER_CONFIG_TOOL,
+                broker_args(desired, false, "broker-repeat-1"),
+                ControlOperation::BrokerConfigPatch,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        let repeat_before_generation = broker_generation(&repeat, "before")?;
+        let repeat_generation = broker_generation(&repeat, "after")?;
+        ensure(
+            repeat_before_generation == applied_generation && repeat_generation > repeat_before_generation,
+            "Broker no-op repeat did not advance from the preceding generation",
+        )?;
+        let mut repeat_before = expected;
+        repeat_before.generation = repeat_before_generation;
+        let mut repeat_after = expected;
+        repeat_after.generation = repeat_generation;
+        ensure(
+            repeat["before"][BROKER] == broker_state_json(repeat_before)
+                && repeat["after"][BROKER] == broker_state_json(repeat_after),
+            "Broker patch repeat changed an allowlisted field",
+        )?;
+        let repeat_target = single_broker_target(&repeat)?;
+        ensure(
+            repeat_target["changed"] == false && repeat_target["applied"] == true,
+            "Broker patch repeat did not report its applied no-op semantics",
+        )?;
+        let repeated = self.fixture_mut()?.broker_state().await?;
+        ensure(
+            repeated == repeat_after,
+            "typed fixture did not observe the no-op repeat generation",
+        )?;
+        self.broker_repeat_generation = Some(repeat_generation);
+
+        ensure(
+            self.restore_broker_config(Some(true), "broker-restore1").await?,
+            "Broker configuration was not restored in the mutation epoch",
+        )
+    }
+
+    async fn exercise_request_mode(&mut self) -> E2eResult<()> {
+        let baseline = RequestModeValue {
+            mode: RequestMode::Pull,
+            pop_share_queue_num: 0,
+        };
+        let topic = self.topic.clone();
+        let group = self.group.clone();
+        let before_baseline_dry = self.fixture_mut()?.request_mode(&topic, &group).await?;
+        let dry = self
+            .invoke(
+                SET_CONSUMER_REQUEST_MODE_TOOL,
+                request_mode_args(&self.topic, &self.group, "pull", 0, true, "mode-dry-base1"),
+                ControlOperation::ConsumerRequestMode,
+                AuditMode::DryRun,
+                AuditResult::Planned,
+            )
+            .await?;
+        ensure(
+            dry["status"] == "planned",
+            "request-mode baseline dry-run was not planned",
+        )?;
+        let after_baseline_dry = self.fixture_mut()?.request_mode(&topic, &group).await?;
+        ensure(
+            after_baseline_dry == before_baseline_dry,
+            "request-mode baseline dry-run changed real Broker state",
+        )?;
+        self.invoke(
+            SET_CONSUMER_REQUEST_MODE_TOOL,
+            request_mode_args(&self.topic, &self.group, "pull", 0, false, "mode-exec-base"),
+            ControlOperation::ConsumerRequestMode,
+            AuditMode::Execute,
+            AuditResult::Applied,
+        )
+        .await?;
+        self.request_mode_baseline = Some(baseline);
+        ensure(
+            self.fixture_mut()?.request_mode(&topic, &group).await?.as_ref() == Some(&baseline),
+            "typed fixture did not observe the request-mode baseline",
+        )?;
+
+        let before_change_dry = self.fixture_mut()?.request_mode(&topic, &group).await?;
+        self.invoke(
+            SET_CONSUMER_REQUEST_MODE_TOOL,
+            request_mode_args(&self.topic, &self.group, "pop", 1, true, "mode-dry-change"),
+            ControlOperation::ConsumerRequestMode,
+            AuditMode::DryRun,
+            AuditResult::Planned,
+        )
+        .await?;
+        let after_change_dry = self.fixture_mut()?.request_mode(&topic, &group).await?;
+        ensure(
+            after_change_dry == before_change_dry,
+            "request-mode change dry-run changed real Broker state",
+        )?;
+        let changed = self
+            .invoke(
+                SET_CONSUMER_REQUEST_MODE_TOOL,
+                request_mode_args(&self.topic, &self.group, "pop", 1, false, "mode-exec-change"),
+                ControlOperation::ConsumerRequestMode,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        self.request_mode_touched = true;
+        ensure(
+            changed["after"][BROKER]["mode"] == "pop" && changed["after"][BROKER]["pop_share_queue_num"] == 1,
+            "request-mode change was not verified",
+        )?;
+        let expected = RequestModeValue {
+            mode: RequestMode::Pop,
+            pop_share_queue_num: 1,
+        };
+        ensure(
+            self.fixture_mut()?.request_mode(&topic, &group).await?.as_ref() == Some(&expected),
+            "typed fixture did not observe the exact request-mode change",
+        )?;
+        let repeat = self
+            .invoke(
+                SET_CONSUMER_REQUEST_MODE_TOOL,
+                request_mode_args(&self.topic, &self.group, "pop", 1, false, "mode-repeat-001"),
+                ControlOperation::ConsumerRequestMode,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        ensure(
+            repeat["before"] == repeat["after"],
+            "request-mode repeat changed the resulting state",
+        )
+    }
+
+    async fn exercise_broker_outage(&mut self) -> E2eResult<()> {
+        self.cluster.stop_broker().await?;
+        let error = self
+            .invoke_error(
+                UPSERT_TOPIC_TOOL,
+                topic_args(&self.topic, true, "outage-dry-0001"),
+                ControlOperation::TopicUpsert,
+                AuditMode::DryRun,
+                ControlErrorCode::ExecutionFailed,
+            )
+            .await?;
+        ensure(
+            error["code"] == "execution_failed",
+            "Broker outage did not return the stable error code",
+        )?;
+        ensure(
+            error["message"] == "mutation execution failed",
+            "Broker outage exposed a raw backend error",
+        )?;
+
+        self.cluster.restart_broker().await?;
+        let fixture = self
+            .fixture
+            .as_mut()
+            .ok_or_else(|| E2eError::new("fixture Admin is unavailable"))?;
+        fixture.wait_for_broker(&self.topic).await?;
+        let restarted = fixture.broker_state().await?;
+        let original = self
+            .original_broker_state
+            .ok_or_else(|| E2eError::new("original Broker configuration is unavailable"))?;
+        let restored_generation = self
+            .broker_restore_generation
+            .ok_or_else(|| E2eError::new("pre-outage Broker restoration generation is unavailable"))?;
+        // Generation is process-local: restart begins a new epoch from the static TOML state.
+        ensure(
+            restarted.generation == original.generation
+                && restarted.generation < restored_generation
+                && same_broker_config_values(restarted, original),
+            "Broker restart did not begin a fresh generation epoch from the original configuration",
+        )?;
+        self.broker_restart_generation = Some(restarted.generation);
+        ensure(
+            matches!(
+                (
+                    self.broker_change_generation,
+                    self.broker_repeat_generation,
+                    self.broker_restore_generation,
+                    self.broker_restart_generation,
+                ),
+                (Some(change), Some(repeat), Some(restore), Some(restart))
+                    if original.generation < change
+                        && change < repeat
+                        && repeat < restore
+                        && restart == original.generation
+            ),
+            "Broker generation evidence did not prove monotonic progress within the original epoch and reset on restart",
+        )?;
+        let recovered = self
+            .invoke(
+                UPSERT_TOPIC_TOOL,
+                topic_args(&self.topic, true, "recovery-dry-01"),
+                ControlOperation::TopicUpsert,
+                AuditMode::DryRun,
+                AuditResult::Planned,
+            )
+            .await?;
+        ensure(
+            recovered["status"] == "planned",
+            "Broker restart did not restore mutation readiness",
+        )
+    }
+
+    async fn restart_control_and_prove_audit_recovery(&mut self) -> E2eResult<()> {
+        self.stop_control().await?;
+        let (control, mcp) = ControlInstance::start(&self.control_config).await?;
+        self.control = Some(control);
+        self.mcp = Some(mcp);
+        let recovered = self
+            .invoke(
+                UPSERT_CONSUMER_GROUP_TOOL,
+                group_args(&self.group, true, "control-recover1"),
+                ControlOperation::ConsumerGroupUpsert,
+                AuditMode::DryRun,
+                AuditResult::Planned,
+            )
+            .await?;
+        ensure(
+            recovered["status"] == "planned",
+            "Control restart did not recover the audit file",
+        )
+    }
+
+    async fn invoke(
+        &mut self,
+        tool: &str,
+        arguments: Value,
+        operation: ControlOperation,
+        mode: AuditMode,
+        result: AuditResult,
+    ) -> E2eResult<Value> {
+        let id = self.next_id();
+        let response = self
+            .mcp
+            .as_mut()
+            .ok_or_else(|| E2eError::new("MCP client is unavailable"))?
+            .call(id, tool, arguments)
+            .await?;
+        self.expected_audit.push(ExpectedAudit {
+            operation,
+            mode,
+            result,
+            error_code: None,
+        });
+        Ok(response)
+    }
+
+    async fn invoke_error(
+        &mut self,
+        tool: &str,
+        arguments: Value,
+        operation: ControlOperation,
+        mode: AuditMode,
+        error_code: ControlErrorCode,
+    ) -> E2eResult<Value> {
+        let id = self.next_id();
+        let response = self
+            .mcp
+            .as_mut()
+            .ok_or_else(|| E2eError::new("MCP client is unavailable"))?
+            .call_expect_error(id, tool, arguments)
+            .await?;
+        self.expected_audit.push(ExpectedAudit {
+            operation,
+            mode,
+            result: AuditResult::Failed,
+            error_code: Some(error_code),
+        });
+        Ok(response)
+    }
+
+    fn next_id(&mut self) -> u64 {
+        let id = self.next_request_id;
+        self.next_request_id += 1;
+        id
+    }
+
+    fn fixture_mut(&mut self) -> E2eResult<&mut FixtureAdmin> {
+        self.fixture
+            .as_mut()
+            .ok_or_else(|| E2eError::new("fixture Admin is unavailable"))
+    }
+
+    pub async fn cleanup(&mut self) -> E2eResult<CleanupEvidence> {
+        if let Some(outcome) = self.cleanup_outcome.clone() {
+            return outcome.map_err(E2eError::new);
+        }
+
+        let mut failures = Vec::new();
+        let needs_live_broker =
+            self.broker_patch_touched || self.request_mode_touched || self.topic_created || self.group_created;
+        if needs_live_broker {
+            if self.cluster.ensure_broker_running().await.is_err() {
+                failures.push("Broker was unavailable during cleanup".to_owned());
+            }
+            if let Some(fixture) = self.fixture.as_mut() {
+                if fixture.wait_for_broker(&self.topic).await.is_err() {
+                    failures.push("Broker did not become ready for cleanup".to_owned());
+                }
+            }
+        }
+
+        let request_mode_restored = self.restore_request_mode().await.unwrap_or(false);
+        if self.request_mode_touched && !request_mode_restored {
+            failures.push("Consumer request mode restoration failed".to_owned());
+        }
+        let broker_config_restored = self
+            .restore_broker_config(None, "broker-cleanup-1")
+            .await
+            .unwrap_or(false);
+        if self.broker_patch_touched && !broker_config_restored {
+            failures.push("Broker configuration restoration failed".to_owned());
+        }
+
+        if let Some(fixture) = self.fixture.as_mut() {
+            if fixture
+                .cleanup_resources(&self.topic, &self.group, self.topic_created, self.group_created)
+                .await
+                .is_err()
+            {
+                failures.push("typed Admin resource cleanup failed".to_owned());
+            } else {
+                self.topic_created = false;
+                self.group_created = false;
+            }
+        }
+        if let Some(mut fixture) = self.fixture.take() {
+            if fixture.shutdown().await.is_err() {
+                failures.push("fixture Admin shutdown failed".to_owned());
+            }
+        }
+        if self.stop_control().await.is_err() {
+            failures.push("Control shutdown failed".to_owned());
+        }
+        if verify_audit(&self.audit_path, &self.expected_audit).is_err() {
+            failures.push("durable audit pair verification failed".to_owned());
+        }
+        if self.cluster.stop_all().await.is_err() {
+            failures.push("cluster child shutdown failed".to_owned());
+        }
+        let children_reaped = self.cluster.all_reaped();
+        if !children_reaped {
+            failures.push("an owned cluster child was not reaped".to_owned());
+        }
+
+        let root = self.root.clone();
+        if let Some(temp) = self.temp.take() {
+            if temp.close().is_err() {
+                failures.push("ephemeral cluster root removal failed".to_owned());
+            }
+        }
+        let cluster_root_removed = !root.exists();
+        if !cluster_root_removed {
+            failures.push("ephemeral cluster root remains on disk".to_owned());
+        }
+        let outcome = if failures.is_empty() {
+            Ok(CleanupEvidence {
+                cluster_root_removed,
+                children_reaped,
+                broker_config_restored: !self.broker_patch_touched || broker_config_restored,
+                consumer_request_mode_restored: !self.request_mode_touched || request_mode_restored,
+            })
+        } else {
+            Err(failures.join("; "))
+        };
+        self.cleanup_outcome = Some(outcome.clone());
+        outcome.map_err(E2eError::new)
+    }
+
+    async fn restore_broker_config(&mut self, expected_changed: Option<bool>, request_key: &str) -> E2eResult<bool> {
+        if !self.broker_patch_touched {
+            return Ok(true);
+        }
+        let Some(original) = self.original_broker_state else {
+            return Ok(false);
+        };
+        let before = self.fixture_mut()?.broker_state().await?;
+        let changed = !same_broker_config_values(before, original);
+        if let Some(expected_changed) = expected_changed {
+            ensure(
+                changed == expected_changed,
+                "Broker restoration pre-state did not have the expected change semantics",
+            )?;
+            ensure(
+                self.broker_repeat_generation == Some(before.generation),
+                "Broker restoration did not start from the saved repeat generation",
+            )?;
+        }
+        let response = self
+            .invoke(
+                PATCH_BROKER_CONFIG_TOOL,
+                broker_args(original.trace_topic_enable, false, request_key),
+                ControlOperation::BrokerConfigPatch,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        ensure(
+            response["before"][BROKER] == broker_state_json(before),
+            "Broker restoration response did not begin from the exact observed state",
+        )?;
+        let restored_generation = broker_generation(&response, "after")?;
+        ensure(
+            restored_generation > before.generation,
+            "Broker restoration generation did not advance within its process epoch",
+        )?;
+        let target = single_broker_target(&response)?;
+        ensure(
+            target["changed"] == changed && target["applied"] == true,
+            "Broker restoration target did not report the expected change semantics",
+        )?;
+        let mut expected = original;
+        expected.generation = restored_generation;
+        ensure(
+            response["after"][BROKER] == broker_state_json(expected),
+            "Broker restoration response did not verify all six original fields",
+        )?;
+        let restored = self
+            .fixture
+            .as_mut()
+            .ok_or_else(|| E2eError::new("fixture Admin is unavailable"))?
+            .broker_state()
+            .await?;
+        ensure(
+            restored == expected,
+            "typed fixture did not observe the exact Broker restoration generation and fields",
+        )?;
+        self.broker_restore_generation = Some(restored_generation);
+        self.broker_patch_touched = false;
+        Ok(true)
+    }
+
+    async fn restore_request_mode(&mut self) -> E2eResult<bool> {
+        if !self.request_mode_touched {
+            return Ok(true);
+        }
+        let Some(baseline) = self.request_mode_baseline else {
+            return Ok(false);
+        };
+        let (mode, share) = match baseline.mode {
+            RequestMode::Pull => ("pull", baseline.pop_share_queue_num),
+            RequestMode::Pop => ("pop", baseline.pop_share_queue_num),
+        };
+        self.invoke(
+            SET_CONSUMER_REQUEST_MODE_TOOL,
+            request_mode_args(&self.topic, &self.group, mode, share, false, "mode-restore-01"),
+            ControlOperation::ConsumerRequestMode,
+            AuditMode::Execute,
+            AuditResult::Applied,
+        )
+        .await?;
+        let restored = self
+            .fixture
+            .as_mut()
+            .ok_or_else(|| E2eError::new("fixture Admin is unavailable"))?
+            .request_mode(&self.topic, &self.group)
+            .await?;
+        Ok(restored.as_ref() == Some(&baseline))
+    }
+
+    async fn stop_control(&mut self) -> E2eResult<()> {
+        let redaction_result = self.mcp.as_ref().map_or(Ok(()), |mcp| {
+            let mut private_surfaces = vec![
+                self.root.to_string_lossy().into_owned(),
+                "127.0.0.1".to_owned(),
+                MESSAGE_BODY.to_owned(),
+            ];
+            private_surfaces.extend(self.tls_private_key_markers.iter().cloned());
+            private_surfaces.extend(
+                [
+                    self.ports.namesrv.value(),
+                    self.ports.namesrv_health.value(),
+                    self.ports.broker.value(),
+                    self.ports.broker_fast.value(),
+                    self.ports.broker_ha.value(),
+                    self.ports.broker_health.value(),
+                    self.ports.control_https.value(),
+                ]
+                .into_iter()
+                .map(|port| port.to_string()),
+            );
+            mcp.assert_public_surfaces_redacted(protocol::operator(), protocol::reason(), &private_surfaces)
+        });
+        self.mcp.take();
+        if let Some(mut control) = self.control.take() {
+            control.stop().await?;
+        }
+        redaction_result
+    }
+}
+
+impl Drop for E2eHarness {
+    fn drop(&mut self) {
+        self.mcp.take();
+        self.control.take();
+        self.fixture.take();
+    }
+}
+
+struct FixtureAdmin {
+    runtime: rocketmq_runtime::RuntimeContext,
+    session: Option<MutationAdminSession>,
+    broker_port: u16,
+}
+
+impl FixtureAdmin {
+    async fn start(namesrv_port: u16, broker_port: u16) -> E2eResult<Self> {
+        let runtime = rocketmq_runtime::RuntimeContext::from_current("mcp-control-real-cluster-fixture");
+        let client_runtime = rocketmq_admin_core::mutation_client_adapter::create_mutation_client_runtime(
+            runtime.service_context("fixture-client"),
+        )
+        .map_err(|_| E2eError::new("create fixture mutation client runtime failed"))?;
+        let session = MutationAdminBuilder::new(client_runtime)
+            .namesrv_addr(format!("127.0.0.1:{namesrv_port}"))
+            .admin_group("mcp-control-e2e-fixture")
+            .instance_name("mcp-control-e2e-fixture")
+            .timeout_millis(5_000)
+            .build_and_start()
+            .await
+            .map_err(|_| E2eError::new("start fixture mutation Admin failed"))?;
+        Ok(Self {
+            runtime,
+            session: Some(session),
+            broker_port,
+        })
+    }
+
+    fn session(&mut self) -> E2eResult<&mut MutationAdminSession> {
+        self.session
+            .as_mut()
+            .ok_or_else(|| E2eError::new("fixture mutation Admin is shut down"))
+    }
+
+    async fn wait_for_broker(&mut self, topic: &str) -> E2eResult<()> {
+        let deadline = tokio::time::Instant::now() + REGISTRATION_TIMEOUT;
+        loop {
+            let failure =
+                match SupervisedMutationAdmin::preflight_broker_config_target(self.session()?, BROKER_CLUSTER, BROKER)
+                    .await
+                {
+                    Ok(_) => {
+                        match SupervisedMutationAdmin::preflight_topic_targets(
+                            self.session()?,
+                            &TopicMutationPreflightRequest {
+                                cluster: BROKER_CLUSTER.to_owned(),
+                                topic: topic.to_owned(),
+                                replacement: TopicReplacement {
+                                    read_queue_nums: 1,
+                                    write_queue_nums: 1,
+                                    perm: 6,
+                                    order: false,
+                                    message_type: TopicMessageType::Normal,
+                                },
+                            },
+                            &[BROKER.to_owned()],
+                        )
+                        .await
+                        {
+                            Ok(_) => return Ok(()),
+                            Err(error) => safe_admin_error(&error),
+                        }
+                    }
+                    Err(error) => safe_admin_error(&error),
+                };
+            if tokio::time::Instant::now() >= deadline {
+                return Err(E2eError::new(format!(
+                    "Broker did not register a usable mutation topology before deadline: {failure}"
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(150)).await;
+        }
+    }
+
+    async fn publish_and_seed_progress(&mut self, topic: &str, group: &str) -> E2eResult<()> {
+        let result = TopicMutationAdmin::send_topic_test_message(
+            self.session()?,
+            &TopicSendRequest {
+                topic: topic.to_owned(),
+                key: "mcp-e2e-key".to_owned(),
+                tag: "McpE2e".to_owned(),
+                message_body: MESSAGE_BODY.to_owned(),
+                trace_enabled: false,
+            },
+        )
+        .await
+        .map_err(|_| E2eError::new("typed fixture message publish failed"))?;
+        ensure(result.queue_offset == 0, "unexpected first fixture queue offset")?;
+        TopicMutationAdmin::reset_topic_consumer_offset(
+            self.session()?,
+            &ResetTopicConsumerOffsetRequest {
+                consumer_group: group.to_owned(),
+                topic: topic.to_owned(),
+                reset_timestamp: current_millis()?.saturating_add(1_000),
+                force: true,
+            },
+        )
+        .await
+        .map_err(|_| E2eError::new("typed fixture Consumer offset seed failed"))?;
+        Ok(())
+    }
+
+    async fn offset_rows(&mut self, topic: &str, group: &str, timestamp: i64) -> E2eResult<Vec<(i32, i64, i64)>> {
+        let plan = SupervisedMutationAdmin::preview_offset_reset(
+            self.session()?,
+            &rocketmq_admin_core::core::supervised_mutation::OffsetResetPreviewRequest {
+                cluster: BROKER_CLUSTER.to_owned(),
+                topic: topic.to_owned(),
+                consumer_group: group.to_owned(),
+                timestamp,
+                force: true,
+            },
+        )
+        .await
+        .map_err(|_| E2eError::new("typed fixture offset read failed"))?;
+        Ok(plan
+            .rows()
+            .into_iter()
+            .map(|row| (row.queue_id, row.current_offset, row.planned_offset))
+            .collect())
+    }
+
+    async fn broker_state(&mut self) -> E2eResult<BrokerMutationConfigState> {
+        let plan = SupervisedMutationAdmin::preflight_broker_config_target(self.session()?, BROKER_CLUSTER, BROKER)
+            .await
+            .map_err(|_| E2eError::new("typed fixture Broker config read failed"))?;
+        plan.targets()
+            .into_iter()
+            .find(|target| target.broker_name == BROKER)
+            .map(|target| target.state)
+            .ok_or_else(|| E2eError::new("typed fixture Broker config target was absent"))
+    }
+
+    async fn request_mode(&mut self, topic: &str, group: &str) -> E2eResult<Option<RequestModeValue>> {
+        let plan = SupervisedMutationAdmin::preflight_request_mode(
+            self.session()?,
+            &RequestModePreflightRequest {
+                cluster: BROKER_CLUSTER.to_owned(),
+                topic: topic.to_owned(),
+                consumer_group: group.to_owned(),
+                replacement: RequestModeValue {
+                    mode: RequestMode::Pull,
+                    pop_share_queue_num: 0,
+                },
+            },
+        )
+        .await
+        .map_err(|_| E2eError::new("typed fixture request-mode read failed"))?;
+        plan.targets()
+            .into_iter()
+            .find(|(broker, _)| broker == BROKER)
+            .map(|(_, value)| value)
+            .ok_or_else(|| E2eError::new("typed fixture request-mode target was absent"))
+    }
+
+    async fn cleanup_resources(
+        &mut self,
+        topic: &str,
+        group: &str,
+        topic_created: bool,
+        group_created: bool,
+    ) -> E2eResult<()> {
+        let broker_addr = format!("127.0.0.1:{}", self.broker_port);
+        if group_created {
+            ConsumerMutationAdmin::delete_subscription_groups(
+                self.session()?,
+                &DeleteSubscriptionGroupsRequest::try_new(broker_addr, vec![group.to_owned()], true)
+                    .map_err(|_| E2eError::new("build typed Consumer Group cleanup request failed"))?,
+            )
+            .await
+            .map_err(|_| E2eError::new("typed Consumer Group cleanup failed"))?;
+        }
+        if topic_created {
+            TopicMutationAdmin::delete_topic(
+                self.session()?,
+                &DeleteTopicAdminRequest {
+                    topic: topic.to_owned(),
+                    cluster_name: Some(BROKER_CLUSTER.to_owned()),
+                    broker_name: None,
+                },
+            )
+            .await
+            .map_err(|_| E2eError::new("typed Topic cleanup failed"))?;
+        }
+        Ok(())
+    }
+
+    async fn shutdown(&mut self) -> E2eResult<()> {
+        let session_result = match self.session.take() {
+            Some(mut session) => tokio::time::timeout(FIXTURE_STOP_TIMEOUT, session.shutdown())
+                .await
+                .map_err(|_| E2eError::new("fixture Admin shutdown deadline expired")),
+            None => Ok(()),
+        };
+        let runtime_result = self
+            .runtime
+            .shutdown_tasks(FIXTURE_STOP_TIMEOUT)
+            .await
+            .assert_no_task_leak()
+            .map_err(E2eError::new);
+        session_result.and(runtime_result)
+    }
+}
+
+impl Drop for FixtureAdmin {
+    fn drop(&mut self) {
+        self.session.take();
+        let _ = self.runtime.shutdown_tasks_now();
+    }
+}
+
+fn same_broker_config_values(left: BrokerMutationConfigState, right: BrokerMutationConfigState) -> bool {
+    left.auto_create_topic_enable == right.auto_create_topic_enable
+        && left.auto_create_subscription_group == right.auto_create_subscription_group
+        && left.broker_permission == right.broker_permission
+        && left.default_topic_queue_nums == right.default_topic_queue_nums
+        && left.message_index_enable == right.message_index_enable
+        && left.trace_topic_enable == right.trace_topic_enable
+}
+
+fn broker_state_json(state: BrokerMutationConfigState) -> Value {
+    serde_json::json!({
+        "generation": state.generation,
+        "autoCreateTopicEnable": state.auto_create_topic_enable,
+        "autoCreateSubscriptionGroup": state.auto_create_subscription_group,
+        "brokerPermission": state.broker_permission,
+        "defaultTopicQueueNums": state.default_topic_queue_nums,
+        "messageIndexEnable": state.message_index_enable,
+        "traceTopicEnable": state.trace_topic_enable,
+    })
+}
+
+fn broker_generation(response: &Value, section: &str) -> E2eResult<u64> {
+    response[section][BROKER]["generation"]
+        .as_u64()
+        .ok_or_else(|| E2eError::new(format!("Broker {section} state omitted its generation")))
+}
+
+fn single_broker_target(response: &Value) -> E2eResult<&Value> {
+    let targets = response["targets"]
+        .as_array()
+        .ok_or_else(|| E2eError::new("Broker response omitted its target array"))?;
+    ensure(
+        targets.len() == 1 && targets[0]["broker_name"] == BROKER,
+        "Broker response did not contain exactly the selected Broker target",
+    )?;
+    Ok(&targets[0])
+}
+
+fn topic_args(topic: &str, dry_run: bool, request_key: &str) -> Value {
+    serde_json::json!({
+        "schema_version": ARGUMENT_SCHEMA,
+        "cluster": CLUSTER,
+        "topic": topic,
+        "broker_names": [BROKER],
+        "read_queue_nums": 1,
+        "write_queue_nums": 1,
+        "perm": 6,
+        "order": false,
+        "message_type": "NORMAL",
+        "dry_run": dry_run,
+        "confirm": !dry_run,
+        "reason": protocol::reason(),
+        "request_key": request_key
+    })
+}
+
+fn group_args(group: &str, dry_run: bool, request_key: &str) -> Value {
+    serde_json::json!({
+        "schema_version": ARGUMENT_SCHEMA,
+        "cluster": CLUSTER,
+        "consumer_group": group,
+        "broker_names": [BROKER],
+        "consume_enable": true,
+        "consume_from_min_enable": false,
+        "consume_broadcast_enable": false,
+        "consume_message_orderly": false,
+        "retry_queue_nums": 1,
+        "retry_max_times": 16,
+        "broker_id": 0,
+        "which_broker_when_consume_slowly": 1,
+        "notify_consumer_ids_changed_enable": true,
+        "group_sys_flag": 0,
+        "consume_timeout_minute": 15,
+        "dry_run": dry_run,
+        "confirm": !dry_run,
+        "reason": protocol::reason(),
+        "request_key": request_key
+    })
+}
+
+fn offset_args(topic: &str, group: &str, timestamp: &str, dry_run: bool, request_key: &str) -> Value {
+    serde_json::json!({
+        "schema_version": ARGUMENT_SCHEMA,
+        "cluster": CLUSTER,
+        "topic": topic,
+        "consumer_group": group,
+        "timestamp": timestamp,
+        "force": true,
+        "dry_run": dry_run,
+        "confirm": !dry_run,
+        "reason": protocol::reason(),
+        "request_key": request_key
+    })
+}
+
+fn broker_args(trace_topic_enable: bool, dry_run: bool, request_key: &str) -> Value {
+    serde_json::json!({
+        "schema_version": ARGUMENT_SCHEMA,
+        "cluster": CLUSTER,
+        "broker_name": BROKER,
+        "properties": {"traceTopicEnable": trace_topic_enable.to_string()},
+        "dry_run": dry_run,
+        "confirm": !dry_run,
+        "reason": protocol::reason(),
+        "request_key": request_key
+    })
+}
+
+fn request_mode_args(topic: &str, group: &str, mode: &str, share: i32, dry_run: bool, key: &str) -> Value {
+    serde_json::json!({
+        "schema_version": ARGUMENT_SCHEMA,
+        "cluster": CLUSTER,
+        "topic": topic,
+        "consumer_group": group,
+        "mode": mode,
+        "pop_share_queue_num": share,
+        "timeout_millis": 5000,
+        "dry_run": dry_run,
+        "confirm": !dry_run,
+        "reason": protocol::reason(),
+        "request_key": key
+    })
+}
+
+fn write_namesrv_config(root: &Path, ports: &PortSet) -> E2eResult<PathBuf> {
+    let home = protocol::path_for_toml(&root.join("namesrv"));
+    let path = root.join("namesrv.toml");
+    let content = format!(
+        "rocketmqHome = \"{home}\"\nkvConfigPath = \"{home}/kvConfig.json\"\nconfigStorePath = \"{home}/namesrv.properties\"\nneedWaitForService = false\nlistenPort = {}\nbindAddress = \"127.0.0.1\"\n",
+        ports.namesrv.value()
+    );
+    std::fs::create_dir_all(root.join("namesrv")).e2e("create NameServer root")?;
+    std::fs::write(&path, content).e2e("write NameServer E2E configuration")?;
+    Ok(path)
+}
+
+fn write_broker_config(root: &Path, ports: &PortSet) -> E2eResult<PathBuf> {
+    let store = protocol::path_for_toml(&root.join("broker"));
+    let path = root.join("broker.toml");
+    let content = format!(
+        "[broker]\nlistenPort = {}\nbrokerIp1 = \"127.0.0.1\"\nstorePathRootDir = \"{store}\"\nnamesrvAddr = \"127.0.0.1:{}\"\nautoCreateTopicEnable = false\nautoCreateSubscriptionGroup = true\ntraceTopicEnable = false\n\n[broker.brokerIdentity]\nbrokerName = \"{BROKER}\"\nbrokerClusterName = \"{BROKER_CLUSTER}\"\nbrokerId = 0\n\n[broker.brokerServerConfig]\nbindAddress = \"127.0.0.1\"\n\n[store]\nstorePathRootDir = \"{store}\"\nhaListenAddress = \"127.0.0.1\"\nhaListenPort = {}\nmappedFileSizeCommitLog = 1048576\nmappedFileSizeConsumeQueue = 6000\nmappedFileSizeConsumeQueueExt = 65536\nmaxHashSlotNum = 1000\nmaxIndexNum = 4000\ntimerWheelEnable = false\n",
+        ports.broker.value(),
+        ports.namesrv.value(),
+        ports.broker_ha.value()
+    );
+    std::fs::create_dir_all(root.join("broker")).e2e("create Broker root")?;
+    std::fs::write(&path, content).e2e("write Broker E2E configuration")?;
+    Ok(path)
+}
+
+fn write_control_config(root: &Path, ports: &PortSet, audit_path: &Path) -> E2eResult<ControlConfigMaterial> {
+    let tls = protocol::write_tls_material(root)?;
+    let audit_path = protocol::path_for_toml(audit_path);
+    let path = root.join("control.toml");
+    let content = format!(
+        "[server]\nbind = \"127.0.0.1:{}\"\nendpoint = \"/mcp\"\npublic_base_url = \"https://{}\"\n\n[server.tls]\ncert_path = \"{cert_path}\"\nkey_path = \"{key_path}\"\n\n[oauth]\nissuer = \"https://issuer.example.test\"\naudience = \"rocketmq-mcp-control\"\njwks_url = \"https://issuer.example.test/jwks\"\n\n[mutations]\nmutations_enabled = true\ndry_run = true\nallowed_operations = [\"topic_upsert\", \"consumer_group_upsert\", \"consumer_offset_reset\", \"broker_config_patch\", \"consumer_request_mode\"]\nallowed_clusters = [\"{CLUSTER}\"]\noperation_timeout_seconds = 8\n\n[[clusters]]\nname = \"{CLUSTER}\"\nnamesrv_addr = \"127.0.0.1:{}\"\nuse_tls = false\n\n[audit]\npath = \"{audit_path}\"\ncapacity = 256\nmax_record_bytes = 4096\n",
+        ports.control_https.value(),
+        protocol::public_host(),
+        ports.namesrv.value(),
+        cert_path = tls.certificate_path,
+        key_path = tls.private_key_path,
+    );
+    std::fs::write(&path, content).e2e("write Control E2E configuration")?;
+    Ok(ControlConfigMaterial {
+        path,
+        tls_private_key_markers: tls.private_key_markers,
+    })
+}
+
+fn verify_audit(path: &Path, expected: &[ExpectedAudit]) -> E2eResult<()> {
+    let text = std::fs::read_to_string(path).e2e("read durable E2E audit file")?;
+    let records = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<AuditRecord>(line).e2e("decode durable E2E audit record"))
+        .collect::<E2eResult<Vec<_>>>()?;
+    ensure_audit_cardinality(expected.len(), records.len())?;
+    let mut invocations = BTreeMap::new();
+    for record in records {
+        invocations
+            .entry(record.invocation_id)
+            .or_insert_with(Vec::new)
+            .push(record);
+    }
+    ensure(
+        invocations.len() == EXPECTED_CALLS,
+        "audit invocation count was not exactly 22",
+    )?;
+    let mut observed = Vec::with_capacity(invocations.len());
+    for pair in invocations.values() {
+        ensure(pair.len() == 2, "an E2E audit invocation was not a pair")?;
+        let started = &pair[0];
+        let terminal = &pair[1];
+        ensure(
+            started.schema_version == AuditSchemaVersion::V2,
+            "audit start was not schema v2",
+        )?;
+        ensure(
+            started.event == AuditEvent::Started,
+            "audit pair did not begin with started",
+        )?;
+        ensure(
+            started.result == AuditResult::Started,
+            "audit start result was not started",
+        )?;
+        let terminal_event = match terminal.result {
+            AuditResult::Planned | AuditResult::Applied => AuditEvent::Completed,
+            AuditResult::Partial | AuditResult::Conflict | AuditResult::Failed | AuditResult::Started => {
+                AuditEvent::Failed
+            }
+        };
+        ensure(
+            terminal.event == terminal_event,
+            "audit terminal event did not match its result",
+        )?;
+        ensure(
+            started.operation == terminal.operation,
+            "audit operation changed within its pair",
+        )?;
+        ensure(started.mode == terminal.mode, "audit mode changed within its pair")?;
+        ensure(
+            started.cluster.as_str() == CLUSTER,
+            "audit start cluster mismatched the call",
+        )?;
+        ensure(
+            terminal.cluster.as_str() == CLUSTER,
+            "audit terminal cluster mismatched the call",
+        )?;
+        ensure(
+            started.operator.as_deref() == Some(protocol::operator())
+                && terminal.operator.as_deref() == Some(protocol::operator()),
+            "audit operator evidence was absent",
+        )?;
+        ensure(
+            started.reason.as_deref() == Some(protocol::reason())
+                && terminal.reason.as_deref() == Some(protocol::reason()),
+            "audit reason evidence was absent",
+        )?;
+        ensure(started.error_code.is_none(), "audit start carried an error code")?;
+        ensure(
+            started.duration_millis.is_none(),
+            "audit start carried a terminal duration",
+        )?;
+        ensure(terminal.duration_millis.is_some(), "audit terminal duration was absent")?;
+        ensure(
+            terminal.sequence > started.sequence,
+            "audit terminal did not follow its start sequence",
+        )?;
+        observed.push(ExpectedAudit {
+            operation: terminal.operation,
+            mode: terminal.mode,
+            result: terminal.result,
+            error_code: terminal.error_code,
+        });
+    }
+    let mut unmatched = expected.to_vec();
+    for actual in observed {
+        let Some(index) = unmatched.iter().position(|expected| *expected == actual) else {
+            return Err(E2eError::new(
+                "durable audit contained an unexpected terminal operation, mode, result, or code",
+            ));
+        };
+        unmatched.swap_remove(index);
+    }
+    ensure(unmatched.is_empty(), "durable audit omitted an expected invocation")?;
+    Ok(())
+}
+
+fn ensure_audit_cardinality(expected_calls: usize, observed_records: usize) -> E2eResult<()> {
+    ensure(
+        expected_calls == EXPECTED_CALLS,
+        format!("expected exactly {EXPECTED_CALLS} E2E calls, observed {expected_calls}"),
+    )?;
+    ensure(
+        observed_records == EXPECTED_AUDIT_RECORDS,
+        format!("expected exactly {EXPECTED_AUDIT_RECORDS} audit records, observed {observed_records}"),
+    )
+}
+
+fn millis_timestamp(millis: u64) -> E2eResult<String> {
+    let millis = i64::try_from(millis).e2e("convert E2E timestamp")?;
+    chrono::DateTime::<Utc>::from_timestamp_millis(millis)
+        .map(|time| time.to_rfc3339_opts(SecondsFormat::Millis, true))
+        .ok_or_else(|| E2eError::new("E2E timestamp was outside RFC3339 range"))
+}
+
+fn current_millis() -> E2eResult<u64> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .e2e("read E2E clock")?
+        .as_millis();
+    u64::try_from(millis).e2e("convert E2E clock")
+}
+
+fn unique_id() -> E2eResult<String> {
+    Ok(format!("{}_{}", std::process::id(), current_millis()?))
+}
+
+fn safe_admin_error(error: &AdminError) -> String {
+    match error {
+        AdminError::InvalidArgument { field, .. } => format!("invalid_argument:{field}"),
+        AdminError::NotFound { resource, .. } => format!("not_found:{resource}"),
+        AdminError::Backend {
+            operation,
+            code,
+            http_status,
+            retryable,
+            ..
+        } => format!(
+            "backend:{operation}:code={}:http={}:retryable={retryable}",
+            code.as_deref().unwrap_or("none"),
+            http_status.map_or_else(|| "none".to_owned(), |status| status.to_string())
+        ),
+        AdminError::SessionClosed => "session_closed".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_audit_cardinality;
+
+    #[test]
+    fn audit_cardinality_cannot_adapt_to_missing_calls_or_records() {
+        assert!(ensure_audit_cardinality(22, 44).is_ok());
+        assert!(ensure_audit_cardinality(21, 42).is_err());
+        assert!(ensure_audit_cardinality(22, 42).is_err());
+    }
+}

--- a/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/scenario.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/scenario.rs
@@ -94,6 +94,27 @@ struct ControlConfigMaterial {
     tls_private_key_markers: Vec<String>,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum RestorationState {
+    #[default]
+    Clean,
+    Required,
+}
+
+impl RestorationState {
+    fn before_execute(&mut self) {
+        *self = Self::Required;
+    }
+
+    fn complete(&mut self) {
+        *self = Self::Clean;
+    }
+
+    const fn is_required(self) -> bool {
+        matches!(self, Self::Required)
+    }
+}
+
 pub(super) struct E2eHarness {
     temp: Option<TempDir>,
     root: PathBuf,
@@ -114,9 +135,9 @@ pub(super) struct E2eHarness {
     broker_repeat_generation: Option<u64>,
     broker_restore_generation: Option<u64>,
     broker_restart_generation: Option<u64>,
-    broker_patch_touched: bool,
+    broker_restoration: RestorationState,
     request_mode_baseline: Option<RequestModeValue>,
-    request_mode_touched: bool,
+    request_mode_restoration: RestorationState,
     topic_created: bool,
     group_created: bool,
     cleanup_outcome: Option<Result<CleanupEvidence, String>>,
@@ -189,9 +210,9 @@ impl E2eHarness {
             broker_repeat_generation: None,
             broker_restore_generation: None,
             broker_restart_generation: None,
-            broker_patch_touched: false,
+            broker_restoration: RestorationState::default(),
             request_mode_baseline: None,
-            request_mode_touched: false,
+            request_mode_restoration: RestorationState::default(),
             topic_created: false,
             group_created: false,
             cleanup_outcome: None,
@@ -442,6 +463,7 @@ impl E2eHarness {
             "Broker dry-run changed the configuration or generation",
         )?;
 
+        self.broker_restoration.before_execute();
         let applied = self
             .invoke(
                 PATCH_BROKER_CONFIG_TOOL,
@@ -451,7 +473,6 @@ impl E2eHarness {
                 AuditResult::Applied,
             )
             .await?;
-        self.broker_patch_touched = true;
         ensure(
             applied["before"][BROKER] == broker_state_json(original),
             "Broker execute pre-state differed from its dry-run pre-state",
@@ -491,6 +512,7 @@ impl E2eHarness {
             "typed fixture did not observe the exact Broker configuration patch",
         )?;
 
+        self.broker_restoration.before_execute();
         let repeat = self
             .invoke(
                 PATCH_BROKER_CONFIG_TOOL,
@@ -559,6 +581,8 @@ impl E2eHarness {
             after_baseline_dry == before_baseline_dry,
             "request-mode baseline dry-run changed real Broker state",
         )?;
+        self.request_mode_baseline = Some(baseline);
+        self.request_mode_restoration.before_execute();
         self.invoke(
             SET_CONSUMER_REQUEST_MODE_TOOL,
             request_mode_args(&self.topic, &self.group, "pull", 0, false, "mode-exec-base"),
@@ -567,7 +591,6 @@ impl E2eHarness {
             AuditResult::Applied,
         )
         .await?;
-        self.request_mode_baseline = Some(baseline);
         ensure(
             self.fixture_mut()?.request_mode(&topic, &group).await?.as_ref() == Some(&baseline),
             "typed fixture did not observe the request-mode baseline",
@@ -587,6 +610,7 @@ impl E2eHarness {
             after_change_dry == before_change_dry,
             "request-mode change dry-run changed real Broker state",
         )?;
+        self.request_mode_restoration.before_execute();
         let changed = self
             .invoke(
                 SET_CONSUMER_REQUEST_MODE_TOOL,
@@ -596,7 +620,6 @@ impl E2eHarness {
                 AuditResult::Applied,
             )
             .await?;
-        self.request_mode_touched = true;
         ensure(
             changed["after"][BROKER]["mode"] == "pop" && changed["after"][BROKER]["pop_share_queue_num"] == 1,
             "request-mode change was not verified",
@@ -609,6 +632,7 @@ impl E2eHarness {
             self.fixture_mut()?.request_mode(&topic, &group).await?.as_ref() == Some(&expected),
             "typed fixture did not observe the exact request-mode change",
         )?;
+        self.request_mode_restoration.before_execute();
         let repeat = self
             .invoke(
                 SET_CONSUMER_REQUEST_MODE_TOOL,
@@ -782,8 +806,12 @@ impl E2eHarness {
         }
 
         let mut failures = Vec::new();
-        let needs_live_broker =
-            self.broker_patch_touched || self.request_mode_touched || self.topic_created || self.group_created;
+        let broker_restore_was_required = self.broker_restoration.is_required();
+        let request_mode_restore_was_required = self.request_mode_restoration.is_required();
+        let needs_live_broker = broker_restore_was_required
+            || request_mode_restore_was_required
+            || self.topic_created
+            || self.group_created;
         if needs_live_broker {
             if self.cluster.ensure_broker_running().await.is_err() {
                 failures.push("Broker was unavailable during cleanup".to_owned());
@@ -796,14 +824,14 @@ impl E2eHarness {
         }
 
         let request_mode_restored = self.restore_request_mode().await.unwrap_or(false);
-        if self.request_mode_touched && !request_mode_restored {
+        if request_mode_restore_was_required && !request_mode_restored {
             failures.push("Consumer request mode restoration failed".to_owned());
         }
         let broker_config_restored = self
             .restore_broker_config(None, "broker-cleanup-1")
             .await
             .unwrap_or(false);
-        if self.broker_patch_touched && !broker_config_restored {
+        if broker_restore_was_required && !broker_config_restored {
             failures.push("Broker configuration restoration failed".to_owned());
         }
 
@@ -852,8 +880,8 @@ impl E2eHarness {
             Ok(CleanupEvidence {
                 cluster_root_removed,
                 children_reaped,
-                broker_config_restored: !self.broker_patch_touched || broker_config_restored,
-                consumer_request_mode_restored: !self.request_mode_touched || request_mode_restored,
+                broker_config_restored: !broker_restore_was_required || broker_config_restored,
+                consumer_request_mode_restored: !request_mode_restore_was_required || request_mode_restored,
             })
         } else {
             Err(failures.join("; "))
@@ -863,7 +891,7 @@ impl E2eHarness {
     }
 
     async fn restore_broker_config(&mut self, expected_changed: Option<bool>, request_key: &str) -> E2eResult<bool> {
-        if !self.broker_patch_touched {
+        if !self.broker_restoration.is_required() {
             return Ok(true);
         }
         let Some(original) = self.original_broker_state else {
@@ -881,6 +909,7 @@ impl E2eHarness {
                 "Broker restoration did not start from the saved repeat generation",
             )?;
         }
+        self.broker_restoration.before_execute();
         let response = self
             .invoke(
                 PATCH_BROKER_CONFIG_TOOL,
@@ -921,12 +950,12 @@ impl E2eHarness {
             "typed fixture did not observe the exact Broker restoration generation and fields",
         )?;
         self.broker_restore_generation = Some(restored_generation);
-        self.broker_patch_touched = false;
+        self.broker_restoration.complete();
         Ok(true)
     }
 
     async fn restore_request_mode(&mut self) -> E2eResult<bool> {
-        if !self.request_mode_touched {
+        if !self.request_mode_restoration.is_required() {
             return Ok(true);
         }
         let Some(baseline) = self.request_mode_baseline else {
@@ -936,21 +965,29 @@ impl E2eHarness {
             RequestMode::Pull => ("pull", baseline.pop_share_queue_num),
             RequestMode::Pop => ("pop", baseline.pop_share_queue_num),
         };
-        self.invoke(
-            SET_CONSUMER_REQUEST_MODE_TOOL,
-            request_mode_args(&self.topic, &self.group, mode, share, false, "mode-restore-01"),
-            ControlOperation::ConsumerRequestMode,
-            AuditMode::Execute,
-            AuditResult::Applied,
-        )
-        .await?;
+        self.request_mode_restoration.before_execute();
+        let response = self
+            .invoke(
+                SET_CONSUMER_REQUEST_MODE_TOOL,
+                request_mode_args(&self.topic, &self.group, mode, share, false, "mode-restore-01"),
+                ControlOperation::ConsumerRequestMode,
+                AuditMode::Execute,
+                AuditResult::Applied,
+            )
+            .await?;
+        let response_restored =
+            response["after"][BROKER]["mode"] == mode && response["after"][BROKER]["pop_share_queue_num"] == share;
         let restored = self
             .fixture
             .as_mut()
             .ok_or_else(|| E2eError::new("fixture Admin is unavailable"))?
             .request_mode(&self.topic, &self.group)
             .await?;
-        Ok(restored.as_ref() == Some(&baseline))
+        let verified = response_restored && restored.as_ref() == Some(&baseline);
+        if verified {
+            self.request_mode_restoration.complete();
+        }
+        Ok(verified)
     }
 
     async fn stop_control(&mut self) -> E2eResult<()> {
@@ -1523,11 +1560,28 @@ fn safe_admin_error(error: &AdminError) -> String {
 #[cfg(test)]
 mod tests {
     use super::ensure_audit_cardinality;
+    use super::RestorationState;
 
     #[test]
     fn audit_cardinality_cannot_adapt_to_missing_calls_or_records() {
         assert!(ensure_audit_cardinality(22, 44).is_ok());
         assert!(ensure_audit_cardinality(21, 42).is_err());
         assert!(ensure_audit_cardinality(22, 42).is_err());
+    }
+
+    #[test]
+    fn restoration_state_survives_execute_error_and_clears_only_after_verified_restore() {
+        let mut state = RestorationState::default();
+        assert!(!state.is_required());
+
+        state.before_execute();
+        let invoke_result = Result::<(), ()>::Err(());
+        assert!(invoke_result.is_err());
+        assert!(state.is_required());
+
+        state.before_execute();
+        assert!(state.is_required());
+        state.complete();
+        assert!(!state.is_required());
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10004

### Brief Description

Closes #10004 when merged.

This change adds an explicitly opted-in, serial real-cluster E2E harness for the five reviewed RocketMQ MCP Control mutation tools. The harness starts repository-native Rust NameServer and Broker processes on dynamically reserved loopback ports, enters Control through authenticated TLS Streamable HTTP with local test-only RS256/JWKS material, and exercises the production mutation-only Admin adapter.

The scenario verifies Topic and Consumer Group upserts, per-queue offset reset, Broker configuration patch and exact restoration, Consumer request-mode change and restoration, Broker outage/recovery, Control restart with durable audit recovery, strict 22-call/44-record audit pairing, response and diagnostic redaction, and bounded idempotent resource cleanup. The production transport remains stateless and the test client echoes an MCP session header only when the server supplies one.

The runner requires no external services, fixed ports, credentials, or containers. Docker was only probed read-only during development; this implementation neither creates nor requires Docker resources. The boundary checker excludes only the dedicated nested test module from production subprocess scanning and continues to validate the production dependency and transport boundary.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-mcp-control -- --check`: passed on the latest head.
- `cargo check --locked`: passed before the final restoration-state hardening.
- `cargo check --locked --features write-tools`: passed before the final restoration-state hardening.
- `cargo test --locked`: passed before the final restoration-state hardening.
- `cargo test --locked --features write-tools`: passed before the final restoration-state hardening with the real-cluster target intentionally ignored.
- `cargo test --locked --features write-tools --lib transport::real_cluster_e2e:: -- --test-threads=1`: passed before the final restoration-state hardening: 10 passed and 1 explicitly ignored.
- Focused latest-head regression `transport::real_cluster_e2e::scenario::tests::restoration_state_survives_execute_error_and_clears_only_after_verified_restore`: passed, 1 test.
- `python scripts/check_control_boundary.py`: passed before the final restoration-state hardening; that increment changes only the dedicated test module excluded from production-source scanning.
- `scripts/run_real_cluster_e2e.ps1 -Help`: rendered the explicit opt-in usage before the final restoration-state hardening.
- `scripts/run_real_cluster_e2e.ps1`: passed before the final failure-path restoration hardening with exit code 0: 1 passed, 0 failed, in 2.92 seconds. The scenario enforced exactly 22 authenticated calls and 44 durable version-2 audit records, restored Broker configuration and Consumer request mode, reaped all owned children, and removed the ephemeral cluster root.
- External cleanup probes before and after that successful E2E run found zero owned NameServer/Broker processes and zero owned temporary roots.
- `git diff --check` and staged diff checking: passed on the latest head.

The final increment only moves restoration bookkeeping ahead of mutation attempts and retains restoration responsibility after failure. It does not change the successful request path, MCP call count, audit count, or owned-process lifecycle, so the real-cluster E2E was not repeated after independent review of that focused hardening.

The workspace-wide `cargo fmt --all -- --check` route reached the known Windows command-line length limitation (`os error 206`) earlier in implementation; the latest package-scoped formatter check above passed. Broader Clippy, documentation, query-contract, routing, and root-workspace checks were not repeated for this test-only stage under the proportional local-validation policy. CI was not polled.
