### PR TITLE
[ISSUE #10237]✨Scope agent validation to affected changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,302 +2,142 @@
 
 ## Scope and precedence
 
-- This file applies to the whole repository unless a deeper `AGENTS.md` overrides it.
-- Follow the nearest `AGENTS.md` for files under standalone projects and dashboard subdirectories.
-- Direct user instructions in the current conversation take precedence over repository instructions.
-- If repository instructions conflict, follow the more specific instruction and report the conflict in the final response.
+- Direct user instructions take precedence over repository and skill guidance.
+- Root engineering rules apply throughout the repository. The nearest `AGENTS.md` selects local commands
+  and exceptions; its validation profile replaces the root fallback rather than accumulating full profiles.
+- Apply only instructions relevant to the files and behavior being changed. Resolve routine choices within
+  the authorized scope and continue; ask only when missing information materially changes the outcome.
+- If an instruction actually blocks authorized work, identify its file and explain the specific conflict.
 
-## Repository boundaries
+## Repository map
 
-- The repository root is the main Cargo workspace. The source of truth is the root `Cargo.toml` `[workspace].members` list.
-- Root workspace validation does not cover standalone Cargo projects or Node/Vite/Docusaurus projects.
+The root `Cargo.toml` `[workspace].members` list owns the main Cargo workspace. Standalone Cargo and
+Node projects require their own commands. Consult the matching local guide when working in these paths:
 
-| Path | Role | Instruction owner |
-|---|---|---|
-| `rocketmq-dashboard/rocketmq-dashboard-common/` | Root workspace member and shared dashboard crate | This file |
-| `rocketmq-example/` | Standalone Cargo project | `rocketmq-example/AGENTS.md` |
-| `rocketmq-macros/tests/fixtures/renamed-consumer/` | Standalone compile fixture for renamed codec dependencies | Its local `AGENTS.md` |
-| `rocketmq-ai/rocketmq-mcp/` | Standalone Rust MCP server | Its local `AGENTS.md` |
-| `rocketmq-ai/rocketmq-mcp-control/` | Standalone isolated MCP control foundation | Its local `AGENTS.md` |
-| `rocketmq-ai/rocketmq-sre/` | Standalone AI SRE Rust workspace and UI | Its local `AGENTS.md` |
-| `rocketmq-ai/rocketmq-sre/ui/` | Standalone React/TypeScript/Vite AI SRE frontend | Its local `AGENTS.md` |
-| `rocketmq-ai/rocketmq-sre/sdk/typescript/` | Standalone read-only AI SRE TypeScript SDK | Its local `AGENTS.md` |
-| `rocketmq-dashboard/rocketmq-dashboard-gpui/` | Standalone Cargo project | Its local `AGENTS.md` |
-| `rocketmq-dashboard/rocketmq-dashboard-tauri/` | Standalone Node/Vite/Tauri frontend | Its local `AGENTS.md` |
-| `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` | Standalone Rust backend | Its local `AGENTS.md` |
-| `rocketmq-dashboard/rocketmq-dashboard-web/` | Web Dashboard container, not a Cargo workspace root | Its local `AGENTS.md` |
-| `rocketmq-dashboard/rocketmq-dashboard-web/backend/` | Standalone Rust backend | Its local `AGENTS.md` |
-| `rocketmq-dashboard/rocketmq-dashboard-web/frontend/` | Standalone React/TypeScript/Vite frontend | Its local `AGENTS.md` |
-| `rocketmq-website/` | Standalone Docusaurus site | `rocketmq-website/AGENTS.md` |
+| Path | Role / local guide |
+| --- | --- |
+| `rocketmq-dashboard/rocketmq-dashboard-common/` | Root workspace member; this guide |
+| `fuzz/` | [Fuzz targets](fuzz/AGENTS.md) |
+| `rocketmq-example/` | [Standalone examples](rocketmq-example/AGENTS.md) |
+| `rocketmq-macros/tests/fixtures/renamed-consumer/` | [Renamed dependency fixture](rocketmq-macros/tests/fixtures/renamed-consumer/AGENTS.md) |
+| `rocketmq-ai/rocketmq-mcp/` | [Read-only MCP](rocketmq-ai/rocketmq-mcp/AGENTS.md) |
+| `rocketmq-ai/rocketmq-mcp-control/` | [Isolated mutation control](rocketmq-ai/rocketmq-mcp-control/AGENTS.md) |
+| `rocketmq-ai/rocketmq-sre/` | [Standalone SRE workspace](rocketmq-ai/rocketmq-sre/AGENTS.md) |
+| `rocketmq-ai/rocketmq-sre/ui/` | [SRE frontend](rocketmq-ai/rocketmq-sre/ui/AGENTS.md) |
+| `rocketmq-ai/rocketmq-sre/sdk/typescript/` | [Read-only TypeScript SDK](rocketmq-ai/rocketmq-sre/sdk/typescript/AGENTS.md) |
+| `rocketmq-dashboard/rocketmq-dashboard-gpui/` | [Standalone native dashboard](rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md) |
+| `rocketmq-dashboard/rocketmq-dashboard-tauri/` | [Tauri frontend](rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md) |
+| `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` | [Tauri backend](rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/AGENTS.md) |
+| `rocketmq-dashboard/rocketmq-dashboard-web/` | [Web dashboard boundary](rocketmq-dashboard/rocketmq-dashboard-web/AGENTS.md) |
+| `rocketmq-dashboard/rocketmq-dashboard-web/backend/` | [Web backend](rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md) |
+| `rocketmq-dashboard/rocketmq-dashboard-web/frontend/` | [Web frontend](rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md) |
+| `rocketmq-website/` | [Docusaurus site](rocketmq-website/AGENTS.md) |
 
 ## Working agreement
 
-- Before editing, inspect the relevant files, the nearest `AGENTS.md`, and `git status --short`.
-- Treat existing uncommitted changes as user work. Do not overwrite, revert, or reformat unrelated changes.
-- Keep the change scoped to the request; avoid unrelated refactors, dependency updates, and configuration churn.
-- Prefer `rg` and `rg --files` for search. If unavailable, use the fastest local equivalent.
-- Follow existing module structure, naming, error handling, and test style before introducing a new pattern.
-- Use patch-style edits for manual changes. Generated files and formatter output may be produced by their normal tools.
-- If a required local command is unavailable, use the documented installation or CI-equivalent path when one exists.
-  Do not change project dependencies or configuration merely to bypass missing tooling.
-- Add or update a focused test for behavior changes when practical; the test should fail without the change.
-- Do not create commits, branches, pull requests, releases, or remote changes unless the user asks.
+- Before editing, inspect relevant files, the nearest guide, and `git status --short`.
+- Preserve existing user changes. Do not overwrite, revert, or reformat unrelated work.
+- Keep changes scoped. Follow existing modules, naming, error handling, and test style; avoid incidental
+  refactors, dependency upgrades, and configuration churn.
+- Prefer `rg` / `rg --files` and patch-style manual edits. Use normal generators and formatters for their outputs.
+- Complete authorized implementation and necessary verification without repeated permission requests.
+  Do not create commits, branches, PRs, releases, or remote changes unless the user asks.
+- Missing optional tools or unrelated historical failures should not block independent work. Use a documented
+  setup path when needed; do not change dependencies or lint/CI settings just to bypass a failure.
 
-## Rust engineering guardrails
+## Rust engineering
 
-### Toolchain, compatibility, and API design
+- Respect the selected toolchain, MSRV, `rustfmt.toml`, and `.clippy.toml`. Toolchain changes must keep affected
+  manifests and CI aligned. Preserve each project's edition: the root defaults to Rust 2021, while
+  `rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/` uses Rust 2024; `fuzz/` remains Rust 2021.
+- Keep the repository's Apache 2.0 header on new Rust files.
+- Keep features additive and optional dependencies explicitly gated. Preserve default behavior and test
+  the changed feature combinations; `--all-features` does not replace feature-absence tests.
+- Treat public APIs, request/response codes, headers, Serde fields/defaults, and persisted layouts as
+  compatibility surfaces. Semantic changes need an explicit decision and migration approach.
+- Prefer enums, config/request structs, builders, and newtypes over ambiguous booleans, numeric modes,
+  or long positional APIs. Keep modules private and exports intentional; preserve needed compatibility
+  through narrow wrappers.
+- Document non-obvious public invariants and applicable `# Errors`, `# Panics`, and `# Safety` contracts.
+  Use exhaustive matches for project-owned, compatibility-sensitive enums.
+- Scope new lint allowances narrowly and give a reason. No broad warning suppression.
+  Prefer native async trait methods; do not add `#[async_trait]`.
+- Roughly 500/800 effective lines are module review signals, not size gates. Split by behavior when useful;
+  do not split unrelated code just to satisfy a count. Comments should explain invariants and decisions.
+- Use typed errors for recoverable input, I/O, network, storage, protocol, and lifecycle failures.
+  Do not add `todo!`, `unimplemented!`, or recoverable-path panic/unwrap/expect. Production panic facades
+  require a documented invariant or a fallible compatibility API; tests may use assertions and unwraps.
+- Keep unsafe regions minimal with an immediately preceding `// SAFETY:` explanation.
+  Safe wrappers establish their own invariants; caller obligations require an unsafe API and safety contract.
+- Own background work through `ServiceContext`, `TaskGroup`, or an established lifecycle owner.
+  Shutdown cancels and awaits owned work. Route blocking work through `BlockingExecutor` or an established
+  top-level boundary; do not add detached tasks, ad hoc runtimes, nested `block_on`, or raw `spawn_blocking`.
+  Explain any new ownership boundary in the change, without requiring a fingerprint/baseline ceremony.
+- Never hold synchronous lock guards across `.await`. Keep lock scopes and hot-path allocations small.
+- Prefer `#[tracing::instrument(skip_all, ...)]` with explicit, low-cardinality fields; attach existing spans
+  at call sites only intentionally. Never log credentials, ACL/TLS material, tokens, message bodies, or
+  entire request/config objects; avoid unsampled per-message spans.
+- Preserve the security and product boundaries defined in local MCP, MCP-control, SRE, and dashboard guides.
+  Lighter development checks do not change runtime authorization, audit, or protocol behavior.
 
-- Use the repository toolchain and respect `rustfmt.toml` and `.clippy.toml`. Do not relax lint, formatting,
-  feature, or CI configuration merely to make a change pass.
-- Prefer clear, idiomatic Rust over clever abstractions. New Rust source files must keep the repository's Apache 2.0 copyright-header style.
-- Treat `rust-version` as the MSRV and `rust-toolchain.toml` as the repository toolchain selection. Changes
-  to either must keep root and standalone manifests, `.clippy.toml`, and CI aligned.
-- Do not normalize editions across projects. The root workspace defaults to Rust 2021;
-  `rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/` explicitly uses Rust 2024. Follow each standalone Cargo
-  project's local edition and toolchain rules; `fuzz/` intentionally remains Rust 2021.
-- Keep Cargo features additive and explicit. Preserve documented default behavior, gate optional dependencies
-  with their owning feature, and validate the exact changed feature combinations.
-- Treat public crate APIs, request/response codes and headers, Serde field names/defaults, and persisted record
-  layouts as compatibility surfaces. Do not remove, renumber, or change their semantics without an explicit
-  compatibility decision and migration plan.
-- Prefer enums, request/config structs, builders, and newtypes over positional booleans, ambiguous `Option`
-  values, numeric modes, or long public parameter lists. Preserve unavoidable legacy signatures through narrow
-  wrappers.
-- Keep modules private by default and expose intentional public API through narrow visibility or explicit re-exports.
-- Public APIs must explain non-obvious invariants. Add `# Errors`, `# Panics`, and `# Safety` sections when
-  applicable, and add examples when they clarify why or how the API is used.
-- Prefer exhaustive matches for project-owned enums and compatibility-sensitive behavior. Use wildcard arms
-  only when intentionally grouping future or irrelevant cases.
-- Any new `#[allow(...)]` must be scoped to the narrowest item and include a reason. Do not add crate- or
-  module-wide `allow(warnings)` or broad Clippy-group suppression.
-- Prefer native `async fn` methods in traits. `#[allow(async_fn_in_trait)]` is permitted when required by the
-  lint for an intentional public async trait API; do not add `#[async_trait]`.
-- Treat roughly 500 lines of code as a module review signal and avoid extending high-touch modules beyond roughly
-  800 lines of code without a strong local reason. For this guideline, exclude comments, attributes/annotations,
-  blank lines, and `use` imports. Do not split unrelated legacy modules solely to meet a number.
-- Keep comments focused on invariants, ordering, error handling, protocol compatibility, or concurrency assumptions; do not restate the code.
+## Development validation
 
-### Errors, unsafe code, async ownership, and tracing
+- Default completion means the affected code compiles, relevant behavior is verified, and intended Rust
+  files pass a package-scoped format check. For behavior changes, reuse or add focused regression coverage.
+- Select the smallest useful target and actual feature set. A test or Clippy run that compiles the affected
+  target can satisfy the compilation check; do not repeat `cargo check` solely to complete a checklist.
+- After relevant checks pass, finish the task. Broaden or repeat only for new edits, failures, or a concrete
+  unresolved risk. Do not add tests that merely restate constants or mirror low-impact implementation details.
+- Keep async tests deterministic with synchronization or virtual time, avoiding sleeps, fixed ports, and
+  external services where practical.
+- Do not run a mutating workspace-wide formatter while unrelated Rust files are dirty.
+- No SHA, file hash, fingerprint, fixed checkout, clean-worktree, historical-baseline, or score requirement
+  is part of routine development. Do not demand all historical findings be cleared before delivering a fix.
+- Report actual results. Address regressions caused by this change; briefly record unrelated failures,
+  missing optional tooling, and untested scope without claiming a pass or expanding into unrelated repairs.
+- Do not kill unrelated Cargo/rustc processes. Allow relevant work to finish within a reasonable task timeout.
+- Pure documentation/instruction changes need only relevant document/script checks. Run Rustdoc or example
+  checks when executable examples or public documentation links could break; website content uses its guide.
 
-- Do not add `todo!`, `unimplemented!`, or panic/unwrap/expect for recoverable input, I/O, network, storage,
-  protocol, or runtime-lifecycle failures in production paths. Return the project's typed error instead.
-- In production paths, permit panic/unwrap/expect only for a documented invariant or an existing compatibility
-  facade backed by a fallible API. Document public panic conditions under `# Panics`. Tests may use these
-  constructs when they make failures clearer.
-- Keep every new or modified `unsafe` region minimal. Place a `// SAFETY:` comment immediately before each
-  `unsafe` block or `unsafe impl`, documenting the invariants that make it sound.
-- A safe wrapper around unsafe operations must establish the required invariants itself. If callers must uphold
-  them, expose an `unsafe fn` or unsafe trait and document its `# Safety` contract.
-- New production background work must be owned by an injected `ServiceContext`, parent `TaskGroup`, or another
-  established lifecycle owner. Shutdown must cancel and await owned work.
-- Route blocking work through the established `BlockingExecutor` or an existing audit-approved top-level
-  boundary. Do not add detached `tokio::spawn`, ad hoc runtimes, nested `block_on`, or raw `spawn_blocking`.
-  A new exception is a runtime-baseline architecture change, not a local code comment.
-- Do not hold synchronous mutex or RwLock guards across `.await`; keep lock scope and hot-path allocations small.
-- Prefer `#[tracing::instrument(skip_all, ...)]` with explicit low-cardinality, non-sensitive fields. Use
-  call-site `.instrument(...)` only when intentionally binding an existing observation/request span to a future.
-- Never record credentials, ACL/TLS material, message bodies, tokens, or whole request/config objects. Avoid
-  per-message hot-loop spans unless sampling and overhead are intentional.
-
-## Validation policy
-
-- Validation routes are cumulative: run every profile, project rule, and specialized gate whose trigger matches.
-- During iteration, use the smallest useful formatter, check, and test scope. Full workspace validation commands
-  are final/pre-PR gates, not requirements after every small edit.
-- Before PR submission or final handoff of Rust code, complete a successful format check and applicable Clippy pass for every affected Cargo project.
-- Do not run a mutating workspace-wide formatter while unrelated dirty Rust files are present. Format only
-  intended files while iterating, then use the non-mutating final checks below.
-- A command counts as passed only if it completed with exit code zero. If a required baseline already fails,
-  report the exact pre-existing findings, prove the change introduced no new findings, and do not describe the
-  passed.
-- Rust validation can be slow because of workspace locks and native dependencies. Let relevant commands finish
-  unless they clearly fail or exceed the chosen timeout, and never kill unrelated Cargo or rustc processes.
-- Documentation-only changes do not require Cargo validation unless they affect generated Rust, build
-  configuration, executable examples, or documented Rust commands that need verification.
-
-### Root workspace Rust profile
-
-Run from the repository root. Repeat the format check for every affected root-workspace package, replacing
-`<package>` with its Cargo package name:
+Root-workspace commands to select from (replace placeholders; these are not an all-targets checklist):
 
 ```bash
 cargo fmt -p <package> -- --check
-cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+cargo check -p <package>
+cargo test -p <package> <test_name>
 ```
 
-Do not use `cargo fmt --all -- --check` for root-workspace changes. Package-scoped format checks for every affected
-package, together with the workspace Clippy command, form the final root-workspace profile.
+When useful for the change, run `cargo clippy -p <package> --no-deps -- -D warnings` with the affected
+features/targets. A routine final response or PR preparation does not automatically require full-workspace
+Clippy, all features, or every specialized suite. Existing CI runs retain their actual requirements.
 
-### Standalone Cargo fallback profile
+For a standalone Cargo project without more specific commands, use `cargo fmt --all -- --check`,
+`cargo check`, and a focused `cargo test <test_name>` from its root, selecting only relevant work as above.
 
-Follow the nearest local `AGENTS.md`. When it does not define a different profile, run from that standalone Cargo root:
+## Shared changes and integration
 
-```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-```
+- Use current manifests to identify consumers when APIs, features, wire/storage contracts, or shared behavior
+  change. Validate the directly affected consumers and scenarios; a local internal edit does not automatically
+  trigger all standalone projects or fuzz targets.
+- Runtime ownership changes need relevant cancellation/shutdown/resource tests. Error mapping changes need
+  relevant error/redaction tests. RocksDB and telemetry changes need their affected feature combinations.
+- Full-workspace Clippy, feature matrices, metadata consumer audits, long fuzzing, interoperability,
+  performance, and deployment/fault tests belong to the corresponding integration, CI, or release task.
+  Select them when the task requires that evidence.
+- See [validation reference](rocketmq-doc/en/agent-validation-reference.md) only when choosing specialist or
+  integration checks; its command lists are not cumulative local gates.
+- For changes to project layout, AGENTS routing, or the routing scripts, run the lightweight
+  `.\scripts\check-agents-routing.ps1` or `bash ./scripts/check-agents-routing.sh`, plus `git diff --check`.
+  The checker covers paths and instruction/workflow existence, not command wording or source identity.
+  See the [routing ADR](rocketmq-doc/en/agents-routing-validation-adr.md).
+- Keep paired Markdown/HTML artifacts aligned. Do not commit build output, audit artifacts, logs, coverage,
+  Node build directories, or other temporary validation output.
 
-## Validation router
+## Project skills and reporting
 
-| Changed area | Run from | Required final validation | Additional validation or scope |
-|---|---|---|---|
-| Root workspace Rust crates and `rocketmq-dashboard/rocketmq-dashboard-common/` | Repository root | Root workspace Rust profile plus applicable focused tests for behavior changes | Apply every matching specialized gate below |
-| `rocketmq-example/` | `rocketmq-example/` | Follow `rocketmq-example/AGENTS.md` | Revalidate when any repository path dependency in its `Cargo.toml` changes, especially client, model, protocol, transport, runtime, error, observability, or admin-core |
-| `rocketmq-ai/rocketmq-sre/` | Its standalone workspace root | Follow `rocketmq-ai/rocketmq-sre/AGENTS.md` | Include every SRE Cargo member and the execution dependency boundary |
-| `rocketmq-ai/rocketmq-sre/ui/` | Its project root | Follow its local `AGENTS.md` | Include OpenAPI, routes, shared UI, and package metadata changes |
-| `rocketmq-ai/rocketmq-sre/sdk/typescript/` | Its project root | Follow its local `AGENTS.md` | Preserve the fixed read-only SDK and local-only draft boundary |
-| `rocketmq-dashboard/rocketmq-dashboard-gpui/` | Its project root | Follow its `AGENTS.md` | Revalidate for `rocketmq-dashboard-common/` or shared dashboard behavior changes |
-| `rocketmq-dashboard/rocketmq-dashboard-tauri/` frontend | Its project root | Follow its `AGENTS.md` | Include shared frontend config, shell behavior, and package metadata changes |
-| `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` | Its Cargo root | Follow its `AGENTS.md` | Revalidate when a root path dependency used by the backend changes |
-| `rocketmq-dashboard/rocketmq-dashboard-web/backend/` | Its Cargo root | Follow its `AGENTS.md` | Include dashboard-common, admin-core, client/model/protocol/transport/error, and API contract changes |
-| `rocketmq-dashboard/rocketmq-dashboard-web/frontend/` | Its project root | Follow its `AGENTS.md` | Include API contract, routing, shared UI, and package metadata changes |
-| `rocketmq-website/` | Its project root | Follow `rocketmq-website/AGENTS.md` | Include Docusaurus config, navigation, generated-doc commands, and package metadata changes |
-| `AGENTS.md`, `**/AGENTS.md`, `**/Cargo.toml`, `**/package.json`, `.github/workflows/**` | Repository root | AGENTS routing drift control below plus `git diff --check` | This row is additive; also run the owning project profile when build configuration or behavior changes |
-
-## Specialized gates
-
-### Runtime ownership and blocking
-
-If production changes touch `tokio::spawn`, `JoinSet`, `std::thread`, runtime creation, `block_on`,
-`spawn_blocking`, scheduler loops, shutdown paths, `TaskGroup`, `ScheduledTaskGroup`, `RuntimeOwner`,
-`ServiceContext`, or `BlockingExecutor`, run:
-
-```powershell
-.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline
-```
-
-On Unix, run the same PowerShell script with PowerShell 7 (`pwsh`). `scripts/runtime-audit.sh` is reporting-only
-and is not an equivalent enforcing gate.
-
-Treat changes to `scripts/runtime-audit-baseline.json` as architecture changes: explain the ownership decision,
-keep the baseline update scoped, and rerun the enforcing command.
-
-### Typed error architecture
-
-If changes touch `rocketmq-error`, public error mapping, remoting/gRPC/HTTP/CLI exits,
-retry/severity/redaction/observability metadata, or sensitive debug fields, run the platform-appropriate guard:
-
-```powershell
-.\scripts\check-error-hygiene.ps1
-```
-
-```bash
-python scripts/error_architecture_guard.py
-```
-
-### Observability feature matrix
-
-If changes touch `rocketmq-observability`, telemetry feature flags, broker observability wiring, or relevant
-`Cargo.toml` feature definitions, run the affected subset of `.github/workflows/rocketmq-rust-ci.yaml`. Cover the
-applicable `cargo check`, Clippy, and `cargo test -p rocketmq-observability` combinations for `observability`,
-`otlp-metrics`, `otel-metrics,prometheus`, `otlp-traces`, `otlp-logs`, and combined OTLP/Prometheus features.
-
-### RocksDB store feature
-
-If changes touch `rocksdb_store` behavior in `rocketmq-store` or `rocketmq-broker`, run:
-
-```bash
-cargo clippy -p rocketmq-store --features rocksdb_store --all-targets -- -D warnings
-cargo clippy -p rocketmq-broker --features rocksdb_store --all-targets -- -D warnings
-cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests
-cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests
-cargo test -p rocketmq-broker --features rocksdb_store rocksdb
-cargo test -p rocketmq-broker --features rocksdb_store pop_consumer
-```
-
-### RocketMQ MCP
-
-If changes touch `rocketmq-ai/rocketmq-mcp/`, its feature definitions, or a shared public API it consumes,
-run the mandatory profile in `rocketmq-ai/rocketmq-mcp/AGENTS.md` from the MCP project root.
-
-Preserve the MCP deny-by-default boundary: default tools remain read-only/diagnostic; `dangerous-tools` requires
-compile-time and runtime opt-in, confirmation, and audit; Streamable HTTP remains authenticated by default;
-stdio writes protocol frames only to stdout; and sensitive output remains sanitized.
-
-### RocketMQ MCP control
-
-If changes touch `rocketmq-ai/rocketmq-mcp-control/`, run the mandatory profile in its local `AGENTS.md` from
-the standalone project root. Preserve the isolated control boundary: HTTPS and OAuth are mandatory, the default
-build has no mutation adapter, `write-tools` contains only the mutation adapter, and no production mutation tool
-is registered until a separately reviewed operation implementation exists.
-
-## Testing policy
-
-- Prefer the smallest effective scope: named test, module test, package test, then broader integration tests.
-- Broaden tests when a change affects shared infrastructure, feature flags, public cross-crate APIs, wire/storage compatibility, or multiple crates.
-- Add regression coverage for bug fixes and externally visible coverage for new behavior.
-- Prefer whole-value or DTO equality when it has meaningful semantics instead of copying field-by-field assertions.
-- Do not add tests that only restate constants or negative tests for behavior that no longer exists.
-- Keep async/concurrency tests deterministic: prefer explicit synchronization or Tokio virtual time over
-  arbitrary sleeps, and avoid fixed ports or external network dependencies when practical.
-- For feature-gated behavior, test the exact changed feature set; `--all-features` alone may not exercise the same conditional compilation path.
-
-Examples:
-
-```bash
-cargo test -p rocketmq-model
-cargo test -p rocketmq-client-rust --lib
-cargo test -p rocketmq-transport some_test_name
-```
-
-## Shared code and cross-project validation
-
-If a shared crate changes, inspect standalone `Cargo.toml` path dependencies and validate every affected consumer. Common shared paths include:
-
-- `rocketmq-model`
-- `rocketmq-protocol`
-- `rocketmq-runtime`
-- `rocketmq-client`
-- `rocketmq-transport`
-- `rocketmq-macros`
-- `rocketmq-error`
-- `rocketmq-observability`
-- `rocketmq-dashboard/rocketmq-dashboard-common`
-- `rocketmq-tools/rocketmq-admin/rocketmq-admin-core`
-
-Changes to `rocketmq-broker`, `rocketmq-controller`, `rocketmq-protocol`, or `rocketmq-store-local` must also
-revalidate the standalone `fuzz/` project because those crates are direct path dependencies.
-
-Do not infer consumer scope from directory names alone; use the current manifests.
-
-## Documentation and generated artifacts
-
-- Changes under `rocketmq-website/` are website changes, not plain Markdown-only changes; follow `rocketmq-website/AGENTS.md`.
-- For public API or Rustdoc changes, run relevant doctests or `cargo doc` for the affected package when examples, links, or feature-gated items could break.
-- Do not commit build output, local logs, runtime audit artifacts under `target/`, coverage output, or Node build directories.
-- For paired Markdown/HTML reports, verify both outputs remain aligned with their source data or generator.
-
-## AGENTS routing drift control
-
-Run when changing project boundaries, validation commands, workflow routes, package manifests, routing scripts, the routing ADR, or any `AGENTS.md`.
-
-Windows PowerShell:
-
-```powershell
-.\scripts\check-agents-routing.ps1
-```
-
-Unix Bash:
-
-```bash
-bash ./scripts/check-agents-routing.sh
-```
-
-The PowerShell and Bash scripts are equivalent and must stay aligned. They verify required standalone routes,
-local instruction files, critical workflow presence, Node/Docusaurus projects, shared-code paths, and specialized
-guard commands. The design is documented in `rocketmq-doc/en/agents-routing-validation-adr.md`.
-
-## Project-local agent assets
-
-- Use `.agents/skills/rocketmq-rust-issue-generator/` when drafting or publishing GitHub issues.
-- Use `.agents/skills/rocketmq-rust-pr-submitter/` when preparing or publishing PR titles, commit messages, and PR bodies.
-- Use `.agents/skills/rust-doc-comment-generator/` for substantial Rustdoc/comment generation.
-- Use `.agents/skills/translate-it-doc-en-zh/` for English-to-Chinese technical documentation translation.
-- Keep duplicated `.agents/skills/**` and `.claude/skills/**` copies aligned.
-
-## Final response expectations
-
-- Summarize changed files and intent.
-- List every validation command run and its result.
-- If required validation was skipped or failed, explain why and identify the remaining risk.
-- Mention pre-existing unrelated worktree changes only when they matter to the task.
+- Use the relevant project skill for issue generation, PR preparation, substantial Rustdoc, or English-to-Chinese
+  translation under `.agents/skills/`. Read only the skill needed for the task; keep edited duplicate
+  `.agents/skills/**` and `.claude/skills/**` copies aligned.
+- Keep the final response concise: what changed, relevant validation results, and any material limitation.
+  Include command details needed to reproduce a failure; summarize routine successful checks.
+  Mention unrelated worktree changes only when they matter.

--- a/fuzz/AGENTS.md
+++ b/fuzz/AGENTS.md
@@ -3,7 +3,7 @@
 ## Scope
 
 This file owns the standalone `fuzz/` Cargo project. Root repository
-instructions remain cumulative.
+engineering rules apply; the local commands below replace the root validation fallback.
 
 ## Toolchain and targets
 
@@ -24,20 +24,24 @@ instructions remain cumulative.
   route. `.github/workflows/fuzz-ci.yml` owns short nightly and longer weekly
   execution, corpus/crash retention, and commit-bound evidence artifacts.
 
-## Validation
+## Development validation
 
-Run from `fuzz/`:
+When a harness or the interface/behavior it consumes changes, check that target with its matching feature.
+For example, from `fuzz/`:
+
+```bash
+cargo +nightly-2026-07-05 check --locked --bin protocol_decode --features protocol_decode
+```
+
+The other target/feature pairs have the same name: `raw_broker_config`, `controller_snapshot`,
+and `store_recovery_record`. A local internal edit in a path dependency does not automatically require
+every fuzz target to rebuild.
+
+For changes spanning the harness feature setup, or a fuzz integration task, use:
 
 ```bash
 cargo +nightly-2026-07-05 check --locked --all-targets --all-features
 ```
 
-When `Cargo.toml` or `Cargo.lock` changes, also run:
-
-```bash
-cargo audit --file Cargo.lock
-```
-
-Changes to the root path dependencies `rocketmq-broker`,
-`rocketmq-controller`, `rocketmq-protocol`, or `rocketmq-store-local` require
-the fixed-nightly build check.
+Choose `cargo audit --file Cargo.lock` for dependency/security review when relevant. Long fuzzing and
+CI evidence collection remain in the fuzz workflow, not the normal development completion condition.

--- a/rocketmq-ai/rocketmq-mcp-control/AGENTS.md
+++ b/rocketmq-ai/rocketmq-mcp-control/AGENTS.md
@@ -49,20 +49,17 @@ This file applies to `rocketmq-ai/rocketmq-mcp-control/`.
   its own durable audit pair.
 - Prefer native async trait methods where object safety is not required; do not add `async_trait`.
 
-## Mandatory validation
+## Development validation
 
-Run from this directory with `INSTA_UPDATE=no` and `RUST_MIN_STACK` unset:
+From this directory, keep `INSTA_UPDATE=no` and `RUST_MIN_STACK` unset when running tests.
+Use `cargo fmt --all -- --check`, `cargo check --locked` and focused `cargo test --locked <test_name>`
+cases for changed behavior; a relevant test build can replace the separate compile check.
 
-```bash
-cargo fmt --all -- --check
-cargo check --locked
-cargo check --locked --features write-tools
-python scripts/check_control_boundary.py
-cargo test --locked
-cargo test --locked --features write-tools
-cargo clippy --locked --all-targets --all-features -- -D warnings
-cargo doc --locked --no-deps --all-features
-```
+Run `python scripts/check_control_boundary.py` when the mutation adapter, registered operations,
+authorization, audit, redaction, or dependency boundary changes. Include `--features write-tools`
+for changes to the adapter and verify the default no-mutation-dependency behavior when feature wiring changes.
+Snapshots that specify protocol behavior must be reviewed when intentionally changed, not blindly updated.
 
-Also run the repository AGENTS routing guard, the query MCP read-only boundary and contract snapshot checks, and
-the root strict Clippy profile required by the root `AGENTS.md` before final handoff.
+For control-service integration, select the broader default/write-tools suites, Clippy, or Rustdoc
+checks required by that scope. Do not automatically add query MCP snapshots or root strict Clippy;
+validate those consumers only when the change actually affects them.

--- a/rocketmq-ai/rocketmq-mcp/AGENTS.md
+++ b/rocketmq-ai/rocketmq-mcp/AGENTS.md
@@ -14,16 +14,16 @@ This file applies to `rocketmq-ai/rocketmq-mcp/`.
 - Tool and Resource output must use the shared authorization, audit, correlation, sanitization, row, and byte policy.
 - Prefer native async fn methods in traits. #[allow(async_fn_in_trait)] is permitted when required by the lint for an intentional public async trait API; do not add #[async_trait].
 
-## Mandatory validation
+## Development validation
 
-Run from this directory:
+From this directory, use `cargo fmt --all -- --check`, `cargo check --locked`,
+and focused `cargo test --locked <test_name>` cases for the changed behavior.
+A test build may replace the separate compile check.
 
-```bash
-cargo fmt --all -- --check
-cargo check --locked
-python scripts/check_read_only_boundary.py
-cargo test --locked
-cargo test --locked --all-features
-cargo clippy --locked --all-targets --features streamable-http -- -D warnings
-cargo doc --locked --no-deps
-```
+Run `python scripts/check_read_only_boundary.py` when tools, resources, authorization, adapter
+dependencies, or feature boundaries change. Test the affected transport/feature combination;
+changes spanning default and HTTP behavior need coverage of both.
+
+For MCP integration, select broader tests, `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`,
+or `cargo doc --locked --no-deps` as relevant. Do not automatically stack root workspace checks or
+run all features for an internal fix.

--- a/rocketmq-ai/rocketmq-sre/AGENTS.md
+++ b/rocketmq-ai/rocketmq-sre/AGENTS.md
@@ -27,19 +27,23 @@ repository instructions also apply unless this file is more specific.
 - Do not expose credentials, message bodies, access tokens, TLS material, or
   full configuration values through logs, evidence, diagnostics, or errors.
 
-## Validation
+## Development validation
 
-Run from this directory:
+Choose the changed member(s) from this standalone workspace rather than running the entire workspace:
 
 ```powershell
-cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check
-cargo check --locked --workspace
-cargo test --locked --workspace --all-features
-cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
-cargo doc --locked --workspace --no-deps
-python scripts/check_source_layout.py
-python scripts/check_execution_dependency_boundary.py
+cargo fmt -p <package> -- --check
+cargo check --locked -p <package>
+cargo test --locked -p <package> <test_name>
 ```
+
+A focused test build may replace the compile check. Select package Clippy and affected features when useful.
+Run `python scripts/check_source_layout.py` for module-layout changes, and
+`python scripts/check_execution_dependency_boundary.py` when execution boundaries or dependencies change.
+
+Shared contract/feature changes need their affected members or direct consumers. Whole-workspace
+tests, all features, and Rustdoc are integration/CI choices, not a default for every local handoff.
+The UI and TypeScript SDK use their own local guides without accumulating this Cargo profile.
 
 Schema artifacts are generated deliberately, not as part of a normal build:
 

--- a/rocketmq-ai/rocketmq-sre/sdk/typescript/AGENTS.md
+++ b/rocketmq-ai/rocketmq-sre/sdk/typescript/AGENTS.md
@@ -20,12 +20,9 @@ more specific.
 
 ## Validation
 
-Run from this directory:
-
-```powershell
-npm ci
-npm test
-```
+From this directory, run `npm test` for SDK behavior/type changes. Reuse installed dependencies;
+run `npm ci` only when dependencies are missing or the lockfile changes. Instruction-only edits
+do not need a Node build. This package does not inherit the parent SRE Cargo validation profile.
 
 Build output under `dist/` and dependencies under `node_modules/` are local
 artifacts and must not be committed.

--- a/rocketmq-ai/rocketmq-sre/ui/AGENTS.md
+++ b/rocketmq-ai/rocketmq-sre/ui/AGENTS.md
@@ -20,14 +20,15 @@ This file applies to `rocketmq-ai/rocketmq-sre/ui/`.
 - Never display credentials, tokens, message bodies, ACL/TLS material, or whole configurations.
 - Do not commit `dist/`, logs, or local environment files.
 
-## Validation
+## Development validation
 
-Run from this directory:
+Reuse installed dependencies; run `npm ci` only when missing or when the lockfile changes.
+Select checks for the actual change from this directory:
 
-```bash
-npm ci
-npm run check:api
-npm run lint
-npm run test -- --run
-npm run build
-```
+- `npm run check:api` for OpenAPI or API-client changes.
+- `npm run lint` for changed frontend code.
+- `npm run test -- --run` with the relevant existing test filter for behavior changes.
+- `npm run build` for TypeScript, routes, shared UI, or build configuration changes.
+
+The full list belongs to broad frontend integration/CI, not every small edit. Instruction-only changes
+need only document checks. Preserve the Control Plane and sensitive-data boundaries above.

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md
@@ -23,8 +23,8 @@
 - Keep GPUI-specific rendering, window behavior, event handling, and view state in this project.
 - Put reusable Dashboard models, client contracts, and UI-independent service logic in
   `../rocketmq-dashboard-common/` when practical; do not duplicate shared domain behavior in views.
-- The direct repository path dependencies are `rocketmq-dashboard-common` and `rocketmq-observability`. A change
-  to either must follow the root instructions for that crate and must revalidate this standalone consumer.
+- The direct repository path dependencies are `rocketmq-dashboard-common` and `rocketmq-observability`.
+  Revalidate this consumer when their API, features, or shared behavior changes affect it.
 - Changes to shared RocketMQ crates consumed through those dependencies may also require GPUI revalidation. Use
   the current manifests and the root shared-code rules to determine the actual consumer scope.
 - Do not modify the Tauri or Web Dashboard implementations merely to mirror a GPUI change unless the user asks
@@ -75,8 +75,7 @@ cargo test test_name
 cargo test --bin rocketmq-dashboard-gpui test_name
 ```
 
-- Run `cargo test` when behavior is broad, shared state changes, startup/shutdown changes, or the final validation
-  profile requires it.
+- Select broader tests when shared state or startup/shutdown changes affect multiple behaviors.
 - For visual, focus, input, window, or platform behavior that automated tests cannot prove, perform a manual
   `cargo run` smoke test on a supported graphical environment and report the platform and scenarios checked.
 
@@ -84,15 +83,17 @@ cargo test --bin rocketmq-dashboard-gpui test_name
 
 Run all commands from `rocketmq-dashboard/rocketmq-dashboard-gpui/`.
 
-Before PR submission or final handoff for Rust code, manifest, build-script, or dependency changes, run the full
-project profile used by `.github/workflows/dashboard-gpui-ci.yml`:
+For routine changes, format intended files, compile the affected target, and select relevant behavior tests:
 
 ```bash
 cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo check --all-targets --all-features
-cargo test
+cargo check
+cargo test test_name
 ```
+
+A relevant test build can replace `cargo check`. Use `cargo clippy --no-deps -- -D warnings`
+when useful; add targets/features only when affected. The complete profile in
+`.github/workflows/dashboard-gpui-ci.yml` belongs to CI or a platform integration task, not every handoff.
 
 On Linux, compilation requires the native UI/build dependencies used by CI:
 
@@ -102,8 +103,8 @@ sudo apt-get install clang cmake make ninja-build pkg-config protobuf-compiler \
   libxkbcommon-dev libxkbcommon-x11-dev
 ```
 
-- GUI execution is not a substitute for the non-interactive validation profile, and the validation profile does
-  not replace a manual smoke test when the change is inherently visual or OS-specific.
+- For visual or OS-specific changes, add the focused graphical smoke test needed to verify that behavior.
+  If the required platform is unavailable, report the untested scenario and continue independent work.
 
 ## Build script and generated artifacts
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md
@@ -9,12 +9,10 @@ This file applies to `rocketmq-dashboard/rocketmq-dashboard-tauri/`.
 - Rust backend code is validated in `src-tauri/`.
 
 ## Frontend validation
-Before PR submission or final handoff for frontend changes, run from this directory:
 
-```bash
-npm ci
-npm run build
-```
+From this directory, run `npm run build` for frontend code or build changes.
+Reuse installed dependencies; run `npm ci` only when dependencies are missing or the lockfile changes.
+Instruction-only edits do not require frontend or Rust builds.
 
 ## Frontend test policy
 - Run only the affected frontend validation by default.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/AGENTS.md
@@ -7,13 +7,12 @@ This file applies to `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/`.
 - This is a standalone Rust Cargo project.
 - Do not rely on root workspace validation for this directory.
 
-## Mandatory validation
-Run from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` before PR submission or final handoff for Rust code changes:
+## Development validation
 
-```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-```
+From this standalone Cargo root, use `cargo fmt --all -- --check` and `cargo check`,
+plus focused tests for changed behavior. A relevant test build can replace the separate compile check.
+Select `cargo clippy --no-deps -- -D warnings` when useful; add only affected features/targets.
+Full-suite validation belongs to the corresponding integration or CI task.
 
 ## Test policy
 - Run only the affected tests by default.
@@ -28,4 +27,5 @@ cargo test
 ```
 
 ## Cross-project rule
-If shared Rust crates referenced by this project are modified, validate those shared crates in the repository root as needed.
+Validate shared crates and this consumer when their API, feature, or behavior changes affect it;
+local internal changes do not automatically add other standalone profiles.

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md
@@ -14,16 +14,11 @@ This file applies to `rocketmq-dashboard/rocketmq-dashboard-web/backend/`.
 - Keep Axum handlers thin; put orchestration in services and reusable logic in common.
 - Prefer explicit error mapping through the local dashboard error and API response model.
 
-## Validation
-Run from this directory before PR submission or final handoff for Rust code changes:
+## Development validation
 
-```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-```
+From this directory, use `cargo fmt --all -- --check` and `cargo check` for the affected code;
+run a focused `cargo test <test_name>` for behavior changes. Tests that compile the changed target
+can replace the separate check.
 
-For compile-scope backend changes, also run:
-
-```bash
-cargo build --all-targets --all-features
-```
+Use `cargo clippy --no-deps -- -D warnings` and additional features/targets when relevant.
+Full-target/all-feature builds belong to backend integration or CI, not every local handoff.

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md
@@ -25,18 +25,14 @@ This file applies to `rocketmq-dashboard/rocketmq-dashboard-web/frontend/`.
 - Preserve Java Dashboard operational flows where practical: Topic, Consumer, Producer, Broker/Cluster, Message, DLQMessage, MessageTrace, Proxy, OPS, and ACL.
 - Do not copy the old Java visual style directly.
 
-## Validation
-Run from this directory before PR submission or final handoff for frontend changes:
+## Development validation
 
-```bash
-npm ci
-npm run build
-```
-
-For iteration when dependencies are already installed:
+Reuse installed dependencies. Run `npm ci` only when dependencies are missing or the lockfile changes.
+For changes to rendered content, TypeScript, routes, or build configuration, run from this directory:
 
 ```bash
 npm run build
 ```
 
+Select existing focused tests for behavior changes. Instruction-only edits do not require a Node build.
 After significant UI changes, inspect the local app in the in-app browser when a dev server is available.

--- a/rocketmq-doc/en/agent-validation-reference.md
+++ b/rocketmq-doc/en/agent-validation-reference.md
@@ -1,0 +1,99 @@
+# Agent validation reference
+
+Read this file when a change needs specialist or integration evidence. These are selectable tools,
+not cumulative development gates. Routine checks and the stopping rule live in the root
+[AGENTS.md](../../AGENTS.md); standalone project commands live in their nearest local guides.
+
+Choose checks for the actual behavior, targets, and features being changed. Reuse a passing test or
+Clippy build as compilation evidence. Do not rerun equivalent checks or sweep unrelated historical
+findings solely because a task reaches final handoff or PR preparation.
+
+## Root workspace integration
+
+For broad workspace or feature integration, run from the repository root:
+
+```bash
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+```
+
+Format-check only the affected packages with `cargo fmt -p <package> -- --check`.
+Select relevant package tests; all features do not replace default/no-feature coverage.
+
+Standalone projects remain outside this command. Inspect their manifests and validate consumers whose
+API, feature, wire/storage contract, or shared behavior is affected. Common shared crates include model,
+protocol, runtime, client, transport, macros, error, observability, dashboard-common, and admin-core.
+Dependency membership alone does not require every consumer or fuzz harness to rebuild for an internal edit.
+
+## Runtime ownership and blocking
+
+For lifecycle changes, start with focused cancellation, shutdown, resource cleanup, and blocking-boundary
+tests. If a repository-wide runtime inventory helps the task, use the reporting mode:
+
+```powershell
+.\scripts\runtime-audit.ps1 -SkipBaseline
+```
+
+PowerShell 7 can run the same script on Unix. `scripts/runtime-audit.sh` is also reporting-only.
+Historical boundary baselines are optional audit inputs, not local completion gates.
+Explain new ownership boundaries and keep production tasks owned and awaited.
+
+## Typed errors and sensitive output
+
+For changes to public error mapping, retry/severity metadata, redaction, or cross-boundary errors,
+run focused behavior tests. Use the architecture guard when the change spans error-policy boundaries:
+
+```powershell
+.\scripts\check-error-hygiene.ps1
+```
+
+```bash
+python scripts/error_architecture_guard.py
+```
+
+Choose the platform-appropriate command. Report unrelated findings without turning a local fix into
+a repository-wide error cleanup.
+
+## Observability features
+
+Select the affected `cargo check`, Clippy, and `cargo test -p rocketmq-observability` combinations
+from `.github/workflows/rocketmq-rust-ci.yaml`. Relevant combinations include `observability`,
+`otlp-metrics`, `otel-metrics,prometheus`, `otlp-traces`, `otlp-logs`, and combined OTLP/Prometheus.
+Run the complete matrix for feature-wide integration, not an unrelated internal edit.
+
+## RocksDB store
+
+For `rocksdb_store` behavior, select the relevant store/broker commands:
+
+```bash
+cargo clippy -p rocketmq-store --features rocksdb_store --all-targets -- -D warnings
+cargo clippy -p rocketmq-broker --features rocksdb_store --all-targets -- -D warnings
+cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests
+cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests
+cargo test -p rocketmq-broker --features rocksdb_store rocksdb
+cargo test -p rocketmq-broker --features rocksdb_store pop_consumer
+```
+
+Run the full set when the change spans those behaviors or the task calls for store integration.
+
+## Standalone boundaries and CI routing
+
+Consult local AGENTS files for MCP read-only/authentication behavior, MCP-control mutation/audit policy,
+SRE execution boundaries, dashboard projects, examples, and fuzz harnesses. Focused boundary checks stay
+appropriate for changes to those contracts; full suites are integration choices.
+
+For a workflow dependency-trigger review, the separate metadata guard is available:
+
+```bash
+python scripts/standalone_workspace_trigger_guard.py --repo-root .
+```
+
+This guard invokes Cargo metadata and can require the standalone projects' toolchains and dependency
+resolution. It is deliberately not called by the lightweight AGENTS routing scripts.
+Use the existing workflow definitions as the source for full CI commands and platform dependencies.
+
+## Documentation and evidence
+
+Run doctests or `cargo doc -p <package> --no-deps` when changed executable examples, links, or
+feature-gated public items need validation. Website content follows the Docusaurus project's guide.
+Keep paired Markdown/HTML reports aligned. Record the commands and meaningful results without requiring
+SHA/hash/fingerprint matching, clean-worktree checks, or a separate evidence package for routine work.

--- a/rocketmq-doc/en/agents-routing-validation-adr.md
+++ b/rocketmq-doc/en/agents-routing-validation-adr.md
@@ -1,78 +1,47 @@
 # ADR: AGENTS Routing Validation
 
 ## Status
-Accepted
+
+Accepted; revised 2026-09-08 for scoped development validation.
 
 ## Context
-The RocketMQ Rust repository is broader than the root Cargo workspace. The root `Cargo.toml` owns the main workspace members, while several projects are intentionally standalone:
 
-- `rocketmq-example/`
-- `rocketmq-ai/rocketmq-mcp/`
-- `rocketmq-ai/rocketmq-mcp-control/`
-- `rocketmq-ai/rocketmq-sre/`
-- `rocketmq-dashboard/rocketmq-dashboard-gpui/`
-- `rocketmq-dashboard/rocketmq-dashboard-tauri/`
-- `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/`
-- `rocketmq-dashboard/rocketmq-dashboard-web/`
-- `rocketmq-dashboard/rocketmq-dashboard-web/backend/`
-- `rocketmq-dashboard/rocketmq-dashboard-web/frontend/`
-- `rocketmq-website/`
+The root `Cargo.toml` owns the main workspace. Standalone Cargo, Node, and Docusaurus projects
+have different commands and platform requirements. Agents need reliable ownership routes without
+automatically running every project, feature matrix, or historical architecture check.
 
-Root workspace commands such as `cargo fmt --all -- --check` and `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` do not validate all standalone Rust, Node/Vite, or Docusaurus projects. The repository also has specialized quality gates for runtime ownership, typed error architecture, observability feature combinations, RocksDB store behavior, and the feature/security boundary of the standalone `rocketmq-mcp` crate.
-
-Without an explicit routing model, agents can incorrectly treat the root Cargo workspace as the whole repository or skip project-specific validation after touching shared crates.
+Checking exact AGENTS sentences and command strings coupled the routing scripts to policy wording.
+Invoking dependency metadata from a routing check also introduced Cargo/toolchain work for instruction
+edits. Neither is needed to determine where a project belongs.
 
 ## Decision
-Use root `AGENTS.md` as the repository-level validation router.
 
-The root file must:
+Root `AGENTS.md` provides common engineering rules and one project map. The nearest local guide
+selects project-specific checks and replaces the root validation fallback. It does not stack complete
+root, local, and specialized profiles.
 
-- Identify the root workspace source of truth as the root `Cargo.toml`.
-- Route standalone Cargo, Node/Vite, Web Dashboard, Tauri, and Docusaurus work to the nearest project `AGENTS.md`.
-- Treat validation routes as cumulative: a manifest, shared crate, or cross-boundary change may require the root profile, a project-local profile, and one or more specialized gates.
-- List one canonical, non-mutating final format/Clippy profile for root workspace changes and a fallback profile for standalone Cargo projects.
-- Define when to run specialized guards and route `rocketmq-mcp` and the isolated `rocketmq-mcp-control`
-  foundation to their local validation profiles.
-- Require `scripts/check-agents-routing.ps1` on Windows or `scripts/check-agents-routing.sh` on Unix when project boundaries, validation commands, workflow routes, package manifests, either routing script, this ADR, or any `AGENTS.md` changes.
+For normal development, validate compilation, formatting, and relevant behavior in the affected scope.
+After those checks pass, finish unless new edits, failures, or a concrete unresolved risk justify more
+work. Shared changes require relevant consumers, selected from actual API, feature, and behavior impact.
 
-Add `rocketmq-website/AGENTS.md` so the Docusaurus website has a local validation contract.
+Keep specialist and integration commands in [the validation reference](agent-validation-reference.md).
+Full-workspace checks, dependency metadata audits, and long-running suites belong to the corresponding
+integration, CI, or release task. Instruction changes do not by themselves require Cargo or Node builds.
+Routine development does not require SHA, fingerprints, a clean worktree, or historical baseline closure.
 
-Add `scripts/check-agents-routing.ps1` and `scripts/check-agents-routing.sh` as lightweight drift checks. The scripts validate that:
+The equivalent `scripts/check-agents-routing.ps1` and `scripts/check-agents-routing.sh` check only:
 
-- Root `AGENTS.md` mentions all required standalone routes.
-- Every standalone Cargo project with its own `[workspace]` has a same-directory `AGENTS.md`.
-- Every discovered `package.json` project has a same-directory `AGENTS.md`.
-- Required workflow files exist and their project routes are represented in root `AGENTS.md`.
-- The shared-code list, cumulative validation policy, and specialized guard commands remain discoverable.
-- The `rocketmq-mcp` and `rocketmq-mcp-control` paths remain present in root guidance, while their exact
-  validation commands remain in their local `AGENTS.md` files.
+- Known standalone project routes and their local instruction files.
+- Discovered standalone Cargo projects with an explicit `[workspace]` and their root/local routes.
+- Discovered `package.json` projects and their root/local routes.
+- Required workflow files and the routing/reference documents.
 
-## Alternatives
-### Only Expand Root AGENTS.md
-This is simpler, but it leaves no automated signal when a new standalone project, `package.json`, workflow path, or shared validation route is added.
+The scripts do not enforce AGENTS wording, exact command profiles, workflow step contents, or dependency
+trigger closure. They do not invoke Python, Cargo metadata, builds, tests, or architecture baseline checks.
+The standalone metadata guard remains available as an explicit integration tool.
 
-### Rely Only on GitHub Actions
-CI validates pull requests but does not help agents choose the right local command before finishing work. It also does not explain routing intent or standalone project boundaries.
-
-### Duplicate Full Instructions Everywhere
-Copying root validation details into every subproject increases drift risk. The chosen model keeps root routing centralized and leaves project-specific details in nearest `AGENTS.md` files.
-
-## Consequences
-Benefits:
-
-- Agents can determine validation scope from path ownership instead of guessing.
-- Standalone project coverage becomes visible and checkable.
-- New project boundaries require an explicit AGENTS update.
-- Runtime, typed error, observability, RocksDB, and `rocketmq-mcp` security/feature guardrails are discoverable from the root workflow.
-
-Costs:
-
-- `scripts/check-agents-routing.ps1` and `scripts/check-agents-routing.sh` must be updated together when intentional validation topology changes.
-- The check is structural. It cannot prove every command is sufficient for every code change or that workflow path filters cover every shared path dependency.
-- CI remains the final cross-platform authority for Linux, macOS, Windows, and Node version behavior.
-
-## Validation
-Run from the repository root before PR submission or final handoff when changes touch project boundaries, validation commands, workflow routes, package manifests, either routing script, this ADR, or any `AGENTS.md`:
+Run the lightweight router after changing project layout, AGENTS routing, or either routing script.
+Use the appropriate platform command, plus `git diff --check`:
 
 ```powershell
 .\scripts\check-agents-routing.ps1
@@ -84,4 +53,16 @@ bash ./scripts/check-agents-routing.sh
 git diff --check
 ```
 
-Rust or Node validation is still required when the changed files affect Rust code, generated Rust, build configuration, examples, frontend behavior, website behavior, or documented commands that need verification.
+When editing the router, use `python -m unittest discover -s scripts/tests -p test_agents_routing.py`
+to exercise both available shells against temporary repositories. On Windows, set `AGENTS_TEST_BASH`
+to Git Bash's executable if the default `bash` is a WSL launcher; `AGENTS_TEST_PWSH` can select PowerShell.
+
+## Consequences
+
+Project ownership remains visible and missing instruction files are caught without native build setup.
+Local work can finish with evidence proportional to the change. Security, compatibility, unsafe-code,
+and task-lifecycle contracts still apply; simplifying development gates does not relax product boundaries.
+
+Both routing implementations must stay aligned when project topology changes. Structural checks cannot
+prove test adequacy or complete workflow path filters; use the separate integration tools when reviewing
+those properties. Existing workflow definitions are unchanged by this policy.

--- a/rocketmq-example/AGENTS.md
+++ b/rocketmq-example/AGENTS.md
@@ -7,13 +7,17 @@ This file applies to `rocketmq-example/`.
 - This is a standalone Cargo project.
 - Do not rely on root workspace validation for this directory.
 
-## Mandatory validation
-Run from `rocketmq-example/` before PR submission or final handoff for Rust code changes:
+## Development validation
+
+From this standalone root, format intended files and compile/test only the affected example:
 
 ```bash
 cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
+cargo check --example example_name
 ```
+
+Use `cargo test some_test_name` for changed testable behavior. Add package Clippy when useful;
+all-target builds and running every example are integration choices, not routine handoff requirements.
 
 ## Test policy
 - Run only the affected tests or examples by default.

--- a/rocketmq-website/AGENTS.md
+++ b/rocketmq-website/AGENTS.md
@@ -12,18 +12,15 @@ This file applies to `rocketmq-website/`.
 - Keep website changes scoped to `rocketmq-website/` unless the user explicitly asks to update source docs, workflows, or shared repository instructions.
 - Do not commit generated Docusaurus build output.
 
-## Validation
-Run from `rocketmq-website/` before PR submission or final handoff for website changes:
+## Development validation
 
-```bash
-npm ci
-npm run build
-```
-
-For iteration when dependencies are already installed:
+Reuse installed dependencies. Run `npm ci` only when dependencies are missing or the lockfile changes.
+For changes to rendered content, TypeScript, routes, or build configuration, run from this directory:
 
 ```bash
 npm run build
 ```
 
-Documentation-only changes outside this directory do not require website validation. Changes inside this directory should be treated as website changes because Docusaurus routing, navigation, MDX rendering, and build configuration can fail independently of Cargo.
+Select existing focused tests for behavior changes. Instruction-only edits do not require a Node build.
+Documentation-only changes outside this directory do not require website validation. Website content uses
+Docusaurus routing and MDX, so validate relevant rendered pages and build output when they change.

--- a/scripts/check-agents-routing.ps1
+++ b/scripts/check-agents-routing.ps1
@@ -49,12 +49,12 @@ function Read-RepositoryText {
         Add-Failure "Missing required file: $RelativePath"
         return ""
     }
-    return Get-Content -LiteralPath $path -Raw -Encoding UTF8
+    return [string](Get-Content -LiteralPath $path -Raw -Encoding UTF8)
 }
 
 function Test-TextContains {
     param(
-        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text,
         [Parameter(Mandatory = $true)][string]$Needle
     )
 
@@ -63,7 +63,7 @@ function Test-TextContains {
 
 function Assert-TextContains {
     param(
-        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text,
         [Parameter(Mandatory = $true)][string]$Needle,
         [Parameter(Mandatory = $true)][string]$Context
     )
@@ -108,8 +108,6 @@ function Assert-SameDirectoryAgents {
 }
 
 $rootAgentsText = Read-RepositoryText -RelativePath "AGENTS.md"
-$mcpAgentsText = Read-RepositoryText -RelativePath "rocketmq-ai/rocketmq-mcp/AGENTS.md"
-$mcpControlAgentsText = Read-RepositoryText -RelativePath "rocketmq-ai/rocketmq-mcp-control/AGENTS.md"
 
 $requiredRoutePaths = @(
     "fuzz/",
@@ -117,6 +115,9 @@ $requiredRoutePaths = @(
     "rocketmq-ai/rocketmq-mcp/",
     "rocketmq-ai/rocketmq-mcp-control/",
     "rocketmq-ai/rocketmq-sre/",
+    "rocketmq-ai/rocketmq-sre/ui/",
+    "rocketmq-ai/rocketmq-sre/sdk/typescript/",
+    "rocketmq-macros/tests/fixtures/renamed-consumer/",
     "rocketmq-dashboard/rocketmq-dashboard-gpui/",
     "rocketmq-dashboard/rocketmq-dashboard-tauri/",
     "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/",
@@ -126,83 +127,11 @@ $requiredRoutePaths = @(
     "rocketmq-website/"
 )
 
+# Check routing structure, not wording or complete command profiles.
 foreach ($routePath in $requiredRoutePaths) {
     Assert-TextContains -Text $rootAgentsText -Needle $routePath -Context "Root AGENTS.md"
-}
-
-$requiredMcpCommands = @(
-    "cargo check --locked",
-    "python scripts/check_read_only_boundary.py",
-    "cargo test --locked",
-    "cargo clippy --locked --all-targets --features streamable-http -- -D warnings",
-    "cargo doc --locked --no-deps"
-)
-
-$requiredRootTerms = @(
-    'root `Cargo.toml`',
-    "cargo fmt --all -- --check",
-    "cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings",
-    "cargo clippy --all-targets --all-features -- -D warnings",
-    ".\scripts\check-agents-routing.ps1",
-    "./scripts/check-agents-routing.sh",
-    ".\scripts\runtime-audit.ps1 -SkipBaseline",
-    ".\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline",
-    ".\scripts\check-error-hygiene.ps1",
-    "python scripts/error_architecture_guard.py",
-    "rocksdb_store",
-    "otlp-metrics",
-    "Validation routes are cumulative",
-    "rocketmq-ai/rocketmq-mcp/",
-    "rocketmq-doc/en/agents-routing-validation-adr.md"
-)
-
-foreach ($term in $requiredRootTerms) {
-    Assert-TextContains -Text $rootAgentsText -Needle $term -Context "Root AGENTS.md"
-}
-
-foreach ($command in $requiredMcpCommands) {
-    Assert-TextContains -Text $mcpAgentsText -Needle $command -Context "rocketmq-mcp AGENTS.md validation"
-}
-
-foreach ($command in @("cargo check --locked", "python scripts/check_control_boundary.py", "cargo test --locked", "cargo clippy --locked --all-targets --all-features -- -D warnings")) {
-    Assert-TextContains -Text $mcpControlAgentsText -Needle $command -Context "rocketmq-mcp-control AGENTS.md validation"
-}
-
-$requiredSharedPaths = @(
-    "rocketmq-model",
-    "rocketmq-protocol",
-    "rocketmq-runtime",
-    "rocketmq-client",
-    "rocketmq-transport",
-    "rocketmq-macros",
-    "rocketmq-error",
-    "rocketmq-observability",
-    "rocketmq-dashboard/rocketmq-dashboard-common",
-    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core"
-)
-
-foreach ($sharedPath in $requiredSharedPaths) {
-    Assert-TextContains -Text $rootAgentsText -Needle $sharedPath -Context "Root AGENTS.md shared code rule"
-}
-
-$expectedProjectAgents = @(
-    "fuzz/AGENTS.md",
-    "rocketmq-example/AGENTS.md",
-    "rocketmq-ai/rocketmq-mcp/AGENTS.md",
-    "rocketmq-ai/rocketmq-mcp-control/AGENTS.md",
-    "rocketmq-ai/rocketmq-sre/AGENTS.md",
-    "rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md",
-    "rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md",
-    "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/AGENTS.md",
-    "rocketmq-dashboard/rocketmq-dashboard-web/AGENTS.md",
-    "rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md",
-    "rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md",
-    "rocketmq-website/AGENTS.md"
-)
-
-foreach ($agentsFile in $expectedProjectAgents) {
-    $path = Join-Path $script:RepoRoot $agentsFile
-    if (-not (Test-Path -LiteralPath $path)) {
+    $agentsFile = $routePath + "AGENTS.md"
+    if (-not (Test-Path -LiteralPath (Join-Path $script:RepoRoot $agentsFile) -PathType Leaf)) {
         Add-Failure "Missing project AGENTS file: $agentsFile"
     }
 }
@@ -233,96 +162,33 @@ foreach ($packageJson in Get-FilesByName -FileName "package.json") {
     Assert-TextContains -Text $rootAgentsText -Needle $relativeDirectory -Context "Root AGENTS.md Node project routing"
 }
 
-$workflowRoutes = [ordered]@{
-    ".github/workflows/rocketmq-rust-ci.yaml" = "Root workspace validation"
-    ".github/workflows/fuzz-ci.yml" = "fuzz/"
-    ".github/workflows/rocketmq-example-ci.yaml" = "rocketmq-example/"
-    ".github/workflows/rocketmq-mcp-ci.yaml" = "rocketmq-ai/rocketmq-mcp/"
-    ".github/workflows/rocketmq-sre-ci.yml" = "rocketmq-ai/rocketmq-sre/"
-    ".github/workflows/dashboard-web-ci.yml" = "rocketmq-dashboard/rocketmq-dashboard-web/"
-    ".github/workflows/dashboard-tauri-ci.yml" = "rocketmq-dashboard/rocketmq-dashboard-tauri/"
-    ".github/workflows/website-check.yml" = "rocketmq-website/"
-    ".github/workflows/deploy.yml" = "rocketmq-website/"
-}
+$requiredWorkflows = @(
+    ".github/workflows/rocketmq-rust-ci.yaml",
+    ".github/workflows/fuzz-ci.yml",
+    ".github/workflows/rocketmq-example-ci.yaml",
+    ".github/workflows/rocketmq-mcp-ci.yaml",
+    ".github/workflows/rocketmq-sre-ci.yml",
+    ".github/workflows/dashboard-gpui-ci.yml",
+    ".github/workflows/dashboard-web-ci.yml",
+    ".github/workflows/dashboard-tauri-ci.yml",
+    ".github/workflows/website-check.yml",
+    ".github/workflows/deploy.yml"
+)
 
-foreach ($entry in $workflowRoutes.GetEnumerator()) {
-    $workflowPath = Join-Path $script:RepoRoot $entry.Key
-    if (-not (Test-Path -LiteralPath $workflowPath)) {
-        Add-Failure "Missing required workflow: $($entry.Key)"
-        continue
-    }
-    Assert-TextContains -Text $rootAgentsText -Needle $entry.Value -Context "Root AGENTS.md workflow routing for $($entry.Key)"
-}
-
-$mcpWorkflowPath = Join-Path $script:RepoRoot ".github/workflows/rocketmq-mcp-ci.yaml"
-if (Test-Path -LiteralPath $mcpWorkflowPath) {
-    $mcpWorkflowText = Get-Content -LiteralPath $mcpWorkflowPath -Raw -Encoding UTF8
-    foreach ($command in $requiredMcpCommands) {
-        Assert-TextContains -Text $mcpWorkflowText -Needle $command -Context "Standalone rocketmq-mcp CI validation"
-    }
-    foreach ($triggerPath in @(
-        "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/**",
-        "rocketmq-auth/**",
-        "rocketmq-client/**",
-        "rocketmq-error/**",
-        "rocketmq-macros/**",
-        "rocketmq-model/**",
-        "rocketmq-observability/**",
-        "rocketmq-protocol/**",
-        "rocketmq-runtime/**",
-        "rocketmq-security-api/**",
-        "rocketmq-transport/**",
-        "Cargo.toml",
-        "Cargo.lock",
-        "rust-toolchain.toml"
-    )) {
-        Assert-TextContains -Text $mcpWorkflowText -Needle $triggerPath -Context "Standalone rocketmq-mcp CI consumer trigger"
+foreach ($workflow in $requiredWorkflows) {
+    if (-not (Test-Path -LiteralPath (Join-Path $script:RepoRoot $workflow) -PathType Leaf)) {
+        Add-Failure "Missing required workflow: $workflow"
     }
 }
 
-$sreWorkflowPath = Join-Path $script:RepoRoot ".github/workflows/rocketmq-sre-ci.yml"
-if (Test-Path -LiteralPath $sreWorkflowPath) {
-    $sreWorkflowText = Get-Content -LiteralPath $sreWorkflowPath -Raw -Encoding UTF8
-    foreach ($triggerPath in @(
-        "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/**",
-        "rocketmq-ai/rocketmq-mcp/**",
-        "rocketmq-auth/**",
-        "rocketmq-client/**",
-        "rocketmq-error/**",
-        "rocketmq-macros/**",
-        "rocketmq-model/**",
-        "rocketmq-observability/**",
-        "rocketmq-protocol/**",
-        "rocketmq-runtime/**",
-        "rocketmq-security-api/**",
-        "rocketmq-transport/**"
-    )) {
-        Assert-TextContains -Text $sreWorkflowText -Needle $triggerPath -Context "Standalone rocketmq-sre CI consumer trigger"
+# Dependency/feature audits are separate integration checks; do not invoke Cargo metadata here.
+foreach ($document in @(
+    "rocketmq-doc/en/agents-routing-validation-adr.md",
+    "rocketmq-doc/en/agent-validation-reference.md"
+)) {
+    if (-not (Test-Path -LiteralPath (Join-Path $script:RepoRoot $document) -PathType Leaf)) {
+        Add-Failure "Missing validation reference: $document"
     }
-}
-
-$standaloneTriggerGuardPath = Join-Path $script:RepoRoot "scripts/standalone_workspace_trigger_guard.py"
-if (Test-Path -LiteralPath $standaloneTriggerGuardPath) {
-    if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
-        Add-Failure "Python is required for standalone workspace consumer-trigger validation"
-    }
-    else {
-        & python $standaloneTriggerGuardPath --repo-root $script:RepoRoot
-        if ($LASTEXITCODE -ne 0) {
-            Add-Failure "Standalone workspace metadata consumer-trigger validation failed"
-        }
-    }
-}
-
-$adrPath = Join-Path $script:RepoRoot "rocketmq-doc/en/agents-routing-validation-adr.md"
-if (Test-Path -LiteralPath $adrPath) {
-    $adrText = Get-Content -LiteralPath $adrPath -Raw -Encoding UTF8
-    foreach ($term in @("AGENTS.md", "check-agents-routing.ps1", "check-agents-routing.sh", 'root `Cargo.toml`', "standalone", "rocketmq-mcp", "rocketmq-mcp-control", "cumulative")) {
-        Assert-TextContains -Text $adrText -Needle $term -Context "AGENTS routing ADR"
-    }
-}
-else {
-    Add-Failure "Missing AGENTS routing ADR: rocketmq-doc/en/agents-routing-validation-adr.md"
 }
 
 if ($script:Failures.Count -gt 0) {

--- a/scripts/check-agents-routing.sh
+++ b/scripts/check-agents-routing.sh
@@ -33,19 +33,6 @@ repo_relative_path() {
   printf '%s\n' "${relative//\\//}"
 }
 
-read_repository_text() {
-  local relative_path="$1"
-  local path="$ROOT/$relative_path"
-
-  if [[ ! -f "$path" ]]; then
-    add_failure "Missing required file: $relative_path"
-    printf '\n'
-    return
-  fi
-
-  cat "$path"
-}
-
 text_contains() {
   local text="$1"
   local needle="$2"
@@ -81,9 +68,12 @@ assert_same_directory_agents() {
   fi
 }
 
-ROOT_AGENTS_TEXT="$(read_repository_text "AGENTS.md")"
-MCP_AGENTS_TEXT="$(read_repository_text "rocketmq-ai/rocketmq-mcp/AGENTS.md")"
-MCP_CONTROL_AGENTS_TEXT="$(read_repository_text "rocketmq-ai/rocketmq-mcp-control/AGENTS.md")"
+ROOT_AGENTS_TEXT=""
+if [[ -f "$ROOT/AGENTS.md" ]]; then
+  ROOT_AGENTS_TEXT="$(cat "$ROOT/AGENTS.md")"
+else
+  add_failure "Missing required file: AGENTS.md"
+fi
 
 REQUIRED_ROUTE_PATHS=(
   "fuzz/"
@@ -91,6 +81,9 @@ REQUIRED_ROUTE_PATHS=(
   "rocketmq-ai/rocketmq-mcp/"
   "rocketmq-ai/rocketmq-mcp-control/"
   "rocketmq-ai/rocketmq-sre/"
+  "rocketmq-ai/rocketmq-sre/ui/"
+  "rocketmq-ai/rocketmq-sre/sdk/typescript/"
+  "rocketmq-macros/tests/fixtures/renamed-consumer/"
   "rocketmq-dashboard/rocketmq-dashboard-gpui/"
   "rocketmq-dashboard/rocketmq-dashboard-tauri/"
   "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/"
@@ -100,81 +93,10 @@ REQUIRED_ROUTE_PATHS=(
   "rocketmq-website/"
 )
 
+# Check routing structure, not wording or complete command profiles.
 for route_path in "${REQUIRED_ROUTE_PATHS[@]}"; do
   assert_text_contains "$ROOT_AGENTS_TEXT" "$route_path" "Root AGENTS.md"
-done
-
-REQUIRED_MCP_COMMANDS=(
-  "cargo check --locked"
-  "python scripts/check_read_only_boundary.py"
-  "cargo test --locked"
-  "cargo clippy --locked --all-targets --features streamable-http -- -D warnings"
-  "cargo doc --locked --no-deps"
-)
-
-REQUIRED_ROOT_TERMS=(
-  'root `Cargo.toml`'
-  "cargo fmt --all -- --check"
-  "cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings"
-  "cargo clippy --all-targets --all-features -- -D warnings"
-  ".\\scripts\\check-agents-routing.ps1"
-  "./scripts/check-agents-routing.sh"
-  ".\\scripts\\runtime-audit.ps1 -SkipBaseline"
-  ".\\scripts\\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline"
-  ".\\scripts\\check-error-hygiene.ps1"
-  "python scripts/error_architecture_guard.py"
-  "rocksdb_store"
-  "otlp-metrics"
-  "Validation routes are cumulative"
-  "rocketmq-ai/rocketmq-mcp/"
-  "rocketmq-doc/en/agents-routing-validation-adr.md"
-)
-
-for term in "${REQUIRED_ROOT_TERMS[@]}"; do
-  assert_text_contains "$ROOT_AGENTS_TEXT" "$term" "Root AGENTS.md"
-done
-
-for command in "${REQUIRED_MCP_COMMANDS[@]}"; do
-  assert_text_contains "$MCP_AGENTS_TEXT" "$command" "rocketmq-mcp AGENTS.md validation"
-done
-
-for command in "cargo check --locked" "python scripts/check_control_boundary.py" "cargo test --locked" "cargo clippy --locked --all-targets --all-features -- -D warnings"; do
-  assert_text_contains "$MCP_CONTROL_AGENTS_TEXT" "$command" "rocketmq-mcp-control AGENTS.md validation"
-done
-
-REQUIRED_SHARED_PATHS=(
-  "rocketmq-model"
-  "rocketmq-protocol"
-  "rocketmq-runtime"
-  "rocketmq-client"
-  "rocketmq-transport"
-  "rocketmq-macros"
-  "rocketmq-error"
-  "rocketmq-observability"
-  "rocketmq-dashboard/rocketmq-dashboard-common"
-  "rocketmq-tools/rocketmq-admin/rocketmq-admin-core"
-)
-
-for shared_path in "${REQUIRED_SHARED_PATHS[@]}"; do
-  assert_text_contains "$ROOT_AGENTS_TEXT" "$shared_path" "Root AGENTS.md shared code rule"
-done
-
-EXPECTED_PROJECT_AGENTS=(
-  "fuzz/AGENTS.md"
-  "rocketmq-example/AGENTS.md"
-  "rocketmq-ai/rocketmq-mcp/AGENTS.md"
-  "rocketmq-ai/rocketmq-mcp-control/AGENTS.md"
-  "rocketmq-ai/rocketmq-sre/AGENTS.md"
-  "rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md"
-  "rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md"
-  "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/AGENTS.md"
-  "rocketmq-dashboard/rocketmq-dashboard-web/AGENTS.md"
-  "rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md"
-  "rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md"
-  "rocketmq-website/AGENTS.md"
-)
-
-for agents_file in "${EXPECTED_PROJECT_AGENTS[@]}"; do
+  agents_file="${route_path}AGENTS.md"
   if [[ ! -f "$ROOT/$agents_file" ]]; then
     add_failure "Missing project AGENTS file: $agents_file"
   fi
@@ -205,92 +127,33 @@ while IFS= read -r package_json; do
   assert_text_contains "$ROOT_AGENTS_TEXT" "$relative_directory" "Root AGENTS.md Node project routing"
 done < <(find_files_by_name "package.json")
 
-WORKFLOW_PATHS=(
-  ".github/workflows/rocketmq-rust-ci.yaml|Root workspace validation"
-  ".github/workflows/fuzz-ci.yml|fuzz/"
-  ".github/workflows/rocketmq-example-ci.yaml|rocketmq-example/"
-  ".github/workflows/rocketmq-mcp-ci.yaml|rocketmq-ai/rocketmq-mcp/"
-  ".github/workflows/rocketmq-sre-ci.yml|rocketmq-ai/rocketmq-sre/"
-  ".github/workflows/dashboard-web-ci.yml|rocketmq-dashboard/rocketmq-dashboard-web/"
-  ".github/workflows/dashboard-tauri-ci.yml|rocketmq-dashboard/rocketmq-dashboard-tauri/"
-  ".github/workflows/website-check.yml|rocketmq-website/"
-  ".github/workflows/deploy.yml|rocketmq-website/"
+REQUIRED_WORKFLOWS=(
+  ".github/workflows/rocketmq-rust-ci.yaml"
+  ".github/workflows/fuzz-ci.yml"
+  ".github/workflows/rocketmq-example-ci.yaml"
+  ".github/workflows/rocketmq-mcp-ci.yaml"
+  ".github/workflows/rocketmq-sre-ci.yml"
+  ".github/workflows/dashboard-gpui-ci.yml"
+  ".github/workflows/dashboard-web-ci.yml"
+  ".github/workflows/dashboard-tauri-ci.yml"
+  ".github/workflows/website-check.yml"
+  ".github/workflows/deploy.yml"
 )
 
-for workflow_entry in "${WORKFLOW_PATHS[@]}"; do
-  workflow_path="${workflow_entry%%|*}"
-  route="${workflow_entry#*|}"
-  if [[ ! -f "$ROOT/$workflow_path" ]]; then
-    add_failure "Missing required workflow: $workflow_path"
-    continue
+for workflow in "${REQUIRED_WORKFLOWS[@]}"; do
+  if [[ ! -f "$ROOT/$workflow" ]]; then
+    add_failure "Missing required workflow: $workflow"
   fi
-  assert_text_contains "$ROOT_AGENTS_TEXT" "$route" "Root AGENTS.md workflow routing for $workflow_path"
 done
 
-MCP_WORKFLOW_PATH="$ROOT/.github/workflows/rocketmq-mcp-ci.yaml"
-if [[ -f "$MCP_WORKFLOW_PATH" ]]; then
-  MCP_WORKFLOW_TEXT="$(cat "$MCP_WORKFLOW_PATH")"
-  for command in "${REQUIRED_MCP_COMMANDS[@]}"; do
-    assert_text_contains "$MCP_WORKFLOW_TEXT" "$command" "Standalone rocketmq-mcp CI validation"
-  done
-  for trigger_path in \
-    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/**" \
-    "rocketmq-auth/**" \
-    "rocketmq-client/**" \
-    "rocketmq-error/**" \
-    "rocketmq-macros/**" \
-    "rocketmq-model/**" \
-    "rocketmq-observability/**" \
-    "rocketmq-protocol/**" \
-    "rocketmq-runtime/**" \
-    "rocketmq-security-api/**" \
-    "rocketmq-transport/**" \
-    "Cargo.toml" \
-    "Cargo.lock" \
-    "rust-toolchain.toml"; do
-    assert_text_contains "$MCP_WORKFLOW_TEXT" "$trigger_path" "Standalone rocketmq-mcp CI consumer trigger"
-  done
-fi
-
-SRE_WORKFLOW_PATH="$ROOT/.github/workflows/rocketmq-sre-ci.yml"
-if [[ -f "$SRE_WORKFLOW_PATH" ]]; then
-  SRE_WORKFLOW_TEXT="$(cat "$SRE_WORKFLOW_PATH")"
-  for trigger_path in \
-    "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/**" \
-    "rocketmq-ai/rocketmq-mcp/**" \
-    "rocketmq-auth/**" \
-    "rocketmq-client/**" \
-    "rocketmq-error/**" \
-    "rocketmq-macros/**" \
-    "rocketmq-model/**" \
-    "rocketmq-observability/**" \
-    "rocketmq-protocol/**" \
-    "rocketmq-runtime/**" \
-    "rocketmq-security-api/**" \
-    "rocketmq-transport/**"; do
-    assert_text_contains "$SRE_WORKFLOW_TEXT" "$trigger_path" "Standalone rocketmq-sre CI consumer trigger"
-  done
-fi
-
-STANDALONE_TRIGGER_GUARD_PATH="$ROOT/scripts/standalone_workspace_trigger_guard.py"
-if [[ -f "$STANDALONE_TRIGGER_GUARD_PATH" ]]; then
-  PYTHON_COMMAND="${PYTHON:-python3}"
-  if ! command -v "$PYTHON_COMMAND" >/dev/null 2>&1; then
-    add_failure "Python is required for standalone workspace consumer-trigger validation"
-  elif ! "$PYTHON_COMMAND" "$STANDALONE_TRIGGER_GUARD_PATH" --repo-root "$ROOT"; then
-    add_failure "Standalone workspace metadata consumer-trigger validation failed"
+# Dependency/feature audits are separate integration checks; do not invoke Cargo metadata here.
+for document in \
+  "rocketmq-doc/en/agents-routing-validation-adr.md" \
+  "rocketmq-doc/en/agent-validation-reference.md"; do
+  if [[ ! -f "$ROOT/$document" ]]; then
+    add_failure "Missing validation reference: $document"
   fi
-fi
-
-ADR_PATH="$ROOT/rocketmq-doc/en/agents-routing-validation-adr.md"
-if [[ -f "$ADR_PATH" ]]; then
-  ADR_TEXT="$(cat "$ADR_PATH")"
-  for term in "AGENTS.md" "check-agents-routing.ps1" "check-agents-routing.sh" 'root `Cargo.toml`' "standalone" "rocketmq-mcp" "rocketmq-mcp-control" "cumulative"; do
-    assert_text_contains "$ADR_TEXT" "$term" "AGENTS routing ADR"
-  done
-else
-  add_failure "Missing AGENTS routing ADR: rocketmq-doc/en/agents-routing-validation-adr.md"
-fi
+done
 
 if (( ${#FAILURES[@]} > 0 )); then
   printf 'AGENTS routing check failed with %d issue(s):\n' "${#FAILURES[@]}"

--- a/scripts/tests/test_agents_routing.py
+++ b/scripts/tests/test_agents_routing.py
@@ -1,0 +1,135 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class AgentsRoutingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.shells: list[tuple[str, list[str]]] = []
+        pwsh = os.environ.get("AGENTS_TEST_PWSH") or shutil.which("pwsh")
+        if pwsh:
+            cls.shells.append(("PowerShell", [
+                pwsh, "-NoLogo", "-NoProfile", "-File",
+                str(ROOT / "scripts/check-agents-routing.ps1"),
+            ]))
+        bash = os.environ.get("AGENTS_TEST_BASH")
+        if not bash and os.name == "nt":
+            git = shutil.which("git")
+            if git:
+                candidate = Path(git).resolve().parents[1] / "bin/bash.exe"
+                if candidate.is_file():
+                    bash = str(candidate)
+        elif not bash:
+            bash = shutil.which("bash")
+        if bash:
+            cls.shells.append(("Bash", [
+                bash, (ROOT / "scripts/check-agents-routing.sh").as_posix(),
+            ]))
+        if not cls.shells:
+            raise unittest.SkipTest("PowerShell or Bash is required for routing script tests")
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="agents-routing-")
+        self.addCleanup(self.temporary.cleanup)
+        self.repository = Path(self.temporary.name)
+        # Preserve the actual project map while allowing arbitrary policy prose.
+        routes = re.findall(
+            r"\]\(([^)\n]+/AGENTS\.md)\)",
+            (ROOT / "AGENTS.md").read_text(encoding="utf-8"),
+        )
+        self.assertTrue(routes, "Root project map must link its local guides")
+        self.write("AGENTS.md", "# Local routing\n\n" + "\n".join(routes) + "\n")
+        self.write("Cargo.toml", "[workspace]\nmembers = []\n")
+        for route in routes:
+            self.write(route, "# Local guide\n\nChoose the relevant check.\n")
+        for workflow in (ROOT / ".github/workflows").iterdir():
+            if workflow.suffix in {".yml", ".yaml"}:
+                self.write(f".github/workflows/{workflow.name}", "name: fixture\n")
+        for document in ("agents-routing-validation-adr.md", "agent-validation-reference.md"):
+            self.write(f"rocketmq-doc/en/{document}", "# Select checks by impact\n")
+        self.write(
+            "scripts/standalone_workspace_trigger_guard.py",
+            "from pathlib import Path\n"
+            "Path(__file__).parents[1].joinpath('metadata-invoked').write_text('unexpected')\n"
+            "raise SystemExit(97)\n",
+        )
+
+    def write(self, relative: str, content: str) -> None:
+        path = self.repository / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def assert_routing(self, expected_code: int, expected_message: str) -> None:
+        for name, command in self.shells:
+            with self.subTest(shell=name):
+                argument = (["-RepoRoot", str(self.repository)] if name == "PowerShell"
+                            else [self.repository.as_posix()])
+                result = subprocess.run(
+                    command + argument, capture_output=True, text=True,
+                    encoding="utf-8", errors="replace", timeout=30, check=False,
+                )
+                output = result.stdout + result.stderr
+                self.assertEqual(expected_code, result.returncode, output)
+                self.assertIn(expected_message, output)
+                self.assertFalse((self.repository / "metadata-invoked").exists(), output)
+
+    def test_routing_accepts_new_wording_without_build_or_metadata_audits(self) -> None:
+        self.write("standalone demo/Cargo.toml", "[workspace]\nmembers = []\n")
+        self.write("standalone demo/AGENTS.md", "# Standalone guide\n")
+        self.write("frontend demo/package.json", "{}\n")
+        self.write("frontend demo/AGENTS.md", "# Frontend guide\n")
+        root_guide = self.repository / "AGENTS.md"
+        with root_guide.open("a", encoding="utf-8") as guide:
+            guide.write("standalone demo/\nfrontend demo/\n")
+        self.assert_routing(0, "AGENTS_ROUTING_CHECK_OK standalone_cargo=1 node_projects=1")
+
+    def test_new_standalone_project_requires_local_instructions(self) -> None:
+        self.write("new-standalone/Cargo.toml", "[workspace]\nmembers = []\n")
+        self.assert_routing(
+            1, "Standalone Cargo project at 'new-standalone' has no same-directory AGENTS.md",
+        )
+
+    def test_new_node_project_requires_local_instructions(self) -> None:
+        self.write("new-ui/package.json", "{}\n")
+        self.assert_routing(1, "Node project at 'new-ui' has no same-directory AGENTS.md")
+
+    def test_new_project_requires_root_route_even_with_local_instructions(self) -> None:
+        self.write("new-standalone/Cargo.toml", "[workspace]\nmembers = []\n")
+        self.write("new-standalone/AGENTS.md", "# Guide\n")
+        self.assert_routing(1, "Root AGENTS.md standalone Cargo routing does not mention 'new-standalone/'")
+
+    def test_missing_workflow_is_reported(self) -> None:
+        (self.repository / ".github/workflows/rocketmq-rust-ci.yaml").unlink()
+        self.assert_routing(1, "Missing required workflow: .github/workflows/rocketmq-rust-ci.yaml")
+
+    def test_missing_root_guide_is_reported(self) -> None:
+        (self.repository / "AGENTS.md").unlink()
+        self.assert_routing(1, "Missing required file: AGENTS.md")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10237

### Brief Description

Small agent tasks could trigger cumulative workspace, standalone, and specialized validation. Simplify root `AGENTS.md` from 303 to 143 lines and align 13 local guides around affected compilation, formatting, focused regression tests, and an explicit stopping rule.

Move specialist commands to an on-demand reference. Select shared consumers by actual impact and remove routine SHA/fingerprint, clean-worktree, and historical-baseline requirements. Preserve compatibility, lifecycle ownership, and local security/audit contracts.

Simplify both AGENTS routers to structural checks, remove exact-policy wording checks and implicit Cargo metadata auditing, update the ADR, and add regression tests. Workflow definitions remain unchanged; the separate dependency-trigger audit is still available for integration work.

### How Did You Test This Change?

- `.\scripts\check-agents-routing.ps1` - passed; 9 standalone Cargo projects, 5 Node projects, and 15 routes.
- `bash ./scripts/check-agents-routing.sh` - passed with the same counts.
- `python -m unittest discover -s scripts/tests -p test_agents_routing.py -v` - all 6 scenarios passed against both PowerShell and Git Bash, covering successful routing without metadata auditing and missing local guides, root routes, workflows, and root instructions.
- `git diff --check` - passed.
- Issue path/language audit and PR content validation - passed.

Cargo/Node builds are not applicable to these instruction and routing-script changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project guidance with clearer instruction precedence, repository boundaries, and scoped validation recommendations.
  - Added a centralized validation reference covering integration checks, platform-specific workflows, and specialized verification scenarios.
  - Clarified development checks for Rust, Node.js, frontend, backend, UI, and documentation work.

- **Tests**
  - Added automated coverage for repository instruction routing, required guidance, workflow presence, and standalone project handling.

- **Chores**
  - Simplified routing validation to focus on required files and project paths rather than rigid command or wording checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->