### PR TITLE
[ISSUE #10250]🐛Preserve consume retry and Proxy request ownership

### DIFF
--- a/distribution/package_publish_workspace.py
+++ b/distribution/package_publish_workspace.py
@@ -159,15 +159,24 @@ def build_plan(
         if entry.get("classification") == "registry-publish"
     }
     dependencies: dict[str, set[str]] = {}
+    dev_dependencies: dict[str, set[str]] = {}
     for name in publishable:
         package_dependencies = workspace[name].get("dependencies", [])
         if not isinstance(package_dependencies, list):
             raise PlannerError(f"metadata dependencies are invalid for {name}")
         internal: set[str] = set()
+        development: set[str] = set()
         for dependency in package_dependencies:
             if not isinstance(dependency, dict) or not isinstance(dependency.get("name"), str):
                 raise PlannerError(f"metadata dependency is invalid for {name}")
             dependency_name = dependency["name"]
+            kind = dependency.get("kind")
+            if kind not in (None, "normal", "build", "dev"):
+                raise PlannerError(f"unknown dependency kind {kind!r} for {name}")
+            if kind == "dev":
+                if dependency_name in workspace:
+                    development.add(dependency_name)
+                continue
             if dependency_name not in scoped:
                 if dependency.get("path") is not None:
                     raise PlannerError(
@@ -184,6 +193,7 @@ def build_plan(
             if dependency_name != name:
                 internal.add(dependency_name)
         dependencies[name] = internal
+        dev_dependencies[name] = development
 
     if selector is None:
         selected = set(publishable)
@@ -224,6 +234,7 @@ def build_plan(
                 "version": package.get("version"),
                 "order": index,
                 "internal_dependencies": sorted(selected_dependencies[name]),
+                "internal_dev_dependencies": sorted(dev_dependencies[name]),
                 "operation_type": "registry-package",
                 "target_registry": "crates.io",
             }

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -76,6 +76,7 @@ cheetah-string = { workspace = true }
 hickory-resolver = { workspace = true, optional = true }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 rocketmq-namesrv   = { workspace = true }
 rocketmq-transport = { workspace = true, features = ["socks", "test-support", "tls"] }
 criterion = { version = "0.8.2", features = ["async_tokio"] }

--- a/rocketmq-client/src/consumer/consumer_impl/bounded_consume_scheduler.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/bounded_consume_scheduler.rs
@@ -39,6 +39,12 @@ struct ScheduledItem<T> {
     _queued_permit: OwnedSemaphorePermit,
 }
 
+/// A retry transfers the admitted item without acquiring another capacity slot.
+pub(crate) enum ConsumeDisposition<T> {
+    Complete,
+    Retry { item: T, after: Duration },
+}
+
 type DelayedCommand<T> = (ScheduledItem<T>, Duration);
 
 impl<T> ScheduledItem<T> {
@@ -118,7 +124,7 @@ where
     ) -> ClientResult<()>
     where
         H: Fn(T) -> F + Send + Sync + Clone + 'static,
-        F: Future<Output = ()> + Send + 'static,
+        F: Future<Output = ConsumeDisposition<T>> + Send + 'static,
     {
         if worker_count == 0 {
             return Err(crate::mq_client_err!(
@@ -213,10 +219,11 @@ where
     ) -> ClientResult<()>
     where
         H: Fn(T) -> F + Send + Sync + 'static,
-        F: Future<Output = ()> + Send + 'static,
+        F: Future<Output = ConsumeDisposition<T>> + Send + 'static,
     {
         let stopping = self.stopping.clone();
         let force_stop = self.force_stop.clone();
+        let delayed_tx = self.delayed_tx.clone();
         let task = self.tasks.track_future(async move {
             loop {
                 let scheduled = tokio::select! {
@@ -230,11 +237,24 @@ where
                 let Some(scheduled) = scheduled else {
                     break;
                 };
-                let item = scheduled.into_item();
-                tokio::select! {
+                let ScheduledItem { item, _queued_permit } = scheduled;
+                let disposition = tokio::select! {
                     biased;
                     _ = force_stop.cancelled() => break,
-                    () = handler(item) => {}
+                    disposition = handler(item) => disposition,
+                };
+                if let ConsumeDisposition::Retry { item, after } = disposition {
+                    if stopping.is_cancelled() {
+                        break;
+                    }
+                    // Every ready, running, and delayed item owns one of K permits.
+                    // This transfer therefore always fits in the K-sized channel.
+                    let scheduled = ScheduledItem { item, _queued_permit };
+                    if let Err(error) = delayed_tx.try_send((scheduled, after)) {
+                        let (_unfinished, _) = error.into_inner();
+                        warn!("consume retry transfer rejected; unfinished messages remain uncommitted");
+                        break;
+                    }
                 }
             }
         });
@@ -295,6 +315,15 @@ where
 
     pub(crate) async fn shutdown(&self, timeout: Duration) -> bool {
         self.stopping.cancel();
+        self.queued_slots.close();
+        self.ready_rx
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        self.delayed_rx
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
         self.tasks.close();
         if tokio::time::timeout(timeout, self.tasks.wait()).await.is_ok() {
             return true;
@@ -371,6 +400,7 @@ mod tests {
                             active.fetch_sub(1, Ordering::AcqRel);
                             completed.fetch_add(1, Ordering::AcqRel);
                             changed.notify_waiters();
+                            ConsumeDisposition::Complete
                         }
                     }
                 },
@@ -412,6 +442,7 @@ mod tests {
                         async move {
                             completed.fetch_add(1, Ordering::AcqRel);
                             changed.notify_waiters();
+                            ConsumeDisposition::Complete
                         }
                     }
                 },
@@ -449,7 +480,7 @@ mod tests {
                         async move {
                             active.store(true, Ordering::Release);
                             entered.notify_waiters();
-                            futures::future::pending::<()>().await;
+                            futures::future::pending::<ConsumeDisposition<usize>>().await
                         }
                     }
                 },
@@ -464,8 +495,7 @@ mod tests {
             }
             notified.await;
         }
-        scheduler.schedule(2).await.expect("one queued item should fit");
-        let blocked = scheduler.schedule(3);
+        let blocked = scheduler.schedule(2);
         tokio::pin!(blocked);
         tokio::select! {
             result = &mut blocked => panic!("admission should wait while the queue is full: {result:?}"),
@@ -474,7 +504,61 @@ mod tests {
 
         assert!(scheduler.shutdown(Duration::ZERO).await);
         let rejected = blocked.await.expect_err("shutdown must reject blocked admission");
-        assert_eq!(rejected.into_item(), 3);
+        assert_eq!(rejected.into_item(), 2);
         assert_eq!(scheduler.queued(), 0);
+    }
+    #[tokio::test(start_paused = true)]
+    async fn saturated_workers_retry_with_original_capacity_and_release_on_shutdown() {
+        for workers in [1, 2] {
+            let scheduler = BoundedConsumeScheduler::new(2).unwrap();
+            let entered = Arc::new(AtomicUsize::new(0));
+            let changed = Arc::new(Notify::new());
+            let releases = Arc::new(Semaphore::new(0));
+            let runs = Arc::new(AtomicUsize::new(0));
+            let runtime = rocketmq_runtime::RuntimeContext::try_from_current("saturated-retry").unwrap();
+            let context = runtime.service_context("saturated-retry-service").component("consume");
+            scheduler
+                .start(&context, workers, {
+                    let entered = entered.clone();
+                    let changed = changed.clone();
+                    let releases = releases.clone();
+                    let runs = runs.clone();
+                    move |(item, attempt)| {
+                        let entered = entered.clone();
+                        let changed = changed.clone();
+                        let releases = releases.clone();
+                        let runs = runs.clone();
+                        async move {
+                            if attempt == 0 {
+                                entered.fetch_add(1, Ordering::AcqRel);
+                                changed.notify_waiters();
+                                releases.acquire().await.unwrap().forget();
+                            }
+                            runs.fetch_add(1, Ordering::AcqRel);
+                            changed.notify_waiters();
+                            ConsumeDisposition::Retry {
+                                item: (item, attempt + 1),
+                                after: Duration::from_secs(5),
+                            }
+                        }
+                    }
+                })
+                .unwrap();
+            scheduler.schedule((0, 0)).await.unwrap();
+            scheduler.schedule((1, 0)).await.unwrap();
+            wait_for(&entered, workers, &changed).await;
+            assert_eq!(scheduler.queued(), 2, "running items retain their permits");
+            releases.add_permits(2);
+            wait_for(&runs, 2, &changed).await;
+            for expected in [4, 6, 8] {
+                tokio::time::timeout(Duration::from_secs(6), wait_for(&runs, expected, &changed))
+                    .await
+                    .unwrap();
+                assert_eq!(scheduler.queued(), 2, "retries must not grow admission");
+            }
+            assert!(scheduler.shutdown(Duration::from_secs(1)).await);
+            assert_eq!(scheduler.queued(), 0);
+            assert_eq!(scheduler.task_count(), 0);
+        }
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -43,6 +43,7 @@ use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
 use crate::consumer::consumer_impl::bounded_consume_scheduler::BoundedConsumeScheduler;
+use crate::consumer::consumer_impl::bounded_consume_scheduler::ConsumeDisposition;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
@@ -224,13 +225,30 @@ impl ConsumeMessageConcurrentlyService {
 
     async fn process_consume_result(
         &self,
-        this: Arc<Self>,
+        _this: Arc<Self>,
         status: ConsumeConcurrentlyStatus,
         context: &ConsumeConcurrentlyContext,
         consume_request: &mut ConsumeRequest,
-    ) {
+    ) -> Vec<Arc<MessageExt>> {
+        self.process_consume_result_with(status, context, consume_request, |mut msg| async move {
+            let sent = self.send_message_back(Arc::make_mut(&mut msg), context).await;
+            (msg, sent)
+        })
+        .await
+    }
+
+    async fn process_consume_result_with<F>(
+        &self,
+        status: ConsumeConcurrentlyStatus,
+        context: &ConsumeConcurrentlyContext,
+        consume_request: &mut ConsumeRequest,
+        mut send_back: impl FnMut(Arc<MessageExt>) -> F,
+    ) -> Vec<Arc<MessageExt>>
+    where
+        F: Future<Output = (Arc<MessageExt>, bool)> + Send,
+    {
         if consume_request.msgs.is_empty() {
-            return;
+            return Vec::new();
         }
         let ack_index = normalize_ack_index(status, context.ack_index, consume_request.msgs.len());
 
@@ -256,6 +274,7 @@ impl ConsumeMessageConcurrentlyService {
             }
         }
 
+        let mut msg_back_failed = Vec::new();
         match self.consumer_config.message_model {
             MessageModel::Broadcasting => {
                 for i in ((ack_index + 1) as usize)..consume_request.msgs.len() {
@@ -269,9 +288,8 @@ impl ConsumeMessageConcurrentlyService {
                 }
             }
             MessageModel::Clustering => {
-                let mut msg_back_failed = Vec::new();
                 let pending = consume_request.msgs.split_off((ack_index + 1) as usize);
-                for mut msg in pending {
+                for msg in pending {
                     if !consume_request.process_queue.contains_message(&msg).await {
                         info!(
                             "Message is not found in its process queue; skip send-back-procedure, topic={}, \
@@ -285,7 +303,7 @@ impl ConsumeMessageConcurrentlyService {
                         continue;
                     }
 
-                    let sent = self.send_message_back(Arc::make_mut(&mut msg), context).await;
+                    let (mut msg, sent) = send_back(msg).await;
                     if sent {
                         consume_request.msgs.push(msg);
                     } else {
@@ -293,15 +311,6 @@ impl ConsumeMessageConcurrentlyService {
                         Arc::make_mut(&mut msg).set_reconsume_times(times);
                         msg_back_failed.push(msg);
                     }
-                }
-                if !msg_back_failed.is_empty() {
-                    self.submit_consume_request_later(
-                        msg_back_failed,
-                        this,
-                        consume_request.process_queue.clone(),
-                        consume_request.message_queue.clone(),
-                    )
-                    .await;
                 }
             }
         }
@@ -315,51 +324,20 @@ impl ConsumeMessageConcurrentlyService {
                     "consume offset update skipped: DefaultMQPushConsumerImpl is not initialized, group={}, mq={}",
                     self.consumer_group, consume_request.message_queue
                 );
-                return;
+                return msg_back_failed;
             };
             let Some(offset_store) = default_mqpush_consumer_impl.offset_store() else {
                 warn!(
                     "consume offset update skipped: OffsetStore is not initialized, group={}, mq={}",
                     self.consumer_group, consume_request.message_queue
                 );
-                return;
+                return msg_back_failed;
             };
             offset_store
                 .update_offset(&consume_request.message_queue, offset, true)
                 .await;
         }
-    }
-
-    async fn submit_consume_request_later(
-        &self,
-        msgs: Vec<Arc<MessageExt>>,
-        _this: Arc<Self>,
-        process_queue: Arc<ProcessQueue>,
-        message_queue: MessageQueue,
-    ) {
-        let request = ConsumeRequest {
-            msgs,
-            message_listener: self.message_listener.clone(),
-            process_queue: process_queue.clone(),
-            message_queue: message_queue.clone(),
-            dispatch_to_consume: true,
-            consumer_group: self.consumer_group.clone(),
-            default_mqpush_consumer_impl: self.consumer_impl(),
-        };
-        if let Err(error) = self
-            .consume_scheduler
-            .schedule_after(request, Duration::from_secs(5))
-            .await
-        {
-            let request = error.into_item();
-            request.process_queue.set_consuming(false);
-            warn!(
-                "concurrent consume retry rejected during shutdown, group={}, mq={}, msgs={}",
-                self.consumer_group,
-                request.message_queue,
-                request.msgs.len()
-            );
-        }
+        msg_back_failed
     }
 
     pub async fn send_message_back(&self, msg: &mut MessageExt, context: &ConsumeConcurrentlyContext) -> bool {
@@ -395,19 +373,23 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                 let service = Arc::clone(&worker_service);
                 async move {
                     if service.shutdown_token.is_cancelled() {
-                        return;
+                        return ConsumeDisposition::Complete;
                     }
                     let limiter = Arc::clone(&service.consume_semaphore);
                     let permit = tokio::select! {
                         biased;
-                        _ = service.shutdown_token.cancelled() => return,
+                        _ = service.shutdown_token.cancelled() => return ConsumeDisposition::Complete,
                         permit = limiter.acquire_owned() => match permit {
                             Ok(permit) => permit,
-                            Err(_) => return,
+                            Err(_) => return ConsumeDisposition::Complete,
                         }
                     };
-                    request.run(Arc::clone(&service)).await;
+                    let retry = request.run(Arc::clone(&service)).await;
                     drop(permit);
+                    match retry {
+                        Some(after) => ConsumeDisposition::Retry { item: request, after },
+                        None => ConsumeDisposition::Complete,
+                    }
                 }
             },
         ) {
@@ -666,13 +648,16 @@ struct ConsumeRequest {
 }
 
 impl ConsumeRequest {
-    async fn run(&mut self, consume_message_concurrently_service: Arc<ConsumeMessageConcurrentlyService>) {
+    async fn run(
+        &mut self,
+        consume_message_concurrently_service: Arc<ConsumeMessageConcurrentlyService>,
+    ) -> Option<Duration> {
         if self.process_queue.is_dropped() {
             info!(
                 "the message queue not be able to consume, because it's dropped. group={} {}",
                 self.consumer_group, self.message_queue,
             );
-            return;
+            return None;
         }
         let mut context = ConsumeConcurrentlyContext {
             message_queue: self.message_queue.clone(),
@@ -687,7 +672,7 @@ impl ConsumeRequest {
                 self.message_queue,
                 self.msgs.len()
             );
-            return;
+            return None;
         };
         DefaultMQPushConsumerImpl::try_reset_pop_retry_topic(&mut self.msgs, self.consumer_group.as_str());
         default_mqpush_consumer_impl.reset_retry_and_namespace(&mut self.msgs, self.consumer_group.as_str());
@@ -865,10 +850,15 @@ impl ConsumeRequest {
             );
         } else {
             let this = consume_message_concurrently_service.clone();
-            consume_message_concurrently_service
+            let failed = consume_message_concurrently_service
                 .process_consume_result(this, final_status, &context, self)
                 .await;
+            if !failed.is_empty() {
+                self.msgs = failed;
+                return Some(Duration::from_secs(5));
+            }
         }
+        None
     }
 }
 
@@ -1270,5 +1260,96 @@ mod tests {
                 &mut request,
             )
             .await;
+    }
+    #[tokio::test]
+    async fn send_back_partial_failure_preserves_queue_and_persisted_offset() {
+        use crate::consumer::store::offset_store::OffsetStore;
+        use crate::consumer::store::read_offset_type::ReadOffsetType;
+        let consumer = new_default_impl();
+        let offsets = Arc::new(OffsetStore::new_test());
+        consumer.set_offset_store(Some(offsets.clone()));
+        let service = new_service(Some(consumer.clone()));
+        let mut request = consume_request(Some(consumer));
+        request.msgs = (10..13)
+            .map(|offset| {
+                let mut msg = MessageExt::default();
+                msg.set_queue_offset(offset);
+                Arc::new(msg)
+            })
+            .collect();
+        request.process_queue.put_message(&request.msgs).await;
+        let originals = request.msgs.clone();
+        let context = ConsumeConcurrentlyContext::new(request.message_queue.clone());
+        let failed = service
+            .process_consume_result_with(
+                ConsumeConcurrentlyStatus::ReconsumeLater,
+                &context,
+                &mut request,
+                |msg| async move {
+                    let sent = msg.queue_offset() != 11;
+                    (msg, sent)
+                },
+            )
+            .await;
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].queue_offset(), 11);
+        assert_eq!(failed[0].reconsume_times(), 1);
+        assert!(!request.process_queue.contains_message(&originals[0]).await);
+        assert!(request.process_queue.contains_message(&originals[1]).await);
+        assert!(!request.process_queue.contains_message(&originals[2]).await);
+        assert_eq!(
+            offsets
+                .read_offset(&request.message_queue, ReadOffsetType::ReadFromMemory)
+                .await,
+            11
+        );
+        offsets
+            .persist_all(&std::collections::HashSet::from([request.message_queue.clone()]))
+            .await;
+        assert_eq!(offsets.test_persisted_offset(&request.message_queue), Some(11));
+        request.msgs = failed;
+        assert!(service
+            .process_consume_result_with(
+                ConsumeConcurrentlyStatus::ReconsumeLater,
+                &context,
+                &mut request,
+                |msg| async move { (msg, true) },
+            )
+            .await
+            .is_empty());
+        assert!(!request.process_queue.contains_message(&originals[1]).await);
+        assert_eq!(
+            offsets
+                .read_offset(&request.message_queue, ReadOffsetType::ReadFromMemory)
+                .await,
+            13
+        );
+        offsets
+            .persist_all(&std::collections::HashSet::from([request.message_queue.clone()]))
+            .await;
+        assert_eq!(offsets.test_persisted_offset(&request.message_queue), Some(13));
+    }
+
+    #[tokio::test]
+    async fn logical_fallback_failure_from_consume_result_never_removes_message() {
+        let consumer = new_default_impl();
+        let service = new_service(Some(consumer.clone()));
+        let mut request = consume_request(Some(consumer));
+        Arc::make_mut(&mut request.msgs[0]).broker_name =
+            format!("{}broker", mix_all::LOGICAL_QUEUE_MOCK_BROKER_PREFIX).into();
+        request.process_queue.put_message(&request.msgs).await;
+        let original = request.msgs[0].clone();
+        let context = ConsumeConcurrentlyContext::new(request.message_queue.clone());
+        let failed = service
+            .process_consume_result(
+                Arc::new(new_service(None)),
+                ConsumeConcurrentlyStatus::ReconsumeLater,
+                &context,
+                &mut request,
+            )
+            .await;
+        assert_eq!(failed.len(), 1);
+        assert!(request.process_queue.contains_message(&original).await);
+        assert!(request.msgs.is_empty());
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -42,6 +42,7 @@ use crate::base::client_config::ClientConfig;
 use crate::consumer::ack_callback::AckCallback;
 use crate::consumer::ack_result::AckResult;
 use crate::consumer::consumer_impl::bounded_consume_scheduler::BoundedConsumeScheduler;
+use crate::consumer::consumer_impl::bounded_consume_scheduler::ConsumeDisposition;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
@@ -140,15 +141,16 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
                 let service = Arc::clone(&worker_service);
                 async move {
                     if service.stopped.load(Ordering::Acquire) {
-                        return;
+                        return ConsumeDisposition::Complete;
                     }
                     let limiter = Arc::clone(&service.concurrency_limiter);
                     let permit = match limiter.acquire_owned().await {
                         Ok(permit) => permit,
-                        Err(_) => return,
+                        Err(_) => return ConsumeDisposition::Complete,
                     };
                     request.run(Arc::clone(&service)).await;
                     drop(permit);
+                    ConsumeDisposition::Complete
                 }
             },
         ) {
@@ -338,38 +340,6 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
 }
 
 impl ConsumeMessagePopConcurrentlyService {
-    /// Submit consume request after 5 seconds delay for retry
-    async fn submit_pop_consume_request_later(
-        &self,
-        _this: Arc<Self>,
-        msgs: Vec<MessageExt>,
-        process_queue: Arc<PopProcessQueue>,
-        message_queue: MessageQueue,
-    ) {
-        let request = ConsumeRequest::new(
-            msgs,
-            process_queue,
-            message_queue,
-            self.consumer_group.clone(),
-            self.message_listener.clone(),
-            self.consumer_impl(),
-        );
-        if let Err(error) = self
-            .consume_scheduler
-            .schedule_after(request, Duration::from_secs(5))
-            .await
-        {
-            let request = error.into_item();
-            request.process_queue.inc_found_msg(request.msgs.len());
-            warn!(
-                "POP concurrent retry rejected during shutdown, group={}, mq={}, msgs={}",
-                self.consumer_group,
-                request.message_queue,
-                request.msgs.len()
-            );
-        }
-    }
-
     async fn process_consume_result(
         &self,
         _this: Arc<Self>,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -47,6 +47,7 @@ use tracing::warn;
 use crate::base::client_config::ClientConfig;
 use crate::consumer::ack_result::AckResult;
 use crate::consumer::consumer_impl::bounded_consume_scheduler::BoundedConsumeScheduler;
+use crate::consumer::consumer_impl::bounded_consume_scheduler::ConsumeDisposition;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
@@ -73,12 +74,12 @@ pub struct ConsumeMessagePopOrderlyService {
     pub(crate) message_listener: ArcMessageListenerOrderly,
     pub(crate) concurrency_limiter: Arc<Semaphore>,
     pub(crate) max_concurrency: Arc<AtomicUsize>,
-    pub(self) consume_request_set: Arc<DashSet<ConsumeRequest>>,
+    pub(self) consume_request_set: Arc<DashSet<PopConsumeKey>>,
     pub(crate) message_queue_lock: MessageQueueLock,
     pub(crate) stopped: Arc<AtomicBool>,
     pub(crate) active_tasks: Arc<AtomicUsize>,
     pub(crate) lock_refresh_task: Arc<Mutex<Option<PopOrderlyTaskHandle>>>,
-    consume_scheduler: BoundedConsumeScheduler<ConsumeRequest>,
+    consume_scheduler: BoundedConsumeScheduler<RegisteredRequest>,
 }
 
 const POP_ORDERLY_SCHEDULER_CAPACITY: usize = 4_096;
@@ -201,10 +202,6 @@ impl ConsumeMessagePopOrderlyService {
         self.default_mqpush_consumer_impl.as_ref().and_then(Weak::upgrade)
     }
 
-    fn remove_consume_request(&self, request: &ConsumeRequest) {
-        self.consume_request_set.remove(request);
-    }
-
     pub async fn lock_mq_periodically(&self) {
         if self.stopped.load(Ordering::Acquire) {
             return;
@@ -306,44 +303,22 @@ impl ConsumeMessagePopOrderlyService {
         }
     }
 
-    async fn submit_consume_request(&self, _this: Arc<Self>, request: ConsumeRequest, force: bool) {
-        if !force && !self.consume_request_set.insert(request.clone()) {
+    async fn submit_consume_request(&self, _this: Arc<Self>, request: ConsumeRequest, _force: bool) {
+        let key = request.key();
+        if !self.consume_request_set.insert(key.clone()) {
             return;
         }
-        if let Err(error) = self.consume_scheduler.schedule(request).await {
-            let request = error.into_item();
-            self.consume_request_set.remove(&request);
-            request.process_queue.dec_found_msg(request.msgs.len());
-            warn!(
-                "POP orderly consume request rejected during shutdown, group={}, mq={}, msgs={}",
-                self.consumer_group,
-                request.message_queue,
-                request.msgs.len()
-            );
-        }
-    }
-
-    async fn submit_consume_request_later(
-        &self,
-        _this: Arc<Self>,
-        request: ConsumeRequest,
-        mut suspend_time_millis: u64,
-    ) {
-        suspend_time_millis = suspend_time_millis.clamp(10, 30_000);
-        if let Err(error) = self
-            .consume_scheduler
-            .schedule_after(request, Duration::from_millis(suspend_time_millis))
-            .await
-        {
-            let request = error.into_item();
-            self.consume_request_set.remove(&request);
-            request.process_queue.dec_found_msg(request.msgs.len());
-            warn!(
-                "POP orderly retry rejected during shutdown, group={}, mq={}, msgs={}",
-                self.consumer_group,
-                request.message_queue,
-                request.msgs.len()
-            );
+        let registered = RegisteredRequest {
+            request,
+            _registration: PopRegistration {
+                key,
+                registrations: Arc::clone(&self.consume_request_set),
+            },
+        };
+        if let Err(error) = self.consume_scheduler.schedule(registered).await {
+            let rejected = error.into_item();
+            warn!(group = %self.consumer_group, mq = %rejected.request.message_queue,
+                "POP orderly consume request rejected during shutdown");
         }
     }
 
@@ -362,28 +337,23 @@ impl ConsumeMessagePopOrderlyService {
         }
     }
 
-    async fn check_reconsume_times(&self, msgs: &mut [Arc<MessageExt>]) -> bool {
-        let mut suspend = false;
+    async fn check_reconsume_times(&self, msgs: &mut Vec<Arc<MessageExt>>) -> bool {
+        let mut retry = Vec::with_capacity(msgs.len());
         let max_times = self.get_max_reconsume_times();
-
-        for msg in msgs {
+        for mut msg in std::mem::take(msgs) {
             let reconsume_times = msg.reconsume_times;
             if reconsume_times >= max_times {
-                MessageAccessor::set_reconsume_time(
-                    Arc::make_mut(msg),
-                    CheetahString::from_string(reconsume_times.to_string()),
-                );
-                if !self.send_message_back(msg.as_ref()).await {
-                    suspend = true;
-                    Arc::make_mut(msg).reconsume_times = reconsume_times + 1;
+                MessageAccessor::set_reconsume_time(Arc::make_mut(&mut msg), reconsume_times.to_string().into());
+                if self.send_message_back(msg.as_ref()).await {
+                    self.ack_messages(std::slice::from_ref(&msg)).await;
+                    continue;
                 }
-            } else {
-                suspend = true;
-                Arc::make_mut(msg).reconsume_times = reconsume_times + 1;
             }
+            Arc::make_mut(&mut msg).reconsume_times = reconsume_times.saturating_add(1);
+            retry.push(msg);
         }
-
-        suspend
+        *msgs = retry;
+        !msgs.is_empty()
     }
 
     async fn send_message_back(&self, msg: &MessageExt) -> bool {
@@ -547,12 +517,12 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
                 let service = Arc::clone(&worker_service);
                 async move {
                     if service.stopped.load(Ordering::Acquire) {
-                        return;
+                        return ConsumeDisposition::Complete;
                     }
                     let limiter = Arc::clone(&service.concurrency_limiter);
                     let permit = match limiter.acquire_owned().await {
                         Ok(permit) => permit,
-                        Err(_) => return,
+                        Err(_) => return ConsumeDisposition::Complete,
                     };
                     service.active_tasks.fetch_add(1, Ordering::SeqCst);
                     struct ActiveTaskGuard(Arc<AtomicUsize>);
@@ -562,8 +532,12 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
                         }
                     }
                     let _active = ActiveTaskGuard(Arc::clone(&service.active_tasks));
-                    request.run(Arc::clone(&service)).await;
+                    let retry = request.request.run(Arc::clone(&service)).await;
                     drop(permit);
+                    match retry {
+                        Some(after) => ConsumeDisposition::Retry { item: request, after },
+                        None => ConsumeDisposition::Complete,
+                    }
                 }
             },
         ) {
@@ -755,6 +729,36 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+struct PopConsumeKey {
+    process_queue: usize,
+    message_queue: MessageQueue,
+    sharding_key_index: i32,
+}
+
+struct PopRegistration {
+    key: PopConsumeKey,
+    registrations: Arc<DashSet<PopConsumeKey>>,
+}
+
+impl Drop for PopRegistration {
+    fn drop(&mut self) {
+        self.registrations.remove(&self.key);
+    }
+}
+
+struct RegisteredRequest {
+    request: ConsumeRequest,
+    _registration: PopRegistration,
+}
+
+impl Drop for RegisteredRequest {
+    fn drop(&mut self) {
+        // Completion, rejected admission, and cancellation release the same batch owner.
+        self.request.process_queue.dec_found_msg(self.request.msgs.len());
+    }
+}
+
 #[derive(Clone)]
 struct ConsumeRequest {
     process_queue: Arc<PopProcessQueue>,
@@ -773,6 +777,14 @@ impl std::fmt::Debug for ConsumeRequest {
 }
 
 impl ConsumeRequest {
+    fn key(&self) -> PopConsumeKey {
+        PopConsumeKey {
+            process_queue: Arc::as_ptr(&self.process_queue) as usize,
+            message_queue: self.message_queue.clone(),
+            sharding_key_index: self.sharding_key_index,
+        }
+    }
+
     pub fn new(process_queue: Arc<PopProcessQueue>, message_queue: MessageQueue, msgs: Vec<Arc<MessageExt>>) -> Self {
         Self {
             process_queue,
@@ -782,14 +794,16 @@ impl ConsumeRequest {
         }
     }
 
-    pub async fn run(&mut self, consume_message_pop_orderly_service: Arc<ConsumeMessagePopOrderlyService>) {
+    pub async fn run(
+        &mut self,
+        consume_message_pop_orderly_service: Arc<ConsumeMessagePopOrderlyService>,
+    ) -> Option<Duration> {
         if self.process_queue.is_dropped() {
             warn!(
                 "run, message queue not be able to consume, because it's dropped. {}",
                 self.message_queue
             );
-            consume_message_pop_orderly_service.remove_consume_request(self);
-            return;
+            return None;
         }
 
         let lock = consume_message_pop_orderly_service
@@ -801,26 +815,29 @@ impl ConsumeRequest {
         let msgs = &mut self.msgs;
 
         if msgs.is_empty() {
-            consume_message_pop_orderly_service
-                .submit_consume_request_later(consume_message_pop_orderly_service.clone(), self.clone(), 1000)
-                .await;
-            return;
+            return None;
         }
-
-        let suspend = consume_message_pop_orderly_service.check_reconsume_times(msgs).await;
-        if suspend {
-            consume_message_pop_orderly_service
-                .submit_consume_request_later(
-                    consume_message_pop_orderly_service.clone(),
-                    self.clone(),
-                    consume_message_pop_orderly_service
-                        .consumer_config
-                        .suspend_current_queue_time_millis,
-                )
-                .await;
-            return;
+        // A receipt may expire while queued or waiting for the queue lock.
+        for msg in msgs.iter() {
+            let Some(extra) = msg.get_property(&CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK)) else {
+                return None;
+            };
+            let parts = rocketmq_protocol::protocol::header::extra_info_util::ExtraInfoUtil::split(&extra);
+            use rocketmq_protocol::protocol::header::extra_info_util::ExtraInfoUtil;
+            let (Ok(pop_time), Ok(invisible)) = (
+                ExtraInfoUtil::get_pop_time(&parts),
+                ExtraInfoUtil::get_invisible_time(&parts),
+            ) else {
+                return None;
+            };
+            if pop_time <= 0
+                || invisible <= 0
+                || rocketmq_runtime::common::time_utils::current_millis().saturating_sub(pop_time as u64)
+                    >= invisible as u64
+            {
+                return None;
+            }
         }
-
         let begin_timestamp = Instant::now();
         let listener = consume_message_pop_orderly_service.message_listener.clone();
         let msgs_for_blocking = msgs.clone();
@@ -871,11 +888,15 @@ impl ConsumeRequest {
             .await;
 
         if continue_consume {
-            drop(_guard);
-            consume_message_pop_orderly_service
-                .submit_consume_request(consume_message_pop_orderly_service.clone(), self.clone(), false)
-                .await;
+            // Successfully acknowledged receipts must never re-enter the listener.
+            None
         } else {
+            let previous = msgs.len();
+            let retry = consume_message_pop_orderly_service.check_reconsume_times(msgs).await;
+            self.process_queue.dec_found_msg(previous - msgs.len());
+            if !retry {
+                return None;
+            }
             let suspend_time = if context.get_suspend_current_queue_time_millis() > 0 {
                 context.get_suspend_current_queue_time_millis() as u64
             } else {
@@ -883,10 +904,7 @@ impl ConsumeRequest {
                     .consumer_config
                     .suspend_current_queue_time_millis
             };
-            drop(_guard);
-            consume_message_pop_orderly_service
-                .submit_consume_request_later(consume_message_pop_orderly_service.clone(), self.clone(), suspend_time)
-                .await;
+            Some(Duration::from_millis(suspend_time.clamp(10, 30_000)))
         }
     }
 }
@@ -910,7 +928,7 @@ impl Eq for ConsumeRequest {}
 impl Hash for ConsumeRequest {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.sharding_key_index.hash(state);
-        self.process_queue.as_ref().hash(state);
+        (Arc::as_ptr(&self.process_queue) as usize).hash(state);
         self.message_queue.hash(state);
     }
 }
@@ -1248,5 +1266,75 @@ mod tests {
             r1, r2,
             "Different process queues with same message queue should not be equal"
         );
+    }
+    #[tokio::test]
+    async fn registration_deduplicates_without_retaining_payload_and_clears_on_shutdown() {
+        let service = Arc::new(new_service(None));
+        let pq = Arc::new(PopProcessQueue::new());
+        let message = Arc::new(MessageExt::default());
+        let first = ConsumeRequest::new(pq.clone(), message_queue(), vec![message.clone()]);
+        let key = first.key();
+        pq.inc_found_msg(1);
+        service.submit_consume_request(service.clone(), first, false).await;
+        assert_eq!(Arc::strong_count(&message), 2, "only scheduler owns the payload");
+        pq.set_last_pop_timestamp(1);
+        assert!(
+            service.consume_request_set.contains(&key),
+            "mutable queue state cannot change registration hash"
+        );
+        let duplicate_message = Arc::new(MessageExt::default());
+        let duplicate = ConsumeRequest::new(pq.clone(), message_queue(), vec![duplicate_message.clone()]);
+        service.submit_consume_request(service.clone(), duplicate, false).await;
+        assert_eq!(
+            Arc::strong_count(&duplicate_message),
+            1,
+            "existing same-key admission behavior is preserved"
+        );
+        assert_eq!(service.consume_scheduler.queued(), 1);
+        service.start(service.clone());
+        service.shutdown(100).await;
+        assert!(service.consume_request_set.is_empty());
+        assert_eq!(Arc::strong_count(&message), 1);
+        assert_eq!(pq.get_wai_ack_msg_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn expired_pop_receipt_completes_without_retry() {
+        use rocketmq_protocol::protocol::header::extra_info_util::ExtraInfoUtil;
+        let service = Arc::new(new_service(None));
+        let mut request = consume_request();
+        let mut msg = MessageExt::default();
+        MessageAccessor::put_property(
+            &mut msg,
+            MessageConst::PROPERTY_POP_CK.into(),
+            ExtraInfoUtil::build_extra_info(0, 1, 1, 0, "topic", "broker-a", 0).into(),
+        );
+        request.msgs.push(Arc::new(msg));
+        assert!(request.run(service).await.is_none());
+        assert_eq!(request.msgs[0].reconsume_times(), 0);
+    }
+    #[tokio::test]
+    async fn successful_pop_listener_completes_without_retrying_acknowledged_payload() {
+        use rocketmq_protocol::protocol::header::extra_info_util::ExtraInfoUtil;
+        let service = Arc::new(new_service(None));
+        let mut request = consume_request();
+        let mut msg = MessageExt::default();
+        MessageAccessor::put_property(
+            &mut msg,
+            MessageConst::PROPERTY_POP_CK.into(),
+            ExtraInfoUtil::build_extra_info(
+                0,
+                rocketmq_runtime::common::time_utils::current_millis() as i64,
+                60000,
+                0,
+                "topic",
+                "broker-a",
+                0,
+            )
+            .into(),
+        );
+        request.msgs.push(Arc::new(msg));
+        assert!(request.run(service.clone()).await.is_none());
+        assert_eq!(request.msgs[0].reconsume_times(), 0);
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -1742,7 +1742,7 @@ impl DefaultMQPushConsumerImpl {
         let queue_is_logical =
             mq.is_some_and(|mq| mq.broker_name().starts_with(mix_all::LOGICAL_QUEUE_MOCK_BROKER_PREFIX));
         if broker_is_logical || queue_is_logical {
-            let _ = self.send_message_back_as_normal_message(msg).await;
+            return self.send_message_back_as_normal_message(msg).await;
         } else {
             let broker_addr = if let Some(ref broker_name_) = broker_name {
                 let Some(client_instance) = self.get_mq_client_factory() else {
@@ -2928,7 +2928,7 @@ mod tests {
             .await
             .expect_err("missing client instance should make fallback send fail");
 
-        assert!(error.to_string().contains("MQClientInstance"));
+        assert!(error.is(&rocketmq_error::CORE_LIFECYCLE_NOT_INITIALIZED));
         assert_eq!(msg.topic().as_str(), "TopicA");
     }
 
@@ -2942,7 +2942,7 @@ mod tests {
         consumer
             .send_message_back(&mut msg, 3, &mq)
             .await
-            .expect("logical broker name from message should use Java normal-message fallback path");
+            .expect_err("logical broker fallback must propagate producer failure");
     }
 
     #[test]

--- a/rocketmq-doc/en/remediation/2026-09-08-p0.md
+++ b/rocketmq-doc/en/remediation/2026-09-08-p0.md
@@ -1,0 +1,43 @@
+# Consume retry and Proxy request ownership remediation
+
+This change implements the P0 work items from the September 8 architecture remediation plan.
+
+## Behavior
+
+- **W01:** Logical queue and logical broker send-back failures propagate the producer error. Failed messages remain in ProcessQueue, and successful messages alone contribute to removal. The offset remains at the earliest unfinished message, including when persisted.
+- **W02:** Ready, running, and delayed consume requests share one admission permit throughout their lifetime. Handlers return a retry disposition; workers never acquire a second permit to retry. The configured capacity K now covers all admitted work, reducing the previous possible K + worker-count peak to K. This is not a bound on the entire consumer cache. POP orderly registrations contain an immutable identity key instead of cloned message bodies and are removed by their owner on completion or cancellation. Successful ACK payloads do not re-enter the listener; expired receipts defer to Broker redelivery. Existing suppression of concurrent duplicate keys is preserved.
+- **W03:** Every Local command carries one absolute deadline and a child cancellation token. Adapter calls preserve the Core context deadline; typed send timeout and remoting timeout narrow it. Dropping a caller cancels queued work while its envelope retains count and byte permits. A started Broker operation remains owned until it exits; cancellation does not undo a write. Send batches preserve completed results and check control before each subsequent entry. Compatibility methods without a deadline retain their existing defaults.
+- **W04:** Gzip decoding uses fixed-capacity resident arenas, acquired before CPU submission. The input permit, compressed backing buffers and arena lease transfer into the returned Bytes owners. Clones and slices retain them across Local and Cluster DTO conversion. No arena grows during decode; a one-byte probe distinguishes an exact limit from overflow and verifies gzip completion. Closing the pool releases idle slots; checked-out slots remain charged until the last owner exits.
+- **W05:** Registry ordering follows normal/build dependencies, retaining optional, target-specific and renamed package edges. Internal dev dependencies remain visible in the plan but no longer introduce false upload cycles. The existing staging and local-registry verification workflow remains intact. Unrelated historical static findings are outside this change.
+
+## Resource policy
+
+The following gRPC settings are restart-required (TOML/JSON use camelCase):
+
+| Setting | Default | Contract |
+| --- | --- | --- |
+| `maxSendMessagesPerRequest` | 1024 | Maximum messages in one send request |
+| `maxDecompressedRequestBytes` | 8388608 | Aggregate decoded bodies, including identity bodies |
+| `gzipDecodeSlots` | 2 | Resident decode arenas; zero explicitly disables gzip |
+| `maxMessageBodySize` | 4194304 | Existing per-message uncompressed limit |
+
+Startup validates nonzero message/count limits, aggregate >= per-message capacity, checked arithmetic, and room for all arenas plus one maximum retained input and the control reserve. Each arena accounts its actual Vec capacity plus 256 KiB of decoder workspace. Inputs account the shared transport buffer, gzip header copies, and actual protobuf container/string capacities. Retained input is capped at eight times the configured protobuf decoding limit. Protobuf allocations made before the service boundary and allocator RSS are not controlled by these permits. Small memory profiles must explicitly reduce the limits or disable gzip.
+
+Gzip bytes, RocketMQ request/response codes, headers, retry topic formats and persisted layouts are unchanged. Aggregate/count limits are explicit resource admission policy; requests are rejected instead of truncated.
+
+## Validation
+
+The affected packages pass package-scoped formatting. Focused validation passed:
+
+- Client consume services: 61 tests; bounded scheduler: 4 tests; send-back: 8 tests.
+- Local facade and execution: 29 unit tests.
+- Proxy gRPC handlers and decode pool: 56 unit tests (excluding one unrelated legacy error-text assertion).
+- Proxy network ingress send scenarios: 3 integration tests.
+- Publish planner: all 15 Python tests, including dependency fixtures and the existing temporary-registry staging test.
+- Plan Markdown/HTML consistency and links.
+
+Reproduce the Rust coverage with `cargo test -p rocketmq-client-rust --lib consumer::consumer_impl::consume_message_`, filters `bounded_consume_scheduler` and `send_message_back`, `cargo test -p rocketmq-proxy-local --lib`, `cargo test -p rocketmq-proxy --lib grpc:: -- --skip query_route_rejects_invalid_grpc_timeout_as_transport_status`, and `cargo test -p rocketmq-proxy --test grpc_ingress send_message`. The planner uses `python -B -m unittest scripts.tests.test_package_publish_workspace`.
+
+Broader exploratory runs encountered existing assertions expecting private error text rather than the current typed/redacted errors (client lifecycle tests and Proxy timeout/readiness tests). These are not claimed as passing. Transactional send fixtures now explicitly select a transactional topic so their retained-body and transaction behavior remains exercised.
+
+Docker interoperability, throughput/latency comparisons, and capacity/fault scenarios belong to the subsequent runtime-evidence work item. No production reliability or throughput claim follows from these unit tests.

--- a/rocketmq-proxy-core/src/config.rs
+++ b/rocketmq-proxy-core/src/config.rs
@@ -43,6 +43,10 @@ pub struct GrpcConfig {
     pub max_encoding_message_size: usize,
     /// Maximum uncompressed body size accepted for one message.
     pub max_message_body_size: usize,
+    /// Restart-required limits on send batches and resident gzip arenas. Zero slots disables gzip.
+    pub max_send_messages_per_request: usize,
+    pub max_decompressed_request_bytes: usize,
+    pub gzip_decode_slots: usize,
     pub concurrency_limit_per_connection: usize,
     pub use_endpoint_port_from_request: bool,
     /// Java-compatible delay admission horizon enforced before forwarding to a Broker.
@@ -60,6 +64,9 @@ impl Default for GrpcConfig {
             max_decoding_message_size: 8 * 1024 * 1024,
             max_encoding_message_size: 8 * 1024 * 1024,
             max_message_body_size: 4 * 1024 * 1024,
+            max_send_messages_per_request: 1024,
+            max_decompressed_request_bytes: 8 * 1024 * 1024,
+            gzip_decode_slots: 2,
             concurrency_limit_per_connection: 256,
             use_endpoint_port_from_request: false,
             timer_max_delay_ms: 24 * 60 * 60 * 1_000,

--- a/rocketmq-proxy-core/src/ingress/grpc/service/admission.rs
+++ b/rocketmq-proxy-core/src/ingress/grpc/service/admission.rs
@@ -40,6 +40,7 @@ use crate::RuntimeConfig;
 /// Admission-control permits shared by the neutral gRPC handlers.
 #[derive(Clone)]
 pub struct ExecutionGuards {
+    root: ResourceBudget,
     route: ResourceBudget,
     producer: ResourceBudget,
     consumer: ResourceBudget,
@@ -70,6 +71,11 @@ impl ExecutionGuards {
     }
 
     pub fn try_from_config(config: &RuntimeConfig) -> ProxyResult<Self> {
+        Self::try_with_resident_slots(config, 0)
+    }
+
+    /// Adds count capacity for resident transformation arenas without producer rate charges.
+    pub fn try_with_resident_slots(config: &RuntimeConfig, resident_slots: usize) -> ProxyResult<Self> {
         if config.consumer_response_permits == 0 {
             return Err(ProxyError::invalid_metadata(
                 "consumerResponsePermits must be greater than zero",
@@ -104,7 +110,10 @@ impl ExecutionGuards {
         let control_permits = config
             .client_manager_permits
             .saturating_add(config.telemetry_queue_capacity);
-        let total_permits = data_permits.saturating_add(control_permits);
+        let total_permits = data_permits
+            .checked_add(control_permits)
+            .and_then(|count| count.checked_add(resident_slots))
+            .ok_or_else(|| ProxyError::invalid_metadata("proxy permit capacity overflow"))?;
         let tree = ResourceBudgetTree::new(
             "proxy",
             BudgetLimit::new(total_permits, managed_bytes.max(1), FullPolicy::Reject)
@@ -167,6 +176,7 @@ impl ExecutionGuards {
             .map_err(|error| ProxyError::from(canonical::invalid_metadata_with_source(error)))?;
 
         Ok(Self {
+            root,
             route,
             producer,
             consumer,
@@ -175,6 +185,27 @@ impl ExecutionGuards {
             telemetry_parent,
             telemetry_limits,
         })
+    }
+
+    /// Creates a resident byte budget under the same process-memory owner.
+    pub fn resident_budget(&self, slots: usize, bytes: usize) -> ProxyResult<ResourceBudget> {
+        self.root
+            .child("gzip-decode-pool", BudgetLimit::new(slots, bytes, FullPolicy::Reject))
+            .map_err(|error| ProxyError::from(canonical::invalid_metadata_with_source(error)))
+    }
+
+    /// Checks that resident arenas leave room for one input and the control reserve.
+    pub fn validate_resident_bytes(&self, resident: usize, input: usize) -> ProxyResult<()> {
+        let probe = self
+            .root
+            .try_acquire_data(
+                resident
+                    .checked_add(input)
+                    .ok_or_else(|| ProxyError::invalid_metadata("gzip pool capacity overflow"))?,
+            )
+            .map_err(|_| ProxyError::invalid_metadata("gzip pool and maximum input exceed the managed data budget"))?;
+        drop(probe);
+        Ok(())
     }
 
     pub fn try_route(&self, retained_bytes: usize) -> ProxyResult<ResourcePermit> {

--- a/rocketmq-proxy-local/src/command_control.rs
+++ b/rocketmq-proxy-local/src/command_control.rs
@@ -1,0 +1,93 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+use std::time::Instant;
+
+use rocketmq_proxy_core::error::canonical;
+use rocketmq_proxy_core::ProxyError;
+use rocketmq_proxy_core::ProxyResult;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone, Debug)]
+pub(crate) struct RequestControl {
+    pub(crate) deadline_at: Option<Instant>,
+    pub(crate) timeout_budget: Option<Duration>,
+    pub(crate) cancellation: CancellationToken,
+}
+
+impl RequestControl {
+    pub(crate) fn new(
+        entry: Instant,
+        deadline: Option<Instant>,
+        timeout: Option<Duration>,
+        parent: &CancellationToken,
+    ) -> ProxyResult<Self> {
+        let typed_deadline = timeout
+            .map(|timeout| {
+                entry.checked_add(timeout).ok_or_else(|| {
+                    ProxyError::from(canonical::argument(
+                        "local request timeout exceeds the supported clock range",
+                    ))
+                })
+            })
+            .transpose()?;
+        let deadline_at = match (deadline, typed_deadline) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, b) => a.or(b),
+        };
+        Ok(Self {
+            deadline_at,
+            timeout_budget: deadline_at.map(|deadline| deadline.saturating_duration_since(entry)),
+            cancellation: parent.child_token(),
+        })
+    }
+
+    pub(crate) fn timeout_error(&self) -> ProxyError {
+        canonical::timed_out(
+            "local broker request",
+            self.timeout_budget
+                .unwrap_or_default()
+                .as_millis()
+                .min(u64::MAX as u128) as u64,
+        )
+        .into()
+    }
+
+    pub(crate) fn check(&self) -> ProxyResult<()> {
+        if self.cancellation.is_cancelled() {
+            return Err(ProxyError::Transport {
+                message: "local broker request cancelled".to_owned(),
+            });
+        }
+        if self.deadline_at.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Err(self.timeout_error());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn remaining(&self, operation_limit: Duration) -> ProxyResult<Duration> {
+        self.check()?;
+        Ok(self.deadline_at.map_or(operation_limit, |deadline| {
+            deadline.saturating_duration_since(Instant::now()).min(operation_limit)
+        }))
+    }
+
+    pub(crate) async fn expired(&self) {
+        match self.deadline_at {
+            Some(deadline) => tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await,
+            None => std::future::pending().await,
+        }
+    }
+}

--- a/rocketmq-proxy-local/src/execution.rs
+++ b/rocketmq-proxy-local/src/execution.rs
@@ -39,6 +39,7 @@ use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
+use crate::command_control::RequestControl;
 use crate::config::LocalConfig;
 use crate::local::LocalBrokerCommand;
 use crate::local::QueuedLocalBrokerCommand;
@@ -89,7 +90,7 @@ impl LocalExecutionPolicy {
 }
 
 pub(crate) trait LocalCommandHandler: Send + Sync + 'static {
-    fn handle(&self, command: LocalBrokerCommand) -> impl Future<Output = ()> + Send;
+    fn handle(&self, command: LocalBrokerCommand, control: RequestControl) -> impl Future<Output = ()> + Send;
 }
 
 struct LocalExecutionLimits {
@@ -280,13 +281,19 @@ fn dispatch_to_lane<H>(
 ) where
     H: LocalCommandHandler,
 {
+    if queued.control.cancellation.is_cancelled() {
+        queued.command.reject_unavailable();
+        return;
+    }
     let now = Instant::now();
     if queued.is_expired(now, policy.max_queue_age) {
         queued.command.reject_overload();
         return;
     }
     if queued.deadline_expired(now) {
-        queued.command.reject_timeout(queued.timeout_budget.unwrap_or_default());
+        queued
+            .command
+            .reject_timeout(queued.control.timeout_budget.unwrap_or_default());
         return;
     }
     let key = queued.command.ordering_key();
@@ -421,13 +428,19 @@ async fn execute_queued_command<H>(
 ) where
     H: LocalCommandHandler,
 {
+    if queued.control.cancellation.is_cancelled() {
+        queued.command.reject_unavailable();
+        return;
+    }
     let now = Instant::now();
     if queued.is_expired(now, max_queue_age) {
         queued.command.reject_overload();
         return;
     }
     if queued.deadline_expired(now) {
-        queued.command.reject_timeout(queued.timeout_budget.unwrap_or_default());
+        queued
+            .command
+            .reject_timeout(queued.control.timeout_budget.unwrap_or_default());
         return;
     }
     let class = queued.command.execution_class();
@@ -435,6 +448,14 @@ async fn execute_queued_command<H>(
         biased;
         () = cancellation.cancelled() => {
             queued.command.reject_unavailable();
+            return;
+        }
+        () = queued.control.cancellation.cancelled() => {
+            queued.command.reject_unavailable();
+            return;
+        }
+        () = queued.control.expired() => {
+            queued.command.reject_timeout(queued.control.timeout_budget.unwrap_or_default());
             return;
         }
         permit = limits.acquire(class) => permit,
@@ -445,15 +466,19 @@ async fn execute_queued_command<H>(
     };
     let now = Instant::now();
     if queued.deadline_expired(now) {
-        queued.command.reject_timeout(queued.timeout_budget.unwrap_or_default());
+        queued
+            .command
+            .reject_timeout(queued.control.timeout_budget.unwrap_or_default());
+        return;
+    }
+    if cancellation.is_cancelled() || queued.control.cancellation.is_cancelled() {
+        queued.command.reject_unavailable();
         return;
     }
     queued.apply_remaining_deadline(now);
-    tokio::select! {
-        biased;
-        () = cancellation.cancelled() => {}
-        () = handler.handle(queued.command) => {}
-    }
+    // Once Broker execution begins, its lane owns the payload and permits until it exits.
+    // Caller cancellation stops waiting and subsequent batch entries, not a committed write.
+    handler.handle(queued.command, queued.control).await;
 }
 
 fn reject_lane(receiver: &mut mpsc::Receiver<QueuedLocalBrokerCommand>) {
@@ -632,7 +657,7 @@ mod tests {
     }
 
     impl LocalCommandHandler for BlockingHandler {
-        async fn handle(&self, command: LocalBrokerCommand) {
+        async fn handle(&self, command: LocalBrokerCommand, _control: RequestControl) {
             let id = match &command {
                 LocalBrokerCommand::ProcessRemoting { request, .. } => request.opaque(),
                 LocalBrokerCommand::QueryRoute { .. } => -1,
@@ -655,8 +680,7 @@ mod tests {
         QueuedLocalBrokerCommand {
             command,
             enqueued_at: Instant::now(),
-            deadline_at: None,
-            timeout_budget: None,
+            control: RequestControl::new(Instant::now(), None, None, &CancellationToken::new()).unwrap(),
             _count_permit: count.try_acquire_owned().expect("count permit"),
             _byte_permit: bytes.try_acquire_owned().expect("byte permit"),
         }
@@ -821,5 +845,80 @@ mod tests {
         assert_eq!(handler.maximum.load(Ordering::Acquire), 1);
         let report = service.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
+    }
+    #[tokio::test]
+    async fn cancelled_or_expired_commands_never_enter_handler() {
+        let (entered, mut events) = mpsc::channel(1);
+        let handler = BlockingHandler {
+            entered,
+            release: Arc::new(Semaphore::new(1)),
+            current: AtomicUsize::new(0),
+            maximum: AtomicUsize::new(0),
+        };
+        let limits = LocalExecutionLimits::new(LocalExecutionPolicy::from_config(&LocalConfig::default()));
+        for expired in [false, true] {
+            let mut command = queued(route_command());
+            if expired {
+                command.control.deadline_at = Some(Instant::now());
+            } else {
+                command.control.cancellation.cancel();
+            }
+            execute_queued_command(
+                command,
+                Duration::from_secs(60),
+                &limits,
+                &handler,
+                &CancellationToken::new(),
+            )
+            .await;
+            assert!(events.try_recv().is_err());
+            assert_eq!(handler.maximum.load(Ordering::Acquire), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_interrupts_slot_wait_without_releasing_running_owner() {
+        let (entered, mut events) = mpsc::channel(2);
+        let release = Arc::new(Semaphore::new(0));
+        let handler = BlockingHandler {
+            entered,
+            release: release.clone(),
+            current: AtomicUsize::new(0),
+            maximum: AtomicUsize::new(0),
+        };
+        let limits = LocalExecutionLimits::new(LocalExecutionPolicy::from_config(&LocalConfig::default()));
+        let command = queued(route_command());
+        let caller = command.control.cancellation.clone();
+        let cancellation = CancellationToken::new();
+        let running = execute_queued_command(command, Duration::from_secs(60), &limits, &handler, &cancellation);
+        let observe = async {
+            events.recv().await.unwrap();
+            caller.cancel();
+            tokio::task::yield_now().await;
+            assert_eq!(
+                handler.current.load(Ordering::Acquire),
+                1,
+                "started handler remains owned"
+            );
+            release.add_permits(1);
+        };
+        tokio::join!(running, observe);
+        assert_eq!(handler.current.load(Ordering::Acquire), 0);
+        let held = limits
+            .total_inflight
+            .clone()
+            .acquire_many_owned(limits.total_inflight.available_permits() as u32)
+            .await
+            .unwrap();
+        let command = queued(route_command());
+        let caller = command.control.cancellation.clone();
+        let waiting = execute_queued_command(command, Duration::from_secs(60), &limits, &handler, &cancellation);
+        let cancel = async {
+            tokio::task::yield_now().await;
+            caller.cancel();
+        };
+        tokio::join!(waiting, cancel);
+        assert!(events.try_recv().is_err());
+        drop(held);
     }
 }

--- a/rocketmq-proxy-local/src/lib.rs
+++ b/rocketmq-proxy-local/src/lib.rs
@@ -18,6 +18,7 @@
 
 //! Embedded Broker-backed local adapter for RocketMQ Proxy Core ports.
 
+mod command_control;
 mod config;
 mod execution;
 mod local;

--- a/rocketmq-proxy-local/src/local.rs
+++ b/rocketmq-proxy-local/src/local.rs
@@ -140,6 +140,7 @@ use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
+use crate::command_control::RequestControl;
 use crate::config::LocalConfig;
 use crate::execution::run_local_execution;
 use crate::execution::LocalCommandHandler;
@@ -159,13 +160,14 @@ pub struct LocalBrokerFacadeClient {
     byte_budget: Arc<Semaphore>,
     rejected: Arc<AtomicU64>,
     broker_name: String,
+    context_deadline: Option<Instant>,
+    cancellation: CancellationToken,
 }
 
 pub(crate) struct QueuedLocalBrokerCommand {
     pub(crate) command: LocalBrokerCommand,
     pub(crate) enqueued_at: Instant,
-    pub(crate) deadline_at: Option<Instant>,
-    pub(crate) timeout_budget: Option<Duration>,
+    pub(crate) control: RequestControl,
     pub(crate) _count_permit: OwnedSemaphorePermit,
     pub(crate) _byte_permit: OwnedSemaphorePermit,
 }
@@ -221,11 +223,11 @@ impl QueuedLocalBrokerCommand {
     }
 
     pub(crate) fn deadline_expired(&self, now: Instant) -> bool {
-        self.deadline_at.is_some_and(|deadline| now >= deadline)
+        self.control.deadline_at.is_some_and(|deadline| now >= deadline)
     }
 
     pub(crate) fn apply_remaining_deadline(&mut self, now: Instant) {
-        let Some(deadline_at) = self.deadline_at else {
+        let Some(deadline_at) = self.control.deadline_at else {
             return;
         };
         if let LocalBrokerCommand::ProcessRemoting { timeout, .. } = &mut self.command {
@@ -238,6 +240,7 @@ impl LocalBrokerCommand {
     fn timeout(&self) -> Option<Duration> {
         match self {
             Self::ProcessRemoting { timeout, .. } => Some(*timeout),
+            Self::SendMessage { request, .. } => request.timeout,
             _ => None,
         }
     }
@@ -480,7 +483,15 @@ impl LocalBrokerFacadeClient {
             byte_budget,
             rejected,
             broker_name,
+            context_deadline: None,
+            cancellation: service_context.task_group().cancellation_token(),
         })
+    }
+
+    fn with_context(&self, context: &ProxyContext) -> Self {
+        let mut client = self.clone();
+        client.context_deadline = context.deadline_at();
+        client
     }
 
     pub fn broker_name(&self) -> &str {
@@ -621,18 +632,30 @@ impl LocalBrokerFacadeClient {
         &self,
         build: impl FnOnce(oneshot::Sender<ProxyResult<T>>) -> LocalBrokerCommand,
     ) -> ProxyResult<T> {
-        let reply_rx = self.enqueue(build)?;
-        reply_rx
-            .await
-            .map_err(|error| ProxyError::from(canonical::transport_unavailable_with_source(error)))?
+        let (reply_rx, control) = self.enqueue(build)?;
+        let _caller = control.cancellation.clone().drop_guard();
+        tokio::select! {
+            biased;
+            reply = reply_rx => reply.map_err(|error| ProxyError::from(canonical::transport_unavailable_with_source(error)))?,
+            () = control.expired() => Err(control.timeout_error()),
+            () = control.cancellation.cancelled() => Err(ProxyError::Transport { message: "local broker request cancelled".to_owned() }),
+        }
     }
 
     fn enqueue<T>(
         &self,
         build: impl FnOnce(oneshot::Sender<ProxyResult<T>>) -> LocalBrokerCommand,
-    ) -> ProxyResult<oneshot::Receiver<ProxyResult<T>>> {
+    ) -> ProxyResult<(oneshot::Receiver<ProxyResult<T>>, RequestControl)> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let command = build(reply_tx);
+        let enqueued_at = Instant::now();
+        let control = RequestControl::new(
+            enqueued_at,
+            self.context_deadline,
+            command.timeout(),
+            &self.cancellation,
+        )?;
+        control.check()?;
         let estimated_bytes = command.estimated_bytes();
         let count_permit = Arc::clone(&self.count_budget)
             .try_acquire_owned()
@@ -641,14 +664,10 @@ impl LocalBrokerFacadeClient {
         let byte_permit = Arc::clone(&self.byte_budget)
             .try_acquire_many_owned(byte_permits)
             .map_err(|_| self.queue_overloaded())?;
-        let timeout_budget = command.timeout();
-        let enqueued_at = Instant::now();
-        let deadline_at = timeout_budget.map(|timeout| enqueued_at.checked_add(timeout).unwrap_or(enqueued_at));
         let queued = QueuedLocalBrokerCommand {
             command,
             enqueued_at,
-            deadline_at,
-            timeout_budget,
+            control: control.clone(),
             _count_permit: count_permit,
             _byte_permit: byte_permit,
         };
@@ -661,7 +680,7 @@ impl LocalBrokerFacadeClient {
                 });
             }
         }
-        Ok(reply_rx)
+        Ok((reply_rx, control))
     }
 
     fn queue_overloaded(&self) -> ProxyError {
@@ -701,11 +720,11 @@ impl LocalRouteService {
 impl RouteService for LocalRouteService {
     fn query_route<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         topic: &'a ResourceIdentity,
         _endpoints: &'a [ResolvedEndpoint],
     ) -> ProxyServiceFuture<'a, TopicRouteData> {
-        Box::pin(async move { self.client.query_route(topic.clone()).await })
+        Box::pin(async move { self.client.with_context(context).query_route(topic.clone()).await })
     }
 }
 
@@ -723,19 +742,29 @@ impl LocalMetadataService {
 impl MetadataService for LocalMetadataService {
     fn topic_message_type<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         topic: &'a ResourceIdentity,
     ) -> ProxyServiceFuture<'a, ProxyTopicMessageType> {
-        Box::pin(async move { self.client.query_topic_message_type(topic.clone()).await })
+        Box::pin(async move {
+            self.client
+                .with_context(context)
+                .query_topic_message_type(topic.clone())
+                .await
+        })
     }
 
     fn subscription_group<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         topic: &'a ResourceIdentity,
         group: &'a ResourceIdentity,
     ) -> ProxyServiceFuture<'a, Option<SubscriptionGroupMetadata>> {
-        Box::pin(async move { self.client.query_subscription_group(topic.clone(), group.clone()).await })
+        Box::pin(async move {
+            self.client
+                .with_context(context)
+                .query_subscription_group(topic.clone(), group.clone())
+                .await
+        })
     }
 }
 
@@ -764,6 +793,7 @@ impl AssignmentService for LocalAssignmentService {
     ) -> ProxyServiceFuture<'a, Option<Vec<MessageQueueAssignment>>> {
         Box::pin(async move {
             self.client
+                .with_context(context)
                 .query_assignment(
                     topic.clone(),
                     group.clone(),
@@ -794,6 +824,7 @@ impl MessageService for LocalMessageService {
     ) -> ProxyServiceFuture<'a, Vec<SendMessageResultEntry>> {
         Box::pin(async move {
             self.client
+                .with_context(context)
                 .send_message(
                     request.clone(),
                     context.client_id().map(ToOwned::to_owned),
@@ -810,6 +841,7 @@ impl MessageService for LocalMessageService {
     ) -> ProxyServiceFuture<'a, RecallMessagePlan> {
         Box::pin(async move {
             self.client
+                .with_context(context)
                 .recall_message(
                     request.clone(),
                     context.client_id().map(ToOwned::to_owned),
@@ -843,6 +875,7 @@ impl TransactionService for LocalTransactionService {
     ) -> ProxyServiceFuture<'a, EndTransactionPlan> {
         Box::pin(async move {
             self.client
+                .with_context(context)
                 .end_transaction(
                     request.clone(),
                     context.client_id().map(ToOwned::to_owned),
@@ -867,11 +900,13 @@ impl LocalConsumerService {
 impl ConsumerService for LocalConsumerService {
     fn sync_lite_subscription<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         client_id: &'a str,
         request: &'a LiteSubscriptionSyncRequest,
     ) -> ProxyServiceFuture<'a, ()> {
-        Box::pin(async move { sync_lite_subscription_via_broker(&self.client, client_id, request).await })
+        Box::pin(async move {
+            sync_lite_subscription_via_broker(&self.client.with_context(context), client_id, request).await
+        })
     }
 
     fn receive_message<'a>(
@@ -879,7 +914,9 @@ impl ConsumerService for LocalConsumerService {
         context: &'a ProxyContext,
         request: &'a ReceiveMessageRequest,
     ) -> ProxyServiceFuture<'a, ReceiveMessagePlan> {
-        Box::pin(async move { receive_message_via_broker(&self.client, request, context.deadline()).await })
+        Box::pin(async move {
+            receive_message_via_broker(&self.client.with_context(context), request, context.deadline()).await
+        })
     }
 
     fn pull_message<'a>(
@@ -887,55 +924,59 @@ impl ConsumerService for LocalConsumerService {
         context: &'a ProxyContext,
         request: &'a PullMessageRequest,
     ) -> ProxyServiceFuture<'a, PullMessagePlan> {
-        Box::pin(async move { pull_message_via_broker(&self.client, request, context.deadline()).await })
+        Box::pin(async move {
+            pull_message_via_broker(&self.client.with_context(context), request, context.deadline()).await
+        })
     }
 
     fn ack_message<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         request: &'a AckMessageRequest,
     ) -> ProxyServiceFuture<'a, Vec<AckMessageResultEntry>> {
-        Box::pin(async move { ack_message_via_broker(&self.client, request).await })
+        Box::pin(async move { ack_message_via_broker(&self.client.with_context(context), request).await })
     }
 
     fn forward_message_to_dead_letter_queue<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         request: &'a ForwardMessageToDeadLetterQueueRequest,
     ) -> ProxyServiceFuture<'a, ForwardMessageToDeadLetterQueuePlan> {
-        Box::pin(async move { forward_message_to_dead_letter_queue_via_broker(&self.client, request).await })
+        Box::pin(async move {
+            forward_message_to_dead_letter_queue_via_broker(&self.client.with_context(context), request).await
+        })
     }
 
     fn change_invisible_duration<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         request: &'a ChangeInvisibleDurationRequest,
     ) -> ProxyServiceFuture<'a, ChangeInvisibleDurationPlan> {
-        Box::pin(async move { change_invisible_duration_via_broker(&self.client, request).await })
+        Box::pin(async move { change_invisible_duration_via_broker(&self.client.with_context(context), request).await })
     }
 
     fn update_offset<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         request: &'a UpdateOffsetRequest,
     ) -> ProxyServiceFuture<'a, UpdateOffsetPlan> {
-        Box::pin(async move { update_offset_via_broker(&self.client, request).await })
+        Box::pin(async move { update_offset_via_broker(&self.client.with_context(context), request).await })
     }
 
     fn get_offset<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         request: &'a GetOffsetRequest,
     ) -> ProxyServiceFuture<'a, GetOffsetPlan> {
-        Box::pin(async move { get_offset_via_broker(&self.client, request).await })
+        Box::pin(async move { get_offset_via_broker(&self.client.with_context(context), request).await })
     }
 
     fn query_offset<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         request: &'a QueryOffsetRequest,
     ) -> ProxyServiceFuture<'a, QueryOffsetPlan> {
-        Box::pin(async move { query_offset_via_broker(&self.client, request).await })
+        Box::pin(async move { query_offset_via_broker(&self.client.with_context(context), request).await })
     }
 }
 
@@ -1065,8 +1106,8 @@ struct BrokerLocalCommandHandler {
 }
 
 impl LocalCommandHandler for BrokerLocalCommandHandler {
-    async fn handle(&self, command: LocalBrokerCommand) {
-        handle_local_broker_command(&self.facade, self.startup_error.as_ref(), command).await;
+    async fn handle(&self, command: LocalBrokerCommand, control: RequestControl) {
+        handle_local_broker_command(&self.facade, self.startup_error.as_ref(), command, control).await;
     }
 }
 
@@ -1096,8 +1137,7 @@ async fn drain_local_commands(
         let QueuedLocalBrokerCommand {
             command,
             enqueued_at: _,
-            deadline_at: _,
-            timeout_budget: _,
+            control,
             _count_permit,
             _byte_permit,
         } = queued;
@@ -1105,9 +1145,12 @@ async fn drain_local_commands(
             command.reject_with_transport(message.to_owned());
             continue;
         }
-        if tokio::time::timeout(deadline.remaining(), handle_local_broker_command(facade, None, command))
-            .await
-            .is_err()
+        if tokio::time::timeout(
+            deadline.remaining(),
+            handle_local_broker_command(facade, None, command, control),
+        )
+        .await
+        .is_err()
         {
             break;
         }
@@ -1118,7 +1161,12 @@ async fn handle_local_broker_command(
     facade: &ProxyBrokerFacade,
     startup_error: Option<&rocketmq_error::SharedError>,
     command: LocalBrokerCommand,
+    control: RequestControl,
 ) {
+    if let Err(error) = control.check() {
+        command.reject_with(error);
+        return;
+    }
     match command {
         LocalBrokerCommand::QueryRoute { topic, reply } => {
             let _ = reply.send(startup_error.map_or_else(
@@ -1158,7 +1206,7 @@ async fn handle_local_broker_command(
             let result = if let Some(error) = startup_error {
                 Err(ProxyError::from(Arc::clone(error)))
             } else {
-                query_assignment(facade, topic, group, client_id, strategy_name).await
+                query_assignment(facade, topic, group, client_id, strategy_name, &control).await
             };
             let _ = reply.send(result);
         }
@@ -1171,7 +1219,7 @@ async fn handle_local_broker_command(
             let result = if let Some(error) = startup_error {
                 Err(ProxyError::from(Arc::clone(error)))
             } else {
-                send_message(facade, request, client_id, request_id).await
+                send_message(facade, request, client_id, request_id, &control).await
             };
             let _ = reply.send(result);
         }
@@ -1184,7 +1232,7 @@ async fn handle_local_broker_command(
             let result = if let Some(error) = startup_error {
                 Err(ProxyError::from(Arc::clone(error)))
             } else {
-                recall_message(facade, request, client_id, request_id).await
+                recall_message(facade, request, client_id, request_id, &control).await
             };
             let _ = reply.send(result);
         }
@@ -1197,7 +1245,7 @@ async fn handle_local_broker_command(
             let result = if let Some(error) = startup_error {
                 Err(ProxyError::from(Arc::clone(error)))
             } else {
-                end_transaction(facade, request, client_id, request_id).await
+                end_transaction(facade, request, client_id, request_id, &control).await
             };
             let _ = reply.send(result);
         }
@@ -1257,6 +1305,7 @@ async fn query_assignment(
     group: ResourceIdentity,
     client_id: String,
     strategy_name: String,
+    control: &RequestControl,
 ) -> ProxyResult<Option<Vec<MessageQueueAssignment>>> {
     let request_body = QueryAssignmentRequestBody {
         topic: CheetahString::from(topic.to_string()),
@@ -1271,7 +1320,8 @@ async fn query_assignment(
             .encode()
             .map_err(|error| ProxyError::from(canonical::transport_unavailable_with_source(error)))?,
     );
-    let response = facade_embedded_response(facade, request, LOCAL_REMOTING_RESPONSE_TIMEOUT).await?;
+    let response =
+        facade_embedded_response(facade, request, control.remaining(LOCAL_REMOTING_RESPONSE_TIMEOUT)?).await?;
     if ResponseCode::from(response.response_code()) != ResponseCode::Success {
         return Err(broker_operation_error("queryAssignment", &response));
     }
@@ -1289,18 +1339,39 @@ async fn send_message(
     request: SendMessageRequest,
     client_id: Option<String>,
     request_id: String,
+    control: &RequestControl,
 ) -> ProxyResult<Vec<SendMessageResultEntry>> {
     let producer_group = build_local_proxy_producer_group(client_id.as_deref(), request_id.as_str());
     let broker_name = facade.broker_config().broker_identity.broker_name.clone();
     let entries = request.messages;
     if compatible_batch_entries(&entries) {
-        return Ok(send_compatible_batch(facade, &broker_name, producer_group.as_str(), entries).await);
+        return Ok(send_compatible_batch(facade, &broker_name, producer_group.as_str(), entries, control).await);
     }
+    Ok(send_entries(entries, control, |entry| {
+        send_message_entry(facade, &broker_name, producer_group.as_str(), entry, control)
+    })
+    .await)
+}
+
+async fn send_entries<F>(
+    entries: Vec<SendMessageEntry>,
+    control: &RequestControl,
+    mut send: impl FnMut(SendMessageEntry) -> F,
+) -> Vec<SendMessageResultEntry>
+where
+    F: std::future::Future<Output = SendMessageResultEntry>,
+{
     let mut results = Vec::with_capacity(entries.len());
     for entry in entries {
-        results.push(send_message_entry(facade, &broker_name, producer_group.as_str(), entry).await);
+        results.push(match control.check() {
+            Ok(()) => send(entry).await,
+            Err(error) => SendMessageResultEntry {
+                status: ProxyStatusMapper::from_error_payload(&error),
+                send_result: None,
+            },
+        });
     }
-    Ok(results)
+    results
 }
 
 async fn sync_lite_subscription_via_broker(
@@ -1345,10 +1416,12 @@ async fn send_compatible_batch(
     broker_name: &CheetahString,
     producer_group: &str,
     entries: Vec<SendMessageEntry>,
+    control: &RequestControl,
 ) -> Vec<SendMessageResultEntry> {
     let result = async {
         let request = build_send_batch_message_request(broker_name, producer_group, &entries)?;
-        let response = facade_embedded_response(facade, request, LOCAL_REMOTING_RESPONSE_TIMEOUT).await?;
+        let response =
+            facade_embedded_response(facade, request, control.remaining(LOCAL_REMOTING_RESPONSE_TIMEOUT)?).await?;
         build_send_result(entries[0].topic.clone(), broker_name, response)
     }
     .await;
@@ -1396,8 +1469,9 @@ async fn send_message_entry(
     broker_name: &CheetahString,
     producer_group: &str,
     entry: SendMessageEntry,
+    control: &RequestControl,
 ) -> SendMessageResultEntry {
-    match send_message_entry_inner(facade, broker_name, producer_group, entry).await {
+    match send_message_entry_inner(facade, broker_name, producer_group, entry, control).await {
         Ok(send_result) => SendMessageResultEntry {
             status: ProxyStatusMapper::from_send_result_payload(&send_result),
             send_result: Some(send_result),
@@ -1414,10 +1488,12 @@ async fn send_message_entry_inner(
     broker_name: &CheetahString,
     producer_group: &str,
     mut entry: SendMessageEntry,
+    control: &RequestControl,
 ) -> ProxyResult<SendResult> {
     attach_transaction_producer_group(&mut entry.message, producer_group);
     let request = build_send_message_request(broker_name, producer_group, &entry)?;
-    let response = facade_embedded_response(facade, request, LOCAL_REMOTING_RESPONSE_TIMEOUT).await?;
+    let response =
+        facade_embedded_response(facade, request, control.remaining(LOCAL_REMOTING_RESPONSE_TIMEOUT)?).await?;
     build_send_result(entry.topic, broker_name, response)
 }
 
@@ -1426,6 +1502,7 @@ async fn recall_message(
     request: RecallMessageRequest,
     client_id: Option<String>,
     request_id: String,
+    control: &RequestControl,
 ) -> ProxyResult<RecallMessagePlan> {
     let producer_group = build_local_proxy_producer_group(client_id.as_deref(), request_id.as_str());
     let header = RecallMessageRequestHeader::new(
@@ -1435,7 +1512,8 @@ async fn recall_message(
     );
     let mut command = RemotingCommand::create_request_command(RequestCode::RecallMessage, header);
     command.make_custom_header_to_net();
-    let response = facade_embedded_response(facade, command, LOCAL_REMOTING_RESPONSE_TIMEOUT).await?;
+    let response =
+        facade_embedded_response(facade, command, control.remaining(LOCAL_REMOTING_RESPONSE_TIMEOUT)?).await?;
     if ResponseCode::from(response.response_code()) != ResponseCode::Success {
         return Err(broker_operation_error("recallMessage", &response));
     }
@@ -1455,6 +1533,7 @@ async fn end_transaction(
     request: EndTransactionRequest,
     client_id: Option<String>,
     request_id: String,
+    control: &RequestControl,
 ) -> ProxyResult<EndTransactionPlan> {
     let producer_group = request
         .producer_group
@@ -1490,7 +1569,8 @@ async fn end_transaction(
     let mut command = RemotingCommand::create_request_command(RequestCode::EndTransaction, header)
         .set_remark(CheetahString::from(request.trace_context.as_deref().unwrap_or("")));
     command.make_custom_header_to_net();
-    let response = facade_embedded_response(facade, command, LOCAL_REMOTING_RESPONSE_TIMEOUT).await?;
+    let response =
+        facade_embedded_response(facade, command, control.remaining(LOCAL_REMOTING_RESPONSE_TIMEOUT)?).await?;
     if ResponseCode::from(response.response_code()) != ResponseCode::Success {
         return Err(broker_operation_error("endTransaction", &response));
     }
@@ -3106,6 +3186,8 @@ mod tests {
             byte_budget: Arc::new(tokio::sync::Semaphore::new(4_096)),
             rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             broker_name: "broker-a".to_owned(),
+            context_deadline: None,
+            cancellation: tokio_util::sync::CancellationToken::new(),
         };
         let _first_reply = client
             .enqueue(|reply| super::LocalBrokerCommand::QueryRoute {
@@ -3137,6 +3219,8 @@ mod tests {
             byte_budget: Arc::new(tokio::sync::Semaphore::new(4_096)),
             rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             broker_name: "broker-a".to_owned(),
+            context_deadline: None,
+            cancellation: tokio_util::sync::CancellationToken::new(),
         };
         let backend = LocalRemotingBackend::new(client);
         let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerConfig).set_opaque(9_852);
@@ -3186,6 +3270,8 @@ mod tests {
             byte_budget: Arc::new(tokio::sync::Semaphore::new(4_096)),
             rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             broker_name: "broker-a".to_owned(),
+            context_deadline: None,
+            cancellation: tokio_util::sync::CancellationToken::new(),
         };
         let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerConfig).set_opaque(9_857);
 
@@ -3244,8 +3330,13 @@ mod tests {
                 reply,
             },
             enqueued_at,
-            deadline_at: None,
-            timeout_budget: None,
+            control: super::RequestControl::new(
+                Instant::now(),
+                None,
+                None,
+                &tokio_util::sync::CancellationToken::new(),
+            )
+            .unwrap(),
             _count_permit: count_permit,
             _byte_permit: permit,
         };
@@ -3305,5 +3396,78 @@ mod tests {
         assert!(report.is_healthy(), "{}", report.to_json());
         assert!(report.to_json().contains("command-lanes"), "{}", report.to_json());
         assert_eq!(service.task_group().task_count(), 0);
+    }
+    #[tokio::test]
+    async fn caller_drop_cancels_envelope_but_keeps_queue_budget() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let count_budget = Arc::new(tokio::sync::Semaphore::new(1));
+        let client = LocalBrokerFacadeClient {
+            sender,
+            count_budget: count_budget.clone(),
+            byte_budget: Arc::new(tokio::sync::Semaphore::new(4096)),
+            rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            broker_name: "broker-a".to_owned(),
+            context_deadline: None,
+            cancellation: tokio_util::sync::CancellationToken::new(),
+        };
+        let mut call = Box::pin(client.query_route(ResourceIdentity::new("", "topic")));
+        tokio::select! { result = &mut call => panic!("must wait for worker: {result:?}"), () = tokio::task::yield_now() => {} }
+        let queued = receiver.recv().await.unwrap();
+        drop(call);
+        assert!(queued.control.cancellation.is_cancelled());
+        assert_eq!(
+            count_budget.available_permits(),
+            0,
+            "caller cannot release an envelope's payload budget"
+        );
+        drop(queued);
+        assert_eq!(count_budget.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn typed_send_rejects_expired_deadline_before_admission() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let client = LocalBrokerFacadeClient {
+            sender,
+            count_budget: Arc::new(tokio::sync::Semaphore::new(1)),
+            byte_budget: Arc::new(tokio::sync::Semaphore::new(4096)),
+            rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            broker_name: "broker-a".to_owned(),
+            context_deadline: Some(Instant::now()),
+            cancellation: tokio_util::sync::CancellationToken::new(),
+        };
+        let error = client
+            .send_message(
+                super::SendMessageRequest {
+                    messages: Vec::new(),
+                    timeout: Some(Duration::from_secs(3)),
+                    validate_message_type: false,
+                },
+                None,
+                "expired".to_owned(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.descriptor(), &rocketmq_error::CORE_OPERATION_TIMED_OUT);
+        assert!(receiver.try_recv().is_err());
+    }
+    #[tokio::test]
+    async fn batch_control_preserves_completed_entry_and_prevents_next_dispatch() {
+        let control =
+            super::RequestControl::new(Instant::now(), None, None, &tokio_util::sync::CancellationToken::new())
+                .unwrap();
+        let calls = std::sync::atomic::AtomicUsize::new(0);
+        let results = super::send_entries(vec![batch_entry("first"), batch_entry("second")], &control, |_| async {
+            calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            control.cancellation.cancel();
+            super::SendMessageResultEntry {
+                status: super::ProxyStatusMapper::ok_payload(),
+                send_result: None,
+            }
+        })
+        .await;
+        assert_eq!(calls.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert!(results[0].status.is_ok());
+        assert!(!results[1].status.is_ok());
     }
 }

--- a/rocketmq-proxy/src/bootstrap.rs
+++ b/rocketmq-proxy/src/bootstrap.rs
@@ -261,7 +261,7 @@ impl ProxyRuntimeBuilder {
             &telemetry,
             rocketmq_observability::PROXY_METER_SCOPE,
         );
-        let response_guards = grpc_guards.clone();
+        let response_guards = grpc_guards.guards.clone();
         let response_capacity_items = self.config.runtime.consumer_response_permits as u64;
         let response_capacity_bytes = self.config.runtime.consumer_response_bytes as u64;
         resource_metrics.register_queue("proxy-grpc", "consumer-response", "stream", move || {
@@ -414,7 +414,7 @@ where
         hooks: ProxyHookChain,
         metrics: ProxyMetrics,
         transport_telemetry: rocketmq_transport::api::TransportTelemetry,
-        grpc_guards: rocketmq_proxy_core::ingress::grpc::service::ExecutionGuards,
+        grpc_guards: crate::grpc::service::GrpcExecutionResources,
         remoting_backend: Option<Arc<dyn ProxyRemotingBackend>>,
         backend_context: Option<ChildServiceContext>,
         service_context: ChildServiceContext,
@@ -498,6 +498,7 @@ where
     where
         F: Future<Output = ShutdownDeadline> + Send + 'static,
     {
+        let _decode_pool_shutdown = self.grpc_service.decode_pool_shutdown_guard();
         let ProxyRuntime {
             config,
             processor,

--- a/rocketmq-proxy/src/grpc.rs
+++ b/rocketmq-proxy/src/grpc.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod adapter;
+mod gzip_decode;
 pub mod middleware;
 pub mod server;
 pub mod service;

--- a/rocketmq-proxy/src/grpc/gzip_decode.rs
+++ b/rocketmq-proxy/src/grpc/gzip_decode.rs
@@ -1,0 +1,561 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Read;
+use std::sync::{Arc, Mutex, Weak};
+
+use bytes::Bytes;
+use rocketmq_proxy_core::error::canonical;
+use rocketmq_proxy_core::ingress::grpc::service::ExecutionGuards;
+use rocketmq_proxy_core::proto::v2;
+use rocketmq_proxy_core::{GrpcConfig, ProxyError, ProxyResult};
+use rocketmq_runtime::ResourcePermit;
+use tokio_util::sync::CancellationToken;
+
+// Includes the inflater window, tables, reader buffer and bounded bookkeeping.
+// Variable gzip header copies are charged to the retained input reservation.
+const DECODER_WORKSPACE: usize = 256 * 1024;
+
+struct Slot {
+    arena: Vec<u8>,
+    _resident: ResourcePermit,
+}
+
+#[derive(Clone)]
+pub(super) struct GzipDecodePool {
+    idle: Arc<Mutex<Option<Vec<Slot>>>>,
+}
+
+pub(super) struct DecodeSlotLease {
+    slot: Option<Slot>,
+    pool: Weak<Mutex<Option<Vec<Slot>>>>,
+}
+
+impl Drop for DecodeSlotLease {
+    fn drop(&mut self) {
+        if let (Some(slot), Some(pool)) = (self.slot.take(), self.pool.upgrade()) {
+            if let Some(idle) = pool.lock().unwrap_or_else(std::sync::PoisonError::into_inner).as_mut() {
+                idle.push(slot);
+            }
+        }
+    }
+}
+
+struct SendRetention {
+    lease: Option<DecodeSlotLease>,
+    _backings: Vec<Bytes>,
+    _input: ResourcePermit,
+}
+
+struct RetainedBodyOwner {
+    body: RetainedBody,
+    retention: Arc<SendRetention>,
+}
+
+enum RetainedBody {
+    Arena(std::ops::Range<usize>),
+    Input(Bytes),
+}
+
+impl AsRef<[u8]> for RetainedBodyOwner {
+    fn as_ref(&self) -> &[u8] {
+        match &self.body {
+            RetainedBody::Arena(range) => {
+                // Only normalized arena bodies use this variant. The lease never moves
+                // out of its retention until the final Bytes owner has been dropped.
+                match self.retention.lease.as_ref().and_then(|lease| lease.slot.as_ref()) {
+                    Some(slot) => &slot.arena[range.clone()],
+                    None => unreachable!("an arena body always retains its decode slot"),
+                }
+            }
+            RetainedBody::Input(body) => body.as_ref(),
+        }
+    }
+}
+
+impl GzipDecodePool {
+    pub(super) fn new(config: &GrpcConfig, guards: &ExecutionGuards) -> ProxyResult<Self> {
+        if config.max_send_messages_per_request == 0
+            || config.max_message_body_size == 0
+            || config.max_decompressed_request_bytes < config.max_message_body_size
+        {
+            return Err(ProxyError::invalid_metadata(
+                "invalid send batch or decompression limits",
+            ));
+        }
+        let pool = Self {
+            idle: Arc::new(Mutex::new(Some(Vec::new()))),
+        };
+        if config.gzip_decode_slots == 0 {
+            return Ok(pool);
+        }
+        let slot_bytes = config
+            .max_decompressed_request_bytes
+            .checked_add(DECODER_WORKSPACE)
+            .ok_or_else(|| ProxyError::invalid_metadata("gzip arena size overflow"))?;
+        let bytes = slot_bytes
+            .checked_mul(config.gzip_decode_slots)
+            .ok_or_else(|| ProxyError::invalid_metadata("gzip pool size overflow"))?;
+        // Protobuf strings/maps may allocate more than their wire representation.
+        let input = config
+            .max_decoding_message_size
+            .checked_mul(8)
+            .ok_or_else(|| ProxyError::invalid_metadata("maximum input size overflow"))?;
+        guards.validate_resident_bytes(bytes, input)?;
+        let budget = guards.resident_budget(config.gzip_decode_slots, bytes)?;
+        let mut slots = pool.idle.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        for _ in 0..config.gzip_decode_slots {
+            // Provision only after the aggregate reservation has been validated.
+            let mut arena = Vec::new();
+            arena
+                .try_reserve_exact(config.max_decompressed_request_bytes)
+                .map_err(canonical::argument_with_source)?;
+            let resident = budget
+                .try_acquire_data(
+                    arena
+                        .capacity()
+                        .checked_add(DECODER_WORKSPACE)
+                        .ok_or_else(|| ProxyError::invalid_metadata("allocated gzip arena size overflow"))?,
+                )
+                .map_err(|_| ProxyError::invalid_metadata("allocated gzip pool exceeds its configured budget"))?;
+            arena.resize(config.max_decompressed_request_bytes, 0);
+            slots
+                .as_mut()
+                .ok_or_else(|| ProxyError::invalid_metadata("gzip pool closed during provisioning"))?
+                .push(Slot {
+                    arena,
+                    _resident: resident,
+                });
+        }
+        drop(slots);
+        Ok(pool)
+    }
+
+    pub(super) fn decode(
+        &self,
+        mut request: v2::SendMessageRequest,
+        config: &GrpcConfig,
+        input: ResourcePermit,
+        cancellation: &CancellationToken,
+        mut lease: Option<DecodeSlotLease>,
+    ) -> ProxyResult<v2::SendMessageRequest> {
+        validate_request(&request, config)?;
+        let mut retained = Vec::with_capacity(request.messages.len());
+        let mut bodies = Vec::with_capacity(request.messages.len());
+        let mut used = 0usize;
+        for message in &mut request.messages {
+            if cancellation.is_cancelled() {
+                return Err(ProxyError::Draining);
+            }
+            let input_body = std::mem::take(&mut message.body);
+            if is_gzip(message) {
+                let slot = lease
+                    .as_mut()
+                    .and_then(|lease| lease.slot.as_mut())
+                    .ok_or_else(|| ProxyError::invalid_metadata("gzip decode slot is unavailable"))?;
+                let end = used
+                    .checked_add(config.max_message_body_size)
+                    .unwrap_or(usize::MAX)
+                    .min(slot.arena.len());
+                let start = used;
+                let mut decoder = flate2::read::GzDecoder::new(input_body.as_ref());
+                while used < end {
+                    if cancellation.is_cancelled() {
+                        return Err(ProxyError::Draining);
+                    }
+                    let count = decoder
+                        .read(&mut slot.arena[used..end])
+                        .map_err(canonical::argument_with_source)?;
+                    if count == 0 {
+                        break;
+                    }
+                    used += count;
+                }
+                let mut probe = [0u8; 1];
+                if decoder.read(&mut probe).map_err(canonical::argument_with_source)? != 0 {
+                    return Err(canonical::argument("decoded message or aggregate body limit exceeded").into());
+                }
+                bodies.push(RetainedBody::Arena(start..used));
+                if let Some(system) = &mut message.system_properties {
+                    system.body_encoding = v2::Encoding::Identity as i32;
+                }
+            } else {
+                let end = used
+                    .checked_add(input_body.len())
+                    .filter(|end| *end <= config.max_decompressed_request_bytes)
+                    .ok_or_else(|| ProxyError::from(canonical::argument("aggregate body limit exceeded")))?;
+                if let Some(slot) = lease.as_mut().and_then(|lease| lease.slot.as_mut()) {
+                    slot.arena[used..end].copy_from_slice(&input_body);
+                    bodies.push(RetainedBody::Arena(used..end));
+                } else {
+                    bodies.push(RetainedBody::Input(input_body.clone()));
+                }
+                used = end;
+            }
+            retained.push(input_body);
+        }
+        let retention = Arc::new(SendRetention {
+            lease,
+            _input: input,
+            _backings: retained,
+        });
+        for (message, body) in request.messages.iter_mut().zip(bodies) {
+            message.body = Bytes::from_owner(RetainedBodyOwner {
+                retention: retention.clone(),
+                body,
+            });
+        }
+        Ok(request)
+    }
+
+    fn close(&self) {
+        self.idle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+    }
+
+    pub(super) fn shutdown_guard(&self) -> DecodePoolShutdown {
+        DecodePoolShutdown(self.clone())
+    }
+
+    pub(super) fn lease_for(&self, request: &v2::SendMessageRequest) -> ProxyResult<Option<DecodeSlotLease>> {
+        if request.messages.iter().any(is_gzip) {
+            self.try_borrow().map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn try_borrow(&self) -> ProxyResult<DecodeSlotLease> {
+        let slot = self
+            .idle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_mut()
+            .and_then(Vec::pop)
+            .ok_or_else(|| ProxyError::too_many_requests("gzip decode slots"))?;
+        Ok(DecodeSlotLease {
+            slot: Some(slot),
+            pool: Arc::downgrade(&self.idle),
+        })
+    }
+}
+
+pub(crate) struct DecodePoolShutdown(GzipDecodePool);
+
+impl Drop for DecodePoolShutdown {
+    fn drop(&mut self) {
+        self.0.close();
+    }
+}
+
+fn is_gzip(message: &v2::Message) -> bool {
+    message
+        .system_properties
+        .as_ref()
+        .is_some_and(|system| system.body_encoding == v2::Encoding::Gzip as i32)
+}
+
+pub(super) fn validate_request(request: &v2::SendMessageRequest, config: &GrpcConfig) -> ProxyResult<()> {
+    if request.messages.len() > config.max_send_messages_per_request {
+        return Err(canonical::argument("send message count exceeds the configured maximum").into());
+    }
+    for message in &request.messages {
+        if let Some(system) = &message.system_properties {
+            if !matches!(
+                v2::Encoding::try_from(system.body_encoding),
+                Ok(v2::Encoding::Identity | v2::Encoding::Gzip | v2::Encoding::Unspecified)
+            ) {
+                return Err(canonical::argument("unsupported message body encoding").into());
+            }
+        }
+        if !is_gzip(message) && message.body.len() > config.max_message_body_size {
+            return Err(canonical::argument("message body limit exceeded").into());
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn retained_input_bytes(request: &v2::SendMessageRequest, config: &GrpcConfig) -> ProxyResult<usize> {
+    // Include the shared Tonic backing allocation, gzip header copies, protobuf
+    // containers and allocator slack. This bounds retained input, not allocator RSS.
+    let wire = rocketmq_proxy_core::ingress::grpc::service::admission::estimated_protobuf_retained_bytes(request)
+        .saturating_sub(std::mem::size_of_val(request));
+    if wire > config.max_decoding_message_size {
+        return Err(canonical::argument("send request exceeds the decoding limit").into());
+    }
+    let mut bytes = config
+        .max_decoding_message_size
+        .checked_add(
+            wire.checked_mul(2)
+                .ok_or_else(|| ProxyError::from(canonical::argument("input size overflow")))?,
+        )
+        .ok_or_else(|| ProxyError::from(canonical::argument("input size overflow")))?;
+    let mut add = |amount: usize| -> ProxyResult<()> {
+        bytes = bytes
+            .checked_add(amount)
+            .ok_or_else(|| ProxyError::from(canonical::argument("input size overflow")))?;
+        Ok(())
+    };
+    add(request
+        .messages
+        .capacity()
+        .checked_mul(std::mem::size_of::<v2::Message>() + 256)
+        .ok_or_else(|| ProxyError::from(canonical::argument("input capacity overflow")))?)?;
+    for message in &request.messages {
+        if let Some(topic) = &message.topic {
+            add(topic.name.capacity())?;
+            add(topic.resource_namespace.capacity())?;
+        }
+        add(message
+            .user_properties
+            .capacity()
+            .checked_mul(2 * (2 * std::mem::size_of::<String>() + 1))
+            .ok_or_else(|| ProxyError::from(canonical::argument("property capacity overflow")))?)?;
+        for (key, value) in &message.user_properties {
+            add(key.capacity())?;
+            add(value.capacity())?;
+        }
+        if let Some(system) = &message.system_properties {
+            for value in [
+                &system.tag,
+                &system.receipt_handle,
+                &system.message_group,
+                &system.trace_context,
+                &system.lite_topic,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                add(value.capacity())?;
+            }
+            for value in [&system.message_id, &system.born_host, &system.store_host] {
+                add(value.capacity())?;
+            }
+            add(system
+                .keys
+                .capacity()
+                .checked_mul(std::mem::size_of::<String>())
+                .ok_or_else(|| ProxyError::from(canonical::argument("key capacity overflow")))?)?;
+            for value in &system.keys {
+                add(value.capacity())?;
+            }
+            if let Some(digest) = &system.body_digest {
+                add(digest.checksum.capacity())?;
+            }
+            if let Some(dlq) = &system.dead_letter_queue {
+                add(dlq.topic.capacity())?;
+                add(dlq.message_id.capacity())?;
+            }
+        }
+    }
+    let maximum = config
+        .max_decoding_message_size
+        .checked_mul(8)
+        .ok_or_else(|| ProxyError::from(canonical::argument("input limit overflow")))?;
+    if bytes > maximum {
+        return Err(canonical::argument("retained send metadata exceeds the configured input budget").into());
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocketmq_runtime::{BudgetLimit, FullPolicy, ResourceBudgetTree};
+    use std::io::Write;
+
+    fn config() -> GrpcConfig {
+        GrpcConfig {
+            max_message_body_size: 5,
+            max_decompressed_request_bytes: 8,
+            max_send_messages_per_request: 4,
+            gzip_decode_slots: 1,
+            max_decoding_message_size: 4096,
+            ..Default::default()
+        }
+    }
+
+    fn pool(config: &GrpcConfig) -> GzipDecodePool {
+        let guards = ExecutionGuards::try_with_resident_slots(
+            &rocketmq_proxy_core::RuntimeConfig {
+                process_memory_limit_bytes: 16 * 1024 * 1024,
+                ..Default::default()
+            },
+            config.gzip_decode_slots,
+        )
+        .unwrap();
+        GzipDecodePool::new(config, &guards).unwrap()
+    }
+
+    fn message(body: &[u8], gzip: bool) -> v2::Message {
+        let body = if gzip {
+            let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+            encoder.write_all(body).unwrap();
+            Bytes::from(encoder.finish().unwrap())
+        } else {
+            Bytes::copy_from_slice(body)
+        };
+        v2::Message {
+            body,
+            system_properties: Some(v2::SystemProperties {
+                body_encoding: if gzip {
+                    v2::Encoding::Gzip
+                } else {
+                    v2::Encoding::Identity
+                } as i32,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn decode(
+        pool: &GzipDecodePool,
+        config: &GrpcConfig,
+        messages: Vec<v2::Message>,
+    ) -> ProxyResult<v2::SendMessageRequest> {
+        let request = v2::SendMessageRequest { messages };
+        let tree = ResourceBudgetTree::new("input", BudgetLimit::new(1, 65536, FullPolicy::Reject)).unwrap();
+        let input = tree
+            .root()
+            .try_acquire_data(retained_input_bytes(&request, config)?)
+            .unwrap();
+        let lease = pool.lease_for(&request)?;
+        pool.decode(request, config, input, &CancellationToken::new(), lease)
+    }
+
+    #[test]
+    fn gzip_limits_include_identity_and_preserve_arena_capacity() {
+        let config = config();
+        let pool = pool(&config);
+        let capacity = pool.idle.lock().unwrap().as_ref().unwrap()[0].arena.capacity();
+        for gzip_first in [false, true] {
+            let decoded = decode(
+                &pool,
+                &config,
+                vec![message(b"hello", gzip_first), message(b"abc", !gzip_first)],
+            )
+            .unwrap();
+            assert_eq!(decoded.messages[0].body.as_ref(), b"hello");
+            assert_eq!(decoded.messages[1].body.as_ref(), b"abc");
+            assert_eq!(
+                decoded.messages[0].system_properties.as_ref().unwrap().body_encoding,
+                v2::Encoding::Identity as i32
+            );
+            drop(decoded);
+            assert_eq!(
+                pool.idle.lock().unwrap().as_ref().unwrap()[0].arena.capacity(),
+                capacity
+            );
+        }
+        assert!(decode(&pool, &config, vec![message(b"123456", true)]).is_err());
+        assert!(decode(&pool, &config, vec![message(b"12345", true), message(b"6789", false)]).is_err());
+        assert!(decode(&pool, &config, vec![message(b"12345", false), message(b"6789", true)]).is_err());
+        let mut corrupt = message(b"hello", true);
+        let mut bytes = corrupt.body.to_vec();
+        let crc = bytes.len() - 8;
+        bytes[crc] ^= 0xff;
+        corrupt.body = bytes.into();
+        assert!(decode(&pool, &config, vec![corrupt]).is_err());
+        assert_eq!(
+            pool.idle.lock().unwrap().as_ref().unwrap()[0].arena.capacity(),
+            capacity
+        );
+    }
+
+    #[test]
+    fn body_slices_hold_input_and_slot_until_last_owner_even_after_pool_drop() {
+        let config = config();
+        let pool = pool(&config);
+        let request = v2::SendMessageRequest {
+            messages: vec![message(b"hello", true), message(b"abc", false)],
+        };
+        let budget = ResourceBudgetTree::new("input", BudgetLimit::new(1, 65536, FullPolicy::Reject))
+            .unwrap()
+            .root();
+        let input = budget.try_acquire_data(123).unwrap();
+        let lease = pool.lease_for(&request).unwrap();
+        let decoded = pool
+            .decode(request, &config, input, &CancellationToken::new(), lease)
+            .unwrap();
+        let body = decoded.messages[1].body.slice(1..2);
+        drop(decoded);
+        assert_eq!(budget.snapshot().current_bytes, 123);
+        assert!(decode(&pool, &config, vec![message(b"hello", true)]).is_err());
+        pool.close();
+        assert!(pool.idle.lock().unwrap().is_none());
+        let weak = Arc::downgrade(&pool.idle);
+        drop(pool);
+        assert!(weak.upgrade().is_none());
+        assert_eq!(body.as_ref(), b"b");
+        assert_eq!(budget.snapshot().current_bytes, 123);
+        drop(body);
+        assert_eq!(budget.snapshot().current_bytes, 0);
+    }
+
+    #[test]
+    fn cancelled_decode_retains_resources_until_blocking_owner_exits() {
+        let config = config();
+        let pool = pool(&config);
+        let request = v2::SendMessageRequest {
+            messages: vec![message(b"hello", true)],
+        };
+        let budget = ResourceBudgetTree::new("input", BudgetLimit::new(1, 65536, FullPolicy::Reject))
+            .unwrap()
+            .root();
+        let input = budget.try_acquire_data(123).unwrap();
+        let lease = pool.lease_for(&request).unwrap();
+        let cancel = CancellationToken::new();
+        let cancellation = cancel.clone();
+        let (release, wait) = std::sync::mpsc::channel();
+        let worker_pool = pool.clone();
+        let worker = std::thread::spawn(move || {
+            wait.recv().unwrap();
+            worker_pool.decode(request, &config, input, &cancellation, lease)
+        });
+        cancel.cancel();
+        assert_eq!(budget.snapshot().current_bytes, 123);
+        assert!(pool.idle.lock().unwrap().as_ref().unwrap().is_empty());
+        release.send(()).unwrap();
+        assert!(worker.join().unwrap().is_err());
+        assert_eq!(budget.snapshot().current_bytes, 0);
+        assert_eq!(pool.idle.lock().unwrap().as_ref().unwrap().len(), 1);
+    }
+    #[test]
+    fn invalid_pool_configuration_fails_before_allocating_and_zero_slots_disables_gzip() {
+        let mut config = config();
+        let guards = ExecutionGuards::try_with_resident_slots(
+            &rocketmq_proxy_core::RuntimeConfig {
+                process_memory_limit_bytes: 16 * 1024 * 1024,
+                ..Default::default()
+            },
+            1,
+        )
+        .unwrap();
+        config.gzip_decode_slots = usize::MAX;
+        assert!(GzipDecodePool::new(&config, &guards).is_err());
+        config.gzip_decode_slots = 1;
+        config.max_decompressed_request_bytes = 4;
+        assert!(GzipDecodePool::new(&config, &guards).is_err());
+        config.max_decompressed_request_bytes = 8;
+        config.gzip_decode_slots = 0;
+        let pool = GzipDecodePool::new(&config, &guards).unwrap();
+        assert!(decode(&pool, &config, vec![message(b"hello", true)]).is_err());
+        assert!(decode(&pool, &config, vec![message(b"hello", false)]).is_ok());
+        config.max_send_messages_per_request = 0;
+        assert!(GzipDecodePool::new(&config, &guards).is_err());
+    }
+}

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Read;
 use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
@@ -270,7 +269,13 @@ const DEFAULT_CONSUMER_CUSTOMIZED_BACKOFF_MS: [u64; 18] = [
     600_000, 1_200_000, 1_800_000, 3_600_000, 7_200_000,
 ];
 
+pub(crate) struct GrpcExecutionResources {
+    pub(crate) guards: ExecutionGuards,
+    gzip_pool: super::gzip_decode::GzipDecodePool,
+}
+
 pub struct ProxyGrpcService<P> {
+    gzip_pool: super::gzip_decode::GzipDecodePool,
     config: Arc<ProxyConfig>,
     processor: Arc<P>,
     sessions: ClientSessionRegistry,
@@ -293,6 +298,7 @@ impl<P> Clone for ProxyGrpcService<P> {
             processor: Arc::clone(&self.processor),
             sessions: self.sessions.clone(),
             guards: self.guards.clone(),
+            gzip_pool: self.gzip_pool.clone(),
             reap_schedule: self.reap_schedule.clone(),
             auth_runtime: self.auth_runtime.clone(),
             hooks: self.hooks.clone(),
@@ -308,7 +314,7 @@ impl<P> ProxyGrpcService<P>
 where
     P: MessagingProcessor + 'static,
 {
-    pub(crate) fn try_execution_guards(config: &ProxyConfig) -> ProxyResult<ExecutionGuards> {
+    pub(crate) fn try_execution_guards(config: &ProxyConfig) -> ProxyResult<GrpcExecutionResources> {
         config.grpc.tls.validate()?;
         #[cfg(not(feature = "tls"))]
         if config.grpc.tls.enabled {
@@ -318,14 +324,16 @@ where
             )
             .into());
         }
-        ExecutionGuards::try_from_config(&config.runtime)
+        let guards = ExecutionGuards::try_with_resident_slots(&config.runtime, config.grpc.gzip_decode_slots)?;
+        let gzip_pool = super::gzip_decode::GzipDecodePool::new(&config.grpc, &guards)?;
+        Ok(GrpcExecutionResources { guards, gzip_pool })
     }
 
     pub(crate) fn from_execution_guards(
         config: Arc<ProxyConfig>,
         processor: Arc<P>,
         sessions: ClientSessionRegistry,
-        guards: ExecutionGuards,
+        resources: GrpcExecutionResources,
     ) -> Self {
         let interval_ms = Self::housekeeping_interval_from_config(config.as_ref())
             .as_millis()
@@ -335,7 +343,8 @@ where
             Arc::clone(&processor),
         ));
         Self {
-            guards,
+            guards: resources.guards,
+            gzip_pool: resources.gzip_pool,
             config,
             processor,
             sessions,
@@ -406,27 +415,31 @@ where
     async fn normalize_send_body_encodings(
         &self,
         request: v2::SendMessageRequest,
+        permit: ResourcePermit,
     ) -> ProxyResult<v2::SendMessageRequest> {
-        let needs_gzip = request.messages.iter().any(|message| {
-            message.system_properties.as_ref().is_some_and(|properties| {
-                v2::Encoding::try_from(properties.body_encoding).unwrap_or(v2::Encoding::Unspecified)
-                    == v2::Encoding::Gzip
-            })
-        });
-        if !needs_gzip {
-            return Ok(request);
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let _caller = cancellation.clone().drop_guard();
+        let lease = self.gzip_pool.lease_for(&request)?;
+        if lease.is_none() {
+            return self
+                .gzip_pool
+                .decode(request, &self.config.grpc, permit, &cancellation, lease);
         }
-
         let Some(executor) = self.cpu_crypto.clone() else {
             return Err(ProxyError::not_implemented("SendMessage(gzip executor unavailable)"));
         };
-        let max_body_size = self.config.grpc.max_message_body_size;
+        let pool = self.gzip_pool.clone();
+        let config = self.config.clone();
         executor
             .spawn("proxy.grpc.decode_gzip", BlockingKind::CpuBound, move || {
-                decode_gzip_message_bodies(request, max_body_size)
+                pool.decode(request, &config.grpc, permit, &cancellation, lease)
             })
             .await
             .map_err(|error| ProxyError::from(canonical::transport_unavailable_with_source(error)))?
+    }
+
+    pub(crate) fn decode_pool_shutdown_guard(&self) -> super::gzip_decode::DecodePoolShutdown {
+        self.gzip_pool.shutdown_guard()
     }
 
     pub fn metrics_snapshot(&self) -> ProxyMetricsSnapshot {
@@ -1136,38 +1149,6 @@ where
     }
 }
 
-fn decode_gzip_message_bodies(
-    mut request: v2::SendMessageRequest,
-    max_body_size: usize,
-) -> ProxyResult<v2::SendMessageRequest> {
-    for message in &mut request.messages {
-        let Some(system) = message.system_properties.as_mut() else {
-            continue;
-        };
-        let encoding = v2::Encoding::try_from(system.body_encoding).unwrap_or(v2::Encoding::Unspecified);
-        if encoding != v2::Encoding::Gzip {
-            continue;
-        }
-
-        let mut decoded = Vec::with_capacity(message.body.len().min(max_body_size));
-        let decoder = flate2::read::GzDecoder::new(message.body.as_ref());
-        let limit = u64::try_from(max_body_size).unwrap_or(u64::MAX).saturating_add(1);
-        decoder
-            .take(limit)
-            .read_to_end(&mut decoded)
-            .map_err(canonical::argument_with_source)?;
-        if decoded.len() > max_body_size {
-            return Err(canonical::argument(format!(
-                "decoded message body exceeds the configured maximum {max_body_size} bytes"
-            ))
-            .into());
-        }
-        message.body = decoded.into();
-        system.body_encoding = v2::Encoding::Identity as i32;
-    }
-    Ok(request)
-}
-
 fn proxy_span_outcome(outcome: &ProxyRequestOutcome) -> rocketmq_observability::trace::proxy::ProxySpanOutcome {
     match outcome {
         ProxyRequestOutcome::Payload(status) if status.is_ok() => {
@@ -1289,11 +1270,17 @@ where
             if let Err(error) = self.validate_client_context(&context) {
                 return adapter::error_send_message_response(ProxyStatusMapper::from_error(&error));
             }
-            let _permit = match self.guards.try_producer(estimated_protobuf_retained_bytes(&request)) {
+            let retained_bytes = match super::gzip_decode::validate_request(&request, &self.config.grpc)
+                .and_then(|()| super::gzip_decode::retained_input_bytes(&request, &self.config.grpc))
+            {
+                Ok(bytes) => bytes,
+                Err(error) => return adapter::error_send_message_response(ProxyStatusMapper::from_error(&error)),
+            };
+            let permit = match self.guards.try_producer(retained_bytes) {
                 Ok(permit) => permit,
                 Err(error) => return adapter::error_send_message_response(ProxyStatusMapper::from_error(&error)),
             };
-            let request = match self.normalize_send_body_encodings(request).await {
+            let request = match self.normalize_send_body_encodings(request, permit).await {
                 Ok(request) => request,
                 Err(error) => return adapter::error_send_message_response(ProxyStatusMapper::from_error(&error)),
             };
@@ -2118,7 +2105,6 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::io::Write;
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::time::Duration;
@@ -2147,7 +2133,6 @@ mod tests {
     use tonic::metadata::MetadataValue;
     use tonic::Request;
 
-    use super::decode_gzip_message_bodies;
     use super::ProxyGrpcService;
     use super::DEFAULT_CONSUMER_CUSTOMIZED_BACKOFF_MS;
     use super::DEFAULT_CONSUMER_MAX_ATTEMPTS;
@@ -2208,54 +2193,6 @@ mod tests {
     use rocketmq_proxy_core::SettingsBackoffPolicy;
     use rocketmq_proxy_core::SettingsPolicyProvider;
 
-    fn gzip_body(body: &[u8]) -> Bytes {
-        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
-        encoder.write_all(body).expect("write gzip body");
-        Bytes::from(encoder.finish().expect("finish gzip body"))
-    }
-
-    #[test]
-    fn gzip_message_body_decodes_to_identity_with_a_hard_limit() {
-        let request = v2::SendMessageRequest {
-            messages: vec![v2::Message {
-                system_properties: Some(v2::SystemProperties {
-                    body_encoding: v2::Encoding::Gzip as i32,
-                    ..Default::default()
-                }),
-                body: gzip_body(b"hello"),
-                ..Default::default()
-            }],
-        };
-
-        let decoded = decode_gzip_message_bodies(request, 5).expect("decode gzip");
-
-        assert_eq!(decoded.messages[0].body.as_ref(), b"hello");
-        assert_eq!(
-            decoded.messages[0]
-                .system_properties
-                .as_ref()
-                .expect("system properties")
-                .body_encoding,
-            v2::Encoding::Identity as i32
-        );
-    }
-
-    #[test]
-    fn gzip_message_body_rejects_invalid_and_oversized_payloads() {
-        let request_with = |body: Bytes| v2::SendMessageRequest {
-            messages: vec![v2::Message {
-                system_properties: Some(v2::SystemProperties {
-                    body_encoding: v2::Encoding::Gzip as i32,
-                    ..Default::default()
-                }),
-                body,
-                ..Default::default()
-            }],
-        };
-
-        assert!(decode_gzip_message_bodies(request_with(Bytes::from_static(b"invalid")), 16).is_err());
-        assert!(decode_gzip_message_bodies(request_with(gzip_body(b"too large")), 4).is_err());
-    }
     use crate::PreparedTransactionRegistration;
     use rocketmq_proxy_core::ProxyContext as CoreProxyContext;
     use rocketmq_proxy_core::ProxyMessage;
@@ -3203,6 +3140,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gzip_send_uses_owned_executor_and_returns_send_result() {
+        use std::io::Write;
+        let runtime = rocketmq_runtime::RuntimeContext::try_from_current("gzip-send-test").unwrap();
+        let context = runtime.service_context("gzip-send-service").component("decode");
+        let service = test_service_with_message_service(
+            StaticRouteService::default(),
+            StaticMetadataService::default(),
+            Arc::new(StaticMessageService::with_send_status(SendStatus::SendOk)),
+        )
+        .with_cpu_crypto_executor(context.cpu_crypto().clone());
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(b"hello").unwrap();
+        let mut request = Request::new(v2::SendMessageRequest {
+            messages: vec![v2::Message {
+                topic: Some(v2::Resource {
+                    resource_namespace: String::new(),
+                    name: "TopicA".to_owned(),
+                }),
+                system_properties: Some(v2::SystemProperties {
+                    message_id: "gzip-msg".to_owned(),
+                    body_encoding: v2::Encoding::Gzip as i32,
+                    ..Default::default()
+                }),
+                body: encoder.finish().unwrap().into(),
+                ..Default::default()
+            }],
+        });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+        let response = service.send_message(request).await.unwrap().into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+        assert_eq!(response.entries[0].message_id, "gzip-msg");
+        assert!(context.task_group().shutdown(Duration::from_secs(1)).await.is_healthy());
+    }
+
+    #[tokio::test]
     async fn recall_message_returns_recalled_message_id() {
         let service = test_service_with_message_service(
             StaticRouteService::default(),
@@ -3227,9 +3201,11 @@ mod tests {
 
     #[tokio::test]
     async fn send_message_tracks_prepared_transactions_for_transactional_entries() {
+        let metadata = StaticMetadataService::default();
+        metadata.set_topic_message_type(ResourceIdentity::new("", "TopicA"), ProxyTopicMessageType::Transaction);
         let service = test_service_with_all_services(
             StaticRouteService::default(),
-            StaticMetadataService::default(),
+            metadata,
             Arc::new(StaticMessageService::with_send_status(SendStatus::SendOk)),
             Arc::new(DefaultConsumerService),
             Arc::new(TestTransactionService::default()),
@@ -4834,9 +4810,11 @@ mod tests {
     #[tokio::test]
     async fn end_transaction_uses_prepared_transaction_state_and_clears_it() {
         let transaction_service = Arc::new(TestTransactionService::default());
+        let metadata = StaticMetadataService::default();
+        metadata.set_topic_message_type(ResourceIdentity::new("", "TopicA"), ProxyTopicMessageType::Transaction);
         let service = test_service_with_all_services(
             StaticRouteService::default(),
-            StaticMetadataService::default(),
+            metadata,
             Arc::new(StaticMessageService::with_send_status(SendStatus::SendOk)),
             Arc::new(DefaultConsumerService),
             transaction_service.clone(),

--- a/scripts/tests/test_package_publish_workspace.py
+++ b/scripts/tests/test_package_publish_workspace.py
@@ -323,6 +323,24 @@ class PackagePublishWorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(self.planner.PlannerError, "cycle"):
             self.planner.build_plan(metadata, scope, selector=None)
 
+    def test_dev_cycle_does_not_block_normal_build_optional_or_renamed_edges(self) -> None:
+        metadata = {
+            "workspace_members": ["a 1", "b 1"],
+            "packages": [
+                {"id": "a 1", "name": "a", "version": "1.0.0", "manifest_path": str(ROOT / "Cargo.toml"),
+                 "dependencies": [{"name": "b", "kind": "build", "optional": True, "rename": "helper", "target": "cfg(windows)"}]},
+                {"id": "b 1", "name": "b", "version": "1.0.0", "manifest_path": str(ROOT / "Cargo.toml"),
+                 "dependencies": [{"name": "a", "kind": "dev"}]},
+            ],
+        }
+        scope = {"core_packages": [{"name": name, "path": name, "classification": "registry-publish"} for name in ("a", "b")]}
+        plan = self.planner.build_plan(metadata, scope, selector="a")
+        self.assertEqual(["b", "a"], [entry["name"] for entry in plan["packages"]])
+        self.assertEqual(["a"], plan["packages"][0]["internal_dev_dependencies"])
+        metadata["packages"][1]["dependencies"][0]["kind"] = "normal"
+        with self.assertRaisesRegex(self.planner.PlannerError, "cycle"):
+            self.planner.build_plan(metadata, scope, selector=None)
+
     def test_unclassified_workspace_package_is_rejected(self) -> None:
         metadata = {
             "workspace_members": ["a 1", "new 1"],


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10250

### Brief Description

Failed logical send-back now retains failed messages and offsets. Consume workers return retry dispositions while keeping the original admission permit, so saturated retries make progress within the configured capacity. POP orderly registration owns an immutable key and successful or expired receipts leave the local scheduler.

Local commands carry the same absolute deadline and child cancellation token through adapters, queueing, slot acquisition and dispatch. Caller cancellation prevents subsequent work while started operations retain their owners and completed batch results.

Gzip normalization uses fixed resident arenas acquired before CPU submission. Input reservations, compressed buffers and arena leases follow the final Bytes owner, including slices and transaction retention. Add explicit message/aggregate/slot limits and startup capacity validation. Wire formats and persisted layouts remain unchanged.

Publish ordering uses normal/build edges, retains optional/target/renamed semantics, and records dev dependencies separately. The delivery note documents resource policy and follow-up deployment evidence.

### How Did You Test This Change?

- Client consume service filter: 61 passed; scheduler filter: 4 passed; send-back filter: 8 passed.
- `cargo test -p rocketmq-proxy-local --lib`: 29 passed.
- `cargo test -p rocketmq-proxy --lib grpc:: -- --skip query_route_rejects_invalid_grpc_timeout_as_transport_status`: 56 passed.
- `cargo test -p rocketmq-proxy --test grpc_ingress send_message`: 3 passed over actual gRPC transport.
- Publish planner unittest suite: 15 passed, including temporary-registry staging and dependency fixtures.
- Package-scoped format checks for client, Proxy Core, Local and Proxy; `git diff --check` passed.

Broader exploratory suites encounter existing client lifecycle and Proxy timeout/readiness assertions against obsolete private error text. Those suites are not claimed as passing. Transactional fixtures were corrected to declare a transactional topic. Docker interoperability and throughput/fault evidence are scheduled in the runtime-evidence work item. CI is not used as a merge gate for this authorized delivery.
