### PR TITLE
[ISSUE #10058]📝Add Apache headers to rocketmq-model

### DIFF
--- a/rocketmq-model/src/common/attribute/subscription_group_attributes.rs
+++ b/rocketmq-model/src/common/attribute/subscription_group_attributes.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/rocketmq-model/src/common/attribute/topic_attributes.rs
+++ b/rocketmq-model/src/common/attribute/topic_attributes.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/rocketmq-model/src/common/boundary_type.rs
+++ b/rocketmq-model/src/common/boundary_type.rs
@@ -1,1 +1,15 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub use crate::boundary_type::*;

--- a/rocketmq-model/src/common/lite/offset_option.rs
+++ b/rocketmq-model/src/common/lite/offset_option.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;

--- a/rocketmq-model/src/common/macros.rs
+++ b/rocketmq-model/src/common/macros.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[macro_export]
 macro_rules! hashset {
 

--- a/rocketmq-model/src/common/sys_flag/message_sys_flag.rs
+++ b/rocketmq-model/src/common/sys_flag/message_sys_flag.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::common::compression::compression_type::CompressionType;
 use rocketmq_error::RocketMQResult;
 

--- a/rocketmq-model/src/utils/queue_type_utils.rs
+++ b/rocketmq-model/src/utils/queue_type_utils.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::common::attribute::cq_type::CQType;
 use crate::common::attribute::Attribute;
 use crate::common::config::TopicConfig;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10058

### Brief Description

Add the repository-standard Apache License 2.0 header to the seven Rust source files identified in `rocketmq-model`. No executable Rust code is changed.

### How Did You Test This Change?

- `cargo fmt --package rocketmq-model -- --check` - passed
- `cargo clippy --locked --no-deps --all-targets --all-features -p rocketmq-model -- -D warnings` - passed
- `cargo test --locked -p rocketmq-model --all-features` - passed (496 unit tests, 20 integration tests, and 18 documentation tests; 12 documentation examples ignored)
- `git diff --check` - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added standardized Apache License 2.0 copyright headers to several source files.
  - Added a public module re-export for boundary type definitions.

- **Maintenance**
  - No user-facing behavior, functionality, or existing logic was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->