### PR TITLE
[ISSUE #10017]🐛Fix strict Clippy failures in RocketMQ MCP Control E2E tests

### DIFF
--- a/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/process.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/process.rs
@@ -478,15 +478,7 @@ fn push_path_redactions(redactions: &mut Vec<String>, path: &Path) {
 fn sanitize_diagnostic(input: &str, redactions: &[String]) -> String {
     let mut diagnostic = strip_terminal_sequences(input)
         .chars()
-        .map(|character| {
-            if character == '\r' || character == '\n' || character == '\t' {
-                ' '
-            } else if character.is_control() {
-                ' '
-            } else {
-                character
-            }
-        })
+        .map(|character| if character.is_control() { ' ' } else { character })
         .collect::<String>();
     for sensitive in redactions {
         if !sensitive.is_empty() {

--- a/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/protocol.rs
+++ b/rocketmq-ai/rocketmq-mcp-control/src/transport/real_cluster_e2e/protocol.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::path::Path;
@@ -71,19 +70,17 @@ pub(super) struct GeneratedTlsMaterial {
 pub(super) struct StaticJwks;
 
 impl JwksSource for StaticJwks {
-    fn fetch(&self) -> impl Future<Output = Result<Vec<u8>, AuthError>> + Send {
-        async {
-            serde_json::to_vec(&serde_json::json!({"keys": [{
-                "kty": "RSA",
-                "kid": "e2e-key",
-                "alg": "RS256",
-                "use": "sig",
-                "key_ops": ["verify"],
-                "n": RSA_N,
-                "e": "AQAB"
-            }]}))
-            .map_err(|_| AuthError::Unavailable)
-        }
+    async fn fetch(&self) -> Result<Vec<u8>, AuthError> {
+        serde_json::to_vec(&serde_json::json!({"keys": [{
+            "kty": "RSA",
+            "kid": "e2e-key",
+            "alg": "RS256",
+            "use": "sig",
+            "key_ops": ["verify"],
+            "n": RSA_N,
+            "e": "AQAB"
+        }]}))
+        .map_err(|_| AuthError::Unavailable)
     }
 }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #10017
- Fixes #10017

### Brief Description

- Simplify the test-only process diagnostic sanitizer so all control characters follow the same existing replacement behavior.
- Implement the test-only static JWKS source with a native async trait method and remove its obsolete `Future` import.
- Keep production code, cluster lifecycle behavior, documentation, and the broker child process stack configuration unchanged.

### How Did You Test This Change?

- `cargo clippy --locked --all-targets --all-features -- -D warnings` (passed with exit code 0 on the reviewed two-file diff; not repeated during delivery)
- `cargo test --locked --all-features transport::real_cluster_e2e` (11 passed, 1 ignored; the ignored real-cluster scenario was not executed; not repeated during delivery)
- `cargo fmt -p rocketmq-mcp-control -- --check` (passed on the final commit content)
- `git diff --check` (passed on the final commit content)
- The real-cluster E2E scenario was not rerun because this patch does not change runtime configuration or cluster behavior.
