### PR TITLE
docs(admin-tui): add Apache 2.0 license header to rocketmq-admin-tui

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/operations.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/operations.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::auth::AuthOperationResult;
 use rocketmq_admin_core::client_adapter::services::auth::AuthService;
 use rocketmq_admin_core::client_adapter::services::auth::CopyAclRequest;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/tests.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::test_client_runtime;
 use super::TuiAdminFacade;
 use rocketmq_admin_core::client_adapter::services::consumer::MonitoringEvent;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::state::CommandFormState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands/catalog.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands/catalog.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::ArgKind;
 use super::ArgSpec;
 use super::CommandCategory;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands/executor.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands/executor.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands/tests.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands/tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::mem::size_of_val;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/event.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/event.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use ratatui::crossterm::event::KeyCode;
 use ratatui::crossterm::event::KeyEvent;
 use ratatui::crossterm::event::KeyModifiers;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::VecDeque;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/state.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/state.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/ui.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/ui.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::ops::Range;
 
 use ratatui::layout::Alignment;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableViewModel {
     pub title: String,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model/conversions.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model/conversions.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt::Debug;
 
 use rocketmq_admin_core::client_adapter::services::auth::AuthOperationResult;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model/tests.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model/tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::auth::AuthOperationResult;
 use rocketmq_admin_core::client_adapter::services::broker::BrokerConsumeStatsResult;
 use rocketmq_admin_core::client_adapter::services::broker::BrokerConsumeStatsRow;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/tests/no_cli_dependency.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/tests/no_cli_dependency.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[test]
 fn tui_depends_on_core_not_cli_adapter() {
     let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))


### PR DESCRIPTION
## Problem

The 14 tracked Rust source files in `rocketmq-admin-tui` were missing the repository-standard copyright and Apache License 2.0 header, breaking license consistency across the crate (Issue #10072, tracking issue #10050).

## Solution

- Prepended the standard Apache License 2.0 and copyright header to all 14 files listed in the issue (`src/` modules + `tests/no_cli_dependency.rs`).
- The header is byte-identical to the one just merged in #10075 for `rocketmq-transport/src/rpc/rpc_request.rs`.
- No executable Rust code was changed — comment lines only, added before any crate attribute / item.

Close #10072


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Apache License 2.0 copyright and licensing notices across the RocketMQ administration tool’s source and test files.
  - No user-facing functionality, behavior, or command-line capabilities were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->