### PR TITLE
docs(namesrv): document BrokerAddrInfo

### DIFF
--- a/rocketmq-namesrv/src/route_info/broker_addr_info.rs
+++ b/rocketmq-namesrv/src/route_info/broker_addr_info.rs
@@ -20,16 +20,18 @@ use serde::Deserialize;
 use serde::Serialize;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+/// Identifies a broker in NameServer route tables by its cluster and address.
 pub struct BrokerAddrInfo {
-    // mq cluster name
+    /// The broker's cluster name, serialized as `clusterName`.
     #[serde(rename = "clusterName")]
     pub cluster_name: CheetahString,
-    // broker ip address
+    /// The broker address, serialized as `brokerAddr`.
     #[serde(rename = "brokerAddr")]
     pub broker_addr: CheetahString,
 }
 
 impl BrokerAddrInfo {
+    /// Creates an identity from a cluster name and broker address.
     pub fn new(cluster_name: impl Into<CheetahString>, broker_addr: impl Into<CheetahString>) -> Self {
         Self {
             cluster_name: cluster_name.into(),
@@ -39,12 +41,14 @@ impl BrokerAddrInfo {
 }
 
 impl AsRef<Self> for BrokerAddrInfo {
+    /// Returns this broker identity by reference.
     fn as_ref(&self) -> &Self {
         self
     }
 }
 
 impl Display for BrokerAddrInfo {
+    /// Formats the cluster name and broker address for display.
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

- Fixes #10171

### Brief Description

Documents `BrokerAddrInfo`, its serde-backed fields, constructor, and formatting/reference implementations without changing behavior.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-namesrv -- --check`
- `cargo doc -p rocketmq-namesrv --no-deps`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation comments for broker address information structures and related interfaces.
  * Clarified the behavior and usage of constructors, references, and display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->