### PR TITLE
[ISSUE #10063]📝Add Apache 2.0 headers in rocketmq-runtime

### DIFF
--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fs;
 use std::path::Path;
 use std::sync::atomic::AtomicUsize;

--- a/rocketmq-runtime/tests/ui/service_context/child_cannot_be_promoted.rs
+++ b/rocketmq-runtime/tests/ui/service_context/child_cannot_be_promoted.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::RootServiceContext;
 

--- a/rocketmq-runtime/tests/ui/service_context/child_cannot_be_promoted.stderr
+++ b/rocketmq-runtime/tests/ui/service_context/child_cannot_be_promoted.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `root_context` found for struct `ChildServiceContext` in the current scope
- --> tests/ui/service_context/child_cannot_be_promoted.rs:5:11
-  |
-5 |     child.root_context()
-  |           ^^^^^^^^^^^^ method not found in `ChildServiceContext`
+  --> tests/ui/service_context/child_cannot_be_promoted.rs:19:11
+   |
+19 |     child.root_context()
+   |           ^^^^^^^^^^^^ method not found in `ChildServiceContext`

--- a/rocketmq-runtime/tests/ui/service_context/child_raw_constructor_is_private.rs
+++ b/rocketmq-runtime/tests/ui/service_context/child_raw_constructor_is_private.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_runtime::ChildServiceContext;
 
 fn forge() -> ChildServiceContext {

--- a/rocketmq-runtime/tests/ui/service_context/child_raw_constructor_is_private.stderr
+++ b/rocketmq-runtime/tests/ui/service_context/child_raw_constructor_is_private.stderr
@@ -1,32 +1,32 @@
 error[E0624]: associated function `new` is private
- --> tests/ui/service_context/child_raw_constructor_is_private.rs:4:26
-  |
-4 |       ChildServiceContext::new()
-  |                            ^^^ private associated function
-  |
- ::: src/service_context.rs
-  |
-  | /     fn new(
-  | |         scope: ScopeId,
-  | |         parent_group: &TaskGroup,
-  | |         blocking_lanes: BlockingLanes,
-  | |         diagnostics: RuntimeDiagnostics,
-  | |         resources: RuntimeResources,
-  | |     ) -> Self {
-  | |_____________- private associated function defined here
+  --> tests/ui/service_context/child_raw_constructor_is_private.rs:18:26
+   |
+18 |       ChildServiceContext::new()
+   |                            ^^^ private associated function
+   |
+  ::: src/service_context.rs
+   |
+   | /     fn new(
+   | |         scope: ScopeId,
+   | |         parent_group: &TaskGroup,
+   | |         blocking_lanes: BlockingLanes,
+   | |         diagnostics: RuntimeDiagnostics,
+   | |         resources: RuntimeResources,
+   | |     ) -> Self {
+   | |_____________- private associated function defined here
 
 error[E0061]: this function takes 5 arguments but 0 arguments were supplied
- --> tests/ui/service_context/child_raw_constructor_is_private.rs:4:5
-  |
-4 |     ChildServiceContext::new()
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^-- multiple arguments are missing
-  |
+  --> tests/ui/service_context/child_raw_constructor_is_private.rs:18:5
+   |
+18 |     ChildServiceContext::new()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^-- multiple arguments are missing
+   |
 note: associated function defined here
- --> src/service_context.rs
-  |
-  |     fn new(
-  |        ^^^
+  --> src/service_context.rs
+   |
+   |     fn new(
+   |        ^^^
 help: provide the arguments
-  |
-4 |     ChildServiceContext::new(/* ScopeId */, /* &TaskGroup */, /* service_context::BlockingLanes */, /* RuntimeDiagnostics */, /* RuntimeResources */)
-  |                              +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+   |
+18 |     ChildServiceContext::new(/* ScopeId */, /* &TaskGroup */, /* service_context::BlockingLanes */, /* RuntimeDiagnostics */, /* RuntimeResources */)
+   |                              +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/rocketmq-runtime/tests/ui/service_context/root_raw_constructor_is_private.rs
+++ b/rocketmq-runtime/tests/ui/service_context/root_raw_constructor_is_private.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_runtime::RootServiceContext;
 
 fn forge() -> RootServiceContext {

--- a/rocketmq-runtime/tests/ui/service_context/root_raw_constructor_is_private.stderr
+++ b/rocketmq-runtime/tests/ui/service_context/root_raw_constructor_is_private.stderr
@@ -1,32 +1,32 @@
 error[E0624]: associated function `new` is private
- --> tests/ui/service_context/root_raw_constructor_is_private.rs:4:25
-  |
-4 |       RootServiceContext::new()
-  |                           ^^^ private associated function
-  |
- ::: src/service_context.rs
-  |
-  | /     pub(crate) fn new(
-  | |         name: Arc<str>,
-  | |         runtime: RuntimeHandle,
-  | |         task_group: TaskGroup,
-... |
-  | |         resources: RuntimeResources,
-  | |     ) -> Self {
-  | |_____________- private associated function defined here
+  --> tests/ui/service_context/root_raw_constructor_is_private.rs:18:25
+   |
+18 |       RootServiceContext::new()
+   |                           ^^^ private associated function
+   |
+  ::: src/service_context.rs
+   |
+   | /     pub(crate) fn new(
+   | |         name: Arc<str>,
+   | |         runtime: RuntimeHandle,
+   | |         task_group: TaskGroup,
+...  |
+   | |         resources: RuntimeResources,
+   | |     ) -> Self {
+   | |_____________- private associated function defined here
 
 error[E0061]: this function takes 7 arguments but 0 arguments were supplied
- --> tests/ui/service_context/root_raw_constructor_is_private.rs:4:5
-  |
-4 |     RootServiceContext::new()
-  |     ^^^^^^^^^^^^^^^^^^^^^^^-- multiple arguments are missing
-  |
+  --> tests/ui/service_context/root_raw_constructor_is_private.rs:18:5
+   |
+18 |     RootServiceContext::new()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^-- multiple arguments are missing
+   |
 note: associated function defined here
- --> src/service_context.rs
-  |
-  |     pub(crate) fn new(
-  |                   ^^^
+  --> src/service_context.rs
+   |
+   |     pub(crate) fn new(
+   |                   ^^^
 help: provide the arguments
-  |
-4 |     RootServiceContext::new(/* Arc<str> */, /* rocketmq_runtime::handle::RuntimeHandle */, /* TaskGroup */, /* BlockingLanePolicies */, /* usize */, /* RuntimeDiagnostics */, /* RuntimeResources */)
-  |                             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+   |
+18 |     RootServiceContext::new(/* Arc<str> */, /* rocketmq_runtime::handle::RuntimeHandle */, /* TaskGroup */, /* BlockingLanePolicies */, /* usize */, /* RuntimeDiagnostics */, /* RuntimeResources */)
+   |                             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
## What

Closes #10063.

Adds the repository-standard copyright / Apache License 2.0 header to the Rust source files in `rocketmq-runtime` that were missing it:

- `rocketmq-runtime/tests/runtime_model.rs`
- `rocketmq-runtime/tests/ui/service_context/child_cannot_be_promoted.rs`
- `rocketmq-runtime/tests/ui/service_context/child_raw_constructor_is_private.rs`
- `rocketmq-runtime/tests/ui/service_context/root_raw_constructor_is_private.rs`

No executable code was changed.

## trybuild snapshots

Three of the affected files are `compile_fail` fixtures under `tests/ui/service_context/`. Prepending the 14-line header shifts the error line numbers, so the committed `.stderr` snapshots were regenerated (`TRYBUILD=overwrite`). The only changes in those `.stderr` files are the shifted line references.

## Validation

```
cargo test -p rocketmq-runtime --test service_context_scope_compile_fail
# test result: ok. 1 passed; 0 failed
# all 5 ui/service_context cases ok

cargo fmt --check -p rocketmq-runtime   # clean
```

Toolchain: repository `rust-toolchain.toml` (1.95.0). Happy to adjust the header year or wording if you prefer a different convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Apache License 2.0 copyright headers to runtime test files.

- **Tests**
  - Updated compiler diagnostic expectations to reflect shifted source locations and formatting.
  - Added coverage confirming restricted service-context constructors remain inaccessible.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->