### PR TITLE
[ISSUE #10078]🐛Preserve RocksDB flush context for closed backends

### DIFF
--- a/rocketmq-store-rocksdb/src/message_store.rs
+++ b/rocketmq-store-rocksdb/src/message_store.rs
@@ -487,6 +487,11 @@ impl RocksDbDerivedStore {
     }
 
     pub fn flush_derived(&self) -> Result<(), StoreError> {
+        // Reject unavailable backends as a flush failure before draining pending index writes.
+        self.rocksdb_store.ensure_open(StoreOperation::Flush)?;
+        self.message_rocksdb_storage
+            .store()
+            .ensure_open(StoreOperation::Flush)?;
         self.rocksdb_index_service.flush_pending()?;
         self.rocksdb_store.flush(rocketmq_store_api::StoreOperation::Flush)?;
         self.message_rocksdb_storage.store().flush(StoreOperation::Flush)?;

--- a/rocketmq-store-rocksdb/src/store.rs
+++ b/rocketmq-store-rocksdb/src/store.rs
@@ -839,7 +839,7 @@ impl RocksDbStore {
         result
     }
 
-    fn ensure_open(&self, operation: StoreOperation) -> Result<(), StoreError> {
+    pub(crate) fn ensure_open(&self, operation: StoreOperation) -> Result<(), StoreError> {
         match self.state() {
             RocksDbStoreState::Open => Ok(()),
             RocksDbStoreState::Reloading | RocksDbStoreState::Closed => Err(unavailable_state(operation)),

--- a/rocketmq-store/tests/rocksdb_store_semantics_tests.rs
+++ b/rocketmq-store/tests/rocksdb_store_semantics_tests.rs
@@ -912,6 +912,42 @@ async fn restart_reput_advances_the_single_local_wal_queue_offset() {
 }
 
 #[test]
+fn rocksdb_flush_rejects_either_closed_backend_before_draining_pending_index() {
+    for closed_backend in ["consume queue", "message"] {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let store = new_owned_test_store(&temp_dir);
+        let index = store.rocksdb_index_service();
+        index
+            .build_index(&DispatchRequest {
+                topic: CheetahString::from_static_str("rocksdb-closed-flush-topic"),
+                keys: CheetahString::from_static_str("pending-key"),
+                commit_log_offset: 0,
+                msg_size: 10,
+                store_timestamp: 1_000,
+                success: true,
+                ..DispatchRequest::default()
+            })
+            .expect("enqueue index record");
+        let pending = index.pending_len();
+        assert!(pending > 0);
+
+        match closed_backend {
+            "consume queue" => store.rocksdb_store().close(),
+            "message" => store.message_rocksdb_storage().store().close(),
+            _ => unreachable!("test backend"),
+        }
+
+        let error = store.try_flush().expect_err(closed_backend);
+        assert_eq!(error.descriptor(), &rocketmq_error::STORAGE_BACKEND_UNAVAILABLE);
+        assert_eq!(error.operation(), StoreOperation::Flush);
+        assert_eq!(error.component(), StoreComponent::RocksDb);
+        assert!(std::error::Error::source(&error).is_none());
+        assert_eq!(index.pending_len(), pending, "{closed_backend}");
+        assert_eq!(store.health_snapshot().last_error, Some(error.descriptor()));
+    }
+}
+
+#[test]
 fn rocksdb_time_lookup_and_closed_backend_mapping_preserve_owner_context() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let topic = CheetahString::from_static_str("rocksdb-time-topic");


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10078

### Brief Description

A flush after RocksDB closure attempted index persistence first and returned AppendDerived instead of Flush. Check both consume-queue and message backend availability before draining pending index writes, reusing the existing state check with crate visibility.

Add a regression covering either backend closed independently with pending index records. It verifies the Flush operation, backend-unavailable descriptor, RocksDb component, absence of a fabricated source, unchanged pending records, and health status. Existing native checks and typed error forwarding remain intact.

### How Did You Test This Change?

Reproduced the original AppendDerived versus Flush assertion before the fix. Validation after the fix:

- cargo fmt -p rocketmq-store -p rocketmq-store-rocksdb -- --check: passed.
- cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings: passed.
- cargo clippy -p rocketmq-store --features rocksdb_store --all-targets -- -D warnings: passed.
- cargo clippy -p rocketmq-broker --features rocksdb_store --all-targets -- -D warnings: passed.
- cargo test -p rocketmq-store-rocksdb: passed, 43 tests with 1 existing ignored test.
- cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests: passed, 82 tests.
- cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests: passed, 11 tests including the original failure and new regression.
- cargo test -p rocketmq-broker --features rocksdb_store rocksdb: passed, 23 tests.
- cargo test -p rocketmq-broker --features rocksdb_store pop_consumer: passed, 5 tests.
- git diff --check: passed.

scripts/check-error-hygiene.ps1 completed with 16 pre-existing findings in unchanged files: 4 generic response mappings in rocketmq-broker/src/processor/notification_processor/core.rs, 11 source stringifications in rocketmq-broker/src/lib.rs and rocketmq-broker/src/pop/profile_store.rs, and 1 sensitive Debug derivation in rocketmq-transport/src/clients/rocketmq_tokio_client/endpoint_state.rs. The guard and all reported files match HEAD exactly; no findings occurred in the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - RocksDB flush operations now fail clearly when required storage backends are unavailable.
  - Pending index updates are preserved when a flush cannot complete.
  - Store health information now records the flush failure for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->