### PR TITLE
[ISSUE #10069]Add Apache 2.0 header to store compile-test fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docs(store):** Add the missing Apache 2.0 header to the store context compile-test fixture ([#10069](https://github.com/mxsm/rocketmq-rust/issues/10069)).
 - **docs(namesrv):** Add the missing Apache 2.0 header to `broker_addr_info.rs` ([#10059](https://github.com/mxsm/rocketmq-rust/issues/10059))
 - **docs:** Add missing Apache 2.0 headers to the observability broker metrics example and configuration resolution tests ([#10060](https://github.com/mxsm/rocketmq-rust/issues/10060)).
 - **fix(sre-ui):** Pin TypeScript to 5.9.3 so clean installs satisfy the OpenAPI generator and ESLint peer dependencies ([#10033](https://github.com/mxsm/rocketmq-rust/issues/10033))

--- a/rocketmq-store/tests/ui/store_context/root_context_is_rejected.rs
+++ b/rocketmq-store/tests/ui/store_context/root_context_is_rejected.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_runtime::RootServiceContext;
 use rocketmq_store::StoreFactory;
 use rocketmq_store::StoreFactoryConfig;

--- a/rocketmq-store/tests/ui/store_context/root_context_is_rejected.stderr
+++ b/rocketmq-store/tests/ui/store_context/root_context_is_rejected.stderr
@@ -1,13 +1,13 @@
 error[E0308]: mismatched types
- --> tests/ui/store_context/root_context_is_rejected.rs:6:40
-  |
-6 |     let _ = StoreFactory::open(config, root);
-  |             ------------------         ^^^^ expected `ChildServiceContext`, found `RootServiceContext`
-  |             |
-  |             arguments to this function are incorrect
-  |
+  --> tests/ui/store_context/root_context_is_rejected.rs:20:40
+   |
+20 |     let _ = StoreFactory::open(config, root);
+   |             ------------------         ^^^^ expected `ChildServiceContext`, found `RootServiceContext`
+   |             |
+   |             arguments to this function are incorrect
+   |
 note: associated function defined here
- --> src/factory.rs
-  |
-  |     pub fn open(
-  |            ^^^^
+  --> src/factory.rs
+   |
+   |     pub fn open(config: StoreFactoryConfig, service_context: ChildServiceContext) -> Result<OpenedStore, StoreError> {
+   |            ^^^^


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10069

### Brief Description

- Add the repository-standard Apache License 2.0 header to `rocketmq-store/tests/ui/store_context/root_context_is_rejected.rs`.
- Update the trybuild `.stderr` snapshot because the added header changes the diagnostic source line and current compiler output formatting.
- Record the documentation update in `CHANGELOG.md`.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-store -- --check` (passed)
- `cargo test -p rocketmq-store --test store_context_scope_compile_fail` (passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the missing Apache 2.0 license header to a store context test fixture.
  * Updated the unreleased changelog to document the correction.

* **Tests**
  * Updated expected compiler output to reflect revised source locations and signature formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->