### PR TITLE
[ISSUE #10071]📝Add Apache headers to admin core

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/errors.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/errors.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_error::RocketMQError;
 use rocketmq_error::SerializationError;
 use rocketmq_error::ToolsError;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/export_data.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/export_data.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Export admin service models and operations.
 
 use cheetah_string::CheetahString;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/lite.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/lite.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Lite message queue admin service models and operations.
 
 use cheetah_string::CheetahString;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/resolver.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/resolver.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/static_topic.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/static_topic.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Static topic admin service models and operations.
 
 use cheetah_string::CheetahString;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/stats.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/stats.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Stats admin service models and operations.
 
 use cheetah_string::CheetahString;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/auth_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/auth_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::auth::AuthTarget;
 use rocketmq_admin_core::client_adapter::services::auth::CopyAclRequest;
 use rocketmq_admin_core::client_adapter::services::auth::CreateAclRequest;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/cluster_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/cluster_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::cluster::ClusterBrokerNameQueryRequest;
 use rocketmq_admin_core::client_adapter::services::cluster::ClusterListMode;
 use rocketmq_admin_core::client_adapter::services::cluster::ClusterListQueryRequest;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/connection_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/connection_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::connection::ConsumerConnectionQueryRequest;
 use rocketmq_admin_core::client_adapter::services::connection::ProducerConnectionQueryRequest;
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/controller_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/controller_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::controller::ControllerConfigQueryRequest;
 use rocketmq_admin_core::client_adapter::services::controller::ControllerConfigUpdateRequest;
 use rocketmq_admin_core::client_adapter::services::controller::ControllerElectMasterRequest;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/export_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/export_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::HashMap;
 use std::fs;
 use std::time::SystemTime;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/ha_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/ha_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::ha::HaStatusQueryRequest;
 use rocketmq_admin_core::client_adapter::services::ha::HaStatusTarget;
 use rocketmq_admin_core::client_adapter::services::ha::SyncStateSetQueryRequest;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/lite_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/lite_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::lite::BrokerLiteInfoQueryRequest;
 use rocketmq_admin_core::client_adapter::services::lite::BrokerLiteInfoTarget;
 use rocketmq_admin_core::client_adapter::services::lite::LiteClientInfoQueryRequest;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/no_cli_ui_boundary.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/no_cli_ui_boundary.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[test]
 fn core_does_not_expose_cli_or_terminal_ui_modules() {
     let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/producer_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/producer_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::producer::CheckMessageSendRtRequest;
 use rocketmq_admin_core::client_adapter::services::producer::ProducerInfoQueryRequest;
 use rocketmq_admin_core::client_adapter::services::producer::SendMessageRequest;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/static_topic_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/static_topic_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::static_topic::RemappingStaticTopicRequest;
 use rocketmq_admin_core::client_adapter::services::static_topic::StaticTopicMappingFileRequest;
 use rocketmq_admin_core::client_adapter::services::static_topic::UpdateStaticTopicRequest;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/stats_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/stats_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_admin_core::client_adapter::services::stats::StatsAllQueryRequest;
 
 #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/topic_list_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/topic_list_core_models.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use cheetah_string::CheetahString;
 use rocketmq_admin_core::client_adapter::services::topic::TopicTarget;
 use rocketmq_admin_core::client_adapter::services::topic::UpdateTopicListRequest;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10071

### Brief Description

Add the repository-standard Apache License 2.0 header to the 18 Rust source and test files identified in `rocketmq-admin-core`. No executable Rust code is changed.

### How Did You Test This Change?

- `cargo fmt --package rocketmq-admin-core -- --check` - passed
- `cargo test -p rocketmq-admin-core --all-features` - passed (301 unit tests and all integration/doc-test targets; 3 documentation examples ignored)
- `git diff --check` - passed
- `cargo clippy -p rocketmq-admin-core --all-targets --all-features -- -D warnings` - blocked by the pre-existing unused `rocketmq-transport::PendingRequestTable::register_for_owner` method on upstream `main`; this PR does not modify `rocketmq-transport`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added standardized Apache License 2.0 headers across administrative service and test files.

* **Tests**
  * Added coverage for request validation, whitespace handling, optional fields, authentication model behavior, producer and static-topic operations, statistics queries, and module boundaries.
  * Added checks for sensitive password redaction and valid feature-gated metadata export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->