### PR TITLE
[ISSUE #10040]🐛Fix SRE and Dashboard CI test failures

### DIFF
--- a/.github/workflows/rocketmq-sre-ci.yml
+++ b/.github/workflows/rocketmq-sre-ci.yml
@@ -138,7 +138,14 @@ jobs:
         run: cargo test --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked --workspace --all-features
 
       - name: Test PostgreSQL repositories
-        run: cargo test --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked -p rocketmq-sre-control-plane -- --include-ignored
+        # Live S3 and model-provider qualifications require separately injected credentials.
+        run: |
+          cargo test --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked \
+            -p rocketmq-sre-control-plane -- --include-ignored \
+            --skip evidence::blob::tests::s3_compatible_https_live_round_trip_uses_external_secret_references \
+            --skip models::service::live_deepseek::deepseek_answers_one_evidence_cited_conversational_metric_query \
+            --skip models::service::live_deepseek::deepseek_responses_produces_persisted_read_only_sre_diagnosis \
+            --skip models::service::live_provider_failover::transient_primary_falls_back_to_live_deepseek_and_failures_remain_rules_only
 
       - name: Test fenced execution recovery
         run: |

--- a/rocketmq-ai/rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/service/smoke.rs
+++ b/rocketmq-ai/rocketmq-sre/crates/rocketmq-sre-control-plane/src/models/service/smoke.rs
@@ -453,6 +453,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lifecycle_smoke_fixture_supports_all_probe_requests() {
+        let profile = test_profile("provider-smoke-fixture".to_owned());
+        let transport = Arc::new(QueueTransport::new(passing_smoke_responses()));
+        let client = AsyncBuiltinProviderClient::new(profile.clone(), transport.clone()).expect("smoke client");
+        let correlation_id = CorrelationId::new();
+        let context = InvocationContext::new(correlation_id);
+        let requests = [
+            connectivity_request(correlation_id, &profile.model),
+            structured_request(correlation_id, &profile.model),
+            tool_request(correlation_id, &profile.model),
+        ];
+        for request in requests {
+            client
+                .invoke(&context, &request, None)
+                .await
+                .expect("supported smoke probe");
+        }
+        assert!(transport.responses.lock().expect("response queue").is_empty());
+    }
+
+    #[tokio::test]
     #[ignore = "requires ROCKETMQ_SRE_TEST_DATABASE_URL pointing to an isolated PostgreSQL database"]
     async fn postgres_provider_lifecycle_smoke_promote_rollback_retire_and_quarantine() {
         let database_url = std::env::var("ROCKETMQ_SRE_TEST_DATABASE_URL").expect("test database URL must be explicit");
@@ -489,19 +510,23 @@ mod tests {
             .expect("profile B")
             .id;
 
+        let smoke_a = service
+            .run_provider_smoke(&auth, profile_a_id)
+            .await
+            .expect("profile A smoke");
         assert!(
-            service
-                .run_provider_smoke(&auth, profile_a_id)
-                .await
-                .expect("profile A smoke")
-                .overall_ok
+            smoke_a.overall_ok,
+            "profile A smoke failures: {:?}",
+            smoke_a.failure_codes
         );
+        let smoke_b = service
+            .run_provider_smoke(&auth, profile_b_id)
+            .await
+            .expect("profile B smoke");
         assert!(
-            service
-                .run_provider_smoke(&auth, profile_b_id)
-                .await
-                .expect("profile B smoke")
-                .overall_ok
+            smoke_b.overall_ok,
+            "profile B smoke failures: {:?}",
+            smoke_b.failure_codes
         );
         let profile_b_lifecycle = service
             .transition_profile_lifecycle(
@@ -631,8 +656,8 @@ mod tests {
     fn test_profile(id: String) -> rocketmq_sre_model_gateway::ProviderProfile {
         let mut profile = rocketmq_sre_model_gateway::builtin_provider_profiles()
             .into_iter()
-            .find(|profile| profile.id == "deepseek")
-            .expect("DeepSeek profile fixture");
+            .find(|profile| profile.id == "openai")
+            .expect("OpenAI profile fixture with strict tools and specific tool choice");
         profile.id = id;
         profile.credential_ref = None;
         profile
@@ -666,7 +691,7 @@ mod tests {
             status: 200,
             body: json!({
                 "id": "provider-smoke",
-                "model": "deepseek-chat",
+                "model": "gpt-configured",
                 "choices": [{
                     "message": {
                         "role": "assistant",

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/file_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/file_store.rs
@@ -3000,7 +3000,8 @@ mod tests {
     fn timed_out_session_touch_rolls_back_before_active_or_reopened_reads() {
         let directory = tempfile::tempdir().expect("temp dir");
         let root = directory.path().join("dashboard");
-        let owner = RuntimeOwner::plan(timeout_runtime_config())
+        let owner = RuntimeOwner::new().expect("runtime owner");
+        let mutation_owner = RuntimeOwner::plan(timeout_runtime_config())
             .expect("runtime configuration is valid")
             .build()
             .expect("runtime owner");
@@ -3016,16 +3017,32 @@ mod tests {
                 .create_session(active_session(token_hash, "touch-owner"))
                 .await
                 .expect("seed active session");
+            // Only the blocked touch uses the short deadline; filesystem setup,
+            // reads, and reopen must not depend on the runner's disk latency.
+            let mutation_store = FilePersistence {
+                service_context: mutation_owner
+                    .root_context()
+                    .component("timeout-session-touch-mutation"),
+                ..store.clone()
+            };
             let (started, release) = install_mutation_blocker(&store);
-            let (result, ()) = tokio::join!(
-                store.touch_session(&token_hash, 2),
-                release_mutation_after_storage_timeout(started, release),
-            );
+            let (result, ()) = tokio::join!(mutation_store.touch_session(&token_hash, 2), async {
+                wait_for_mutation_start(started).await;
+                tokio::time::timeout(Duration::from_secs(5), async {
+                    while !store.unavailable.load(AtomicOrdering::Acquire) {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .expect("touch owner must observe the storage timeout before release");
+                release.send(()).expect("release timed-out touch mutation");
+            },);
             assert_eq!(
                 runtime_condition(result.expect_err("mutation must time out")),
                 CanonicalCondition::DeadlineExceeded
             );
             store.mutation_blocker.clear();
+            drop(mutation_store);
             assert_eq!(
                 store
                     .find_session(&token_hash)
@@ -3055,6 +3072,9 @@ mod tests {
                 1
             );
         });
+        mutation_owner
+            .shutdown_runtime_blocking()
+            .expect("mutation runtime shutdown");
         owner.shutdown_runtime_blocking().expect("runtime shutdown");
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10040

### Brief Description

Fix three CI test configuration failures across SRE and Dashboard Web:

- In `.github/workflows/rocketmq-sre-ci.yml`, exclude exactly four live S3/DeepSeek tests from the PostgreSQL step. Their external credential requirements remain intact.
- In the SRE control-plane lifecycle smoke test, use the OpenAI mock profile that supports strict tools and specific tool choice. Add a database-independent regression exercising all three probes and report bounded failure codes in lifecycle assertions.
- In the Dashboard file-store timeout test, give setup, seeding, reads, and reopen the normal I/O budget. Apply the 250 ms deadline to the blocked touch through a separate owned runtime sharing the store's locks and availability state. Release the hook after the mutation owner observes timeout, and preserve both active and reopened rollback assertions.

The SRE lifecycle failure was reproduced locally with `tool_arguments.capability_unsupported`. Dashboard CI run 33951953013 failed during initialization at `file_store.rs:3011`, before its touch/rollback assertions. Production storage logic and model capability declarations are unchanged.

### How Did You Test This Change?

Rust 1.95.0; native Windows validation, isolated PostgreSQL 17 for SRE database tests, and WSL for the Dashboard full format check. Scope identifies the working directory (SRE and Dashboard backend are standalone Cargo projects).

| Scope | Command | Result |
| --- | --- | --- |
| SRE | `cargo test --locked -p rocketmq-sre-control-plane models::service::smoke::tests:: -- --include-ignored` | PASS; 4 passed, 0 failed, 0 ignored |
| SRE | `cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check` | PASS |
| SRE | `cargo check --locked --workspace` | PASS |
| SRE | `cargo test --locked --workspace --all-features` | PASS; 696 passed, 0 failed, 87 ignored |
| SRE | `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` | PASS |
| SRE | `cargo doc --locked --workspace --no-deps` | PASS |
| Repository root | `cargo test --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked -p rocketmq-sre-control-plane -- --include-ignored --skip evidence::blob::tests::s3_compatible_https_live_round_trip_uses_external_secret_references --skip models::service::live_deepseek::deepseek_answers_one_evidence_cited_conversational_metric_query --skip models::service::live_deepseek::deepseek_responses_produces_persisted_read_only_sre_diagnosis --skip models::service::live_provider_failover::transient_primary_falls_back_to_live_deepseek_and_failures_remain_rules_only` | PASS; 311 passed, 0 failed, 0 ignored |
| Dashboard backend | `cargo test --locked --all-features --lib persistence::file_store::tests::` | PASS; 26 passed, 0 failed, 1 ignored |
| Dashboard backend | `cargo test --locked --all-targets --all-features` | PASS; 180 passed, 0 failed, 22 ignored |
| Dashboard backend | `cargo clippy --all-targets --all-features -- -D warnings` | PASS |
| Dashboard backend | `cargo build --all-targets --all-features` | PASS |
| SRE | `python scripts/check_source_layout.py` | PASS |
| SRE | `python scripts/check_execution_dependency_boundary.py` | PASS |
| Dashboard backend (WSL) | `cargo fmt --all -- --check` | PASS; Windows invocation exceeded command-line length |
| Dashboard backend | `cargo test --locked --all-features --lib persistence::file_store::tests::timed_out_session_touch_rolls_back_before_active_or_reopened_reads -- --exact` | PASS; 1 test |
| Dashboard backend | Same compiled timeout test, repeated with `--exact` | PASS; 20/20 |
| Repository root | `.\scripts\check-agents-routing.ps1` | PASS |
| Repository root | `git diff --check` | PASS |

The final PostgreSQL workflow command ran directly from the workflow: 310 unit tests and 1 boundary test passed, with exactly four live tests filtered out. The SRE baseline lifecycle assertion failed before the fixture correction and passed afterward.

The full Linux Docker storage matrix and live S3/DeepSeek qualifications were not rerun. Existing ignored tests are reported above; no ignored test is counted as passing. Remote CI will not be awaited, as requested.
