### PR TITLE
[ISSUE #10086]🐛Stabilize admin message track error assertion

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/message.rs
@@ -2243,10 +2243,14 @@ mod tests {
         );
         assert_eq!(failed.message.msg_id().as_str(), "MSGID");
         assert!(failed.tracks.is_empty());
-        assert_eq!(
-            failed.track_error.as_deref(),
-            Some("Broker operation failed: operation=<redacted>, broker_code=<redacted>, message=<redacted>")
-        );
+        let track_error = failed
+            .track_error
+            .as_deref()
+            .expect("failed track lookup should retain its public error message");
+        assert!(track_error == "Broker operation failed" || track_error.starts_with("Broker operation failed: "));
+        assert!(!track_error.contains("MESSAGE_TRACK"));
+        assert!(!track_error.contains("-1"));
+        assert!(!track_error.contains("broker-b unavailable"));
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10086

### Brief Description

Update the admin message-track regression test to treat the redacted diagnostic context as optional while preserving the stable public broker failure message. The assertions also verify that the operation name, broker code, and backend error text are never exposed.

### How Did You Test This Change?

- `cargo test -p rocketmq-admin-core --lib --all-features client_adapter::services::message::tests::unique_key_message_entry_preserves_backend_track_rows_and_failures -- --exact` (passed: 1 test)
- `cargo test -p rocketmq-admin-core --lib --all-features` (passed: 301 tests)
- `cargo fmt -p rocketmq-admin-core -- --check` (passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- `git diff --check` (passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed message-tracking lookups now preserve a clear public error message.
  - Error details no longer expose internal operation names, broker codes, or broker addresses.

- **Tests**
  - Added coverage to verify the returned error message remains accurate while protecting sensitive backend details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->