### PR TITLE
[ISSUE #10239]✨Scope CI validation and replace approval polling

### DIFF
--- a/.github/workflows/architecture-documentation.yml
+++ b/.github/workflows/architecture-documentation.yml
@@ -1,87 +1,16 @@
 name: Architecture documentation
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - ".github/workflows/**"
-      - "Cargo.toml"
-      - "README.md"
-      - "rust-toolchain.toml"
-      - "fuzz/Cargo.toml"
-      - "rocketmq-example/Cargo.toml"
-      - "rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.toml"
-      - "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml"
-      - "rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml"
-      - "rocketmq-doc/en/architecture-major-version-migration.md"
-      - "rocketmq-doc/en/core-capability-contracts.md"
-      - "rocketmq-doc/en/acknowledgement-failover-contract-adr.md"
-      - "rocketmq-doc/en/regional-disaster-recovery-adr.md"
-      - "rocketmq-doc/en/architecture-release-evidence-index.md"
-      - "distribution/config/ack-failover-evidence-schema.json"
-      - "rocketmq-store-api/src/**"
-      - "rocketmq-runtime/src/**"
-      - "rocketmq-error/src/**"
-      - "rocketmq-security-api/src/**"
-      - "scripts/architecture-validation-inventory.json"
-      - "scripts/architecture-risk-test-matrix.json"
-      - "scripts/property-state-suite-registry.json"
-      - "scripts/run_property_state_suites.py"
-      - "scripts/architecture_evidence_governance_guard.py"
-      - "scripts/tests/test_architecture_evidence_governance_guard.py"
-      - "rocketmq-protocol/tests/remoting_wire_golden.rs"
-      - "rocketmq-store-local/tests/storage_layout_golden.rs"
-      - "rocketmq-controller/src/openraft/state_machine.rs"
-      - "rocketmq-broker/tests/config_contract.rs"
-      - "rocketmq-filter/src/filter/filter_sql_filter.rs"
-      - "rocketmq-proxy-cluster/src/cluster_behavior_tests.rs"
-      - "rocketmq-runtime/tests/resource_budget_tree.rs"
-      - "fuzz/corpus-registry.json"
-      - "codecov.yml"
-      - "scripts/architecture_documentation_guard.py"
-      - "scripts/tests/test_architecture_documentation_guard.py"
-  pull_request:
-    branches: [ "main" ]
-    paths:
-      - ".github/workflows/**"
-      - "Cargo.toml"
-      - "README.md"
-      - "rust-toolchain.toml"
-      - "fuzz/Cargo.toml"
-      - "rocketmq-example/Cargo.toml"
-      - "rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.toml"
-      - "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml"
-      - "rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml"
-      - "rocketmq-doc/en/architecture-major-version-migration.md"
-      - "rocketmq-doc/en/core-capability-contracts.md"
-      - "rocketmq-doc/en/acknowledgement-failover-contract-adr.md"
-      - "rocketmq-doc/en/regional-disaster-recovery-adr.md"
-      - "rocketmq-doc/en/architecture-release-evidence-index.md"
-      - "distribution/config/ack-failover-evidence-schema.json"
-      - "rocketmq-store-api/src/**"
-      - "rocketmq-runtime/src/**"
-      - "rocketmq-error/src/**"
-      - "rocketmq-security-api/src/**"
-      - "scripts/architecture-validation-inventory.json"
-      - "scripts/architecture-risk-test-matrix.json"
-      - "scripts/property-state-suite-registry.json"
-      - "scripts/run_property_state_suites.py"
-      - "scripts/architecture_evidence_governance_guard.py"
-      - "scripts/tests/test_architecture_evidence_governance_guard.py"
-      - "rocketmq-protocol/tests/remoting_wire_golden.rs"
-      - "rocketmq-store-local/tests/storage_layout_golden.rs"
-      - "rocketmq-controller/src/openraft/state_machine.rs"
-      - "rocketmq-broker/tests/config_contract.rs"
-      - "rocketmq-filter/src/filter/filter_sql_filter.rs"
-      - "rocketmq-proxy-cluster/src/cluster_behavior_tests.rs"
-      - "rocketmq-runtime/tests/resource_budget_tree.rs"
-      - "fuzz/corpus-registry.json"
-      - "codecov.yml"
-      - "scripts/architecture_documentation_guard.py"
-      - "scripts/tests/test_architecture_documentation_guard.py"
+  workflow_dispatch:
+  schedule:
+    - cron: '41 20 * * 0'
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   documentation:
@@ -91,12 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Install native build dependencies
-        run: >-
-          sudo apt-get update &&
-          sudo apt-get install -y
-          clang llvm libclang-dev cmake make ninja-build pkg-config protobuf-compiler
-
       - name: Validate architecture documentation
         run: python scripts/architecture_documentation_guard.py --check
 
@@ -105,6 +28,3 @@ jobs:
 
       - name: Validate evidence governance
         run: python scripts/architecture_evidence_governance_guard.py
-
-      - name: Execute deterministic property and state suites
-        run: python scripts/run_property_state_suites.py

--- a/.github/workflows/architecture-nightly-evidence.yml
+++ b/.github/workflows/architecture-nightly-evidence.yml
@@ -12,6 +12,10 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_PROFILE_TEST_DEBUG: "false"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   governance:
     name: Evidence registry governance

--- a/.github/workflows/auto-comment-pr.yml
+++ b/.github/workflows/auto-comment-pr.yml
@@ -14,9 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
       - name: Create a comment
         uses: actions/github-script@v9
         with:

--- a/.github/workflows/auto_approve_pull_requests.yml
+++ b/.github/workflows/auto_approve_pull_requests.yml
@@ -2,18 +2,31 @@ name: Auto Approve Pull Requests
 
 on:
   pull_request_target:
-    types: [ opened, synchronize, reopened ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+  # GitHub Actions does not emit check_suite triggers for its own check suites.
+  workflow_run:
+    workflows: [ "RocketMQ Rust CI" ]
+    types: [ completed ]
   check_suite:
     types: [ completed ]
 
 permissions:
   pull-requests: write
   checks: read
+  contents: read
+
+concurrency:
+  group: approve-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.event.check_suite.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target' || (github.event_name == 'check_suite' && github.event.check_suite.pull_requests[0])
+    timeout-minutes: 3
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request') ||
+      (github.event_name == 'check_suite' && github.event.check_suite.pull_requests[0])
 
     steps:
       - name: Verify required status checks
@@ -22,82 +35,85 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_TOKEN }}
           script: |
-
-            const retryInterval1 = 540 * 1000; // 7 minutes
-            await new Promise(resolve => setTimeout(resolve, retryInterval1));
+            // Completion events trigger another short check; do not occupy a runner waiting for CI.
+            // This privileged workflow reads metadata only: never check out or execute PR code.
             const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request || context.payload.check_suite.pull_requests[0];
-            const sha = pr.head.sha;
-            core.setOutput('pull_request_number', pr.number);
-            
-            console.log(`Processing PR #${pr.number}, HEAD SHA: ${sha}`);
-            
-            // Get required status checks for the base branch
-            const { data: branch } = await github.rest.repos.getBranch({
-              owner,
-              repo,
-              branch: pr.base.ref,
-            });
-
-            const requiredChecks = branch.protection?.required_status_checks?.contexts || [];
-            console.log('Required status checks:', requiredChecks);
-
-            // Function to check the status of required checks
-            async function checkRequiredStatusChecks() {
-              const { data: checks } = await github.rest.checks.listForRef({
-                owner,
-                repo,
-                ref: sha,
-                per_page: 100,
+            const { pull_request, workflow_run, check_suite } = context.payload;
+            if (workflow_run && workflow_run.event !== 'pull_request') return false;
+            const eventHead = workflow_run?.head_sha || check_suite?.head_sha || pull_request?.head.sha;
+            let candidate = pull_request || workflow_run?.pull_requests?.[0] || check_suite?.pull_requests?.[0];
+            // Fork workflow completions can omit pull_requests; resolve them through the commit API.
+            if (!candidate && workflow_run) {
+              const associated = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+                owner, repo, commit_sha: eventHead, per_page: 100,
               });
-
-              console.log('Found status checks:', checks.check_runs.length);
-
-              // Filter out non-required checks
-              const requiredCheckRuns = checks.check_runs.filter(check => requiredChecks.includes(check.name));
-              console.log('Required status checks found:', requiredCheckRuns.length);
-
-              // Check for any failed or pending required checks
-              const failedChecks = requiredCheckRuns.filter(check => check.status === 'completed' && check.conclusion !== 'success');
-              const pendingChecks = requiredCheckRuns.filter(check => check.status !== 'completed');
-
-              if (failedChecks.length > 0) {
-                const failedNames = failedChecks.map(f => f.name).join(', ');
-                console.log(`Failed checks: ${failedNames}`);
-                return 'failed';
-              }
-
-              if (pendingChecks.length > 0) {
-                const pendingNames = pendingChecks.map(p => p.name).join(', ');
-                console.log(`Pending checks: ${pendingNames}`);
-                return 'pending';
-              }
-
-              console.log('All required status checks have passed successfully');
-              return 'passed';
+              const current = associated.filter(pr =>
+                pr.state === 'open' && pr.head.sha === eventHead &&
+                pr.base.repo.full_name === `${owner}/${repo}`
+              );
+              if (current.length !== 1) return false;
+              [candidate] = current;
             }
-            // Poll for status checks until they complete
-            const maxRetries = 15;
-            const retryInterval = 60 * 1000; // 30 seconds
-            for (let i = 0; i < maxRetries; i++) {
-              const status = await checkRequiredStatusChecks();
-              if (status === 'passed') {
-                return true;
-              }
-              if (status === 'failed') {
-                return false;
-              }
-              console.log(`Retrying in ${retryInterval / 1000} seconds... (${i + 1}/${maxRetries})`);
-              await new Promise(resolve => setTimeout(resolve, retryInterval));
+            if (!candidate) return false;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+            if (pr.state !== 'open' || pr.draft || pr.head.sha !== eventHead) return false;
+
+            const { data: branch } = await github.rest.repos.getBranch({
+              owner, repo, branch: pr.base.ref,
+            });
+            const protection = branch.protection?.required_status_checks;
+            const appChecks = protection?.checks || [];
+            const required = [...appChecks, ...(protection?.contexts || [])
+              .filter(name => !appChecks.some(check => check.context === name))
+              .map(context => ({ context, app_id: null }))];
+            if (required.length === 0) {
+              core.info('No required checks were returned; leave approval to a reviewer.');
+              return false;
             }
 
-            console.log('Timeout waiting for required status checks to complete');
-            return false;
+            const checks = await github.paginate(github.rest.checks.listForRef, {
+              owner, repo, ref: pr.head.sha, filter: 'latest', per_page: 100,
+            });
+            const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
+              owner, repo, ref: pr.head.sha,
+            });
+            const successful = new Set(['success', 'neutral', 'skipped']);
+            const ready = required.every(({ context: name, app_id }) => {
+              const appBound = app_id != null && app_id !== -1;
+              const matching = checks.filter(check =>
+                check.name === name && (!appBound || check.app?.id === app_id)
+              );
+              const legacy = appBound ? [] : combined.statuses.filter(status => status.context === name);
+              if (matching.length === 0 && legacy.length === 0) return false;
+              return matching.every(check =>
+                check.status === 'completed' && successful.has(check.conclusion)
+              ) && legacy.every(status => status.state === 'success');
+            });
+            core.info(ready ? 'Required checks passed.' : 'Required checks are missing, pending, or failed.');
+            if (ready) {
+              core.setOutput('pull_request_number', pr.number);
+              core.setOutput('checked_commit', pr.head.sha);
+            }
+            return ready;
 
       - name: Auto approve PR
         if: steps.check-status.outputs.result == 'true'
