### PR TITLE
[ISSUE #10149]♻️Close error hygiene guard false positives

### DIFF
--- a/scripts/error_architecture_guard.py
+++ b/scripts/error_architecture_guard.py
@@ -19,11 +19,16 @@
 from __future__ import annotations
 
 import argparse
+import bisect
 import dataclasses
+import functools
 import re
 import sys
 from pathlib import Path
 from typing import Iterable
+
+import environment_write_guard as rust_source
+import rust_hygiene_guard
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -278,6 +283,7 @@ class Finding:
         return f"{rel}:{self.line}: {self.message}"
 
 
+@functools.cache
 def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
@@ -309,57 +315,141 @@ def is_test_source_path(path: Path) -> bool:
     )
 
 
+BUILTIN_TEST_CFG = re.compile(r"\s*test\s*")
+BROKER_TEST_SUPPORT_CFG = re.compile(
+    r'\s*any\s*\(\s*test\s*,\s*feature\s*=\s*"test-support"\s*\)\s*'
+)
+UNIT_TEST_MODULE = re.compile(
+    r"(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+tests\s*(?P<opening>\{)"
+)
+BROKER_TEST_SUPPORT_MODULE = re.compile(r"pub\s+mod\s+test_support\s*(?P<opening>\{)")
+BROKER_TEST_SUPPORT_PATH = "rocketmq-broker/src/lib.rs"
+
+
+@dataclasses.dataclass(frozen=True)
+class RustSourceAnalysis:
+    source: str
+    masked: str
+    lines: tuple[str, ...]
+    masked_lines: tuple[str, ...]
+    line_starts: tuple[int, ...]
+    test_ranges: tuple[tuple[int, int], ...]
+
+
+def skip_outer_attributes(masked: str, cursor: int) -> int:
+    """Skip whitespace and attributes between a cfg and its item."""
+    while True:
+        whitespace = re.match(r"\s*", masked[cursor:])
+        cursor += len(whitespace.group(0)) if whitespace is not None else 0
+        if not masked.startswith("#[", cursor):
+            return cursor
+        closing = rust_hygiene_guard.matching_delimiter(masked, cursor + 1, "[", "]")
+        if closing is None:
+            return len(masked)
+        cursor = closing + 1
+
+
+def exact_test_module_ranges(source: str, masked: str, relative_path: str) -> tuple[tuple[int, int], ...]:
+    """Find only the repository's two explicitly recognized inline test modules."""
+    ranges: list[tuple[int, int]] = []
+    for cfg in rust_hygiene_guard.CFG_ATTRIBUTE.finditer(masked):
+        body = source[cfg.start("body") : cfg.end("body")]
+        if BUILTIN_TEST_CFG.fullmatch(body):
+            module_pattern = UNIT_TEST_MODULE
+        elif relative_path == BROKER_TEST_SUPPORT_PATH and BROKER_TEST_SUPPORT_CFG.fullmatch(body):
+            module_pattern = BROKER_TEST_SUPPORT_MODULE
+        else:
+            continue
+
+        cursor = skip_outer_attributes(masked, cfg.end())
+        module = module_pattern.match(masked, cursor)
+        if module is None:
+            continue
+        opening = module.start("opening")
+        closing = rust_hygiene_guard.matching_delimiter(masked, opening, "{", "}")
+        if closing is not None:
+            ranges.append((cfg.start(), closing + 1))
+    return tuple(ranges)
+
+
+@functools.cache
+def rust_source_analysis(path: Path, relative_path: str) -> RustSourceAnalysis:
+    """Read, mask, and classify a Rust source file once."""
+    source = read_text(path)
+    masked = rust_source.mask_comments_and_literals(source)
+    lines = tuple(source.splitlines())
+    line_starts = [0]
+    line_starts.extend(match.end() for match in re.finditer("\n", source))
+    ranges = (
+        ((0, len(source)),)
+        if is_test_source_path(path)
+        else exact_test_module_ranges(source, masked, relative_path)
+    )
+    return RustSourceAnalysis(
+        source,
+        masked,
+        lines,
+        tuple(masked.splitlines()),
+        tuple(line_starts[: len(lines)]),
+        ranges,
+    )
+
+
+def analysis_for(path: Path) -> RustSourceAnalysis:
+    return rust_source_analysis(path, rel_path(path))
+
+
+def line_bounds(analysis: RustSourceAnalysis, line_number: int) -> tuple[int, int] | None:
+    if line_number < 1 or line_number > len(analysis.lines):
+        return None
+    start = analysis.line_starts[line_number - 1]
+    return start, start + len(analysis.lines[line_number - 1])
+
+
+def overlaps_test_range(start: int, end: int, ranges: tuple[tuple[int, int], ...]) -> bool:
+    return any(range_start < end and start < range_end for range_start, range_end in ranges)
+
+
+def without_test_ranges(line: str, start: int, ranges: tuple[tuple[int, int], ...]) -> tuple[str, bool]:
+    """Blank test-module spans on one line while preserving production on partial lines."""
+    characters = list(line)
+    end = start + len(line)
+    overlapped = False
+    for range_start, range_end in ranges:
+        overlap_start = max(start, range_start)
+        overlap_end = min(end, range_end)
+        if overlap_start >= overlap_end:
+            continue
+        overlapped = True
+        characters[overlap_start - start : overlap_end - start] = " " * (overlap_end - overlap_start)
+    return "".join(characters), overlapped
+
+
+def iter_non_test_line_pairs(path: Path) -> Iterable[tuple[int, str, str]]:
+    """Yield aligned original/masked production lines from one cached source analysis."""
+    analysis = analysis_for(path)
+    for line_number, (line, masked_line, start) in enumerate(
+        zip(analysis.lines, analysis.masked_lines, analysis.line_starts),
+        start=1,
+    ):
+        production_line, overlapped = without_test_ranges(line, start, analysis.test_ranges)
+        production_masked, _ = without_test_ranges(masked_line, start, analysis.test_ranges)
+        if overlapped and not production_line.strip():
+            continue
+        yield line_number, production_line, production_masked
+
+
 def is_test_context(path: Path, line_number: int) -> bool:
