### PR TITLE
[ISSUE #10016]📝Complete RocketMQ MCP tool references and operations runbooks

### DIFF
--- a/rocketmq-ai/rocketmq-mcp-control/README.md
+++ b/rocketmq-ai/rocketmq-mcp-control/README.md
@@ -5,6 +5,10 @@ standalone Cargo project and is not part of the root workspace. The reviewed `wr
 exactly five typed tools: Topic and Consumer Group upsert, consumer offset reset, Broker configuration patch,
 and consumer request mode. The default build contains neither Admin Core nor production mutation tools.
 
+Read the [reviewed mutation Tool Reference](docs/tool-reference.md) before operating the server. The
+[operations runbook](docs/operations-runbook.md) covers rollout, rollback, audit, and emergency stop-write
+handling; the [real-cluster E2E runbook](docs/e2e-runbook.md) covers the opt-in local harness and its cleanup.
+
 ## Security boundary
 
 - Streamable MCP is served only over an enforcing TLS listener. There is no plaintext or stdio transport.

--- a/rocketmq-ai/rocketmq-mcp-control/docs/e2e-runbook.md
+++ b/rocketmq-ai/rocketmq-mcp-control/docs/e2e-runbook.md
@@ -1,0 +1,85 @@
+# RocketMQ MCP Control real-cluster E2E runbook
+
+This runbook operates the checked-in ignored real-cluster test. It validates the five reviewed
+Control MCP mutations against an ephemeral local Rust NameServer and Broker. It is not a production
+deployment procedure and it does not add a delete MCP Tool.
+
+## Preconditions
+
+- PowerShell 7 or a compatible PowerShell host is available.
+- Cargo and the repository's locked Rust toolchain can build the repository NameServer and Broker binaries
+  and the standalone Control project.
+- Run from `rocketmq-ai/rocketmq-mcp-control` in a working tree with the repository source available above it.
+- Ensure the host can reserve loopback ports and create temporary files. The harness chooses its own unique
+  loopback ports and temporary root.
+
+Docker is not a runner dependency. The test does not create a Docker container, image, network, Compose stack,
+or volume. It may be run on a local development machine that also has Docker installed, but the runner itself
+uses only the repository's Rust binaries and an owned process harness.
+
+## Run the scenario
+
+Read the runner usage first:
+
+```powershell
+.\scripts\run_real_cluster_e2e.ps1 -Help
+```
+
+Then start the scenario:
+
+```powershell
+.\scripts\run_real_cluster_e2e.ps1
+```
+
+The script builds `rocketmq-namesrv-rust` and `rocketmq-broker-rust` from the repository manifest, resolves
+their output locations through Cargo metadata, sets the test-only opt-in environment, and runs exactly one
+ignored test with `--test-threads=1`. The test remains ignored unless the runner explicitly sets
+`ROCKETMQ_MCP_CONTROL_REAL_CLUSTER_E2E=1`; do not run it as part of ordinary unit tests.
+
+## What the harness proves
+
+The harness starts and owns an isolated Rust NameServer and Broker on dynamically reserved loopback ports. It
+then starts the real TLS Streamable HTTP Control MCP server with the real Admin mutation factory and a
+test-only RS256/JWK identity seam. It exercises all five reviewed tools over TLS MCP:
+
+1. Topic upsert: dry-run, execute, and idempotent execution.
+2. Consumer Group upsert: dry-run, execute, and idempotent execution.
+3. Consumer offset reset: dry-run, execute, idempotent execution, and per-queue readback.
+4. Broker configuration patch: dry-run, execute, idempotent execution, and exact restoration of all six
+   reviewed Broker fields with a monotonic generation.
+5. Consumer request mode: baseline dry-run/execute, changed dry-run/execute, idempotent execution, and exact
+   baseline restoration.
+
+The scenario makes 22 authenticated TLS MCP calls and verifies 44 durable
+`rocketmq-mcp-control.audit.v2` records: one `started` and one terminal record per call. It checks closed
+operation, mode, result/error-code relationship, safe cluster/operator/reason evidence, sequence ordering, and
+terminal duration. It also exercises a Broker outage and restart, a Control restart with audit recovery, and a
+post-restart successful dry-run.
+
+## State restoration and failure handling
+
+Before a mutable fixture step, the harness records the relevant original state. Cleanup restores all six
+Broker configuration fields—`autoCreateTopicEnable`, `autoCreateSubscriptionGroup`, `brokerPermission`,
+`defaultTopicQueueNums`, `messageIndexEnable`, and `traceTopicEnable`—and restores the Consumer request mode.
+It conditionally removes only the uniquely named test Topic and Consumer Group that it created using the
+underlying typed test fixture (the `McpE2eTopic_` and `McpE2eGroup_` prefixes); no MCP delete Tool is
+registered or required.
+
+The harness owns its NameServer, Broker, Control server, fixture state, and a unique temporary root created
+with the `rocketmq-mcp-control-e2e-` prefix. It uses bounded readiness, liveness, shutdown, kill/wait, and
+drop cleanup. On a successful run it asserts that owned children were reaped and the temporary root was
+removed; cleanup is idempotent. On failure, inspect sanitized harness diagnostics, which redact filesystem
+paths, and handle only resources whose harness ownership can be proved. Do not terminate unrelated RocketMQ
+processes, delete a shared store, or remove an unknown temporary directory.
+
+If restoration or cleanup reports a failure, keep the test failure evidence and let the harness-owned cleanup
+handle resources it can prove it created. A fixed test prefix is not sufficient evidence by itself; never
+delete an uncertain process, directory, Topic, Group, or Broker state. Reconcile the recorded Broker and
+request-mode state through an authorized path before another run. Do not turn the test into a broad cleanup
+command and do not add a delete operation to the Control MCP surface.
+
+## Expected completion evidence
+
+A passing runner exits zero and reports completion after the test verifies state restoration and reaping. The
+expected proof is one serial ignored test pass together with its fixed 22 TLS MCP invocation and 44 durable v2
+audit-record checks. The runner restores the environment variables that it temporarily owns before returning.

--- a/rocketmq-ai/rocketmq-mcp-control/docs/operations-runbook.md
+++ b/rocketmq-ai/rocketmq-mcp-control/docs/operations-runbook.md
@@ -56,3 +56,81 @@ JSONL is recovered in place and is never rewritten; new writes are version 2 onl
 To stop new mutations, set `mutations_enabled=false` and restart. Removing an operation or cluster from the
 server allowlist also requires restart. Keep the service unavailable until incomplete or partial targets are
 reconciled explicitly; the control server never retries conflicts or invents compensating mutations.
+
+## Controlled rollout
+
+Use a narrow, reversible rollout. The configuration is read only during startup; neither
+`mutations_enabled` nor either allowlist hot reloads.
+
+1. Build the `write-tools` variant and deploy it with the checked-in default configuration:
+   `mutations_enabled=false`, `dry_run=true`, and empty mutation allowlists.
+2. Confirm TLS and the remote OAuth resource-server configuration. Authentication uses RS256 JWT signatures
+   verified against HTTPS JWKS; this identity verification is unrelated to, and does not introduce, a
+   change-plan signature or approval provider.
+3. Configure the private logical cluster registry, durable audit destination, and only the intended
+   operation and cluster allowlists. After those prerequisites are in place, set
+   `mutations_enabled=true` and restart the service. The initial `false` value is a pre-deployment
+   safety state; no write Tool can be discovered until this enable-and-restart step completes.
+4. Authenticate an authorized principal and inspect `tools/list` plus
+   `rocketmq-control://capabilities`. Confirm that the visible catalog is the intended subset, not merely
+   that the feature was compiled.
+5. Send a dry-run for each operation being introduced. Review the complete aggregate `before`, `requested`,
+   ordered target evidence, warnings, and any `partial` signal before considering an execute call.
+6. Execute only the reviewed dry-run payload with `dry_run=false`, `confirm=true`, and a safe reason. Check
+   the structured result rather than HTTP delivery alone.
+7. Read the durable audit trail for a `started` record and its matching terminal v2 record. Confirm the
+   operation, cluster alias, mode, result, terminal error code, sequence ordering, and duration. Operator
+   and reason are audit-only evidence and must not be copied from public responses or logs.
+8. Expand to another allowed operation or cluster only by editing the startup configuration and repeating
+   the same restart, discovery, dry-run, execute, and audit review sequence.
+
+This is intentionally an operational sequence, not an approval system: it adds no plan hash, fingerprint,
+signature for a change plan, or release gate.
+
+## Rollback and result handling
+
+Keep the complete pre-change state from the dry-run/result before execution. Use a new typed restore request
+with the normal explicit confirmation and reason only when that Tool can express the recorded `before` state.
+Topic and Consumer Group creation has no delete Tool, an offset reset has no exact per-queue restore, and an
+absent Consumer request mode cannot be restored through a set operation. For those cases, preserve the
+evidence and use a separately authorized operational path; do not invent a generic compensating command,
+CLI, RPC, or delete operation. Do not reuse a request key with different content.
+
+| Result or code | Meaning | Required operator action |
+| --- | --- | --- |
+| `planned` | Dry-run produced a sealed candidate without mutation. | Review it; no rollback is needed. |
+| `applied` | Every target verified, including `changed=false` idempotent success. | Record the terminal audit evidence and continue normal monitoring. |
+| `precondition_conflict` / `conflict` | Sealed state changed before the conditional write. | Re-run dry-run, compare new state, and choose a new explicit action; never automatic-retry. |
+| `partial_apply` / `partial` | Some targets persisted or verified and others did not. | Treat returned `targets`, `before`, `after`, persistence, and verification fields as source of truth; reconcile each target explicitly before retrying. |
+| `verification_failed` | A write may have persisted but complete post-read verification or order reconciliation failed. | Preserve the result, inspect the affected logical target using an authorized operational path, then restore or complete the intended state with a new typed request. |
+| `audit_unavailable` | Durable audit recovery, append, or timeout failed. | Stop mutation attempts and repair/recover the audit sink before retrying. A failed `started` record means no session/RPC began. |
+| `timeout`, `cancelled`, or `shutdown_failed` | The request/session lifecycle did not reach a normal terminal path. | Wait for/reconcile the durable terminal audit state and target state before any new request. |
+| `execution_failed` or `operation_unavailable` | The typed operation/session cannot complete or is not registered. | Correct deployment/runtime policy or the underlying authorized service condition; do not substitute a CLI, shell, or arbitrary RPC. |
+
+For rollback of server policy rather than a RocketMQ resource, restore the prior configuration file and restart
+the Control process. After restart, repeat authenticated `tools/list` and capability-resource verification;
+configuration edits do not take effect in a running process.
+
+## Emergency stop-write procedure
+
+Use this procedure for an immediate policy stop. It stops new mutation Tool registration; it does not erase
+audit records or mutate any RocketMQ state.
+
+1. Edit the active Control configuration and set `mutations_enabled=false`. Keep `dry_run=true`; reducing
+   `allowed_operations` and `allowed_clusters` is optional defense in depth, not a substitute for disabling
+   mutations.
+2. Restart the Control process. There is no hot reload for this setting.
+3. With an authenticated request, call `tools/list`. Verify that no reviewed write Tool is present:
+   `rocketmq_upsert_topic`, `rocketmq_upsert_consumer_group`, `rocketmq_reset_consumer_offset`,
+   `rocketmq_patch_broker_config`, and `rocketmq_set_consumer_request_mode` must all be absent.
+4. Read `rocketmq-control://capabilities`. Verify
+   `mutations_runtime_enabled=false`, `registered_operations=0`, and `mutation_supported=false`.
+   In a `write-tools` binary, `write_tools_compiled` can remain true; compile availability is intentionally
+   distinct from runtime enablement and registration.
+5. Preserve and inspect existing durable audit records. Reconcile any already-started, partial, failed, or
+   verification-incomplete operations through the returned target evidence before permitting new writes.
+
+To restore writes, reverse the configuration change only after the incident is resolved: set
+`mutations_enabled=true`, restore only the necessary closed operation/cluster allowlists, restart, verify the
+capability fields and intended `tools/list` catalog, then begin again with dry-run. There is no emergency
+override, generic delete Tool, shell, or free-form RPC.

--- a/rocketmq-ai/rocketmq-mcp-control/docs/tool-reference.md
+++ b/rocketmq-ai/rocketmq-mcp-control/docs/tool-reference.md
@@ -114,6 +114,207 @@ Endpoints remain internal.
 }
 ```
 
+## Complete request examples
+
+The following are complete `tools/call.params.arguments` values for the five reviewed Tools. They
+use only the checked-in `rocketmq-mcp-control.arguments.v1` schema. A dry-run is a plan request and
+therefore uses `dry_run=true` with `confirm=false`; it does not require `reason`. Every execute
+example sets `dry_run=false`, `confirm=true`, and a safe, bounded reason. The logical `cluster`
+must be allowed by both the principal and server cluster allowlists, and the operation must be
+allowed by both their operation allowlists. Broker names are not allowlisted in either policy; each
+must instead be a member of the selected cluster topology.
+
+### `rocketmq_upsert_topic`
+
+Dry-run:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "topic": "orders",
+  "broker_names": ["broker-a"],
+  "read_queue_nums": 8,
+  "write_queue_nums": 8,
+  "perm": 6,
+  "order": false,
+  "message_type": "NORMAL",
+  "dry_run": true,
+  "confirm": false
+}
+```
+
+Execute:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "topic": "orders",
+  "broker_names": ["broker-a"],
+  "read_queue_nums": 8,
+  "write_queue_nums": 8,
+  "perm": 6,
+  "order": false,
+  "message_type": "NORMAL",
+  "dry_run": false,
+  "confirm": true,
+  "reason": "CHG-10016 create orders Topic"
+}
+```
+
+### `rocketmq_upsert_consumer_group`
+
+Dry-run:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "consumer_group": "orders-consumer",
+  "broker_names": ["broker-a"],
+  "consume_enable": true,
+  "consume_from_min_enable": false,
+  "consume_broadcast_enable": false,
+  "consume_message_orderly": false,
+  "retry_queue_nums": 1,
+  "retry_max_times": 16,
+  "broker_id": 0,
+  "which_broker_when_consume_slowly": 1,
+  "notify_consumer_ids_changed_enable": true,
+  "group_sys_flag": 0,
+  "consume_timeout_minute": 15,
+  "dry_run": true,
+  "confirm": false
+}
+```
+
+Execute:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "consumer_group": "orders-consumer",
+  "broker_names": ["broker-a"],
+  "consume_enable": true,
+  "consume_from_min_enable": false,
+  "consume_broadcast_enable": false,
+  "consume_message_orderly": false,
+  "retry_queue_nums": 1,
+  "retry_max_times": 16,
+  "broker_id": 0,
+  "which_broker_when_consume_slowly": 1,
+  "notify_consumer_ids_changed_enable": true,
+  "group_sys_flag": 0,
+  "consume_timeout_minute": 15,
+  "dry_run": false,
+  "confirm": true,
+  "reason": "CHG-10016 configure orders Consumer Group"
+}
+```
+
+### `rocketmq_reset_consumer_offset`
+
+Dry-run:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "topic": "orders",
+  "consumer_group": "orders-consumer",
+  "timestamp": "2026-09-04T12:00:00Z",
+  "force": false,
+  "dry_run": true,
+  "confirm": false
+}
+```
+
+Execute:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "topic": "orders",
+  "consumer_group": "orders-consumer",
+  "timestamp": "2026-09-04T12:00:00Z",
+  "force": false,
+  "dry_run": false,
+  "confirm": true,
+  "reason": "CHG-10016 reset orders Consumer offset"
+}
+```
+
+### `rocketmq_patch_broker_config`
+
+Dry-run:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "broker_name": "broker-a",
+  "properties": {
+    "traceTopicEnable": "true"
+  },
+  "dry_run": true,
+  "confirm": false
+}
+```
+
+Execute:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "broker_name": "broker-a",
+  "properties": {
+    "traceTopicEnable": "true"
+  },
+  "dry_run": false,
+  "confirm": true,
+  "reason": "CHG-10016 enable trace Topic"
+}
+```
+
+### `rocketmq_set_consumer_request_mode`
+
+Dry-run:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "topic": "orders",
+  "consumer_group": "orders-consumer",
+  "mode": "pop",
+  "pop_share_queue_num": 4,
+  "timeout_millis": 12000,
+  "dry_run": true,
+  "confirm": false
+}
+```
+
+Execute:
+
+```json
+{
+  "schema_version": "rocketmq-mcp-control.arguments.v1",
+  "cluster": "production-a",
+  "topic": "orders",
+  "consumer_group": "orders-consumer",
+  "mode": "pop",
+  "pop_share_queue_num": 4,
+  "timeout_millis": 12000,
+  "dry_run": false,
+  "confirm": true,
+  "reason": "CHG-10016 enable orders pop mode"
+}
+```
+
 ## Result contract
 
 Every successful tool invocation returns `rocketmq-mcp-mutation.v1` structured content. Each tool schema fixes
