### PR TITLE
[ISSUE #10107]🐛Stabilize broker shutdown and controller failure handling

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_broker_role_change_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_broker_role_change_handler.rs
@@ -81,8 +81,12 @@ impl NotifyBrokerRoleChangeHandler {
             .replicas_manager()
             .is_none()
         {
-            warn!("Ignore notifyBrokerRoleChanged because controller mode is not initialized");
-            return Ok(Some(response.set_code(ResponseCode::Success)));
+            warn!("Reject notifyBrokerRoleChanged because controller mode is not initialized");
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark("controller mode is not initialized"),
+            ));
         }
 
         let sync_state_set = sync_state_set_info.get_sync_state_set().cloned().unwrap_or_default();
@@ -179,6 +183,10 @@ mod tests {
             .expect("notification should return a response");
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+        assert_eq!(
+            response.remark().map(CheetahString::as_str),
+            Some("controller mode is not initialized")
+        );
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/topic/manager/topic_config_coordinator.rs
+++ b/rocketmq-broker/src/topic/manager/topic_config_coordinator.rs
@@ -197,6 +197,16 @@ impl TopicConfigCoordinator {
             .count()
     }
 
+    async fn wait_for_blocking_tasks_until(&self, deadline: ShutdownDeadline) -> usize {
+        loop {
+            let blocking_still_running = self.blocking_still_running();
+            if blocking_still_running == 0 || deadline.is_expired() {
+                return blocking_still_running;
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
     async fn ensure_started(&self) -> RocketMQResult<()> {
         let mut lifecycle = self.lifecycle.lock().await;
         if lifecycle.finalized {
@@ -370,13 +380,13 @@ impl TopicConfigCoordinator {
         } else {
             false
         };
-        let timed_out = deadline.is_expired() || (!final_persist_succeeded && detail.is_none());
+        let persistence_timed_out = deadline.is_expired() || (!final_persist_succeeded && detail.is_none());
         let worker_exited = self
             .runtime_capabilities()
             .task_group
             .wait_task(run.worker, deadline.remaining())
             .await;
-        let blocking_still_running = self.blocking_still_running();
+        let blocking_still_running = self.wait_for_blocking_tasks_until(deadline).await;
         let report = TopicConfigCoordinatorShutdownReport {
             admission_closed,
             pending_at_end: self.pending_count(),
@@ -385,7 +395,7 @@ impl TopicConfigCoordinator {
             registration_quiesced: worker_exited,
             unregister_succeeded: false,
             blocking_still_running,
-            timed_out: timed_out || !worker_exited,
+            timed_out: persistence_timed_out || !worker_exited || blocking_still_running > 0,
             elapsed: started.elapsed(),
             detail,
         };


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10107

### Brief Description

Wait for topic-config blocking tasks to leave the runtime registry within the shared broker shutdown deadline. This prevents a transient registry entry from stopping shutdown before scheduled tasks release message-store leases.

Reject controller role-change requests with `SystemError` and a fixed non-sensitive remark when controller mode has no replicas manager. Extend the existing regression test to verify the response remark.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --lib uninitialized_controller_fails_closed_without_retaining_runtime_owner -- --nocapture`
- `cargo test -p rocketmq-broker --lib broker_shutdown_cancels_scheduled_store_lease_before_store_lock_release -- --nocapture`
- `cargo fmt -p rocketmq-broker -- --check`
- `cargo clippy -p rocketmq-broker --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `git diff --check`

The runtime boundary audit remains blocked by existing findings in `rocketmq-ai/rocketmq-mcp-control` and controller tests. The error hygiene check remains blocked by existing findings in notification processing, source stringification, and transport redaction; its processor boundary mapping checks pass and neither report identifies the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Role-change notifications now return a system error when controller mode is not initialized, with a clear diagnostic message.
  * Shutdown now waits for active background tasks to finish, accurately reporting timeouts when tasks remain after the deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->