-    """Best-effort detector for unit-test modules inside Rust source files."""
-    if is_test_source_path(path):
-        return True
-
-    depth = 0
-    test_module_depth: int | None = None
-    pending_test_cfg = False
-    for current_line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        stripped = line.strip()
-        if stripped == "#[cfg(test)]":
-            pending_test_cfg = True
-        elif pending_test_cfg and re.match(r"(pub\([^)]*\)\s+|pub\s+)?mod\s+tests\b", stripped):
-            test_module_depth = depth + stripped.count("{") - stripped.count("}")
-            pending_test_cfg = False
-        elif stripped and not stripped.startswith("#"):
-            pending_test_cfg = False
-
-        if current_line_number == line_number:
-            return test_module_depth is not None
-
-        depth += line.count("{") - line.count("}")
-        if test_module_depth is not None and depth < test_module_depth:
-            test_module_depth = None
-    return False
+    """Return whether a line overlaps an exactly recognized test-only module."""
+    analysis = analysis_for(path)
+    bounds = line_bounds(analysis, line_number)
+    return bounds is not None and overlaps_test_range(*bounds, analysis.test_ranges)
 
 
 def iter_non_test_lines(path: Path) -> Iterable[tuple[int, str]]:
-    """Yield source lines while skipping test-only modules in one pass."""
-    if is_test_source_path(path):
-        return
-
-    depth = 0
-    test_module_depth: int | None = None
-    pending_test_cfg = False
-    for line_number, line in enumerate(read_text(path).splitlines(), start=1):
-        stripped = line.strip()
-        if stripped == "#[cfg(test)]":
-            pending_test_cfg = True
-        elif pending_test_cfg and re.match(r"(pub\([^)]*\)\s+|pub\s+)?mod\s+tests\b", stripped):
-            test_module_depth = depth + stripped.count("{") - stripped.count("}")
-            pending_test_cfg = False
-        elif stripped and not stripped.startswith("#"):
-            pending_test_cfg = False
-
-        if test_module_depth is None:
-            yield line_number, line
-
-        depth += line.count("{") - line.count("}")
-        if test_module_depth is not None and depth < test_module_depth:
-            test_module_depth = None
+    """Yield production source lines from one cached masked/range analysis."""
+    for line_number, line, _ in iter_non_test_line_pairs(path):
+        yield line_number, line
 
 
 def is_anyhow_result_allowlisted(path: Path) -> bool:
