### PR TITLE
[ISSUE #10175]🧪Add compression round-trip and factory tests in rocketmq-protocol

### DIFF
--- a/rocketmq-protocol/src/common/compression/compressor_factory.rs
+++ b/rocketmq-protocol/src/common/compression/compressor_factory.rs
@@ -33,3 +33,126 @@ impl CompressorFactory {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_TYPES: [CompressionType; 3] = [CompressionType::LZ4, CompressionType::Zlib, CompressionType::Zstd];
+
+    const COMPRESSORS: [(&str, &dyn Compressor); 3] = [
+        ("lz4", &Lz4Compressor),
+        ("zlib", &ZlibCompressor),
+        ("zstd", &ZstdCompressor),
+    ];
+
+    const TYPICAL_PAYLOAD: &[u8] =
+        b"Hello RocketMQ Rust! {\"topic\":\"TopicTest\",\"tags\":\"TagA\",\"keys\":\"KEY-1\"} 0123456789";
+
+    /// Deterministic pseudo-random bytes (xorshift64), so no compressor can shrink them.
+    fn incompressible_payload(len: usize) -> Vec<u8> {
+        let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+        (0..len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                state as u8
+            })
+            .collect()
+    }
+
+    fn assert_round_trip(payload: &[u8], level: i32) {
+        for (name, compressor) in COMPRESSORS {
+            let compressed = compressor
+                .compress(payload, level)
+                .unwrap_or_else(|e| panic!("{name} compress at level {level} failed: {e}"));
+            let decompressed = compressor
+                .decompress(&compressed)
+                .unwrap_or_else(|e| panic!("{name} decompress at level {level} failed: {e}"));
+            assert_eq!(decompressed.as_ref(), payload, "{name} round trip at level {level}");
+        }
+    }
+
+    #[test]
+    fn get_compressor_returns_same_singleton_for_same_type() {
+        for compression_type in ALL_TYPES {
+            let first = CompressorFactory::get_compressor(compression_type);
+            let second = CompressorFactory::get_compressor(compression_type);
+            assert!(
+                std::ptr::addr_eq(first, second),
+                "{compression_type:?} compressor should be a process-wide singleton"
+            );
+        }
+    }
+
+    #[test]
+    fn get_compressor_maps_each_type_to_matching_algorithm() {
+        for compression_type in ALL_TYPES {
+            let compressed = CompressorFactory::get_compressor(compression_type)
+                .compress(TYPICAL_PAYLOAD, 5)
+                .unwrap_or_else(|e| panic!("{compression_type:?} compress failed: {e}"));
+            let decompressed = compression_type.try_decompression(&compressed).unwrap_or_else(|e| {
+                panic!("{compression_type:?} output should be decodable by its own algorithm: {e}")
+            });
+            assert_eq!(
+                decompressed.as_ref(),
+                TYPICAL_PAYLOAD,
+                "{compression_type:?} factory mapping"
+            );
+        }
+    }
+
+    #[test]
+    fn round_trips_typical_payload() {
+        assert_round_trip(TYPICAL_PAYLOAD, 5);
+    }
+
+    #[test]
+    fn round_trips_empty_payload() {
+        assert_round_trip(&[], 5);
+    }
+
+    #[test]
+    fn round_trips_repetitive_payload_and_shrinks_it() {
+        let payload = vec![b'a'; 64 * 1024];
+        assert_round_trip(&payload, 5);
+        for (name, compressor) in COMPRESSORS {
+            let compressed = compressor
+                .compress(&payload, 5)
+                .expect("repetitive payload should compress");
+            assert!(
+                compressed.len() < payload.len(),
+                "{name} should shrink a repetitive payload, got {} bytes from {}",
+                compressed.len(),
+                payload.len()
+            );
+        }
+    }
+
+    #[test]
+    fn round_trips_incompressible_payload() {
+        assert_round_trip(&incompressible_payload(4096), 5);
+    }
+
+    #[test]
+    fn round_trips_at_level_bounds() {
+        for level in [0, 9] {
+            assert_round_trip(TYPICAL_PAYLOAD, level);
+            assert_round_trip(&incompressible_payload(1024), level);
+        }
+    }
+
+    #[test]
+    fn decompress_rejects_invalid_input_without_panic() {
+        for (name, compressor) in COMPRESSORS {
+            let error = compressor
+                .decompress(b"definitely not compressed data")
+                .expect_err("garbage input should be rejected");
+            assert!(
+                error.to_string().contains("decompression failed"),
+                "{name} error should describe the failure, got: {error}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10175

### Brief Description

Adds a `#[cfg(test)] mod tests` to `rocketmq-protocol/src/common/compression/compressor_factory.rs` covering the compression layer, which previously had no tests in this crate. Eight cases, following the checklist in the issue:

- `CompressorFactory::get_compressor` returns the same singleton for repeated calls with the same `CompressionType` (`std::ptr::addr_eq` on the returned trait objects). Cross-type inequality is deliberately not asserted: the three statics are zero-sized, so distinct addresses are not guaranteed.
- `get_compressor` maps each `CompressionType` to the matching algorithm: the factory output is decoded with `CompressionType::try_decompression` of the same variant. This is the one test that fails if the `match` arms are swapped (verified by mutating `LZ4 => &ZLIB_COMPRESSOR` locally).
- Round-trip through `Lz4Compressor`, `ZlibCompressor`, and `ZstdCompressor` for a typical payload, an empty payload, a 64 KiB repetitive payload (also asserting the output is smaller than the input), and a 4 KiB deterministic xorshift payload that no compressor can shrink.
- Round-trip at `level` `0` and `9` for both the typical and the incompressible payload. All three compressors currently ignore `level`, so this pins the contract that any level decompresses back to the original bytes.
- `decompress` of garbage input returns `Err` for all three compressors, with the error text containing `decompression failed`.

No production code changed. The existing `CompressionType` tests in `rocketmq-model` are untouched.

### How Did You Test This Change?

From the repository root:

- `cargo test -p rocketmq-protocol compression` - 17 passed (8 new), 0 failed
- `cargo test -p rocketmq-protocol` - lib: 955 passed, 0 failed. One pre-existing integration test failure, `ext_key_length_matches_java_signed_short_boundary` in `rocketmq-protocol/tests/remoting_command_java_business_compatibility.rs`, fails identically on a pristine `upstream/main` checkout (the error text does not contain `dynamic header key length exceeds the ROCKETMQ wire limit`), so it is unrelated to this change.
- `cargo fmt -p rocketmq-protocol -- --check` - passed
- `cargo clippy -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - fails on my macOS host with pre-existing `dead_code` / `unused_imports` errors confined to `rocketmq-store-local` (`mapped_file/retirement/platform/*`, `utils/ffi.rs`, `bootstrap_tests/inventory.rs`), the same set already noted in #10186 and reproduced there on a pristine `upstream/main`. No diagnostics are reported for `rocketmq-protocol`; this change is `#[cfg(test)]`-only inside that crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for compression and decompression across supported algorithms and compression levels.
  * Verified handling of empty, repetitive, typical, and incompressible data.
  * Added checks for invalid compressed input and consistent compressor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->