### PR TITLE
[ISSUE #10116]♻️Separate NameServer route absence from lookup failures

### DIFF
--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -2038,6 +2038,8 @@ mod tests {
     }
     use crate::processor::default_request_processor::DefaultRequestProcessor;
     use crate::processor::ClientRequestProcessor;
+    use crate::processor::ClusterTestTopicRouteOutcome;
+    use crate::route::route_info_manager::TopicRouteLookupOutcome;
     use crate::route::types::BrokerSession;
 
     fn test_broker_session(remote_addr: SocketAddr) -> (BrokerSession, SessionId) {
@@ -2336,8 +2338,11 @@ mod tests {
             })
         }
 
-        fn lookup_topic_route(&self, _topic: &CheetahString) -> TestRouteLookupFuture<'_, Option<TopicRouteData>> {
-            Box::pin(async { Ok(None) })
+        fn lookup_topic_route(
+            &self,
+            _topic: &CheetahString,
+        ) -> TestRouteLookupFuture<'_, ClusterTestTopicRouteOutcome> {
+            Box::pin(async { Ok(ClusterTestTopicRouteOutcome::NotFound) })
         }
 
         fn shutdown(&self) -> TestRouteLookupFuture<'_, ()> {
@@ -3388,12 +3393,14 @@ mod tests {
             ResponseCode::Success
         );
         assert!(
-            bootstrap
-                .name_server_runtime
-                .inner
-                .route_info_manager()
-                .pickup_topic_route_data(&registered_topic)
-                .is_ok(),
+            matches!(
+                bootstrap
+                    .name_server_runtime
+                    .inner
+                    .route_info_manager()
+                    .pickup_topic_route_data(&registered_topic),
+                Ok(TopicRouteLookupOutcome::Found(_))
+            ),
             "registered topic should be visible through route manager"
         );
 
@@ -3406,12 +3413,14 @@ mod tests {
             process_with_default_processor(&bootstrap, &harness, &mut delete_topic_request).await;
         assert_eq!(ResponseCode::from(delete_topic_response.code()), ResponseCode::Success);
         assert!(
-            bootstrap
-                .name_server_runtime
-                .inner
-                .route_info_manager()
-                .pickup_topic_route_data(&registered_topic)
-                .is_err(),
+            matches!(
+                bootstrap
+                    .name_server_runtime
+                    .inner
+                    .route_info_manager()
+                    .pickup_topic_route_data(&registered_topic),
+                Ok(TopicRouteLookupOutcome::NotFound)
+            ),
             "deleted topic should no longer have route data"
         );
     }
