### PR TITLE
[ISSUE #10032]🐛Fix standalone SRE telemetry owner coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **fix(sre):** Include Required Signals manifest owners in capability coverage validation so standalone MCP ownership is accepted while invalid mappings remain rejected ([#10032](https://github.com/mxsm/rocketmq-rust/issues/10032))
 - **docs:** Fix Rustdoc generic type markup, broken public links, and references to private items across the workspace ([#10030](https://github.com/mxsm/rocketmq-rust/issues/10030))
 - **fix(transport):** Remove unused `RuntimeConfig` imports that break Linux sendfile test and benchmark compilation with warnings denied ([#10026](https://github.com/mxsm/rocketmq-rust/issues/10026))
 

--- a/rocketmq-ai/rocketmq-sre/crates/rocketmq-sre-control-plane/src/api.rs
+++ b/rocketmq-ai/rocketmq-sre/crates/rocketmq-sre-control-plane/src/api.rs
@@ -352,10 +352,18 @@ fn validate_semantic_registry_owners(
     configured: &[SemanticRegistryOwnerCoverage],
     manifests: &[RequiredSignalManifest],
 ) -> Result<BTreeSet<String>, ControlPlaneError> {
-    let registry_owners = registry
+    // The core-release registry excludes standalone components such as MCP.
+    // Their owners are declared by the SRE required-signal manifests instead.
+    let expected_owners = registry
         .signals
         .iter()
-        .map(|signal| signal.owner.clone())
+        .map(|signal| &signal.owner)
+        .chain(
+            manifests
+                .iter()
+                .flat_map(|manifest| manifest.signals.iter().map(|signal| &signal.owner)),
+        )
+        .cloned()
         .collect::<BTreeSet<_>>();
     let mut configured_owners = BTreeSet::new();
     for owner in configured {
@@ -398,13 +406,13 @@ fn validate_semantic_registry_owners(
         }
     }
 
-    if configured_owners != registry_owners {
-        let missing = registry_owners
+    if configured_owners != expected_owners {
+        let missing = expected_owners
             .difference(&configured_owners)
             .cloned()
             .collect::<Vec<_>>();
         let unknown = configured_owners
-            .difference(&registry_owners)
+            .difference(&expected_owners)
             .cloned()
             .collect::<Vec<_>>();
         return Err(ControlPlaneError::CapabilityDocument {
@@ -414,7 +422,7 @@ fn validate_semantic_registry_owners(
             ),
         });
     }
-    Ok(registry_owners)
+    Ok(expected_owners)
 }
 
 fn owner_has_protected_query_route(owner: &str, manifests: &[RequiredSignalManifest]) -> bool {
@@ -1569,6 +1577,53 @@ mod tests {
             error,
             ControlPlaneError::CapabilityDocument { detail }
                 if detail.contains("mapped more than once")
+        ));
+    }
+
+    #[test]
+    fn standalone_signal_owners_require_exact_coverage() {
+        let coverage: CoverageDocument =
+            serde_yaml::from_str(COVERAGE).expect("coverage YAML should match its contract");
+        let mut registry: TelemetryRegistry =
+            serde_json::from_str(TELEMETRY_REGISTRY).expect("semantic registry should match its contract");
+        registry.signals.retain(|signal| signal.owner != "mcp");
+        let manifests = required_signal_manifests().expect("required-signal manifests should parse");
+
+        let owners = validate_semantic_registry_owners(&registry, &coverage.semantic_registry_owners, &manifests)
+            .expect("standalone manifest owners must be included without a core registry entry");
+        assert_eq!(
+            owners,
+            coverage
+                .semantic_registry_owners
+                .iter()
+                .map(|owner| owner.owner.clone())
+                .collect()
+        );
+
+        let mut missing = coverage.clone();
+        missing.semantic_registry_owners.retain(|owner| owner.owner != "mcp");
+        let error = validate_semantic_registry_owners(&registry, &missing.semantic_registry_owners, &manifests)
+            .expect_err("standalone manifest owners still require a coverage mapping");
+        assert!(matches!(
+            error,
+            ControlPlaneError::CapabilityDocument { detail }
+                if detail.contains("missing=[\"mcp\"]") && detail.contains("unknown=[]")
+        ));
+
+        let mut unknown = coverage;
+        let mut owner = unknown.semantic_registry_owners[0].clone();
+        owner.owner = "unknown-component".to_owned();
+        owner.exposure = "implemented_local".to_owned();
+        for source in &mut owner.notable_sources {
+            source.exposure = "implemented_local".to_owned();
+        }
+        unknown.semantic_registry_owners.push(owner);
+        let error = validate_semantic_registry_owners(&registry, &unknown.semantic_registry_owners, &manifests)
+            .expect_err("owners absent from both the registry and manifests must be rejected");
+        assert!(matches!(
+            error,
+            ControlPlaneError::CapabilityDocument { detail }
+                if detail.contains("missing=[]") && detail.contains("unknown=[\"unknown-component\"]")
         ));
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10032

### Brief Description

SRE capability initialization rejected MCP because it compared all configured owners against a telemetry registry scoped to the core release. Build the expected owner set from the registry and SRE Required Signals manifests so standalone components are covered. Preserve exact coverage, metadata completeness, and protected-query-route validation.

Add a regression test for standalone MCP coverage, missing MCP mappings, and unknown owners. Record the fix in the changelog.

### How Did You Test This Change?

Run from `rocketmq-ai/rocketmq-sre` on Windows with Rust 1.95.0:

- `cargo test --locked -p rocketmq-sre-control-plane --lib api::tests::` - reproduced the original three failures before the fix; 18 tests passed after the fix.
- `cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check` - passed.
- `cargo check --locked --workspace` - passed.
- `cargo test --locked --workspace --all-features` - passed: 695 tests passed, 87 ignored; control-plane library tests: 259 passed, 54 ignored.
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` - passed.
- `cargo doc --locked --workspace --no-deps` - passed.
- `python scripts/check_source_layout.py` - passed.
- `python scripts/check_execution_dependency_boundary.py` - passed.
- `git diff --check` - passed from the repository root.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SRE capability coverage validation now recognizes owners declared in Required Signals manifests.
  - Standalone components such as MCP are accepted when their ownership is properly mapped.
  - Invalid, missing, or unknown ownership mappings continue to be rejected.

- **Documentation**
  - Added a changelog entry describing the expanded ownership validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->