### PR TITLE
[ISSUE #10049]♻️Close the opaque canonical error core

### DIFF
--- a/rocketmq-auth/src/layered_authorization.rs
+++ b/rocketmq-auth/src/layered_authorization.rs
@@ -40,7 +40,7 @@ pub const fn project_policy_decision(decision: PolicyDecision) -> DetailedDecisi
 /// fixed denial output from `rocketmq-security-api` rather than returning the
 /// source error to a peer.
 #[must_use]
-pub const fn project_authorization_error(error: &AuthorizationError) -> LayerFailureKind {
+pub fn project_authorization_error(error: &AuthorizationError) -> LayerFailureKind {
     match error {
         AuthorizationError::ConfigurationError(_)
         | AuthorizationError::NotInitialized(_)

--- a/rocketmq-doc/en/07-error-architecture-adr.md
+++ b/rocketmq-doc/en/07-error-architecture-adr.md
@@ -2,7 +2,7 @@
 title: "Error Architecture Redesign ADR"
 permalink: /docs/error-architecture-adr/
 excerpt: "Accepted direction for the RocketMQ Rust error architecture redesign."
-last_modified_at: 2026-08-31T00:00:00+08:00
+last_modified_at: 2026-09-05T00:00:00+08:00
 toc: true
 classes: wide
 ---
@@ -11,10 +11,12 @@ classes: wide
 
 ## Status
 
-Accepted. This decision supersedes the previously accepted transitional
-public `RocketMQError` enum/`ErrorKind`/`ErrorSpec` architecture. The target
-implementation remains pending; this document must not be read as evidence
-that every target type or classification already exists.
+Accepted and partially implemented. The opaque canonical core, its complete
+descriptor policy, and the Store, Runtime, and Transport facade ownership are
+effective. The public `RocketMQError` enum, `ErrorKind`, and `ErrorSpec`
+migration, remaining domain cutovers, retry decisions, and boundary adapters
+are still pending; this document is not evidence that those later stages are
+complete.
 
 ## Context and current state
 
@@ -36,9 +38,13 @@ The baseline has no `RocketmqError` or `Legacy*` aliases, no public
 `StoreError::General`. `AdminErrorCode::RocketMqError` in dashboard code is a
 dashboard response-code name, not evidence of a legacy `rocketmq-error` type.
 
-This distinction matters: the current mega-enum and existing support types are
-effective repository APIs today, while the opaque canonical contract below is
-the migration target.
+Since that pinned baseline, `rocketmq-error` has added a one-pointer,
+non-`Clone` canonical `Error`, `Result<T>`, `SharedError = Arc<Error>`, typed
+context and safe views, and an exact 35-entry declarative catalog. `StoreError`
+owns one canonical `Error`; cloneable `RuntimeError` and `TransportError`
+facades share one canonical value. Their `source()` implementations delegate
+directly to the original typed leaf. The legacy mega-enum and its 73-spec
+migration remain separate follow-up work.
 
 ## Decision
 
@@ -71,18 +77,20 @@ target implementation is effective in each consumer.
    a public mega-enum to classify failures.
 
 The declarative `ErrorCatalog` is a supporting mechanism and the sole owner of
-stable dotted codes, `CanonicalCondition`, fixed public messages, severity,
-`RecoveryHint`, and projection metadata. Boundary adapters project catalog
-metadata into remoting, gRPC, HTTP, CLI, and other local primitives.
+stable dotted codes, class, `CanonicalCondition`, fault attribution, component,
+fixed public messages, severity, `RecoveryHint`, backtrace policy, exposure,
+and projection metadata. Boundary adapters project catalog metadata into
+remoting, gRPC, HTTP, CLI, and other local primitives.
 Presentation and observability render the approved views with redaction; they
 do not create a second semantic catalog.
 
 ### Canonical metadata and views
 
-Each catalog entry owns a stable dotted code and its
-`CanonicalCondition`, fixed public message, severity, `RecoveryHint`, and
-projection metadata. A free-form remark or a source display string is not an
-entry key, policy, or compatibility value.
+Each catalog entry owns a stable dotted code and its class,
+`CanonicalCondition`, fault attribution, component, fixed public message,
+severity, `RecoveryHint`, backtrace policy, exposure, projection, and ordered
+field schema. A free-form remark or a source display string is not an entry
+key, policy, or compatibility value.
 
 Catalog codes use lowercase dotted stable domain semantics, for example
 `storage.commit_log.corrupt_record`. A code must never contain a dynamic topic,
@@ -99,10 +107,11 @@ Context has an explicit visibility class:
   never the value itself.
 
 `PublicErrorView` contains only catalog-approved identity, fixed public message,
-safe public context, and boundary-safe projection fields. `DiagnosticView` may
-add redacted diagnostic context and typed source information subject to its
-visibility policy. Neither view treats arbitrary remarks or source
-stringification as stable input.
+safe public context, and boundary-safe projection fields. A descriptor with
+`Exposure::Generic` exposes no dynamic public context. `DiagnosticView` adds
+only descriptor-declared, bounded diagnostic values and value-free redaction
+markers; it never renders or exposes the source, caller location, or backtrace.
+Typed causes remain available through `std::error::Error::source()`.
 
 `RetryDecision` is a separate decision, not a catalog field copied into an
 error. It considers operation idempotency, operation stage, and remaining
@@ -130,16 +139,16 @@ The migration freezes three accidental contracts now:
 
 | Concern | Effective current repository | Target after migration |
 | --- | --- | --- |
-| Public error value | Large public `RocketMQError` enum | Opaque canonical `Error` with safe projections |
+| Public error value | Opaque canonical `Error` is available; the large public `RocketMQError` enum remains during its pending migration | Opaque canonical `Error` with safe projections and no public mega-enum |
 | Outcome/control flow | Existing APIs mix error and operation-specific outcomes | `Outcome`/`Decision`/`Rejection` are explicit public control-flow concepts |
 | Contract failures | Not uniformly separated from operational errors | `ContractViolation` is a distinct layer |
 | Leaf errors | Domain-specific leaves plus a domain override path | Private leaf `Error` retained behind each domain facade |
-| Domain facades | Opaque `StoreError` exists; other domains vary | Narrow operational facades preserve source and policy information |
-| Catalog | `ErrorKind`, `ErrorSpec`, and `ALL_ERROR_SPECS` exist, but the target declarative ownership is incomplete | `ErrorCatalog` solely owns dotted code, condition, fixed public message, severity, recovery hint, and projections |
-| Context/views | Free-string `ErrorContext` and `BoundaryErrorView` exist | Visibility-tagged context feeds `PublicErrorView` and `DiagnosticView` |
+| Domain facades | `StoreError`, `RuntimeError`, and `TransportError` own/share canonical errors; other domains vary | Narrow operational facades preserve typed sources without duplicating canonical policy |
+| Catalog | Exact 35-entry declarative catalog owns complete canonical policy; legacy `ErrorKind`/`ErrorSpec` still await migration | `ErrorCatalog` solely owns canonical metadata and the legacy spec table is removed |
+| Context/views | Typed visibility context and safe views are effective; legacy boundary views still exist | Visibility-tagged context feeds `PublicErrorView` and `DiagnosticView` at every boundary |
 | Retry | Decisions remain distributed | Separate `RetryDecision` uses idempotency, stage, and budget |
 | Boundaries | Local adapters can emit arbitrary remarks and inspect display text | Adapters project catalog metadata and safe views |
-| Dependencies | `rocketmq-error` still depends on anyhow/config/serde_json | Dependencies are reduced or isolated without widening the public contract |
+| Dependencies | Owner-specific anyhow/config/serde_json dependencies have been removed from `rocketmq-error` | Dependencies stay reduced or isolated without widening the public contract |
 | Sensitive data | Shared `Sensitive` support exists | Public, diagnostic, and secret-presence-only views enforce default redaction |
 
 ## Compatibility and dependency direction
@@ -223,6 +232,6 @@ evidence rather than asserting completion.
 
 This is a deliberate Rust API break with a narrow compatibility promise for
 remoting, gRPC, HTTP, wire, and persistence contracts. Stable semantic meaning
-lives in the declarative catalog, typed causes remain available to controlled
-diagnostics, and safe public views prevent accidental leakage or coupling to
-the mega-enum.
+lives in the declarative catalog, typed causes remain available through the
+standard source chain, and safe views prevent accidental leakage or coupling
+to the mega-enum.

--- a/rocketmq-doc/en/07-error-inventory.md
+++ b/rocketmq-doc/en/07-error-inventory.md
@@ -2,7 +2,7 @@
 title: "Error Architecture Inventory"
 permalink: /docs/error-inventory/
 excerpt: "Current RocketMQ Rust error ownership and migration inventory."
-last_modified_at: 2026-08-31T00:00:00+08:00
+last_modified_at: 2026-09-05T00:00:00+08:00
 toc: true
 classes: wide
 ---
@@ -29,9 +29,16 @@ arbitrary, and source `Display` output remains observable; neither is stable
 semantic data.
 
 The target vocabulary is the exact five-layer model in the [Error Architecture
-Redesign ADR](07-error-architecture-adr.md). The itemized classifications below
-remain pending implementation; the presence of a target schema or migration wave
-does not assert that any implementation row is complete.
+Redesign ADR](07-error-architecture-adr.md). The tables remain a pinned baseline;
+individual rows may be advanced only by their recorded implementation issue.
+
+Live implementation note: issue #10049 closes the canonical carrier portion of
+the target. `rocketmq-error` now exposes a one-pointer, non-`Clone` `Error`,
+`Result<T>`, and `SharedError = Arc<Error>` backed by a private `ErrorInner` and
+an exact 35-entry catalog. `StoreError` owns the canonical value, while
+`RuntimeError` and `TransportError` clone one shared canonical value and
+delegate `source()` directly to the original typed leaf. This note does not
+advance the legacy 73-spec, remaining domain, retry, or boundary rows.
 
 ## Counting scope and methodology
 
@@ -111,7 +118,7 @@ is changed.
 | ContractViolation | Caller, protocol, and invariant violations distinct from operational failures | Not yet uniformly separated |
 | Private leaf `Error` | Domain implementation errors retain typed sources behind private representation | Current domain errors vary; public mega-enum remains central |
 | Domain operational facade | Narrow domain facade hides private leaves while retaining source and policy information | Opaque `StoreError` exists; other domains vary |
-| Opaque canonical `Error` with safe projections | One canonical value with private representation projected through `PublicErrorView` and `DiagnosticView` | Target migration from public mega-enum is pending |
+| Opaque canonical `Error` with safe projections | One canonical value with private representation projected through `PublicErrorView` and `DiagnosticView` | Core carrier and Store/Runtime/Transport facade ownership implemented by issue #10049; public mega-enum migration remains pending |
 
 `ErrorCatalog`, boundary adapters, and presentation/observability are supporting
 mechanisms for these five layers, not extra layers. The declarative catalog is
@@ -122,11 +129,12 @@ message, severity, `RecoveryHint`, and projection metadata.
 
 Every catalog entry must declaratively own:
 
-- one stable dotted code;
-- one `CanonicalCondition`;
-- one fixed public message;
-- severity and `RecoveryHint`; and
-- projection metadata for remoting, gRPC, HTTP, CLI, and observability.
+- one stable dotted code and class;
+- one `CanonicalCondition`, fault attribution, and component owner;
+- one fixed public message, severity, and `RecoveryHint`;
+- backtrace and public-exposure policy;
+- projection metadata for remoting, gRPC, HTTP, CLI, and observability; and
+- an ordered typed-field schema.
 
 Catalog codes use lowercase dotted stable domain semantics, for example
 `storage.commit_log.corrupt_record`. A code must never contain a dynamic topic,
@@ -143,10 +151,11 @@ Context visibility is explicit:
   its value.
 
 `PublicErrorView` contains catalog-approved identity, fixed public message,
-safe public context, and boundary-safe projection fields. `DiagnosticView` may
-add redacted diagnostic context and typed source information according to
-visibility policy. Free-form remarks and source `Display` text are not fields
-that define either view.
+safe public context, and boundary-safe projection fields; Generic exposure
+suppresses dynamic public fields. `DiagnosticView` adds only declared bounded
+diagnostic values and value-free redaction markers. It never exposes the
+source, caller location, or backtrace. Free-form remarks and source `Display`
+text are not fields that define either view.
 
 `RetryDecision` is separate from catalog identity and error rendering. It uses
 operation idempotency, operation stage, and remaining budget together with the
@@ -301,7 +310,7 @@ gate.
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `rocketmq_store_api::checkpoint_artifact::CheckpointArtifactError` | `rocketmq-store-api` — [rocketmq-store-api/src/checkpoint_artifact.rs:42](../../rocketmq-store-api/src/checkpoint_artifact.rs#L42) | removed public baseline declaration | rocketmq-store, rocketmq-store-local, rocketmq-store-rocksdb migrated together | PrivateLeaf | `StoreContractViolation::CheckpointArtifact*` plus private `CheckpointArtifactIoError` behind `StoreError` | N/A | yes — filesystem failures retain operation, path, and `io::Error`; six deterministic cases retain their typed evidence in the canonical contract | Storage / rocketmq-store-api | 2 (Storage vertical) | implemented by issue #9935 |
 | `rocketmq_store_api::checkpoint::CheckpointValidationError` | `rocketmq-store-api` — [rocketmq-store-api/src/checkpoint.rs:288](../../rocketmq-store-api/src/checkpoint.rs#L288) | removed public baseline declaration | rocketmq-store-local, rocketmq-store-rocksdb migrated together | Contract | `StoreContractViolation::Checkpoint*` | N/A | N/A — retains checkpoint semantic values and identifiers; no causal source exists | Storage / rocketmq-store-api | 2 (Storage vertical) | implemented by issue #9935 |
-| `rocketmq_store_api::error::StoreError` | `rocketmq-store-api` — [rocketmq-store-api/src/error.rs:193](../../rocketmq-store-api/src/error.rs#L193) | pub; Rustdoc/API reachability checked | rocketmq-broker, rocketmq-store, rocketmq-store-rocksdb | Facade | `sole storage StoreError facade with stable catalog metadata and boxed typed source/context` | existing | yes — the existing boxed source chain is the canonical cross-backend preservation point | Storage / rocketmq-store-api | 2 (Storage vertical) | pending implementation |
+| `rocketmq_store_api::error::StoreError` | `rocketmq-store-api` — [rocketmq-store-api/src/error.rs:193](../../rocketmq-store-api/src/error.rs#L193) | pub; Rustdoc/API reachability checked | rocketmq-broker, rocketmq-store, rocketmq-store-rocksdb | Facade | `sole storage StoreError facade owning one opaque canonical Error plus closed operation/component metadata` | existing | yes — boxed and concrete typed causes remain direct canonical source leaves | Storage / rocketmq-store-api | 2 (Storage vertical) | implemented by issues #9940 and #10049 |
 | `rocketmq_store_api::ha_contract::HaContractError` | `rocketmq-store-api` — [rocketmq-store-api/src/ha_contract.rs:444](../../rocketmq-store-api/src/ha_contract.rs#L444) | removed public baseline declaration | rocketmq-controller migrated together | Contract | `StoreContractViolation::Ha*` | N/A | N/A — retains epoch, broker ID, replica/ACK policy, offset, and lease-generation evidence; no term or source is stored | Storage / rocketmq-store-api | 2 (Storage vertical) | implemented by issue #9935 |
 | `rocketmq_store_api::AppendReceiptError` | `rocketmq-store-api` — [rocketmq-store-api/src/lib.rs:185](../../rocketmq-store-api/src/lib.rs#L185) | removed public baseline declaration | rocketmq-store migrated together | Contract | `StoreContractViolation::AppendReceipt*` | N/A | N/A — retains receipt invariant values; no nested source exists | Storage / rocketmq-store-api | 2 (Storage vertical) | implemented by issue #9935 |
 | `rocketmq_store_api::progress::DerivedRecordIdError` | `rocketmq-store-api` — [rocketmq-store-api/src/progress.rs:124](../../rocketmq-store-api/src/progress.rs#L124) | removed public baseline declaration | rocketmq-store-local and rocketmq-tieredstore migrated together | Contract | `StoreContractViolation::DerivedRecord*` | N/A | N/A — retains epoch, offset, and record-length evidence | Storage / rocketmq-store-api | 2 (Storage vertical) | implemented by issue #9935 |
@@ -440,7 +449,7 @@ gate.
 | Type | Crate/Path | Visibility | Current Consumers | Category | Target Type | Catalog Code | Source Preserved | Owner | Wave | Status |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `rocketmq_runtime::common::parse_config_file::RedactedConfigError` | `rocketmq-runtime` — `rocketmq-runtime/src/common/parse_config_file.rs` | removed | rocketmq-broker migrated | Delete | `render_safe_config_error` | N/A | yes — `config::ConfigError` remains typed and the public rendering boundary is redacted | Runtime, transport, and foundations / rocketmq-runtime | 3 (Runtime/Protocol/Transport) | implemented by issue #10013 |
-| `rocketmq_runtime::error::RuntimeError` | `rocketmq-runtime` — [rocketmq-runtime/src/error.rs:26](../../rocketmq-runtime/src/error.rs#L26) | pub; Rustdoc/API reachability checked | rocketmq-auth, rocketmq-broker, rocketmq-controller, rocketmq-dashboard-web-backend, rocketmq-proxy, rocketmq-store, rocketmq-store-local, rocketmq-transport | Facade | `catalog-backed opaque RuntimeError` | `runtime.*` | yes — operational I/O and join sources remain typed behind a closed operation and bounded component context; deterministic configuration and lifecycle states use contracts or outcomes | Runtime, transport, and foundations / rocketmq-runtime | 3 (Runtime/Protocol/Transport) | implemented by issue #10013 |
+| `rocketmq_runtime::error::RuntimeError` | `rocketmq-runtime` — [rocketmq-runtime/src/error.rs:26](../../rocketmq-runtime/src/error.rs#L26) | pub; Rustdoc/API reachability checked | rocketmq-auth, rocketmq-broker, rocketmq-controller, rocketmq-dashboard-web-backend, rocketmq-proxy, rocketmq-store, rocketmq-store-local, rocketmq-transport | Facade | `catalog-backed opaque RuntimeError sharing one canonical Error` | `runtime.*` | yes — operational I/O and join sources remain direct typed leaves; clones preserve canonical source, location, backtrace, operation, and bounded component context | Runtime, transport, and foundations / rocketmq-runtime | 3 (Runtime/Protocol/Transport) | implemented by issues #10013 and #10049 |
 | `rocketmq_runtime::metadata_io::MetadataIoError` | `rocketmq-runtime` — `rocketmq-runtime/src/metadata_io.rs` | removed | rocketmq-auth, rocketmq-broker, rocketmq-dashboard-web-backend, rocketmq-namesrv migrated | Facade | `catalog-backed opaque RuntimeError` | `runtime.*` | yes — I/O and worker sources stay typed; operation, component, condition, and recovery remain catalog-derived | Runtime, transport, and foundations / rocketmq-runtime | 3 (Runtime/Protocol/Transport) | implemented by issue #10013 |
 | `rocketmq_runtime::resource_budget::budget::BudgetAcquireError` | `rocketmq-runtime` — `rocketmq-runtime/src/resource_budget/budget.rs` | removed | rocketmq-client-rust, rocketmq-store-local, rocketmq-transport migrated | Outcome | `BudgetRejection` | N/A | N/A — budget path, exhausted ancestor, dimension, and full policy are source-free rejection data | Runtime, transport, and foundations / rocketmq-runtime | 3 (Runtime/Protocol/Transport) | implemented by issue #10013 |
 | `rocketmq_runtime::resource_budget::budget::PermitRebindError` | `rocketmq-runtime` — `rocketmq-runtime/src/resource_budget/budget.rs` | removed | same crate migrated | Outcome | `Result<PermitRebindOutcome, RuntimeContractViolation>` | N/A | N/A — contract invariants and `BudgetRejection` are explicit non-error outcomes | Runtime, transport, and foundations / rocketmq-runtime | 3 (Runtime/Protocol/Transport) | implemented by issue #10013 |
@@ -795,7 +804,7 @@ This table is separate from the 301 `Error` rows. `Keep public` is intentionally
 | `rocketmq_broker::long_polling::pull_deferred::service::PullDeferredRegisterErrorKind` | `rocketmq_broker::long_polling::pull_deferred::service::PullDeferredRegisterError` | pub(crate); not externally reachable | same crate only | Delete | Service and boundary crates / rocketmq-broker | 4 (Service/boundary) | pending implementation | [rocketmq-broker/src/long_polling/pull_deferred/service.rs:1264](../../rocketmq-broker/src/long_polling/pull_deferred/service.rs#L1264); kind() is asserted in acceptance tests; outcome retains prepared registration, responder source, request ID, and failure kind |
 | `rocketmq_client_rust::nameserver_discovery::dns::DnsErrorKind` | `rocketmq_client_rust::nameserver_discovery::dns::DnsResolutionError` | pub(crate); not externally reachable | same crate only | Make private | Service and boundary crates / rocketmq-client-rust | 4 (Service/boundary) | pending implementation | [rocketmq-client/src/nameserver_discovery/dns.rs:44](../../rocketmq-client/src/nameserver_discovery/dns.rs#L44); DnsResolutionError::kind() feeds same-crate retry/category logic and tests; no cross-crate use exists |
 | `rocketmq_proxy_core::error::ProxyErrorKind` | `rocketmq_proxy_core::error::ProxyError` | pub; Rustdoc/API reachability checked | same crate only | Delete | Service and boundary crates / rocketmq-proxy-core | 4 (Service/boundary) | pending implementation | [rocketmq-proxy-core/src/error.rs:21](../../rocketmq-proxy-core/src/error.rs#L21); ProxyError::local_kind() maps every variant and status.rs exhaustively maps Kind to gRPC; catalog projection replaces this second taxonomy |
-| `rocketmq_store_api::error::StoreErrorKind` | `rocketmq_store_api::error::StoreError` | pub; Rustdoc/API reachability checked | rocketmq-broker, rocketmq-store | Delete | Storage / rocketmq-store-api | 2 (Storage vertical) | pending implementation | [rocketmq-store-api/src/error.rs:73](../../rocketmq-store-api/src/error.rs#L73); StoreError::kind() is used by rocketmq-store and broker; keep a compatibility mapping to existing catalog metadata while consumers cut over |
+| `rocketmq_store_api::error::StoreErrorKind` | `rocketmq_store_api::error::StoreError` | removed | none | Delete | Storage / rocketmq-store-api | 2 (Storage vertical) | implemented by issue #9940 | StoreError now uses the descriptor as its sole stable identity; no compatibility Kind remains |
 | `rocketmq_store_local::commit_log::append::sequencer::AppendAdmissionErrorKind` | `rocketmq_store_local::commit_log::append::sequencer::AppendAdmissionError` | pub; Rustdoc/API reachability checked | rocketmq-store | Delete | Storage / rocketmq-store-local | 2 (Storage vertical) | implemented by issue #9957 | [rocketmq-store-local/src/commit_log/append/sequencer.rs:247](../../rocketmq-store-local/src/commit_log/append/sequencer.rs#L247); AppendAdmissionError::kind() exposes Saturated/Closed; rocketmq-store exhaustively maps both to PutMessageStatus, so inline them in the outcome |
 | `rocketmq_store_local::commit_log::record_parser::CommitLogRecordErrorKind` | `rocketmq_store_local::commit_log::record_parser::CommitLogRecordError` | pub; Rustdoc/API reachability checked | rocketmq-store | Delete | Storage / rocketmq-store-local | 2 (Storage vertical) | implemented by issue #9957 | [rocketmq-store-local/src/commit_log/record_parser.rs:99](../../rocketmq-store-local/src/commit_log/record_parser.rs#L99); CommitLogRecordError stores kind; the parser constructs it and rocketmq-store imports/matches it, so inline variants in the contract |
 | `rocketmq_store_local::mapped_file::retirement::activation::ManagedLifecycleActivationErrorKind` | `rocketmq_store_local::mapped_file::retirement::activation::ManagedLifecycleActivationError` | pub; Rustdoc/API reachability checked | rocketmq-store | Delete | Storage / rocketmq-store-local | 2 (Storage vertical) | implemented by issue #9957 | [rocketmq-store-local/src/mapped_file/retirement/activation.rs:43](../../rocketmq-store-local/src/mapped_file/retirement/activation.rs#L43); ManagedLifecycleActivationError::kind() is exhaustively mapped by rocketmq-store managed_recovery; retain the private Error source while deleting this parallel kind |

--- a/rocketmq-doc/en/19-error-contribution-guide.md
+++ b/rocketmq-doc/en/19-error-contribution-guide.md
@@ -2,28 +2,28 @@
 title: "Error Architecture Contribution Guide"
 permalink: /docs/error-contribution-guide/
 excerpt: "How to add, map, test, and review typed RocketMQ Rust errors."
-last_modified_at: 2026-08-31T00:00:00+08:00
+last_modified_at: 2026-09-05T00:00:00+08:00
 toc: true
 classes: wide
 ---
 
 # Error Architecture Contribution Guide
 
-This guide separates rules effective in the current repository from the target
-opaque canonical architecture. The [Error Architecture Redesign
-ADR](07-error-architecture-adr.md) defines the target, and the [Error
-Architecture Inventory](07-error-inventory.md) pins the baseline and records
-pending migration evidence. Naming a target type here does not make a future
-API available to current callers.
+This guide separates the canonical core that is effective now from the
+remaining migration target. The [Error Architecture Redesign
+ADR](07-error-architecture-adr.md) defines both, and the [Error Architecture
+Inventory](07-error-inventory.md) pins the baseline and records per-owner
+migration evidence.
 
 ## Effective-now rules
 
-At the pinned baseline, the effective central API is the public mega
-`RocketMQError` enum and the existing `ErrorKind`, `ErrorSpec`,
-`ALL_ERROR_SPECS`, `DomainError`, `ErrorContext`, `BoundaryErrorView`, and
-shared `Sensitive` support. Client callback errors are typed and `StoreError`
-is an opaque domain facade. Work in a crate must follow that crate's existing
-public API until its migration wave lands.
+The effective central API now includes the one-pointer, non-`Clone` canonical
+`Error`, `Result<T>`, `SharedError = Arc<Error>`, typed `ErrorContext`, safe
+views, and the complete policy fields on the exact 35-entry declarative
+catalog. `StoreError` owns one canonical `Error`; `RuntimeError` and
+`TransportError` clone through `SharedError`. The legacy public
+`RocketMQError` enum, `ErrorKind`, `ErrorSpec`, and their consumers remain
+effective until their own migration stages land.
 
 1. Preserve typed sources for I/O, serde, storage, raft, transport, and runtime
    failures. Do not replace a source with rendered text.
@@ -49,7 +49,7 @@ These rules apply now, including while a private migration bridge is present.
 A bridge must remain private and temporary; it must not become a public,
 deprecated, feature-gated, or long-lived dual API.
 
-## Future target, not current imports
+## Five-layer migration contract
 
 When an owning migration lands, it follows these five layers exactly:
 
@@ -67,8 +67,9 @@ When an owning migration lands, it follows these five layers exactly:
 
 `ErrorCatalog`, boundary adapters, and presentation/observability are
 supporting mechanisms, not additional layers. The declarative catalog is the
-sole owner of stable dotted code, `CanonicalCondition`, fixed public message,
-severity, `RecoveryHint`, and projection metadata.
+sole owner of stable dotted code, class, `CanonicalCondition`, fault
+attribution, component, fixed public message, severity, `RecoveryHint`,
+backtrace policy, exposure, projection, and ordered field schemas.
 
 Catalog codes use lowercase dotted stable domain semantics, for example
 `storage.commit_log.corrupt_record`. Never include a dynamic topic, group, path,
@@ -80,18 +81,21 @@ Context visibility is explicit: `Public` is safe for the public view,
 `Diagnostic` is restricted to controlled diagnostics and operational telemetry,
 and `SecretPresenceOnly` records only that secret-bearing data was present.
 `PublicErrorView` contains only catalog-approved identity, fixed public message,
-safe public context, and boundary-safe projection fields. `DiagnosticView` may
-add redacted context and typed source information according to its visibility
-policy.
+safe public context, and boundary-safe projection fields; Generic exposure
+suppresses all dynamic public fields. `DiagnosticView` adds only declared,
+bounded diagnostic values and value-free redaction markers. Neither view
+exposes the source, caller location, or backtrace; typed causes are inspected
+through `std::error::Error::source()`.
 
 `RetryDecision` remains separate from canonical error identity. It uses
 operation idempotency, operation stage, and remaining budget together with the
 catalog's `RecoveryHint`; it never uses a response message or source string as
 the decision.
 
-These are target concepts, not instructions to add future imports to an
-unmigrated crate. A target API becomes usable only in the owning migration,
-with its inventory evidence and focused tests.
+The canonical core types are current imports from `rocketmq-error`. Other
+target types become usable only in their owning migration, with inventory
+evidence and focused tests; do not invent a compatibility alias or parallel
+catalog in an unmigrated crate.
 
 ## Where changes belong
 

--- a/rocketmq-error/src/catalog.rs
+++ b/rocketmq-error/src/catalog.rs
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::descriptor::ErrorClass;
 use crate::descriptor::ErrorCode;
 use crate::descriptor::ErrorDescriptor;
 use crate::field::fields;
 use crate::field::FieldSchema;
 use crate::projection::ProjectionSpec;
+use crate::BacktracePolicy;
 use crate::CanonicalCondition;
 use crate::CliExitCode;
 use crate::CliSpec;
+use crate::ComponentId;
 use crate::ErrorSeverity;
+use crate::Exposure;
+use crate::FaultAttribution;
 use crate::GrpcPayloadCode;
 use crate::GrpcSpec;
 use crate::GrpcStatusCode;
@@ -36,10 +41,15 @@ macro_rules! define_error_catalog {
             $(#[$metadata:meta])*
             $name:ident {
                 code: $code:literal,
+                class: $class:path,
                 condition: $condition:path,
+                fault: $fault:path,
+                component: $component:path,
                 public_message: $public_message:literal,
                 severity: $severity:path,
                 recovery_hint: $recovery_hint:path,
+                backtrace: $backtrace:path,
+                exposure: $exposure:path,
                 fields: [$($field:path),* $(,)?],
                 projection: {
                     remoting: $remoting:path,
@@ -64,10 +74,15 @@ macro_rules! define_error_catalog {
 
                 match ErrorDescriptor::try_new(
                     CODE,
+                    $class,
                     $condition,
+                    $fault,
+                    $component,
                     $public_message,
                     $severity,
                     $recovery_hint,
+                    $backtrace,
+                    $exposure,
                     ProjectionSpec::new(
                         RemotingSpec::new($remoting),
                         GrpcSpec::new($grpc_payload, $grpc_status),
@@ -94,10 +109,15 @@ define_error_catalog! {
     /// Invalid request-header syntax or values.
     PROTOCOL_HEADER_INVALID {
         code: "protocol.header.invalid",
+        class: ErrorClass::VALIDATION,
         condition: CanonicalCondition::InvalidArgument,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::PROTOCOL,
         public_message: "Request header is invalid",
         severity: ErrorSeverity::Info,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::INVALID_VALUE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::InvalidParameter,
@@ -112,10 +132,15 @@ define_error_catalog! {
     /// Missing routing information for a topic.
     ROUTE_TOPIC_NOT_FOUND {
         code: "route.topic.not_found",
+        class: ErrorClass::ROUTING,
         condition: CanonicalCondition::NotFound,
+        fault: FaultAttribution::RemotePeer,
+        component: ComponentId::ROUTE,
         public_message: "Topic route was not found",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::RefreshRoute,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [fields::TOPIC],
         projection: {
             remoting: RemotingResponseCode::TopicNotExist,
@@ -130,10 +155,15 @@ define_error_catalog! {
     /// Invalid authentication credentials or signature.
     AUTH_CREDENTIALS_INVALID {
         code: "auth.credentials.invalid",
+        class: ErrorClass::AUTHENTICATION,
         condition: CanonicalCondition::Unauthenticated,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::AUTH,
         public_message: "Authentication credentials are invalid",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::RefreshCredentials,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [fields::CREDENTIALS_PRESENT],
         projection: {
             remoting: RemotingResponseCode::NoPermission,
@@ -148,10 +178,15 @@ define_error_catalog! {
     /// Permission denied for an authenticated principal.
     AUTH_PERMISSION_DENIED {
         code: "auth.permission.denied",
+        class: ErrorClass::AUTHORIZATION,
         condition: CanonicalCondition::PermissionDenied,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::AUTH,
         public_message: "Permission was denied",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [fields::OPERATION],
         projection: {
             remoting: RemotingResponseCode::NoPermission,
@@ -166,10 +201,15 @@ define_error_catalog! {
     /// Saturated transport admission queue.
     TRANSPORT_ADMISSION_QUEUE_SATURATED {
         code: "transport.admission.queue_saturated",
+        class: ErrorClass::CAPACITY,
         condition: CanonicalCondition::ResourceExhausted,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport admission queue is saturated",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [fields::REMOTE_ADDR],
         projection: {
             remoting: RemotingResponseCode::SystemBusy,
@@ -184,10 +224,15 @@ define_error_catalog! {
     /// Operation sent to a controller that is not the leader.
     CONTROLLER_LEADERSHIP_NOT_LEADER {
         code: "controller.leadership.not_leader",
+        class: ErrorClass::ROUTING,
         condition: CanonicalCondition::FailedPrecondition,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::CONTROLLER,
         public_message: "Controller is not the leader",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::RefreshLeader,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [fields::LEADER_ID],
         projection: {
             remoting: RemotingResponseCode::ControllerNotLeader,
@@ -202,10 +247,15 @@ define_error_catalog! {
     /// Timed-out transport connection attempt.
     TRANSPORT_CONNECTION_TIMEOUT {
         code: "transport.connection.timeout",
+        class: ErrorClass::TIMEOUT,
         condition: CanonicalCondition::DeadlineExceeded,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport connection timed out",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [fields::TIMEOUT_MS, fields::REMOTE_ADDR],
         projection: {
             remoting: RemotingResponseCode::SystemBusy,
@@ -220,10 +270,15 @@ define_error_catalog! {
     /// A transport request failed with a legacy request or connection timeout.
     TRANSPORT_REQUEST_TIMEOUT {
         code: "transport.request.timeout",
+        class: ErrorClass::TIMEOUT,
         condition: CanonicalCondition::DeadlineExceeded,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport request timed out",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemBusy,
@@ -238,10 +293,15 @@ define_error_catalog! {
     /// Transport server startup failed.
     TRANSPORT_START_FAILED {
         code: "transport.start.failed",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::Unknown,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport server could not be started",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemError,
@@ -256,10 +316,15 @@ define_error_catalog! {
     /// Transport request dispatch failed.
     TRANSPORT_DISPATCH_FAILED {
         code: "transport.dispatch.failed",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport request dispatch failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemError,
@@ -274,10 +339,15 @@ define_error_catalog! {
     /// Transport response delivery failed.
     TRANSPORT_RESPONSE_FAILED {
         code: "transport.response.failed",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport response delivery failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemError,
@@ -292,10 +362,15 @@ define_error_catalog! {
     /// Transport session operation failed.
     TRANSPORT_SESSION_FAILED {
         code: "transport.session.failed",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport session operation failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemError,
@@ -310,10 +385,15 @@ define_error_catalog! {
     /// Storage lifecycle operation attempted before startup completed.
     STORAGE_LIFECYCLE_NOT_STARTED {
         code: "storage.lifecycle.not_started",
+        class: ErrorClass::VALIDATION,
         condition: CanonicalCondition::FailedPrecondition,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::STORAGE,
         public_message: "Storage service is not started",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -333,10 +413,15 @@ define_error_catalog! {
     /// Configured storage backend is unavailable.
     STORAGE_BACKEND_UNAVAILABLE {
         code: "storage.backend.unavailable",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::STORAGE,
         public_message: "Storage backend is unavailable",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -356,10 +441,15 @@ define_error_catalog! {
     /// Invalid request at the storage capability boundary.
     STORAGE_REQUEST_INVALID {
         code: "storage.request.invalid",
+        class: ErrorClass::VALIDATION,
         condition: CanonicalCondition::InvalidArgument,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::STORAGE,
         public_message: "Storage request is invalid",
         severity: ErrorSeverity::Info,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -379,10 +469,15 @@ define_error_catalog! {
     /// Requested mapped file does not exist.
     STORAGE_MAPPED_FILE_NOT_FOUND {
         code: "storage.mapped_file.not_found",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::NotFound,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Mapped file was not found",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -402,10 +497,15 @@ define_error_catalog! {
     /// Storage has no remaining capacity for the operation.
     STORAGE_CAPACITY_EXHAUSTED {
         code: "storage.capacity.exhausted",
+        class: ErrorClass::CAPACITY,
         condition: CanonicalCondition::ResourceExhausted,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage capacity is exhausted",
         severity: ErrorSeverity::Critical,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -425,10 +525,15 @@ define_error_catalog! {
     /// Storage read operation failed.
     STORAGE_READ_FAILED {
         code: "storage.read.failed",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage read failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -448,10 +553,15 @@ define_error_catalog! {
     /// Storage write operation failed.
     STORAGE_WRITE_FAILED {
         code: "storage.write.failed",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage write failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -471,10 +581,15 @@ define_error_catalog! {
     /// Storage I/O operation failed.
     STORAGE_IO_FAILED {
         code: "storage.io.failed",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage I/O operation failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -494,10 +609,15 @@ define_error_catalog! {
     /// Storage state is corrupted.
     STORAGE_STATE_CORRUPTED {
         code: "storage.state.corrupted",
+        class: ErrorClass::DATA_CORRUPTION,
         condition: CanonicalCondition::DataLoss,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage state is corrupted",
         severity: ErrorSeverity::Critical,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -517,10 +637,15 @@ define_error_catalog! {
     /// Storage operation exceeded its deadline.
     STORAGE_OPERATION_TIMED_OUT {
         code: "storage.operation.timed_out",
+        class: ErrorClass::TIMEOUT,
         condition: CanonicalCondition::DeadlineExceeded,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage operation timed out",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -540,10 +665,15 @@ define_error_catalog! {
     /// Storage operation is not implemented by the backend.
     STORAGE_OPERATION_UNSUPPORTED {
         code: "storage.operation.unsupported",
+        class: ErrorClass::UNSUPPORTED,
         condition: CanonicalCondition::Unimplemented,
+        fault: FaultAttribution::Configuration,
+        component: ComponentId::STORAGE,
         public_message: "Storage operation is unsupported",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -563,10 +693,15 @@ define_error_catalog! {
     /// Internal storage failure without a more specific descriptor.
     STORAGE_INTERNAL_FAILURE {
         code: "storage.internal.failure",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Unknown,
+        component: ComponentId::STORAGE,
         public_message: "Internal storage failure",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         fields: [
             fields::STORE_OPERATION,
             fields::STORE_COMPONENT,
@@ -586,10 +721,15 @@ define_error_catalog! {
     /// Protocol version that this implementation does not support.
     PROTOCOL_VERSION_UNSUPPORTED {
         code: "protocol.version.unsupported",
+        class: ErrorClass::UNSUPPORTED,
         condition: CanonicalCondition::Unimplemented,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::PROTOCOL,
         public_message: "Protocol version is unsupported",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [fields::ORDINAL],
         projection: {
             remoting: RemotingResponseCode::RequestCodeNotSupported,
@@ -604,10 +744,15 @@ define_error_catalog! {
     /// Internal failure without a more specific catalog identity.
     CORE_INTERNAL_FAILURE {
         code: "core.internal.failure",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Unknown,
+        component: ComponentId::CORE,
         public_message: "Internal error",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemError,
@@ -622,10 +767,15 @@ define_error_catalog! {
     /// Runtime configuration could not be loaded or interpreted.
     RUNTIME_CONFIGURATION_FAILED {
         code: "runtime.configuration.failed",
+        class: ErrorClass::VALIDATION,
         condition: CanonicalCondition::InvalidArgument,
+        fault: FaultAttribution::Configuration,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime configuration is invalid",
         severity: ErrorSeverity::Info,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::InvalidParameter,
@@ -640,10 +790,15 @@ define_error_catalog! {
     /// Runtime construction failed.
     RUNTIME_BUILD_FAILED {
         code: "runtime.build.failed",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::Configuration,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime could not be started",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemError,
@@ -658,10 +813,15 @@ define_error_catalog! {
     /// Runtime I/O failed.
     RUNTIME_IO_FAILED {
         code: "runtime.io.failed",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime I/O operation failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemError,
@@ -676,10 +836,15 @@ define_error_catalog! {
     /// A required Tokio runtime context is unavailable.
     RUNTIME_CONTEXT_UNAVAILABLE {
         code: "runtime.context.unavailable",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime context is unavailable",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC],
         projection: {
             remoting: RemotingResponseCode::SystemError,
@@ -694,10 +859,15 @@ define_error_catalog! {
     /// Runtime capacity needed by an operational path is exhausted.
     RUNTIME_CAPACITY_EXHAUSTED {
         code: "runtime.capacity.exhausted",
+        class: ErrorClass::CAPACITY,
         condition: CanonicalCondition::ResourceExhausted,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime capacity is exhausted",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC],
         projection: {
             remoting: RemotingResponseCode::SystemBusy,
@@ -712,10 +882,15 @@ define_error_catalog! {
     /// A runtime operation exceeded its deadline.
     RUNTIME_OPERATION_TIMED_OUT {
         code: "runtime.operation.timed_out",
+        class: ErrorClass::TIMEOUT,
         condition: CanonicalCondition::DeadlineExceeded,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime operation timed out",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC],
         projection: {
             remoting: RemotingResponseCode::SystemBusy,
@@ -730,10 +905,15 @@ define_error_catalog! {
     /// A runtime operation is unsupported.
     RUNTIME_OPERATION_UNSUPPORTED {
         code: "runtime.operation.unsupported",
+        class: ErrorClass::UNSUPPORTED,
         condition: CanonicalCondition::Unimplemented,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime operation is unsupported",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         fields: [fields::OPERATION_DIAGNOSTIC],
         projection: {
             remoting: RemotingResponseCode::RequestCodeNotSupported,
@@ -748,10 +928,15 @@ define_error_catalog! {
     /// A runtime task could not be joined.
     RUNTIME_TASK_JOIN_FAILED {
         code: "runtime.task.join_failed",
+        class: ErrorClass::BUG,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Bug,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime task failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemError,
@@ -766,10 +951,15 @@ define_error_catalog! {
     /// An internal runtime failure occurred.
     RUNTIME_INTERNAL_FAILURE {
         code: "runtime.internal.failure",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Unknown,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime operation failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         fields: [fields::OPERATION_DIAGNOSTIC, fields::SOURCE_PRESENT],
         projection: {
             remoting: RemotingResponseCode::SystemError,

--- a/rocketmq-error/src/descriptor.rs
+++ b/rocketmq-error/src/descriptor.rs
@@ -17,8 +17,144 @@ use std::fmt;
 use crate::field::FieldSchema;
 use crate::projection::ProjectionSpec;
 use crate::CanonicalCondition;
-use crate::ErrorSeverity;
 use crate::RecoveryHint;
+
+/// Broad classification used for stable diagnostic policy.
+///
+/// Values are closed to the associated constants exposed by this crate. The
+/// catalog owns the class for every descriptor; error instances and domain
+/// facades cannot override it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ErrorClass(&'static str);
+
+impl ErrorClass {
+    /// Deterministic input or contract validation failure.
+    pub const VALIDATION: Self = Self("validation");
+    /// Authentication failure.
+    pub const AUTHENTICATION: Self = Self("authentication");
+    /// Authorization failure.
+    pub const AUTHORIZATION: Self = Self("authorization");
+    /// Routing or leadership failure.
+    pub const ROUTING: Self = Self("routing");
+    /// Resource-capacity failure.
+    pub const CAPACITY: Self = Self("capacity");
+    /// Deadline or timeout failure.
+    pub const TIMEOUT: Self = Self("timeout");
+    /// Temporarily unavailable service or resource.
+    pub const UNAVAILABLE: Self = Self("unavailable");
+    /// Input/output failure.
+    pub const IO: Self = Self("io");
+    /// Corrupted or irrecoverable data.
+    pub const DATA_CORRUPTION: Self = Self("data_corruption");
+    /// Unsupported operation or capability.
+    pub const UNSUPPORTED: Self = Self("unsupported");
+    /// Internal operational failure.
+    pub const INTERNAL: Self = Self("internal");
+    /// Violation of an implementation invariant.
+    pub const BUG: Self = Self("bug");
+
+    /// Returns the stable class name.
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+impl fmt::Display for ErrorClass {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+/// Catalog owner for a canonical descriptor.
+///
+/// Domain-specific operation and subcomponent values remain typed context and
+/// do not replace this catalog-level owner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ComponentId(&'static str);
+
+impl ComponentId {
+    /// Canonical error core.
+    pub const CORE: Self = Self("core");
+    /// Protocol encoding and validation.
+    pub const PROTOCOL: Self = Self("protocol");
+    /// Route discovery and leadership.
+    pub const ROUTE: Self = Self("route");
+    /// Authentication and authorization.
+    pub const AUTH: Self = Self("auth");
+    /// Controller services.
+    pub const CONTROLLER: Self = Self("controller");
+    /// Storage services.
+    pub const STORAGE: Self = Self("storage");
+    /// Runtime services.
+    pub const RUNTIME: Self = Self("runtime");
+    /// Transport services.
+    pub const TRANSPORT: Self = Self("transport");
+
+    /// Returns the stable component name.
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+impl fmt::Display for ComponentId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+/// Party or resource attributed with a canonical failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum FaultAttribution {
+    /// The caller supplied invalid input or violated a contract.
+    Caller,
+    /// A remote peer failed or rejected an operation.
+    RemotePeer,
+    /// A local resource failed or became exhausted.
+    LocalResource,
+    /// A required dependency failed.
+    Dependency,
+    /// Configuration caused the failure.
+    Configuration,
+    /// An implementation invariant was violated.
+    Bug,
+    /// The failure cannot be attributed safely.
+    Unknown,
+}
+
+/// Public-context exposure policy for a descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Exposure {
+    /// The fixed message and descriptor-approved public fields may be exposed.
+    Public,
+    /// Only the fixed descriptor message may be exposed.
+    Generic,
+}
+
+/// Catalog-controlled backtrace capture policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BacktracePolicy {
+    /// Never capture a backtrace.
+    Never,
+    /// Capture only when the standard library's backtrace environment enables it.
+    OnDemand,
+}
+
+/// Default severity for logs, metrics, traces, and alert routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ErrorSeverity {
+    /// Diagnostic-only failure.
+    Debug,
+    /// Informational failure.
+    Info,
+    /// Warning-level failure.
+    Warn,
+    /// Error-level failure.
+    Error,
+    /// Critical failure requiring immediate attention.
+    Critical,
+}
 
 /// Stable machine-readable error code.
 ///
@@ -77,23 +213,30 @@ impl fmt::Display for ErrorCode {
 
 /// Immutable catalog metadata for one canonical error identity.
 ///
-/// A descriptor owns the stable code, protocol-independent condition, fixed
-/// public message, operational severity, recovery hint, and explicit boundary
-/// projections for an error. Its ordered field schemas define the only context
-/// accepted by later descriptor-aware views. Catalog consumers can inspect
-/// this metadata but cannot construct or modify descriptors outside this crate.
+/// A descriptor owns stable identity, classification, fault attribution,
+/// component ownership, the fixed public message, operational policy, public
+/// exposure, backtrace capture, and explicit boundary projections. Its ordered
+/// field schemas define the only context accepted by descriptor-aware views.
+/// Catalog consumers can inspect this metadata but cannot construct or modify
+/// descriptors outside this crate.
 ///
 /// ```compile_fail
 /// use rocketmq_error::{
-///     CanonicalCondition, ErrorCode, ErrorDescriptor, ErrorSeverity, RecoveryHint,
+///     BacktracePolicy, CanonicalCondition, ComponentId, ErrorClass, ErrorCode,
+///     ErrorDescriptor, ErrorSeverity, Exposure, FaultAttribution, RecoveryHint,
 /// };
 ///
 /// let descriptor = ErrorDescriptor {
 ///     code: ErrorCode::try_new("example.operation.failed").unwrap(),
+///     class: ErrorClass::INTERNAL,
 ///     condition: CanonicalCondition::Internal,
+///     fault: FaultAttribution::Unknown,
+///     component: ComponentId::CORE,
 ///     public_message: "The operation failed",
 ///     severity: ErrorSeverity::Error,
 ///     recovery_hint: RecoveryHint::OperatorAction,
+///     backtrace: BacktracePolicy::OnDemand,
+///     exposure: Exposure::Generic,
 ///     projection: todo!(),
 ///     fields: &[],
 /// };
@@ -101,10 +244,15 @@ impl fmt::Display for ErrorCode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ErrorDescriptor {
     code: ErrorCode,
+    class: ErrorClass,
     condition: CanonicalCondition,
+    fault: FaultAttribution,
+    component: ComponentId,
     public_message: &'static str,
     severity: ErrorSeverity,
     recovery_hint: RecoveryHint,
+    backtrace: BacktracePolicy,
+    exposure: Exposure,
     projection: ProjectionSpec,
     fields: &'static [FieldSchema],
 }
@@ -113,10 +261,15 @@ impl ErrorDescriptor {
     #[inline]
     pub(crate) const fn try_new(
         code: ErrorCode,
+        class: ErrorClass,
         condition: CanonicalCondition,
+        fault: FaultAttribution,
+        component: ComponentId,
         public_message: &'static str,
         severity: ErrorSeverity,
         recovery_hint: RecoveryHint,
+        backtrace: BacktracePolicy,
+        exposure: Exposure,
         projection: ProjectionSpec,
         fields: &'static [FieldSchema],
     ) -> Option<Self> {
@@ -125,10 +278,15 @@ impl ErrorDescriptor {
         }
         Some(Self {
             code,
+            class,
             condition,
+            fault,
+            component,
             public_message,
             severity,
             recovery_hint,
+            backtrace,
+            exposure,
             projection,
             fields,
         })
@@ -140,10 +298,28 @@ impl ErrorDescriptor {
         self.code
     }
 
+    /// Returns the broad catalog-owned class.
+    #[inline]
+    pub const fn class(&self) -> ErrorClass {
+        self.class
+    }
+
     /// Returns the protocol-independent canonical condition.
     #[inline]
     pub const fn condition(&self) -> CanonicalCondition {
         self.condition
+    }
+
+    /// Returns the catalog-owned fault attribution.
+    #[inline]
+    pub const fn fault(&self) -> FaultAttribution {
+        self.fault
+    }
+
+    /// Returns the catalog component that owns this descriptor.
+    #[inline]
+    pub const fn component(&self) -> ComponentId {
+        self.component
     }
 
     /// Returns the fixed, boundary-safe public message.
@@ -162,6 +338,18 @@ impl ErrorDescriptor {
     #[inline]
     pub const fn recovery_hint(&self) -> RecoveryHint {
         self.recovery_hint
+    }
+
+    /// Returns the catalog-controlled backtrace policy.
+    #[inline]
+    pub const fn backtrace_policy(&self) -> BacktracePolicy {
+        self.backtrace
+    }
+
+    /// Returns the public-context exposure policy.
+    #[inline]
+    pub const fn exposure(&self) -> Exposure {
+        self.exposure
     }
 
     /// Returns the explicit boundary projections.

--- a/rocketmq-error/src/error.rs
+++ b/rocketmq-error/src/error.rs
@@ -1,0 +1,273 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::backtrace::Backtrace;
+use std::backtrace::BacktraceStatus;
+use std::error::Error as StdError;
+use std::fmt;
+use std::panic::Location;
+use std::sync::Arc;
+
+use crate::BacktracePolicy;
+use crate::CanonicalCondition;
+use crate::ComponentId;
+use crate::DiagnosticView;
+use crate::ErrorClass;
+use crate::ErrorCode;
+use crate::ErrorContext;
+use crate::ErrorDescriptor;
+use crate::ErrorSeverity;
+use crate::Exposure;
+use crate::FaultAttribution;
+use crate::ProjectionSpec;
+use crate::PublicErrorView;
+use crate::RecoveryHint;
+use crate::ViewContextViolation;
+
+type BoxError = Box<dyn StdError + Send + Sync + 'static>;
+
+/// Opaque canonical RocketMQ error.
+///
+/// Identity and policy are owned by a reviewed catalog descriptor. Each value
+/// retains typed context, at most one direct typed source, its first-promotion
+/// caller location, and an optional catalog-controlled backtrace behind one
+/// boxed pointer.
+///
+/// `Error` is intentionally not cloneable. Use [`SharedError`] when multiple
+/// owners must observe the same error instance.
+///
+/// ```compile_fail
+/// use rocketmq_error::{Error, CORE_INTERNAL_FAILURE};
+///
+/// let error = Error::new(&CORE_INTERNAL_FAILURE);
+/// let _copy = error.clone();
+/// ```
+pub struct Error {
+    inner: Box<ErrorInner>,
+}
+
+struct ErrorInner {
+    descriptor: &'static ErrorDescriptor,
+    context: ErrorContext,
+    source: Option<BoxError>,
+    location: &'static Location<'static>,
+    backtrace: Option<Backtrace>,
+}
+
+/// Result whose error is the canonical [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Shared ownership of one canonical [`Error`] instance.
+pub type SharedError = Arc<Error>;
+
+impl Error {
+    /// Creates a source-free canonical error from a catalog descriptor.
+    #[must_use]
+    #[track_caller]
+    pub fn new(descriptor: &'static ErrorDescriptor) -> Self {
+        Self::from_parts(descriptor, None)
+    }
+
+    /// Creates a canonical error while retaining the direct typed source.
+    #[must_use]
+    #[track_caller]
+    pub fn caused_by(descriptor: &'static ErrorDescriptor, source: impl StdError + Send + Sync + 'static) -> Self {
+        Self::from_parts(descriptor, Some(Box::new(source)))
+    }
+
+    #[track_caller]
+    fn from_parts(descriptor: &'static ErrorDescriptor, source: Option<BoxError>) -> Self {
+        Self {
+            inner: Box::new(ErrorInner {
+                descriptor,
+                context: ErrorContext::new(),
+                source,
+                location: Location::caller(),
+                backtrace: capture_backtrace(descriptor.backtrace_policy()),
+            }),
+        }
+    }
+
+    /// Replaces the typed context without changing source or provenance.
+    #[must_use]
+    pub fn with_context(mut self, context: ErrorContext) -> Self {
+        self.inner.context = context;
+        self
+    }
+
+    /// Replaces the direct typed source without changing context or provenance.
+    #[must_use]
+    pub fn with_source(mut self, source: impl StdError + Send + Sync + 'static) -> Self {
+        self.inner.source = Some(Box::new(source));
+        self
+    }
+
+    /// Replaces the direct boxed source without adding another causal layer.
+    #[must_use]
+    pub fn with_boxed_source(mut self, source: Box<dyn StdError + Send + Sync + 'static>) -> Self {
+        self.inner.source = Some(source);
+        self
+    }
+
+    /// Returns the catalog descriptor that owns identity and policy.
+    #[must_use]
+    pub const fn descriptor(&self) -> &'static ErrorDescriptor {
+        self.inner.descriptor
+    }
+
+    /// Returns the stable catalog code.
+    #[must_use]
+    pub const fn code(&self) -> ErrorCode {
+        self.descriptor().code()
+    }
+
+    /// Returns the broad catalog-owned class.
+    #[must_use]
+    pub const fn class(&self) -> ErrorClass {
+        self.descriptor().class()
+    }
+
+    /// Returns the protocol-independent canonical condition.
+    #[must_use]
+    pub const fn condition(&self) -> CanonicalCondition {
+        self.descriptor().condition()
+    }
+
+    /// Returns the catalog-owned fault attribution.
+    #[must_use]
+    pub const fn fault(&self) -> FaultAttribution {
+        self.descriptor().fault()
+    }
+
+    /// Returns the catalog component that owns this identity.
+    #[must_use]
+    pub const fn component(&self) -> ComponentId {
+        self.descriptor().component()
+    }
+
+    /// Returns the catalog-owned severity.
+    #[must_use]
+    pub const fn severity(&self) -> ErrorSeverity {
+        self.descriptor().severity()
+    }
+
+    /// Returns the catalog-owned recovery hint.
+    #[must_use]
+    pub const fn recovery_hint(&self) -> RecoveryHint {
+        self.descriptor().recovery_hint()
+    }
+
+    /// Returns the public-context exposure policy.
+    #[must_use]
+    pub const fn exposure(&self) -> Exposure {
+        self.descriptor().exposure()
+    }
+
+    /// Returns the catalog-controlled backtrace policy.
+    #[must_use]
+    pub const fn backtrace_policy(&self) -> BacktracePolicy {
+        self.descriptor().backtrace_policy()
+    }
+
+    /// Returns descriptor-owned boundary projections.
+    #[must_use]
+    pub const fn projection(&self) -> ProjectionSpec {
+        self.descriptor().projection()
+    }
+
+    /// Returns the typed context retained by this error.
+    #[must_use]
+    pub const fn context(&self) -> &ErrorContext {
+        &self.inner.context
+    }
+
+    /// Creates a descriptor-validated public projection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the retained context does not match the selected
+    /// catalog descriptor.
+    pub fn public_view(&self) -> std::result::Result<PublicErrorView<'_>, ViewContextViolation> {
+        PublicErrorView::try_new(self.descriptor(), self.context())
+    }
+
+    /// Creates a descriptor-validated diagnostic projection.
+    ///
+    /// The view never includes the source, caller location, or backtrace.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the retained context does not match the selected
+    /// catalog descriptor.
+    pub fn diagnostic_view(&self) -> std::result::Result<DiagnosticView<'_>, ViewContextViolation> {
+        DiagnosticView::try_new(self.descriptor(), self.context())
+    }
+
+    /// Returns the first-promotion caller location.
+    #[must_use]
+    pub const fn location(&self) -> &'static Location<'static> {
+        self.inner.location
+    }
+
+    /// Returns the captured backtrace, if standard-library capture was enabled.
+    #[must_use]
+    pub const fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace.as_ref()
+    }
+}
+
+fn capture_backtrace(policy: BacktracePolicy) -> Option<Backtrace> {
+    match policy {
+        BacktracePolicy::Never => None,
+        BacktracePolicy::OnDemand => {
+            let backtrace = Backtrace::capture();
+            matches!(backtrace.status(), BacktraceStatus::Captured).then_some(backtrace)
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code(), self.descriptor().public_message())
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Error")
+            .field("code", &self.code())
+            .field("class", &self.class())
+            .field("condition", &self.condition())
+            .field("fault", &self.fault())
+            .field("component", &self.component())
+            .field("severity", &self.severity())
+            .field("recovery_hint", &self.recovery_hint())
+            .field("exposure", &self.exposure())
+            .field("backtrace_policy", &self.backtrace_policy())
+            .field("context", &self.context())
+            .field("source_present", &self.inner.source.is_some())
+            .field("backtrace_captured", &self.inner.backtrace.is_some())
+            .finish()
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.inner
+            .source
+            .as_deref()
+            .map(|source| source as &(dyn StdError + 'static))
+    }
+}

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -14,42 +14,34 @@
 
 #![deny(missing_docs)]
 
-//! # RocketMQ Error Handling System
+//! # RocketMQ Error Handling
 //!
-//! This crate provides a unified, semantic, and performant error handling system
-//! for the RocketMQ Rust implementation.
+//! This crate provides the canonical catalog, opaque [`Error`] envelope,
+//! typed context, safe views, and boundary-neutral policy used by RocketMQ
+//! components.
 //!
-//! ## New Unified Error System (v0.7.0+)
-//!
-//! The new error system provides:
-//! - **Semantic clarity**: Each error type clearly expresses what went wrong
-//! - **Performance**: Minimal heap allocations, optimized for hot paths
-//! - **Ergonomics**: Automatic error conversions via `From` trait
-//! - **Debuggability**: Rich context for production debugging
-//!
-//! ### Usage
+//! Catalog descriptors are the sole owners of stable identity and policy.
+//! Error instances retain one direct typed source and record the first caller
+//! that promotes a failure into the canonical envelope. Formatting and safe
+//! views never render source text, caller paths, or backtrace frames.
 //!
 //! ```rust
-//! use rocketmq_error::RocketMQError;
-//! use rocketmq_error::RocketMQResult;
+//! use std::io;
+//! use rocketmq_error::{Error, Result, RUNTIME_IO_FAILED};
 //!
-//! fn send_message(addr: &str) -> RocketMQResult<()> {
-//!     if addr.is_empty() {
-//!         return Err(RocketMQError::network_connection_failed(
-//!             "localhost:9876",
-//!             "invalid address",
-//!         ));
-//!     }
-//!     Ok(())
+//! fn read_metadata() -> Result<()> {
+//!     Err(Error::caused_by(
+//!         &RUNTIME_IO_FAILED,
+//!         io::Error::other("metadata read failed"),
+//!     ))
 //! }
-//! # send_message("localhost:9876").unwrap();
+//!
+//! let error = read_metadata().expect_err("example failure");
+//! assert_eq!(error.code().as_str(), "runtime.io.failed");
 //! ```
 //!
-//! ## Public Error Surface
-//!
-//! The crate exports the typed `RocketMQError` enum and stable supporting
-//! contracts only. Pre-typed compatibility aliases and enum variants are not
-//! part of the public API.
+//! The public `RocketMQError` and related spec types remain available only for
+//! domains that have not yet migrated to the canonical envelope.
 
 mod auth_error;
 mod boundary;
@@ -59,6 +51,7 @@ mod context;
 mod controller_error;
 mod descriptor;
 mod domain;
+mod error;
 mod field;
 mod filter_error;
 mod kind;
@@ -130,9 +123,18 @@ pub use context::Sensitive;
 pub use context::REDACTED;
 pub use controller_error::ControllerError;
 pub use controller_error::ControllerResult;
+pub use descriptor::BacktracePolicy;
+pub use descriptor::ComponentId;
+pub use descriptor::ErrorClass;
 pub use descriptor::ErrorCode;
 pub use descriptor::ErrorDescriptor;
+pub use descriptor::ErrorSeverity;
+pub use descriptor::Exposure;
+pub use descriptor::FaultAttribution;
 pub use domain::DomainError;
+pub use error::Error;
+pub use error::Result;
+pub use error::SharedError;
 pub use field::fields;
 pub use field::BoolField;
 pub use field::ContextVisibility;
@@ -153,7 +155,6 @@ pub use kind::ErrorCategory;
 pub use kind::ErrorKind;
 pub use kind::ErrorScope;
 pub use observability_error::ObservabilityError;
-pub use policy::ErrorSeverity;
 pub use policy::ObserveSpec;
 pub use policy::RecoverySpec;
 pub use policy::RetryClass;

--- a/rocketmq-error/src/policy.rs
+++ b/rocketmq-error/src/policy.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::descriptor::ErrorSeverity;
 use crate::ErrorKind;
 
 /// Retry or recovery classification for one error kind.
@@ -79,21 +80,6 @@ impl RecoverySpec {
             _ => RetryClass::Never,
         })
     }
-}
-
-/// Default severity for logs, metrics, traces, and alert routing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ErrorSeverity {
-    /// Represents the debug case.
-    Debug,
-    /// Represents the info case.
-    Info,
-    /// Represents the warn case.
-    Warn,
-    /// Represents the error case.
-    Error,
-    /// Represents the critical case.
-    Critical,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/rocketmq-error/src/view.rs
+++ b/rocketmq-error/src/view.rs
@@ -24,6 +24,7 @@ use crate::ErrorCode;
 use crate::ErrorContext;
 use crate::ErrorDescriptor;
 use crate::ErrorSeverity;
+use crate::Exposure;
 use crate::FieldSchema;
 use crate::ProjectionSpec;
 use crate::RecoveryHint;
@@ -102,9 +103,11 @@ impl fmt::Display for ViewContextViolation {
 /// A borrowed public projection of one descriptor-validated error context.
 ///
 /// This view exposes only the descriptor's stable identity, fixed public
-/// message, explicitly public context fields, and descriptor-owned protocol
-/// projections. It borrows its inputs and performs no allocation after the
-/// [`ErrorContext`] has been constructed.
+/// message, and descriptor-owned protocol projections. Descriptors with
+/// [`Exposure::Public`] may additionally expose declared public context fields;
+/// [`Exposure::Generic`] descriptors expose no dynamic fields. The view borrows
+/// its inputs and performs no allocation after the [`ErrorContext`] has been
+/// constructed.
 ///
 /// ```compile_fail,E0616
 /// use rocketmq_error::{ErrorContext, PublicErrorView, ROUTE_TOPIC_NOT_FOUND};
@@ -149,7 +152,9 @@ impl<'a> PublicErrorView<'a> {
         self.descriptor.public_message()
     }
 
-    /// Iterates present public fields in descriptor declaration order.
+    /// Iterates permitted public fields in descriptor declaration order.
+    ///
+    /// Generic-exposure descriptors always return an empty iterator.
     #[inline]
     pub fn fields(&self) -> PublicFields<'a> {
         PublicFields::new(self.descriptor, self.context)
@@ -184,8 +189,9 @@ impl fmt::Debug for PublicErrorView<'_> {
 /// A borrowed controlled-diagnostics projection of one descriptor-validated context.
 ///
 /// `DiagnosticView` exposes descriptor-approved diagnostic fields and
-/// key-only secret-presence markers for operational diagnostics. It must not
-/// be serialized into public protocol responses. Like [`PublicErrorView`], it
+/// key-only secret-presence markers for operational diagnostics. It never
+/// exposes source errors, caller locations, or backtraces and must not be
+/// serialized into public protocol responses. Like [`PublicErrorView`], it
 /// borrows its inputs and performs no allocation after [`ErrorContext`] has
 /// been constructed.
 pub struct DiagnosticView<'a> {
@@ -277,12 +283,14 @@ impl fmt::Debug for DiagnosticView<'_> {
 #[derive(Clone)]
 pub struct PublicFields<'a> {
     inner: ViewFields<'a>,
+    enabled: bool,
 }
 
 impl<'a> PublicFields<'a> {
     fn new(descriptor: &'static ErrorDescriptor, context: &'a ErrorContext) -> Self {
         Self {
             inner: ViewFields::new(descriptor, context),
+            enabled: matches!(descriptor.exposure(), Exposure::Public),
         }
     }
 }
@@ -291,7 +299,11 @@ impl<'a> Iterator for PublicFields<'a> {
     type Item = ViewFieldRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next_field(false)
+        if self.enabled {
+            self.inner.next_field(false)
+        } else {
+            None
+        }
     }
 }
 
@@ -475,15 +487,43 @@ mod tests {
     static BOOLEAN_FIELDS: [FieldSchema; 1] = [fields::ATTEMPTED.schema()];
     static BOOLEAN_DESCRIPTOR: ErrorDescriptor = match ErrorDescriptor::try_new(
         BOOLEAN_CODE,
+        crate::ErrorClass::INTERNAL,
         CanonicalCondition::Internal,
+        crate::FaultAttribution::Unknown,
+        crate::ComponentId::CORE,
         "Synthetic Boolean view test",
         ErrorSeverity::Info,
         RecoveryHint::Never,
+        crate::BacktracePolicy::Never,
+        crate::Exposure::Public,
         crate::ROUTE_TOPIC_NOT_FOUND.projection(),
         &BOOLEAN_FIELDS,
     ) {
         Some(descriptor) => descriptor,
         None => panic!("synthetic Boolean descriptor must be valid"),
+    };
+
+    const GENERIC_CODE: ErrorCode = match ErrorCode::try_new("test.view.generic") {
+        Some(code) => code,
+        None => panic!("synthetic test code must be valid"),
+    };
+    static GENERIC_FIELDS: [FieldSchema; 1] = [fields::ACTUAL_BYTES.schema()];
+    static GENERIC_DESCRIPTOR: ErrorDescriptor = match ErrorDescriptor::try_new(
+        GENERIC_CODE,
+        crate::ErrorClass::INTERNAL,
+        CanonicalCondition::Internal,
+        crate::FaultAttribution::Unknown,
+        crate::ComponentId::CORE,
+        "Synthetic Generic view test",
+        ErrorSeverity::Info,
+        RecoveryHint::Never,
+        crate::BacktracePolicy::Never,
+        crate::Exposure::Generic,
+        crate::ROUTE_TOPIC_NOT_FOUND.projection(),
+        &GENERIC_FIELDS,
+    ) {
+        Some(descriptor) => descriptor,
+        None => panic!("synthetic Generic descriptor must be valid"),
     };
 
     #[test]
@@ -496,6 +536,19 @@ mod tests {
         assert_eq!(
             diagnostic.fields().next().expect("Boolean field").value(),
             ViewValueRef::Bool(true)
+        );
+    }
+
+    #[test]
+    fn generic_exposure_suppresses_descriptor_declared_public_fields() {
+        let context = ErrorContext::new().with_u64(fields::ACTUAL_BYTES, 42);
+        let public = PublicErrorView::try_new(&GENERIC_DESCRIPTOR, &context).expect("public view");
+        let diagnostic = DiagnosticView::try_new(&GENERIC_DESCRIPTOR, &context).expect("diagnostic view");
+
+        assert!(public.fields().next().is_none());
+        assert_eq!(
+            diagnostic.fields().next().expect("diagnostic field").value(),
+            ViewValueRef::U64(42)
         );
     }
 }

--- a/rocketmq-error/tests/error_core.rs
+++ b/rocketmq-error/tests/error_core.rs
@@ -1,0 +1,202 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as StdError;
+use std::fmt;
+use std::io;
+use std::mem::size_of;
+use std::process::Command;
+use std::sync::Arc;
+
+use rocketmq_error::fields;
+use rocketmq_error::BacktracePolicy;
+use rocketmq_error::CanonicalCondition;
+use rocketmq_error::ComponentId;
+use rocketmq_error::Error;
+use rocketmq_error::ErrorClass;
+use rocketmq_error::ErrorContext;
+use rocketmq_error::Exposure;
+use rocketmq_error::FaultAttribution;
+use rocketmq_error::SharedError;
+use rocketmq_error::ViewValueRef;
+use rocketmq_error::CORE_INTERNAL_FAILURE;
+use rocketmq_error::ROUTE_TOPIC_NOT_FOUND;
+use rocketmq_error::STORAGE_STATE_CORRUPTED;
+
+#[derive(Debug)]
+struct OuterCause {
+    source: io::Error,
+}
+
+impl fmt::Display for OuterCause {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("outer-cause")
+    }
+}
+
+impl StdError for OuterCause {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[derive(Debug)]
+struct ReplacementCause;
+
+impl fmt::Display for ReplacementCause {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("replacement-cause")
+    }
+}
+
+impl StdError for ReplacementCause {}
+
+#[test]
+fn canonical_error_is_one_pointer_and_exposes_descriptor_policy() {
+    assert!(size_of::<Error>() <= 2 * size_of::<usize>());
+
+    let error = Error::new(&CORE_INTERNAL_FAILURE);
+    assert_eq!(error.descriptor(), &CORE_INTERNAL_FAILURE);
+    assert_eq!(error.code(), CORE_INTERNAL_FAILURE.code());
+    assert_eq!(error.class(), ErrorClass::INTERNAL);
+    assert_eq!(error.condition(), CanonicalCondition::Internal);
+    assert_eq!(error.fault(), FaultAttribution::Unknown);
+    assert_eq!(error.component(), ComponentId::CORE);
+    assert_eq!(error.exposure(), Exposure::Generic);
+    assert_eq!(error.backtrace_policy(), BacktracePolicy::OnDemand);
+    assert_eq!(error.projection(), CORE_INTERNAL_FAILURE.projection());
+}
+
+#[test]
+fn typed_sources_remain_direct_and_follow_the_original_causal_order() {
+    let error = Error::caused_by(
+        &CORE_INTERNAL_FAILURE,
+        OuterCause {
+            source: io::Error::other("typed-leaf"),
+        },
+    );
+
+    let outer = StdError::source(&error)
+        .and_then(|source| source.downcast_ref::<OuterCause>())
+        .expect("direct typed source");
+    let leaf = outer
+        .source()
+        .and_then(|source| source.downcast_ref::<io::Error>())
+        .expect("second-level typed source");
+    assert_eq!(leaf.to_string(), "typed-leaf");
+}
+
+#[test]
+fn context_and_latest_source_survive_sharing_without_recapturing_location() {
+    let expected_line = line!() + 1;
+    let error = Error::caused_by(&ROUTE_TOPIC_NOT_FOUND, io::Error::other("first-source"));
+    assert_eq!(error.location().line(), expected_line);
+    assert!(error.location().file().ends_with("error_core.rs"));
+
+    let error = error
+        .with_context(ErrorContext::new().with_text(fields::TOPIC, "orders"))
+        .with_source(ReplacementCause);
+    assert_eq!(error.location().line(), expected_line);
+    assert!(StdError::source(&error)
+        .and_then(|source| source.downcast_ref::<ReplacementCause>())
+        .is_some());
+    assert!(StdError::source(&error)
+        .and_then(|source| source.downcast_ref::<io::Error>())
+        .is_none());
+
+    let shared: SharedError = Arc::new(error);
+    let cloned = Arc::clone(&shared);
+    assert!(Arc::ptr_eq(&shared, &cloned));
+    assert_eq!(shared.location(), cloned.location());
+    assert_eq!(shared.context(), cloned.context());
+    let first_source = StdError::source(shared.as_ref()).expect("shared source");
+    let cloned_source = StdError::source(cloned.as_ref()).expect("cloned source");
+    assert!(std::ptr::eq(first_source, cloned_source));
+
+    let public = shared.public_view().expect("valid public view");
+    assert_eq!(
+        public.fields().next().expect("topic").value(),
+        ViewValueRef::Text("orders")
+    );
+}
+
+#[test]
+fn fixed_and_redacted_formatting_never_renders_source_location_or_secret_values() {
+    const SOURCE_SENTINEL: &str = "canonical-source-secret";
+    let error = Error::caused_by(&STORAGE_STATE_CORRUPTED, io::Error::other(SOURCE_SENTINEL)).with_context(
+        ErrorContext::new()
+            .with_text(fields::STORE_OPERATION, "read")
+            .with_text(fields::STORE_COMPONENT, "commit_log")
+            .with_secret_presence(fields::STORE_DETAIL_PRESENT)
+            .with_secret_presence(fields::SOURCE_PRESENT),
+    );
+
+    let display = error.to_string();
+    let debug = format!("{error:?}");
+    assert_eq!(display, "storage.state.corrupted: Storage state is corrupted");
+    assert!(!display.contains(SOURCE_SENTINEL));
+    assert!(!debug.contains(SOURCE_SENTINEL));
+    assert!(!debug.contains(error.location().file()));
+    assert!(!debug.contains("error_core::"));
+
+    let public = error.public_view().expect("valid public view");
+    assert!(public.fields().next().is_none());
+    let public_debug = format!("{public:?}");
+    assert!(!public_debug.contains(SOURCE_SENTINEL));
+    assert!(!public_debug.contains("commit_log"));
+
+    let diagnostic = error.diagnostic_view().expect("valid diagnostic view");
+    let fields = diagnostic.fields().collect::<Vec<_>>();
+    assert_eq!(fields.len(), 4);
+    assert_eq!(fields[0].value(), ViewValueRef::Text("read"));
+    assert_eq!(fields[1].value(), ViewValueRef::Text("commit_log"));
+    assert_eq!(fields[2].value(), ViewValueRef::Redacted);
+    assert_eq!(fields[3].value(), ViewValueRef::Redacted);
+    assert!(!format!("{diagnostic:?}").contains(SOURCE_SENTINEL));
+}
+
+#[test]
+fn backtrace_policy_uses_isolated_standard_environment_probes() {
+    run_backtrace_probe("on_demand_backtrace_enabled_probe", "1");
+    run_backtrace_probe("on_demand_backtrace_disabled_probe", "0");
+}
+
+fn run_backtrace_probe(test_name: &str, rust_backtrace: &str) {
+    let status = Command::new(std::env::current_exe().expect("current test executable"))
+        .args(["--ignored", "--exact", test_name])
+        .env("RUST_BACKTRACE", rust_backtrace)
+        .env_remove("RUST_LIB_BACKTRACE")
+        .status()
+        .expect("spawn isolated backtrace probe");
+    assert!(status.success(), "backtrace probe {test_name} failed");
+}
+
+#[test]
+#[ignore = "executed in an isolated child process"]
+fn on_demand_backtrace_enabled_probe() {
+    let internal = Error::new(&CORE_INTERNAL_FAILURE);
+    let ordinary = Error::new(&ROUTE_TOPIC_NOT_FOUND);
+    assert!(internal.backtrace().is_some());
+    assert!(ordinary.backtrace().is_none());
+    let debug = format!("{internal:?}");
+    assert!(!debug.contains("on_demand_backtrace_enabled_probe"));
+    assert!(!debug.contains(internal.location().file()));
+}
+
+#[test]
+#[ignore = "executed in an isolated child process"]
+fn on_demand_backtrace_disabled_probe() {
+    assert!(Error::new(&CORE_INTERNAL_FAILURE).backtrace().is_none());
+    assert!(Error::new(&ROUTE_TOPIC_NOT_FOUND).backtrace().is_none());
+}

--- a/rocketmq-error/tests/error_descriptor_catalog.rs
+++ b/rocketmq-error/tests/error_descriptor_catalog.rs
@@ -16,12 +16,17 @@ use std::collections::HashSet;
 
 use rocketmq_error::descriptor_by_code;
 use rocketmq_error::fields;
+use rocketmq_error::BacktracePolicy;
 use rocketmq_error::CanonicalCondition;
 use rocketmq_error::CliExitCode;
+use rocketmq_error::ComponentId;
 use rocketmq_error::ContextVisibility;
+use rocketmq_error::ErrorClass;
 use rocketmq_error::ErrorCode;
 use rocketmq_error::ErrorDescriptor;
 use rocketmq_error::ErrorSeverity;
+use rocketmq_error::Exposure;
+use rocketmq_error::FaultAttribution;
 use rocketmq_error::FieldValueKind;
 use rocketmq_error::GrpcPayloadCode;
 use rocketmq_error::GrpcStatusCode;
@@ -69,10 +74,15 @@ use rocketmq_error::TRANSPORT_START_FAILED;
 struct ExpectedDescriptor {
     descriptor: ErrorDescriptor,
     code: &'static str,
+    class: ErrorClass,
     condition: CanonicalCondition,
+    fault: FaultAttribution,
+    component: ComponentId,
     public_message: &'static str,
     severity: ErrorSeverity,
     recovery_hint: RecoveryHint,
+    backtrace: BacktracePolicy,
+    exposure: Exposure,
     remoting: RemotingResponseCode,
     grpc_payload: GrpcPayloadCode,
     grpc_status: GrpcStatusCode,
@@ -84,10 +94,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: PROTOCOL_HEADER_INVALID,
         code: "protocol.header.invalid",
+        class: ErrorClass::VALIDATION,
         condition: CanonicalCondition::InvalidArgument,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::PROTOCOL,
         public_message: "Request header is invalid",
         severity: ErrorSeverity::Info,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::InvalidParameter,
         grpc_payload: GrpcPayloadCode::BadRequest,
         grpc_status: GrpcStatusCode::InvalidArgument,
@@ -97,10 +112,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: ROUTE_TOPIC_NOT_FOUND,
         code: "route.topic.not_found",
+        class: ErrorClass::ROUTING,
         condition: CanonicalCondition::NotFound,
+        fault: FaultAttribution::RemotePeer,
+        component: ComponentId::ROUTE,
         public_message: "Topic route was not found",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::RefreshRoute,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::TopicNotExist,
         grpc_payload: GrpcPayloadCode::TopicNotFound,
         grpc_status: GrpcStatusCode::NotFound,
@@ -110,10 +130,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: AUTH_CREDENTIALS_INVALID,
         code: "auth.credentials.invalid",
+        class: ErrorClass::AUTHENTICATION,
         condition: CanonicalCondition::Unauthenticated,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::AUTH,
         public_message: "Authentication credentials are invalid",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::RefreshCredentials,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::NoPermission,
         grpc_payload: GrpcPayloadCode::Unauthorized,
         grpc_status: GrpcStatusCode::Unauthenticated,
@@ -123,10 +148,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: AUTH_PERMISSION_DENIED,
         code: "auth.permission.denied",
+        class: ErrorClass::AUTHORIZATION,
         condition: CanonicalCondition::PermissionDenied,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::AUTH,
         public_message: "Permission was denied",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::NoPermission,
         grpc_payload: GrpcPayloadCode::Forbidden,
         grpc_status: GrpcStatusCode::PermissionDenied,
@@ -136,10 +166,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: TRANSPORT_ADMISSION_QUEUE_SATURATED,
         code: "transport.admission.queue_saturated",
+        class: ErrorClass::CAPACITY,
         condition: CanonicalCondition::ResourceExhausted,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport admission queue is saturated",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::SystemBusy,
         grpc_payload: GrpcPayloadCode::TooManyRequests,
         grpc_status: GrpcStatusCode::ResourceExhausted,
@@ -149,10 +184,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: CONTROLLER_LEADERSHIP_NOT_LEADER,
         code: "controller.leadership.not_leader",
+        class: ErrorClass::ROUTING,
         condition: CanonicalCondition::FailedPrecondition,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::CONTROLLER,
         public_message: "Controller is not the leader",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::RefreshLeader,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::ControllerNotLeader,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::FailedPrecondition,
@@ -162,10 +202,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: TRANSPORT_CONNECTION_TIMEOUT,
         code: "transport.connection.timeout",
+        class: ErrorClass::TIMEOUT,
         condition: CanonicalCondition::DeadlineExceeded,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport connection timed out",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::SystemBusy,
         grpc_payload: GrpcPayloadCode::RequestTimeout,
         grpc_status: GrpcStatusCode::DeadlineExceeded,
@@ -175,10 +220,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: TRANSPORT_REQUEST_TIMEOUT,
         code: "transport.request.timeout",
+        class: ErrorClass::TIMEOUT,
         condition: CanonicalCondition::DeadlineExceeded,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport request timed out",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemBusy,
         grpc_payload: GrpcPayloadCode::RequestTimeout,
         grpc_status: GrpcStatusCode::DeadlineExceeded,
@@ -188,10 +238,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: TRANSPORT_START_FAILED,
         code: "transport.start.failed",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::Unknown,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport server could not be started",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Unavailable,
@@ -201,10 +256,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: TRANSPORT_DISPATCH_FAILED,
         code: "transport.dispatch.failed",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport request dispatch failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -214,10 +274,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: TRANSPORT_RESPONSE_FAILED,
         code: "transport.response.failed",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport response delivery failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -227,10 +292,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: TRANSPORT_SESSION_FAILED,
         code: "transport.session.failed",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::TRANSPORT,
         public_message: "Transport session operation failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Unavailable,
@@ -240,10 +310,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_LIFECYCLE_NOT_STARTED,
         code: "storage.lifecycle.not_started",
+        class: ErrorClass::VALIDATION,
         condition: CanonicalCondition::FailedPrecondition,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::STORAGE,
         public_message: "Storage service is not started",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::FailedPrecondition,
@@ -253,10 +328,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_BACKEND_UNAVAILABLE,
         code: "storage.backend.unavailable",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::STORAGE,
         public_message: "Storage backend is unavailable",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Unavailable,
@@ -266,10 +346,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_REQUEST_INVALID,
         code: "storage.request.invalid",
+        class: ErrorClass::VALIDATION,
         condition: CanonicalCondition::InvalidArgument,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::STORAGE,
         public_message: "Storage request is invalid",
         severity: ErrorSeverity::Info,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::InvalidParameter,
         grpc_payload: GrpcPayloadCode::BadRequest,
         grpc_status: GrpcStatusCode::InvalidArgument,
@@ -279,10 +364,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_MAPPED_FILE_NOT_FOUND,
         code: "storage.mapped_file.not_found",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::NotFound,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Mapped file was not found",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::QueryNotFound,
         grpc_payload: GrpcPayloadCode::NotFound,
         grpc_status: GrpcStatusCode::NotFound,
@@ -292,10 +382,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_CAPACITY_EXHAUSTED,
         code: "storage.capacity.exhausted",
+        class: ErrorClass::CAPACITY,
         condition: CanonicalCondition::ResourceExhausted,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage capacity is exhausted",
         severity: ErrorSeverity::Critical,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::ResourceExhausted,
@@ -305,10 +400,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_READ_FAILED,
         code: "storage.read.failed",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage read failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -318,10 +418,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_WRITE_FAILED,
         code: "storage.write.failed",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage write failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -331,10 +436,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_IO_FAILED,
         code: "storage.io.failed",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage I/O operation failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -344,10 +454,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_STATE_CORRUPTED,
         code: "storage.state.corrupted",
+        class: ErrorClass::DATA_CORRUPTION,
         condition: CanonicalCondition::DataLoss,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage state is corrupted",
         severity: ErrorSeverity::Critical,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::DataLoss,
@@ -357,10 +472,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_OPERATION_TIMED_OUT,
         code: "storage.operation.timed_out",
+        class: ErrorClass::TIMEOUT,
         condition: CanonicalCondition::DeadlineExceeded,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::STORAGE,
         public_message: "Storage operation timed out",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemBusy,
         grpc_payload: GrpcPayloadCode::RequestTimeout,
         grpc_status: GrpcStatusCode::DeadlineExceeded,
@@ -370,10 +490,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_OPERATION_UNSUPPORTED,
         code: "storage.operation.unsupported",
+        class: ErrorClass::UNSUPPORTED,
         condition: CanonicalCondition::Unimplemented,
+        fault: FaultAttribution::Configuration,
+        component: ComponentId::STORAGE,
         public_message: "Storage operation is unsupported",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::RequestCodeNotSupported,
         grpc_payload: GrpcPayloadCode::Unsupported,
         grpc_status: GrpcStatusCode::Unimplemented,
@@ -383,10 +508,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: STORAGE_INTERNAL_FAILURE,
         code: "storage.internal.failure",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Unknown,
+        component: ComponentId::STORAGE,
         public_message: "Internal storage failure",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -396,10 +526,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: PROTOCOL_VERSION_UNSUPPORTED,
         code: "protocol.version.unsupported",
+        class: ErrorClass::UNSUPPORTED,
         condition: CanonicalCondition::Unimplemented,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::PROTOCOL,
         public_message: "Protocol version is unsupported",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::RequestCodeNotSupported,
         grpc_payload: GrpcPayloadCode::Unsupported,
         grpc_status: GrpcStatusCode::Unimplemented,
@@ -409,10 +544,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: CORE_INTERNAL_FAILURE,
         code: "core.internal.failure",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Unknown,
+        component: ComponentId::CORE,
         public_message: "Internal error",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -422,10 +562,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: RUNTIME_CONFIGURATION_FAILED,
         code: "runtime.configuration.failed",
+        class: ErrorClass::VALIDATION,
         condition: CanonicalCondition::InvalidArgument,
+        fault: FaultAttribution::Configuration,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime configuration is invalid",
         severity: ErrorSeverity::Info,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::InvalidParameter,
         grpc_payload: GrpcPayloadCode::BadRequest,
         grpc_status: GrpcStatusCode::InvalidArgument,
@@ -435,10 +580,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: RUNTIME_BUILD_FAILED,
         code: "runtime.build.failed",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::Configuration,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime could not be started",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Unavailable,
@@ -448,10 +598,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: RUNTIME_IO_FAILED,
         code: "runtime.io.failed",
+        class: ErrorClass::IO,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime I/O operation failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -461,10 +616,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: RUNTIME_CONTEXT_UNAVAILABLE,
         code: "runtime.context.unavailable",
+        class: ErrorClass::UNAVAILABLE,
         condition: CanonicalCondition::Unavailable,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime context is unavailable",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Unavailable,
@@ -474,10 +634,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: RUNTIME_CAPACITY_EXHAUSTED,
         code: "runtime.capacity.exhausted",
+        class: ErrorClass::CAPACITY,
         condition: CanonicalCondition::ResourceExhausted,
+        fault: FaultAttribution::LocalResource,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime capacity is exhausted",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemBusy,
         grpc_payload: GrpcPayloadCode::TooManyRequests,
         grpc_status: GrpcStatusCode::ResourceExhausted,
@@ -487,10 +652,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: RUNTIME_OPERATION_TIMED_OUT,
         code: "runtime.operation.timed_out",
+        class: ErrorClass::TIMEOUT,
         condition: CanonicalCondition::DeadlineExceeded,
+        fault: FaultAttribution::Dependency,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime operation timed out",
         severity: ErrorSeverity::Warn,
         recovery_hint: RecoveryHint::Backoff,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemBusy,
         grpc_payload: GrpcPayloadCode::RequestTimeout,
         grpc_status: GrpcStatusCode::DeadlineExceeded,
@@ -500,10 +670,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: RUNTIME_OPERATION_UNSUPPORTED,
         code: "runtime.operation.unsupported",
+        class: ErrorClass::UNSUPPORTED,
         condition: CanonicalCondition::Unimplemented,
+        fault: FaultAttribution::Caller,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime operation is unsupported",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::Never,
+        backtrace: BacktracePolicy::Never,
+        exposure: Exposure::Public,
         remoting: RemotingResponseCode::RequestCodeNotSupported,
         grpc_payload: GrpcPayloadCode::Unsupported,
         grpc_status: GrpcStatusCode::Unimplemented,
@@ -513,10 +688,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: RUNTIME_TASK_JOIN_FAILED,
         code: "runtime.task.join_failed",
+        class: ErrorClass::BUG,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Bug,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime task failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -526,10 +706,15 @@ const EXPECTED_DESCRIPTORS: &[ExpectedDescriptor] = &[
     ExpectedDescriptor {
         descriptor: RUNTIME_INTERNAL_FAILURE,
         code: "runtime.internal.failure",
+        class: ErrorClass::INTERNAL,
         condition: CanonicalCondition::Internal,
+        fault: FaultAttribution::Unknown,
+        component: ComponentId::RUNTIME,
         public_message: "Runtime operation failed",
         severity: ErrorSeverity::Error,
         recovery_hint: RecoveryHint::OperatorAction,
+        backtrace: BacktracePolicy::OnDemand,
+        exposure: Exposure::Generic,
         remoting: RemotingResponseCode::SystemError,
         grpc_payload: GrpcPayloadCode::InternalError,
         grpc_status: GrpcStatusCode::Internal,
@@ -546,10 +731,15 @@ fn representative_descriptor_table_is_exact() {
     for (actual, expected) in ALL_DESCRIPTORS.iter().zip(EXPECTED_DESCRIPTORS) {
         assert_eq!(*actual, expected.descriptor, "{}", expected.code);
         assert_eq!(actual.code().as_str(), expected.code);
+        assert_eq!(actual.class(), expected.class, "{}", expected.code);
         assert_eq!(actual.condition(), expected.condition, "{}", expected.code);
+        assert_eq!(actual.fault(), expected.fault, "{}", expected.code);
+        assert_eq!(actual.component(), expected.component, "{}", expected.code);
         assert_eq!(actual.public_message(), expected.public_message, "{}", expected.code);
         assert_eq!(actual.severity(), expected.severity, "{}", expected.code);
         assert_eq!(actual.recovery_hint(), expected.recovery_hint, "{}", expected.code);
+        assert_eq!(actual.backtrace_policy(), expected.backtrace, "{}", expected.code);
+        assert_eq!(actual.exposure(), expected.exposure, "{}", expected.code);
 
         let projection = actual.projection();
         assert_eq!(projection.remoting().code, expected.remoting, "{}", expected.code);
@@ -557,6 +747,38 @@ fn representative_descriptor_table_is_exact() {
         assert_eq!(projection.grpc().status, expected.grpc_status, "{}", expected.code);
         assert_eq!(projection.http().status, expected.http, "{}", expected.code);
         assert_eq!(projection.cli().exit_code, expected.cli, "{}", expected.code);
+    }
+}
+
+#[test]
+fn on_demand_backtraces_are_limited_to_internal_bug_or_data_loss_descriptors() {
+    for descriptor in ALL_DESCRIPTORS {
+        if descriptor.backtrace_policy() == BacktracePolicy::OnDemand {
+            assert!(
+                matches!(descriptor.class(), ErrorClass::INTERNAL | ErrorClass::BUG)
+                    || descriptor.condition() == CanonicalCondition::DataLoss,
+                "{}",
+                descriptor.code()
+            );
+        }
+
+        if matches!(
+            descriptor.class(),
+            ErrorClass::VALIDATION
+                | ErrorClass::AUTHENTICATION
+                | ErrorClass::AUTHORIZATION
+                | ErrorClass::CAPACITY
+                | ErrorClass::TIMEOUT
+                | ErrorClass::UNAVAILABLE
+                | ErrorClass::UNSUPPORTED
+        ) {
+            assert_eq!(
+                descriptor.backtrace_policy(),
+                BacktracePolicy::Never,
+                "{}",
+                descriptor.code()
+            );
+        }
     }
 }
 
@@ -774,6 +996,7 @@ fn every_storage_descriptor_has_the_exact_allowed_fields() {
 #[test]
 fn descriptor_construction_and_catalog_macro_remain_private() {
     let descriptor_source = include_str!("../src/descriptor.rs");
+    let policy_source = include_str!("../src/policy.rs");
     let projection_source = include_str!("../src/projection.rs");
     let catalog_source = include_str!("../src/catalog.rs");
     let crate_root = include_str!("../src/lib.rs");
@@ -781,8 +1004,27 @@ fn descriptor_construction_and_catalog_macro_remain_private() {
     assert!(descriptor_source.contains("pub(crate) const fn try_new("));
     assert!(projection_source.contains("pub(crate) const fn new("));
     assert!(!descriptor_source.contains("pub code: ErrorCode"));
+    assert!(!descriptor_source.contains("pub class: ErrorClass"));
+    assert!(!descriptor_source.contains("pub fault: FaultAttribution"));
+    assert!(!descriptor_source.contains("pub component: ComponentId"));
+    assert!(!descriptor_source.contains("pub exposure: Exposure"));
+    assert!(!descriptor_source.contains("pub backtrace: BacktracePolicy"));
+    assert!(descriptor_source.contains("pub enum ErrorSeverity"));
+    assert!(!policy_source.contains("pub enum ErrorSeverity"));
     assert!(!projection_source.contains("pub remoting: RemotingSpec"));
     assert!(catalog_source.contains("macro_rules! define_error_catalog"));
+    for required in [
+        "class: $class:path",
+        "fault: $fault:path",
+        "component: $component:path",
+        "backtrace: $backtrace:path",
+        "exposure: $exposure:path",
+    ] {
+        assert!(
+            catalog_source.contains(required),
+            "missing required macro field {required}"
+        );
+    }
     assert!(!catalog_source.contains("#[macro_export]"));
     assert!(!crate_root.contains("pub mod catalog;"));
     assert!(!crate_root.contains("pub mod descriptor;"));

--- a/rocketmq-error/tests/typed_error_public_api.rs
+++ b/rocketmq-error/tests/typed_error_public_api.rs
@@ -16,6 +16,7 @@
 fn error_crate_public_api_exposes_only_typed_error_surface() {
     let source = include_str!("../src/lib.rs");
     let context_source = include_str!("../src/context.rs");
+    let core_source = include_str!("../src/error.rs");
     let removed_symbols = [
         concat!("Legacy", "RocketMQResult"),
         concat!("pub enum Rocket", "mqError"),
@@ -53,6 +54,7 @@ fn error_crate_public_api_exposes_only_typed_error_surface() {
         "controller_error",
         "descriptor",
         "domain",
+        "error",
         "field",
         "filter_error",
         "kind",
@@ -93,4 +95,23 @@ fn error_crate_public_api_exposes_only_typed_error_surface() {
         .expect("diagnostic view");
     assert_eq!(public.code(), descriptor.code());
     assert_eq!(diagnostic.projection(), projection);
+
+    let error = rocketmq_error::Error::new(&rocketmq_error::CORE_INTERNAL_FAILURE);
+    let result: rocketmq_error::Result<()> = Err(error);
+    let shared: rocketmq_error::SharedError = match result {
+        Ok(()) => panic!("expected canonical error"),
+        Err(error) => std::sync::Arc::new(error),
+    };
+    assert_eq!(shared.class(), rocketmq_error::ErrorClass::INTERNAL);
+    assert_eq!(shared.component(), rocketmq_error::ComponentId::CORE);
+    assert_eq!(shared.fault(), rocketmq_error::FaultAttribution::Unknown);
+    assert_eq!(shared.exposure(), rocketmq_error::Exposure::Generic);
+    assert_eq!(shared.backtrace_policy(), rocketmq_error::BacktracePolicy::OnDemand);
+
+    assert!(core_source.contains("pub struct Error {"));
+    assert!(core_source.contains("inner: Box<ErrorInner>"));
+    assert!(core_source.contains("struct ErrorInner {"));
+    assert!(core_source.contains("pub type SharedError = Arc<Error>;"));
+    assert!(!core_source.contains("impl Clone for Error"));
+    assert!(!core_source.contains("operation:"));
 }

--- a/rocketmq-runtime/src/error.rs
+++ b/rocketmq-runtime/src/error.rs
@@ -12,17 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::backtrace::Backtrace;
 use std::error::Error;
 use std::fmt;
+use std::panic::Location;
 use std::sync::Arc;
 
 use rocketmq_error::CanonicalCondition;
 use rocketmq_error::DiagnosticView;
+use rocketmq_error::Error as CanonicalError;
 use rocketmq_error::ErrorCode;
 use rocketmq_error::ErrorContext;
 use rocketmq_error::ErrorDescriptor;
 use rocketmq_error::PublicErrorView;
 use rocketmq_error::RecoveryHint;
+use rocketmq_error::SharedError;
 
 use crate::resource_budget::BudgetDimension;
 
@@ -465,65 +469,63 @@ impl RuntimeContractViolation {
 /// expose implementation variants for callers to match.
 #[derive(Clone)]
 pub struct RuntimeError {
-    descriptor: &'static ErrorDescriptor,
+    error: SharedError,
     operation: RuntimeOperation,
     component: Arc<str>,
-    context: ErrorContext,
-    source: Option<Arc<dyn Error + Send + Sync + 'static>>,
 }
 
 impl RuntimeError {
     /// Creates a source-free operational failure.
     #[must_use]
+    #[track_caller]
     fn new(descriptor: &'static ErrorDescriptor, operation: RuntimeOperation, component: impl Into<Arc<str>>) -> Self {
+        let error = CanonicalError::new(descriptor).with_context(runtime_context(operation, false));
         Self {
-            descriptor,
-            context: runtime_context(operation, false),
+            error: Arc::new(error),
             operation,
             component: component.into(),
-            source: None,
         }
     }
 
     /// Creates an operational failure while retaining its typed cause.
     #[must_use]
+    #[track_caller]
     fn caused_by(
         descriptor: &'static ErrorDescriptor,
         operation: RuntimeOperation,
         component: impl Into<Arc<str>>,
         source: impl Error + Send + Sync + 'static,
     ) -> Self {
+        let error = CanonicalError::caused_by(descriptor, source).with_context(runtime_context(operation, true));
         Self {
-            descriptor,
-            context: runtime_context(operation, true),
+            error: Arc::new(error),
             operation,
             component: component.into(),
-            source: Some(Arc::new(source)),
         }
     }
 
     /// Returns the catalog descriptor.
     #[must_use]
-    pub const fn descriptor(&self) -> &'static ErrorDescriptor {
-        self.descriptor
+    pub fn descriptor(&self) -> &'static ErrorDescriptor {
+        self.error.descriptor()
     }
 
     /// Returns the stable catalog code.
     #[must_use]
-    pub const fn code(&self) -> ErrorCode {
-        self.descriptor.code()
+    pub fn code(&self) -> ErrorCode {
+        self.error.code()
     }
 
     /// Returns the descriptor-owned canonical condition.
     #[must_use]
-    pub const fn condition(&self) -> CanonicalCondition {
-        self.descriptor.condition()
+    pub fn condition(&self) -> CanonicalCondition {
+        self.error.condition()
     }
 
     /// Returns the descriptor-owned recovery hint.
     #[must_use]
-    pub const fn recovery_hint(&self) -> RecoveryHint {
-        self.descriptor.recovery_hint()
+    pub fn recovery_hint(&self) -> RecoveryHint {
+        self.error.recovery_hint()
     }
 
     /// Returns the closed operation label.
@@ -540,8 +542,20 @@ impl RuntimeError {
 
     /// Returns bounded descriptor context.
     #[must_use]
-    pub const fn context(&self) -> &ErrorContext {
-        &self.context
+    pub fn context(&self) -> &ErrorContext {
+        self.error.context()
+    }
+
+    /// Returns the first-promotion caller location.
+    #[must_use]
+    pub fn location(&self) -> &'static Location<'static> {
+        self.error.location()
+    }
+
+    /// Returns the catalog-controlled captured backtrace, when enabled.
+    #[must_use]
+    pub fn backtrace(&self) -> Option<&Backtrace> {
+        self.error.backtrace()
     }
 
     /// Creates a safe public projection when the context matches the descriptor.
@@ -551,7 +565,7 @@ impl RuntimeError {
     /// Returns an error only if an internal descriptor/context invariant has
     /// been violated.
     pub fn public_view(&self) -> Result<PublicErrorView<'_>, rocketmq_error::ViewContextViolation> {
-        PublicErrorView::try_new(self.descriptor, &self.context)
+        self.error.public_view()
     }
 
     /// Creates a controlled diagnostic projection when the context matches the descriptor.
@@ -561,11 +575,12 @@ impl RuntimeError {
     /// Returns an error only if an internal descriptor/context invariant has
     /// been violated.
     pub fn diagnostic_view(&self) -> Result<DiagnosticView<'_>, rocketmq_error::ViewContextViolation> {
-        DiagnosticView::try_new(self.descriptor, &self.context)
+        self.error.diagnostic_view()
     }
 
     /// Creates an external configuration failure.
     #[must_use]
+    #[track_caller]
     pub fn configuration(operation: RuntimeOperation) -> Self {
         Self::new(
             &rocketmq_error::RUNTIME_CONFIGURATION_FAILED,
@@ -576,6 +591,7 @@ impl RuntimeError {
 
     /// Creates a configuration-loading failure while retaining its typed source.
     #[must_use]
+    #[track_caller]
     pub fn configuration_failure(operation: RuntimeOperation, source: impl Error + Send + Sync + 'static) -> Self {
         Self::caused_by(
             &rocketmq_error::RUNTIME_CONFIGURATION_FAILED,
@@ -587,6 +603,7 @@ impl RuntimeError {
 
     /// Creates a runtime-build failure while retaining the build source.
     #[must_use]
+    #[track_caller]
     pub fn build(operation: RuntimeOperation, source: std::io::Error) -> Self {
         Self::caused_by(
             &rocketmq_error::RUNTIME_BUILD_FAILED,
@@ -598,6 +615,7 @@ impl RuntimeError {
 
     /// Creates an I/O failure while retaining the I/O source.
     #[must_use]
+    #[track_caller]
     pub fn io(operation: RuntimeOperation, source: std::io::Error) -> Self {
         Self::caused_by(
             &rocketmq_error::RUNTIME_IO_FAILED,
@@ -609,6 +627,7 @@ impl RuntimeError {
 
     /// Creates a runtime-context-unavailable failure.
     #[must_use]
+    #[track_caller]
     pub fn context_unavailable(operation: RuntimeOperation) -> Self {
         Self::new(
             &rocketmq_error::RUNTIME_CONTEXT_UNAVAILABLE,
@@ -619,6 +638,7 @@ impl RuntimeError {
 
     /// Creates an operational capacity-exhausted failure.
     #[must_use]
+    #[track_caller]
     pub fn capacity(operation: RuntimeOperation) -> Self {
         Self::new(
             &rocketmq_error::RUNTIME_CAPACITY_EXHAUSTED,
@@ -629,6 +649,7 @@ impl RuntimeError {
 
     /// Creates an operation timeout failure.
     #[must_use]
+    #[track_caller]
     pub fn timed_out(operation: RuntimeOperation) -> Self {
         Self::new(
             &rocketmq_error::RUNTIME_OPERATION_TIMED_OUT,
@@ -639,6 +660,7 @@ impl RuntimeError {
 
     /// Creates an unsupported-operation failure.
     #[must_use]
+    #[track_caller]
     pub fn unsupported(operation: RuntimeOperation) -> Self {
         Self::new(
             &rocketmq_error::RUNTIME_OPERATION_UNSUPPORTED,
@@ -649,6 +671,7 @@ impl RuntimeError {
 
     /// Creates a task join failure while retaining the join source.
     #[must_use]
+    #[track_caller]
     pub fn join(operation: RuntimeOperation, source: tokio::task::JoinError) -> Self {
         Self::caused_by(
             &rocketmq_error::RUNTIME_TASK_JOIN_FAILED,
@@ -660,6 +683,7 @@ impl RuntimeError {
 
     /// Creates an internal runtime failure while retaining a typed source.
     #[must_use]
+    #[track_caller]
     pub fn internal(operation: RuntimeOperation, source: impl Error + Send + Sync + 'static) -> Self {
         Self::caused_by(
             &rocketmq_error::RUNTIME_INTERNAL_FAILURE,
@@ -671,6 +695,7 @@ impl RuntimeError {
 
     /// Creates a source-free internal runtime failure.
     #[must_use]
+    #[track_caller]
     pub fn internal_failure(operation: RuntimeOperation) -> Self {
         Self::new(
             &rocketmq_error::RUNTIME_INTERNAL_FAILURE,
@@ -694,7 +719,7 @@ fn runtime_context(operation: RuntimeOperation, source_present: bool) -> ErrorCo
 
 impl fmt::Display for RuntimeError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "{}: {}", self.code(), self.descriptor.public_message())
+        fmt::Display::fmt(self.error.as_ref(), formatter)
     }
 }
 
@@ -706,18 +731,19 @@ impl fmt::Debug for RuntimeError {
             .field("condition", &self.condition())
             .field("operation", &self.operation)
             .field("component", &self.component)
-            .field("has_source", &self.source.is_some())
+            .field("has_source", &self.error.source().is_some())
             .finish()
     }
 }
 
 impl Error for RuntimeError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.source.as_deref().map(|source| source as &(dyn Error + 'static))
+        self.error.source()
     }
 }
 
 impl From<std::io::Error> for RuntimeError {
+    #[track_caller]
     fn from(source: std::io::Error) -> Self {
         Self::io(RuntimeOperation::ReadFile, source)
     }
@@ -751,6 +777,31 @@ mod tests {
         assert!(!format!("{error:?}").contains(SENTINEL));
         assert!(error.public_view().is_ok());
         assert!(error.diagnostic_view().is_ok());
+    }
+
+    #[test]
+    fn runtime_clone_shares_source_location_and_backtrace() {
+        let caller_line = line!() + 1;
+        let error = RuntimeError::internal(RuntimeOperation::PersistRuntimeMetadata, io::Error::other("typed leaf"));
+        let cloned = error.clone();
+
+        assert!(Arc::ptr_eq(&error.error, &cloned.error));
+        assert!(std::ptr::eq(
+            error.source().expect("runtime source"),
+            cloned.source().expect("cloned runtime source")
+        ));
+        assert!(error
+            .source()
+            .and_then(|source| source.downcast_ref::<io::Error>())
+            .is_some());
+        assert_eq!(error.location().file(), file!());
+        assert_eq!(error.location().line(), caller_line);
+
+        match (error.backtrace(), cloned.backtrace()) {
+            (Some(left), Some(right)) => assert!(std::ptr::eq(left, right)),
+            (None, None) => {}
+            _ => panic!("a clone must share the canonical backtrace state"),
+        }
     }
 
     #[test]

--- a/rocketmq-runtime/tests/ui/service_context/root_raw_constructor_is_private.stderr
+++ b/rocketmq-runtime/tests/ui/service_context/root_raw_constructor_is_private.stderr
@@ -12,8 +12,8 @@ error[E0624]: associated function `new` is private
   | |         task_group: TaskGroup,
 ... |
   | |         resources: RuntimeResources,
-  | |     ) -> RuntimeResult<Self> {
-  | |____________________________- private associated function defined here
+  | |     ) -> Self {
+  | |_____________- private associated function defined here
 
 error[E0061]: this function takes 7 arguments but 0 arguments were supplied
  --> tests/ui/service_context/root_raw_constructor_is_private.rs:4:5
@@ -30,18 +30,3 @@ help: provide the arguments
   |
 4 |     RootServiceContext::new(/* Arc<str> */, /* rocketmq_runtime::handle::RuntimeHandle */, /* TaskGroup */, /* BlockingLanePolicies */, /* usize */, /* RuntimeDiagnostics */, /* RuntimeResources */)
   |                             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-error[E0308]: mismatched types
- --> tests/ui/service_context/root_raw_constructor_is_private.rs:4:5
-  |
-3 | fn forge() -> RootServiceContext {
-  |               ------------------ expected `RootServiceContext` because of return type
-4 |     RootServiceContext::new()
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `RootServiceContext`, found `Result<RootServiceContext, RuntimeError>`
-  |
-  = note: expected struct `RootServiceContext`
-               found enum `Result<RootServiceContext, RuntimeError>`
-help: consider using `Result::expect` to unwrap the `Result<RootServiceContext, RuntimeError>` value, panicking if the value is a `Result::Err`
-  |
-4 |     RootServiceContext::new().expect("REASON")
-  |                              +++++++++++++++++

--- a/rocketmq-store-api/src/error.rs
+++ b/rocketmq-store-api/src/error.rs
@@ -14,12 +14,15 @@
 
 //! Canonical errors exposed by storage capabilities.
 
+use std::backtrace::Backtrace;
 use std::error::Error as StdError;
 use std::fmt;
+use std::panic::Location;
 
 use rocketmq_error::fields;
 use rocketmq_error::CanonicalCondition;
 use rocketmq_error::DiagnosticView;
+use rocketmq_error::Error as CanonicalError;
 use rocketmq_error::ErrorCode;
 use rocketmq_error::ErrorContext;
 use rocketmq_error::ErrorDescriptor;
@@ -145,12 +148,10 @@ impl StoreComponent {
 /// typed source are retained for local diagnosis, but their values are never
 /// formatted by this facade or exposed through its public view.
 pub struct StoreError {
-    descriptor: &'static ErrorDescriptor,
+    error: CanonicalError,
     operation: StoreOperation,
     component: StoreComponent,
-    context: ErrorContext,
     private_detail: Option<Sensitive<String>>,
-    source: Option<BoxError>,
 }
 
 impl StoreError {
@@ -164,6 +165,7 @@ impl StoreError {
     /// Panics when `descriptor` is not one of the twelve canonical storage
     /// descriptors. This is a programmer contract: runtime failures select a
     /// reviewed storage identity before constructing the facade.
+    #[track_caller]
     pub fn new(descriptor: &'static ErrorDescriptor, operation: StoreOperation) -> Self {
         Self::try_new(descriptor, operation)
             .expect("StoreError requires one of the twelve canonical storage descriptors")
@@ -174,72 +176,67 @@ impl StoreError {
     /// Returns `None` when `descriptor` belongs to another error domain. The
     /// facade never accepts caller-provided context, so successful construction
     /// also guarantees that only the four storage context fields can be emitted.
+    #[track_caller]
     pub fn try_new(descriptor: &'static ErrorDescriptor, operation: StoreOperation) -> Option<Self> {
         if !is_storage_descriptor(descriptor) {
             return None;
         }
         let component = StoreComponent::Store;
         Some(Self {
-            descriptor,
+            error: CanonicalError::new(descriptor).with_context(store_context(operation, component, false, false)),
             operation,
             component,
-            context: store_context(operation, component, false, false),
             private_detail: None,
-            source: None,
         })
     }
 
     /// Adds the closed component classification as diagnostic context.
     pub fn in_component(mut self, component: StoreComponent) -> Self {
         self.component = component;
-        self.rebuild_context();
-        self
+        self.rebuild_context()
     }
 
     /// Retains sensitive diagnostic detail without exposing its value.
     pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
         self.private_detail = Some(Sensitive::new(detail.into()));
-        self.rebuild_context();
-        self
+        self.rebuild_context()
     }
 
     /// Preserves a typed cause in the standard source chain.
     pub fn with_source(mut self, source: impl StdError + Send + Sync + 'static) -> Self {
-        self.source = Some(Box::new(source));
-        self.rebuild_context();
-        self
+        self.error = self.error.with_source(source);
+        self.rebuild_context()
     }
 
     /// Preserves an already boxed typed cause in the standard source chain.
     pub fn with_boxed_source(mut self, source: BoxError) -> Self {
-        self.source = Some(source);
-        self.rebuild_context();
-        self
+        self.error = self.error.with_boxed_source(source);
+        self.rebuild_context()
     }
 
     /// Returns the immutable catalog descriptor that owns this error's identity.
     pub const fn descriptor(&self) -> &'static ErrorDescriptor {
-        self.descriptor
+        self.error.descriptor()
     }
 
     /// Returns the stable dotted catalog code.
     pub const fn code(&self) -> ErrorCode {
-        self.descriptor.code()
+        self.error.code()
     }
 
     /// Returns the protocol-independent condition.
     pub const fn condition(&self) -> CanonicalCondition {
-        self.descriptor.condition()
+        self.error.condition()
     }
 
     /// Returns the catalog-owned severity.
     pub const fn severity(&self) -> ErrorSeverity {
-        self.descriptor.severity()
+        self.error.severity()
     }
 
     /// Returns the catalog-owned recovery hint.
     pub const fn recovery_hint(&self) -> RecoveryHint {
-        self.descriptor.recovery_hint()
+        self.error.recovery_hint()
     }
 
     /// Returns the operation that failed.
@@ -252,6 +249,21 @@ impl StoreError {
         self.component
     }
 
+    /// Returns the bounded context retained by the canonical error.
+    pub const fn context(&self) -> &ErrorContext {
+        self.error.context()
+    }
+
+    /// Returns the first-promotion caller location.
+    pub const fn location(&self) -> &'static Location<'static> {
+        self.error.location()
+    }
+
+    /// Returns the catalog-controlled captured backtrace, when enabled.
+    pub const fn backtrace(&self) -> Option<&Backtrace> {
+        self.error.backtrace()
+    }
+
     /// Creates the descriptor-validated public projection.
     ///
     /// # Errors
@@ -259,7 +271,7 @@ impl StoreError {
     /// Returns a schema violation if the catalog and the internally generated
     /// storage context become inconsistent.
     pub fn public_view(&self) -> Result<PublicErrorView<'_>, ViewContextViolation> {
-        PublicErrorView::try_new(self.descriptor, &self.context)
+        self.error.public_view()
     }
 
     /// Creates the descriptor-validated controlled diagnostic projection.
@@ -269,16 +281,20 @@ impl StoreError {
     /// Returns a schema violation if the catalog and the internally generated
     /// storage context become inconsistent.
     pub fn diagnostic_view(&self) -> Result<DiagnosticView<'_>, ViewContextViolation> {
-        DiagnosticView::try_new(self.descriptor, &self.context)
+        self.error.diagnostic_view()
     }
 
-    fn rebuild_context(&mut self) {
-        self.context = store_context(
+    fn rebuild_context(self) -> Self {
+        let context = store_context(
             self.operation,
             self.component,
             self.private_detail.is_some(),
-            self.source.is_some(),
+            self.error.source().is_some(),
         );
+        Self {
+            error: self.error.with_context(context),
+            ..self
+        }
     }
 }
 
@@ -320,7 +336,7 @@ fn store_context(
 
 impl fmt::Display for StoreError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "{}: {}", self.code(), self.descriptor.public_message())
+        fmt::Display::fmt(&self.error, formatter)
     }
 }
 
@@ -329,18 +345,18 @@ impl fmt::Debug for StoreError {
         formatter
             .debug_struct("StoreError")
             .field("code", &self.code())
-            .field("message", &self.descriptor.public_message())
+            .field("message", &self.descriptor().public_message())
             .field("operation", &self.operation)
             .field("component", &self.component)
             .field("detail_present", &self.private_detail.is_some())
-            .field("source_present", &self.source.is_some())
+            .field("source_present", &self.error.source().is_some())
             .finish()
     }
 }
 
 impl StdError for StoreError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        self.source.as_deref().map(|source| source as &(dyn StdError + 'static))
+        self.error.source()
     }
 }
 
@@ -447,5 +463,30 @@ mod tests {
             .expect("leaf cause follows the wrapper");
         assert_eq!(leaf.to_string(), "typed leaf");
         assert!(leaf.source().is_none());
+    }
+
+    #[test]
+    fn storage_error_preserves_an_already_boxed_source_as_the_direct_leaf() {
+        let source: BoxError = Box::new(io::Error::other("boxed leaf"));
+        let error = StoreError::new(&STORAGE_WRITE_FAILED, StoreOperation::Flush).with_boxed_source(source);
+
+        let leaf = error
+            .source()
+            .and_then(|source| source.downcast_ref::<io::Error>())
+            .expect("boxed source remains the direct typed leaf");
+        assert_eq!(leaf.to_string(), "boxed leaf");
+    }
+
+    #[test]
+    fn storage_error_builders_preserve_first_promotion_provenance() {
+        let caller_line = line!() + 1;
+        let error = StoreError::new(&STORAGE_WRITE_FAILED, StoreOperation::Flush)
+            .in_component(StoreComponent::MappedFile)
+            .with_detail("private detail")
+            .with_source(io::Error::other("typed leaf"));
+
+        assert_eq!(error.location().file(), file!());
+        assert_eq!(error.location().line(), caller_line);
+        assert_eq!(error.context().len(), 4);
     }
 }

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -282,7 +282,7 @@ where
                 Some(session_cleanup),
             )
             .await
-            .map_err(TransportError::dispatch)
+            .map_err(|source| TransportError::dispatch(source))
     }
 
     pub(crate) fn open_network_session(&self) -> crate::dispatch::NetworkSession {
@@ -351,7 +351,7 @@ impl AuthorizedDispatchSession {
         if context.deadline().is_some_and(|deadline| deadline.is_expired()) {
             send_handler_boundary_response(&response_session, is_one_way, deadline_response(opaque))
                 .await
-                .map_err(TransportError::dispatch)?;
+                .map_err(|source| TransportError::dispatch(source))?;
             return Ok(DispatchOutcome::Rejected);
         }
         if let Decision::Deny { reason } = self.boundary.security.authorize_for_dispatch(
@@ -371,7 +371,7 @@ impl AuthorizedDispatchSession {
                 .set_opaque(opaque),
             )
             .await
-            .map_err(TransportError::dispatch)?;
+            .map_err(|source| TransportError::dispatch(source))?;
             return Ok(DispatchOutcome::Rejected);
         }
 
@@ -408,7 +408,7 @@ impl AuthorizedDispatchSession {
                 drop(retained_partial);
                 send_handler_boundary_response(&response_session, is_one_way, admission_response(opaque, &rejection))
                     .await
-                    .map_err(TransportError::dispatch)?;
+                    .map_err(|source| TransportError::dispatch(source))?;
                 Ok(DispatchOutcome::Rejected)
             }
             Ok(SessionDispatchAttempt::AdmissionRejected {

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/embedded.rs
@@ -438,7 +438,7 @@ where
 }
 
 fn converge_embedded_result(result: TerminalResult) -> Result<EmbeddedDispatchOutcome, TransportError> {
-    result.map_err(TransportError::dispatch)
+    result.map_err(|source| TransportError::dispatch(source))
 }
 
 struct EmbeddedDeferredLifecycle {

--- a/rocketmq-transport/src/error.rs
+++ b/rocketmq-transport/src/error.rs
@@ -12,21 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::backtrace::Backtrace;
 use std::error::Error as StdError;
 use std::fmt;
+use std::panic::Location;
 use std::sync::Arc;
 
 use rocketmq_error::CanonicalCondition;
 use rocketmq_error::DiagnosticView;
+use rocketmq_error::Error as CanonicalError;
 use rocketmq_error::ErrorCode;
 use rocketmq_error::ErrorContext;
 use rocketmq_error::ErrorDescriptor;
 use rocketmq_error::ErrorSeverity;
 use rocketmq_error::PublicErrorView;
 use rocketmq_error::RecoveryHint;
+use rocketmq_error::SharedError;
 use rocketmq_error::ViewContextViolation;
-
-type SharedError = Arc<dyn StdError + Send + Sync>;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum TransportOperation {
@@ -91,13 +93,12 @@ impl RequestOperation {
 /// retained without rendering source text or request and session identifiers.
 #[derive(Clone)]
 pub struct TransportError {
-    descriptor: &'static ErrorDescriptor,
+    error: SharedError,
     operation: TransportOperation,
-    context: ErrorContext,
-    source: SharedError,
 }
 
 impl TransportError {
+    #[track_caller]
     pub(crate) fn start(source: impl StdError + Send + Sync + 'static) -> Self {
         Self::new(
             &rocketmq_error::TRANSPORT_START_FAILED,
@@ -106,6 +107,7 @@ impl TransportError {
         )
     }
 
+    #[track_caller]
     pub(crate) fn dispatch(source: impl StdError + Send + Sync + 'static) -> Self {
         Self::new(
             &rocketmq_error::TRANSPORT_DISPATCH_FAILED,
@@ -114,6 +116,7 @@ impl TransportError {
         )
     }
 
+    #[track_caller]
     pub(crate) fn resume(source: impl StdError + Send + Sync + 'static) -> Self {
         Self::new(
             &rocketmq_error::TRANSPORT_DISPATCH_FAILED,
@@ -122,6 +125,7 @@ impl TransportError {
         )
     }
 
+    #[track_caller]
     pub(crate) fn response(source: impl StdError + Send + Sync + 'static) -> Self {
         Self::new(
             &rocketmq_error::TRANSPORT_RESPONSE_FAILED,
@@ -130,6 +134,7 @@ impl TransportError {
         )
     }
 
+    #[track_caller]
     pub(crate) fn push(source: impl StdError + Send + Sync + 'static) -> Self {
         Self::new(
             &rocketmq_error::TRANSPORT_SESSION_FAILED,
@@ -138,6 +143,7 @@ impl TransportError {
         )
     }
 
+    #[track_caller]
     pub(crate) fn request_failed(operation: RequestOperation, source: impl StdError + Send + Sync + 'static) -> Self {
         Self::new(
             &rocketmq_error::TRANSPORT_SESSION_FAILED,
@@ -146,6 +152,7 @@ impl TransportError {
         )
     }
 
+    #[track_caller]
     pub(crate) fn request_timeout(operation: RequestOperation, source: impl StdError + Send + Sync + 'static) -> Self {
         Self::new(
             &rocketmq_error::TRANSPORT_REQUEST_TIMEOUT,
@@ -154,6 +161,7 @@ impl TransportError {
         )
     }
 
+    #[track_caller]
     pub(crate) fn close(
         cause: crate::server::SessionCloseCause,
         source: impl StdError + Send + Sync + 'static,
@@ -169,6 +177,7 @@ impl TransportError {
         Self::new(&rocketmq_error::TRANSPORT_SESSION_FAILED, operation, source)
     }
 
+    #[track_caller]
     fn new(
         descriptor: &'static ErrorDescriptor,
         operation: TransportOperation,
@@ -177,42 +186,59 @@ impl TransportError {
         let context = ErrorContext::new()
             .with_text(rocketmq_error::fields::OPERATION_DIAGNOSTIC, operation.as_str())
             .with_secret_presence(rocketmq_error::fields::SOURCE_PRESENT);
+        let error = CanonicalError::caused_by(descriptor, source).with_context(context);
         Self {
-            descriptor,
+            error: Arc::new(error),
             operation,
-            context,
-            source: Arc::new(source),
         }
     }
 
     /// Returns the catalog descriptor that owns this failure's identity.
     #[must_use]
-    pub const fn descriptor(&self) -> &'static ErrorDescriptor {
-        self.descriptor
+    pub fn descriptor(&self) -> &'static ErrorDescriptor {
+        self.error.descriptor()
     }
 
     /// Returns the stable dotted catalog code.
     #[must_use]
-    pub const fn code(&self) -> ErrorCode {
-        self.descriptor.code()
+    pub fn code(&self) -> ErrorCode {
+        self.error.code()
     }
 
     /// Returns the protocol-independent condition.
     #[must_use]
-    pub const fn condition(&self) -> CanonicalCondition {
-        self.descriptor.condition()
+    pub fn condition(&self) -> CanonicalCondition {
+        self.error.condition()
     }
 
     /// Returns the catalog-owned severity.
     #[must_use]
-    pub const fn severity(&self) -> ErrorSeverity {
-        self.descriptor.severity()
+    pub fn severity(&self) -> ErrorSeverity {
+        self.error.severity()
     }
 
     /// Returns the catalog-owned recovery hint.
     #[must_use]
-    pub const fn recovery_hint(&self) -> RecoveryHint {
-        self.descriptor.recovery_hint()
+    pub fn recovery_hint(&self) -> RecoveryHint {
+        self.error.recovery_hint()
+    }
+
+    /// Returns the bounded context retained by the canonical error.
+    #[must_use]
+    pub fn context(&self) -> &ErrorContext {
+        self.error.context()
+    }
+
+    /// Returns the first-promotion caller location.
+    #[must_use]
+    pub fn location(&self) -> &'static Location<'static> {
+        self.error.location()
+    }
+
+    /// Returns the catalog-controlled captured backtrace, when enabled.
+    #[must_use]
+    pub fn backtrace(&self) -> Option<&Backtrace> {
+        self.error.backtrace()
     }
 
     /// Creates the descriptor-validated public projection.
@@ -222,7 +248,7 @@ impl TransportError {
     /// Returns a schema violation if the catalog and internally generated
     /// Transport context become inconsistent.
     pub fn public_view(&self) -> Result<PublicErrorView<'_>, ViewContextViolation> {
-        PublicErrorView::try_new(self.descriptor, &self.context)
+        self.error.public_view()
     }
 
     /// Creates the descriptor-validated controlled diagnostic projection.
@@ -232,13 +258,13 @@ impl TransportError {
     /// Returns a schema violation if the catalog and internally generated
     /// Transport context become inconsistent.
     pub fn diagnostic_view(&self) -> Result<DiagnosticView<'_>, ViewContextViolation> {
-        DiagnosticView::try_new(self.descriptor, &self.context)
+        self.error.diagnostic_view()
     }
 }
 
 impl fmt::Display for TransportError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "{}: {}", self.code(), self.descriptor.public_message())
+        fmt::Display::fmt(self.error.as_ref(), formatter)
     }
 }
 
@@ -256,6 +282,51 @@ impl fmt::Debug for TransportError {
 
 impl StdError for TransportError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(self.source.as_ref())
+        self.error.source()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    #[test]
+    fn startup_clone_shares_canonical_error_and_direct_typed_source() {
+        let caller_line = line!() + 1;
+        let error = TransportError::start(io::Error::other("bind failed"));
+        let cloned = error.clone();
+
+        assert!(Arc::ptr_eq(&error.error, &cloned.error));
+        assert!(std::ptr::eq(
+            error.source().expect("startup source"),
+            cloned.source().expect("cloned startup source")
+        ));
+        assert!(error
+            .source()
+            .and_then(|source| source.downcast_ref::<io::Error>())
+            .is_some());
+        assert_eq!(error.location().file(), file!());
+        assert_eq!(error.location().line(), caller_line);
+        assert_eq!(error.context().len(), 2);
+
+        match (error.backtrace(), cloned.backtrace()) {
+            (Some(left), Some(right)) => assert!(std::ptr::eq(left, right)),
+            (None, None) => {}
+            _ => panic!("a clone must share the canonical backtrace state"),
+        }
+    }
+
+    #[test]
+    fn closure_map_err_records_the_promotion_site() {
+        let result: Result<(), io::Error> = Err(io::Error::other("dispatch failed"));
+        let caller_line = line!() + 2;
+        let error = result
+            .map_err(|source| TransportError::dispatch(source))
+            .expect_err("dispatch error");
+
+        assert_eq!(error.location().file(), file!());
+        assert_eq!(error.location().line(), caller_line);
     }
 }

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/server.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/server.rs
@@ -390,7 +390,7 @@ where
                 };
                 Arc::new(
                     AdmissionController::try_new_with_budget(limits, &self.service_context.process_budget())
-                        .map_err(TransportError::start)?,
+                        .map_err(|source| TransportError::start(source))?,
                 )
             }
         };
@@ -432,7 +432,7 @@ where
         let tls_runtime =
             TlsServerRuntime::initialize_with_service_context(self.config.tls_config.clone(), &remoting_context)
                 .await
-                .map_err(TransportError::start)?;
+                .map_err(|source| TransportError::start(source))?;
 
         // Hook mutation is deliberately the final preparation step. Failed
         // validation and boundary conflicts cannot contaminate a shared dispatcher.

--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -354,12 +354,29 @@ def check_error_and_model_public_surface() -> list[Finding]:
         "rocketmq_error::Result": "old rocketmq_error::Result alias must not be used",
         "anyhow::Result": "rocketmq-error/model must not expose public anyhow Result",
         "anyhow::Error": "rocketmq-error/model must not expose anyhow Error",
-        "pub type Result": "rocketmq-error/model must use typed crate-local aliases, not generic public Result",
     }
-    return scan_forbidden_terms(
-        [*rust_files_under("rocketmq-error", "src"), *rust_files_under("rocketmq-model", "src")],
-        forbidden,
-    )
+    paths = [*rust_files_under("rocketmq-error", "src"), *rust_files_under("rocketmq-model", "src")]
+    findings = scan_forbidden_terms(paths, forbidden)
+    for path in paths:
+        relative_path = rel_path(path)
+        for line_number, line in enumerate(read_text(path).splitlines(), start=1):
+            if is_test_context(path, line_number):
+                continue
+            message = generic_public_result_message(relative_path, line)
+            if message:
+                findings.append(Finding(path, line_number, message))
+    return findings
+
+
+def generic_public_result_message(relative_path: str, line: str) -> str | None:
+    if "pub type Result" not in line:
+        return None
+    if (
+        relative_path == "rocketmq-error/src/error.rs"
+        and line.strip() == "pub type Result<T> = std::result::Result<T, Error>;"
+    ):
+        return None
+    return "rocketmq-error/model must use typed crate-local aliases, not generic public Result"
 
 
 def check_processor_boundary_mappings() -> list[Finding]:
@@ -851,14 +868,14 @@ def check_backend_source_preservation() -> list[Finding]:
 def check_source_stringification_allowlist() -> list[Finding]:
     required_tokens = {
         ROOT / "rocketmq-store-api" / "src" / "error.rs": [
-            "descriptor: &'static ErrorDescriptor",
-            "context: ErrorContext",
+            "error: CanonicalError",
             "private_detail: Option<Sensitive<String>>",
-            "source: Option<BoxError>",
             "pub fn with_source",
+            "pub fn with_boxed_source",
             "pub fn public_view",
             "pub fn diagnostic_view",
             "impl StdError for StoreError",
+            "self.error.source()",
         ],
         ROOT / "rocketmq-store-local" / "src" / "mapped_file" / "mapped_file_error.rs": [
             "MmapFailed(#[source] io::Error)",

--- a/scripts/public-api-freeze-policy.json
+++ b/scripts/public-api-freeze-policy.json
@@ -120,6 +120,16 @@
       "reason": "The unreleased Transport boundary replaces overlapping and mixed lifecycle/error enums with one opaque catalog-backed operational facade and one deterministic contract enum; normal capacity, lifecycle, deadline, terminal, cancellation, and closed states are source-free outcomes that preserve caller-owned permits, requests, builders, deferred parts, job cells, queued writes, and shared close completion without compatibility aliases or wire-codec changes.",
       "approved_by": "repository-owner",
       "approved_on": "2026-09-05"
+    },
+    {
+      "id": "API-0.9-013",
+      "classification": "approved-break",
+      "applies_to": "0.9-to-1.0",
+      "old_item_path": "rocketmq_runtime::RuntimeError::{descriptor,code,condition,recovery_hint,context} const qualifiers; rocketmq_transport::TransportError::{descriptor,code,condition,severity,recovery_hint} const qualifiers; rocketmq_auth::project_authorization_error const qualifier",
+      "replacement": "rocketmq_error root exports {Error,Result,SharedError,ErrorClass,FaultAttribution,ComponentId,Exposure,BacktracePolicy}; ErrorDescriptor owns the complete canonical policy; StoreError owns Error; RuntimeError and TransportError own SharedError; the listed metadata accessors and the directly dependent authorization projection delegate through the canonical allocation as ordinary functions; facade context/location/backtrace accessors expose borrowed canonical state",
+      "reason": "The opaque canonical core removes duplicate descriptor, context, and source storage from the unreleased Store, Runtime, and Transport facades. Arc-backed cloneable facades and the authorization projection that reads RuntimeError metadata cannot retain const callability without duplicating canonical policy, so the affected const qualifiers are removed while runtime values, typed sources, safe views, authorization classification, and operational behavior remain unchanged.",
+      "approved_by": "repository-owner",
+      "approved_on": "2026-09-05"
     }
   ],
   "frozen_contracts": [

--- a/scripts/tests/test_error_architecture_guard.py
+++ b/scripts/tests/test_error_architecture_guard.py
@@ -118,6 +118,22 @@ class ErrorArchitectureGuardTests(unittest.TestCase):
             self.assertFalse(self.guard.is_test_context(test_path, 1))
             self.assertEqual([(1, source_line)], list(self.guard.iter_non_test_lines(test_path)))
 
+    def test_allows_only_the_canonical_generic_result_alias(self):
+        alias = "pub type Result<T> = std::result::Result<T, Error>;"
+
+        self.assertIsNone(
+            self.guard.generic_public_result_message("rocketmq-error/src/error.rs", alias)
+        )
+        self.assertIsNotNone(
+            self.guard.generic_public_result_message("rocketmq-model/src/lib.rs", alias)
+        )
+        self.assertIsNotNone(
+            self.guard.generic_public_result_message(
+                "rocketmq-error/src/error.rs",
+                "pub type Result<T> = anyhow::Result<T>;",
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10049
- Closes #10049

### Brief Description

- Add the non-`Clone`, one-box canonical `rocketmq_error::Error`, private `ErrorInner`, canonical `Result<T>`, and `SharedError = Arc<Error>` with direct typed causes, first-promotion locations, descriptor-controlled backtraces, and redacted formatting.
- Complete all 35 current descriptors with explicit class, fault attribution, component, exposure, backtrace, projection, and typed field policy. Enforce Generic exposure in `PublicErrorView` while keeping `DiagnosticView` bounded and cause-free.
- Make Store, Runtime, and Transport operational errors thin delegates over one canonical value. Preserve their closed public behavior, direct leaf-source chains, caller provenance, and Transport startup dual-publication identity.
- Record the required Runtime, Transport, and Auth const-callability decision, update the architecture documentation and structural API snapshot, and narrowly align the existing error guard and stale Runtime compile-fail diagnostic fixture.

### How Did You Test This Change?

- Package-scoped `cargo fmt -- --check` passes for `rocketmq-error`, `rocketmq-store-api`, `rocketmq-runtime`, `rocketmq-transport`, and `rocketmq-auth`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-error` and `cargo test -p rocketmq-store-api`
- Focused Runtime/Transport/Auth facade, source-chain, caller-location, startup dual-publication, and authorized-dispatcher tests
- `cargo test -p rocketmq-runtime --test service_context_scope_compile_fail` and `cargo doc -p rocketmq-error --no-deps`
- Error architecture guard unit tests and the architecture documentation semantic guard/unit tests
- Example, MCP, MCP-control, GPUI, Tauri Rust backend, and Web Rust backend standalone consumer profiles
- SRE multi-package format and locked workspace check on Linux, followed by a successful Windows all-feature workspace test, strict Clippy, Rustdoc, source-layout guard, and execution-dependency guard
- Final structural public API reconstruction with 9 changed profiles, 41 reused profiles, current Auth `is_const:false`, `API-0.9-013`, and zero reconstruction differences
- The full Runtime aggregate reached an inherited stale trybuild expectation after all preceding suites passed and remains recorded as failed; the expected diagnostic was synchronized to the unchanged private constructor and its exact compile-fail target then passed.
- The error-hygiene guard remains nonzero with the exact historical 16 findings; the new canonical-core checks pass and no baseline finding is relabeled as passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a canonical error API with shared errors, typed context, source chains, metadata, location tracking, and optional backtraces.
  * Added structured error classifications, component ownership, fault attribution, severity, exposure, and recovery information.
  * Added public and diagnostic error views with controlled field exposure and redaction.

* **Improvements**
  * Runtime, transport, and storage errors now share consistent canonical details and preserve provenance across cloning and wrapping.

* **Documentation**
  * Updated error architecture, inventory, and contribution guidance to reflect the current implementation and migration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->