### PR TITLE
[ISSUE #10151]🧪Complete boundary and retry decision coverage

### DIFF
--- a/rocketmq-client/src/common/retry_policy.rs
+++ b/rocketmq-client/src/common/retry_policy.rs
@@ -391,6 +391,177 @@ mod tests {
     }
 
     #[test]
+    fn representative_retry_policy_decisions_are_deterministic() {
+        let retry_after = RetryFacts::Response {
+            code: ResponseCode::SystemBusy.to_i32(),
+            retry_after: Some(Duration::from_millis(1_500)),
+        };
+        let cases = [
+            (
+                "contract failures never retry",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Contract,
+                RetryAction::Stop,
+            ),
+            (
+                "remote rate pressure backs off",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Operational {
+                    descriptor: &rocketmq_error::TRANSPORT_REMOTE_RATE_LIMITED,
+                    stage: Some(OutboundRequestStage::BeforeWrite),
+                },
+                RetryAction::RetryAfter(Duration::from_millis(7)),
+            ),
+            (
+                "queue pressure backs off",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Rejected {
+                    reason: OutboundRequestRejectionReason::QueueSaturated,
+                    stage: OutboundRequestStage::BeforeWrite,
+                },
+                RetryAction::RetryAfter(Duration::from_millis(7)),
+            ),
+            (
+                "non-idempotent requests stop after writing",
+                context(RetryOperation::ProducerSend, RetryIdempotency::NonIdempotent, 1, 3),
+                RetryFacts::Operational {
+                    descriptor: &rocketmq_error::TRANSPORT_CONNECTION_FAILED,
+                    stage: Some(OutboundRequestStage::Writing),
+                },
+                RetryAction::Stop,
+            ),
+            (
+                "idempotent requests can retry after writing",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Operational {
+                    descriptor: &rocketmq_error::TRANSPORT_CONNECTION_FAILED,
+                    stage: Some(OutboundRequestStage::Writing),
+                },
+                RetryAction::RetryAfter(Duration::from_millis(7)),
+            ),
+            (
+                "route errors refresh route",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Operational {
+                    descriptor: &rocketmq_error::ROUTE_TOPIC_NOT_FOUND,
+                    stage: Some(OutboundRequestStage::BeforeWrite),
+                },
+                RetryAction::RefreshRoute,
+            ),
+            (
+                "leader errors refresh leader",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Operational {
+                    descriptor: &rocketmq_error::CONTROLLER_LEADERSHIP_NOT_LEADER,
+                    stage: Some(OutboundRequestStage::BeforeWrite),
+                },
+                RetryAction::RefreshLeader,
+            ),
+            (
+                "attempt exhaustion stops before retry",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 3, 3),
+                RetryFacts::Operational {
+                    descriptor: &rocketmq_error::TRANSPORT_CONNECTION_FAILED,
+                    stage: Some(OutboundRequestStage::BeforeWrite),
+                },
+                RetryAction::Stop,
+            ),
+            (
+                "deadline exhaustion stops before retry",
+                RetryContext {
+                    remaining: Duration::ZERO,
+                    ..context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3)
+                },
+                RetryFacts::Operational {
+                    descriptor: &rocketmq_error::TRANSPORT_CONNECTION_FAILED,
+                    stage: Some(OutboundRequestStage::BeforeWrite),
+                },
+                RetryAction::Stop,
+            ),
+            (
+                "retry budget exhaustion stops",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Operational {
+                    descriptor: &rocketmq_error::CLIENT_RETRY_BUDGET_EXHAUSTED,
+                    stage: Some(OutboundRequestStage::BeforeWrite),
+                },
+                RetryAction::Stop,
+            ),
+            (
+                "deadline-rejected requests stop",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Rejected {
+                    reason: OutboundRequestRejectionReason::DeadlineExpired,
+                    stage: OutboundRequestStage::BeforeWrite,
+                },
+                RetryAction::Stop,
+            ),
+            (
+                "cancelled requests stop",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Rejected {
+                    reason: OutboundRequestRejectionReason::Cancelled,
+                    stage: OutboundRequestStage::BeforeWrite,
+                },
+                RetryAction::Stop,
+            ),
+            (
+                "shutting down clients stop",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Rejected {
+                    reason: OutboundRequestRejectionReason::ClientStopping,
+                    stage: OutboundRequestStage::BeforeWrite,
+                },
+                RetryAction::Stop,
+            ),
+            (
+                "closed sessions stop",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Rejected {
+                    reason: OutboundRequestRejectionReason::SessionClosed,
+                    stage: OutboundRequestStage::BeforeWrite,
+                },
+                RetryAction::Stop,
+            ),
+            (
+                "trusted retry-after fits strictly inside the deadline",
+                RetryContext {
+                    remaining: Duration::from_millis(1_501),
+                    ..context(RetryOperation::NameServerKv, RetryIdempotency::Idempotent, 1, 3)
+                },
+                retry_after,
+                RetryAction::RetryAfter(Duration::from_millis(1_500)),
+            ),
+            (
+                "trusted retry-after equal to the deadline stops",
+                RetryContext {
+                    remaining: Duration::from_millis(1_500),
+                    ..context(RetryOperation::NameServerKv, RetryIdempotency::Idempotent, 1, 3)
+                },
+                retry_after,
+                RetryAction::Stop,
+            ),
+            (
+                "operational failures without a request stage fail closed",
+                context(RetryOperation::AssignmentQuery, RetryIdempotency::Idempotent, 1, 3),
+                RetryFacts::Operational {
+                    descriptor: &rocketmq_error::TRANSPORT_CONNECTION_FAILED,
+                    stage: None,
+                },
+                RetryAction::Stop,
+            ),
+        ];
+
+        for (name, context, facts, expected) in cases {
+            assert_eq!(
+                RetryPolicy::decide_with_jitter(context, facts, |_| Duration::from_millis(7)),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
     fn non_idempotent_progress_stops_after_writing_but_not_before_write() {
         let context = context(RetryOperation::ProducerSend, RetryIdempotency::NonIdempotent, 1, 3);
         let retry = RetryPolicy::decide_with_jitter(

--- a/rocketmq-transport/src/error_response.rs
+++ b/rocketmq-transport/src/error_response.rs
@@ -58,8 +58,20 @@ mod tests {
     use rocketmq_error::Error;
     use rocketmq_error::ErrorContext;
     use rocketmq_error::PublicErrorView;
+    use rocketmq_error::AUTH_CREDENTIALS_INVALID;
+    use rocketmq_error::AUTH_PERMISSION_DENIED;
+    use rocketmq_error::BROKER_TRANSACTION_REJECTED;
+    use rocketmq_error::CLIENT_LIFECYCLE_ALREADY_STARTED;
+    use rocketmq_error::CONTROLLER_LEADERSHIP_NOT_LEADER;
     use rocketmq_error::CORE_INTERNAL_FAILURE;
     use rocketmq_error::PROTOCOL_BODY_INVALID;
+    use rocketmq_error::PROTOCOL_HEADER_INVALID;
+    use rocketmq_error::ROUTE_TOPIC_NOT_FOUND;
+    use rocketmq_error::STORAGE_OPERATION_UNSUPPORTED;
+    use rocketmq_error::STORAGE_STATE_CORRUPTED;
+    use rocketmq_error::TRANSPORT_ADMISSION_QUEUE_SATURATED;
+    use rocketmq_error::TRANSPORT_CONNECTION_TIMEOUT;
+    use rocketmq_error::TRANSPORT_START_FAILED;
     use rocketmq_protocol::protocol::header::empty_header::EmptyHeader;
     use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
     use rocketmq_protocol::protocol::SerializeType;
@@ -78,6 +90,40 @@ mod tests {
         assert!(response.is_response_type());
         assert_eq!(response.code(), 1);
         assert_eq!(response.remark().map(CheetahString::as_str), Some("Internal error"));
+    }
+
+    #[test]
+    fn representative_canonical_conditions_keep_remoting_codes_and_public_remarks() {
+        let factory = RemotingCommandFactory::new(RemotingCommandDefaults::default());
+        let cases = [
+            (&PROTOCOL_HEADER_INVALID, 29, "Request header is invalid"),
+            (&ROUTE_TOPIC_NOT_FOUND, 17, "Topic route was not found"),
+            (&CLIENT_LIFECYCLE_ALREADY_STARTED, 1, "Client is already started"),
+            (&AUTH_CREDENTIALS_INVALID, 16, "Authentication credentials are invalid"),
+            (&AUTH_PERMISSION_DENIED, 16, "Permission was denied"),
+            (
+                &TRANSPORT_ADMISSION_QUEUE_SATURATED,
+                2,
+                "Transport admission queue is saturated",
+            ),
+            (&CONTROLLER_LEADERSHIP_NOT_LEADER, 2007, "Controller is not the leader"),
+            (&BROKER_TRANSACTION_REJECTED, 1, "Transaction message was rejected"),
+            (&TRANSPORT_START_FAILED, 1, "Transport server could not be started"),
+            (&TRANSPORT_CONNECTION_TIMEOUT, 2, "Transport connection timed out"),
+            (&STORAGE_STATE_CORRUPTED, 1, "Storage state is corrupted"),
+            (&STORAGE_OPERATION_UNSUPPORTED, 3, "Storage operation is unsupported"),
+            (&CORE_INTERNAL_FAILURE, 1, "Internal error"),
+        ];
+
+        for (descriptor, expected_code, expected_remark) in cases {
+            let response = error_response(
+                PublicErrorView::descriptor_only(descriptor),
+                RemotingErrorTarget::Fresh(&factory),
+            );
+
+            assert_eq!(response.code(), expected_code);
+            assert_eq!(response.remark().map(CheetahString::as_str), Some(expected_remark));
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10151

### Brief Description

- Add a table-driven test through the real Transport `error_response` sink for representative descriptors across all 13 canonical conditions.
- Freeze the existing RocketMQ remoting numeric response code and fixed public remark as hard-coded expectations for every representative case.
- Add one deterministic Client retry decision table covering contract failures, pressure, idempotency and request stage, route/leader recovery, attempt/deadline/retry-budget exhaustion, terminal rejections, trusted retry-after, and missing-stage fail-closed behavior.
- Retain all existing command-state, jitter, GO_AWAY, producer-response, send-status, and broker-target tests.
- Keep the change entirely inside existing `#[cfg(test)]` modules; no production code, public API, dependency, DTO, header, wire mapping, compatibility path, or remoting numeric code changes.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check` and `cargo fmt -p rocketmq-client-rust -- --check` (passed).
- `cargo test -p rocketmq-transport error_response` (passed; 6/6).
- `cargo test -p rocketmq-client-rust retry_policy` (passed; 13/13).
- `cargo test -p rocketmq-error --test error_descriptor_catalog --test error_safe_views --test boundary_mapping_golden` (passed; 17/17).
- `cargo test -p rocketmq-proxy-core --all-features --lib status::tests` (passed; 15/15).
- `cargo test -p rocketmq-error --all-features --lib cli::tests` (passed; 7/7).
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed).
- `.\scripts\check-error-hygiene.ps1` and `git diff --check` (passed).
- `cargo test -p rocketmq-proxy --test grpc_ingress` ran 11/12; the unchanged timeout-message assertion in `query_route_integration_rejects_invalid_grpc_timeout_before_business_logic` failed outside this test-only diff.
- `cargo test -p rocketmq-admin-cli --all-features --test cli_help` could not link RocksDB after the temporary target exhausted D-drive space; existing process-level CLI evidence remains unchanged, the core CLI suite passed, and the 83.52 GiB worktree target was cleaned immediately.
- Independent Sol final review: **APPROVED, 97/100, P0/P1/P2 = 0/0/0**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify retry decisions remain deterministic across representative failure, backoff, idempotency, routing, and deadline scenarios.
  * Added coverage confirming canonical error responses preserve remoting codes and public remarks for fresh targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->