### PR TITLE
[ISSUE #10216]🧪Remove redundant GetConsumeStatsRequestHeader accessor test

### DIFF
--- a/rocketmq-protocol/src/protocol/header/get_consume_stats_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_consume_stats_request_header.rs
@@ -73,24 +73,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn get_consume_stats_request_header_serde() {
-        let mut header = GetConsumeStatsRequestHeader {
-            consumer_group: CheetahString::new(),
-            topic: CheetahString::new(),
-            topic_list: None,
-            topic_request_header: None,
-        };
-        header.set_consumer_group(CheetahString::from("testGroup"));
-        header.set_topic(CheetahString::from("testTopic"));
-
-        let json = serde_json::to_string(&header).unwrap();
-
-        let deserialized: GetConsumeStatsRequestHeader = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.get_consumer_group(), "testGroup");
-        assert_eq!(deserialized.get_topic(), "testTopic");
-    }
-
-    #[test]
     fn get_consume_stats_request_header_deserialize_with_extra_fields() {
         let json = r#"
         {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10216

### Brief Description

Removes `get_consume_stats_request_header_serde` from
`rocketmq-protocol/src/protocol/header/get_consume_stats_request_header.rs`.

The test built a `GetConsumeStatsRequestHeader`, set `consumer_group` and `topic`
through setters, round-tripped it through `serde_json`, and asserted the same two
values back through `get_consumer_group()` / `get_topic()`. That is a
setter-to-accessor check rather than an independent wire-level contract, and both
of its assertions are already covered by the tests that remain in the file:

- `get_consume_stats_request_header_with_topic_request_header_some` performs the
  same serialize/deserialize round trip and asserts the same two accessors, plus
  nested `TopicRequestHeader` presence.
- `get_consume_stats_request_header_deserialize_with_extra_fields` asserts the
  same two accessors against a payload carrying unknown fields.

Only the test function was deleted. No production header type, constructor,
accessor, codec or Serde attribute changed, and `use super::*;` is still needed by
the remaining tests, so no imports became unused. Extra-field deserialization and
nested-header presence coverage are preserved.

### How Did You Test This Change?

From the repository root:

- `cargo fmt -p rocketmq-protocol -- --check` — clean.
- `cargo test -p rocketmq-protocol` — the two remaining tests in the file pass.
  One unrelated pre-existing failure,
  `common::compression::compressor_factory::tests::decompress_rejects_invalid_input_without_panic`,
  reproduces identically on an unmodified `main` checkout.
- `cargo clippy -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings`
  — clean. The `--workspace` variant does not build on my macOS host because of
  pre-existing platform-specific FFI errors in the untouched `rocketmq-store-local`
  crate; this PR touches only `rocketmq-protocol` test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a unit test covering serialization and deserialization of consume statistics request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->