### PR TITLE
[ISSUE #10060]📝Add missing Apache 2.0 headers in rocketmq-observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docs:** Add missing Apache 2.0 headers to the observability broker metrics example and configuration resolution tests ([#10060](https://github.com/mxsm/rocketmq-rust/issues/10060)).
 - **fix(sre-ui):** Pin TypeScript to 5.9.3 so clean installs satisfy the OpenAPI generator and ESLint peer dependencies ([#10033](https://github.com/mxsm/rocketmq-rust/issues/10033))
 - **fix(sre):** Include Required Signals manifest owners in capability coverage validation so standalone MCP ownership is accepted while invalid mappings remain rejected ([#10032](https://github.com/mxsm/rocketmq-rust/issues/10032))
 - **docs:** Fix Rustdoc generic type markup, broken public links, and references to private items across the workspace ([#10030](https://github.com/mxsm/rocketmq-rust/issues/10030))

--- a/rocketmq-observability/examples/broker_metrics.rs
+++ b/rocketmq-observability/examples/broker_metrics.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[cfg(feature = "otlp-metrics")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use opentelemetry::KeyValue;

--- a/rocketmq-observability/tests/config_resolution.rs
+++ b/rocketmq-observability/tests/config_resolution.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::HashMap;
 
 use rocketmq_observability::{


### PR DESCRIPTION
### Summary

Added the exact Apache 2.0 headers to both requested files and the required changelog entry. Original Rust contents are unchanged; all changes remain uncommitted.

### Which Issue(s) This PR Fixes(Closes)

- `Fixes` #10060

### Brief Description

Add the repository-standard 2026 copyright and Apache 2.0 headers to `rocketmq-observability/examples/broker_metrics.rs` and `rocketmq-observability/tests/config_resolution.rs`. Add the required changelog entry. Executable Rust code is unchanged. Prepared with AI assistance.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-observability -- --check` — passed.
- Inline Python regression check — passed; verified exact headers, byte-for-byte preservation of original contents, and intended file scope.
- `git diff --check` — passed.

Runtime tests, Clippy, and feature-matrix builds were not run because this change only adds comments and a changelog entry. History is shallow; the omission was confirmed against local `main`, but the latest remote state was not checked. No PR was published.

Fixes #10060

### Verification
- cargo fmt -p rocketmq-observability -- --check — passed before and after editing.
- python3 inline regression check — passed: exact headers added, original file bytes preserved, omission confirmed on local main, and only three intended files changed.
- git diff --check — passed.
- Runtime tests, Clippy, and feature-matrix builds were not run for this comment-only documentation change.

> Prepared by IssuePilot with Codex. This is a draft and requires human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog documentation for license headers added to observability examples and configuration tests.

* **Examples**
  * Added a broker metrics example demonstrating OTLP gRPC metric export and sample broker measurements when the required feature is enabled.
  * Added guidance for running the example without the required feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->