### PR TITLE
[ISSUE #10030]📝Fix workspace Rustdoc warnings and outdated links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docs:** Fix Rustdoc generic type markup, broken public links, and references to private items across the workspace ([#10030](https://github.com/mxsm/rocketmq-rust/issues/10030))
 - **fix(transport):** Remove unused `RuntimeConfig` imports that break Linux sendfile test and benchmark compilation with warnings denied ([#10026](https://github.com/mxsm/rocketmq-rust/issues/10026))
 
 ### Added

--- a/rocketmq-auth/src/authorization/model/environment.rs
+++ b/rocketmq-auth/src/authorization/model/environment.rs
@@ -53,7 +53,7 @@ impl Environment {
     /// Returns true if this environment matches `other` according to rules:
     /// - if self.source_ips empty -> true
     /// - if other's source_ips empty -> false
-    /// - target = other.source_ips[0]; check if any src pattern in self matches target
+    /// - `target = other.source_ips[0]`; check if any src pattern in self matches target
     pub fn is_match(&self, other: &Environment) -> bool {
         if self.source_ips.is_empty() {
             return true;

--- a/rocketmq-broker/src/client/manager/consumer_manager.rs
+++ b/rocketmq-broker/src/client/manager/consumer_manager.rs
@@ -126,7 +126,7 @@ pub struct ConsumerManager {
     consumer_table: Arc<DashMap<CheetahString, ConsumerGroupInfo>>,
     /// Compensation table for consumers without heartbeat
     consumer_compensation_table: Arc<DashMap<CheetahString, ConsumerGroupInfo>>,
-    /// Topic -> Set<Group> reverse index for fast topic-to-group lookup
+    /// `Topic -> Set<Group>` reverse index for fast topic-to-group lookup
     topic_group_table: Arc<DashMap<CheetahString, HashSet<CheetahString>>>,
     /// Canonical session -> all consumer groups registered by that session.
     session_to_groups: Arc<DashMap<SessionId, HashSet<CheetahString>>>,
@@ -150,7 +150,7 @@ pub struct ConsumerManager {
     /// Striped serialization for canonical client-session multi-index transitions.
     session_transition_locks: Arc<ClientSessionTransitionLocks>,
     /// Listeners notified on consumer registration/unregistration events
-    /// Uses Arc<RwLock<Vec>> to support dynamic listener registration at runtime
+    /// Uses `Arc<RwLock<Vec>>` to support dynamic listener registration at runtime
     consumer_ids_change_listener_list: Arc<RwLock<Vec<ConsumerListener>>>,
     /// Optional broker statistics manager (set once during initialization)
     broker_stats_manager: Option<Weak<BrokerStatsManager>>,

--- a/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
+++ b/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
@@ -65,7 +65,7 @@ use crate::trace::trace_dispatcher::Type;
 /// Default implementation of a lite pull consumer.
 ///
 /// This is the main entry point for creating and using a lite pull consumer. It acts as a facade
-/// over the internal implementation ([`DefaultLitePullConsumerImpl`]) and provides:
+/// over the internal implementation (`DefaultLitePullConsumerImpl`) and provides:
 ///
 /// - Configuration management via [`DefaultLitePullConsumerBuilder`]
 /// - Namespace handling (automatic topic name wrapping/unwrapping)

--- a/rocketmq-client/src/consumer/lite_pull_consumer.rs
+++ b/rocketmq-client/src/consumer/lite_pull_consumer.rs
@@ -405,7 +405,7 @@ pub trait MessagePoll: Send + Sync {
     /// # Performance
     ///
     /// Message contents are not copied. For workloads processing messages without long-term
-    /// storage, this eliminates allocation overhead compared to [`poll()`].
+    /// storage, this eliminates allocation overhead compared to [`poll()`](Self::poll).
     ///
     /// # Examples
     ///
@@ -430,7 +430,7 @@ pub trait MessagePoll: Send + Sync {
     /// Fetches the next batch of messages without allocating owned copies, with a specified
     /// timeout.
     ///
-    /// Behaves identically to [`poll_zero_copy()`], but waits up to `timeout` milliseconds
+    /// Behaves identically to [`poll_zero_copy()`](Self::poll_zero_copy), but waits up to `timeout` milliseconds
     /// for messages to become available.
     ///
     /// # Arguments
@@ -460,7 +460,7 @@ pub trait MessagePoll: Send + Sync {
     /// each poll returning 32 messages allocates approximately 90KB. At 100 polls per second,
     /// this results in approximately 9MB/s of allocations.
     ///
-    /// For workloads that do not require owned messages, [`poll_zero_copy()`] avoids
+    /// For workloads that do not require owned messages, [`poll_zero_copy()`](Self::poll_zero_copy) avoids
     /// this allocation overhead.
     ///
     /// # Examples
@@ -476,7 +476,7 @@ pub trait MessagePoll: Send + Sync {
 
     /// Fetches the next batch of messages with a specified timeout, returning owned copies.
     ///
-    /// Behaves identically to [`poll()`], but waits up to `timeout` milliseconds for
+    /// Behaves identically to [`poll()`](Self::poll), but waits up to `timeout` milliseconds for
     /// messages to become available. All messages are deep-cloned.
     ///
     /// # Arguments

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -600,7 +600,7 @@ impl MQClientInstance {
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = state;
     }
 
-    /// Returns a reference to the [`ConsumerStatsManager`] held by this instance.
+    /// Returns a reference to the `ConsumerStatsManager` held by this instance.
     pub fn consumer_stats_manager(&self) -> &ConsumerStatsManager {
         &self.consumer_stats_manager
     }
@@ -2523,7 +2523,7 @@ impl MQClientInstance {
 
     /// Removes the current producer registration unconditionally by group.
     ///
-    /// Producer lifecycle cleanup should use [`Self::unregister_producer_if_owner`]
+    /// Producer lifecycle cleanup should use `Self::unregister_producer_if_owner`
     /// so a delayed cleanup cannot remove a replacement producer.
     pub async fn unregister_producer(&self, group: impl Into<CheetahString>) -> bool {
         let group = group.into();

--- a/rocketmq-client/src/session.rs
+++ b/rocketmq-client/src/session.rs
@@ -62,7 +62,7 @@ impl fmt::Debug for ClientSession {
 ///
 /// Publicly constructed handles always return `Some`. `None` is reserved for
 /// crate-internal bootstrap producers that are owned directly by a
-/// [`crate::runtime::ServiceContext`] instead of a public client session.
+/// [`rocketmq_runtime::ChildServiceContext`] instead of a public client session.
 pub trait ClientSessionProvider {
     #[must_use]
     fn client_session(&self) -> Option<&ClientSession>;

--- a/rocketmq-model/src/common/message/message_single.rs
+++ b/rocketmq-model/src/common/message/message_single.rs
@@ -107,7 +107,7 @@ impl Message {
         Self::with_details_bytes(topic, CheetahString::empty(), CheetahString::empty(), 0, body, true)
     }
 
-    /// Create a new message with topic and Vec<u8> (zero-copy conversion to Bytes)
+    /// Create a new message with topic and `Vec<u8>` (zero-copy conversion to `Bytes`)
     #[deprecated(since = "0.8.0", note = "Use Message::builder() instead")]
     #[allow(deprecated)]
     #[inline]

--- a/rocketmq-model/src/utils/crc32_utils.rs
+++ b/rocketmq-model/src/utils/crc32_utils.rs
@@ -137,13 +137,13 @@ pub fn crc32_bytes_offset(array: &[u8], offset: usize, length: usize) -> u32 {
     crc32_range(array, offset, length)
 }
 
-/// Calculate CRC32 checksum for a byte buffer (Vec<u8>).
+/// Calculate CRC32 checksum for a byte buffer (`Vec<u8>`).
 ///
 /// Equivalent to Java's `crc32(ByteBuffer byteBuffer)`
 ///
 /// # Arguments
 ///
-/// * `byte_buffer` - Reference to Vec<u8>
+/// * `byte_buffer` - Reference to `Vec<u8>`
 ///
 /// # Returns
 ///
@@ -173,7 +173,7 @@ pub fn crc32_bytebuffer(byte_buffer: &[u8]) -> u32 {
 ///
 /// # Arguments
 ///
-/// * `byte_buffers` - Slice of Vec<u8> buffers
+/// * `byte_buffers` - Slice of `Vec<u8>` buffers
 ///
 /// # Returns
 ///

--- a/rocketmq-model/src/utils/simd_json_utils.rs
+++ b/rocketmq-model/src/utils/simd_json_utils.rs
@@ -229,7 +229,7 @@ impl SimdJsonUtils {
     ///
     /// # Arguments
     ///
-    /// * `writer` - A mutable reference to a Vec<u8> to write JSON into
+    /// * `writer` - A mutable reference to a `Vec<u8>` to write JSON into
     /// * `value` - A reference to the value to serialize
     ///
     /// # Returns

--- a/rocketmq-namesrv/src/route/tables/cluster_table.rs
+++ b/rocketmq-namesrv/src/route/tables/cluster_table.rs
@@ -31,7 +31,7 @@ use crate::route::types::ClusterName;
 use crate::route::types::RouteBrokerName;
 use crate::route::types::RouteClusterName;
 
-/// Cluster address table: ClusterName -> Set<BrokerName>
+/// Cluster address table: `ClusterName -> Set<BrokerName>`
 ///
 /// This table maintains the mapping of cluster names to the set of
 /// broker names that belong to each cluster. Uses DashSet for

--- a/rocketmq-namesrv/src/route/tables/filter_server_table.rs
+++ b/rocketmq-namesrv/src/route/tables/filter_server_table.rs
@@ -23,7 +23,7 @@ use dashmap::DashMap;
 
 use crate::route_info::broker_addr_info::BrokerAddrInfo;
 
-/// Filter server table: BrokerAddrInfo -> List<FilterServer>
+/// Filter server table: `BrokerAddrInfo -> List<FilterServer>`
 ///
 /// This table maintains the mapping from broker addresses to their associated
 /// filter servers. Filter servers are used for message filtering in RocketMQ.

--- a/rocketmq-observability/src/stats/stats_item.rs
+++ b/rocketmq-observability/src/stats/stats_item.rs
@@ -58,7 +58,8 @@ impl StatsItem {
     /// Atomically adds `value_delta` to the value counter and `times_delta` to the times counter.
     ///
     /// Also records the current wall-clock millisecond as the last-update timestamp, which is
-    /// used by idle-entry eviction in [`StatsItemSet::clean_resource`].
+    /// used by idle-entry eviction in
+    /// [`StatsItemSet::clean_resource`](crate::stats::stats_item_set::StatsItemSet::clean_resource).
     #[inline]
     pub fn add(&self, value_delta: u64, times_delta: u64) {
         self.value.fetch_add(value_delta, Ordering::Relaxed);

--- a/rocketmq-store/src/base/message_arriving_listener.rs
+++ b/rocketmq-store/src/base/message_arriving_listener.rs
@@ -26,8 +26,8 @@ pub trait MessageArrivingListener {
     /// * `logic_offset` - An i64 that represents the logical offset of the message in the queue.
     /// * `tags_code` - An i64 that represents the tags associated with the message.
     /// * `msg_store_time` - An i64 that represents the time when the message was stored.
-    /// * `filter_bit_map` - A Vec<u8> that represents the filter bit map for the message.
-    /// * `properties` - An Option containing a reference to a HashMap<String, String> that holds
+    /// * `filter_bit_map` - A `Vec<u8>` that represents the filter bit map for the message.
+    /// * `properties` - An `Option` containing a reference to a `HashMap<String, String>` that holds
     ///   the properties of the message.
     fn arriving(
         &self,

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -1633,7 +1633,7 @@ impl MappedFileQueue {
     /// Create an iterator over mapped files
     ///
     /// # Returns
-    /// Iterator that yields Arc<DefaultMappedFile>
+    /// Iterator that yields `Arc<DefaultMappedFile>`
     ///
     /// # Example
     /// ```ignore
@@ -1650,7 +1650,7 @@ impl MappedFileQueue {
     /// Iterates from newest to oldest file.
     ///
     /// # Returns
-    /// Reversed iterator that yields Arc<DefaultMappedFile>
+    /// Reversed iterator that yields `Arc<DefaultMappedFile>`
     ///
     /// # Example
     /// ```ignore

--- a/rocketmq-store/src/timer/timeline/ha.rs
+++ b/rocketmq-store/src/timer/timeline/ha.rs
@@ -126,7 +126,7 @@ impl TimelinePromotionGate {
 /// Source-free result of evaluating an Extended Timeline role promotion.
 ///
 /// Every non-promotable variant is a deterministic rejection; operational promotion failures
-/// are returned separately as [`StoreError`].
+/// are returned separately as [`StoreError`](crate::StoreError).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TimelinePromotionOutcome {
     /// Promotion prerequisites are satisfied.

--- a/rocketmq-transport/src/tls.rs
+++ b/rocketmq-transport/src/tls.rs
@@ -661,7 +661,7 @@ pub fn build_server_acceptor(tls_config: &TlsConfig) -> RocketMQResult<tokio_rus
 
 /// Builds a server acceptor from exactly the supplied snapshot.
 ///
-/// Unlike [`build_server_acceptor`], this entry point does not merge the Java-compatible
+/// Unlike `build_server_acceptor`, this entry point does not merge the Java-compatible
 /// transport TLS properties file. It is intended for callers that already own an atomic,
 /// validated configuration generation.
 #[cfg(feature = "tls")]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10030

### Brief Description

Fix the 24 reported Rustdoc warnings across eight workspace crates. Mark generic types and indexing expressions as inline code, qualify public type and method links, replace links to private implementation items with code formatting, and update the client session link to `rocketmq_runtime::ChildServiceContext`. Record the fix in the Unreleased changelog.

All Rust source changes are documentation comments; runtime behavior and public API visibility are unchanged.

### How Did You Test This Change?

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` - passed on Windows using Rust 1.95.0 with no documentation warnings.
- `cargo fmt -p rocketmq-model -p rocketmq-observability -p rocketmq-transport -p rocketmq-store -p rocketmq-namesrv -p rocketmq-auth -p rocketmq-broker -p rocketmq-client-rust -- --check` - passed.
- `git diff --check` - passed.

Behavior tests and Clippy were not rerun for this documentation-only change, in accordance with the repository documentation validation policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Rustdoc formatting and clarity across public APIs.
  * Fixed generic type markup, code references, intra-document links, and type descriptions.
  * Corrected references to public and private items, including session ownership and promotion errors.
  * Updated iterator, serialization, message, CRC, and networking documentation for clearer usage.
  * Added a changelog entry documenting these documentation fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->