### PR TITLE
[ISSUE #10176]🧪Add ConsumeType serde and Display tests in rocketmq-protocol

### DIFF
--- a/rocketmq-protocol/src/protocol/heartbeat/consume_type.rs
+++ b/rocketmq-protocol/src/protocol/heartbeat/consume_type.rs
@@ -86,3 +86,73 @@ impl Display for ConsumeType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WIRE_PAIRS: [(ConsumeType, &str); 3] = [
+        (ConsumeType::ConsumeActively, "\"CONSUME_ACTIVELY\""),
+        (ConsumeType::ConsumePassively, "\"CONSUME_PASSIVELY\""),
+        (ConsumeType::ConsumePop, "\"CONSUME_POP\""),
+    ];
+
+    #[test]
+    fn serialize_consume_type_to_java_wire_string() {
+        for (consume_type, json) in WIRE_PAIRS {
+            assert_eq!(serde_json::to_string(&consume_type).unwrap(), json);
+        }
+    }
+
+    #[test]
+    fn deserialize_java_wire_string_to_consume_type() {
+        for (consume_type, json) in WIRE_PAIRS {
+            let deserialized: ConsumeType = serde_json::from_str(json).unwrap();
+            assert_eq!(deserialized, consume_type);
+
+            let round_tripped: ConsumeType =
+                serde_json::from_str(&serde_json::to_string(&consume_type).unwrap()).unwrap();
+            assert_eq!(round_tripped, consume_type);
+        }
+    }
+
+    #[test]
+    fn display_consume_type() {
+        assert_eq!(ConsumeType::ConsumeActively.to_string(), "PULL");
+        assert_eq!(ConsumeType::ConsumePassively.to_string(), "PUSH");
+        assert_eq!(ConsumeType::ConsumePop.to_string(), "POP");
+    }
+
+    #[test]
+    fn deserialize_consume_type_unknown_string_names_supported_variants() {
+        for json in ["\"CONSUME_UNKNOWN\"", "\"PULL\""] {
+            let message = serde_json::from_str::<ConsumeType>(json).unwrap_err().to_string();
+            assert!(message.contains("unknown variant"), "{message}");
+            for variant in ["ConsumeActively", "ConsumePassively", "ConsumePop"] {
+                assert!(message.contains(variant), "{message}");
+            }
+        }
+    }
+
+    #[test]
+    fn default_consume_type_is_consume_actively() {
+        assert_eq!(ConsumeType::default(), ConsumeType::ConsumeActively);
+    }
+
+    #[test]
+    fn consume_type_embedded_in_struct_uses_java_wire_string() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Wrapper {
+            consume_type: ConsumeType,
+        }
+
+        let wrapper = Wrapper {
+            consume_type: ConsumeType::ConsumePassively,
+        };
+        let json = serde_json::to_string(&wrapper).unwrap();
+        assert_eq!(json, r#"{"consume_type":"CONSUME_PASSIVELY"}"#);
+
+        let deserialized: Wrapper = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, wrapper);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10176

### Brief Description

Adds a `#[cfg(test)] mod tests` to `rocketmq-protocol/src/protocol/heartbeat/consume_type.rs` covering the hand-written `Serialize`/`Deserialize` impls and the `Display` impl, which previously had no tests. The six cases from the issue:

- each variant serializes to its Java wire string (`CONSUME_ACTIVELY`, `CONSUME_PASSIVELY`, `CONSUME_POP`)
- each wire string deserializes back to the matching variant, plus a `serde_json` round-trip
- `Display` prints `PULL`, `PUSH`, `POP`
- unknown strings (`CONSUME_UNKNOWN`, `PULL`) fail with an `unknown variant` error that names the supported variants
- `ConsumeType::default()` is `ConsumeActively`
- a struct embedding `ConsumeType` carries the Java string value inside the JSON in both directions

No production code changed.

### How Did You Test This Change?

From the repository root:

- `cargo test -p rocketmq-protocol consume_type` - 6 passed, 0 failed
- `cargo fmt -p rocketmq-protocol -- --check` - passed
- `cargo clippy -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - fails on my macOS host with 6 pre-existing `dead_code` errors in `rocketmq-store-local` (`mapped_file/retirement/platform/creation.rs`, `utils/ffi.rs`). I re-ran `cargo clippy -p rocketmq-store-local` on a pristine `upstream/main` checkout and got the identical 6 errors, so they are not introduced by this PR; this change is `#[cfg(test)]`-only inside `rocketmq-protocol` and touches no other crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for consume type serialization and deserialization.
  * Verified display formatting, default behavior, unknown-value handling, and embedded structure serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->