### PR TITLE
[ISSUE #10172]♻️Remove derive-trait restatement tests from protocol request and response code enums

### DIFF
--- a/rocketmq-protocol/src/code/request_code.rs
+++ b/rocketmq-protocol/src/code/request_code.rs
@@ -411,32 +411,6 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_traits() {
-        // Test Debug
-        let code = RequestCode::SendMessage;
-        assert_eq!(format!("{:?}", code), "SendMessage");
-
-        // Test Clone and Copy
-        let code1 = RequestCode::HeartBeat;
-        let code2 = code1;
-        let code3 = code1;
-        assert_eq!(code1, code2);
-        assert_eq!(code1, code3);
-
-        // Test PartialEq and Eq
-        assert_eq!(RequestCode::SendMessage, RequestCode::SendMessage);
-        assert_ne!(RequestCode::SendMessage, RequestCode::PullMessage);
-
-        // Test Hash (by using in a HashSet)
-        use std::collections::HashSet;
-        let mut set = HashSet::new();
-        set.insert(RequestCode::SendMessage);
-        set.insert(RequestCode::SendMessage); // Duplicate
-        set.insert(RequestCode::PullMessage);
-        assert_eq!(set.len(), 2);
-    }
-
-    #[test]
     fn test_special_codes() {
         // Test Pop message range (200050-200055)
         assert_eq!(RequestCode::from(200050), RequestCode::PopMessage);

--- a/rocketmq-protocol/src/code/response_code.rs
+++ b/rocketmq-protocol/src/code/response_code.rs
@@ -366,30 +366,6 @@ mod tests {
     }
 
     #[test]
-    fn test_response_code_derive_traits() {
-        // Test Debug
-        let code = ResponseCode::Success;
-        assert_eq!(format!("{:?}", code), "Success");
-
-        // Test Clone and Copy
-        let code1 = ResponseCode::SystemError;
-        let code2 = code1;
-        assert_eq!(code1, code2);
-
-        // Test PartialEq and Eq
-        assert_eq!(ResponseCode::Success, ResponseCode::Success);
-        assert_ne!(ResponseCode::Success, ResponseCode::SystemError);
-
-        // Test Hash
-        use std::collections::HashSet;
-        let mut set = HashSet::new();
-        set.insert(ResponseCode::Success);
-        set.insert(ResponseCode::Success); // Duplicate
-        set.insert(ResponseCode::SystemError);
-        assert_eq!(set.len(), 2);
-    }
-
-    #[test]
     fn test_response_code_repr_i32_size() {
         use std::mem::size_of;
         assert_eq!(size_of::<ResponseCode>(), size_of::<i32>());


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10172 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed internal unit tests covering derived behavior for request and response code types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->