### PR TITLE
[ISSUE #10212]🧪Remove redundant SearchOffsetRequestHeader accessor test

### DIFF
--- a/rocketmq-protocol/src/protocol/header/search_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/search_offset_request_header.rs
@@ -203,27 +203,6 @@ mod tests {
     }
 
     #[test]
-    fn topic_request_trait_reads_and_updates_every_forwarded_field() {
-        let mut header = header_with_rpc_envelope();
-
-        header.set_topic(CheetahString::from("topic-b"));
-        header.set_queue_id(2);
-        header.set_lo(Some(true));
-        header.set_broker_name(CheetahString::from("broker-a"));
-        header.set_namespace(CheetahString::from("namespace-a"));
-        header.set_namespaced(true);
-        header.set_oneway(false);
-
-        assert_eq!(header.topic(), "topic-b");
-        assert_eq!(header.queue_id(), 2);
-        assert_eq!(header.lo(), Some(true));
-        assert_eq!(header.broker_name().map(|value| value.as_str()), Some("broker-a"));
-        assert_eq!(header.namespace(), Some("namespace-a"));
-        assert_eq!(header.namespaced(), Some(true));
-        assert_eq!(header.oneway(), Some(false));
-    }
-
-    #[test]
     fn nested_setters_are_noops_without_an_rpc_envelope() {
         let mut header = SearchOffsetRequestHeader::default();
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10212 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a test covering forwarded request-header field access and updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->