@@ -486,6 +576,17 @@ def sensitive_debug_field_name(field_name: str) -> bool:
     return any(term in lower for term in SENSITIVE_DEBUG_FIELD_TERMS)
 
 
+def is_known_non_sensitive_debug_field(path: Path, struct_name: str, field_name: str, declaration: str) -> bool:
+    """Recognize exact field/type pairs whose token name does not carry secret data."""
+    if (
+        rel_path(path) != "rocketmq-transport/src/clients/rocketmq_tokio_client/endpoint_state.rs"
+        or struct_name != "EndpointLease"
+        or field_name != "identity_token"
+    ):
+        return False
+    return re.fullmatch(r"identity_token\s*:\s*Arc\s*<\s*\(\s*\)\s*>\s*,?", declaration) is not None
+
+
 def find_sensitive_derive_debug_fields(paths: Iterable[Path]) -> list[Finding]:
     findings: list[Finding] = []
     field_pattern = re.compile(r"(?:pub(?:\([^)]*\))?\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:")
@@ -504,15 +605,26 @@ def find_sensitive_derive_debug_fields(paths: Iterable[Path]) -> list[Finding]:
             if stripped.startswith("#[") or not stripped:
                 continue
 
-            if not struct_pattern.match(stripped):
+            struct_match = struct_pattern.match(stripped)
+            if struct_match is None:
                 pending_debug_derive_line = None
                 continue
+            struct_name = struct_match.group(1)
 
             depth = line.count("{") - line.count("}")
             for field_index in range(index + 1, len(lines)):
                 _, field_line = lines[field_index]
                 field_match = field_pattern.match(field_line.strip())
