### PR TITLE
docs(namesrv): add crate and module documentation

### DIFF
--- a/rocketmq-namesrv/src/kvconfig.rs
+++ b/rocketmq-namesrv/src/kvconfig.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Namespaced key-value configuration storage and persistence.
+//!
+//! [`kvconfig_mananger::KVConfigManager`] manages configuration values, while
+//! [`KVConfigSerializeWrapper`] defines their serialized representation.
+
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;

--- a/rocketmq-namesrv/src/lib.rs
+++ b/rocketmq-namesrv/src/lib.rs
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! RocketMQ NameServer implementation.
+//!
+//! This crate provides broker registration and liveness tracking, topic route metadata,
+//! zone-aware route filtering, KV configuration, and shutdown and observability support.
+//! The main entry points are [`NamesrvConfig`], [`bootstrap`], [`RouteInfoManager`],
+//! [`KVConfigManager`], and [`parse_command_and_config_file`].
+//!
+//! TLS support is enabled by default with `tls`. Optional features include
+//! `embedded-controller` and the `observability`, `otel-*`, and `otlp-*` integrations.
+
 #![allow(clippy::result_large_err)]
 #![recursion_limit = "512"]
 

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Request processors and workload admission for the NameServer remoting protocol.
+//!
+//! [`NameServerRequestProcessorWrapper`] dispatches requests to the exported client,
+//! cluster-test, and default processors.
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;

--- a/rocketmq-namesrv/src/route_info.rs
+++ b/rocketmq-namesrv/src/route_info.rs
@@ -12,5 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Broker identity and housekeeping support used by the route tables.
+//!
+//! The module contains [`broker_addr_info::BrokerAddrInfo`] and the broker
+//! housekeeping service that removes inactive route entries.
+
 pub(crate) mod broker_addr_info;
 pub(crate) mod broker_housekeeping_service;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

- Fixes #10170

### Brief Description

Adds a crate overview for `rocketmq-namesrv` and module-level documentation for request processing, route information, and KV configuration.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-namesrv -- --check`
- `cargo doc -p rocketmq-namesrv --no-deps`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing NameServer functionality, including configuration storage, request processing, route management, TLS, observability, and integrations.
  * Clarified the roles of key NameServer components and their support for broker housekeeping and request dispatch.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->