### PR TITLE
[ISSUE #10099]✨Skip shutdown deadline in NameServer tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **fix(namesrv):** Exclude shutdown deadlines from NameServer trace spans ([#10099](https://github.com/mxsm/rocketmq-rust/issues/10099)).
 - **fix(namesrv):** Default the legacy public-listener compatibility setting to enabled while preserving an
   explicit secure opt-out and the secure-enforced profile rejection ([#10097](https://github.com/mxsm/rocketmq-rust/issues/10097)).
 - **docs(admin-cli):** Add missing copyright and Apache License 2.0 headers to three Rust files ([#10070](https://github.com/mxsm/rocketmq-rust/issues/10070)).

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -811,7 +811,7 @@ impl NameServerRuntime {
     /// 3. Shutdown route info manager (broker unregistration)
     /// 4. Wait for server task to complete (with timeout)
     /// 5. Release all resources
-    #[instrument(skip(self), name = "runtime_shutdown")]
+    #[instrument(skip(self, deadline), name = "runtime_shutdown")]
     async fn shutdown_until(&mut self, deadline: ShutdownDeadline) -> NameServerShutdownReport {
         let started_at = Instant::now();
         let mut shutdown_report = NameServerShutdownReport::default();


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10099

### Brief Description

Exclude the `ShutdownDeadline` argument from the `runtime_shutdown` tracing
span while continuing to pass it unchanged through the graceful-shutdown path.
This removes low-value deadline implementation details from span metadata
without changing shutdown timing or behavior.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-namesrv -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`

The complete `cargo test -p rocketmq-namesrv` run passed 272 library tests and
failed the same two unrelated KV persistence tests previously reproduced on
`upstream/main`: `persistence_failure_leaves_memory_unchanged` and
`queue_capacity_and_bytes_fail_fast`.

Developed with assistance from OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected shutdown tracing so deadline context is handled consistently in NameServer trace spans.

* **Documentation**
  * Added a changelog entry documenting the shutdown tracing correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->