### PR TITLE
[ISSUE #10139]🐛Box large task futures before lifecycle wrapping

### DIFF
--- a/rocketmq-client/tests/windows_consumer_process_startup.rs
+++ b/rocketmq-client/tests/windows_consumer_process_startup.rs
@@ -36,6 +36,7 @@ use rocketmq_client_rust::MQPushConsumer;
 use rocketmq_client_rust::MessageListenerConcurrently;
 use rocketmq_error::RocketMQResult;
 use rocketmq_model::common::message::message_ext::MessageExt;
+use rocketmq_model::common::message::message_single::Message;
 use rocketmq_namesrv::bootstrap::Builder as NameServerBuilder;
 use rocketmq_namesrv::NamesrvConfig;
 use rocketmq_observability::TelemetryHandle;
@@ -257,6 +258,21 @@ async fn run_producer_startup(client_runtime: Arc<ClientRuntime>, namesrv_addr: 
 
     println!("{PRODUCER_STARTUP_MARKER}");
     std::io::stdout().flush().expect("flush producer startup marker");
+
+    // Keep the send/select state in the caller, as in the quickstart example. A startup-only
+    // caller has a smaller poll frame and can hide submission-time stack overflows.
+    let message = Message::builder()
+        .topic("WindowsStackOverflowTest")
+        .body_slice(b"stack probe")
+        .build_unchecked();
+    tokio::select! {
+        result = producer.send_with_timeout(message, 2000) => {
+            assert!(result.is_err(), "the isolated NameServer has no registered brokers");
+        }
+        _ = tokio::time::sleep(Duration::from_secs(10)) => {
+            panic!("route lookup should complete within the send timeout");
+        }
+    }
 
     producer.shutdown().await;
     println!("{PRODUCER_SHUTDOWN_MARKER}");

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -53,6 +53,10 @@ const STATE_CLOSED: u8 = 2;
 const STATE_SHUTDOWN_COMPLETED: u8 = 3;
 const STATE_POISONED: u8 = 4;
 
+// Apply the large-future boundary before adding lifecycle and tracker wrappers. Waiting for
+// Tokio's spawn boundary leaves their by-value stack frames live during task submission.
+const MAX_INLINE_TASK_FUTURE_SIZE: usize = 16 * 1024;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 /// Represents task id.
 pub struct TaskId(u64);
@@ -629,6 +633,24 @@ impl TaskGroup {
     }
 
     fn spawn_inner_with_handle<F>(
+        &self,
+        name: Arc<str>,
+        kind: TaskKind,
+        detached_policy: Option<DetachedTaskPolicy>,
+        propagate_panic: bool,
+        future: F,
+    ) -> RuntimeResult<(TaskId, tokio::task::JoinHandle<()>)>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        if std::mem::size_of::<F>() > MAX_INLINE_TASK_FUTURE_SIZE {
+            self.spawn_registered(name, kind, detached_policy, propagate_panic, Box::pin(future))
+        } else {
+            self.spawn_registered(name, kind, detached_policy, propagate_panic, future)
+        }
+    }
+
+    fn spawn_registered<F>(
         &self,
         name: Arc<str>,
         kind: TaskKind,

--- a/rocketmq-runtime/tests/task_submission_stack.rs
+++ b/rocketmq-runtime/tests/task_submission_stack.rs
@@ -1,0 +1,98 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::process::Command;
+use std::time::Duration;
+
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ScheduledTaskConfig;
+use rocketmq_runtime::ScheduledTaskGroup;
+use rocketmq_runtime::TaskKind;
+
+const CHILD_MODE: &str = "ROCKETMQ_RUNTIME_STACK_TEST_CHILD";
+const STACK_SIZE: usize = 1024 * 1024;
+
+#[test]
+fn large_tasks_submit_on_one_mib_stack() {
+    if std::env::var_os(CHILD_MODE).is_none() {
+        // Stack overflow aborts the process; isolate it from the rest of the test suite.
+        let output = Command::new(std::env::current_exe().expect("test executable"))
+            .args(["--exact", "large_tasks_submit_on_one_mib_stack", "--nocapture"])
+            .env(CHILD_MODE, "1")
+            .output()
+            .expect("run stack probe subprocess");
+        assert!(
+            output.status.success(),
+            "stack probe failed: {}\nstdout: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return;
+    }
+
+    std::thread::Builder::new()
+        .name("runtime-submission-stack-probe".to_owned())
+        .stack_size(STACK_SIZE)
+        .spawn(run_stack_probe)
+        .expect("start small-stack thread")
+        .join()
+        .expect("small-stack thread completed");
+}
+
+fn run_stack_probe() {
+    let owner = RuntimeOwner::plan(RuntimeConfig {
+        worker_threads: 2,
+        ..RuntimeConfig::default()
+    })
+    .expect("valid runtime configuration")
+    .build()
+    .expect("runtime owner");
+    let context = owner.root_context().component("stack-probe");
+    let group = context.task_group();
+
+    let (_, handle) = group
+        .spawn_with_handle("large-task", TaskKind::Service, large_task())
+        .expect("submit large task");
+    owner.block_on(handle).expect("large task completed");
+
+    let schedules = ScheduledTaskGroup::new(group.clone());
+    let (completed, received) = std::sync::mpsc::sync_channel(1);
+    schedules
+        .schedule_fixed_delay(
+            ScheduledTaskConfig::fixed_delay("large-scheduled-task", Duration::from_secs(60)),
+            move || {
+                let completed = completed.clone();
+                async move {
+                    large_task().await;
+                    completed.send(()).expect("report scheduled completion");
+                }
+            },
+        )
+        .expect("submit large scheduled task");
+    received
+        .recv_timeout(Duration::from_secs(10))
+        .expect("large scheduled task completed");
+
+    let report = owner.block_on(owner.shutdown_tasks());
+    assert!(report.is_healthy(), "{}", report.to_json());
+    owner.shutdown_runtime_blocking().expect("runtime stopped");
+}
+
+async fn large_task() {
+    let payload = [7_u8; 16 * 1024];
+    tokio::task::yield_now().await;
+    assert_eq!(std::hint::black_box(payload)[0], 7);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10139

### Brief Description

Windows quickstart Producer and Consumer startup can exhaust the default 1 MiB main-thread stack while registering the internal producer's fault-detector schedule. Large futures are copied through generic task-submission wrappers before Tokio's own boxing boundary is reached.

Box task futures larger than 16 KiB at the TaskGroup submission boundary, before lifecycle and TaskTracker wrapping. Keep the small-future path and preserve existing registration, cancellation, panic propagation, tracking, and shutdown behavior.

Add a process-isolated runtime regression for ordinary and scheduled tasks on a 1 MiB stack, and extend the Windows Producer regression with the quickstart send/select caller state. The new runtime test reproduces `0xc00000fd` on the unmodified base and passes with this change.

### How Did You Test This Change?

All code validation below was completed locally on Windows with the repository toolchain before submission:

- `cargo fmt -p rocketmq-runtime -- --check` and `cargo fmt -p rocketmq-client-rust -- --check`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo test -p rocketmq-runtime --test runtime_model --test task_submission_stack --all-features`: 51 passed.
- `cargo test -p rocketmq-client-rust --test windows_consumer_process_startup -- --nocapture`: 2 passed.
- `cargo test -p rocketmq-client-rust --all-features --test windows_consumer_process_startup -- --nocapture`: 2 passed.
- `cargo build -p rocketmq-client-rust --example producer --example consumer`: passed; LLDB confirmed both original examples reach the code after `start().await` using the default stack.
- `cargo test -p rocketmq-runtime --test task_submission_stack -- --nocapture` against an unmodified base snapshot: expected failure with a child-process `0xc00000fd`; the same test passes with the fix.
- `git diff --check` and `scripts/check-agents-routing.ps1`: passed.
- Standalone Example, Web backend, Tauri, GPUI, query MCP, MCP control, and SRE strict Clippy profiles: passed.
- GPUI tests: 166 passed; query MCP default/all-feature tests: 268/313 passed; MCP control default/write-tools tests: 75/115 passed; SRE all-feature workspace tests: 696 passed. Existing ignored cases remain ignored.
- Required MCP/control/SRE compile, documentation, and boundary checks: passed.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`: passed.

Validation limitations and environment recovery:

- `scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` fails on 13 existing boundary findings. Running the same audit on an unmodified base snapshot produces identical failure fingerprints and counts; this change adds none.
- Six standalone `cargo fmt --all -- --check` commands exceed the Windows command-line length limit. Explicit package-scoped checks all pass, as does the prescribed SRE package-scoped profile.
- Stale security dependency artifacts were refreshed before successful standalone rechecks. Inaccessible pre-existing target-directory junctions were bypassed with a process-local validation output directory; repository configuration and dependencies were not changed.

The maintainer requested immediate squash merge without waiting for CI.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime reliability when submitting large asynchronous tasks, including from threads with limited stack space.
  * Improved handling of scheduled tasks and runtime shutdown after processing larger workloads.

* **Tests**
  * Added coverage for task submission, delayed execution, completion, and clean shutdown in constrained-stack environments.
  * Expanded Windows startup coverage for producer send behavior when broker routes are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->