### PR TITLE
[ISSUE #10154]📝Document the final public error surface audit

### DIFF
--- a/rocketmq-doc/en/07-error-inventory.md
+++ b/rocketmq-doc/en/07-error-inventory.md
@@ -2,7 +2,7 @@
 title: "Error Architecture Inventory"
 permalink: /docs/error-inventory/
 excerpt: "Current RocketMQ Rust error ownership and migration inventory."
-last_modified_at: 2026-09-05T00:00:00+08:00
+last_modified_at: 2026-09-06T00:00:00+08:00
 toc: true
 classes: wide
 ---
@@ -862,6 +862,98 @@ This table is separate from the 301 `Error` rows. `Keep public` is intentionally
 | `rocketmq_tieredstore::error::TieredStoreErrorKind` | none; local semantic table | removed | none | Delete | Storage / rocketmq-tieredstore | 2 (Storage vertical) | implemented by issue #9969 | the kind table and eight arbitrary-string helpers were deleted; owner operations now select the canonical descriptor and retain typed provider sources |
 
 The itemized tables above are the Wave 0B audit trail. A later implementation change may update a row only after rechecking its producer, every listed consumer, typed-source behavior, and applicable protocol or persistence evidence.
+
+## E8-3 current-main live audit addendum
+
+Audit date: 2026-09-06. This addendum is a separate current-main review and
+does not rewrite the frozen inventory above. The historical `301/104`
+denominator remains frozen: 301 lexical non-central `*Error` enum/struct
+candidates in the implementation-plan scan, and 104 lexical public `*Error`
+candidates in the historical eight high-priority crates
+(`rocketmq-store`, `rocketmq-store-api`, `rocketmq-store-local`,
+`rocketmq-transport`, `rocketmq-runtime`, `rocketmq-broker`, `rocketmq-auth`,
+and `rocketmq-security-api`). Lexical `pub` is only a candidate signal;
+Rustdoc reachability through the module chain and re-exports is the supported
+API authority.
+
+### Current public `Error` counts
+
+| Reviewed scope | Lexical enum/struct declarations | Rustdoc-reachable supported types | Disposition |
+| --- | ---: | ---: | --- |
+| Historical eight high-priority crates | 9 | 8 | Below the 16-type target; the ninth is the private-module `ConsumerAttrError` false positive |
+| Complete root workspace outside `rocketmq-error` | 24 | 23 | Below the 40-type target; includes four `rocketmq-dashboard-common` types and one feature-gated observability export |
+| `rocketmq-store-local` | — | 0 public `Error` | No supported public Error remains |
+| Supported public Error with neither a checked consumer nor public-signature purpose | — | 0 | No orphan supported public Error |
+
+The complete-root 24/23 count includes the historical-eight candidates plus
+the current client, controller, dashboard-common, filter, observability, and
+proxy-core surfaces. `ConsumerAttrError` is the only lexical false positive:
+its declaration is `pub`, but `rocketmq-broker::metrics` is private and the
+type has no public re-export or Rustdoc path. `InfrastructureObservationReadError`
+is public only under the Client `admin-read` feature, and
+`ReleaseIdentityRegistrationError` is public only under Observability's
+`otel-metrics` feature; both are reachable in their enabled profiles. Private
+implementation modules that are explicitly re-exported at a crate root are
+counted as reachable.
+
+### Manually reviewed reachable candidates
+
+The 23 rows below are the complete reachable set outside `rocketmq-error`.
+Each row has a code-checked consumer or a public signature; test-only uses are
+listed only as supporting evidence and do not create a public API by
+themselves.
+
+| Candidate declaration | Reachability | Checked consumer or public-signature purpose |
+| --- | --- | --- |
+| [`AdminError`](../../rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/error.rs#L20) (`rocketmq-admin-core`) | root re-export; reachable | `AdminResult`/`AdminFuture`; Dashboard GPUI, Tauri, and Web adapters consume and project it |
+| [`AuthServiceError`](../../rocketmq-auth/src/error.rs#L120) (`rocketmq-auth`) | root re-export; reachable | `AuthServiceResult<T>` and authentication/authorization, secret-provider, broker, and proxy paths |
+| [`BrokerArgsError`](../../rocketmq-broker/src/command.rs#L26) (`rocketmq-broker`) | public `command` module; reachable | `Args::validate() -> Result<(), BrokerArgsError>` and broker CLI argument validation |
+| [`BrokerConfigError`](../../rocketmq-broker/src/config/error.rs#L46) (`rocketmq-broker`) | public `config::error` module; reachable | Broker config load/validation APIs return it and preserve typed config causes |
+| [`BrokerStartupError`](../../rocketmq-broker/src/lifecycle.rs#L52) (`rocketmq-broker`) | root re-export; reachable | `BrokerBootstrap`/broker-runtime startup, readiness, and rollback paths |
+| [`InfrastructureObservationReadError`](../../rocketmq-client/src/admin/mq_admin_infrastructure_observation_read_ext.rs#L41) (`rocketmq-client-rust`) | `admin-read` feature re-export; reachable when enabled | Four `MQAdminInfrastructureObservationReadExt` methods return `Result<_, InfrastructureObservationReadError>` |
+| [`QualificationError`](../../rocketmq-controller/src/qualification.rs#L605) (`rocketmq-controller`) | root re-export; reachable | Public failover timeline, PutOk audit, and confirm-offset audit methods return it |
+| [`DashboardCommonError`](../../rocketmq-dashboard/rocketmq-dashboard-common/src/error.rs#L24) (`rocketmq-dashboard-common`) | public module/root re-export; reachable | Dashboard Tauri and Web backend services consume the shared facade |
+| [`ProducerValidationError`](../../rocketmq-dashboard/rocketmq-dashboard-common/src/producer/domain.rs#L229) (`rocketmq-dashboard-common`) | public module/root re-export; reachable | Producer domain validation and GPUI producer store consume the typed contract |
+| [`ConsumerValidationError`](../../rocketmq-dashboard/rocketmq-dashboard-common/src/consumer/domain.rs#L967) (`rocketmq-dashboard-common`) | public module/root re-export; reachable | Consumer domain validation returns the typed contract for group/client/config rules |
+| [`TopicValidationError`](../../rocketmq-dashboard/rocketmq-dashboard-common/src/topic/domain.rs#L640) (`rocketmq-dashboard-common`) | public module/root re-export; reachable | Topic domain validation returns the typed contract for topic/target/queue rules |
+| [`EvaluationError`](../../rocketmq-filter/src/expression.rs#L126) (`rocketmq-filter`) | public `expression` module; reachable | Expression evaluation returns `Result<_, EvaluationError>`; broker filter paths consume it |
+| [`FilterError`](../../rocketmq-filter/src/filter/filter_spi.rs#L51) (`rocketmq-filter`) | public `filter` module; reachable | Filter SPI result paths and broker filter manager consume the legacy string-based facade |
+| [`TelemetryQueueConfigError`](../../rocketmq-observability/src/exporter/outage.rs#L134) (`rocketmq-observability`) | re-exported from exporter; reachable | Telemetry outage queue construction validates record/queue byte limits |
+| [`ReleaseIdentityError`](../../rocketmq-observability/src/metrics/release_identity.rs#L119) (`rocketmq-observability`) | reachable through release-identity APIs | Release identity resolution/validation returns the typed contract |
+| [`ProcessTelemetryConfigError`](../../rocketmq-observability/src/metrics/release_identity.rs#L355) (`rocketmq-observability`) | reachable through process-telemetry configuration APIs | Environment/config selection returns it and preserves `ReleaseIdentityError` detail |
+| [`ReleaseIdentityRegistrationError`](../../rocketmq-observability/src/handle.rs#L180) (`rocketmq-observability`) | `otel-metrics` feature re-export; reachable when enabled | Telemetry handle release-identity registration returns the outcome/error type |
+| [`ProxyDrainError`](../../rocketmq-proxy-core/src/drain.rs#L80) (`rocketmq-proxy-core`) | root re-export; reachable | `ProxyDrainController::{attach_lifecycle,try_admit,begin,cancel}` return it; proxy consumes it |
+| [`ProxyError`](../../rocketmq-proxy-core/src/error.rs#L106) (`rocketmq-proxy-core`) | root re-export; reachable | `ProxyResult<T>` and proxy, proxy-cluster, and proxy-local ingress paths consume it |
+| [`RuntimeError`](../../rocketmq-runtime/src/error.rs#L471) (`rocketmq-runtime`) | root re-export; reachable | `RuntimeResult<T>` plus auth, broker, controller, dashboard Web, proxy, store, and transport signatures |
+| [`SecurityProviderError`](../../rocketmq-security-api/src/error.rs#L273) (`rocketmq-security-api`) | root re-export; reachable | `SecretProvider`/signing and `read_secret_file` signatures; auth, client, proxy, and transport consume it |
+| [`StoreError`](../../rocketmq-store-api/src/error.rs#L150) (`rocketmq-store-api`) | store-api root and Store public API re-exports; reachable | Store capability/message/timer/checkpoint operations return `Result<_, StoreError>` across store and RocksDB consumers |
+| [`TransportError`](../../rocketmq-transport/src/error.rs#L105) (`rocketmq-transport`) | curated `api` re-export; reachable | Transport server/session/dispatcher APIs and broker/client/proxy callers return or consume it |
+
+### Exact public `ErrorKind` set
+
+The live review finds exactly five public `ErrorKind` declarations. These are
+classification/metric or compatibility surfaces, not an additional Error
+denominator.
+
+| Declaration | Reachability and checked use |
+| --- | --- |
+| [`FilterCompileErrorKind`](../../rocketmq-error/src/filter_error.rs#L26) | `rocketmq-error` root export and `rocketmq-filter` compile APIs/tests use `kind()` and its variants |
+| [`DashboardStorageErrorKind`](../../rocketmq-observability/src/metrics/dashboard.rs#L89) | observability root export; Dashboard Web storage metrics map `DashboardError`/`PersistenceError` to it |
+| [`McpErrorKind`](../../rocketmq-observability/src/metrics/mcp.rs#L76) | observability metric API; MCP executor/protocol server map rejection/resource errors to it |
+| [`NameServerRouteErrorKind`](../../rocketmq-observability/src/metrics/namesrv.rs#L68) | observability metric API; NameServer processor records route rejection/not-found/internal outcomes |
+| [`ProxyErrorKind`](../../rocketmq-proxy-core/src/error.rs#L54) | proxy-core error/status mapping exhaustively classifies `ProxyError` for gRPC projection |
+
+### Catalog-facade boundary
+
+The reviewed catalog-facade set is 5/9 directly or owner mapped:
+`StoreError`, `RuntimeError`, `TransportError`, `AuthServiceError`, and
+`ProxyError`. The literal bodies of `AdminError`, `BrokerStartupError`,
+`DashboardCommonError`, and `SecurityProviderError` are not directly
+catalog-backed; they remain explicit E9-1 owner/deletion work and are not
+changed in this documentation-only stage. Separately, the deprecated
+string-based `rocketmq_filter::FilterError` remains an E9-1 deletion
+candidate; it is not counted as one of the nine opaque facades above. The
+final master catalog-facade acceptance item is intentionally not checked.
 
 ## Compatibility constraints
 

--- a/rocketmq-doc/en/architecture-public-api-compatibility.md
+++ b/rocketmq-doc/en/architecture-public-api-compatibility.md
@@ -6,19 +6,33 @@ paths removed by the architecture migration.
 
 ## Public API snapshot
 
-- Scope: every core-release library target (`library_targets=26`); excluded
-  Dashboard, MCP, and SRE projects are not part of this denominator
+- Scope: every core-release library target (`library_targets=26`); Dashboard,
+  MCP, and SRE projects are not part of this denominator. Cargo metadata
+  currently reports 27 root-workspace library targets; the core-release scope
+  deliberately excludes `rocketmq-dashboard-common`, which is included only
+  in the complete-root denominator.
 - Structural profiles: `profiles=50` (26 workspace defaults plus the 24 frozen
   public-feature matrix entries)
-- Snapshot comparison: `differences=0`
-- Current classified source-export counts:
+- Last accepted pinned snapshot comparison: `differences=0`
+- Current public API intent counts (`scripts/public-api-intent.json`):
 
-  | Package | Classified exports |
+  | Package | Intent entries |
   |---|---:|
-  | `rocketmq-client-rust` | 224 |
-  | `rocketmq-runtime` | 134 |
-  | `rocketmq-transport` | 219 |
-  | `rocketmq-store` | 211 |
+  | `rocketmq-client-rust` | 251 |
+  | `rocketmq-model` | 20 |
+  | `rocketmq-protocol` | 21 |
+  | `rocketmq-runtime` | 145 |
+  | `rocketmq-store` | 204 |
+  | `rocketmq-store-local` | 19 |
+  | `rocketmq-store-rocksdb` | 27 |
+  | `rocketmq-transport` | 193 |
+
+- The intent guard's eight crates are a different denominator from the E8-3
+  historical eight priority crates (`store`, `store-api`, `store-local`,
+  `transport`, `runtime`, `broker`, `auth`, and `security-api`). The manifest
+  contains exactly five supported `*Error` exports: `RocketMQError`,
+  `InfrastructureObservationReadError`, `RuntimeError`, `StoreError`, and
+  `TransportError`; this count must not be mixed with the live Error inventory.
 
 - The current Transport surface has one unversioned `api` module, one
   `RequestProcessor` contract, one authorized dispatcher facade, and one
@@ -45,6 +59,22 @@ unreleased source and observation surfaces.
 
 The package count is derived from `cargo metadata`; the guard rejects a
 baseline that is missing a current library target or retains a removed one.
+
+### E8-3 fresh pinned-nightly snapshot review
+
+The fresh pinned `nightly-2026-07-05` structural check covered the
+core-release's 26 packages and 50 profiles. It exited 1 with
+`status=review-required`, not pass: `197` differences consist of `58 allowed
+additions + 139 incompatible removals`. Manual review classifies the 139
+removals as `admin-cli=1`, `protocol=6`, Windows `store-local` sendfile=12,
+and Transport old helpers=120. They touch 39 unique paths, and there is no
+`Error`/`ErrorKind` identity difference. The nonzero result is drift from
+earlier completed API-removal stages, not a new Error identity change.
+
+E8-3 therefore does not refresh the checked-in baseline. After E9-1 completes
+the final old-API deletion, the repository will perform one reconciliation to
+avoid double churn; this review-required snapshot must not be recorded as a
+passing gate.
 
 ## Canonical-path cutover inventory
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10154

### Brief Description

- document the E8-3 live public Error audit without rewriting the frozen 301/104 inventory
- distinguish the historical priority-eight denominator from the public API intent guard's eight crates
- record 23 reachable non-central Error types, five public ErrorKind types, and the remaining E9-1 facade work
- disclose the fresh structural snapshot as review-required drift rather than a passing gate

### How Did You Test This Change?

- [x] `python -B scripts/architecture_documentation_guard.py --mode semantic --scope core-release`
- [x] `python -B scripts/public_api_intent_guard.py --scope core-release`
- [x] `python -B scripts/stable_surface_guard.py --mode target --scope core-release`
- [x] `python -B -m unittest scripts.tests.test_public_api_snapshot scripts.tests.test_public_api_intent_guard scripts.tests.test_m09_public_api_compatibility -v` (47 passed)
- [x] `.\scripts\check-error-hygiene.ps1`
- [x] `git diff --check`
- [x] Independent review: 98/100, P0/P1/P2/P3 = 0

The fresh pinned-nightly structural snapshot was also executed and reviewed. It returned `status=review-required` with 197 existing differences (58 additions and 139 removals) and no Error/ErrorKind identity drift. This PR deliberately does not update the baseline; one reconciliation is deferred until E9-1 completes the remaining deletion work.

### Scope

- [x] Documentation only: two existing Markdown files
- [x] No production Rust, remoting numeric code/header, public API baseline, manifest, guard, workflow, V1/V2 compatibility layer, fingerprint, or complex gate change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the error inventory with a current-main audit addendum, including reviewed public error declarations and catalog-facade coverage.
  * Revised the public API compatibility documentation to reflect intent-based API counts and clarify release scope.
  * Documented the latest pinned structural compatibility check and its review-required status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->