### PR TITLE
[ISSUE #10178]🧪Add tests for data_version_compat version helpers in rocketmq-protocol

### DIFF
--- a/rocketmq-protocol/src/protocol/data_version_compat.rs
+++ b/rocketmq-protocol/src/protocol/data_version_compat.rs
@@ -38,3 +38,66 @@ fn current_millis() -> i64 {
         .map(|duration| duration.as_millis() as i64)
         .unwrap_or(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::current_millis;
+    use super::new_data_version;
+    use super::DataVersionExt;
+
+    #[test]
+    fn new_data_version_starts_at_zero_with_wall_clock_timestamp() {
+        let before = current_millis();
+        let version = new_data_version();
+        let after = current_millis();
+
+        assert_eq!(version.state_version(), 0);
+        assert_eq!(version.counter(), 0);
+        assert!(version.timestamp() > 0);
+        assert!((before..=after).contains(&version.timestamp()));
+    }
+
+    #[test]
+    fn next_version_bumps_counter_and_keeps_state_version_zero() {
+        let mut version = new_data_version();
+        let previous_timestamp = version.timestamp();
+
+        version.next_version();
+
+        assert_eq!(version.counter(), 1);
+        assert_eq!(version.state_version(), 0);
+        assert!(version.timestamp() >= previous_timestamp);
+        assert!(version.timestamp() <= current_millis());
+    }
+
+    #[test]
+    fn next_version_with_sets_state_version_and_bumps_counter() {
+        let mut version = new_data_version();
+        let previous_timestamp = version.timestamp();
+
+        version.next_version_with(7);
+
+        assert_eq!(version.state_version(), 7);
+        assert_eq!(version.counter(), 1);
+        assert!(version.timestamp() >= previous_timestamp);
+    }
+
+    #[test]
+    fn repeated_version_helpers_yield_strictly_increasing_counters() {
+        let mut version = new_data_version();
+        let mut previous_counter = version.counter();
+
+        for state_version in 1..=5 {
+            version.next_version();
+            assert!(version.counter() > previous_counter);
+            previous_counter = version.counter();
+
+            version.next_version_with(state_version);
+            assert!(version.counter() > previous_counter);
+            assert_eq!(version.state_version(), state_version);
+            previous_counter = version.counter();
+        }
+
+        assert_eq!(version.counter(), 10);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10178

### Brief Description

Adds a `#[cfg(test)] mod tests` to `rocketmq-protocol/src/protocol/data_version_compat.rs` covering `new_data_version`, `DataVersionExt::next_version`, and `DataVersionExt::next_version_with`, which previously had no tests. Four cases, matching the checklist in the issue:

- `new_data_version` starts with `state_version() == 0`, `counter() == 0`, and a timestamp that is `> 0` and bracketed by two wall-clock reads taken around the call
- `next_version` bumps the counter from 0 to 1, keeps `state_version() == 0`, and produces a timestamp that is not less than the previous one (and not in the future)
- `next_version_with(7)` sets `state_version() == 7` and bumps the counter
- alternating `next_version` / `next_version_with(n)` ten times yields strictly increasing counters, ending at 10, with `state_version` tracking the last `n`

Timestamps come from the wall clock, so the tests assert on ranges and relative ordering rather than exact values. The existing `DataVersion` tests in `src/protocol.rs` are untouched. No production code changed.

### How Did You Test This Change?

From the repository root:

- `cargo test -p rocketmq-protocol data_version_compat` - 4 passed, 0 failed
- `cargo fmt -p rocketmq-protocol -- --check` - passed
- `cargo clippy -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - fails on my macOS host with pre-existing `unused_imports` / `dead_code` errors in `rocketmq-store-local` (`mapped_file/retirement/platform/*`, `utils/ffi.rs`, `bootstrap_tests/inventory.rs`). I re-ran `cargo clippy -p rocketmq-store-local` on a pristine `upstream/main` worktree and got the identical error set, so they are not introduced by this PR; this change is `#[cfg(test)]`-only inside `rocketmq-protocol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated coverage for data-version creation and progression.
  - Verified initial version state, counter increments, state-version updates, timestamp behavior, and consistent counter growth across repeated updates.
  - These checks help ensure version tracking remains reliable and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->