-                if field_match and sensitive_debug_field_name(field_match.group(1)):
+                if (
+                    field_match
+                    and sensitive_debug_field_name(field_match.group(1))
+                    and not is_known_non_sensitive_debug_field(
+                        path,
+                        struct_name,
+                        field_match.group(1),
+                        field_line.strip(),
+                    )
+                ):
                     findings.append(
                         Finding(
                             path,
@@ -1043,18 +1155,79 @@ def is_source_stringification_allowlisted(path: Path) -> bool:
     return rel in SOURCE_STRINGIFICATION_ALLOWLIST
 
 
-def source_stringification_message(relative_path: str, line: str) -> str | None:
-    backend_root = any(
+FORMAT_MACRO = re.compile(r"\bformat\s*!\s*(?P<opening>\()")
+FORMAT_STRING_LITERAL = re.compile(
+    r'\s*(?:"(?:\\.|[^"\\])*"|r(?P<hash>#{0,255})".*?"(?P=hash))',
+    re.DOTALL,
+)
+SOURCE_INTERPOLATION = re.compile(r"\{(error|err|e|source)(?::[^}]*)?\}")
+
+
+def is_backend_source_path(relative_path: str) -> bool:
+    return any(
         relative_path == root or relative_path.startswith(f"{root}/")
         for root in ("rocketmq-store-rocksdb", "rocketmq-tieredstore")
     )
-    backend_source_to_text = backend_root and (
-        re.search(r"\b(error|err|e|source)\.to_string\(\)", line) is not None
-        or re.search(r"\{(error|err|e|source)(?::[^}]*)?\}", line) is not None
+
+
+def source_stringification_message(
+    relative_path: str,
+    code: str,
+    *,
+    format_source_interpolation: bool = False,
+) -> str | None:
+    backend_source_to_text = is_backend_source_path(relative_path) and (
+        re.search(r"\b(error|err|e|source)\.to_string\(\)", code) is not None
+        or format_source_interpolation
     )
-    if (backend_source_to_text or is_source_stringification_line(line)) and relative_path not in SOURCE_STRINGIFICATION_ALLOWLIST:
+    if (backend_source_to_text or is_source_stringification_line(code)) and relative_path not in SOURCE_STRINGIFICATION_ALLOWLIST:
         return "source stringification requires a typed source wrapper or SOURCE_STRINGIFICATION_ALLOWLIST entry"
     return None
+
+
+def source_interpolating_format_ranges(analysis: RustSourceAnalysis) -> tuple[tuple[int, int], ...]:
+    """Find real format! calls whose first string literal interpolates a source."""
+    ranges: list[tuple[int, int]] = []
+    for macro in FORMAT_MACRO.finditer(analysis.masked):
+        if any(start <= macro.start() < end for start, end in analysis.test_ranges):
+            continue
+        opening = macro.start("opening")
+        closing = rust_hygiene_guard.matching_delimiter(analysis.masked, opening, "(", ")")
+        if closing is None:
+            continue
+        arguments = analysis.source[opening + 1 : closing]
+        format_string = FORMAT_STRING_LITERAL.match(arguments)
+        if format_string is not None and SOURCE_INTERPOLATION.search(format_string.group(0)) is not None:
+            ranges.append((macro.start(), closing + 1))
+    return tuple(ranges)
+
+
+def find_source_stringification(paths: Iterable[Path]) -> list[Finding]:
+    """Find source-to-text promotion outside narrowly recognized test modules."""
+    findings: list[Finding] = []
+    for path in paths:
+        relative_path = rel_path(path)
+        analysis = analysis_for(path)
+        format_ranges = (
+            source_interpolating_format_ranges(analysis)
+            if is_backend_source_path(relative_path)
+            else ()
+        )
+        for start, _ in format_ranges:
+            message = source_stringification_message(
+                relative_path,
+                "",
+                format_source_interpolation=True,
+            )
+            if message is not None:
+                findings.append(Finding(path, bisect.bisect_right(analysis.line_starts, start), message))
+        for line_number, _, masked_line in iter_non_test_line_pairs(path):
+            line_start = analysis.line_starts[line_number - 1]
+            code, _ = without_test_ranges(masked_line, line_start, format_ranges)
+            message = source_stringification_message(relative_path, code)
+            if message is not None:
+                findings.append(Finding(path, line_number, message))
+    return sorted(findings, key=lambda finding: (finding.path, finding.line, finding.message))
 
 
 def is_source_stringification_line(line: str) -> bool:
@@ -1188,20 +1361,7 @@ def check_source_stringification_allowlist() -> list[Finding]:
     ]
     findings.extend(check_store_error_detail_stringification(store_facade_paths))
     findings.extend(check_backend_source_preservation())
-    for path in domain_paths:
-        for line_number, line in enumerate(read_text(path).splitlines(), start=1):
-            stripped = line.strip()
-            if stripped.startswith("//") or stripped.startswith("///") or is_test_context(path, line_number):
-                continue
-            message = source_stringification_message(rel_path(path), line)
-            if message is not None:
-                findings.append(
-                    Finding(
-                        path,
-                        line_number,
-                        message,
-                    )
-                )
+    findings.extend(find_source_stringification(domain_paths))
     return findings
 
 
@@ -1329,7 +1489,7 @@ def check_redaction_guards() -> list[Finding]:
             "REDACTED",
         ],
         ROOT / "rocketmq-dashboard" / "rocketmq-dashboard-web" / "backend" / "src" / "model" / "auth_model.rs": [
-            "auth_model_debug_redacts_password_and_session_id",
+            "auth_model_debug_redacts_password",
             "REDACTED",
         ],
         ROOT / "rocketmq-dashboard" / "rocketmq-dashboard-web" / "backend" / "src" / "config" / "app_config.rs": [

--- a/scripts/tests/test_error_architecture_guard.py
+++ b/scripts/tests/test_error_architecture_guard.py
@@ -81,6 +81,7 @@ class ErrorArchitectureGuardTests(unittest.TestCase):
                     self.guard.source_stringification_message(
                         f"{backend_root}/src/probe.rs",
                         'let error = RocketMQError::Internal(format!("backend failed: {error}"));',
+                        format_source_interpolation=True,
                     ),
                 )
                 self.assertEqual(
@@ -95,11 +96,64 @@ class ErrorArchitectureGuardTests(unittest.TestCase):
                     self.guard.source_stringification_message(
                         f"{backend_root}/src/probe.rs",
                         'let detail = format!("backend failed: {source}");',
+                        format_source_interpolation=True,
                     ),
                 )
 
         self.assertIn(("rocketmq-store-rocksdb", "src"), self.guard.SOURCE_STRINGIFICATION_DOMAIN_ROOTS)
         self.assertIn(("rocketmq-tieredstore", "src"), self.guard.SOURCE_STRINGIFICATION_DOMAIN_ROOTS)
+
+    def test_format_comment_interpolation_and_fake_format_macros_are_ignored(self):
+        source = '''
+fn render_constant() {
+    let rendered = format!("constant"); // {source}
+    let also_constant = format!(
+        "constant" /* {source} */
+    );
+}
+
+/* format!("comment: {source}") */
+const FAKE_FORMAT: &str = r#"format!("raw: {source}")"#;
+'''
+        with tempfile.TemporaryDirectory(prefix="error-guard-format-negative-") as directory:
+            fixture_root = Path(directory)
+            fixture_path = fixture_root / "rocketmq-tieredstore" / "src" / "probe.rs"
+            fixture_path.parent.mkdir(parents=True)
+            fixture_path.write_text(source, encoding="utf-8")
+
+            original_root = self.guard.ROOT
+            self.guard.ROOT = fixture_root
+            try:
+                findings = self.guard.find_source_stringification([fixture_path])
+            finally:
+                self.guard.ROOT = original_root
+
+        self.assertEqual([], findings)
+
+    def test_multiline_format_source_interpolation_is_reported_once(self):
+        source = '''
+fn render_source() {
+    let rendered = format!(
+        "failure: {source}",
+        source = source.to_string(),
+    );
+}
+'''
+        with tempfile.TemporaryDirectory(prefix="error-guard-format-multiline-") as directory:
+            fixture_root = Path(directory)
+            fixture_path = fixture_root / "rocketmq-tieredstore" / "src" / "probe.rs"
+            fixture_path.parent.mkdir(parents=True)
+            fixture_path.write_text(source, encoding="utf-8")
+            format_line = source.splitlines().index("    let rendered = format!(") + 1
+
+            original_root = self.guard.ROOT
+            self.guard.ROOT = fixture_root
+            try:
+                findings = self.guard.find_source_stringification([fixture_path])
+            finally:
+                self.guard.ROOT = original_root
+
+        self.assertEqual([format_line], [finding.line for finding in findings])
 
     def test_recognizes_allowlisted_external_unit_test_module(self):
         test_path = ROOT / "rocketmq-store-rocksdb" / "src" / "release_checkpoint_tests.rs"
@@ -117,6 +171,321 @@ class ErrorArchitectureGuardTests(unittest.TestCase):
             self.assertFalse(self.guard.is_test_source_path(test_path))
             self.assertFalse(self.guard.is_test_context(test_path, 1))
             self.assertEqual([(1, source_line)], list(self.guard.iter_non_test_lines(test_path)))
+
+    def test_inline_test_modules_allow_intermediate_attributes_and_share_context_detection(self):
+        source = '''
+fn production() {
+    operation().map_err(|error| error.to_string())?;
+}
+
+#[cfg(test)] /* multi */ mod tests
+{ /* opening comment */
+    fn unit_fixture() {
+        let opening = "{";
+        let raw_opening = r#"{"#;
+        // }
+        let raw_multiline = r###"
+}
+"###;
+/*
+}
+*/
+        operation().map_err(|error| error.to_string())?;
+    }
+} /* close */
+
+#[cfg(any(test, feature = "test-support"))]
+/* The cfg remains attached across a
+ * multiline block comment and attributes. */
+// This exact feature-gated module is test support, not production.
+#[doc(hidden)]
+pub mod test_support {
+    fn feature_fixture() {
+        let closing = "}";
+        // {
+        operation().map_err(|error| error.to_string())?;
+    }
+}
+
+fn production_after_test_modules() {
+    operation().map_err(|error| error.to_string())?;
+}
+'''
+        with tempfile.TemporaryDirectory(prefix="error-guard-context-") as directory:
+            fixture_root = Path(directory)
+            fixture_path = fixture_root / "rocketmq-broker" / "src" / "lib.rs"
+            fixture_path.parent.mkdir(parents=True)
+            fixture_path.write_text(source, encoding="utf-8")
+            lines = source.splitlines()
+            production_lines = [
+                index + 1
+                for index, line in enumerate(lines)
+                if line == "    operation().map_err(|error| error.to_string())?;"
+            ]
+            test_lines = [
+                index + 1
+                for index, line in enumerate(lines)
+                if line == "        operation().map_err(|error| error.to_string())?;"
+            ]
+            unit_line, feature_line = test_lines
+
+            original_root = self.guard.ROOT
+            self.guard.ROOT = fixture_root
+            try:
+                self.assertTrue(all(not self.guard.is_test_context(fixture_path, line) for line in production_lines))
+                self.assertTrue(self.guard.is_test_context(fixture_path, unit_line))
+                self.assertTrue(self.guard.is_test_context(fixture_path, feature_line))
+                non_test_lines = dict(self.guard.iter_non_test_lines(fixture_path))
+                findings = self.guard.find_source_stringification([fixture_path])
+            finally:
+                self.guard.ROOT = original_root
+
+        self.assertTrue(all(line in non_test_lines for line in production_lines))
+        self.assertNotIn(unit_line, non_test_lines)
+        self.assertNotIn(feature_line, non_test_lines)
+        self.assertEqual(production_lines, [finding.line for finding in findings])
+
+    def test_near_miss_test_module_cfg_or_name_does_not_hide_production_source_stringification(self):
+        source = '''
+#[cfg(test)]
+mod tests; // {
+fn production_after_external_test_module() {
+    operation().map_err(|error| error.to_string())?;
+}
+
+#[cfg(any(test, feature = "other-support"))]
+// A non-canonical feature must not hide this module.
+mod test_support {
+    fn first() {
+        operation().map_err(|error| error.to_string())?;
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+// A non-canonical module name must not inherit the test-support exemption.
+mod support_helpers {
+    fn second() {
+        operation().map_err(|error| error.to_string())?;
+    }
+}
+'''
+        with tempfile.TemporaryDirectory(prefix="error-guard-near-miss-") as directory:
+            fixture_root = Path(directory)
+            fixture_path = fixture_root / "rocketmq-broker" / "src" / "lib.rs"
+            fixture_path.parent.mkdir(parents=True)
+            fixture_path.write_text(source, encoding="utf-8")
+            lines = source.splitlines()
+            external_module_line = lines.index("mod tests; // {") + 1
+            external_production_line = lines.index("    operation().map_err(|error| error.to_string())?;") + 1
+
+            original_root = self.guard.ROOT
+            self.guard.ROOT = fixture_root
+            try:
+                self.assertFalse(self.guard.is_test_context(fixture_path, external_module_line))
+                self.assertFalse(self.guard.is_test_context(fixture_path, external_production_line))
+                findings = self.guard.find_source_stringification([fixture_path])
+            finally:
+                self.guard.ROOT = original_root
+
+        self.assertEqual(3, len(findings))
+
+    def test_nested_test_module_ends_at_the_closing_brace_with_its_declaration_indentation(self):
+        source = '''
+mod outer {
+    #[cfg(test)]
+    mod tests {
+        fn fixture() {
+            let opening = "{";
+            // }
+            operation().map_err(|error| error.to_string())?;
+        }
+    }
+
+    fn production_after_nested_tests() {
+        operation().map_err(|error| error.to_string())?;
+    }
+}
+'''
+        with tempfile.TemporaryDirectory(prefix="error-guard-nested-") as directory:
+            fixture_root = Path(directory)
+            fixture_path = fixture_root / "rocketmq-broker" / "src" / "lib.rs"
+            fixture_path.parent.mkdir(parents=True)
+            fixture_path.write_text(source, encoding="utf-8")
+            lines = source.splitlines()
+            test_line = lines.index("            operation().map_err(|error| error.to_string())?;") + 1
+            production_line = lines.index("        operation().map_err(|error| error.to_string())?;") + 1
+
+            original_root = self.guard.ROOT
+            self.guard.ROOT = fixture_root
+            try:
+                self.assertTrue(self.guard.is_test_context(fixture_path, test_line))
+                self.assertFalse(self.guard.is_test_context(fixture_path, production_line))
+                findings = self.guard.find_source_stringification([fixture_path])
+            finally:
+                self.guard.ROOT = original_root
+
+        self.assertEqual([production_line], [finding.line for finding in findings])
+
+    def test_fake_test_modules_in_comments_and_multiline_literals_do_not_hide_production(self):
+        fixtures = {
+            "block_comment": '''
+/*
+#[cfg(test)]
+mod tests {
+}
+*/
+fn production() {
+    operation().map_err(|error| error.to_string())?;
+}
+''',
+            "multiline_string": '''
+const FAKE_MODULE: &str = "
+#[cfg(test)]
+mod tests {
+}
+";
+fn production() {
+    operation().map_err(|error| error.to_string())?;
+}
+''',
+            "raw_string": '''
+const FAKE_MODULE: &str = r###"
+#[cfg(test)]
+mod tests {
+}
+"###;
+fn production() {
+    operation().map_err(|error| error.to_string())?;
+}
+''',
+        }
+        with tempfile.TemporaryDirectory(prefix="error-guard-masked-near-miss-") as directory:
+            fixture_root = Path(directory)
+            original_root = self.guard.ROOT
+            self.guard.ROOT = fixture_root
+            try:
+                for name, source in fixtures.items():
+                    with self.subTest(name=name):
+                        fixture_path = fixture_root / "rocketmq-broker" / "src" / f"{name}.rs"
+                        fixture_path.parent.mkdir(parents=True, exist_ok=True)
+                        fixture_path.write_text(source, encoding="utf-8")
+                        production_line = source.splitlines().index(
+                            "    operation().map_err(|error| error.to_string())?;"
+                        ) + 1
+
+                        findings = self.guard.find_source_stringification([fixture_path])
+
+                        self.assertEqual([production_line], [finding.line for finding in findings])
+            finally:
+                self.guard.ROOT = original_root
+
+    def test_test_module_range_ignores_indentation_and_masks_trailing_multiline_comment(self):
+        source = '''
+#[cfg(test)]
+#[allow(dead_code)]
+mod tests {
+    fn fixture() {
+        operation().map_err(|error| error.to_string())?;
+    }
+      } /* trailing comment after the differently indented closing brace
+operation().map_err(|error| error.to_string())?;
+*/
+fn production_after_tests() {
+    operation().map_err(|error| error.to_string())?;
+}
+'''
+        with tempfile.TemporaryDirectory(prefix="error-guard-range-") as directory:
+            fixture_root = Path(directory)
+            fixture_path = fixture_root / "rocketmq-broker" / "src" / "range.rs"
+            fixture_path.parent.mkdir(parents=True)
+            fixture_path.write_text(source, encoding="utf-8")
+            lines = source.splitlines()
+            test_line = lines.index("        operation().map_err(|error| error.to_string())?;") + 1
+            comment_line = lines.index("operation().map_err(|error| error.to_string())?;") + 1
+            production_line = lines.index("    operation().map_err(|error| error.to_string())?;") + 1
+
+            original_root = self.guard.ROOT
+            self.guard.ROOT = fixture_root
+            try:
+                self.assertTrue(self.guard.is_test_context(fixture_path, test_line))
+                self.assertFalse(self.guard.is_test_context(fixture_path, comment_line))
+                findings = self.guard.find_source_stringification([fixture_path])
+            finally:
+                self.guard.ROOT = original_root
+
+        self.assertEqual([production_line], [finding.line for finding in findings])
+
+    def test_feature_test_support_module_is_exempt_only_in_broker_lib(self):
+        source = '''
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod test_support {
+    fn fixture() {
+        operation().map_err(|error| error.to_string())?;
+    }
+}
+'''
+        with tempfile.TemporaryDirectory(prefix="error-guard-test-support-path-") as directory:
+            fixture_root = Path(directory)
+            fixture_path = fixture_root / "rocketmq-controller" / "src" / "lib.rs"
+            fixture_path.parent.mkdir(parents=True)
+            fixture_path.write_text(source, encoding="utf-8")
+            finding_line = source.splitlines().index(
+                "        operation().map_err(|error| error.to_string())?;"
+            ) + 1
+
+            original_root = self.guard.ROOT
+            self.guard.ROOT = fixture_root
+            try:
+                findings = self.guard.find_source_stringification([fixture_path])
+            finally:
+                self.guard.ROOT = original_root
+
+        self.assertEqual([finding_line], [finding.line for finding in findings])
+
+    def test_identity_token_arc_unit_is_the_only_non_sensitive_derive_debug_exception(self):
+        safe_source = '''
+#[derive(Debug)]
+struct EndpointLease {
+    identity_token: Arc<()>,
+}
+'''
+        unsafe_source = '''
+#[derive(Debug)]
+struct EndpointLease {
+    identity_token: Arc<()>,
+}
+
+#[derive(Debug)]
+struct StringToken {
+    identity_token: String,
+}
+
+#[derive(Debug)]
+struct OtherToken {
+    session_token: Arc<()>,
+}
+'''
+        with tempfile.TemporaryDirectory(prefix="error-guard-debug-") as directory:
+            fixture_root = Path(directory)
+            fixture_dir = fixture_root / "rocketmq-transport" / "src" / "clients" / "rocketmq_tokio_client"
+            fixture_dir.mkdir(parents=True)
+            safe_path = fixture_dir / "endpoint_state.rs"
+            unsafe_path = fixture_dir / "other.rs"
+            safe_path.write_text(safe_source, encoding="utf-8")
+            unsafe_path.write_text(unsafe_source, encoding="utf-8")
+
+            original_root = self.guard.ROOT
+            self.guard.ROOT = fixture_root
+            try:
+                safe_findings = self.guard.find_sensitive_derive_debug_fields([safe_path])
+                unsafe_findings = self.guard.find_sensitive_derive_debug_fields([unsafe_path])
+            finally:
+                self.guard.ROOT = original_root
+
+        self.assertEqual([], safe_findings)
+        self.assertEqual(3, len(unsafe_findings))
+        self.assertTrue(all("manual redacted Debug" in finding.message for finding in unsafe_findings))
 
     def test_allows_only_the_canonical_generic_result_alias(self):
         alias = "pub type Result<T> = std::result::Result<T, Error>;"


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10149

### Brief Description

- Reuse the repository's existing Rust comment/literal masking and delimiter matching to classify only real inline test modules, with one cached analysis per source file.
- Recognize `cfg(test) mod tests` and the exact Broker `cfg(any(test, feature = "test-support")) pub mod test_support` boundary without broad feature or path allowlists.
- Keep production source stringification visible even when comments or multiline strings contain fake test declarations, and inspect real multiline `format!` source interpolation without duplicate findings.
- Exempt only the exact non-secret `EndpointLease::identity_token: Arc<()>` marker from sensitive-Debug findings and align the Dashboard redaction-test contract token.
- Add focused positive and negative fixtures; no production Rust, dependency, remoting numeric code, header, DTO, wire mapping, V1/V2 path, or legacy shim changes.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_error_architecture_guard -v` (passed; 29/29 tests in approximately 1.7 seconds).
- `python scripts/error_architecture_guard.py` (passed; every error architecture guard group reported `OK` in approximately 14 seconds).
- `.\scripts\check-error-hygiene.ps1` (passed; every wrapper group reported `OK` in approximately 14 seconds).
- `git diff --check -- scripts/error_architecture_guard.py scripts/tests/test_error_architecture_guard.py` (passed; line-ending notices only).
- Independent Sol final review: **APPROVED, 95/100, P0/P1/P2 = 0/0/0**. One non-blocking P3 format-syntax edge remains intentionally outside this lightweight guard scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of sensitive error and source-string interpolation in backend formatting.
  * Reduced false positives by ignoring comments, literals, and test-only code.
  * Added a narrowly scoped exception for safe identity-token debug output.
  * Reports affected source locations more precisely and avoids duplicate reports.

* **Tests**
  * Expanded coverage for multiline formatting, nested test modules, comments, literals, feature-gated support code, and debug-output exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->