### PR TITLE
[ISSUE #10111]♻️Canonicalize Broker notification mappings and POP profile failures

### DIFF
--- a/rocketmq-broker/src/pop/profile_store.rs
+++ b/rocketmq-broker/src/pop/profile_store.rs
@@ -17,7 +17,12 @@ use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use parking_lot::Mutex;
+use rocketmq_error::fields;
+use rocketmq_error::Error;
+use rocketmq_error::ErrorContext;
 use rocketmq_error::RocketMQError;
+use rocketmq_error::SerializationError;
+use rocketmq_error::CORE_CONFIGURATION_INVALID;
 use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
 use rocketmq_model::common::pop_retry_policy::PopRetryTopicVersion;
 use rocketmq_model::PopRetryPolicyOutcome;
@@ -88,7 +93,7 @@ impl PopConsumerProfileStore {
         let mut profiles = BTreeMap::new();
         for (key, value) in records {
             let record: StoredProfileRecord = serde_json::from_slice(&value)
-                .map_err(|error| codec_error(format!("profile record JSON is invalid: {error}")))?;
+                .map_err(|error| codec_source_error("deserialize profile record", "JSON", error))?;
             match record {
                 StoredProfileRecord::Profile { mut profile } => {
                     normalize_retry_policy(&mut profile)?;
@@ -179,7 +184,7 @@ impl PopConsumerProfileStore {
         let value = serde_json::to_vec(&StoredProfileRecord::Profile {
             profile: profile.clone(),
         })
-        .map_err(|error| codec_error(format!("profile record encode failed: {error}")))?;
+        .map_err(|error| codec_source_error("serialize profile record", "JSON", error))?;
         self.rocksdb.write_profile_record(
             marker,
             pop_consumer_profile_key(group.as_str()).map_err(broker_storage_error)?,
@@ -208,7 +213,7 @@ impl PopConsumerProfileStore {
             last_seen,
             format_version: POP_CONSUMER_PROFILE_FORMAT_VERSION,
         })
-        .map_err(|error| codec_error(format!("profile tombstone encode failed: {error}")))?;
+        .map_err(|error| codec_source_error("serialize profile tombstone", "JSON", error))?;
         self.rocksdb.write_profile_record(
             marker,
             pop_consumer_profile_key(group.as_str()).map_err(broker_storage_error)?,
@@ -263,7 +268,7 @@ fn validate_profile(profile: &PopConsumerProfile) -> Result<(), RocketMQError> {
         .ok_or_else(|| codec_error("persisted POP profile is missing retry policy"))?;
     retry_policy
         .state()
-        .map_err(|error| codec_error(format!("invalid persisted POP retry policy: {error}")))?;
+        .map_err(|error| codec_source_error("validate persisted POP retry policy", "POP retry policy", error))?;
     if retry_policy.generation != profile.generation || retry_policy.write_version.number() != profile.retry_version {
         return Err(codec_error(
             "persisted POP retry policy generation/version does not match the profile",
@@ -294,13 +299,9 @@ fn next_retry_policy(
     requested: PopRetryPolicy,
     generation: u64,
 ) -> Result<PopRetryPolicy, RocketMQError> {
-    let requested_state = requested.state().map_err(|error| {
-        invalid_profile(
-            "retryPolicy",
-            error.to_string(),
-            "a supported POP retry migration state",
-        )
-    })?;
+    let requested_state = requested
+        .state()
+        .map_err(|error| invalid_profile_source("retryPolicy", error))?;
     let Some(existing) = existing else {
         return Ok(PopRetryPolicy::for_state(requested_state, generation));
     };
@@ -308,12 +309,16 @@ fn next_retry_policy(
         .retry_policy
         .as_ref()
         .ok_or_else(|| codec_error("existing POP profile is missing retry policy"))?;
-    if current.state().map_err(|error| codec_error(error.to_string()))? == requested_state {
+    if current
+        .state()
+        .map_err(|error| codec_source_error("validate existing POP retry policy", "POP retry policy", error))?
+        == requested_state
+    {
         return Ok(PopRetryPolicy::for_state(requested_state, generation));
     }
     match current
         .transition_to(requested_state, generation)
-        .map_err(|_| codec_error("existing POP retry policy is invalid"))?
+        .map_err(|error| codec_source_error("transition existing POP retry policy", "POP retry policy", error))?
     {
         PopRetryPolicyOutcome::Transitioned(policy) => Ok(policy),
         PopRetryPolicyOutcome::Rejected => Err(invalid_profile(
@@ -345,4 +350,92 @@ fn invalid_profile(key: &'static str, value: impl Into<String>, reason: impl Int
 
 fn codec_error(reason: impl Into<String>) -> RocketMQError {
     RocketMQError::deserialization_failed("POP consumer profile", reason.into())
+}
+
+fn codec_source_error(
+    operation: &'static str,
+    format: &'static str,
+    source: impl std::error::Error + Send + Sync + 'static,
+) -> RocketMQError {
+    SerializationError::source(operation, format, source).into()
+}
+
+fn invalid_profile_source(key: &'static str, source: impl std::error::Error + Send + Sync + 'static) -> RocketMQError {
+    RocketMQError::Shared(Arc::new(
+        Error::caused_by(&CORE_CONFIGURATION_INVALID, source).with_context(
+            ErrorContext::new()
+                .with_text(fields::KEY, key)
+                .with_secret_presence(fields::VALUE_PRESENT)
+                .with_secret_presence(fields::REASON_PRESENT),
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as StdError;
+
+    use rocketmq_error::CORE_SERIALIZATION_FAILED;
+    use rocketmq_model::common::pop_retry_policy::PopRetryTopicVersion;
+    use rocketmq_model::ModelContractViolation;
+
+    use super::*;
+
+    fn malformed_retry_policy(generation: u64) -> PopRetryPolicy {
+        PopRetryPolicy {
+            write_version: PopRetryTopicVersion::V1,
+            read_fallback_order: vec![PopRetryTopicVersion::V1],
+            accept_v1: false,
+            accept_v2: false,
+            generation,
+        }
+    }
+
+    fn has_source<T>(error: &(dyn StdError + 'static)) -> bool
+    where
+        T: StdError + 'static,
+    {
+        let mut current = error.source();
+        while let Some(source) = current {
+            if source.downcast_ref::<T>().is_some() {
+                return true;
+            }
+            current = source.source();
+        }
+        false
+    }
+
+    #[test]
+    fn profile_codec_failure_preserves_the_typed_json_source() {
+        let source = serde_json::from_slice::<StoredProfileRecord>(b"{").expect_err("malformed profile JSON must fail");
+        let error = codec_source_error("deserialize profile record", "JSON", source);
+
+        assert_eq!(error.descriptor(), &CORE_SERIALIZATION_FAILED);
+        assert!(has_source::<serde_json::Error>(&error));
+        assert!(!error.to_string().contains("EOF while parsing"));
+    }
+
+    #[test]
+    fn profile_retry_policy_failures_preserve_descriptor_and_typed_source() {
+        let requested = next_retry_policy(None, malformed_retry_policy(1), 2)
+            .expect_err("malformed requested policy must be rejected");
+        assert_eq!(requested.descriptor(), &CORE_CONFIGURATION_INVALID);
+        assert!(has_source::<ModelContractViolation>(&requested));
+        assert!(!requested.to_string().contains("POP retry policy does not describe"));
+
+        let existing = PopConsumerProfile {
+            group: CheetahString::from_static_str("group-a"),
+            subscriptions: Vec::new(),
+            retry_version: 1,
+            retry_policy: Some(malformed_retry_policy(1)),
+            generation: 1,
+            last_seen: 0,
+            format_version: POP_CONSUMER_PROFILE_FORMAT_VERSION,
+        };
+        let persisted = next_retry_policy(Some(&existing), PopRetryPolicy::v2_only(1), 2)
+            .expect_err("malformed persisted policy must fail");
+        assert_eq!(persisted.descriptor(), &CORE_SERIALIZATION_FAILED);
+        assert!(has_source::<ModelContractViolation>(&persisted));
+        assert!(!persisted.to_string().contains("POP retry policy does not describe"));
+    }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
@@ -45,6 +45,8 @@ use super::AdminRequestMetadata;
 use crate::subscription::manager::subscription_group_manager::SubscriptionGroupConfigCasError;
 use crate::subscription::manager::subscription_group_manager::SubscriptionGroupConfigCasOutcome;
 
+const POP_PROFILE_PERSISTENCE_UNAVAILABLE_REMARK: &str = "POP consumer profile persistence is unavailable";
+
 pub(super) struct SubscriptionGroupHandler;
 
 impl SubscriptionGroupHandler {
@@ -580,14 +582,12 @@ impl SubscriptionGroupHandler {
             .delete_subscription_group_config(request_header.group_name.as_str());
 
         if let Some(processor) = broker_runtime_inner.pop_message_processor() {
-            if let Err(error) = processor
+            if processor
                 .remove_consumer_profile(request_header.group_name.clone())
                 .await
+                .is_err()
             {
-                return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::ServiceNotAvailable,
-                    format!("failed to remove POP consumer profile: {error}"),
-                )));
+                return Ok(Some(pop_profile_persistence_unavailable_response()));
             }
         }
 
@@ -672,11 +672,8 @@ impl SubscriptionGroupHandler {
             .delete_subscription_group_config_list(&groups);
         if let Some(processor) = broker_runtime_inner.pop_message_processor() {
             for group in &groups {
-                if let Err(error) = processor.remove_consumer_profile(group.clone()).await {
-                    return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
-                        ResponseCode::ServiceNotAvailable,
-                        format!("failed to remove POP consumer profile for {group}: {error}"),
-                    )));
+                if processor.remove_consumer_profile(group.clone()).await.is_err() {
+                    return Ok(Some(pop_profile_persistence_unavailable_response()));
                 }
             }
         }
@@ -732,6 +729,13 @@ impl SubscriptionGroupHandler {
     }
 }
 
+fn pop_profile_persistence_unavailable_response() -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code_remark(
+        ResponseCode::ServiceNotAvailable,
+        POP_PROFILE_PERSISTENCE_UNAVAILABLE_REMARK,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -782,6 +786,21 @@ mod tests {
         let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
         assert!(runtime.initialize().await.is_ok());
         runtime
+    }
+
+    #[test]
+    fn pop_profile_remove_failure_uses_a_fixed_safe_r14_response() {
+        let response = pop_profile_persistence_unavailable_response();
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::ServiceNotAvailable);
+        assert_eq!(
+            response.remark().map(CheetahString::as_str),
+            Some(POP_PROFILE_PERSISTENCE_UNAVAILABLE_REMARK)
+        );
+        assert!(!response
+            .remark()
+            .is_some_and(|remark| remark.contains("group-secret") || remark.contains("storage-secret")));
+        assert!(response.body().is_none());
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/processor/notification_processor/core.rs
+++ b/rocketmq-broker/src/processor/notification_processor/core.rs
@@ -15,12 +15,18 @@
 use std::net::SocketAddr;
 
 use rand::RngExt;
+use rocketmq_error::Error;
+use rocketmq_error::PublicErrorView;
+use rocketmq_error::AUTH_PERMISSION_DENIED;
+use rocketmq_error::CORE_ARGUMENT_INVALID;
 use rocketmq_model::common::constant::PermName;
 use rocketmq_model::common::FAQUrl;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_store::BrokerReadWriteStore;
+use rocketmq_transport::api::error_response as remoting_error_response;
+use rocketmq_transport::api::RemotingErrorTarget;
 use tracing::error;
 use tracing::warn;
 
@@ -49,7 +55,7 @@ where
         effective_peer: SocketAddr,
         opaque: i32,
         frozen_filter: Option<NotificationFilterContract>,
-    ) -> NotificationCoreOutcome {
+    ) -> rocketmq_error::Result<NotificationCoreOutcome> {
         let mut response = self
             .context
             .command_factory
@@ -57,12 +63,7 @@ where
         response.set_opaque_mut(opaque);
 
         if !PermName::is_readable(self.context.policy.broker_permission.get()) {
-            response.set_code_ref(ResponseCode::NoPermission);
-            response.set_remark_mut(format!(
-                "the broker[{}] peeking message is forbidden",
-                self.context.policy.broker_ip1
-            ));
-            return NotificationCoreOutcome::Reply(response);
+            return Err(Error::new(&AUTH_PERMISSION_DENIED));
         }
 
         let Some(topic_config) = self
@@ -80,16 +81,11 @@ where
                 request_header.topic,
                 FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
             ));
-            return NotificationCoreOutcome::Reply(response);
+            return Ok(NotificationCoreOutcome::Reply(response));
         };
 
         if !PermName::is_readable(topic_config.perm) {
-            response.set_code_ref(ResponseCode::NoPermission);
-            response.set_remark_mut(format!(
-                "the topic[{}] peeking message is forbidden",
-                request_header.topic
-            ));
-            return NotificationCoreOutcome::Reply(response);
+            return Err(Error::new(&AUTH_PERMISSION_DENIED));
         }
 
         if request_header.queue_id >= topic_config.get_read_queue_nums() as i32 {
@@ -101,9 +97,7 @@ where
                 effective_peer
             );
             warn!("{}", error_info);
-            response.set_code_ref(ResponseCode::InvalidParameter);
-            response.set_remark_mut(&error_info);
-            return NotificationCoreOutcome::Reply(response);
+            return Err(Error::new(&CORE_ARGUMENT_INVALID));
         }
 
         let Some(subscription_group_config) = self
@@ -117,16 +111,11 @@ where
                 request_header.consumer_group,
                 FAQUrl::suggest_todo(FAQUrl::SUBSCRIPTION_GROUP_NOT_EXIST)
             ));
-            return NotificationCoreOutcome::Reply(response);
+            return Ok(NotificationCoreOutcome::Reply(response));
         };
 
         if !subscription_group_config.consume_enable() {
-            response.set_code_ref(ResponseCode::NoPermission);
-            response.set_remark_mut(format!(
-                "subscription group no permission, {}",
-                request_header.consumer_group
-            ));
-            return NotificationCoreOutcome::Reply(response);
+            return Err(Error::new(&AUTH_PERMISSION_DENIED));
         }
 
         let filter_contract = match frozen_filter {
@@ -144,7 +133,7 @@ where
                     );
                     response.set_code_ref(ResponseCode::SubscriptionParseFailed);
                     response.set_remark_mut("parse the consumer's subscription failed");
-                    return NotificationCoreOutcome::Reply(response);
+                    return Ok(NotificationCoreOutcome::Reply(response));
                 }
             },
         };
@@ -194,9 +183,21 @@ where
             }
         }
 
-        NotificationCoreOutcome::Ready(NotificationCoreReady {
+        Ok(NotificationCoreOutcome::Ready(NotificationCoreReady {
             has_msg,
             filter_contract,
-        })
+        }))
+    }
+
+    pub(super) fn notification_error_response(&self, error: &Error, opaque: i32) -> RemotingCommand {
+        let view = error
+            .public_view()
+            .unwrap_or_else(|_| PublicErrorView::descriptor_only(error.descriptor()));
+        let response = self
+            .context
+            .command_factory
+            .create_java_default_error_response_command()
+            .set_opaque(opaque);
+        remoting_error_response(view, RemotingErrorTarget::Existing(response))
     }
 }

--- a/rocketmq-broker/src/processor/notification_processor/handler.rs
+++ b/rocketmq-broker/src/processor/notification_processor/handler.rs
@@ -89,21 +89,21 @@ where
             }
         };
 
-        match self
-            .execute_notification_core(
-                &request_header,
-                effective_peer,
-                request.original_identity().original_opaque(),
-                None,
-            )
+        let opaque = request.original_identity().original_opaque();
+        let outcome = match self
+            .execute_notification_core(&request_header, effective_peer, opaque, None)
             .await
         {
+            Ok(outcome) => outcome,
+            Err(error) => return command_outcome(self.notification_error_response(&error, opaque)),
+        };
+        match outcome {
             NotificationCoreOutcome::Reply(response) => command_outcome(response),
             NotificationCoreOutcome::Ready(ready) if ready.has_msg => command_outcome(compose_notification_response(
                 &self.context.command_factory,
                 true,
                 false,
-                request.original_identity().original_opaque(),
+                opaque,
             )),
             NotificationCoreOutcome::Ready(ready) => {
                 let Some(service) = self.notification_deferred_service.get() else {

--- a/rocketmq-broker/src/processor/notification_processor/resume.rs
+++ b/rocketmq-broker/src/processor/notification_processor/resume.rs
@@ -58,9 +58,13 @@ where
             _ => None,
         };
         let (header, effective_peer) = request.into_parts();
-        let outcome = self
+        let outcome = match self
             .execute_notification_core(&header, effective_peer, 0, frozen_filter)
-            .await;
+            .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => return Ok(self.notification_error_response(&error, 0)),
+        };
         match outcome {
             NotificationCoreOutcome::Reply(command) => Ok(command),
             NotificationCoreOutcome::Ready(ready) => Ok(super::response::compose_notification_response(

--- a/rocketmq-broker/tests/unit/processor/notification/resume.rs
+++ b/rocketmq-broker/tests/unit/processor/notification/resume.rs
@@ -222,6 +222,7 @@ async fn notification_core_finds_message_from_configured_retry_topic() {
     let ready = match processor
         .execute_notification_core(&core_header("topic-a", "group-a", 0), peer, 20_005, None)
         .await
+        .expect("retry-store Notification core")
     {
         NotificationCoreOutcome::Ready(ready) => ready,
         NotificationCoreOutcome::Reply(response) => {
@@ -247,6 +248,34 @@ fn assert_notification_header(
         .expect("Notification response header");
     assert_eq!(header.has_msg, has_msg);
     assert!(!header.polling_full);
+}
+
+fn assert_owner_error_response_state(
+    processor: &NotificationProcessor<BrokerMessageStore>,
+    response: &rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+    expected_code: ResponseCode,
+    expected_opaque: i32,
+    expected_remark: &'static str,
+) {
+    let owner_seed = processor
+        .context
+        .command_factory
+        .create_java_default_error_response_command()
+        .set_opaque(expected_opaque);
+    assert_eq!(response.code(), expected_code as i32);
+    assert_eq!(response.opaque(), expected_opaque);
+    assert_eq!(response.remark().map(CheetahString::as_str), Some(expected_remark));
+    assert_eq!(response.version(), owner_seed.version());
+    assert_eq!(response.serialize_type(), owner_seed.serialize_type());
+    assert_eq!(response.flag(), owner_seed.flag());
+    assert_eq!(response.ext_fields(), owner_seed.ext_fields());
+    assert_eq!(response.body(), owner_seed.body());
+    assert_eq!(
+        response.command_custom_header_ref().is_some(),
+        owner_seed.command_custom_header_ref().is_some()
+    );
+    assert_eq!(response.suspended(), owner_seed.suspended());
+    assert!(response.is_response_type());
 }
 
 #[tokio::test]
@@ -287,20 +316,22 @@ async fn notification_core_characterizes_permission_topic_group_queue_filter_and
     let mut denied_policy = NotificationPolicy::from_config(&denied_broker_config, BrokerPermissionState::new(0));
     denied_policy.broker_ip1 = CheetahString::from_static_str("127.0.0.1");
     let (denied, denied_bridge) = processor_with_policy(runtime.runtime_state_mut(), denied_policy);
-    let denied_response = match denied
+    let denied_error = match denied
         .execute_notification_core(&core_header("topic-a", "group-a", 0), peer, 20_001, None)
         .await
     {
-        NotificationCoreOutcome::Reply(response) => response,
-        NotificationCoreOutcome::Ready(_) => panic!("broker permission denial must be terminal"),
+        Err(error) => error,
+        Ok(_) => panic!("broker permission denial must be canonical"),
     };
-    assert_eq!(denied_response.code(), ResponseCode::NoPermission as i32);
-    assert_eq!(denied_response.opaque(), 20_001);
-    assert_eq!(
-        denied_response.remark().map(CheetahString::as_str),
-        Some("the broker[127.0.0.1] peeking message is forbidden")
+    assert_eq!(denied_error.descriptor(), &rocketmq_error::AUTH_PERMISSION_DENIED);
+    let denied_response = denied.notification_error_response(&denied_error, 20_001);
+    assert_owner_error_response_state(
+        &denied,
+        &denied_response,
+        ResponseCode::NoPermission,
+        20_001,
+        "Permission was denied",
     );
-    assert!(denied_response.body().is_none());
     drop((denied, denied_bridge));
 
     let (processor, escape_bridge) = processor(&mut runtime);
@@ -321,14 +352,13 @@ async fn notification_core_characterizes_permission_topic_group_queue_filter_and
                 FAQUrl::suggest_todo(FAQUrl::SUBSCRIPTION_GROUP_NOT_EXIST)
             ),
         ),
-        (
-            core_header("topic-a", "group-a", 99),
-            ResponseCode::InvalidParameter,
-            format!("queueId[99] is illegal, topic:[topic-a] topicConfig.readQueueNums:[1] consumer:[{peer}]"),
-        ),
     ];
     for (header, expected, expected_remark) in cases {
-        let response = match processor.execute_notification_core(&header, peer, 20_002, None).await {
+        let response = match processor
+            .execute_notification_core(&header, peer, 20_002, None)
+            .await
+            .expect("owner-controlled Notification validation response")
+        {
             NotificationCoreOutcome::Reply(response) => response,
             NotificationCoreOutcome::Ready(_) => panic!("Notification validation failure must be terminal"),
         };
@@ -341,24 +371,43 @@ async fn notification_core_characterizes_permission_topic_group_queue_filter_and
         assert!(response.body().is_none());
     }
 
+    let queue_error = match processor
+        .execute_notification_core(&core_header("topic-a", "group-a", 99), peer, 20_002, None)
+        .await
+    {
+        Err(error) => error,
+        Ok(_) => panic!("queue validation must be canonical"),
+    };
+    assert_eq!(queue_error.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
+    let queue_response = processor.notification_error_response(&queue_error, 20_002);
+    assert_owner_error_response_state(
+        &processor,
+        &queue_response,
+        ResponseCode::InvalidParameter,
+        20_002,
+        "Argument is invalid",
+    );
+
     let _ = runtime
         .runtime_state_mut()
         .topic_config_manager_handle()
         .update_topic_config(TopicConfig::with_perm("topic-a", 1, 1, PermName::PERM_WRITE), 0);
-    let topic_denied = match processor
+    let topic_error = match processor
         .execute_notification_core(&core_header("topic-a", "group-a", 0), peer, 20_003, None)
         .await
     {
-        NotificationCoreOutcome::Reply(response) => response,
-        NotificationCoreOutcome::Ready(_) => panic!("unreadable topic must be terminal"),
+        Err(error) => error,
+        Ok(_) => panic!("unreadable topic must be canonical"),
     };
-    assert_eq!(topic_denied.code(), ResponseCode::NoPermission as i32);
-    assert_eq!(topic_denied.opaque(), 20_003);
-    assert_eq!(
-        topic_denied.remark().map(CheetahString::as_str),
-        Some("the topic[topic-a] peeking message is forbidden")
+    assert_eq!(topic_error.descriptor(), &rocketmq_error::AUTH_PERMISSION_DENIED);
+    let topic_denied = processor.notification_error_response(&topic_error, 20_003);
+    assert_owner_error_response_state(
+        &processor,
+        &topic_denied,
+        ResponseCode::NoPermission,
+        20_003,
+        "Permission was denied",
     );
-    assert!(topic_denied.body().is_none());
     let _ = runtime
         .runtime_state_mut()
         .topic_config_manager_handle()
@@ -370,20 +419,22 @@ async fn notification_core_characterizes_permission_topic_group_queue_filter_and
         .runtime_state_mut()
         .subscription_group_manager()
         .update_subscription_group_config(&mut disabled_group));
-    let group_denied = match processor
+    let group_error = match processor
         .execute_notification_core(&core_header("topic-a", "group-a", 0), peer, 20_004, None)
         .await
     {
-        NotificationCoreOutcome::Reply(response) => response,
-        NotificationCoreOutcome::Ready(_) => panic!("disabled group must be terminal"),
+        Err(error) => error,
+        Ok(_) => panic!("disabled group must be canonical"),
     };
-    assert_eq!(group_denied.code(), ResponseCode::NoPermission as i32);
-    assert_eq!(group_denied.opaque(), 20_004);
-    assert_eq!(
-        group_denied.remark().map(CheetahString::as_str),
-        Some("subscription group no permission, group-a")
+    assert_eq!(group_error.descriptor(), &rocketmq_error::AUTH_PERMISSION_DENIED);
+    let group_denied = processor.notification_error_response(&group_error, 20_004);
+    assert_owner_error_response_state(
+        &processor,
+        &group_denied,
+        ResponseCode::NoPermission,
+        20_004,
+        "Permission was denied",
     );
-    assert!(group_denied.body().is_none());
     disabled_group.set_consume_enable(true);
     assert!(runtime
         .runtime_state_mut()
@@ -415,7 +466,11 @@ async fn notification_core_characterizes_permission_topic_group_queue_filter_and
 
     let mut ordered = core_header("topic-a", "group-a", 0);
     ordered.order = true;
-    let ready = match processor.execute_notification_core(&ordered, peer, 20_005, None).await {
+    let ready = match processor
+        .execute_notification_core(&ordered, peer, 20_005, None)
+        .await
+        .expect("unblocked order Notification core")
+    {
         NotificationCoreOutcome::Ready(ready) => ready,
         NotificationCoreOutcome::Reply(response) => {
             panic!("unblocked order request failed with code {}", response.code())
@@ -424,7 +479,11 @@ async fn notification_core_characterizes_permission_topic_group_queue_filter_and
     assert!(ready.has_msg, "a missing attempt id intentionally skips order blocking");
 
     ordered.attempt_id = Some(attempt);
-    let same_attempt = match processor.execute_notification_core(&ordered, peer, 20_006, None).await {
+    let same_attempt = match processor
+        .execute_notification_core(&ordered, peer, 20_006, None)
+        .await
+        .expect("same-attempt order Notification core")
+    {
         NotificationCoreOutcome::Ready(ready) => ready,
         NotificationCoreOutcome::Reply(response) => {
             panic!("same-attempt order request failed with code {}", response.code())
@@ -433,7 +492,11 @@ async fn notification_core_characterizes_permission_topic_group_queue_filter_and
     assert!(same_attempt.has_msg, "the active order attempt remains readable");
 
     ordered.attempt_id = Some(CheetahString::from_static_str("attempt-2"));
-    let blocked_attempt = match processor.execute_notification_core(&ordered, peer, 20_007, None).await {
+    let blocked_attempt = match processor
+        .execute_notification_core(&ordered, peer, 20_007, None)
+        .await
+        .expect("blocked order Notification core")
+    {
         NotificationCoreOutcome::Ready(ready) => ready,
         NotificationCoreOutcome::Reply(response) => {
             panic!("blocked order request failed with code {}", response.code())
@@ -455,6 +518,7 @@ async fn notification_core_characterizes_permission_topic_group_queue_filter_and
     let response = match filtered
         .execute_notification_core(&invalid_filter, peer, 20_008, None)
         .await
+        .expect("filter parse remains an owner-controlled response")
     {
         NotificationCoreOutcome::Reply(response) => response,
         NotificationCoreOutcome::Ready(_) => panic!("enabled invalid Notification filter must be terminal"),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #10111

### Brief Description

- Return canonical typed errors for the four Notification permission/queue failures and project them through the sole remoting error adapter at the Broker-owned boundary.
- Preserve the actual RocketMQ wire ledger: permission failures remain R16, invalid queue remains R29, and the explicit R17/R23/R26 Notification responses are unchanged. The migrated public remarks are fixed catalog messages while opaque and complete command state remain owner-preserved.
- Preserve all seven current POP profile `serde_json::Error` and `ModelContractViolation` causes as typed sources without placing source text in public context or output. Existing serialization R1 and invalid-configuration R29 descriptor semantics remain unchanged.
- Keep single and batch POP profile removal failures at R14 with one fixed safe remark instead of exposing error or group text.
- Keep persistence-before-memory-update ordering, admin partial-mutation ordering, deferred behavior, and public APIs unchanged. No V1/V2 error compatibility, alternate adapter, fingerprint, checksum, or complex gate is added.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check` — passed.
- `cargo check -p rocketmq-broker --all-targets --all-features` — passed.
- Four exact focused tests for Notification wire state, JSON source retention, retry-policy source retention, and fixed R14 output — 1/1 passed each.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` — passed.
- Fixed-nightly locked `fuzz/` all-target/all-feature check — passed.
- RocksDB specialized checks: Store and Broker Clippy passed; `rocksdb_foundation_tests` passed 82/82; `rocksdb_store_semantics_tests` passed 11/11. The later Broker `rocksdb` filter did not start tests because the Windows linker hit PDB LIMIT and the disposable target volume filled; the subsequent `pop_consumer` filter was not run. The temporary 85.1 GiB target was then cleaned.
- `python scripts/error_architecture_guard.py` — expected non-zero baseline reduced from 16 to 11 findings: the four targeted Notification findings and the tracked POP finding are gone, no changed file is reported, and only ten test-support source-stringification findings plus one pre-existing Transport redaction finding remain.
- Independent cross-review of both implementation halves approved with zero P0–P2 findings.
- `git diff --check` — passed; line-ending advisories only.

CI was not run or awaited for this reduced-validation delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for notification requests, including clearer responses for permission, validation, and unavailable-resource failures.
  * Sanitized error responses to prevent sensitive internal details from appearing in subscription-group and profile persistence failures.
  * Standardized error descriptors and messages for malformed profile data and invalid retry policies.
* **Tests**
  * Added coverage verifying consistent error responses and sanitized failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->