-        uses: hmarr/auto-approve-action@v4
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.check-status.outputs.pull_request_number }}
+          CHECKED_COMMIT: ${{ steps.check-status.outputs.checked_commit }}
         with:
           github-token: ${{ secrets.BOT_TOKEN }}
-          pull-request-number: ${{ steps.check-status.outputs.pull_request_number }}
-          review-message: "LGTM - All CI checks passed ✅"
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = Number(process.env.PR_NUMBER);
+            const commit_id = process.env.CHECKED_COMMIT;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+            if (pr.state !== 'open' || pr.draft || pr.head.sha !== commit_id) {
+              core.info('PR changed after checking; wait for its next completion event.');
+              return;
+            }
+            await github.rest.pulls.createReview({
+              owner, repo, pull_number, commit_id, event: 'APPROVE',
+              body: 'LGTM - Required CI checks passed ✅',
+            });

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -13,8 +13,16 @@ on:
     types:
       - completed
   status: { }
+concurrency:
+  group: merge-${{ github.event.pull_request.number || github.event.check_suite.head_sha || github.event.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   automerge:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'auto merge'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -9,6 +9,10 @@ on:
     types: [ opened, ready_for_review, reopened, synchronize ]
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   auto-request-review:
     name: Auto Request Review

--- a/.github/workflows/container-foundation-ci.yml
+++ b/.github/workflows/container-foundation-ci.yml
@@ -29,8 +29,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: container-foundation
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   verify-foundation:
@@ -41,20 +41,24 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
+        if: github.event_name != 'pull_request'
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Install Syft
+        if: github.event_name != 'pull_request'
         uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
           syft-version: v1.48.0
 
       - name: Install Trivy
+        if: github.event_name != 'pull_request'
         uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
         with:
           version: v0.72.0
           cache: true
 
       - name: Install Cosign
+        if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: v3.1.2
@@ -65,17 +69,19 @@ jobs:
           python -m unittest scripts.tests.test_m11_container_foundation
 
       - name: Build and verify runtime foundation
+        if: github.event_name != 'pull_request'
         shell: pwsh
         run: |
           ./scripts/container-supply-chain.ps1 -OutputDirectory target/container-foundation
 
       - name: Build and verify five service images
+        if: github.event_name != 'pull_request'
         shell: pwsh
         run: |
           ./scripts/service-image-contract.ps1 -OutputDirectory target/service-images
 
       - name: Upload supply-chain evidence
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: container-foundation

--- a/.github/workflows/core-kubernetes-assets-ci.yml
+++ b/.github/workflows/core-kubernetes-assets-ci.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-core-assets:
     runs-on: ubuntu-latest

--- a/.github/workflows/dashboard-gpui-ci.yml
+++ b/.github/workflows/dashboard-gpui-ci.yml
@@ -19,6 +19,7 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/dashboard-gpui-ci.yml"
+      - '!**/AGENTS.md'
   pull_request:
     branches: [main]
     paths:
@@ -34,15 +35,20 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/dashboard-gpui-ci.yml"
+      - '!**/AGENTS.md'
 
 env:
   CARGO_TERM_COLOR: always
   CARGO_PROFILE_DEV_DEBUG: "false"
   CARGO_PROFILE_TEST_DEBUG: "false"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
-    name: GPUI fmt, Clippy, check, and test
+    name: GPUI fmt, Clippy, and test
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -70,9 +76,6 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Check all targets
-        run: cargo check --all-targets --all-features
 
       - name: Test
         run: cargo test

--- a/.github/workflows/dashboard-tauri-ci.yml
+++ b/.github/workflows/dashboard-tauri-ci.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
     paths:
@@ -15,6 +16,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/dashboard-tauri-ci.yml'
+      - '!**/AGENTS.md'
   pull_request:
     branches: [ "main" ]
     paths:
@@ -26,6 +28,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/dashboard-tauri-ci.yml'
+      - '!**/AGENTS.md'
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +38,10 @@ env:
 defaults:
   run:
     working-directory: rocketmq-dashboard/rocketmq-dashboard-tauri
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # =========================
@@ -114,6 +121,7 @@ jobs:
   # Tauri Build (Multi-platform)
   # =========================
   tauri-build:
+    if: github.event_name != 'pull_request'
     name: Tauri Build (${{ matrix.platform.os }} / ${{ matrix.platform.target }})
     needs: [frontend-check, rust-check]
     

--- a/.github/workflows/dashboard-web-ci.yml
+++ b/.github/workflows/dashboard-web-ci.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
     paths:
@@ -19,6 +20,7 @@ on:
       - 'rustfmt.toml'
       - '.clippy.toml'
       - '.github/workflows/dashboard-web-ci.yml'
+      - '!**/AGENTS.md'
   pull_request:
     branches: [ "main" ]
     paths:
@@ -34,6 +36,7 @@ on:
       - 'rustfmt.toml'
       - '.clippy.toml'
       - '.github/workflows/dashboard-web-ci.yml'
+      - '!**/AGENTS.md'
 
 env:
   CARGO_TERM_COLOR: always
@@ -44,6 +47,10 @@ env:
   CARGO_PROFILE_DEV_OPT_LEVEL: 1
   CARGO_PROFILE_DEV_OVERFLOW_CHECKS: "false"
   ROCKSDB_DISABLE_JEMALLOC: 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   frontend-build:
@@ -123,9 +130,6 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
-      - name: Build backend
-        run: cargo build --all-targets --all-features
-
       - name: Clippy check
         run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -133,6 +137,7 @@ jobs:
         run: cargo test --locked --all-targets --all-features
 
   storage-contract:
+    if: github.event_name != 'pull_request'
     name: Storage Contract (File, SQLite, MySQL, PostgreSQL)
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,12 +7,6 @@ on:
     paths:
       - 'rocketmq-website/**'
       - '.github/workflows/deploy.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'rocketmq-website/**'
-      - '.github/workflows/deploy.yml'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/fuzz-ci.yml
+++ b/.github/workflows/fuzz-ci.yml
@@ -18,6 +18,7 @@ on:
       - 'scripts/architecture-debt-registry.json'
       - 'codecov.yml'
       - '.github/workflows/fuzz-ci.yml'
+      - '!**/AGENTS.md'
   pull_request:
     branches: [main]
     paths:
@@ -32,13 +33,14 @@ on:
       - 'scripts/architecture-debt-registry.json'
       - 'codecov.yml'
       - '.github/workflows/fuzz-ci.yml'
+      - '!**/AGENTS.md'
   workflow_dispatch:
   schedule:
     - cron: "17 18 * * 1-6"
     - cron: "17 18 * * 0"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -66,7 +68,7 @@ jobs:
 
   exercise:
     name: Exercise ${{ matrix.target }}
-    if: github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -77,7 +79,7 @@ jobs:
           - controller_snapshot
           - store_recovery_record
     env:
-      FUZZ_SECONDS: ${{ github.event.schedule == '17 18 * * 0' && '900' || github.event_name == 'pull_request' && '10' || '60' }}
+      FUZZ_SECONDS: ${{ github.event.schedule == '17 18 * * 0' && '900' || '60' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/kubernetes-assets-ci.yml
+++ b/.github/workflows/kubernetes-assets-ci.yml
@@ -33,6 +33,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Helm, Kustomize, and schema contract

--- a/.github/workflows/remove-label-on-approve.yml
+++ b/.github/workflows/remove-label-on-approve.yml
@@ -13,9 +13,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
       - name: Remove multiple labels using github-script
         uses: actions/github-script@v9
         with:

--- a/.github/workflows/rocketmq-example-ci.yaml
+++ b/.github/workflows/rocketmq-example-ci.yaml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
     paths:
@@ -19,6 +20,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/rocketmq-example-ci.yaml'
+      - '!**/AGENTS.md'
   pull_request:
     branches: [ "main" ]
     paths:
@@ -34,6 +36,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/rocketmq-example-ci.yaml'
+      - '!**/AGENTS.md'
 
 env:
   CARGO_TERM_COLOR: always
@@ -42,12 +45,16 @@ env:
   CARGO_PROFILE_DEV_DEBUG: "false"
   CARGO_PROFILE_TEST_DEBUG: "false"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # =========================
   # Format + Clippy
   # =========================
   check:
-    name: Check (fmt + clippy)
+    name: Example fmt, Clippy, and tests
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -100,6 +107,7 @@ jobs:
   # Build Examples
   # =========================
   build-examples:
+    if: github.event_name != 'pull_request'
     name: Build Examples (${{ matrix.os }})
     needs: check
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rocketmq-mcp-ci.yaml
+++ b/.github/workflows/rocketmq-mcp-ci.yaml
@@ -2,6 +2,7 @@ name: RocketMQ MCP CI
 
 on:
   push:
+    branches: [main]
     paths:
       - "rocketmq-ai/rocketmq-mcp/**"
       - "rocketmq-tools/rocketmq-admin/rocketmq-admin-core/**"
@@ -19,6 +20,7 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/rocketmq-mcp-ci.yaml"
+      - '!**/AGENTS.md'
   pull_request:
     paths:
       - "rocketmq-ai/rocketmq-mcp/**"
@@ -37,9 +39,14 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/rocketmq-mcp-ci.yaml"
+      - '!**/AGENTS.md'
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:
@@ -56,19 +63,9 @@ jobs:
         with:
           workspaces: rocketmq-ai/rocketmq-mcp
       - run: cargo fmt --all -- --check
-      - run: cargo check --locked
       - run: python scripts/check_read_only_boundary.py
       - run: cargo test --locked
       - run: cargo test --locked --all-features
       - run: cargo clippy --locked --all-targets --features streamable-http -- -D warnings
-      - run: cargo doc --locked --no-deps
-
-  msrv:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: rocketmq-ai/rocketmq-mcp
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.95.0
-      - run: cargo check --locked
+      - if: github.event_name != 'pull_request'
+        run: cargo doc --locked --no-deps

--- a/.github/workflows/rocketmq-rust-ci.yaml
+++ b/.github/workflows/rocketmq-rust-ci.yaml
@@ -3,33 +3,19 @@ name: RocketMQ Rust CI
 permissions:
   contents: read
 
+# Always publish the existing required contexts; select work inside the workflow.
 on:
   push:
-    branches: [ "main" ]
-    paths-ignore:
-      - 'rocketmq-doc/**'
-      - 'rocketmq-website/**'
-      - 'docker/**'
-      - 'resources/**'
-      - 'distribution/**'
-      - 'rocketmq-dashboard/rocketmq-dashboard-gpui/**'
-      - 'rocketmq-dashboard/rocketmq-dashboard-tauri/**'
-      - 'rocketmq-dashboard/rocketmq-dashboard-web/**'
-      - 'rocketmq-dashboard/README*.md'
-      - 'rocketmq-example/**'
+    branches: [main]
   pull_request:
-    branches: [ "main" ]
-    paths-ignore:
-      - 'rocketmq-doc/**'
-      - 'rocketmq-website/**'
-      - 'docker/**'
-      - 'resources/**'
-      - 'distribution/**'
-      - 'rocketmq-dashboard/rocketmq-dashboard-gpui/**'
-      - 'rocketmq-dashboard/rocketmq-dashboard-tauri/**'
-      - 'rocketmq-dashboard/rocketmq-dashboard-web/**'
-      - 'rocketmq-dashboard/README*.md'
-      - 'rocketmq-example/**'
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '23 20 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -43,8 +29,10 @@ env:
   CARGO_TARGET_DIR: target
   ROCKSDB_DISABLE_JEMALLOC: 1
 
+
 jobs:
   core-release-short-checks:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Core Release Short Checks
     runs-on: ubuntu-latest
 
@@ -70,6 +58,8 @@ jobs:
         run: python scripts/core_release_static_guard.py
 
   request-header-codec-contract:
+    needs: check
+    if: needs.check.outputs.header == 'true'
     name: Request Header Codec Contract
     runs-on: ubuntu-latest
 
@@ -91,6 +81,7 @@ jobs:
         run: python -m unittest discover -s scripts/request-header-codec/tests -p 'test_*.py'
 
       - name: Check migration inventory and frozen legacy surface
+        if: github.event_name != 'pull_request'
         run: python scripts/request-header-codec/migrate.py check
 
       - name: Check pinned Java schema compatibility
@@ -100,6 +91,8 @@ jobs:
         run: cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry
 
   error-architecture:
+    needs: check
+    if: needs.check.outputs.errors == 'true'
     name: Error Architecture
     runs-on: ubuntu-latest
 
@@ -119,6 +112,7 @@ jobs:
   # Architecture migration guards
   # =========================
   architecture-guards:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Architecture Guards (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
@@ -190,6 +184,7 @@ jobs:
         run: python scripts/stable_surface_guard.py --scope core-release --mode target
 
   architecture-contracts:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Architecture Contracts
     runs-on: windows-latest
 
@@ -209,6 +204,7 @@ jobs:
         run: python scripts/run_architecture_tests.py --tier milestone_contract --tier phase_contract --tier dynamic_fixture
 
   architecture-target:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Architecture Strict Target
     runs-on: ubuntu-latest
 
@@ -251,12 +247,38 @@ jobs:
   check:
     name: Check (fmt + clippy)
     runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.scope.outputs.rust }}
+      full_features: ${{ steps.scope.outputs.full_features }}
+      observability: ${{ steps.scope.outputs.observability }}
+      rocksdb: ${{ steps.scope.outputs.rocksdb }}
+      header: ${{ steps.scope.outputs.header }}
+      errors: ${{ steps.scope.outputs.errors }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Select checks from changed paths
+        id: scope
+        run: python scripts/ci_scope.py
+
+      - name: Test CI scope selection
+        if: steps.scope.outputs.routing == 'true'
+        run: python -m unittest discover -s scripts/tests -p test_ci_scope.py -v
+
+      - name: Check AGENTS routing
+        if: steps.scope.outputs.routing == 'true'
+        run: bash ./scripts/check-agents-routing.sh
+
+      - name: Test automatic approval decisions
+        if: steps.scope.outputs.automation == 'true'
+        run: node --test scripts/tests/test_auto_approve.cjs
 
       - name: Install system dependencies (Ubuntu)
+        if: steps.scope.outputs.rust == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -294,11 +316,13 @@ jobs:
           fi
 
       - name: Use repository Rust 1.95 toolchain
+        if: steps.scope.outputs.rust == 'true'
         run: |
           rustup show active-toolchain
           rustup component add rustfmt clippy
 
       - name: Cache Rust + RocksDB
+        if: steps.scope.outputs.rust == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: rocketmq-rust-ubuntu
@@ -313,23 +337,31 @@ jobs:
             ROCKSDB_DISABLE_JEMALLOC
 
       - name: Format check
+        if: steps.scope.outputs.rust == 'true'
         run: cargo fmt --all -- --check
 
-      - name: Check AGENTS routing
-        run: bash ./scripts/check-agents-routing.sh
-
-      - name: Clippy (all features)
-        run: cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+      - name: Clippy workspace
+        if: steps.scope.outputs.rust == 'true'
+        env:
+          FULL_FEATURES: ${{ github.event_name != 'pull_request' || steps.scope.outputs.full_features == 'true' }}
+        run: |
+          if [ "$FULL_FEATURES" = true ]; then
+            cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+          else
+            cargo clippy --workspace --no-deps --all-targets -- -D warnings
+          fi
 
       - name: Document workspace public API
+        if: steps.scope.outputs.rust == 'true' && github.event_name != 'pull_request'
         run: cargo doc --workspace --no-deps --all-features
 
   # =========================
   # Observability feature matrix
   # =========================
   observability-feature-matrix:
-    name: Observability Features (${{ matrix.features || 'default' }})
     needs: check
+    if: needs.check.outputs.observability == 'true'
+    name: Observability Features (${{ matrix.features || 'default' }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -347,20 +379,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Install system dependencies (Ubuntu)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            clang llvm libclang-dev \
-            cmake make ninja-build pkg-config \
-            protobuf-compiler \
-            libsnappy-dev liblz4-dev libzstd-dev zlib1g-dev \
-            libxcb1-dev libxkbcommon-dev libxkbcommon-x11-dev
-
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
-          echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
 
       - name: Use repository Rust 1.95 toolchain
         run: |
@@ -391,24 +409,14 @@ jobs:
             LIBCLANG_PATH
             ROCKSDB_DISABLE_JEMALLOC
 
-      - name: Check observability feature set
-        env:
-          FEATURES: ${{ matrix.features }}
-        run: |
-          if [ -n "$FEATURES" ]; then
-            cargo check --workspace --all-targets --features "$FEATURES"
-          else
-            cargo check --workspace --all-targets
-          fi
-
       - name: Clippy observability feature set
         env:
           FEATURES: ${{ matrix.features }}
         run: |
           if [ -n "$FEATURES" ]; then
-            cargo clippy --workspace --no-deps --all-targets --features "$FEATURES" -- -D warnings
+            cargo clippy -p rocketmq-observability --no-deps --all-targets --features "$FEATURES" -- -D warnings
           else
-            cargo clippy --workspace --no-deps --all-targets -- -D warnings
+            cargo clippy -p rocketmq-observability --no-deps --all-targets -- -D warnings
           fi
 
       - name: Test rocketmq-observability feature set
@@ -425,8 +433,9 @@ jobs:
   # RocksDB feature validation
   # =========================
   rocksdb-store:
-    name: RocksDB Store Feature (${{ matrix.os }})
     needs: check
+    if: needs.check.outputs.rocksdb == 'true'
+    name: RocksDB Store Feature (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -496,14 +505,10 @@ jobs:
   # Build + Test
   # =========================
   build-test:
-    name: Build & Test (${{ matrix.os }})
+    name: Build & Test (ubuntu-latest)
     needs: check
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    if: needs.check.outputs.rust == 'true'
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -511,7 +516,6 @@ jobs:
 
       # ---------- Ubuntu ----------
       - name: Install system dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -548,34 +552,13 @@ jobs:
             fi
           fi
 
-      # ---------- macOS ----------
-      - name: Install system dependencies (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew update
-          brew install cmake protobuf snappy lz4 zstd llvm
-
-          # Set up LLVM paths for bindgen on macOS
-          LLVM_PREFIX=$(brew --prefix llvm)
-          echo "LLVM_PREFIX=$LLVM_PREFIX" >> $GITHUB_ENV
-          echo "LIBCLANG_PATH=$LLVM_PREFIX/lib" >> $GITHUB_ENV
-          echo "DYLD_FALLBACK_LIBRARY_PATH=$LLVM_PREFIX/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "PATH=$LLVM_PREFIX/bin:$PATH" >> $GITHUB_ENV
-          echo "Configured LLVM at: $LLVM_PREFIX"
-
-      # ---------- Windows ----------
-      - name: Install system dependencies (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install cmake ninja protoc -y
-
       - name: Use repository Rust 1.95 toolchain
         run: rustup show active-toolchain
 
       - name: Cache Rust + RocksDB
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rocketmq-rust-${{ matrix.os }}
+          shared-key: rocketmq-rust-ubuntu-latest
           workspaces: |
             .
           env-vars: |
@@ -586,14 +569,18 @@ jobs:
             DYLD_FALLBACK_LIBRARY_PATH
             ROCKSDB_DISABLE_JEMALLOC
 
-      - name: Build (all features)
-        run: cargo build --workspace --all-features
-
-      - name: Test (all features)
-        if: matrix.os == 'ubuntu-latest'
-        run: cargo test --workspace --all-features
+      - name: Test workspace
+        env:
+          FULL_FEATURES: ${{ github.event_name != 'pull_request' || needs.check.outputs.full_features == 'true' }}
+        run: |
+          if [ "$FULL_FEATURES" = true ]; then
+            cargo test --workspace --all-features
+          else
+            cargo test --workspace
+          fi
 
   interface-contracts:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Store, Producer, Tiered, and Loom contracts
     needs: check
     runs-on: ubuntu-latest
@@ -641,6 +628,7 @@ jobs:
   coverage:
     name: Code Coverage
     needs: check
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
@@ -712,5 +700,83 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
+  build-windows:
+    name: Build & Test (windows-latest)
+    needs: check
+    if: needs.check.outputs.rust == 'true' && github.event_name != 'pull_request'
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # ---------- Windows ----------
+      - name: Install system dependencies (Windows)
+        run: |
+          choco install cmake ninja protoc -y
+
+      - name: Use repository Rust 1.95 toolchain
+        run: rustup show active-toolchain
+
+      - name: Cache Rust + RocksDB
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rocketmq-rust-windows-latest
+          workspaces: |
+            .
+          env-vars: |
+            CC
+            CXX
+            LIBCLANG_PATH
+            LLVM_PREFIX
+            DYLD_FALLBACK_LIBRARY_PATH
+            ROCKSDB_DISABLE_JEMALLOC
+
+      - name: Build (all features)
+        run: cargo build --workspace --all-features
+
+  build-macos:
+    name: Build & Test (macos-latest)
+    needs: check
+    if: needs.check.outputs.rust == 'true' && github.event_name != 'pull_request'
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # ---------- macOS ----------
+      - name: Install system dependencies (macOS)
+        run: |
+          brew update
+          brew install cmake protobuf snappy lz4 zstd llvm
+
+          # Set up LLVM paths for bindgen on macOS
+          LLVM_PREFIX=$(brew --prefix llvm)
+          echo "LLVM_PREFIX=$LLVM_PREFIX" >> $GITHUB_ENV
+          echo "LIBCLANG_PATH=$LLVM_PREFIX/lib" >> $GITHUB_ENV
+          echo "DYLD_FALLBACK_LIBRARY_PATH=$LLVM_PREFIX/lib:$DYLD_FALLBACK_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "PATH=$LLVM_PREFIX/bin:$PATH" >> $GITHUB_ENV
+          echo "Configured LLVM at: $LLVM_PREFIX"
+
+      - name: Use repository Rust 1.95 toolchain
+        run: rustup show active-toolchain
+
+      - name: Cache Rust + RocksDB
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rocketmq-rust-macos-latest
+          workspaces: |
+            .
+          env-vars: |
+            CC
+            CXX
+            LIBCLANG_PATH
+            LLVM_PREFIX
+            DYLD_FALLBACK_LIBRARY_PATH
+            ROCKSDB_DISABLE_JEMALLOC
+
+      - name: Build (all features)
+        run: cargo build --workspace --all-features

--- a/.github/workflows/rocketmq-sre-ci.yml
+++ b/.github/workflows/rocketmq-sre-ci.yml
@@ -31,6 +31,7 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/rocketmq-sre-ci.yml"
+      - '!**/AGENTS.md'
   pull_request:
     branches: ["main"]
     paths:
@@ -58,11 +59,16 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/rocketmq-sre-ci.yml"
+      - '!**/AGENTS.md'
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
   CI: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   rust:
@@ -103,12 +109,6 @@ jobs:
         with:
           workspaces: rocketmq-ai/rocketmq-sre -> target
 
-      - name: Check metadata
-        run: cargo metadata --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked --no-deps
-
-      - name: Check workspace
-        run: cargo check --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked --workspace
-
       - name: Check Rust 2024 source layout
         run: python rocketmq-ai/rocketmq-sre/scripts/check_source_layout.py
 
@@ -141,7 +141,7 @@ jobs:
         # Live S3 and model-provider qualifications require separately injected credentials.
         run: |
           cargo test --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked \
-            -p rocketmq-sre-control-plane -- --include-ignored \
+            -p rocketmq-sre-control-plane -- --ignored \
             --skip evidence::blob::tests::s3_compatible_https_live_round_trip_uses_external_secret_references \
             --skip models::service::live_deepseek::deepseek_answers_one_evidence_cited_conversational_metric_query \
             --skip models::service::live_deepseek::deepseek_responses_produces_persisted_read_only_sre_diagnosis \
@@ -164,6 +164,7 @@ jobs:
         run: cargo clippy --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked --workspace --all-targets --all-features -- -D warnings
 
       - name: Rustdoc
+        if: github.event_name != 'pull_request'
         run: cargo doc --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked --workspace --no-deps
 
       - name: Check capability catalog
@@ -177,18 +178,6 @@ jobs:
           python scripts/telemetry_semantic_guard.py
           python -m unittest scripts.tests.test_telemetry_semantic_guard -v
 
-  msrv:
-    name: Rust 1.95 MSRV
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up Rust 1.95
-        uses: dtolnay/rust-toolchain@1.95.0
-
-      - name: Check workspace
-        run: cargo check --manifest-path rocketmq-ai/rocketmq-sre/Cargo.toml --locked --workspace
 
   ui:
     name: Read-only UI

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,22 +9,12 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
-      - 'fuzz/**'
-      - 'rocketmq-broker/**'
-      - 'rocketmq-controller/**'
-      - 'rocketmq-protocol/**'
-      - 'rocketmq-store-local/**'
       - '.github/workflows/security-audit.yml'
   pull_request:
     branches: [ "main" ]
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
-      - 'fuzz/**'
-      - 'rocketmq-broker/**'
-      - 'rocketmq-controller/**'
-      - 'rocketmq-protocol/**'
-      - 'rocketmq-store-local/**'
       - '.github/workflows/security-audit.yml'
   schedule:
     # Run security audit daily at 00:00 UTC
@@ -33,7 +23,7 @@ on:
 
 # Cancel previous runs if a new commit is pushed
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sync-issue-labels.yml
+++ b/.github/workflows/sync-issue-labels.yml
@@ -15,10 +15,6 @@ jobs:
 
 
     steps:
-      # Checkout the repository
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-
       - name: Sync Labels from Linked Issue
         uses: actions/github-script@v9
         with:

--- a/.github/workflows/website-check.yml
+++ b/.github/workflows/website-check.yml
@@ -8,6 +8,11 @@ on:
     paths:
       - 'rocketmq-website/**'
       - '.github/workflows/website-check.yml'
+      - '.github/workflows/deploy.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/rocketmq-doc/en/agent-validation-reference.md
+++ b/rocketmq-doc/en/agent-validation-reference.md
@@ -3,6 +3,7 @@
 Read this file when a change needs specialist or integration evidence. These are selectable tools,
 not cumulative development gates. Routine checks and the stopping rule live in the root
 [AGENTS.md](../../AGENTS.md); standalone project commands live in their nearest local guides.
+For automatic PR checks versus scheduled/manual integration, see the [CI policy](ci-validation-policy.md).
 
 Choose checks for the actual behavior, targets, and features being changed. Reuse a passing test or
 Clippy build as compilation evidence. Do not rerun equivalent checks or sweep unrelated historical
@@ -55,8 +56,9 @@ a repository-wide error cleanup.
 
 ## Observability features
 
-Select the affected `cargo check`, Clippy, and `cargo test -p rocketmq-observability` combinations
-from `.github/workflows/rocketmq-rust-ci.yaml`. Relevant combinations include `observability`,
+Select the affected package Clippy and `cargo test -p rocketmq-observability` combinations
+from `.github/workflows/rocketmq-rust-ci.yaml`. Clippy already covers compilation; do not add a
+duplicate workspace check for each combination. Relevant combinations include `observability`,
 `otlp-metrics`, `otel-metrics,prometheus`, `otlp-traces`, `otlp-logs`, and combined OTLP/Prometheus.
 Run the complete matrix for feature-wide integration, not an unrelated internal edit.
 

--- a/rocketmq-doc/en/architecture-release-evidence-index.md
+++ b/rocketmq-doc/en/architecture-release-evidence-index.md
@@ -10,8 +10,9 @@ commit SHA; this document does not claim that a scheduled or release run succeed
 
 - Formal Rust toolchain and MSRV: `1.95.0`.
 - Root workspace packages: 28.
-- Root final gates: `cargo fmt --all -- --check`, strict workspace Clippy, all-feature tests, and
-  `cargo doc --workspace --no-deps --all-features`.
+- Full integration checks: `cargo fmt --all -- --check`, workspace Clippy, all-feature tests, and
+  `cargo doc --workspace --no-deps --all-features`. Routine PR work is selected by changed paths;
+  see the [CI validation policy](ci-validation-policy.md) for feature and platform routing.
 
 | Package | Workspace path |
 |---|---|
@@ -75,11 +76,11 @@ must reference this baseline ID or a deliberately versioned successor.
 |---|---|---|---|---|---|
 | fuzz | Fuzz and production input maintainers | `nightly-2026-07-05` | `fuzz/Cargo.toml` | `cargo +nightly-2026-07-05 check --locked --manifest-path fuzz/Cargo.toml --all-targets --all-features` | `.github/workflows/fuzz-ci.yml` |
 | example | Examples maintainers | `1.95.0` | `rocketmq-example/Cargo.toml` | `cargo fmt --all -- --check`<br>`cargo clippy --all-targets -- -D warnings`<br>`cargo test`<br>`cargo build --examples` | `.github/workflows/rocketmq-example-ci.yaml` |
-| rocketmq-mcp | RocketMQ MCP maintainers | `1.95.0` | `rocketmq-ai/rocketmq-mcp/Cargo.toml` | `cargo fmt --all -- --check`<br>`cargo check --locked`<br>`python scripts/check_read_only_boundary.py`<br>`cargo test --locked`<br>`cargo test --locked --all-features`<br>`cargo clippy --locked --all-targets --features streamable-http -- -D warnings`<br>`cargo doc --locked --no-deps` | `.github/workflows/rocketmq-mcp-ci.yaml` |
-| rocketmq-sre | RocketMQ AI SRE maintainers | `1.95.0` | `rocketmq-ai/rocketmq-sre/Cargo.toml` | `cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check`<br>`cargo check --locked --workspace`<br>`cargo test --locked --workspace --all-features`<br>`cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`<br>`cargo doc --locked --workspace --no-deps`<br>`python scripts/check_source_layout.py`<br>`python scripts/check_execution_dependency_boundary.py` | `.github/workflows/rocketmq-sre-ci.yml` |
-| dashboard-gpui | Dashboard GPUI maintainers | `1.95.0` | `rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.toml` | `cargo fmt --all -- --check`<br>`cargo clippy --all-targets --all-features -- -D warnings`<br>`cargo check --all-targets --all-features`<br>`cargo test` | `.github/workflows/dashboard-gpui-ci.yml` |
+| rocketmq-mcp | RocketMQ MCP maintainers | `1.95.0` | `rocketmq-ai/rocketmq-mcp/Cargo.toml` | `cargo fmt --all -- --check`<br>`python scripts/check_read_only_boundary.py`<br>`cargo test --locked`<br>`cargo test --locked --all-features`<br>`cargo clippy --locked --all-targets --features streamable-http -- -D warnings`<br>`cargo doc --locked --no-deps` | `.github/workflows/rocketmq-mcp-ci.yaml` |
+| rocketmq-sre | RocketMQ AI SRE maintainers | `1.95.0` | `rocketmq-ai/rocketmq-sre/Cargo.toml` | `cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check`<br>`cargo test --locked --workspace --all-features`<br>`cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`<br>`cargo doc --locked --workspace --no-deps`<br>`python scripts/check_source_layout.py`<br>`python scripts/check_execution_dependency_boundary.py` | `.github/workflows/rocketmq-sre-ci.yml` |
+| dashboard-gpui | Dashboard GPUI maintainers | `1.95.0` | `rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.toml` | `cargo fmt --all -- --check`<br>`cargo clippy --all-targets --all-features -- -D warnings`<br>`cargo test` | `.github/workflows/dashboard-gpui-ci.yml` |
 | dashboard-tauri-backend | Dashboard Tauri maintainers | `1.95.0` | `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml` | `cargo fmt --all -- --check`<br>`cargo clippy --all-targets --all-features -- -D warnings`<br>`cargo test --all-features` | `.github/workflows/dashboard-tauri-ci.yml` |
-| dashboard-web-backend | Dashboard Web backend maintainers | `1.95.0` | `rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml` | `cargo fmt --all -- --check`<br>`cargo clippy --all-targets --all-features -- -D warnings`<br>`cargo build --all-targets --all-features`<br>`cargo test` | `.github/workflows/dashboard-web-ci.yml` |
+| dashboard-web-backend | Dashboard Web backend maintainers | `1.95.0` | `rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml` | `cargo fmt --all -- --check`<br>`cargo clippy --all-targets --all-features -- -D warnings`<br>`cargo test` | `.github/workflows/dashboard-web-ci.yml` |
 
 ## Shared crate to standalone consumer edges
 
@@ -230,13 +231,13 @@ and inject `ChildServiceContext`/`TaskGroup` capabilities.
 
 ## Python architecture test inventory
 
-- Inventoried test modules: 119.
+- Inventoried test modules: 121.
 - Guard runner: `python scripts/run_architecture_tests.py --tier pr_static`.
 - Contract runner: `python scripts/run_architecture_tests.py --tier milestone_contract --tier phase_contract --tier dynamic_fixture`.
 
 | Tier | Modules |
 |---|---:|
-| `pr_static` | 39 |
+| `pr_static` | 41 |
 | `milestone_contract` | 26 |
 | `phase_contract` | 24 |
 | `dynamic_fixture` | 25 |

--- a/rocketmq-doc/en/ci-validation-policy.md
+++ b/rocketmq-doc/en/ci-validation-policy.md
@@ -1,0 +1,147 @@
+# CI validation policy and audit
+
+Reviewed on 2026-09-08 across all 29 workflows. This policy reduces routine PR work while retaining
+compilation, focused behavior coverage, feature checks when relevant, and release/security boundaries.
+
+## Routine PR checks
+
+The root workflow starts on every PR to main so required statuses are always reported.
+`scripts/ci_scope.py` reads the actual root workspace members and the changed paths. It does not
+invoke Cargo metadata, compile code, require a clean checkout, or compare source fingerprints.
+
+- Ordinary root Rust changes run format/Clippy and Linux workspace tests with default features.
+- Documentation outside workspace crates and standalone-only changes skip root Rust builds.
+  Markdown inside crates can be embedded or consumed as data and keeps its owning build coverage.
+- AGENTS, project routing, and CI selector changes run lightweight routing/selector tests.
+- Approval automation changes run focused decision tests.
+- Protocol/header, error, observability, and RocksDB changes select the corresponding specialist checks.
+- Root dependency/toolchain changes and member feature definitions select all-feature Clippy/tests
+  as well as the specialist feature matrices, covering optional dependencies before merge.
+- Full feature builds and Windows/macOS builds run after relevant changes reach main and during
+  scheduled/manual integration. Coverage and full architecture audits run scheduled/manual.
+- Workflow concurrency cancels superseded validation runs for the same PR/ref and event type.
+  Main pushes do not cancel scheduled or manually requested integration work.
+
+A failed Git diff or selector fails the required check. Renames include both old and new paths;
+declared workspace patterns still match a package whose manifest was deleted.
+The selector uses Git revisions only to identify the diff, not as a source-identity acceptance gate.
+
+## Required GitHub statuses
+
+The main branch protection inspected during this review requires these five contexts:
+
+- `Check (fmt + clippy)`
+- `Build & Test (ubuntu-latest)`
+- `Build & Test (windows-latest)`
+- `Build & Test (macos-latest)`
+- `Code Coverage`
+
+Keep these names stable. Windows/macOS and coverage are fixed-name jobs with job-level conditions;
+on routine PRs they report skipped rather than disappearing. The root workflow has no path-level
+filter that could leave a required check pending. The example workflow now has a distinct check name.
+
+GitHub documents that a skipped job satisfies required-check status, while a workflow skipped by
+path filtering can leave required checks pending:
+[job conditions](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions),
+[workflow path filters](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore).
+
+No branch protection or ruleset settings are changed by this patch. The workflow changes take effect
+when published and merged; local validation cannot measure the resulting hosted runner time.
+
+## Expected task reduction
+
+These counts are derived from workflow matrices and selector scenarios, not measured duration.
+They count executed root jobs and exclude skipped contexts and independently triggered project workflows.
+
+| Change | Previous root workflow | Updated root workflow |
+| --- | ---: | ---: |
+| Internal client Rust change | 22 jobs | 2 jobs |
+| Protocol header change | 22 jobs | 3 jobs |
+| Observability crate change | 22 jobs | 9 jobs; feature Clippy is package-scoped |
+| Root README or AGENTS change | 22 jobs | 1 lightweight job |
+| Website documentation | Root workflow could be absent | 1 lightweight root job; one website PR build |
+
+The seven observability combinations remain, but redundant workspace `cargo check` is removed and
+Clippy runs on `rocketmq-observability` instead of compiling the entire workspace per combination.
+Full-workspace all-feature integration still runs on main and scheduled/manual runs.
+
+## Workflow inventory and decisions
+
+| Workflow file | Decision |
+| --- | --- |
+| `rocketmq-rust-ci.yaml` | Select work by actual changed paths; retain required context names; default-feature Linux PR checks; move full architecture contracts, debt reports, coverage, and redundant interface suites to scheduled/manual integration. |
+| `rocketmq-example-ci.yaml` | Keep Linux format/Clippy/tests; move three-platform example builds to main/manual; use a unique check name. |
+| `rocketmq-mcp-ci.yaml` | Keep read-only boundary and default/HTTP tests; remove duplicate same-toolchain check/MSRV job; Rustdoc after merge; push only on main to avoid branch push plus PR duplication. |
+| `rocketmq-sre-ci.yml` | Keep execution boundaries, tests, PostgreSQL recovery, UI, and Clippy; remove duplicate metadata/check/MSRV work; run only ignored PostgreSQL tests in the second pass; Rustdoc after merge. |
+| `dashboard-gpui-ci.yml` | Remove `cargo check` already covered by Clippy/tests. |
+| `dashboard-web-ci.yml` | Remove separate build already covered by tests/Clippy; four-engine storage Compose integration runs on main/manual. |
+| `dashboard-tauri-ci.yml` | Keep frontend and Rust tests; move four-platform application packaging to main/manual. |
+| `fuzz-ci.yml` | Keep harness compilation on PRs; four runtime fuzz jobs execute on nightly/weekly/manual runs. |
+| `security-audit.yml` | Keep eight lockfile audits and daily advisory checks; trigger on manifests/lockfiles rather than ordinary broker/protocol/storage source edits. |
+| `website-check.yml` | Own the single website PR build, including deployment workflow changes. |
+| `deploy.yml` | Build/deploy only on main push or manual dispatch; preserve serialized deployment. |
+| `container-foundation-ci.yml` | Keep static contract/tests on PRs; foundation/five-image builds and supply-chain evidence after merge/manual; isolate concurrency per PR/ref. |
+| `core-kubernetes-assets-ci.yml` | Keep path-scoped core candidate boundary checks; cancel superseded runs. |
+| `kubernetes-assets-ci.yml` | Keep path-scoped Helm/Kustomize contract validation; cancel superseded runs. |
+| `architecture-documentation.yml` | Generated evidence and governance become weekly/manual; remove property suites already run nightly and their unused native dependency installation. |
+| `architecture-nightly-evidence.yml` | Retain scheduled/manual Loom, property, Miri, and standalone coverage; cancel superseded runs. |
+| `architecture-performance-evidence.yml` | Retain existing scheduled/manual benchmark workflow; already outside PR gates. |
+| `architecture-slo-evidence.yml` | Retain path-scoped static contracts; six-hour dynamic work was already scheduled/manual only. |
+| `kubernetes-fault-matrix.yml` | Retain path-scoped static checks; dynamic fault runs were already scheduled/manual only. |
+| `release-candidate.yml` | Retain explicit candidate preparation/build/qualification; not a routine PR gate. |
+| `core-service-image-publish.yml` | Retain manual local-candidate checks and remote-publication boundary. |
+| `service-image-publish.yml` | Retain release/manual publication, signatures, scanning, and immutable artifact checks. |
+| `v1-functional-acceptance.yml` | Retain manual candidate handoff/qualification. |
+| `auto_approve_pull_requests.yml` | Remove nine-minute initial sleep and fifteen-minute polling; recheck on root CI completion or PR readiness events; honor required check names/apps and skipped contexts; approve only the checked commit. |
+| `auto_merge.yml` | Ignore unrelated label churn and cancel superseded attempts; keep merge label, approval count, and merge policy. |
+| `auto_request_review.yml` | Keep reviewer routing and cancel superseded runs. |
+| `auto-comment-pr.yml` | Remove unnecessary checkout from metadata-only automation. |
+| `remove-label-on-approve.yml` | Remove unnecessary checkout from metadata-only automation. |
+| `sync-issue-labels.yml` | Remove unnecessary checkout from metadata-only automation. |
+
+Standalone source workflows exclude only `AGENTS.md`; the root routing job handles those edits.
+MCP prompt Markdown, its README compatibility fixture, and the SRE operations runbook remain covered.
+Product authorization, audit, wire/storage compatibility, and cryptographic release-artifact integrity
+are unchanged. Download checksums and release signatures are distinct from routine development gates.
+
+Automatic approval uses `workflow_run` because GitHub Actions does not trigger `check_suite` workflows
+for its own suites. A missing PR list is resolved through the commit association API. Old completion
+events cannot approve a newer PR head, and the review is attached to the checked commit. This workflow
+uses trusted metadata-only scripts and never checks out PR code or downloads its artifacts.
+See GitHub's [event documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows).
+The completion trigger becomes active after this workflow is present on the default branch.
+
+## Verification and limitations
+
+- Parse all workflow YAML and run actionlint on changed workflows.
+- `python -m unittest discover -s scripts/tests -p test_ci_scope.py -v`
+- `node --test scripts/tests/test_auto_approve.cjs`
+- Check existing workflow contract tests and the Python test inventory; keep its generated index aligned.
+- `scripts/check-agents-routing.ps1` or `bash scripts/check-agents-routing.sh`
+- `git diff --check`
+
+The Python and Node tests use standard libraries. PyYAML and actionlint are local review tools, not
+new project dependencies or required PR jobs. No Cargo/Node application build is required to validate
+these workflow/selector changes locally; hosted builds are not claimed to have passed.
+The existing documentation inventory and generated index reflect the removed duplicate commands;
+the documentation guard no longer requires Codecov upload failures to fail integration.
+
+Review results: 21 selector tests (including real Git deletion/rename/event scenarios), 13 approval
+tests, 6 routing tests, and 9 documentation tests passed. All 29 workflow YAML files passed duplicate-key
+and job-dependency checks; all 22 changed workflows passed actionlint. The actual root shell branches
+were exercised with a Cargo stub for default/all-feature selection, without compiling applications.
+The documentation guard and `git diff --check` passed.
+
+The pre-change full-repository actionlint baseline already reports the unlisted custom runner label
+`rocketmq-release-candidate` in `release-candidate.yml` and `v1-functional-acceptance.yml`.
+These unchanged workflows are outside this patch's successful changed-workflow lint check.
+
+The existing container contract test reports `mcp_stdio entrypoint must use the shared lifecycle
+SIGINT/SIGTERM waiter`. Substituting the HEAD workflow into the same audit returns the identical
+finding; these workflow edits introduce no additional container contract findings.
+
+MCP/SRE currently use Rust 1.95 for both normal checks and their MSRV. Restore a distinct MSRV job
+only if the development toolchain and supported minimum diverge. Cross-platform regressions and full
+coverage now surface during integration instead of blocking every PR. Platform-sensitive root changes
+can run the root workflow manually before merge; Tauri packaging, Web storage integration, and example
+platform builds have their own manual workflow entry points.

--- a/scripts/architecture-validation-inventory.json
+++ b/scripts/architecture-validation-inventory.json
@@ -83,7 +83,6 @@
       "toolchain": "1.95.0",
       "commands": [
         "cargo fmt --all -- --check",
-        "cargo check --locked",
         "python scripts/check_read_only_boundary.py",
         "cargo test --locked",
         "cargo test --locked --all-features",
@@ -100,7 +99,6 @@
       "toolchain": "1.95.0",
       "commands": [
         "cargo fmt -p rocketmq-sre-contracts -p rocketmq-sre-core -p rocketmq-sre-model-gateway -p rocketmq-sre-control-plane -p rocketmq-sre-connector -p rocketmq-sre-executor -p rocketmq-sre-execution-agent -p rocketmq-sre-probe -p rocketmq-sre-eval -p rocketmq-sre-client -p rocketmq-sre-cli -- --check",
-        "cargo check --locked --workspace",
         "cargo test --locked --workspace --all-features",
         "cargo clippy --locked --workspace --all-targets --all-features -- -D warnings",
         "cargo doc --locked --workspace --no-deps",
@@ -118,7 +116,6 @@
       "commands": [
         "cargo fmt --all -- --check",
         "cargo clippy --all-targets --all-features -- -D warnings",
-        "cargo check --all-targets --all-features",
         "cargo test"
       ]
     },
@@ -145,7 +142,6 @@
       "commands": [
         "cargo fmt --all -- --check",
         "cargo clippy --all-targets --all-features -- -D warnings",
-        "cargo build --all-targets --all-features",
         "cargo test"
       ]
     }
@@ -241,12 +237,13 @@
     ]
   },
   "python_tests": {
-    "expected_count": 119,
+    "expected_count": 121,
     "ci": {
       "guards": "python scripts/run_architecture_tests.py --tier pr_static",
       "contracts": "python scripts/run_architecture_tests.py --tier milestone_contract --tier phase_contract --tier dynamic_fixture"
     },
     "entries": [
+      {"path": "scripts/tests/test_agents_routing.py", "owner": "ci", "tier": "pr_static", "trigger_paths": ["**/AGENTS.md", "scripts/check-agents-routing.*", "scripts/tests/test_agents_routing.py"], "command": "python -m unittest scripts.tests.test_agents_routing -v", "estimated_seconds": 10, "platform": "any", "fixture_policy": "temporary-only"},
       {"path": "scripts/tests/test_arc_mut_guard.py", "owner": "runtime", "tier": "pr_static", "trigger_paths": ["scripts/**", "**/*.rs"], "command": "python -m unittest scripts.tests.test_arc_mut_guard -v", "estimated_seconds": 30, "platform": "any", "fixture_policy": "repository-fixtures"},
       {"path": "scripts/tests/test_arc_mut_soundness_probe.py", "owner": "runtime", "tier": "dynamic_fixture", "trigger_paths": ["scripts/**", "**/*.rs"], "command": "python -m unittest scripts.tests.test_arc_mut_soundness_probe -v", "estimated_seconds": 120, "platform": "any", "fixture_policy": "temporary-only"},
       {"path": "scripts/tests/test_architecture_debt_guard.py", "owner": "architecture", "tier": "pr_static", "trigger_paths": ["scripts/**", "rocketmq-doc/en/**"], "command": "python -m unittest scripts.tests.test_architecture_debt_guard -v", "estimated_seconds": 10, "platform": "any", "fixture_policy": "temporary-only"},
@@ -261,6 +258,7 @@
       {"path": "scripts/tests/test_architecture_slo_guard.py", "owner": "sre", "tier": "deferred_validation", "trigger_paths": ["scripts/**", "distribution/**"], "command": "python -m unittest scripts.tests.test_architecture_slo_guard -v", "estimated_seconds": 30, "platform": "any", "fixture_policy": "repository-fixtures"},
       {"path": "scripts/tests/test_architecture_target_runner.py", "owner": "architecture", "tier": "dynamic_fixture", "trigger_paths": ["scripts/**", "**/Cargo.toml"], "command": "python -m unittest scripts.tests.test_architecture_target_runner -v", "estimated_seconds": 300, "platform": "any", "fixture_policy": "temporary-only"},
       {"path": "scripts/tests/test_canonical_public_paths.py", "owner": "architecture", "tier": "pr_static", "trigger_paths": ["scripts/**", "rocketmq-client/**", "rocketmq-runtime/**", "rocketmq-transport/**", "rocketmq-store/**"], "command": "python -m unittest scripts.tests.test_canonical_public_paths -v", "estimated_seconds": 30, "platform": "any", "fixture_policy": "repository-fixtures"},
+      {"path": "scripts/tests/test_ci_scope.py", "owner": "ci", "tier": "pr_static", "trigger_paths": ["scripts/ci_scope.py", "scripts/tests/test_ci_scope.py", ".github/workflows/**"], "command": "python -m unittest scripts.tests.test_ci_scope -v", "estimated_seconds": 5, "platform": "any", "fixture_policy": "temporary-only"},
       {"path": "scripts/tests/test_critical_architecture_freeze_guard.py", "owner": "architecture", "tier": "pr_static", "trigger_paths": ["scripts/**", "rocketmq-runtime/**", "rocketmq-client/**", "rocketmq-broker/**", "rocketmq-transport/**"], "command": "python -m unittest scripts.tests.test_critical_architecture_freeze_guard -v", "estimated_seconds": 30, "platform": "any", "fixture_policy": "temporary-only"},
       {"path": "scripts/tests/test_environment_write_guard.py", "owner": "architecture", "tier": "pr_static", "trigger_paths": ["scripts/**", "**/*.rs"], "command": "python -m unittest scripts.tests.test_environment_write_guard -v", "estimated_seconds": 30, "platform": "any", "fixture_policy": "temporary-only"},
       {"path": "scripts/tests/test_generate_metric_catalog.py", "owner": "observability", "tier": "pr_static", "trigger_paths": ["scripts/**", "rocketmq-observability/**"], "command": "python -m unittest scripts.tests.test_generate_metric_catalog -v", "estimated_seconds": 30, "platform": "any", "fixture_policy": "temporary-only"},

--- a/scripts/architecture_documentation_guard.py
+++ b/scripts/architecture_documentation_guard.py
@@ -616,9 +616,6 @@ def validate_coverage(root: Path, policy: dict[str, Any]) -> list[Finding]:
     ):
         if token not in config:
             findings.append(Finding("coverage-policy", coverage["config"], f"missing {token}"))
-    root_workflow = (root / policy["root"]["workflow"]).read_text(encoding="utf-8")
-    if "fail_ci_if_error: true" not in root_workflow:
-        findings.append(Finding("coverage-upload-optional", policy["root"]["workflow"], "Codecov upload must fail clearly"))
     standalone = (root / coverage["standalone_workflow"]).read_text(encoding="utf-8")
     for entry in policy["standalone"]:
         if entry["id"] == "fuzz":
@@ -807,8 +804,9 @@ def render_document(policy: dict[str, Any], facts: Facts) -> str:
         "",
         f"- Formal Rust toolchain and MSRV: `{facts.formal_toolchain}`.",
         f"- Root workspace packages: {len(facts.root_packages)}.",
-        "- Root final gates: `cargo fmt --all -- --check`, strict workspace Clippy, all-feature tests, and",
-        "  `cargo doc --workspace --no-deps --all-features`.",
+        "- Full integration checks: `cargo fmt --all -- --check`, workspace Clippy, all-feature tests, and",
+        "  `cargo doc --workspace --no-deps --all-features`. Routine PR work is selected by changed paths;",
+        "  see the [CI validation policy](ci-validation-policy.md) for feature and platform routing.",
         "",
         "| Package | Workspace path |",
         "|---|---|",

--- a/scripts/ci_scope.py
+++ b/scripts/ci_scope.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Select root CI work from changed paths without builds or baseline checks."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+from pathlib import Path
+import subprocess
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def workspace_members(root: Path) -> tuple[str, ...]:
+    manifest = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+    # Keep declared paths/patterns even if a package or its manifest was deleted.
+    return tuple(pattern.rstrip("/") for pattern in manifest["workspace"]["members"])
+
+
+def classify(paths: list[str], members: tuple[str, ...], *, full: bool = False) -> dict[str, bool]:
+    paths = [path.replace("\\", "/").removeprefix("./") for path in paths]
+    # Markdown can be embedded with include_str! or used as runtime prompt data.
+    code = [path for path in paths if path.rsplit("/", 1)[-1] != "AGENTS.md"]
+
+    def under(path: str, roots: tuple[str, ...]) -> bool:
+        return any(fnmatch.fnmatchcase(path, root) or fnmatch.fnmatchcase(path, root + "/**") for root in roots)
+
+    global_config = any(
+        path in {"Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "rust-toolchain"}
+        or path.startswith(".cargo/")
+        for path in code
+    )
+    member_manifest = any(path.endswith("/Cargo.toml") and under(path, members) for path in code)
+    feature_config = global_config or member_manifest
+    root_workflow = ".github/workflows/rocketmq-rust-ci.yaml" in paths
+
+    return {
+        "full_features": full or feature_config,
+        "automation": full or any(path in {
+            ".github/workflows/auto_approve_pull_requests.yml",
+            "scripts/tests/test_auto_approve.cjs",
+        } for path in paths),
+        "rust": full or global_config or root_workflow
+        or any(path in {"rustfmt.toml", ".clippy.toml"} or under(path, members) for path in code),
+        "observability": full or feature_config or any(
+            under(path, ("rocketmq-observability", "rocketmq-runtime", "rocketmq-error", "rocketmq-model"))
+            or (path.startswith("rocketmq-broker/") and "observability" in path)
+            for path in code
+        ),
+        "rocksdb": full or feature_config or any(
+            under(path, ("rocketmq-store", "rocketmq-store-rocksdb", "rocketmq-store-api",
+                         "rocketmq-store-local", "rocketmq-broker"))
+            for path in code
+        ),
+        "header": full or global_config or any(
+            under(path, ("rocketmq-protocol", "rocketmq-macros", "scripts/request-header-codec"))
+            for path in code
+        ),
+        "errors": full or global_config or any(
+            under(path, ("rocketmq-error",))
+            or path in {"scripts/error_architecture_guard.py", "scripts/check-error-hygiene.ps1",
+                        "scripts/tests/test_error_architecture_guard.py"}
+            for path in code
+        ),
+        "routing": full or any(
+            path == "AGENTS.md" or path.endswith(("/AGENTS.md", "/Cargo.toml", "/package.json"))
+            or path.startswith(".github/workflows/")
+            or path in {"Cargo.toml", "package.json", "scripts/ci_scope.py",
+                        "scripts/tests/test_ci_scope.py", "scripts/tests/test_agents_routing.py",
+                        "scripts/check-agents-routing.ps1", "scripts/check-agents-routing.sh",
+                        "rocketmq-doc/en/agents-routing-validation-adr.md",
+                        "rocketmq-doc/en/agent-validation-reference.md"}
+            for path in paths
+        ),
+    }
+
+
+def changed_paths(root: Path, base: str) -> list[str]:
+    # Include both old and new paths when a file moves between projects.
+    result = subprocess.run(
+        ["git", "diff", "--no-renames", "--name-only", "-z", base, "HEAD", "--"],
+        cwd=root, check=True, capture_output=True,
+    )
+    return [os.fsdecode(path) for path in result.stdout.split(b"\0") if path]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paths", nargs="*", help="Explicit paths for local scope inspection")
+    args = parser.parse_args()
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    full = event_name in {"schedule", "workflow_dispatch"}
+    if args.paths is not None:
+        paths = args.paths
+    elif full:
+        paths = []
+    else:
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+        if event_name == "pull_request":
+            base = event["pull_request"]["base"]["sha"]
+        elif event_name == "push":
+            base = event["before"]
+        else:
+            raise ValueError(f"Unsupported CI event: {event_name}")
+        if base and set(base) == {"0"}:
+            full, paths = True, []
+        else:
+            paths = changed_paths(ROOT, base)
+
+    scope = classify(paths, workspace_members(ROOT), full=full)
+    print(json.dumps({"changed_files": len(paths), "checks": scope}, sort_keys=True))
+    if output := os.environ.get("GITHUB_OUTPUT"):
+        with Path(output).open("a", encoding="utf-8") as stream:
+            for name, enabled in scope.items():
+                stream.write(f"{name}={str(enabled).lower()}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_architecture_documentation_guard.py
+++ b/scripts/tests/test_architecture_documentation_guard.py
@@ -52,13 +52,14 @@ class ArchitectureDocumentationGuardTest(unittest.TestCase):
         for record in payload["documents"]:
             self.assertEqual({"path", "sections", "link_targets", "commands"}, set(record))
 
-    def test_documentation_workflow_provisions_property_suite_native_dependencies(self) -> None:
+    def test_ci_routes_test_inventory_and_coverage_match_current_workflows(self) -> None:
         root = Path(__file__).resolve().parents[2]
-        workflow = (root / ".github/workflows/architecture-documentation.yml").read_text(encoding="utf-8")
-
-        self.assertIn("Install native build dependencies", workflow)
-        self.assertIn("clang llvm libclang-dev", workflow)
-        self.assertIn("protobuf-compiler", workflow)
+        policy = guard.load_json(root / guard.POLICY_RELATIVE)
+        facts = guard.collect_facts(root, policy)
+        findings = guard.validate_routes(root, policy, facts)
+        findings.extend(guard.validate_python_tests(root, policy))
+        findings.extend(guard.validate_coverage(root, policy))
+        self.assertEqual([], findings)
 
     def test_observability_cache_key_is_normalized_for_feature_lists(self) -> None:
         root = Path(__file__).resolve().parents[2]

--- a/scripts/tests/test_auto_approve.cjs
+++ b/scripts/tests/test_auto_approve.cjs
@@ -1,0 +1,180 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const workflow = readFileSync(
+  path.join(__dirname, '../../.github/workflows/auto_approve_pull_requests.yml'), 'utf8',
+);
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+function workflowScript(index) {
+  const lines = workflow.split(/\r?\n/);
+  const starts = lines.flatMap((line, offset) => line === '          script: |' ? [offset + 1] : []);
+  assert.ok(starts[index], `Approval workflow must contain script ${index}`);
+  const body = [];
+  for (const line of lines.slice(starts[index])) {
+    if (line.trim() && !line.startsWith('            ')) break;
+    body.push(line.slice(12));
+  }
+  return new AsyncFunction('github', 'context', 'core', 'process', body.join('\n'));
+}
+const evaluate = workflowScript(0);
+const contextRepo = { owner: 'owner', repo: 'repo' };
+const pullRequest = {
+  number: 7, state: 'open', draft: false,
+  base: { ref: 'main', repo: { full_name: 'owner/repo' } }, head: { sha: 'current-head' },
+};
+const completion = pull_requests => ({
+  workflow_run: { event: 'pull_request', head_sha: 'current-head', pull_requests },
+});
+
+async function ready({
+  checks = [], statuses = [], required = ['Linux', 'Coverage'], appChecks = [],
+  pr = pullRequest, associated = [pullRequest],
+  payload = { check_suite: { head_sha: 'current-head', pull_requests: [{ number: 7 }] } },
+  outputs = {},
+} = {}) {
+  const listForRef = () => {};
+  const listAssociated = () => {};
+  return evaluate({
+    rest: {
+      pulls: { get: async () => ({ data: pr }) },
+      repos: {
+        getBranch: async () => ({ data: { protection: {
+          required_status_checks: { contexts: required, checks: appChecks },
+        } } }),
+        getCombinedStatusForRef: async () => ({ data: { statuses } }),
+        listPullRequestsAssociatedWithCommit: listAssociated,
+      },
+      checks: { listForRef },
+    },
+    paginate: async (method, options) => {
+      if (method === listForRef) {
+        assert.equal(options.ref, 'current-head');
+        return checks;
+      }
+      assert.equal(method, listAssociated);
+      assert.equal(options.commit_sha, 'current-head');
+      return associated;
+    },
+  }, { repo: contextRepo, payload }, {
+    setOutput(name, value) { outputs[name] = value; }, info() {},
+  });
+}
+
+const success = name => ({ name, status: 'completed', conclusion: 'success' });
+
+test('missing required checks do not approve', async () => {
+  assert.equal(await ready({ checks: [success('Linux')] }), false);
+  assert.equal(await ready(), false);
+});
+test('pending or failed required checks do not approve', async () => {
+  for (const check of [
+    { name: 'Coverage', status: 'in_progress' },
+    { name: 'Coverage', status: 'completed', conclusion: 'failure' },
+  ]) assert.equal(await ready({ checks: [success('Linux'), check] }), false);
+});
+test('explicitly skipped optional work satisfies its existing required context', async () => {
+  assert.equal(await ready({ checks: [
+    success('Linux'), { name: 'Coverage', status: 'completed', conclusion: 'skipped' },
+  ] }), true);
+});
+test('unrelated failed checks do not add new approval gates', async () => {
+  assert.equal(await ready({ checks: [
+    success('Linux'), success('Coverage'),
+    { name: 'Optional audit', status: 'completed', conclusion: 'failure' },
+  ] }), true);
+});
+test('legacy commit statuses are honored', async () => {
+  assert.equal(await ready({
+    checks: [success('Linux')], statuses: [{ context: 'Coverage', state: 'success' }],
+  }), true);
+  assert.equal(await ready({
+    checks: [success('Linux'), success('Coverage')],
+    statuses: [{ context: 'Coverage', state: 'failure' }],
+  }), false);
+});
+test('drafts and missing branch protection do not receive automatic approval', async () => {
+  assert.equal(await ready({ checks: [success('Linux'), success('Coverage')],
+    pr: { ...pullRequest, draft: true } }), false);
+  assert.equal(await ready({ required: [] }), false);
+});
+
+test('Actions completion resolves the PR and returns the checked commit', async () => {
+  const outputs = {};
+  assert.equal(await ready({ payload: completion([{ number: 7 }]), outputs,
+    checks: [success('Linux'), success('Coverage')] }), true);
+  assert.equal(outputs.pull_request_number, 7);
+  assert.equal(outputs.checked_commit, 'current-head');
+});
+
+test('Actions completion with no PR array resolves an associated open PR', async () => {
+  assert.equal(await ready({ payload: completion([]),
+    checks: [success('Linux'), success('Coverage')] }), true);
+  assert.equal(await ready({ payload: completion([]), associated: [],
+    checks: [success('Linux'), success('Coverage')] }), false);
+});
+
+test('stale completion cannot approve a newer PR head', async () => {
+  assert.equal(await ready({ payload: completion([{ number: 7 }]),
+    pr: { ...pullRequest, head: { sha: 'newer-head' } },
+    checks: [success('Linux'), success('Coverage')] }), false);
+});
+
+test('closed PRs and push workflow completions do not approve', async () => {
+  assert.equal(await ready({ pr: { ...pullRequest, state: 'closed' },
+    checks: [success('Linux'), success('Coverage')] }), false);
+  assert.equal(await ready({ payload: { workflow_run: {
+    ...completion([{ number: 7 }]).workflow_run, event: 'push',
+  } }, checks: [success('Linux'), success('Coverage')] }), false);
+});
+
+test('a required GitHub App check cannot be supplied by another app or a legacy status', async () => {
+  const options = { required: ['Linux'], appChecks: [{ context: 'Linux', app_id: 15368 }] };
+  assert.equal(await ready({ ...options,
+    checks: [{ ...success('Linux'), app: { id: 15368 } }] }), true);
+  assert.equal(await ready({ ...options,
+    checks: [{ ...success('Linux'), app: { id: 123 } }] }), false);
+  assert.equal(await ready({ ...options,
+    statuses: [{ context: 'Linux', state: 'success' }] }), false);
+});
+
+async function approve(pr) {
+  const reviews = [];
+  await workflowScript(1)({ rest: { pulls: {
+    get: async () => ({ data: pr }),
+    createReview: async review => { reviews.push(review); },
+  } } }, { repo: contextRepo }, { info() {} }, {
+    env: { PR_NUMBER: '7', CHECKED_COMMIT: 'current-head' },
+  });
+  return reviews;
+}
+
+test('approval is attached to the checked commit', async () => {
+  const reviews = await approve(pullRequest);
+  assert.equal(reviews.length, 1);
+  assert.equal(reviews[0].commit_id, 'current-head');
+  assert.equal(reviews[0].event, 'APPROVE');
+});
+
+test('a push, closure, or draft conversion between checking and approval cancels approval', async () => {
+  for (const pr of [
+    { ...pullRequest, head: { sha: 'newer-head' } },
+    { ...pullRequest, state: 'closed' },
+    { ...pullRequest, draft: true },
+  ]) assert.deepEqual(await approve(pr), []);
+});

--- a/scripts/tests/test_ci_scope.py
+++ b/scripts/tests/test_ci_scope.py
@@ -1,0 +1,211 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import subprocess
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import ci_scope
+
+
+class CiScopeTests(unittest.TestCase):
+    members = (
+        "rocketmq-client", "rocketmq-protocol", "rocketmq-runtime", "rocketmq-error",
+        "rocketmq-observability", "rocketmq-broker", "rocketmq-store",
+        "rocketmq-dashboard/rocketmq-dashboard-common",
+    )
+
+    def scope(self, *paths: str) -> dict[str, bool]:
+        return ci_scope.classify(list(paths), self.members)
+
+    def test_documentation_does_not_compile_rust(self) -> None:
+        self.assertFalse(any(self.scope("README.md", "rocketmq-doc/en/design.md").values()))
+
+    def test_markdown_inside_a_crate_can_be_a_compile_time_asset(self) -> None:
+        self.assertTrue(self.scope("rocketmq-client/prompts/diagnose.md")["rust"])
+
+    def test_local_instructions_only_run_routing(self) -> None:
+        enabled = {name for name, value in self.scope("rocketmq-client/AGENTS.md").items() if value}
+        self.assertEqual({"routing"}, enabled)
+
+    def test_approval_changes_run_decision_tests_without_compiling_rust(self) -> None:
+        scope = self.scope(".github/workflows/auto_approve_pull_requests.yml")
+        self.assertTrue(scope["automation"] and scope["routing"])
+        self.assertFalse(scope["rust"])
+
+    def test_standalone_frontend_and_rust_do_not_compile_root_workspace(self) -> None:
+        for path in (
+            "rocketmq-ai/rocketmq-mcp/src/main.rs",
+            "rocketmq-ai/rocketmq-sre/crates/core/src/lib.rs",
+            "rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/App.tsx",
+            "rocketmq-dashboard/rocketmq-dashboard-web/backend/src/lib.rs",
+        ):
+            with self.subTest(path=path):
+                self.assertFalse(self.scope(path)["rust"])
+
+    def test_shared_dashboard_crate_still_compiles_root_workspace(self) -> None:
+        self.assertTrue(self.scope("rocketmq-dashboard/rocketmq-dashboard-common/src/lib.rs")["rust"])
+
+    def test_internal_client_change_does_not_trigger_specialist_matrices(self) -> None:
+        enabled = {name for name, value in self.scope("rocketmq-client/src/consumer.rs").items() if value}
+        self.assertEqual({"rust"}, enabled)
+
+    def test_affected_feature_and_contract_checks_are_selected(self) -> None:
+        for path, expected in (
+            ("rocketmq-broker/src/observability/service.rs", {"rust", "observability", "rocksdb"}),
+            ("rocketmq-protocol/src/header.rs", {"rust", "header"}),
+            ("scripts/request-header-codec/compare_header_schema.py", {"header"}),
+            ("scripts/error_architecture_guard.py", {"errors"}),
+        ):
+            with self.subTest(path=path):
+                enabled = {name for name, value in self.scope(path).items() if value}
+                self.assertEqual(expected, enabled)
+
+    def test_root_dependency_and_member_feature_changes_cover_matrices(self) -> None:
+        for path in ("Cargo.lock", "Cargo.toml", "rocketmq-client/Cargo.toml"):
+            with self.subTest(path=path):
+                scope = self.scope(path)
+                self.assertTrue(scope["rust"] and scope["observability"] and scope["rocksdb"])
+                self.assertTrue(scope["full_features"])
+
+    def test_ordinary_source_changes_keep_default_feature_checks(self) -> None:
+        self.assertFalse(self.scope("rocketmq-client/src/consumer.rs")["full_features"])
+
+    def test_scheduled_and_manual_runs_cover_all_checks(self) -> None:
+        self.assertTrue(all(ci_scope.classify([], self.members, full=True).values()))
+
+    def test_failed_change_detection_is_not_treated_as_an_empty_diff(self) -> None:
+        with patch("scripts.ci_scope.subprocess.run", side_effect=subprocess.CalledProcessError(1, "git")):
+            with self.assertRaises(subprocess.CalledProcessError):
+                ci_scope.changed_paths(Path("."), "base")
+
+    def test_git_diff_preserves_spaces_deletions_and_both_sides_of_moves(self) -> None:
+        result = subprocess.CompletedProcess([], 0, stdout=b"rocketmq-client/old name.rs\0docs/new name.rs\0")
+        with patch("scripts.ci_scope.subprocess.run", return_value=result) as run:
+            self.assertEqual(
+                ["rocketmq-client/old name.rs", "docs/new name.rs"],
+                ci_scope.changed_paths(Path("."), "base"),
+            )
+        self.assertIn("--no-renames", run.call_args.args[0])
+        self.assertIn("-z", run.call_args.args[0])
+
+    def test_workspace_member_patterns_also_cover_deleted_packages(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ci-scope-") as directory:
+            root = Path(directory)
+            (root / "Cargo.toml").write_text('[workspace]\nmembers = ["crates/*"]\n', encoding="utf-8")
+            (root / "crates/member").mkdir(parents=True)
+            (root / "crates/member/Cargo.toml").write_text('[package]\nname = "member"\n', encoding="utf-8")
+            (root / "standalone").mkdir()
+            (root / "standalone/Cargo.toml").write_text("[workspace]\n", encoding="utf-8")
+            members = ci_scope.workspace_members(root)
+            self.assertTrue(ci_scope.classify(["crates/member/src/lib.rs"], members)["rust"])
+            self.assertTrue(ci_scope.classify(["crates/deleted/Cargo.toml"], members)["rust"])
+            self.assertFalse(ci_scope.classify(["standalone/src/lib.rs"], members)["rust"])
+
+
+class CiScopeEventTests(unittest.TestCase):
+    """Exercise the CLI against real Git history and GitHub event/output files."""
+
+    def setUp(self) -> None:
+        directory = tempfile.TemporaryDirectory(prefix="ci-scope-event-")
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name)
+        (self.root / "scripts").mkdir()
+        (self.root / "scripts/ci_scope.py").write_bytes(Path(ci_scope.__file__).read_bytes())
+        (self.root / "Cargo.toml").write_text('[workspace]\nmembers = ["member"]\n', encoding="utf-8")
+        (self.root / "member").mkdir()
+        (self.root / "member/Cargo.toml").write_text('[package]\nname = "member"\n', encoding="utf-8")
+        (self.root / "member/old name.rs").write_text("pub fn original() {}\n", encoding="utf-8")
+        self.git("init", "--quiet")
+        self.git("add", ".")
+        self.commit()
+        self.base = self.git("rev-parse", "HEAD").strip()
+
+    def git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", *args], cwd=self.root, check=True, capture_output=True, text=True,
+        ).stdout
+
+    def commit(self) -> None:
+        self.git("-c", "user.name=CI Test", "-c", "user.email=ci@example.invalid",
+                 "-c", "commit.gpgsign=false", "commit", "--quiet", "--no-verify", "-m", "test input")
+
+    def run_event(self, event_name: str, payload: dict) -> tuple[subprocess.CompletedProcess, dict[str, str]]:
+        event = self.root / "event.json"
+        output = self.root / "outputs.txt"
+        event.write_text(json.dumps(payload), encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(self.root / "scripts/ci_scope.py")], cwd=self.root,
+            env={**os.environ, "GITHUB_EVENT_NAME": event_name, "GITHUB_EVENT_PATH": str(event),
+                 "GITHUB_OUTPUT": str(output)}, capture_output=True, text=True,
+        )
+        values = dict(line.split("=", 1) for line in output.read_text().splitlines()) if output.exists() else {}
+        return result, values
+
+    def test_pr_move_out_of_workspace_still_validates_original_consumer(self) -> None:
+        (self.root / "docs").mkdir()
+        self.git("mv", "member/old name.rs", "docs/new name.rs")
+        self.commit()
+        result, values = self.run_event("pull_request", {"pull_request": {"base": {"sha": self.base}}})
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("true", values["rust"])
+        self.assertEqual(2, json.loads(result.stdout)["changed_files"])
+
+    def test_push_deletion_is_not_an_empty_change(self) -> None:
+        self.git("rm", "member/old name.rs")
+        self.commit()
+        result, values = self.run_event("push", {"before": self.base})
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("true", values["rust"])
+
+    def test_deleting_a_member_manifest_cannot_skip_rust_validation(self) -> None:
+        self.git("rm", "member/Cargo.toml")
+        self.commit()
+        result, values = self.run_event("push", {"before": self.base})
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("true", values["rust"])
+        self.assertEqual("true", values["full_features"])
+
+    def test_empty_pr_diff_emits_false_outputs(self) -> None:
+        result, values = self.run_event("pull_request", {"pull_request": {"base": {"sha": self.base}}})
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(values and all(value == "false" for value in values.values()))
+
+    def test_initial_push_selects_full_validation(self) -> None:
+        result, values = self.run_event("push", {"before": "0" * 40})
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(values and all(value == "true" for value in values.values()))
+
+    def test_manual_and_scheduled_events_need_no_diff_payload(self) -> None:
+        for event in ("schedule", "workflow_dispatch"):
+            with self.subTest(event=event):
+                result, values = self.run_event(event, {})
+                self.assertEqual(0, result.returncode, result.stderr)
+                self.assertTrue(values and all(value == "true" for value in values.values()))
+
+    def test_missing_git_revision_fails_without_success_outputs(self) -> None:
+        result, values = self.run_event("push", {"before": "missing-revision"})
+        self.assertNotEqual(0, result.returncode)
+        self.assertEqual({}, values)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10239

### Brief Description

Select root CI work by changed paths and workspace membership while preserving required status names. Routine PRs retain default-feature Linux checks and affected specialist coverage; broader architecture, coverage, platform, and packaging checks run on main or scheduled/manual integration as appropriate.

Replace approval polling with completion events, validate required checks and GitHub App bindings, and attach approval only to the checked current commit. Add regression coverage and align CI policy and the validation inventory.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_ci_scope scripts.tests.test_agents_routing scripts.tests.test_architecture_documentation_guard -v`: 36 tests passed.
- `node --test scripts/tests/test_auto_approve.cjs`: 13 tests passed.
- `scripts/check-agents-routing.ps1`: passed.
- `python scripts/architecture_documentation_guard.py --check`: passed.
- `git diff --check` and staged diff whitespace checks: passed.
- Hosted CI is not awaited, per maintainer request. Application builds and actionlint were not run in this submission session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added path-based CI routing to run relevant checks for each change.
  * Added manual and scheduled workflow runs, with automatic cancellation of superseded runs.
  * Improved pull request approval automation with broader status verification.
  * Added CI validation policy documentation and expanded architecture evidence coverage.

* **Changes**
  * Reduced resource-intensive builds, fuzzing, documentation, and integration checks during pull requests.
  * Limited deployment and artifact-building workflows to appropriate non-pull-request events.
  * Added support for Windows and macOS builds in scheduled or manually triggered Rust CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->