@@ -149,6 +350,8 @@ mutation schema before those checks pass.
 
 | Code | Trigger | Operator action |
 | --- | --- | --- |
+| `invalid_config` | Control startup or session creation cannot read, parse, validate, bind, or resolve configured transport, TLS, OAuth/JWKS, cluster, runtime, or credential-reference inputs. | Correct the referenced Control configuration and protected TLS/credential inputs, then restart. Do not retry a Tool until initialization succeeds. |
+| `request_rejected` | The `Host` does not exactly match the configured public host, or a supplied `Origin` does not exactly match the configured public HTTPS origin. | Send the request to the configured public HTTPS origin with the exact `Host` and, when present, matching `Origin`; do not bypass the origin policy. |
 | `unauthorized` | Bearer authentication fails, or the OAuth subject violates the audit-operator grammar | Issue a valid RS256 token with a documented operator ID; never retry a malformed or unsafe subject unchanged. |
 | `permission_denied` | OAuth principal lacks `rocketmq:write` | Request the write scope; do not retry unchanged credentials. |
 | `cluster_not_allowed` | Cluster alias is invalid or outside the principal/server intersection | Use an allowed logical alias or update both policies. |

--- a/rocketmq-ai/rocketmq-mcp/README.md
+++ b/rocketmq-ai/rocketmq-mcp/README.md
@@ -8,6 +8,8 @@ Production release gates, external-cluster expectations, and rollback guidance a
 [production validation guide](docs/production-validation.md).
 The checked-in surface and validation baseline are listed in the
 [implementation baseline](docs/implementation-baseline.md).
