### PR TITLE
[ISSUE #10055]📝Add Apache 2.0 headers in rocketmq-dashboard-tauri

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/mod.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub(crate) mod commands;
 mod service;
 mod types;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10055

### Brief Description

Adds the repository-standard copyright and Apache License 2.0 header to `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/mod.rs`, the only tracked Rust file in `src-tauri` that was missing it. The header is byte-identical to the one in the sibling `dashboard/commands.rs`. No executable code changed.

### How Did You Test This Change?

From `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/`:

- `cargo fmt --all -- --check` - passed
- `git diff --check` - passed

Clippy not run: the change is comment-only, with no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Apache License 2.0 copyright and licensing information to the dashboard module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->