### PR TITLE
docs(protocol): expand crate and module documentation

### DIFF
--- a/rocketmq-protocol/src/code.rs
+++ b/rocketmq-protocol/src/code.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Request and response codes used by the RocketMQ remoting protocol.
+//!
+//! The module exports [`RequestCode`], [`RemotingSysResponseCode`], and
+//! [`BrokerRequestCode`].
+
 pub mod broker_request_code;
 pub mod request_code;
 pub mod response_code;

--- a/rocketmq-protocol/src/common.rs
+++ b/rocketmq-protocol/src/common.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Compression codecs, message wire types, and shared wire constants.
+//!
+//! [`compression`] provides payload compression, [`message`] contains message
+//! encodings, and [`wire_constants`] exposes values shared across the protocol.
+
 pub mod compression;
 pub mod message;
 pub mod wire_constants {

--- a/rocketmq-protocol/src/lib.rs
+++ b/rocketmq-protocol/src/lib.rs
@@ -13,6 +13,13 @@
 // limitations under the License.
 
 //! Runtime-neutral RocketMQ wire protocol contracts.
+//!
+//! This crate defines request and response codes, [`RemotingCommand`] frames,
+//! custom-header codecs, protocol bodies, compression, and trace encoding.
+//! Its main entry points include [`RequestCode`], [`RemotingCommand`],
+//! [`CommandCustomHeader`], [`HeaderCodec`], and [`RpcRequestHeader`].
+//!
+//! Enable the `simd` feature to use accelerated protocol decoding paths.
 
 mod contract;
 

--- a/rocketmq-protocol/src/trace.rs
+++ b/rocketmq-protocol/src/trace.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Trace records, transfer types, constants, and wire codecs.
+//!
+//! Use [`encode_records`] and [`decode_records`] with [`TraceRecord`],
+//! [`TraceTransferBean`], and [`TraceType`] to exchange trace data.
+
 pub mod trace_codec;
 pub mod trace_constants;
 pub mod trace_record;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

- Fixes #10181

### Brief Description

Expands the `rocketmq-protocol` crate overview and documents the common, code, and trace module roots with links to their principal APIs.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo doc -p rocketmq-protocol --no-deps`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added crate and module documentation describing RocketMQ protocol components, including request and response codes, message encoding, compression, trace records, and wire formats.
  * Documented key protocol entry points and optional SIMD support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->