+The complete argument, output, pagination, authorization, and example reference for the checked-in Tool catalog is
+available in the [Tool Reference](docs/tool-reference.md).
 
 ## What It Is
 

--- a/rocketmq-ai/rocketmq-mcp/docs/tool-reference.md
+++ b/rocketmq-ai/rocketmq-mcp/docs/tool-reference.md
@@ -1,0 +1,729 @@
+# RocketMQ MCP Tool Reference
+
+This reference documents the checked-in Query MCP catalog. It is derived from the default and
+`change-planning` Tool contracts in `src/tools/catalog.rs` and their checked-in schema snapshots. The
+default catalog has 24 Tools; enabling `change-planning` adds five non-mutating planning Tools for a
+total of 29. Use `tools/list` as the live authority for the caller-visible subset.
+
+All default Tools have `readOnlyHint=true`, `destructiveHint=false`, and do not create a RocketMQ
+Admin mutation session. See the authorization matrix for discovery and call-time checks. Logical
+aliases such as `cluster`, `proxy_name`, and fields explicitly marked logical in the argument
+tables are not network addresses.
+
+## Authorization scope matrix
+
+Each Tool has a risk level and requires the corresponding principal scope. For HTTP, scopes come
+from verified OAuth claims. For stdio, `Principal::local(profile)` synthesizes them: every profile
+gets `rocketmq:read`; `diagnose`, `diagnostic`, and `operator` also get `rocketmq:diagnose`; and
+`plan` and `operator` also get `rocketmq:plan`.
+
+| Risk level | Required scope |
+| --- | --- |
+| ReadOnly | `rocketmq:read` |
+| Diagnose | `rocketmq:diagnose` |
+| Plan | `rocketmq:plan` |
+
+`tools/list` discovery checks only the principal scope and the role's Tool allow/deny rule. It does
+not check configured clusters, the principal cluster claim, tenant binding, or runtime
+`allow_change_planning`; discovery therefore does not prove that a call will be accepted. At
+call-time, an explicit `cluster` is checked against server configuration, the role cluster rule,
+the principal `rocketmq_clusters` claim when present, and the configured tenant binding. A planning
+call also checks the compiled feature and runtime `allow_change_planning=true` then.
+
+The two inventory Tools permit `cluster` omission. Their server-default/sole-configured-cluster
+fallback therefore has no per-cluster authorization or tenant check at call-time; do not treat an
+omitted-cluster inventory request as a stronger per-cluster authorization guarantee.
+
+Unless a Tool section says otherwise, input objects reject unknown fields and have no mutually
+exclusive fields. Examples are `tools/call.params.arguments` objects. Each response example is a
+representative JSON fragment: every actual success carries the complete common envelope.
+
+## Common input validation
+
+The following checked-in validation rules are referenced by every argument table below. They apply
+after JSON type validation. An optional argument typed `... or null` defaults to `null` when
+omitted unless the relevant table says otherwise. This maps every `cursor` and `filter` entry and
+the nullable planning fields below; `limit` is the stated exception with a default of 50.
+
+| Input category | Contract |
+| --- | --- |
+| `cursor` | Optional opaque continuation from `data.next_cursor`, at most 256 bytes. It is not a client-defined offset or address. |
+| Inventory `filter` | Optional Topic or Consumer Group inventory filter: trim it, convert ASCII letters to lowercase, and require at most 1,024 bytes. |
+| Exact identifier | Trimmed nonempty identifier of 1--255 bytes. This category applies to Topic, Consumer Group, Producer Group, and message identifiers. |
+| Logical alias | Trimmed 1--100 byte ASCII token using only letters, digits, `.`, `_`, and `-`. `.` and `..` are permitted; IP literals, socket/endpoint forms, `:`, `/`, `\\`, `@`, `=`, `&`, `?`, and control characters are rejected. |
+| Broker logger | Original (not case-normalized) value of at most 128 bytes which must be an allowlisted `rocketmq_broker::` module path. |
+| Configuration-state Broker selection | A nonempty 1--64 element selection of logical aliases; it is sorted and deduplicated before lookup. |
+| HA selection | `broker_names` is zero through 64 logical aliases. `controller_names` is zero through 32 non-duplicate logical aliases; a nonempty `controller_names` list requires `include_sync_state=true`. |
+| Controller metadata selection | `controller_names` is zero through 32 non-duplicate logical aliases. |
+
+For `rocketmq_list_topics` and `rocketmq_list_consumer_groups`, an omitted or `null` `cluster`
+selects the explicit default cluster only when one is configured; otherwise it is valid only when
+the server configuration contains exactly one cluster. In every other case the request is invalid.
+
+## Common response and paging behavior
+
+Successful calls return the `rocketmq-mcp.v2` envelope with `schema_version`, `request_id`,
+`cluster`, `observed_at`, `freshness_ms`, `cache_status`, `partial`, `warnings`, and typed
+`data`. `cache_status` is `hit`, `miss`, or `bypass`. `source_failures` is serialized only when it
+is nonempty: entries are sanitized, sorted and deduplicated, capped at 16, make `partial=true`,
+and add `source_failures_present` to `warnings`. If the cap is exceeded, `warnings` also includes
+`source_failures_truncated` and the response remains partial. `warnings` can also include
+`output_rows_truncated`. The controlled Query/Admin projections omit addresses, credentials,
+tokens, message bodies, and other configured sensitive values.
+
+The paginated Tools use `limit` and `cursor`. `limit` is an optional unsigned integer from 1 through
+200 and defaults to 50. `cursor` follows the common 256-byte opaque-cursor rule. Paged `data`
+contains `items`, `count`, `total_count`, `has_more`, and `next_cursor`. More than 1,000 output
+rows are truncated, with `partial=true` and `output_rows_truncated`. A serialized response over
+1 MiB instead fails with `OutputTooLarge` (`output_too_large`); it is not returned as a truncated
+partial response.
+
+```json
+{
+  "schema_version": "rocketmq-mcp.v2",
+  "request_id": "request-opaque",
+  "cluster": "production-a",
+  "observed_at": "2026-09-04T12:00:00Z",
+  "freshness_ms": 0,
+  "cache_status": "miss",
+  "partial": false,
+  "warnings": [],
+  "data": {
+    "cluster": "production-a"
+  }
+}
+```
+
+## Default read-only catalog (24 Tools)
+
+### `rocketmq_get_cluster_overview`
+
+**Purpose and access.** Summarizes Brokers plus Topic and Consumer Group counts for one configured
+cluster. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+
+**Output.** `data` contains the logical cluster, `brokers` summaries, `topic_count`,
+`consumer_group_count`, and `generated_at`.
+
+```json
+{"cluster":"production-a"}
+```
+
+```json
+{"cluster":"production-a","data":{"topic_count":42,"consumer_group_count":9,"brokers":[{"broker_name":"broker-a","broker_active":true}]}}
+```
+
+### `rocketmq_list_topics`
+
+**Purpose and access.** Lists a bounded, optionally filtered Topic page. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string or null | no | Optional logical alias; omission/`null` follows the explicit-default or sole-configured-cluster rule. |
+| `filter` | string or null | no | Optional Topic inventory filter; trim, ASCII-lowercase, at most 1,024 bytes. |
+| `limit` | integer or null | no | Page limit, 1--200; defaults to 50. |
+| `cursor` | string or null | no | Opaque continuation from the preceding response, at most 256 bytes. |
+
+**Output.** Paged `data.items` contains Topic entries with their visible cluster and optional
+consumer-group context.
+
+```json
+{"cluster":"production-a","filter":"orders","limit":25}
+```
+
+```json
+{"cluster":"production-a","data":{"items":[{"topic":"orders","cluster":"production-a","consumer_group":null}],"count":1,"total_count":1,"has_more":false,"next_cursor":null}}
+```
+
+### `rocketmq_describe_topic`
+
+**Purpose and access.** Describes one Topic with bounded queue-route data. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `topic` | string | yes | Exact Topic name. |
+| `limit` | integer or null | no | Queue-route page limit, 1--200; defaults to 50. |
+| `cursor` | string or null | no | Opaque queue-route continuation, at most 256 bytes. |
+
+**Output.** `data` identifies the Topic and returns its bounded route/queue observations with normal
+page metadata. Internal Broker addresses are not serialized.
+
+```json
+{"cluster":"production-a","topic":"orders","limit":50}
+```
+
+```json
+{"cluster":"production-a","data":{"topic":"orders","brokers":[],"items":[],"count":0,"total_count":0,"has_more":false,"next_cursor":null}}
+```
+
+### `rocketmq_get_topic_route`
+
+**Purpose and access.** Returns bounded route data for one Topic. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `topic` | string | yes | Exact Topic name. |
+| `limit` | integer or null | no | Route page limit, 1--200; defaults to 50. |
+| `cursor` | string or null | no | Opaque route continuation, at most 256 bytes. |
+
+**Output.** `data` contains the Topic's Broker and queue route observations with page metadata;
+address-bearing source fields remain omitted.
+
+```json
+{"cluster":"production-a","topic":"orders"}
+```
+
+```json
+{"cluster":"production-a","data":{"topic":"orders","brokers":[],"items":[],"count":0,"total_count":0,"has_more":false,"next_cursor":null}}
+```
+
+### `rocketmq_list_consumer_groups`
+
+**Purpose and access.** Lists a bounded, optionally filtered Consumer Group page and consumption
+summaries. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string or null | no | Optional logical alias; omission/`null` follows the explicit-default or sole-configured-cluster rule. |
+| `filter` | string or null | no | Optional Consumer Group inventory filter; trim, ASCII-lowercase, at most 1,024 bytes. |
+| `limit` | integer or null | no | Page limit, 1--200; defaults to 50. |
+| `cursor` | string or null | no | Opaque continuation, at most 256 bytes. |
+
+**Output.** Paged `data.items` contains the visible Consumer Group records and the standard page
+metadata.
+
+```json
+{"cluster":"production-a","filter":"orders","limit":25}
+```
+
+```json
+{"cluster":"production-a","data":{"items":[],"count":0,"total_count":0,"has_more":false,"next_cursor":null}}
+```
+
+### `rocketmq_get_consumer_lag`
+
+**Purpose and access.** Gets bounded per-queue lag for one Topic and Consumer Group. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `topic` | string | yes | Exact Topic name. |
+| `consumer_group` | string | yes | Exact Consumer Group name. |
+| `limit` | integer or null | no | Queue page limit, 1--200; defaults to 50. |
+| `cursor` | string or null | no | Opaque continuation. |
+
+**Output.** Paged `data` contains per-queue current, broker, and lag observations plus page
+metadata.
+
+```json
+{"cluster":"production-a","topic":"orders","consumer_group":"orders-consumer","limit":50}
+```
+
+```json
+{"cluster":"production-a","data":{"topic":"orders","consumer_group":"orders-consumer","items":[],"count":0,"total_count":0,"has_more":false,"next_cursor":null}}
+```
+
+### `rocketmq_describe_broker`
+
+**Purpose and access.** Describes one logical Broker's state. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `broker_name` | string | yes | Trimmed nonempty exact identifier, 1--255 bytes; used only for Broker-name lookup, not as a network endpoint. It does not apply logical-alias or endpoint-shaped rejection. |
+
+**Output.** `data` contains the logical Broker, bounded Broker summaries, and `generated_at`; the
+source NameServer address is not serialized.
+
+```json
+{"cluster":"production-a","broker_name":"broker-a"}
+```
+
+```json
+{"cluster":"production-a","data":{"broker_name":"broker-a","brokers":[{"broker_name":"broker-a","broker_active":true}]}}
+```
+
+### `rocketmq_get_broker_diagnostics`
+
+**Purpose and access.** Returns bounded readiness, store, recovery, HA, and security diagnostics for
+one logical Broker. It is read-only and **diagnose** risk.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `broker_name` | string | yes | Logical Broker name. |
+
+**Output.** `data` includes the diagnostics schema version, observed time, Broker diagnostic rows,
+unavailable-Broker count, and sanitized warnings.
+
+```json
+{"cluster":"production-a","broker_name":"broker-a"}
+```
+
+```json
+{"cluster":"production-a","data":{"broker_name":"broker-a","diagnostics_schema_version":"rocketmq-broker-diagnostics.v1","unavailable_brokers":0,"brokers":[{"broker_name":"broker-a","coverage":"available"}]}}
+```
+
+### `rocketmq_get_broker_config_summary`
+
+**Purpose and access.** Reads the fixed allowlisted configuration summary for one logical Broker. It
+is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `broker_name` | string | yes | Logical Broker name. |
+
+**Output.** `data.brokers` reports generation and the fixed summary fields; it never returns a
+free-form configuration dump.
+
+```json
+{"cluster":"production-a","broker_name":"broker-a"}
+```
+
+```json
+{"cluster":"production-a","data":{"broker_name":"broker-a","brokers":[{"broker_name":"broker-a","generation":12,"send_message_thread_pool_nums":8}]}}
+```
+
+### `rocketmq_get_broker_log_filter_state`
+
+**Purpose and access.** Reads temporary filter state for one allowlisted `rocketmq_broker` logger
+target. It is read-only and **diagnose** risk.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `broker_name` | string | yes | Logical Broker name. |
+| `logger` | string | yes | Original form, at most 128 bytes, and an allowlisted `rocketmq_broker::` module path. |
+
+**Output.** `data.brokers` reports support, logger, optional `INFO` or `DEBUG` level, temporary
+operation identifiers, and expiry only when available.
+
+```json
+{"cluster":"production-a","broker_name":"broker-a","logger":"rocketmq_broker::processor"}
+```
+
+```json
+{"cluster":"production-a","data":{"broker_name":"broker-a","logger":"rocketmq_broker::processor","brokers":[{"broker_name":"broker-a","supported":true,"level":"INFO"}]}}
+```
+
+### `rocketmq_get_proxy_drain_state`
+
+**Purpose and access.** Reads bounded drain progress for one configured logical Proxy. It is
+read-only and **diagnose** risk.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `proxy_name` | string | yes | Configured logical Proxy alias. |
+
+**Output.** `data` reports phase, admission/routing/readiness flags, zero-pending state, and bounded
+pending counters.
+
+```json
+{"cluster":"production-a","proxy_name":"proxy-a"}
+```
+
+```json
+{"cluster":"production-a","data":{"proxy_name":"proxy-a","admission_open":true,"routing_open":true,"readiness_published":true,"zero_pending":false}}
+```
+
+### `rocketmq_diagnose_consumer_lag`
+
+**Purpose and access.** Correlates read-only lag, route, and Broker evidence into a diagnosis report.
+It is read-only and **diagnose** risk; callers cannot supply a time range or thresholds.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `topic` | string | yes | Exact Topic name. |
+| `consumer_group` | string | yes | Exact Consumer Group name. |
+
+**Output.** `data` is the versioned diagnosis report, including its evidence snapshot, findings,
+recommendations, and sanitized warnings.
+
+```json
+{"cluster":"production-a","topic":"orders","consumer_group":"orders-consumer"}
+```
+
+```json
+{"cluster":"production-a","data":{"summary":"No lag diagnosis finding was produced","root_causes":[],"recommendations":[]}}
+```
+
+### `rocketmq_list_consumer_connections`
+
+**Purpose and access.** Lists a bounded page of pseudonymous consumer connections for one exact
+Consumer Group. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `consumer_group` | string | yes | Exact Consumer Group name. |
+| `limit` | integer or null | no | Page limit, 1--200; defaults to 50. |
+| `cursor` | string or null | no | Opaque continuation. |
+
+**Output.** Paged `data.items` has logical Broker names, pseudonymous `client_alias`, language,
+version, and optional update time; client addresses are not exposed.
+
+```json
+{"cluster":"production-a","consumer_group":"orders-consumer","limit":25}
+```
+
+```json
+{"cluster":"production-a","data":{"consumer_group":"orders-consumer","items":[{"broker_name":"broker-a","client_alias":"consumer-1","language":"RUST","version":1}],"count":1,"total_count":1,"has_more":false,"next_cursor":null}}
+```
+
+### `rocketmq_list_producer_connections`
+
+**Purpose and access.** Lists a bounded page of pseudonymous producer connections for one exact
+Topic and Producer Group. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `topic` | string | yes | Exact Topic name. |
+| `producer_group` | string | yes | Exact Producer Group name. |
+| `limit` | integer or null | no | Page limit, 1--200; defaults to 50. |
+| `cursor` | string or null | no | Opaque continuation. |
+
+**Output.** Paged `data.items` has pseudonymous connection observations and page metadata.
+
+```json
+{"cluster":"production-a","topic":"orders","producer_group":"orders-producer","limit":25}
+```
+
+```json
+{"cluster":"production-a","data":{"topic":"orders","producer_group":"orders-producer","items":[{"broker_name":"broker-a","client_alias":"producer-1","language":"RUST","version":1}],"count":1,"total_count":1,"has_more":false,"next_cursor":null}}
+```
+
+### `rocketmq_get_message_metadata`
+
+**Purpose and access.** Reads fixed body-free metadata for one message using process-lifetime aliases.
+It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `message_id` | string | yes | Exact message identifier. |
+
+**Output.** `data` supplies aliases, Topic, optional born/stored times, queue position, size, flags,
+reconsume count, and transaction offset. Message body and address data are absent.
+
+```json
+{"cluster":"production-a","message_id":"message-opaque"}
+```
+
+```json
+{"cluster":"production-a","data":{"message_alias":"message-1","unique_message_alias":null,"topic":"orders","queue_id":0,"queue_offset":42,"store_size":128}}
+```
+
+### `rocketmq_get_topic_config_state`
+
+**Purpose and access.** Reads version-CAS observations for one Topic at selected logical Brokers. It
+is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `topic` | string | yes | Exact Topic name. |
+| `broker_names` | array of strings | yes | 1--64 logical aliases; sorted and deduplicated configuration-state selection. |
+
+**Output.** `data.brokers` returns each Broker's version, queue counts, and ordering state.
+
+```json
+{"cluster":"production-a","topic":"orders","broker_names":["broker-a"]}
+```
+
+```json
+{"cluster":"production-a","data":{"topic":"orders","brokers":[{"broker_name":"broker-a","version":12,"read_queue_nums":8,"write_queue_nums":8,"order":false}]}}
+```
+
+### `rocketmq_get_consumer_group_config_state`
+
+**Purpose and access.** Reads version-CAS Consumer Group observations at selected logical Brokers.
+It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `group` | string | yes | Exact Consumer Group name. |
+| `broker_names` | array of strings | yes | 1--64 logical aliases; sorted and deduplicated configuration-state selection. |
+
+**Output.** `data.brokers` contains group configuration observations including version, retries,
+timeouts, consume flags, and Broker selection fields.
+
+```json
+{"cluster":"production-a","group":"orders-consumer","broker_names":["broker-a"]}
+```
+
+```json
+{"cluster":"production-a","data":{"group":"orders-consumer","brokers":[{"broker_name":"broker-a","version":12,"retry_max_times":16,"retry_queue_nums":1,"consume_enable":true}]}}
+```
+
+### `rocketmq_get_topic_stats`
+
+**Purpose and access.** Returns a bounded snapshot page of deterministic per-queue Topic statistics
+and aggregate totals. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `topic` | string | yes | Exact Topic name. |
+| `limit` | integer or null | no | Queue page limit, 1--200; defaults to 50. |
+| `cursor` | string or null | no | Opaque continuation. |
+
+**Output.** `data` includes deterministic per-queue items, normal page metadata, and complete
+aggregate totals.
+
+```json
+{"cluster":"production-a","topic":"orders","limit":50}
+```
+
+```json
+{"cluster":"production-a","data":{"topic":"orders","items":[],"count":0,"total_count":0,"has_more":false,"next_cursor":null}}
+```
+
+### `rocketmq_get_topic_config`
+
+**Purpose and access.** Reads fixed address-free Topic configuration observations and semantic
+differences across Brokers. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `topic` | string | yes | Exact Topic name. |
+
+**Output.** `data` contains observations per logical Broker and explicit inconsistent fields, not a
+free-form Broker configuration.
+
+```json
+{"cluster":"production-a","topic":"orders"}
+```
+
+```json
+{"cluster":"production-a","data":{"topic":"orders","brokers":[{"broker_name":"broker-a","read_queue_nums":8,"write_queue_nums":8}],"inconsistent_fields":[]}}
+```
+
+### `rocketmq_get_consumer_group_details`
+
+**Purpose and access.** Reads fixed address-free configuration and connection observations for one
+Consumer Group. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `consumer_group` | string | yes | Exact Consumer Group name. |
+
+**Output.** `data` contains the Group's configuration and connection observations, with endpoints
+and credential material omitted.
+
+```json
+{"cluster":"production-a","consumer_group":"orders-consumer"}
+```
+
+```json
+{"cluster":"production-a","data":{"consumer_group":"orders-consumer","brokers":[{"broker_name":"broker-a"}],"total_connection_count":0}}
+```
+
+### `rocketmq_get_consumer_progress`
+
+**Purpose and access.** Returns a bounded snapshot page of deterministic per-queue progress and
+complete aggregate totals. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `consumer_group` | string | yes | Exact Consumer Group name. |
+| `limit` | integer or null | no | Queue page limit, 1--200; defaults to 50. |
+| `cursor` | string or null | no | Opaque continuation. |
+
+**Output.** `data` includes per-queue progress rows, normal page metadata, and aggregate totals.
+
+```json
+{"cluster":"production-a","consumer_group":"orders-consumer","limit":50}
+```
+
+```json
+{"cluster":"production-a","data":{"consumer_group":"orders-consumer","items":[],"count":0,"total_count":0,"has_more":false,"next_cursor":null}}
+```
+
+### `rocketmq_get_ha_status`
+
+**Purpose and access.** Reads bounded HA observations for logical master Brokers, optionally with
+configured Controller synchronization state. It is read-only and **diagnose** risk.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `broker_names` | array of strings | no | Defaults to `[]`; zero through 64 logical master aliases. |
+| `include_sync_state` | boolean | no | Defaults to `false`; must be `true` when `controller_names` is nonempty. |
+| `controller_names` | array of strings | no | Defaults to `[]`; zero through 32 non-duplicate logical Controller aliases. |
+
+**Output.** `data` contains bounded Broker HA observations and, when requested and available,
+Controller synchronization observations.
+
+```json
+{"cluster":"production-a","broker_names":["broker-a"],"include_sync_state":true,"controller_names":["controller-a"]}
+```
+
+```json
+{"cluster":"production-a","data":{"brokers":[{"broker_name":"broker-a","broker_id":0,"in_sync_slave_count":1}],"controller_sync_states":[]}}
+```
+
+### `rocketmq_get_controller_metadata`
+
+**Purpose and access.** Reads bounded metadata for configured logical Controllers. It is read-only
+and **diagnose** risk.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+| `controller_names` | array of strings | no | Defaults to `[]`; zero through 32 non-duplicate logical Controller aliases. |
+
+**Output.** `data.controllers` provides group, leadership, peer-count, and log-index observations
+where available.
+
+```json
+{"cluster":"production-a","controller_names":["controller-a"]}
+```
+
+```json
+{"cluster":"production-a","data":{"controllers":[{"controller_name":"controller-a","is_leader":true,"peer_count":3}]}}
+```
+
+### `rocketmq_get_nameserver_config_summary`
+
+**Purpose and access.** Reads fixed allowlisted configuration values and differences for configured
+NameServers. It is read-only.
+
+| Argument | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `cluster` | string | yes | Configured logical cluster alias. |
+
+**Output.** `data.nameservers` contains the fixed summary fields and `inconsistent_fields`; it never
+returns a free-form NameServer configuration dump.
+
+```json
+{"cluster":"production-a"}
+```
+
+```json
+{"cluster":"production-a","data":{"nameservers":[{"nameserver_name":"nameserver-a","values":{"cluster_test":false}}],"inconsistent_fields":[]}}
+```
+
+## Optional `change-planning` catalog (5 Tools)
+
+`change-planning` is compiled separately and remains disabled until runtime policy permits it. Each
+Tool has `readOnlyHint=true` and produces a plan only: none has Apply mode, confirmation, operator
+identity, or a RocketMQ mutation API call. The `ToolResponse<ChangePlan>.data` object reports
+`mutates_cluster=false`, planned changes, impact analysis, and rollback suggestions. Do not treat a
+generated plan as authorization to change a cluster.
+
+All five inputs reject unknown fields. Each has required string `cluster`, required string `reason`,
+and required object `desired`. The Guard authorizes `cluster` against a configured cluster before
+the current-state query; planning does not add a separate logical-alias normalization. `reason` is
+an ordinary required string. There are no mutually exclusive fields declared by these contracts.
+The rules column identifies the current-state query validation that applies after decoding, if any.
+
+Planning output is intentionally not a redacted Resource projection. It returns `reason`, and
+`planned_changes` can echo `config_value` and other desired strings. Never put credentials, tokens,
+secrets, or other sensitive values in any planning input.
+
+### `rocketmq_plan_create_topic`
+
+**Purpose.** Generates a non-mutating Topic creation plan.
+
+| `desired` field | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `topic` | string | yes | Current planner does no extra runtime normalization; schema type is only string. |
+| `read_queue_nums` | integer (`u32`) or null | no | Defaults to `null`; minimum 0. |
+| `write_queue_nums` | integer (`u32`) or null | no | Defaults to `null`; minimum 0. |
+| `perm` | string or null | no | Defaults to `null`; no additional scalar bound in this schema. |
+
+```json
+{"cluster":"production-a","reason":"capacity preparation","desired":{"topic":"orders","read_queue_nums":8,"write_queue_nums":8,"perm":"read_write"}}
+```
+
+```json
+{"schema_version":"rocketmq-mcp.v2","request_id":"request-opaque","cluster":"production-a","observed_at":"2026-09-04T12:00:00Z","freshness_ms":0,"cache_status":"bypass","partial":false,"warnings":[],"data":{"mutates_cluster":false,"plan_type":"create_topic"}}
+```
+
+### `rocketmq_plan_update_topic_config`
+
+**Purpose.** Generates a non-mutating Topic configuration update plan.
+
+| `desired` field | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `topic` | string | yes | Passed to `describe_topic`: trimmed nonempty exact identifier, 1--255 bytes. |
+| `config_key` | string | yes | No additional scalar bound in this schema. |
+| `config_value` | string | yes | No additional scalar bound in this schema. |
+
+```json
+{"cluster":"production-a","reason":"review config change","desired":{"topic":"orders","config_key":"message.type","config_value":"normal"}}
+```
+
+```json
+{"schema_version":"rocketmq-mcp.v2","request_id":"request-opaque","cluster":"production-a","observed_at":"2026-09-04T12:00:00Z","freshness_ms":0,"cache_status":"bypass","partial":false,"warnings":[],"data":{"mutates_cluster":false,"plan_type":"update_topic_config"}}
+```
+
+### `rocketmq_plan_update_topic_permissions`
+
+**Purpose.** Generates a non-mutating Topic permission update plan.
+
+| `desired` field | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `topic` | string | yes | Passed to `describe_topic`: trimmed nonempty exact identifier, 1--255 bytes. |
+| `perm` | string | yes | No additional scalar bound in this schema. |
+
+```json
+{"cluster":"production-a","reason":"review access change","desired":{"topic":"orders","perm":"read_write"}}
+```
+
+```json
+{"schema_version":"rocketmq-mcp.v2","request_id":"request-opaque","cluster":"production-a","observed_at":"2026-09-04T12:00:00Z","freshness_ms":0,"cache_status":"bypass","partial":false,"warnings":[],"data":{"mutates_cluster":false,"plan_type":"update_topic_permissions"}}
+```
+
+### `rocketmq_plan_update_broker_config`
+
+**Purpose.** Generates a non-mutating Broker configuration update plan.
+
+| `desired` field | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `broker_name` | string | yes | Passed to `describe_broker`: trimmed nonempty exact identifier, 1--255 bytes. |
+| `config_key` | string | yes | No additional scalar bound in this schema. |
+| `config_value` | string | yes | No additional scalar bound in this schema. |
+
+```json
+{"cluster":"production-a","reason":"review broker configuration","desired":{"broker_name":"broker-a","config_key":"flushDiskType","config_value":"ASYNC_FLUSH"}}
+```
+
+```json
+{"schema_version":"rocketmq-mcp.v2","request_id":"request-opaque","cluster":"production-a","observed_at":"2026-09-04T12:00:00Z","freshness_ms":0,"cache_status":"bypass","partial":false,"warnings":[],"data":{"mutates_cluster":false,"plan_type":"update_broker_config"}}
+```
+
+### `rocketmq_plan_reset_consumer_offset`
+
+**Purpose.** Generates a non-mutating Consumer offset reset plan.
+
+| `desired` field | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `topic` | string | yes | Passed to `query_consumer_lag`: trimmed nonempty exact identifier, 1--255 bytes. |
+| `consumer_group` | string | yes | Passed to `query_consumer_lag`: trimmed nonempty exact identifier, 1--255 bytes. |
+| `target_offset` | integer (`i64`/int64) or null | no | Defaults to `null`; no additional scalar bound in this schema. |
+| `timestamp_millis` | integer (`i64`/int64) or null | no | Defaults to `null`; no additional scalar bound in this schema. |
+
+`target_offset` and `timestamp_millis` are both optional in the schema; the schema declares no
+mutual-exclusion rule for them.
+
+```json
+{"cluster":"production-a","reason":"review offset recovery","desired":{"topic":"orders","consumer_group":"orders-consumer","target_offset":42}}
+```
+
+```json
+{"schema_version":"rocketmq-mcp.v2","request_id":"request-opaque","cluster":"production-a","observed_at":"2026-09-04T12:00:00Z","freshness_ms":0,"cache_status":"bypass","partial":false,"warnings":[],"data":{"mutates_cluster":false,"plan_type":"reset_consumer_offset"}}
+```


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #10016
- Fixes #10016

