### PR TITLE
[ISSUE #10036]🐛Prevent Dashboard file-store reopen failures after completed

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/file_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/file_store.rs
@@ -780,6 +780,8 @@ impl FilePersistence {
             .spawn_service(name, async move {
                 let _write_guard = write_guard;
                 let result = store.execute_file_mutation(name, operation).await;
+                // Release the task's directory-lock owner before waking the caller.
+                drop(store);
                 let _ = sender.send(result);
             })
             .map_err(PersistenceError::Runtime)?;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10036

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file operation coordination by releasing directory locks promptly after mutations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->