### PR TITLE
[ISSUE #10173]♻️Remove getter and setter restatement tests from protocol body and header structs

### DIFF
--- a/rocketmq-protocol/src/protocol/body/check_client_request_body.rs
+++ b/rocketmq-protocol/src/protocol/body/check_client_request_body.rs
@@ -74,32 +74,6 @@ mod tests {
     }
 
     #[test]
-    fn test_new_and_getters() {
-        let sub_data = create_mock_subscription();
-        let body = CheckClientRequestBody::new(
-            "some_client-123".to_string(),
-            "some_group-abc".to_string(),
-            sub_data.clone(),
-        );
-
-        assert_eq!(body.get_client_id(), "some_client-123");
-        assert_eq!(body.get_group(), "some_group-abc");
-        assert_eq!(body.get_subscription_data().topic, "test-topic");
-        assert!(body.namespace.is_none());
-    }
-
-    #[test]
-    fn test_setters() {
-        let mut body = CheckClientRequestBody::new("old_id".into(), "old_group".into(), create_mock_subscription());
-
-        body.set_client_id("new_id".into());
-        body.set_group("new_group".into());
-
-        assert_eq!(body.client_id, "new_id");
-        assert_eq!(body.group, "new_group");
-    }
-
-    #[test]
     fn test_serialization_camel_case() {
         let sub_data = create_mock_subscription();
         let body = CheckClientRequestBody::new("c1".into(), "g1".into(), sub_data);

--- a/rocketmq-protocol/src/protocol/body/topic_info_wrapper/topic_queue_wrapper.rs
+++ b/rocketmq-protocol/src/protocol/body/topic_info_wrapper/topic_queue_wrapper.rs
@@ -69,18 +69,6 @@ mod tests {
     }
 
     #[test]
-    fn test_new_and_getters() {
-        let map = create_test_map();
-        let version = DataVersion::default();
-
-        let wrapper = TopicQueueMappingSerializeWrapper::new(Some(map), Some(version.clone()));
-
-        assert!(wrapper.topic_queue_mapping_info_map().is_some());
-        assert_eq!(wrapper.topic_queue_mapping_info_map().unwrap().len(), 1);
-        assert!(wrapper.data_version().is_some());
-    }
-
-    #[test]
     fn test_take_topic_queue_mapping_info_map() {
         let map = create_test_map();
         let mut wrapper = TopicQueueMappingSerializeWrapper::new(Some(map), None);

--- a/rocketmq-protocol/src/protocol/header/peek_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/peek_message_request_header.rs
@@ -148,7 +148,6 @@ impl TopicRequestHeaderTrait for PeekMessageRequestHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rpc::rpc_request_header::RpcRequestHeader;
 
     #[test]
     fn test_default_implementation() {
@@ -159,64 +158,6 @@ mod tests {
         assert_eq!(header.max_msg_nums, 32);
         assert!(header.topic_request_header.is_none());
     }
-    #[test]
-    fn test_topic_request_header_trait_methods() {
-        let mut header = PeekMessageRequestHeader::default();
-
-        // Test set_topic and topic
-        let test_topic = CheetahString::from("test_topic");
-        header.set_topic(test_topic.clone());
-        assert_eq!(header.topic(), &test_topic);
-
-        // Test set_queue_id and queue_id
-        header.set_queue_id(10);
-        assert_eq!(header.queue_id(), 10);
-
-        // Test with topic_request_header set
-        let rpc_header = RpcRequestHeader {
-            broker_name: Some(CheetahString::from("test_broker")),
-            namespace: Some(CheetahString::from("test_namespace")),
-            namespaced: Some(true),
-            oneway: Some(false),
-        };
-
-        let topic_request_header = TopicRequestHeader {
-            lo: Some(true),
-            rpc: Some(rpc_header),
-        };
-
-        header.topic_request_header = Some(topic_request_header);
-
-        // Test broker_name
-        assert_eq!(header.broker_name(), Some(&CheetahString::from("test_broker")));
-
-        let new_broker = CheetahString::from("new_broker");
-        header.set_broker_name(new_broker.clone());
-        assert_eq!(header.broker_name(), Some(&new_broker));
-
-        // Test namespace
-        assert_eq!(header.namespace(), Some("test_namespace"));
-
-        let new_namespace = CheetahString::from("new_namespace");
-        header.set_namespace(new_namespace);
-        assert_eq!(header.namespace(), Some("new_namespace"));
-
-        // Test namespaced
-        assert_eq!(header.namespaced(), Some(true));
-        header.set_namespaced(false);
-        assert_eq!(header.namespaced(), Some(false));
-
-        // Test oneway
-        assert_eq!(header.oneway(), Some(false));
-        header.set_oneway(true);
-        assert_eq!(header.oneway(), Some(true));
-
-        // Test lo
-        assert_eq!(header.lo(), Some(true));
-        header.set_lo(Some(false));
-        assert_eq!(header.lo(), Some(false));
-    }
-
     #[test]
     fn test_serialization_deserialization() {
         let header = PeekMessageRequestHeader {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10173 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed unit tests covering client request body accessors and constructors.
  * Removed unit tests covering topic queue mapping wrapper accessors.
  * Removed trait-method coverage for peek message request headers.
  * Serialization, deserialization, and default implementation tests remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->