### PR TITLE
[ISSUE #10026]🐛Fix unused imports in Linux sendfile tests and benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **fix(transport):** Remove the unused `RuntimeConfig` import that breaks Linux file-send benchmark compilation with warnings denied ([#10026](https://github.com/mxsm/rocketmq-rust/issues/10026))
+- **fix(transport):** Remove unused `RuntimeConfig` imports that break Linux sendfile test and benchmark compilation with warnings denied ([#10026](https://github.com/mxsm/rocketmq-rust/issues/10026))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix(transport):** Remove the unused `RuntimeConfig` import that breaks Linux file-send benchmark compilation with warnings denied ([#10026](https://github.com/mxsm/rocketmq-rust/issues/10026))
+
 ### Added
 
 - **test(remoting):** Add comprehensive test coverage for `QueryMessageResponseHeader` including integration with RemotingCommand, boundary checks, and error handling

--- a/rocketmq-transport/benches/linux_file_send.rs
+++ b/rocketmq-transport/benches/linux_file_send.rs
@@ -24,7 +24,6 @@ mod linux_bench {
     use criterion::Throughput;
     use rocketmq_protocol::protocol::RemotingCommand;
     use rocketmq_runtime::BlockingExecutor;
-    use rocketmq_runtime::RuntimeConfig;
     use rocketmq_runtime::RuntimeOwner;
     use rocketmq_transport::api::FileRegion;
     use rocketmq_transport::api::FileTransferMode;

--- a/rocketmq-transport/tests/linux_sendfile.rs
+++ b/rocketmq-transport/tests/linux_sendfile.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_protocol::protocol::RemotingCommand;
-use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
 use rocketmq_transport::api::file_transfer_snapshot;
 use rocketmq_transport::api::ConnectionState;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10026

### Brief Description

Remove unused `RuntimeConfig` imports from `rocketmq-transport/tests/linux_sendfile.rs` and `rocketmq-transport/benches/linux_file_send.rs`. Both already use `RuntimeOwner::new()` without a configuration argument, so the stale imports cause Linux compilation to fail when warnings are denied. Test and benchmark behavior is unchanged. Record the fix in the Unreleased changelog.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check` - passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed on Windows with Rust 1.95.0.
- `CARGO_TARGET_DIR=target/linux-sendfile-validation cargo clippy -p rocketmq-transport --test linux_sendfile --bench linux_file_send --features linux-sendfile,test-support -- -D warnings` - passed on WSL Ubuntu 24.04 with the repository toolchain, compiling both Linux-only targets.
- `git diff --check` - passed.
- `python scripts/error_architecture_guard.py` - failed (exit 1) with 16 pre-existing findings, detailed below. All affected production source files and the guard script are identical to `origin/main`, verified with `git diff --exit-code origin/main HEAD -- rocketmq-broker/src rocketmq-transport/src scripts/error_architecture_guard.py` (passed). This PR only removes test and benchmark imports and updates the changelog.

Existing error architecture findings:

- Generic processor response mapping: `rocketmq-broker/src/processor/notification_processor/core.rs` at lines 60, 87, 104, and 124 requires typed error-response helpers or allowlist entries.
- Source stringification: `rocketmq-broker/src/lib.rs` at lines 106, 109, 149, 155, 170, 182, 187, 190, 219, and 235, and `rocketmq-broker/src/pop/profile_store.rs` at line 310 requires typed source wrappers or allowlist entries.
- Sensitive debug output: `rocketmq-transport/src/clients/rocketmq_tokio_client/endpoint_state.rs` at line 41 requires a manual redacted `Debug` implementation.

No behavior tests were added for this import-only code change.
