### PR TITLE
[ISSUE #10174]♻️Remove clone-and-debug and setter restatement tests from namesrv and trace modules

### DIFF
--- a/rocketmq-protocol/src/protocol/namesrv.rs
+++ b/rocketmq-protocol/src/protocol/namesrv.rs
@@ -44,24 +44,6 @@ mod tests {
     }
 
     #[test]
-    fn test_clone_and_debug() {
-        let mut table = HashMap::new();
-        table.insert(CheetahString::from("key"), CheetahString::from("value"));
-
-        let original = RegisterBrokerResult {
-            ha_server_addr: CheetahString::from("127.0.0.1:10912"),
-            master_addr: CheetahString::from("127.0.0.1:10911"),
-            kv_table: KVTable { table },
-        };
-
-        let cloned = original.clone();
-        assert_eq!(original.ha_server_addr, cloned.ha_server_addr);
-
-        let debug_str = format!("{:?}", cloned);
-        assert!(debug_str.contains("ha_server_addr"));
-    }
-
-    #[test]
     fn test_serialization() {
         let mut table = HashMap::new();
         table.insert(CheetahString::from("version"), CheetahString::from("1.0"));

--- a/rocketmq-protocol/src/trace/trace_transfer_bean.rs
+++ b/rocketmq-protocol/src/trace/trace_transfer_bean.rs
@@ -95,7 +95,6 @@ impl TraceTransferBean {
 mod tests {
     use super::*;
     use cheetah_string::CheetahString;
-    use std::collections::HashSet;
 
     #[test]
     fn test_new_creates_empty_bean() {
@@ -103,33 +102,6 @@ mod tests {
         assert!(bean.trans_data.is_empty());
         assert!(bean.trans_key.is_empty());
         assert!(bean.is_empty());
-    }
-
-    #[test]
-    fn test_with_data_initializes_correctly() {
-        let data = CheetahString::from("trace_payload");
-        let mut keys = HashSet::new();
-        keys.insert(CheetahString::from("key1"));
-
-        let bean = TraceTransferBean::with_data(data.clone(), keys.clone());
-
-        assert_eq!(bean.trans_data(), &data);
-        assert_eq!(bean.trans_key(), &keys);
-        assert!(!bean.is_empty());
-    }
-
-    #[test]
-    fn test_setters_and_getters() {
-        let mut bean = TraceTransferBean::new();
-        let data = CheetahString::from("new_data");
-        let mut keys = HashSet::new();
-        keys.insert(CheetahString::from("key_a"));
-
-        bean.set_trans_data(data.clone());
-        bean.set_trans_key(keys.clone());
-
-        assert_eq!(bean.trans_data(), &data);
-        assert_eq!(bean.trans_key(), &keys);
     }
 
     #[test]
@@ -164,16 +136,5 @@ mod tests {
         bean.set_trans_data(CheetahString::from(""));
         bean.add_key(CheetahString::from("key"));
         assert!(!bean.is_empty());
-    }
-
-    #[test]
-    fn test_clone_and_debug() {
-        let bean =
-            TraceTransferBean::with_data(CheetahString::from("data"), HashSet::from([CheetahString::from("key")]));
-        let cloned = bean.clone();
-
-        assert_eq!(bean.trans_data, cloned.trans_data);
-        let debug_str = format!("{:?}", bean);
-        assert!(debug_str.contains("TraceTransferBean"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10174 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed several internal unit tests related to cloning, debugging, and data initialization.
  * Existing default-value, serialization, and deserialization tests remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->