@@ -3531,12 +3540,14 @@ mod tests {
         let register_response = process_with_default_processor(&bootstrap, &harness, &mut register_request).await;
         assert_eq!(ResponseCode::from(register_response.code()), ResponseCode::Success);
         assert!(
-            bootstrap
-                .name_server_runtime
-                .inner
-                .route_info_manager()
-                .pickup_topic_route_data(&topic_name)
-                .is_ok(),
+            matches!(
+                bootstrap
+                    .name_server_runtime
+                    .inner
+                    .route_info_manager()
+                    .pickup_topic_route_data(&topic_name),
+                Ok(TopicRouteLookupOutcome::Found(_))
+            ),
             "registered topic route should exist before unregister"
         );
 
@@ -3557,12 +3568,14 @@ mod tests {
         assert_eq!(ResponseCode::from(unregister_response.code()), ResponseCode::Success);
 
         wait_until("processor unregister broker route cleanup", || {
-            bootstrap
-                .name_server_runtime
-                .inner
-                .route_info_manager()
-                .pickup_topic_route_data(&topic_name)
-                .is_err()
+            matches!(
+                bootstrap
+                    .name_server_runtime
+                    .inner
+                    .route_info_manager()
+                    .pickup_topic_route_data(&topic_name),
+                Ok(TopicRouteLookupOutcome::NotFound)
+            )
         })
         .await;
         shutdown_unregister_service(&bootstrap).await;
@@ -3789,12 +3802,15 @@ mod tests {
         )
         .await;
 
-        let topic_route_data = bootstrap
+        let TopicRouteLookupOutcome::Found(topic_route_data) = bootstrap
             .name_server_runtime
             .inner
             .route_info_manager()
             .pickup_topic_route_data(&topic_name)
-            .expect("topic route data should exist");
+            .expect("topic route lookup should succeed")
+        else {
+            panic!("topic route data should exist");
+        };
         let broker_data = topic_route_data
             .broker_datas
             .iter()
@@ -3852,10 +3868,12 @@ mod tests {
             let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
             let cluster_info = route_manager.get_all_cluster_info();
 
-            route_manager.pickup_topic_route_data(&topic_name).is_err()
-                && route_manager
-                    .query_broker_topic_config(cluster_name.clone(), broker_addr.clone())
-                    .is_none()
+            matches!(
+                route_manager.pickup_topic_route_data(&topic_name),
+                Ok(TopicRouteLookupOutcome::NotFound)
+            ) && route_manager
+                .query_broker_topic_config(cluster_name.clone(), broker_addr.clone())
+                .is_none()
                 && cluster_info
                     .cluster_addr_table
                     .as_ref()
@@ -3956,10 +3974,12 @@ mod tests {
             let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
             let cluster_info = route_manager.get_all_cluster_info();
 
-            route_manager.pickup_topic_route_data(&topic_name).is_err()
-                && route_manager
-                    .query_broker_topic_config(cluster_name.clone(), broker_addr.clone())
-                    .is_none()
+            matches!(
+                route_manager.pickup_topic_route_data(&topic_name),
+                Ok(TopicRouteLookupOutcome::NotFound)
+            ) && route_manager
+                .query_broker_topic_config(cluster_name.clone(), broker_addr.clone())
+                .is_none()
                 && cluster_info
                     .cluster_addr_table
                     .as_ref()
@@ -4043,7 +4063,8 @@ mod tests {
         wait_until("duplicate unregister cleanup", || {
             let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
             let cluster_info = route_manager.get_all_cluster_info();
-            let Ok(route_data) = route_manager.pickup_topic_route_data(&topic_name) else {
+            let Ok(TopicRouteLookupOutcome::Found(route_data)) = route_manager.pickup_topic_route_data(&topic_name)
+            else {
                 return false;
             };
             let Some(route_broker_data) = route_data
@@ -4141,7 +4162,8 @@ mod tests {
         wait_until("channel destroy cleanup", || {
             let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
             let cluster_info = route_manager.get_all_cluster_info();
-            let Ok(route_data) = route_manager.pickup_topic_route_data(&topic_name) else {
+            let Ok(TopicRouteLookupOutcome::Found(route_data)) = route_manager.pickup_topic_route_data(&topic_name)
+            else {
                 return false;
             };
 
@@ -4241,7 +4263,8 @@ mod tests {
         wait_until("acting master cleanup", || {
             let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
             let cluster_info = route_manager.get_all_cluster_info();
-            let Ok(route_data) = route_manager.pickup_topic_route_data(&topic_name) else {
+            let Ok(TopicRouteLookupOutcome::Found(route_data)) = route_manager.pickup_topic_route_data(&topic_name)
+            else {
                 return false;
             };
             let Some(route_broker_data) = route_data
@@ -4629,10 +4652,10 @@ mod tests {
         let first_session = tokio::time::timeout(Duration::from_secs(2), next_connected(&mut session_events))
             .await
             .expect("first broker session should publish connect");
-        assert!(runtime
-            .route_info_manager()
-            .pickup_topic_route_data(&topic_name)
-            .is_ok());
+        assert!(matches!(
+            runtime.route_info_manager().pickup_topic_route_data(&topic_name),
+            Ok(TopicRouteLookupOutcome::Found(_))
+        ));
 
         let mut replacement = connect(&addr).await;
         send_registration(&mut replacement, registration().set_opaque(0x72b2)).await;
@@ -4657,10 +4680,10 @@ mod tests {
         })
         .await;
         assert!(
-            runtime
-                .route_info_manager()
-                .pickup_topic_route_data(&topic_name)
-                .is_ok(),
+            matches!(
+                runtime.route_info_manager().pickup_topic_route_data(&topic_name),
+                Ok(TopicRouteLookupOutcome::Found(_))
+            ),
             "an old session disconnect must not remove its replacement registration"
         );
 
@@ -4676,10 +4699,10 @@ mod tests {
         })
         .await;
         wait_until("replacement disconnect route cleanup", || {
-            runtime
-                .route_info_manager()
-                .pickup_topic_route_data(&topic_name)
-                .is_err()
+            matches!(
+                runtime.route_info_manager().pickup_topic_route_data(&topic_name),
+                Ok(TopicRouteLookupOutcome::NotFound)
+            )
         })
         .await;
 
@@ -4910,11 +4933,18 @@ mod tests {
         let response = process_with_client_processor(&bootstrap, &harness, &mut request).await;
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::TopicNotExist);
+        assert_eq!(
+            response.remark().map(CheetahString::as_str),
+            Some("Topic route was not found")
+        );
         assert_eq!(response.version(), 660);
         assert_eq!(
             response.serialize_type(),
             rocketmq_protocol::protocol::SerializeType::ROCKETMQ
         );
+        assert!(response.is_response_type());
+        assert!(response.body().is_none());
+        assert!(response.ext_fields().is_none());
     }
 
     #[tokio::test]

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -46,6 +46,8 @@ use rocketmq_transport::api::ResponseWriteOutcome;
 pub use self::client_request_processor::ClientRequestProcessor;
 pub use self::cluster_test_request_processor::ClusterTestRequestProcessor;
 pub(crate) use self::cluster_test_request_processor::ClusterTestRouteLookup;
+#[cfg(test)]
+pub(crate) use self::cluster_test_request_processor::ClusterTestTopicRouteOutcome;
 pub(crate) use self::cluster_test_request_processor::TransportClusterTestRouteLookup;
 use crate::bootstrap::InFlightRequestTracker;
 use crate::bootstrap::NameServerRuntimeHandle;

--- a/rocketmq-namesrv/src/processor/client_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/client_request_processor.rs
@@ -19,7 +19,6 @@ use std::time::Instant;
 use bytes::Bytes;
 use cheetah_string::CheetahString;
 use rocketmq_error::PublicErrorView;
-use rocketmq_model::common::FAQUrl;
 use rocketmq_model::version::RocketMqVersion;
 use rocketmq_observability::metrics::namesrv::NameServerRouteCacheOutcome;
 use rocketmq_observability::metrics::namesrv::NameServerRouteStage;
@@ -45,6 +44,7 @@ use crate::route::response_cache::JsonEncoding;
 use crate::route::response_cache::RouteCacheKey;
 use crate::route::response_cache::RouteCacheOutcomeKind;
 use crate::route::response_cache::RouteCachePolicy;
+use crate::route::route_info_manager::TopicRouteLookupOutcome;
 use crate::route::zone_filter::filter_route_by_zone;
 use crate::route::zone_filter::ZoneRequest;
 use crate::route::zone_filter::TYPED_ZONE_ROUTE_ENABLED;
@@ -142,21 +142,13 @@ impl ClientRequestProcessor {
             .route_info_manager()
             .load_topic_route_view(request_header.topic.as_ref())
         {
-            Ok(data) => data,
-            Err(
-                rocketmq_error::RocketMQError::TopicNotExist { .. }
-                | rocketmq_error::RocketMQError::RouteNotFound { .. },
-            ) => {
+            Ok(TopicRouteLookupOutcome::Found(data)) => data,
+            Ok(TopicRouteLookupOutcome::NotFound) => {
                 route_span.record("result", "not_found");
-                return Ok(Some(
-                    self.command_factory
-                        .create_response_command_with_code(ResponseCode::TopicNotExist)
-                        .set_remark(format!(
-                            "No topic route info in name server for the topic: {}{}",
-                            request_header.topic,
-                            FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
-                        )),
-                ));
+                return Ok(Some(error_response(
+                    PublicErrorView::descriptor_only(&rocketmq_error::ROUTE_TOPIC_NOT_FOUND),
+                    RemotingErrorTarget::Fresh(&self.command_factory),
+                )));
             }
             Err(error) => {
                 route_span.record("result", "internal");

--- a/rocketmq-namesrv/src/processor/cluster_test_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/cluster_test_request_processor.rs
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_model::common::FAQUrl;
+use rocketmq_error::PublicErrorView;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+use rocketmq_transport::api::error_response;
 use rocketmq_transport::api::HandlerOutcome;
+use rocketmq_transport::api::RemotingErrorTarget;
 use rocketmq_transport::api::RemotingRequest;
 use rocketmq_transport::api::RequestProcessor;
 use tracing::debug;
@@ -28,6 +30,7 @@ use tracing::info;
 use crate::bootstrap::NameServerRuntimeHandle;
 use crate::processor::client_request_processor::encode_topic_route_response_for_zone;
 use crate::processor::NAMESPACE_ORDER_TOPIC_CONFIG;
+use crate::route::route_info_manager::TopicRouteLookupOutcome;
 use crate::route::zone_filter::filter_route_by_zone;
 use crate::route::zone_filter::ZoneRequest;
 use crate::route::zone_filter::TYPED_ZONE_ROUTE_ENABLED;
@@ -38,6 +41,7 @@ mod lookup_cache;
 mod route_lookup;
 
 pub(crate) use route_lookup::ClusterTestRouteLookup;
+pub(crate) use route_lookup::ClusterTestTopicRouteOutcome;
 pub(crate) use route_lookup::TransportClusterTestRouteLookup;
 
 pub struct ClusterTestRequestProcessor {
@@ -66,11 +70,8 @@ impl ClusterTestRequestProcessor {
             .route_info_manager()
             .pickup_topic_route_data(request_header.topic.as_ref())
         {
-            Ok(route_data) => Some(route_data),
-            Err(
-                rocketmq_error::RocketMQError::TopicNotExist { .. }
-                | rocketmq_error::RocketMQError::RouteNotFound { .. },
-            ) => None,
+            Ok(TopicRouteLookupOutcome::Found(route_data)) => Some(route_data),
+            Ok(TopicRouteLookupOutcome::NotFound) => None,
             Err(error) => return Err(error),
         };
 
@@ -84,14 +85,15 @@ impl ClusterTestRequestProcessor {
                 .lookup_topic_route(&request_header.topic)
                 .await
             {
-                Ok(Some(route_data)) => {
+                Ok(ClusterTestTopicRouteOutcome::Found(route_data)) => {
                     topic_route_data = Some(route_data);
                 }
-                Ok(None) => {}
+                Ok(ClusterTestTopicRouteOutcome::NotFound | ClusterTestTopicRouteOutcome::Unavailable) => {}
                 Err(error) => {
                     info!(
-                        "get route info by topic from product environment failed. envName={}, error={}",
-                        route_config.product_env_name, error
+                        product_env = %route_config.product_env_name,
+                        error_code = %error.descriptor().code(),
+                        "product environment route lookup failed"
                     );
                 }
             }
@@ -125,15 +127,10 @@ impl ClusterTestRequestProcessor {
             ));
         }
 
-        Ok(Some(
-            self.command_factory
-                .create_response_command_with_code(ResponseCode::TopicNotExist)
-                .set_remark(format!(
-                    "No topic route info in name server for the topic: {}{}",
-                    request_header.topic,
-                    FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
-                )),
-        ))
+        Ok(Some(error_response(
+            PublicErrorView::descriptor_only(&rocketmq_error::ROUTE_TOPIC_NOT_FOUND),
+            RemotingErrorTarget::Fresh(&self.command_factory),
+        )))
     }
 
     pub(crate) async fn handle_request(
@@ -176,8 +173,14 @@ mod tests {
 
     use super::route_lookup::ClusterTestLookupFuture;
 
+    #[derive(Clone)]
+    enum TestLookupResult {
+        Outcome(ClusterTestTopicRouteOutcome),
+        Failure,
+    }
+
     struct TestClusterTestRouteLookup {
-        route: Option<TopicRouteData>,
+        result: TestLookupResult,
     }
 
     impl ClusterTestRouteLookup for TestClusterTestRouteLookup {
@@ -185,9 +188,19 @@ mod tests {
             Box::pin(async { Ok(()) })
         }
 
-        fn lookup_topic_route(&self, _topic: &CheetahString) -> ClusterTestLookupFuture<'_, Option<TopicRouteData>> {
-            let route = self.route.clone();
-            Box::pin(async move { Ok(route) })
+        fn lookup_topic_route(
+            &self,
+            _topic: &CheetahString,
+        ) -> ClusterTestLookupFuture<'_, ClusterTestTopicRouteOutcome> {
+            let result = self.result.clone();
+            Box::pin(async move {
+                match result {
+                    TestLookupResult::Outcome(outcome) => Ok(outcome),
+                    TestLookupResult::Failure => Err(rocketmq_error::RocketMQError::not_initialized(
+                        "private product lookup failure",
+                    )),
+                }
+            })
         }
 
         fn shutdown(&self) -> ClusterTestLookupFuture<'_, ()> {
@@ -220,7 +233,7 @@ mod tests {
             ..NamesrvConfig::default()
         };
         let mock_lookup = Arc::new(TestClusterTestRouteLookup {
-            route: Some(sample_topic_route_data()),
+            result: TestLookupResult::Outcome(ClusterTestTopicRouteOutcome::Found(sample_topic_route_data())),
         });
 
         let runtime = rocketmq_runtime::RuntimeContext::from_current("namesrv-cluster-test-processor");
@@ -265,5 +278,60 @@ mod tests {
             body.as_ref(),
             route_data.encode().expect("legacy encoding should succeed").as_slice()
         );
+    }
+
+    #[tokio::test]
+    async fn cluster_test_absence_unavailable_and_failure_keep_fixed_owner_r17() {
+        for result in [
+            TestLookupResult::Outcome(ClusterTestTopicRouteOutcome::NotFound),
+            TestLookupResult::Outcome(ClusterTestTopicRouteOutcome::Unavailable),
+            TestLookupResult::Failure,
+        ] {
+            let namesrv_config = NamesrvConfig {
+                cluster_test: true,
+                ..NamesrvConfig::default()
+            };
+            let runtime = rocketmq_runtime::RuntimeContext::from_current("namesrv-cluster-test-r17");
+            let command_factory = rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory::new(
+                rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults::new(
+                    657,
+                    rocketmq_protocol::protocol::SerializeType::ROCKETMQ,
+                ),
+            );
+            let bootstrap = Builder::new(
+                runtime.service_context("namesrv"),
+                rocketmq_observability::TelemetryHandle::noop(),
+            )
+            .set_name_server_config(namesrv_config)
+            .set_remoting_command_factory(command_factory)
+            .set_cluster_test_route_lookup(Arc::new(TestClusterTestRouteLookup { result }))
+            .build();
+            let runtime_inner = bootstrap.runtime_inner();
+            let processor = ClusterTestRequestProcessor::new(NameServerRuntimeHandle::new(&runtime_inner));
+            let mut request = RemotingCommand::create_request_command(
+                RequestCode::GetRouteinfoByTopic,
+                GetRouteInfoRequestHeader::new(CheetahString::from("missing-topic"), Some(true)),
+            );
+            request.make_custom_header_to_net();
+
+            let response = processor
+                .handle_request(&mut request)
+                .await
+                .expect("fallback should retain the owner response")
+                .expect("cluster-test route lookup should respond");
+
+            assert_eq!(ResponseCode::from(response.code()), ResponseCode::TopicNotExist);
+            assert_eq!(
+                response.remark().map(CheetahString::as_str),
+                Some("Topic route was not found")
+            );
+            assert_eq!(response.version(), 657);
+            assert_eq!(
+                response.serialize_type(),
+                rocketmq_protocol::protocol::SerializeType::ROCKETMQ
+            );
+            assert!(response.is_response_type());
+            assert!(response.body().is_none());
+        }
     }
 }

--- a/rocketmq-namesrv/src/processor/cluster_test_request_processor/route_lookup.rs
+++ b/rocketmq-namesrv/src/processor/cluster_test_request_processor/route_lookup.rs
@@ -72,10 +72,17 @@ pub(super) enum RouteLookupOutcome<T> {
     Cancelled,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ClusterTestTopicRouteOutcome {
+    Found(TopicRouteData),
+    NotFound,
+    Unavailable,
+}
+
 pub(crate) trait ClusterTestRouteLookup: Send + Sync {
     fn start(&self) -> ClusterTestLookupFuture<'_, ()>;
 
-    fn lookup_topic_route(&self, topic: &CheetahString) -> ClusterTestLookupFuture<'_, Option<TopicRouteData>>;
+    fn lookup_topic_route(&self, topic: &CheetahString) -> ClusterTestLookupFuture<'_, ClusterTestTopicRouteOutcome>;
 
     fn shutdown(&self) -> ClusterTestLookupFuture<'_, ()>;
 }
@@ -301,7 +308,7 @@ impl ClusterTestRouteLookup for TransportClusterTestRouteLookup {
         })
     }
 
-    fn lookup_topic_route(&self, topic: &CheetahString) -> ClusterTestLookupFuture<'_, Option<TopicRouteData>> {
+    fn lookup_topic_route(&self, topic: &CheetahString) -> ClusterTestLookupFuture<'_, ClusterTestTopicRouteOutcome> {
         let topic = topic.clone();
         Box::pin(async move {
             let deadline = RequestDeadline::after(self.request_timeout);
@@ -312,8 +319,9 @@ impl ClusterTestRouteLookup for TransportClusterTestRouteLookup {
                 result = self.lookup_topic_route_until(&topic, deadline) => result,
             }?;
             match outcome {
-                RouteLookupOutcome::Resolved(route) => Ok(route),
-                RouteLookupOutcome::Unavailable => Ok(None),
+                RouteLookupOutcome::Resolved(Some(route)) => Ok(ClusterTestTopicRouteOutcome::Found(route)),
+                RouteLookupOutcome::Resolved(None) => Ok(ClusterTestTopicRouteOutcome::NotFound),
+                RouteLookupOutcome::Unavailable => Ok(ClusterTestTopicRouteOutcome::Unavailable),
                 RouteLookupOutcome::Cancelled => Err(route_lookup_cancelled_error()),
             }
         })
@@ -599,6 +607,17 @@ mod tests {
     }
 
     #[derive(Clone)]
+    struct MissingRouteProcessor;
+
+    impl RequestProcessor for MissingRouteProcessor {
+        async fn process(&mut self, _request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+            response_outcome(RemotingCommand::create_response_command_with_code(
+                ResponseCode::TopicNotExist,
+            ))
+        }
+    }
+
+    #[derive(Clone)]
     struct BlockingRouteProcessor {
         entered: Arc<Notify>,
         release: Arc<Notify>,
@@ -742,12 +761,73 @@ mod tests {
             .lookup_topic_route(&CheetahString::from("missing-topic"))
             .await
             .unwrap();
-        assert_eq!(first, Some(sample_route()));
+        assert_eq!(first, ClusterTestTopicRouteOutcome::Found(sample_route()));
         assert_eq!(second, first);
         assert_eq!(resolver.calls.load(Ordering::SeqCst), 1);
 
         lookup.shutdown().await.unwrap();
         server.shutdown().await;
+        runtime
+            .shutdown_tasks(Duration::from_secs(1))
+            .await
+            .assert_no_task_leak()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn transport_lookup_returns_explicit_not_found_and_caches_it() {
+        let runtime = RuntimeContext::from_current("namesrv-route-lookup-not-found-test");
+        let server = RunningRouteServer::bind(runtime.service_context("route-server"), MissingRouteProcessor).await;
+        let resolver = Arc::new(FixedEndpointResolver::new(vec![server.local_addr()]));
+        let lookup = TransportClusterTestRouteLookup::with_resolver(
+            runtime.service_context("route-lookup"),
+            resolver.clone(),
+            Duration::from_secs(1),
+            TransportTelemetry::noop(),
+        );
+        lookup.start().await.unwrap();
+
+        let first = lookup
+            .lookup_topic_route(&CheetahString::from("missing-topic"))
+            .await
+            .unwrap();
+        let second = lookup
+            .lookup_topic_route(&CheetahString::from("missing-topic"))
+            .await
+            .unwrap();
+
+        assert_eq!(first, ClusterTestTopicRouteOutcome::NotFound);
+        assert_eq!(second, first);
+        assert_eq!(resolver.calls.load(Ordering::SeqCst), 1);
+
+        lookup.shutdown().await.unwrap();
+        server.shutdown().await;
+        runtime
+            .shutdown_tasks(Duration::from_secs(1))
+            .await
+            .assert_no_task_leak()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn transport_lookup_returns_explicit_unavailable_without_endpoints() {
+        let runtime = RuntimeContext::from_current("namesrv-route-lookup-unavailable-test");
+        let lookup = TransportClusterTestRouteLookup::with_resolver(
+            runtime.service_context("route-lookup"),
+            Arc::new(FixedEndpointResolver::new(Vec::new())),
+            Duration::from_secs(1),
+            TransportTelemetry::noop(),
+        );
+        lookup.start().await.unwrap();
+
+        let outcome = lookup
+            .lookup_topic_route(&CheetahString::from("missing-topic"))
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, ClusterTestTopicRouteOutcome::Unavailable);
+
+        lookup.shutdown().await.unwrap();
         runtime
             .shutdown_tasks(Duration::from_secs(1))
             .await

--- a/rocketmq-namesrv/src/route/response_cache.rs
+++ b/rocketmq-namesrv/src/route/response_cache.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::error::Error as StdError;
+use std::fmt;
 use std::mem::size_of;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
@@ -99,6 +101,31 @@ impl CachedRouteBody {
             Self::Ready(body) | Self::Oversize(body) => body,
         }
     }
+}
+
+#[derive(Debug)]
+struct SharedRouteEncodeFailure {
+    source: Arc<RocketMQError>,
+}
+
+impl fmt::Display for SharedRouteEncodeFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("NameServer route response encoding failed")
+    }
+}
+
+impl StdError for SharedRouteEncodeFailure {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+fn route_encode_failure(source: Arc<RocketMQError>) -> RocketMQError {
+    RocketMQError::Serialization(SerializationError::source(
+        "encode",
+        "namesrv-route-response",
+        SharedRouteEncodeFailure { source },
+    ))
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -197,12 +224,7 @@ impl RouteResponseCache {
                     }
                 })
             })
-            .map_err(|error| {
-                RocketMQError::Serialization(SerializationError::encode_failed(
-                    "namesrv-route-response",
-                    error.to_string(),
-                ))
-            })?;
+            .map_err(route_encode_failure)?;
 
         match value {
             CachedRouteBody::Ready(body) => Ok(RouteCacheOutcome {
@@ -248,7 +270,23 @@ struct RouteResponseCacheConfig {
 mod tests {
     use std::sync::atomic::AtomicUsize;
 
+    use rocketmq_error::Error;
+    use rocketmq_error::PublicErrorView;
+    use rocketmq_error::CORE_SERIALIZATION_FAILED;
+
     use super::*;
+
+    fn find_source<'a, T>(mut error: &'a (dyn StdError + 'static)) -> Option<&'a T>
+    where
+        T: StdError + 'static,
+    {
+        loop {
+            if let Some(source) = error.downcast_ref::<T>() {
+                return Some(source);
+            }
+            error = error.source()?;
+        }
+    }
 
     fn cache(max_bytes: u64, max_entries: u64, max_single_response_bytes: u64) -> RouteResponseCache {
         RouteResponseCache::new(RouteResponseCacheConfig {
@@ -340,6 +378,42 @@ mod tests {
 
         assert!(stats.entry_count <= 2, "{stats:?}");
         assert!(stats.weighted_size <= 300, "{stats:?}");
+    }
+
+    #[test]
+    fn shared_encode_failure_preserves_typed_source_and_is_not_cached() {
+        let cache = cache(1024, 10, 512);
+        let key = key(1, RouteVariant::Base, JsonEncoding::Legacy);
+        let canonical = Arc::new(Error::caused_by(
+            &CORE_SERIALIZATION_FAILED,
+            std::io::Error::other("private route encoder detail"),
+        ));
+
+        let error =
+            match cache.get_or_try_insert_with(key.clone(), || Err(RocketMQError::Shared(Arc::clone(&canonical)))) {
+                Ok(_) => panic!("route encoding failure must remain visible"),
+                Err(error) => error,
+            };
+
+        assert_eq!(error.descriptor(), &CORE_SERIALIZATION_FAILED);
+        assert_eq!(error.descriptor().projection().remoting().code.as_i32(), 1);
+        let context = error.context();
+        let view = PublicErrorView::try_new(error.descriptor(), &context).expect("source context must be valid");
+        assert_eq!(view.message(), "Serialization failed");
+        assert!(!error.to_string().contains("private route encoder detail"));
+        let wrapper = find_source::<SharedRouteEncodeFailure>(&error)
+            .expect("cache failure must retain its shared typed source wrapper");
+        let RocketMQError::Shared(retained) = wrapper.source.as_ref() else {
+            panic!("cache failure wrapper must retain the original canonical carrier")
+        };
+        assert!(Arc::ptr_eq(retained, &canonical));
+        assert!(find_source::<std::io::Error>(&error).is_some());
+
+        let retry = cache
+            .get_or_try_insert_with(key, || Ok(vec![1, 2, 3]))
+            .expect("failed route encoding must not be cached");
+        assert_eq!(retry.kind, RouteCacheOutcomeKind::Miss);
+        assert_eq!(retry.body, Bytes::from_static(&[1, 2, 3]));
     }
 
     #[test]

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -49,7 +49,6 @@ use tracing::warn;
 use crate::bootstrap::NameServerRuntimeHandle;
 use crate::route::batch_unregistration_service::BatchUnregistrationService;
 use crate::route::batch_unregistration_service::BrokerUnregistrationRequest;
-use crate::route::error::RocketMQError;
 use crate::route::error::RouteResult;
 use crate::route::tables::BrokerAddrTable;
 use crate::route::tables::BrokerLiveInfo;
@@ -63,6 +62,9 @@ use crate::route::topic_route_snapshot::RouteMutationGuard;
 use crate::route::topic_route_snapshot::TopicRouteView;
 use crate::route::types::BrokerName;
 use crate::route::types::BrokerSession;
+
+#[cfg(test)]
+use crate::route::error::RocketMQError;
 use crate::route::types::RemotingConnectionId;
 use crate::route::types::TopicName;
 use crate::route_info::broker_addr_info::BrokerAddrInfo;
@@ -70,6 +72,15 @@ use crate::route_info::broker_addr_info::BrokerAddrInfo;
 mod management;
 
 const DEFAULT_BROKER_CHANNEL_EXPIRED_TIME: u64 = 1000 * 60 * 2; // 2 minutes
+
+/// Result of looking up route data for a topic.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TopicRouteLookupOutcome<T> {
+    /// The requested topic has published route data.
+    Found(T),
+    /// The requested topic has no published route data.
+    NotFound,
+}
 
 /// Canonical route manager with serialized mutations and immutable route snapshots
 ///
@@ -1546,18 +1557,19 @@ impl RouteInfoManager {
     ///
     /// This method loads one immutable snapshot. Source tables are consulted only
     /// by the serialized write model when publishing a replacement snapshot.
-    pub fn pickup_topic_route_data(&self, topic: &str) -> RouteResult<TopicRouteData> {
-        self.load_topic_route_view(topic)
-            .map(|view| view.route_data().as_ref().clone())
+    pub fn pickup_topic_route_data(&self, topic: &str) -> RouteResult<TopicRouteLookupOutcome<TopicRouteData>> {
+        self.load_topic_route_view(topic).map(|outcome| match outcome {
+            TopicRouteLookupOutcome::Found(view) => TopicRouteLookupOutcome::Found(view.route_data().as_ref().clone()),
+            TopicRouteLookupOutcome::NotFound => TopicRouteLookupOutcome::NotFound,
+        })
     }
 
-    pub(crate) fn load_topic_route_view(&self, topic: &str) -> RouteResult<TopicRouteView> {
+    pub(crate) fn load_topic_route_view(&self, topic: &str) -> RouteResult<TopicRouteLookupOutcome<TopicRouteView>> {
         use rocketmq_model::common::topic::TopicValidator;
 
-        let snapshot = self
-            .route_mutations
-            .load(topic)
-            .ok_or_else(|| RocketMQError::route_not_found(topic))?;
+        let Some(snapshot) = self.route_mutations.load(topic) else {
+            return Ok(TopicRouteLookupOutcome::NotFound);
+        };
         debug!(
             "Loaded topic route snapshot: topic={}, version={}, published_at={}",
             topic, snapshot.version, snapshot.published_at
@@ -1569,10 +1581,12 @@ impl RouteInfoManager {
             .support_acting_master
             || topic.starts_with(TopicValidator::SYNC_BROKER_MEMBER_GROUP_PREFIX)
         {
-            return Ok(snapshot.base_view());
+            return Ok(TopicRouteLookupOutcome::Found(snapshot.base_view()));
         }
 
-        Ok(snapshot.acting_master_view(build_acting_master_route_data))
+        Ok(TopicRouteLookupOutcome::Found(
+            snapshot.acting_master_view(build_acting_master_route_data),
+        ))
     }
 }
 
@@ -2045,6 +2059,13 @@ mod tests {
     use rocketmq_transport::test_support::session_id_for_test;
     use rocketmq_transport::test_support::LocalChannelHarness;
 
+    fn expect_found<T>(result: RouteResult<TopicRouteLookupOutcome<T>>, expectation: &str) -> T {
+        match result.expect(expectation) {
+            TopicRouteLookupOutcome::Found(value) => value,
+            TopicRouteLookupOutcome::NotFound => panic!("{expectation}"),
+        }
+    }
+
     use super::*;
     use crate::bootstrap::Builder;
 
@@ -2265,15 +2286,18 @@ mod tests {
         );
         manager.register_topic(topic.clone(), vec![QueueData::new(broker_name, 4, 4, 6, 0)]);
 
-        let first = manager
-            .load_topic_route_view(topic.as_str())
-            .expect("first shared view should exist");
-        let second = manager
-            .load_topic_route_view(topic.as_str())
-            .expect("second shared view should exist");
-        let owned = manager
-            .pickup_topic_route_data(topic.as_str())
-            .expect("the compatibility API should still return a route");
+        let first = expect_found(
+            manager.load_topic_route_view(topic.as_str()),
+            "first shared view should exist",
+        );
+        let second = expect_found(
+            manager.load_topic_route_view(topic.as_str()),
+            "second shared view should exist",
+        );
+        let owned = expect_found(
+            manager.pickup_topic_route_data(topic.as_str()),
+            "the owned API should return a route",
+        );
 
         assert_eq!(first.variant(), crate::route::topic_route_snapshot::RouteVariant::Base);
         assert_eq!(first.version(), second.version());
@@ -2306,9 +2330,10 @@ mod tests {
         let first_version = manager
             .topic_route_snapshot_version(topic.as_str())
             .expect("registering the topic should publish a snapshot");
-        let route_before_rejected_update = manager
-            .pickup_topic_route_data(topic.as_str())
-            .expect("registered topic should have a route");
+        let route_before_rejected_update = expect_found(
+            manager.pickup_topic_route_data(topic.as_str()),
+            "registered topic should have a route",
+        );
         manager.register_topic(
             topic.clone(),
             vec![QueueData::new(
@@ -2324,9 +2349,10 @@ mod tests {
             Some(first_version)
         );
         assert_eq!(
-            manager
-                .pickup_topic_route_data(topic.as_str())
-                .expect("rejected update must preserve the old snapshot"),
+            expect_found(
+                manager.pickup_topic_route_data(topic.as_str()),
+                "rejected update must preserve the old snapshot",
+            ),
             route_before_rejected_update
         );
 
@@ -2336,9 +2362,10 @@ mod tests {
             .expect("permission mutation should republish the topic");
         assert!(second_version > first_version);
 
-        let initial_route = manager
-            .pickup_topic_route_data(topic.as_str())
-            .expect("registered topic should have a complete route");
+        let initial_route = expect_found(
+            manager.pickup_topic_route_data(topic.as_str()),
+            "registered topic should have a complete route",
+        );
         assert_eq!(initial_route.queue_datas.len(), 1);
         assert_eq!(initial_route.broker_datas.len(), 1);
         assert!(!PermName::is_writeable(initial_route.queue_datas[0].perm()));
@@ -2385,11 +2412,16 @@ mod tests {
             .expect("management read should complete after mutation publication");
         management_thread.join().expect("management thread should not panic");
 
-        let route_while_unregistration_is_paused = route_while_unregistration_is_paused
-            .expect("an unpublished unregister mutation must leave the complete old route visible");
+        let route_while_unregistration_is_paused = expect_found(
+            route_while_unregistration_is_paused,
+            "an unpublished unregister mutation must leave the complete old route visible",
+        );
         assert_eq!(route_while_unregistration_is_paused, initial_route);
         assert!(matches!(management_result, Err(RocketMQError::ClusterNotFound { .. })));
-        assert!(manager.pickup_topic_route_data(topic.as_str()).is_err());
+        assert!(matches!(
+            manager.pickup_topic_route_data(topic.as_str()),
+            Ok(TopicRouteLookupOutcome::NotFound)
+        ));
     }
 
     #[test]
@@ -2436,9 +2468,10 @@ mod tests {
             .topic_route_snapshot_version(topic.as_str())
             .expect("metadata mutation should republish the snapshot");
         assert!(metadata_version > initial_version);
-        let route = manager
-            .pickup_topic_route_data(topic.as_str())
-            .expect("metadata update should keep a complete route");
+        let route = expect_found(
+            manager.pickup_topic_route_data(topic.as_str()),
+            "metadata update should keep a complete route",
+        );
         assert_eq!(route.filter_server_table.get(&broker_addr), Some(&vec![filter_server]));
         assert!(route
             .topic_queue_mapping_by_broker
@@ -2446,7 +2479,24 @@ mod tests {
             .is_some_and(|mapping| mapping.contains_key(&broker_name)));
 
         manager.delete_topic(topic.clone(), None);
-        assert!(manager.pickup_topic_route_data(topic.as_str()).is_err());
+        assert!(matches!(
+            manager.pickup_topic_route_data(topic.as_str()),
+            Ok(TopicRouteLookupOutcome::NotFound)
+        ));
+    }
+
+    #[test]
+    fn missing_topic_is_an_explicit_normal_lookup_outcome() {
+        let (_bootstrap, manager) = test_route_manager();
+
+        assert!(matches!(
+            manager.pickup_topic_route_data("missing-topic"),
+            Ok(TopicRouteLookupOutcome::NotFound)
+        ));
+        assert!(matches!(
+            manager.load_topic_route_view("missing-topic"),
+            Ok(TopicRouteLookupOutcome::NotFound)
+        ));
     }
 
     #[tokio::test]

--- a/scripts/public-api-freeze-policy.json
+++ b/scripts/public-api-freeze-policy.json
@@ -170,6 +170,19 @@
       "reason": "The repository owner approved the unreleased E5-2 Controller convergence. Controller operational failures now use the catalog-backed canonical Error with typed Raft, storage, runtime, configuration, persistence, and lifecycle sources; existing RocketMQResult boundaries explicitly share the same Arc allocation. The duplicate public leaf, error aliases, nested and direct mega-enum variants, and convenience constructors are removed without compatibility shims, blanket conversion, or changes to owner-controlled response state and remoting values 2007 and 2015.",
       "approved_by": "repository-owner",
       "approved_on": "2026-09-05"
+    },
+    {
+      "id": "API-1.0-001",
+      "classification": "approved-break",
+      "applies_to": "post-freeze",
+      "profile_id": "rocketmq-namesrv:default",
+      "package": "rocketmq-namesrv",
+      "item_path": "rocketmq_namesrv::route::route_info_manager::RouteInfoManager::pickup_topic_route_data",
+      "change": "signature",
+      "replacement": "RouteResult<TopicRouteLookupOutcome<TopicRouteData>>",
+      "reason": "Issue #10116 separates ordinary NameServer route absence from operational lookup failure with one explicit outcome. The unreleased API changes directly without a compatibility wrapper while RocketMQ remoting response codes and wire state remain unchanged.",
+      "approved_by": "repository-owner",
+      "approved_on": "2026-09-06"
     }
   ],
   "frozen_contracts": [


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Closes #10116

### Brief Description

- Introduces `TopicRouteLookupOutcome::{Found, NotFound}` and changes the current NameServer route API directly, without V1/V2 aliases or compatibility wrappers.
- Separates cluster-test topic results into `Found`, `NotFound`, and `Unavailable` while retaining operational failures as typed errors and preserving the existing owner fallback policy.
- Replaces both hand-built missing-route responses with the sole Transport error adapter and the fixed catalog message while preserving R17, factory defaults, response state, and wire opaque binding.
- Preserves the typed Moka route-cache encoding source through a fixed-display Arc-backed wrapper; the descriptor remains `CORE_SERIALIZATION_FAILED` and remoting remains R1.
- Records the intentional unreleased public API break as `API-1.0-001` and refreshes only the `rocketmq-namesrv:default` structural snapshot.
- Keeps every RocketMQ remoting numeric code unchanged.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-namesrv -- --check`
- `cargo check -p rocketmq-namesrv --all-targets --all-features`
- Six focused `cargo test -p rocketmq-namesrv --lib <test-name>` runs covering cache source retention, local NotFound, cluster fallback, remote NotFound caching, endpoint unavailability, and client R17 command state
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `python -m unittest scripts.tests.test_m07_namesrv_route_lookup_contract -v` (2 passed)
- `python -m unittest scripts.tests.test_m09_public_api_compatibility -v` (8 passed)
- Regenerated and compared `rocketmq-namesrv:default`; structural snapshot differences: 0
- `python scripts/error_architecture_guard.py` (known non-zero baseline only: 10 Broker test-support source-stringification findings and 1 pre-existing Transport redaction finding; no changed file reported)
- `git diff --check`
- Three complementary independent reviews: APPROVE, no remaining P0-P2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Route lookups now distinguish between available routes, missing routes, and temporarily unavailable results.
  - Missing-topic responses now consistently report that the topic route was not found.

- **Bug Fixes**
  - Preserved more accurate response details for missing routes, including response metadata and empty-body behavior.
  - Route response encoding failures now retain their underlying error information and can be retried without reusing failed results.
  - Improved handling and reporting of route lookup failures in cluster-test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->