### PR TITLE
[ISSUE #10209]🧪Remove redundant CreateUserRequestHeader mutator test

### DIFF
--- a/rocketmq-protocol/src/protocol/header/create_user_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/create_user_request_header.rs
@@ -43,21 +43,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::protocol::command_custom_header::CommandCustomHeader;
     use crate::protocol::command_custom_header::FromMap;
-
-    #[test]
-    fn create_user_request_header_serializes_correctly() {
-        let mut header = CreateUserRequestHeader::new(CheetahString::from_static_str("test_admin"));
-        assert_eq!(header.username, "test_admin");
-
-        header.set_username(CheetahString::from_static_str("updated_admin"));
-        let map = header.to_map().unwrap();
-        assert_eq!(
-            map.get(&CheetahString::from_static_str("username")).unwrap(),
-            "updated_admin"
-        );
-    }
 
     #[test]
     fn create_user_request_header_deserializes_correctly() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10209 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a redundant serialization test while retaining coverage for request-header deserialization and JSON round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->