### PR TITLE
[ISSUE #10211]🧪Remove redundant GetMaxOffsetRequestHeader accessor test

### DIFF
--- a/rocketmq-protocol/src/protocol/header/get_max_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_max_offset_request_header.rs
@@ -137,46 +137,12 @@ impl TopicRequestHeaderTrait for GetMaxOffsetRequestHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rpc::rpc_request_header::RpcRequestHeader;
-
-    fn header_with_rpc_envelope() -> GetMaxOffsetRequestHeader {
-        GetMaxOffsetRequestHeader {
-            topic: CheetahString::from("topic-a"),
-            queue_id: 1,
-            committed: true,
-            topic_request_header: Some(TopicRequestHeader {
-                rpc_request_header: Some(RpcRequestHeader::default()),
-                lo: None,
-            }),
-        }
-    }
 
     #[test]
     fn serde_defaults_committed_to_java_default() {
         let header: GetMaxOffsetRequestHeader = serde_json::from_str(r#"{"topic":"topic-a","queueId":1}"#).unwrap();
 
         assert!(header.committed);
-    }
-
-    #[test]
-    fn topic_request_trait_reads_and_updates_every_forwarded_field() {
-        let mut header = header_with_rpc_envelope();
-
-        header.set_topic(CheetahString::from("topic-b"));
-        header.set_queue_id(2);
-        header.set_lo(Some(true));
-        header.set_broker_name(CheetahString::from("broker-a"));
-        header.set_namespace(CheetahString::from("namespace-a"));
-        header.set_namespaced(true);
-        header.set_oneway(false);
-
-        assert_eq!(header.topic(), "topic-b");
-        assert_eq!(header.queue_id(), 2);
-        assert_eq!(header.lo(), Some(true));
-        assert_eq!(header.broker_name().map(|value| value.as_str()), Some("broker-a"));
-        assert_eq!(header.namespace(), Some("namespace-a"));
-        assert_eq!(header.namespaced(), Some(true));
-        assert_eq!(header.oneway(), Some(false));
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10211 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Removed obsolete test helpers and a test case related to RPC envelope field forwarding.
  - Retained coverage for Java-compatible defaults and setter behavior without an RPC envelope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->