### PR TITLE
[ISSUE #10090]🐛Align Dashboard error response tests with canonical codes

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
@@ -273,7 +273,6 @@ mod tests {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
     use rocketmq_admin_core::core::AdminError;
-    use rocketmq_error::REDACTED;
     use rocketmq_error::RocketMQError;
     use rocketmq_runtime::RuntimeError;
     use serde_json::Value;
@@ -298,13 +297,13 @@ mod tests {
 
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert!(!body.success);
-        assert_eq!(body.code, "ROUTE_NOT_FOUND");
+        assert_eq!(body.code, "route.topic.not_found");
         assert!(body.message.starts_with(public_message));
         assert!(body.message.contains("topic=TopicA"));
     }
 
     #[tokio::test]
-    async fn rocketmq_error_response_uses_redacted_context() {
+    async fn rocketmq_internal_error_response_omits_diagnostic_context() {
         let (status, body) = failure_response(DashboardError::from(RocketMQError::internal(
             "run dashboard request",
             std::io::Error::other("password=plain-text"),
@@ -312,8 +311,9 @@ mod tests {
         .await;
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(body.code, "INTERNAL");
-        assert!(body.message.contains(REDACTED));
+        assert_eq!(body.code, "core.internal.failure");
+        assert_eq!(body.message, "Internal error");
+        assert!(!body.message.contains("run dashboard request"));
         assert!(!body.message.contains("password=plain-text"));
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10090

### Brief Description

Align the Dashboard Web backend error response tests with the canonical error boundary. Route failures now assert the stable `route.topic.not_found` code, while generic internal failures assert `core.internal.failure` and verify that diagnostic operation and source details are omitted from the public HTTP response.

### How Did You Test This Change?

- `cargo test --lib error::dashboard_error::tests::rocketmq_`: passed, 2 tests.
- `cargo test --lib`: passed, 179 tests; 22 Docker-only tests ignored by the local profile.
- `cargo fmt -p rocketmq-dashboard-web-backend -- --check`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `cargo build --all-targets --all-features`: passed.
- `python scripts/error_architecture_guard.py`: the Dashboard HTTP boundary passed; the repository-wide command still reports pre-existing Broker allowlist and Transport redaction findings outside this change.
- `cargo fmt --all -- --check` could not start on Windows because path dependency expansion exceeded the OS path-length limit (error 206); the affected package-specific format check passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Error responses now use standardized error codes, including `route.topic.not_found` and `core.internal.failure`.
  - Internal error responses display a generic “Internal error” message without exposing diagnostic context.

- **Tests**
  - Updated error-handling coverage to verify the standardized codes and protected internal-error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->