### PR TITLE
[ISSUE #10080]🐛Align auth runtime error assertions

### DIFF
--- a/rocketmq-auth/src/runtime_bridge.rs
+++ b/rocketmq-auth/src/runtime_bridge.rs
@@ -82,6 +82,11 @@ mod tests {
             .spawn_io("auth.blocking.missing", || ())
             .await
             .expect_err("missing metadata lane must fail closed");
-        assert!(error.to_string().contains("injected ChildServiceContext"));
+        assert_eq!(error.descriptor(), &rocketmq_error::RUNTIME_CONTEXT_UNAVAILABLE);
+        assert_eq!(error.operation(), RuntimeOperation::AuthMetadataIoLane);
+        assert_eq!(error.component(), "runtime");
+        assert!(std::error::Error::source(&error).is_none());
+        assert!(error.public_view().is_ok());
+        assert!(error.diagnostic_view().is_ok());
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10080

### Brief Description

Update the missing auth metadata lane test to verify the stable `RuntimeError` contract instead of a removed free-form error message. The test now checks the runtime-context-unavailable descriptor, auth metadata I/O operation, runtime component, absent source, and valid public and diagnostic projections.

This is a test-only change. Production runtime behavior, error rendering, and redaction remain unchanged.

### How Did You Test This Change?

- `cargo test -p rocketmq-auth runtime_bridge::tests::auth_blocking_executor_rejects_missing_capability`: passed.
- `cargo test -p rocketmq-auth --lib --all-features`: passed all 358 tests.
- `cargo fmt -p rocketmq-auth -- --check`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated error-handling coverage to verify structured runtime error details, including its descriptor, operation, component, source, and view information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->