### PR TITLE
[ISSUE #10210]🧪Remove redundant DeleteAclRequestHeader mutator test

### DIFF
--- a/rocketmq-protocol/src/protocol/header/delete_acl_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/delete_acl_request_header.rs
@@ -108,31 +108,6 @@ mod tests {
     }
 
     #[test]
-    fn constructors_and_mutators_preserve_optional_wire_fields() {
-        let with_resource = DeleteAclRequestHeader::new(
-            CheetahString::from_static_str("user:alice"),
-            Some(CheetahString::from_static_str("Topic:test")),
-        );
-        assert_eq!(with_resource.subject, "user:alice");
-        assert!(with_resource.policy_type.is_none());
-        assert_eq!(with_resource.resource.as_deref(), Some("Topic:test"));
-
-        let mut header = DeleteAclRequestHeader::with_subject(CheetahString::from_static_str("user:before"));
-        assert_eq!(header.subject, "user:before");
-        assert!(header.policy_type.is_none());
-        assert!(header.resource.is_none());
-
-        header.set_subject(CheetahString::from_static_str("user:alice"));
-        header.set_policy_type(Some(CheetahString::from_static_str("Custom")));
-        header.set_resource(Some(CheetahString::from_static_str("Topic:test")));
-
-        let map = header.to_map().unwrap();
-        assert_eq!(map.get("subject").map(CheetahString::as_str), Some("user:alice"));
-        assert_eq!(map.get("policyType").map(CheetahString::as_str), Some("Custom"));
-        assert_eq!(map.get("resource").map(CheetahString::as_str), Some("Topic:test"));
-    }
-
-    #[test]
     fn delete_acl_request_header_deserializes_correctly() {
         let mut map: HashMap<CheetahString, CheetahString> = HashMap::new();
         map.insert(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10210 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Removed an internal test covering preservation and serialization of optional wire fields in ACL deletion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->