### PR TITLE
[ISSUE #10163]🧪Add unit tests for NameServer shutdown signal relay and wait

### DIFF
--- a/rocketmq-namesrv/src/bootstrap/signals.rs
+++ b/rocketmq-namesrv/src/bootstrap/signals.rs
@@ -48,3 +48,82 @@ pub(super) async fn wait(shutdown_rx: &mut watch::Receiver<bool>) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+    use std::pin::pin;
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn relay_broadcasts_shutdown_when_the_signal_completes() {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (signal_tx, signal_rx) = oneshot::channel::<()>();
+        signal_tx
+            .send(())
+            .expect("shutdown signal receiver should still be alive");
+
+        relay(
+            shutdown_tx,
+            async {
+                signal_rx.await.expect("shutdown signal sender should not be dropped");
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        assert!(*shutdown_rx.borrow(), "relay should broadcast the shutdown signal");
+    }
+
+    #[tokio::test]
+    async fn relay_cancelled_before_the_signal_leaves_the_value_unchanged() {
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+
+        relay(shutdown_tx, pending::<()>(), cancellation).await;
+
+        assert!(!*shutdown_rx.borrow(), "a cancelled relay must not broadcast shutdown");
+        assert!(
+            shutdown_rx.changed().await.is_err(),
+            "a returning relay drops the sender, closing the channel"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_returns_immediately_when_shutdown_already_broadcast() {
+        let (_shutdown_tx, mut shutdown_rx) = watch::channel(true);
+
+        assert!(
+            futures::poll!(pin!(wait(&mut shutdown_rx))).is_ready(),
+            "wait should not suspend when the current value is already true"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_suspends_until_shutdown_is_broadcast() {
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let mut waiter = pin!(wait(&mut shutdown_rx));
+
+        assert!(
+            futures::poll!(waiter.as_mut()).is_pending(),
+            "wait should suspend while the value is still false"
+        );
+
+        shutdown_tx.send(true).expect("waiter keeps a receiver alive");
+        waiter.await;
+    }
+
+    #[tokio::test]
+    async fn wait_returns_when_the_sender_is_dropped_without_a_change() {
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        drop(shutdown_tx);
+
+        wait(&mut shutdown_rx).await;
+
+        assert!(!*shutdown_rx.borrow(), "a closed channel keeps its last value");
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10163

### Brief Description

`relay` and `wait` in `rocketmq-namesrv/src/bootstrap/signals.rs` sit on the NameServer shutdown path and had no test coverage. This adds a `#[cfg(test)] mod tests` covering the five cases listed in the issue:

- `relay` broadcasts `true` on the watch channel when the shutdown signal completes.
- `relay` cancelled before the signal returns without broadcasting; the value stays `false` and the channel is closed because the relay drops the sender on return.
- `wait` returns without suspending when the current value is already `true`.
- `wait` suspends while the value is `false` and completes after a `send(true)`.
- `wait` returns when the sender is dropped without a value change.

Test-only change, no production code touched. The tests are deterministic and sleep-free: `std::future::pending()` supplies the never-completing signal, and `futures::poll!` on a pinned `wait` future asserts pending/ready directly instead of racing a timer.

### How Did You Test This Change?

```
cargo test -p rocketmq-namesrv --lib signals   # 5 passed
cargo fmt -p rocketmq-namesrv -- --check
cargo clippy -p rocketmq-namesrv --no-deps --all-targets --all-features -- -D warnings
```

Also mutation-checked the assertions: dropping the `*shutdown_rx.borrow()` early return in `wait` and flipping `shutdown_tx.send(true)` to `send(false)` in `relay` each make the new tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for shutdown signal handling, including broadcasting on completion, cancellation behavior, waiting for shutdown, and sender closure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->