### PR TITLE
[ISSUE #10164]🧪Add serde round-trip tests for KVConfigSerializeWrapper

### DIFF
--- a/rocketmq-namesrv/src/kvconfig.rs
+++ b/rocketmq-namesrv/src/kvconfig.rs
@@ -41,3 +41,219 @@ impl KVConfigSerializeWrapper {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_protocol::protocol::RemotingSerializable;
+
+    use super::*;
+
+    type ConfigTable = dashmap::DashMap<CheetahString, HashMap<CheetahString, CheetahString>>;
+
+    fn namespace_entries(entries: &[(&'static str, &'static str)]) -> HashMap<CheetahString, CheetahString> {
+        entries
+            .iter()
+            .map(|(key, value)| {
+                (
+                    CheetahString::from_static_str(key),
+                    CheetahString::from_static_str(value),
+                )
+            })
+            .collect()
+    }
+
+    fn sample_table() -> ConfigTable {
+        let table = ConfigTable::new();
+        table.insert(
+            CheetahString::from_static_str("ORDER_TOPIC_CONFIG"),
+            namespace_entries(&[("topic-a", "broker-a:4"), ("topic-b", "broker-b:8")]),
+        );
+        table.insert(
+            CheetahString::from_static_str("PROJECT_CONFIG"),
+            namespace_entries(&[("tenant-a", "project-alpha")]),
+        );
+        table
+    }
+
+    #[test]
+    fn new_with_config_table_stores_all_namespaces_and_keys() {
+        let wrapper = KVConfigSerializeWrapper::new_with_config_table(sample_table());
+        let table = wrapper
+            .config_table
+            .expect("constructor should store the provided table");
+
+        assert_eq!(table.len(), 2);
+        let order_namespace = table
+            .get("ORDER_TOPIC_CONFIG")
+            .expect("ORDER_TOPIC_CONFIG namespace should be stored");
+        assert_eq!(order_namespace.len(), 2);
+        assert_eq!(order_namespace.get("topic-a").cloned().as_deref(), Some("broker-a:4"));
+        assert_eq!(order_namespace.get("topic-b").cloned().as_deref(), Some("broker-b:8"));
+        let project_namespace = table
+            .get("PROJECT_CONFIG")
+            .expect("PROJECT_CONFIG namespace should be stored");
+        assert_eq!(
+            project_namespace.get("tenant-a").cloned().as_deref(),
+            Some("project-alpha")
+        );
+    }
+
+    #[test]
+    fn serialized_json_uses_the_config_table_rename() {
+        let wrapper = KVConfigSerializeWrapper::new_with_config_table(sample_table());
+        let serialized = serde_json::to_string(&wrapper).expect("wrapper should serialize to JSON");
+
+        assert!(
+            serialized.contains("\"configTable\""),
+            "serialized wrapper must use the persisted `configTable` field name"
+        );
+        assert!(
+            !serialized.contains("config_table"),
+            "serialized wrapper must never leak the Rust-side `config_table` name"
+        );
+        let value: serde_json::Value =
+            serde_json::from_str(&serialized).expect("serialized wrapper should be valid JSON");
+        let object = value.as_object().expect("wrapper should serialize to a JSON object");
+        assert_eq!(object.len(), 1);
+        assert_eq!(
+            object
+                .get("configTable")
+                .and_then(serde_json::Value::as_object)
+                .map(serde_json::Map::len),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn round_trip_preserves_namespaces_keys_and_values() {
+        let wrapper = KVConfigSerializeWrapper::new_with_config_table(sample_table());
+        let serialized = serde_json::to_string(&wrapper).expect("wrapper should serialize to JSON");
+        let deserialized: KVConfigSerializeWrapper =
+            serde_json::from_str(&serialized).expect("wrapper should deserialize from its JSON");
+        let table = deserialized
+            .config_table
+            .expect("round trip should keep the config table");
+
+        assert_eq!(table.len(), 2);
+        assert_eq!(
+            table.get("ORDER_TOPIC_CONFIG").map(|namespace| namespace.len()),
+            Some(2)
+        );
+        assert_eq!(
+            table
+                .get("ORDER_TOPIC_CONFIG")
+                .and_then(|namespace| namespace.get("topic-a").cloned())
+                .as_deref(),
+            Some("broker-a:4")
+        );
+        assert_eq!(
+            table
+                .get("ORDER_TOPIC_CONFIG")
+                .and_then(|namespace| namespace.get("topic-b").cloned())
+                .as_deref(),
+            Some("broker-b:8")
+        );
+        assert_eq!(
+            table
+                .get("PROJECT_CONFIG")
+                .and_then(|namespace| namespace.get("tenant-a").cloned())
+                .as_deref(),
+            Some("project-alpha")
+        );
+    }
+
+    #[test]
+    fn none_table_serializes_as_null_and_round_trips() {
+        let wrapper = KVConfigSerializeWrapper { config_table: None };
+        let serialized = serde_json::to_string(&wrapper).expect("wrapper without a table should serialize to JSON");
+
+        assert_eq!(serialized, "{\"configTable\":null}");
+
+        let deserialized: KVConfigSerializeWrapper =
+            serde_json::from_str(&serialized).expect("a null config table should deserialize");
+        assert!(deserialized.config_table.is_none());
+    }
+
+    #[test]
+    fn empty_table_serializes_as_an_empty_object_and_round_trips() {
+        let wrapper = KVConfigSerializeWrapper::new_with_config_table(ConfigTable::new());
+        let serialized = serde_json::to_string(&wrapper).expect("an empty table should serialize to JSON");
+
+        assert_eq!(serialized, "{\"configTable\":{}}");
+
+        let deserialized: KVConfigSerializeWrapper =
+            serde_json::from_str(&serialized).expect("an empty table should deserialize from its JSON");
+        let table = deserialized
+            .config_table
+            .expect("an empty table should remain present after the round trip");
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn pretty_persistence_format_matches_kv_config_json_layout() {
+        let table = ConfigTable::new();
+        table.insert(
+            CheetahString::from_static_str("ORDER_TOPIC_CONFIG"),
+            namespace_entries(&[("orders-eu", "broker-a:4")]),
+        );
+        let persisted = KVConfigSerializeWrapper::new_with_config_table(table)
+            .serialize_json_pretty()
+            .expect("persistence path should pretty print the wrapper");
+
+        assert_eq!(
+            persisted,
+            r#"{
+  "configTable": {
+    "ORDER_TOPIC_CONFIG": {
+      "orders-eu": "broker-a:4"
+    }
+  }
+}"#
+        );
+
+        let reloaded: KVConfigSerializeWrapper =
+            serde_json::from_str(&persisted).expect("persisted pretty JSON should reload");
+        assert_eq!(
+            reloaded
+                .config_table
+                .expect("persisted pretty JSON should keep the table")
+                .get("ORDER_TOPIC_CONFIG")
+                .and_then(|namespace| namespace.get("orders-eu").cloned())
+                .as_deref(),
+            Some("broker-a:4")
+        );
+    }
+
+    #[test]
+    fn java_config_table_fixture_deserializes_into_namespaces() {
+        let fixture = include_str!("../tests/fixtures/kv/java-config-table.json");
+        let wrapper: KVConfigSerializeWrapper =
+            serde_json::from_str(fixture).expect("Java KV fixture should deserialize");
+
+        let table = wrapper
+            .config_table
+            .expect("Java KV fixture should carry a config table");
+        assert_eq!(table.len(), 2);
+        assert_eq!(
+            table
+                .get("ORDER_TOPIC_CONFIG")
+                .and_then(|namespace| namespace.get("orders-eu").cloned())
+                .as_deref(),
+            Some("broker-a:4;broker-b:4")
+        );
+        assert_eq!(
+            table
+                .get("PROJECT_CONFIG")
+                .and_then(|namespace| namespace.get("tenant-a").cloned())
+                .as_deref(),
+            Some("project-alpha")
+        );
+        assert_eq!(
+            table
+                .get("PROJECT_CONFIG")
+                .and_then(|namespace| namespace.get("tenant-unicode").cloned())
+                .as_deref(),
+            Some("生产")
+        );
+    }
+}


### PR DESCRIPTION
Adds a `#[cfg(test)]` module to `rocketmq-namesrv/src/kvconfig.rs` locking the persisted JSON contract of `KVConfigSerializeWrapper`, the wire format behind kvConfig.json.

The tests cover `new_with_config_table` storage semantics, the `configTable` serde rename (asserting the Rust-side `config_table` name never leaks into serialized output), and serialize/deserialize round-trips for populated, empty (`"configTable": {}`), and absent (`"configTable": null`) tables. The pretty-printed layout emitted by `serialize_json_pretty` — the exact format the persistence worker writes — is pinned against an expected literal, and the Java-style fixture `tests/fixtures/kv/java-config-table.json` is decoded through the wrapper to guard cross-language compatibility, including its Unicode value. Fixtures are built with `CheetahString::from_static_str` and `DashMap`/`HashMap` exactly as production code constructs them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for key-value configuration serialization and deserialization.
  - Verified JSON naming, round-trip compatibility, empty and missing configuration handling, formatting, and compatibility with Java-generated data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->