### Brief Description

- Add `rocketmq-ai/rocketmq-mcp/docs/tool-reference.md` with the checked-in 24-tool default catalog, five optional non-mutating planning tools, argument contracts, output semantics, authorization boundaries, limits, and safe request/response examples.
- Complete dry-run and execute examples plus error guidance in `rocketmq-ai/rocketmq-mcp-control/docs/tool-reference.md`.
- Expand `rocketmq-ai/rocketmq-mcp-control/docs/operations-runbook.md` with controlled rollout, rollback, audit, failure handling, and an emergency stop-write verification checklist.
- Add `rocketmq-ai/rocketmq-mcp-control/docs/e2e-runbook.md` for the existing opt-in Rust NameServer/Broker harness, state restoration, and owned-resource cleanup.
- Link the references and runbooks from both project READMEs. This is a six-file, Markdown-only documentation change; it does not change the Website or add HTML output.

### How Did You Test This Change?

- A focused static contract/document check passed on the final branch: the two checked-in Query snapshots contain 24 default tools plus five planning tools; all 29 headings match source order; 29 four-column argument tables cover their schema fields; 59 Query JSON examples and 74 JSON blocks across the six documents parse; all five Control tools have complete dry-run and execute examples; all 18 source error codes are documented; and all 10 relative links resolve.
- `git diff --check` passed, and both new files have final newlines with no trailing whitespace.
- `./scripts/run_real_cluster_e2e.ps1 -Help` passed from the Control project on the final branch. The real-cluster scenario was not rerun.
- During the initial documentation implementation on base `f5b4b581`, `cargo doc --locked --no-deps --all-features` passed from the Control project and `./scripts/check-agents-routing.ps1` passed from the repository root. Later revisions changed only Markdown, and the rebase added only the two test-only lint fixes from #10022, so these commands were not repeated on this delivery head.
- The Control Clippy blocker was resolved by merged PR #10022 at `e2421bf7`. Its candidate diff passed `cargo clippy --locked --all-targets --all-features -- -D warnings` with exit code 0 before merge; this documentation delivery did not rerun Clippy.
- No CI or additional release gate was run for this Markdown-only change.
