### PR TITLE
[ISSUE #10180]🧪Add tests for RequestType and protocol facade default helpers

### DIFF
--- a/rocketmq-protocol/src/protocol/header_facade.rs
+++ b/rocketmq-protocol/src/protocol/header_facade.rs
@@ -21,3 +21,34 @@ fn current_millis() -> i64 {
         .map(|duration| duration.as_millis() as i64)
         .unwrap_or(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now_millis() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be later than the unix epoch")
+            .as_millis() as u64
+    }
+
+    #[test]
+    fn default_elect_master_request_header_matches_production_defaults() {
+        let header = default_elect_master_request_header();
+
+        assert_eq!(header.cluster_name, "");
+        assert_eq!(header.broker_name, "");
+        assert_eq!(header.broker_id, 0);
+        assert!(!header.designate_elect);
+    }
+
+    #[test]
+    fn default_elect_master_request_header_uses_wall_clock_invoke_time() {
+        let before = now_millis();
+        let header = default_elect_master_request_header();
+
+        assert!(header.invoke_time > 0);
+        assert!(header.invoke_time >= before);
+    }
+}

--- a/rocketmq-protocol/src/protocol/heartbeat_facade.rs
+++ b/rocketmq-protocol/src/protocol/heartbeat_facade.rs
@@ -24,3 +24,38 @@ fn current_millis() -> i64 {
         .map(|duration| duration.as_millis() as i64)
         .unwrap_or(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now_millis() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be later than the unix epoch")
+            .as_millis() as i64
+    }
+
+    #[test]
+    fn default_subscription_data_uses_wall_clock_sub_version() {
+        let before = now_millis();
+        let data = default_subscription_data();
+
+        assert!(data.sub_version > 0);
+        assert!(data.sub_version >= before);
+    }
+
+    #[test]
+    fn default_subscription_data_keeps_remaining_defaults() {
+        let data = default_subscription_data();
+        let expected = SubscriptionData::default();
+
+        assert_eq!(data.class_filter_mode, expected.class_filter_mode);
+        assert_eq!(data.topic, expected.topic);
+        assert_eq!(data.sub_string, expected.sub_string);
+        assert_eq!(data.tags_set, expected.tags_set);
+        assert_eq!(data.code_set, expected.code_set);
+        assert_eq!(data.expression_type, expected.expression_type);
+        assert_eq!(data.filter_class_source, expected.filter_class_source);
+    }
+}

--- a/rocketmq-protocol/src/protocol/request_type.rs
+++ b/rocketmq-protocol/src/protocol/request_type.rs
@@ -41,3 +41,29 @@ impl RequestType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_of_maps_zero_to_stream() {
+        assert_eq!(RequestType::value_of(0), Some(RequestType::Stream));
+    }
+
+    #[test]
+    fn value_of_rejects_unknown_codes() {
+        assert_eq!(RequestType::value_of(1), None);
+        assert_eq!(RequestType::value_of(255), None);
+    }
+
+    #[test]
+    fn get_code_returns_zero_for_stream() {
+        assert_eq!(RequestType::Stream.get_code(), 0);
+    }
+
+    #[test]
+    fn display_prints_stream_for_stream_variant() {
+        assert_eq!(RequestType::Stream.to_string(), "STREAM");
+    }
+}


### PR DESCRIPTION
Adds unit tests for the protocol helpers listed in #10180 — test-only change across three files in `rocketmq-protocol`:

- `request_type.rs`: `RequestType::value_of` (code-to-variant mapping, unknown codes rejected), `get_code`, and `Display` for the stream variant
- `header_facade.rs`: `default_elect_master_request_header` pins the production default fields and asserts `invoke_time` tracks the wall clock
- `heartbeat_facade.rs`: `default_subscription_data` asserts `sub_version` tracks the wall clock and the remaining fields keep their defaults

`cargo test -p rocketmq-protocol` passes (12 tests); `cargo fmt --check` and `cargo clippy` with `-D warnings` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for default request headers and subscription data, including field values and timestamp behavior.
  * Added validation for request type conversion, code mapping, and display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->