### PR TITLE
[ISSUE #10179]🧪Add tests for uncovered TopicQueueMappingUtils helpers in rocketmq-protocol

### DIFF
--- a/rocketmq-protocol/src/protocol/static_topic/topic_queue_mapping_utils.rs
+++ b/rocketmq-protocol/src/protocol/static_topic/topic_queue_mapping_utils.rs
@@ -1075,4 +1075,137 @@ mod tests {
 
         assert!(TopicQueueMappingUtils::find_next(&items, None, true).is_none());
     }
+
+    fn item(gen: i32, logic_offset: i64) -> LogicQueueMappingItem {
+        LogicQueueMappingItem {
+            gen,
+            logic_offset,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn find_next_returns_following_item_and_none_after_last() {
+        let items = vec![item(0, 0), item(1, 10), item(2, -1)];
+
+        assert_eq!(
+            TopicQueueMappingUtils::find_next(&items, Some(&items[0]), true),
+            Some(&items[1])
+        );
+        assert!(TopicQueueMappingUtils::find_next(&items, Some(&items[2]), true).is_none());
+        assert!(TopicQueueMappingUtils::find_next(&items, Some(&items[1]), true).is_none());
+        assert_eq!(
+            TopicQueueMappingUtils::find_next(&items, Some(&items[1]), false),
+            Some(&items[2])
+        );
+    }
+
+    #[test]
+    fn find_logic_queue_mapping_item_scans_from_end_for_covering_item() {
+        let items = vec![item(0, 0), item(1, 100), item(2, -1)];
+
+        assert_eq!(
+            TopicQueueMappingUtils::find_logic_queue_mapping_item(&items, 150, true),
+            Some(&items[1])
+        );
+        assert_eq!(
+            TopicQueueMappingUtils::find_logic_queue_mapping_item(&items, 100, true),
+            Some(&items[1])
+        );
+        assert_eq!(
+            TopicQueueMappingUtils::find_logic_queue_mapping_item(&items, 99, true),
+            Some(&items[0])
+        );
+        assert_eq!(
+            TopicQueueMappingUtils::find_logic_queue_mapping_item(&items, 150, false),
+            Some(&items[2])
+        );
+    }
+
+    #[test]
+    fn find_logic_queue_mapping_item_falls_back_to_first_non_negative_item() {
+        let items = vec![item(0, -1), item(1, 10), item(2, 20)];
+
+        assert_eq!(
+            TopicQueueMappingUtils::find_logic_queue_mapping_item(&items, 5, true),
+            Some(&items[1])
+        );
+        assert!(TopicQueueMappingUtils::find_logic_queue_mapping_item(&items[..1], 5, true).is_none());
+    }
+
+    #[test]
+    fn find_logic_queue_mapping_item_returns_none_for_empty_items() {
+        assert!(TopicQueueMappingUtils::find_logic_queue_mapping_item(&[], 0, true).is_none());
+        assert!(TopicQueueMappingUtils::find_logic_queue_mapping_item(&[], 0, false).is_none());
+    }
+
+    #[test]
+    fn get_leader_item_returns_last_item_and_rejects_empty_items() {
+        let items = vec![item(0, 0), item(1, 10)];
+
+        let leader = TopicQueueMappingUtils::get_leader_item(&items).expect("non-empty items have a leader");
+        assert_eq!(leader, items[1]);
+
+        let error = TopicQueueMappingUtils::get_leader_item(&[]).expect_err("empty items should be rejected");
+        assert_eq!(error.descriptor(), &rocketmq_error::ROUTE_TOPIC_INCONSISTENT);
+    }
+
+    #[test]
+    fn check_leader_in_target_brokers_requires_every_leader_broker_in_targets() {
+        let mapping_one = |bname: &str| {
+            TopicQueueMappingOne::new(
+                TopicQueueMappingDetail {
+                    topic_queue_mapping_info: TopicQueueMappingInfo::default(),
+                    hosted_queues: None,
+                },
+                "TopicA".to_string(),
+                bname.to_string(),
+                0,
+                vec![],
+            )
+        };
+        let mapping_ones = vec![mapping_one("broker-a"), mapping_one("broker-b")];
+        let broker_a = CheetahString::from_static_str("broker-a");
+        let broker_b = CheetahString::from_static_str("broker-b");
+
+        let complete = HashSet::from([broker_a.clone(), broker_b]);
+        assert!(TopicQueueMappingUtils::check_leader_in_target_brokers(&mapping_ones, &complete).is_ok());
+
+        let missing_b = HashSet::from([broker_a]);
+        let error = TopicQueueMappingUtils::check_leader_in_target_brokers(&mapping_ones, &missing_b)
+            .expect_err("leader broker outside target brokers should be rejected");
+        assert_eq!(error.descriptor(), &rocketmq_error::ROUTE_TOPIC_INCONSISTENT);
+        assert!(error.to_string().contains("The leader broker is not in target brokers"));
+    }
+
+    #[test]
+    fn get_mock_broker_name_prefixes_scope() {
+        let prefix = mix_all::LOGICAL_QUEUE_MOCK_BROKER_PREFIX;
+
+        assert_eq!(
+            TopicQueueMappingUtils::get_mock_broker_name("scope-a").as_str(),
+            format!("{prefix}scope-a")
+        );
+        assert_eq!(
+            TopicQueueMappingUtils::get_mock_broker_name(mix_all::METADATA_SCOPE_GLOBAL).as_str(),
+            format!("{prefix}{}", &mix_all::METADATA_SCOPE_GLOBAL[2..])
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Scope cannot be null")]
+    fn get_mock_broker_name_panics_on_empty_scope() {
+        TopicQueueMappingUtils::get_mock_broker_name("");
+    }
+
+    #[test]
+    fn block_seq_round_up_rounds_by_half_block() {
+        for (offset, expected) in [(0, 8), (1, 8), (4, 16), (8, 16), (11, 16), (12, 24)] {
+            assert_eq!(
+                TopicQueueMappingUtils::block_seq_round_up(offset, 8),
+                expected,
+                "offset {offset}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10179

### Brief Description

Extends the existing `mod tests` in `rocketmq-protocol/src/protocol/static_topic/topic_queue_mapping_utils.rs` with nine tests for the helpers that had no coverage, following the checklist in the issue:

- `block_seq_round_up`: the half-block rounding table `(0, 8) -> 8`, `(1, 8) -> 8`, `(4, 8) -> 16`, `(8, 8) -> 16`, `(11, 8) -> 16`, `(12, 8) -> 24`
- `get_mock_broker_name`: plain scope gets `LOGICAL_QUEUE_MOCK_BROKER_PREFIX` prepended; `METADATA_SCOPE_GLOBAL` gets the prefix plus the scope with its first two characters stripped; empty scope panics (`#[should_panic(expected = "Scope cannot be null")]`)
- `find_logic_queue_mapping_item`: scanning from the end returns the item whose `logic_offset` is at or below the requested offset (checked at, above, and below the boundary, and with `ignore_negative = false` picking the trailing `-1` item); out-of-range falls back to the first non-negative item; an all-negative list with `ignore_negative = true` and an empty list both return `None`
- `get_leader_item`: returns a clone of the last item; empty list errors with `ROUTE_TOPIC_INCONSISTENT`
- `check_leader_in_target_brokers`: `Ok(())` when every leader broker is in the target set; `ROUTE_TOPIC_INCONSISTENT` carrying "The leader broker is not in target brokers" when one is missing
- `find_next`: returns the item after the current one (matched by `gen`), `None` when the current item is last, `None` when the next item has a negative `logic_offset` and `ignore_negative = true`, and that same item when `ignore_negative = false`

The success path of `check_logic_queue_mapping_item_offset` listed in the issue is already covered by the existing `check_logic_queue_mapping_item_offset_accepts_monotonic_items`, so I did not add a duplicate. A small `item(gen, logic_offset)` helper builds the `LogicQueueMappingItem` fixtures shared by the new tests; everything else uses the same `..Default::default()` / `TopicQueueMappingOne::new` construction as the existing tests. The 8 existing tests are unchanged and no production code changed.

### How Did You Test This Change?

From the repository root:

- `cargo test -p rocketmq-protocol topic_queue_mapping` - 37 passed, 0 failed (28 before this change, 9 new)
- `cargo fmt -p rocketmq-protocol -- --check` - passed
- `cargo clippy -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - fails on my macOS host with pre-existing `dead_code` errors in `rocketmq-store-local` (`utils/ffi.rs`, `mapped_file/retirement/platform/creation.rs`: `sys_mincore`, `memory_residency`, `residency_page_count`, unused `Namespace`/`OpenParent`/... variants). These are the same findings reported against pristine `upstream/main` in #10186; this PR only adds `#[cfg(test)]` code inside `rocketmq-protocol` and does not touch that crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for topic queue mapping behavior, including leader selection, broker validation, sequence rounding, and mock broker name generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->