### PR TITLE
[ISSUE #10177]🧪Add TraceType parsing and TraceRecord tests in rocketmq-protocol

### DIFF
--- a/rocketmq-protocol/src/trace/trace_record.rs
+++ b/rocketmq-protocol/src/trace/trace_record.rs
@@ -27,3 +27,38 @@ impl TraceRecord {
         Self { trace_type, fields }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fields() -> Vec<CheetahString> {
+        vec![
+            CheetahString::from_static_str("1710000000000"),
+            CheetahString::from_static_str("region"),
+            CheetahString::from_static_str("topic"),
+        ]
+    }
+
+    #[test]
+    fn new_stores_trace_type_and_fields_in_order() {
+        let record = TraceRecord::new(TraceType::SubAfter, fields());
+        assert_eq!(record.trace_type, TraceType::SubAfter);
+        assert_eq!(record.fields, fields());
+    }
+
+    #[test]
+    fn records_built_from_same_inputs_are_equal() {
+        let left = TraceRecord::new(TraceType::Pub, fields());
+        let right = TraceRecord::new(TraceType::Pub, fields());
+        assert_eq!(left, right);
+        assert_eq!(left.clone(), right);
+    }
+
+    #[test]
+    fn records_differ_when_trace_type_or_fields_differ() {
+        let base = TraceRecord::new(TraceType::Pub, fields());
+        assert_ne!(base, TraceRecord::new(TraceType::Recall, fields()));
+        assert_ne!(base, TraceRecord::new(TraceType::Pub, Vec::new()));
+    }
+}

--- a/rocketmq-protocol/src/trace/trace_type.rs
+++ b/rocketmq-protocol/src/trace/trace_type.rs
@@ -48,3 +48,54 @@ impl Display for TraceType {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WIRE_NAMES: [(&str, TraceType); 5] = [
+        ("Pub", TraceType::Pub),
+        ("SubBefore", TraceType::SubBefore),
+        ("SubAfter", TraceType::SubAfter),
+        ("EndTransaction", TraceType::EndTransaction),
+        ("Recall", TraceType::Recall),
+    ];
+
+    #[test]
+    fn parse_maps_each_wire_name_to_its_variant() {
+        for (name, expected) in WIRE_NAMES {
+            assert_eq!(TraceType::parse(name), Some(expected), "parse({name:?})");
+        }
+    }
+
+    #[test]
+    fn parse_rejects_unknown_empty_and_case_variants() {
+        for input in [
+            "",
+            "Unknown",
+            "pub",
+            "PUB",
+            "subBefore",
+            "SUBAFTER",
+            " Pub",
+            "Pub ",
+            "Pub\u{1}",
+        ] {
+            assert_eq!(TraceType::parse(input), None, "parse({input:?}) should be None");
+        }
+    }
+
+    #[test]
+    fn display_prints_exact_wire_name_and_round_trips_through_parse() {
+        for (name, variant) in WIRE_NAMES {
+            let rendered = variant.to_string();
+            assert_eq!(rendered, name, "{variant:?} wire name");
+            assert_eq!(TraceType::parse(&rendered), Some(variant), "{variant:?} round trip");
+        }
+    }
+
+    #[test]
+    fn default_is_pub() {
+        assert_eq!(TraceType::default(), TraceType::Pub);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10177

### Brief Description

`TraceType::parse`, its `Display` impl, and `TraceRecord::new` had no unit tests. The five trace names are a persisted trace-format surface, so this pins them down:

- `trace_type.rs`: a `WIRE_NAMES` table drives `parse` for every variant, `Display` renders the exact wire name and round-trips through `parse`, `parse` returns `None` for empty/unknown/case-variant/padded input, and `Default` is `Pub`.
- `trace_record.rs`: `new` stores the type and fields in order; derived equality holds for same inputs and breaks when either the type or the fields differ.

Test-only change, no production code touched.

### How Did You Test This Change?

```
cargo test -p rocketmq-protocol trace          # 16 passed (7 new)
cargo fmt -p rocketmq-protocol -- --check
cargo clippy -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings
```

The workspace-wide clippy command from the issue currently fails on upstream `main` inside `rocketmq-store-local` (lib test: unresolved names / unused imports), which this PR does not touch, so the package-scoped pass above is what I could verify end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for trace record field ordering, equality, cloning, and inequality scenarios.
  - Added validation for trace type parsing, formatting, default behavior, and rejection of invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->