### PR TITLE
[ISSUE #10053] Add Apache 2.0 headers in rocketmq-client

### DIFF
--- a/rocketmq-client/benches/select_queue_benchmark.rs
+++ b/rocketmq-client/benches/select_queue_benchmark.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![recursion_limit = "256"]
 
 use criterion::criterion_group;

--- a/rocketmq-client/src/trace/trace_constants.rs
+++ b/rocketmq-client/src/trace/trace_constants.rs
@@ -1,1 +1,15 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub use rocketmq_protocol::trace::trace_constants::TraceConstants;

--- a/rocketmq-client/src/trace/trace_transfer_bean.rs
+++ b/rocketmq-client/src/trace/trace_transfer_bean.rs
@@ -1,1 +1,15 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub use rocketmq_protocol::trace::TraceTransferBean;

--- a/rocketmq-client/src/trace/trace_type.rs
+++ b/rocketmq-client/src/trace/trace_type.rs
@@ -1,1 +1,15 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub use rocketmq_protocol::trace::TraceType;

--- a/rocketmq-client/tests/public_api_exports_test.rs
+++ b/rocketmq-client/tests/public_api_exports_test.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![recursion_limit = "256"]
 
 use std::collections::HashSet;

--- a/rocketmq-client/tests/thread_local_index_test.rs
+++ b/rocketmq-client/tests/thread_local_index_test.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![recursion_limit = "256"]
 
 use rand::RngExt;

--- a/rocketmq-client/tests/ui/client_runtime/builders_require_client_runtime.rs
+++ b/rocketmq-client/tests/ui/client_runtime/builders_require_client_runtime.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_client_rust::DefaultMQAdminExt;
 use rocketmq_client_rust::DefaultLitePullConsumer;
 use rocketmq_client_rust::DefaultMQPushConsumer;

--- a/rocketmq-client/tests/ui/client_runtime/builders_require_client_runtime.stderr
+++ b/rocketmq-client/tests/ui/client_runtime/builders_require_client_runtime.stderr
@@ -1,39 +1,39 @@
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
- --> tests/ui/client_runtime/builders_require_client_runtime.rs:8:13
-  |
-8 |     let _ = DefaultMQProducer::builder();
-  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^-- argument #1 of type `Arc<ClientRuntime>` is missing
-  |
+ --> tests/ui/client_runtime/builders_require_client_runtime.rs:22:13
+   |
+22 |     let _ = DefaultMQProducer::builder();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^-- argument #1 of type `Arc<ClientRuntime>` is missing
+   |
 note: associated function defined here
  --> src/producer/default_mq_producer.rs
   |
   |     pub fn builder(client_runtime: Arc<ClientRuntime>) -> DefaultMQProducerBuilder {
   |            ^^^^^^^
 help: provide the argument
-  |
-8 |     let _ = DefaultMQProducer::builder(/* Arc<ClientRuntime> */);
-  |                                        ++++++++++++++++++++++++
+   |
+22 |     let _ = DefaultMQProducer::builder(/* Arc<ClientRuntime> */);
+   |                                        ++++++++++++++++++++++++
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
- --> tests/ui/client_runtime/builders_require_client_runtime.rs:9:13
-  |
-9 |     let _ = DefaultMQPushConsumer::builder();
-  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- argument #1 of type `Arc<ClientRuntime>` is missing
-  |
+ --> tests/ui/client_runtime/builders_require_client_runtime.rs:23:13
+   |
+23 |     let _ = DefaultMQPushConsumer::builder();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- argument #1 of type `Arc<ClientRuntime>` is missing
+   |
 note: associated function defined here
  --> src/consumer/default_mq_push_consumer.rs
   |
   |     pub fn builder(client_runtime: Arc<ClientRuntime>) -> DefaultMQPushConsumerBuilder {
   |            ^^^^^^^
 help: provide the argument
-  |
-9 |     let _ = DefaultMQPushConsumer::builder(/* Arc<ClientRuntime> */);
-  |                                            ++++++++++++++++++++++++
+   |
+23 |     let _ = DefaultMQPushConsumer::builder(/* Arc<ClientRuntime> */);
+   |                                            ++++++++++++++++++++++++
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> tests/ui/client_runtime/builders_require_client_runtime.rs:10:13
+  --> tests/ui/client_runtime/builders_require_client_runtime.rs:24:13
    |
-10 |     let _ = DefaultLitePullConsumer::builder();
+24 |     let _ = DefaultLitePullConsumer::builder();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- argument #1 of type `Arc<ClientRuntime>` is missing
    |
 note: associated function defined here
@@ -43,13 +43,13 @@ note: associated function defined here
    |            ^^^^^^^
 help: provide the argument
    |
-10 |     let _ = DefaultLitePullConsumer::builder(/* Arc<ClientRuntime> */);
+24 |     let _ = DefaultLitePullConsumer::builder(/* Arc<ClientRuntime> */);
    |                                              ++++++++++++++++++++++++
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> tests/ui/client_runtime/builders_require_client_runtime.rs:11:13
+  --> tests/ui/client_runtime/builders_require_client_runtime.rs:25:13
    |
-11 |     let _ = TransactionMQProducer::builder();
+25 |     let _ = TransactionMQProducer::builder();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- argument #1 of type `Arc<ClientRuntime>` is missing
    |
 note: associated function defined here
@@ -59,13 +59,13 @@ note: associated function defined here
    |            ^^^^^^^
 help: provide the argument
    |
-11 |     let _ = TransactionMQProducer::builder(/* Arc<ClientRuntime> */);
+25 |     let _ = TransactionMQProducer::builder(/* Arc<ClientRuntime> */);
    |                                            ++++++++++++++++++++++++
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> tests/ui/client_runtime/builders_require_client_runtime.rs:12:13
+  --> tests/ui/client_runtime/builders_require_client_runtime.rs:26:13
    |
-12 |     let _ = DefaultMQAdminExt::new();
+26 |     let _ = DefaultMQAdminExt::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^-- argument #1 of type `Arc<ClientRuntime>` is missing
    |
 note: associated function defined here
@@ -75,5 +75,5 @@ note: associated function defined here
    |            ^^^
 help: provide the argument
    |
-12 |     let _ = DefaultMQAdminExt::new(/* Arc<ClientRuntime> */);
+26 |     let _ = DefaultMQAdminExt::new(/* Arc<ClientRuntime> */);
    |                                    ++++++++++++++++++++++++

--- a/rocketmq-client/tests/ui/client_runtime/root_context_is_rejected.rs
+++ b/rocketmq-client/tests/ui/client_runtime/root_context_is_rejected.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rocketmq_client_rust::ClientRuntime;
 use rocketmq_client_rust::ClientRuntimeConfig;
 use rocketmq_client_rust::TelemetryHandle;

--- a/rocketmq-client/tests/ui/client_runtime/root_context_is_rejected.stderr
+++ b/rocketmq-client/tests/ui/client_runtime/root_context_is_rejected.stderr
@@ -1,9 +1,9 @@
 error[E0308]: mismatched types
-  --> tests/ui/client_runtime/root_context_is_rejected.rs:10:9
+  --> tests/ui/client_runtime/root_context_is_rejected.rs:24:9
    |
- 9 |     let _ = ClientRuntime::try_new(
+23 |     let _ = ClientRuntime::try_new(
    |             ---------------------- arguments to this function are incorrect
-10 |         owner.root_context(),
+24 |         owner.root_context(),
    |         ^^^^^^^^^^^^^^^^^^^^ expected `ChildServiceContext`, found `&RootServiceContext`
    |
 note: associated function defined here


### PR DESCRIPTION
- Fixes #10053

Adding Apache 2.0 headers to
rocketmq-client/benches/select_queue_benchmark.rs
rocketmq-client/src/trace/trace_constants.rs
rocketmq-client/src/trace/trace_transfer_bean.rs
rocketmq-client/src/trace/trace_type.rs
rocketmq-client/tests/public_api_exports_test.rs
rocketmq-client/tests/thread_local_index_test.rs
rocketmq-client/tests/ui/client_runtime/builders_require_client_runtime.rs
rocketmq-client/tests/ui/client_runtime/root_context_is_rejected.rs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Apache License 2.0 notices across client benchmark, tracing, API, and test sources.
* **Tests**
  * Added coverage confirming that creating a client runtime from a root context is rejected.
  * Existing benchmark, tracing, API export, thread-local, and runtime-builder behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->