### PR TITLE
docs(transport): add Apache 2.0 license header to rpc_request.rs

### DIFF
--- a/rocketmq-transport/src/rpc/rpc_request.rs
+++ b/rocketmq-transport/src/rpc/rpc_request.rs
@@ -1,1 +1,15 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub use rocketmq_protocol::rpc::rpc_request::*;


### PR DESCRIPTION
## Problem
\ocketmq-transport/src/rpc/rpc_request.rs\ was missing the repository-standard Apache License 2.0 and copyright header. Adding the notice ensures license consistency and compliance across crates without altering executable behavior (Issue #10073, tracking issue #10050).

## Solution
- Added the standard Apache License 2.0 and copyright header to \ocketmq-transport/src/rpc/rpc_request.rs\.
- Preserved existing exports and executable code without modifications.

Close #10073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Apache License 2.0 copyright information to the RPC request source file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->