### PR TITLE
[ISSUE #10251]🧪Add edge-case tests for static-topic i32 map keys

### DIFF
--- a/rocketmq-protocol/src/protocol/static_topic/i32_key_map_serde.rs
+++ b/rocketmq-protocol/src/protocol/static_topic/i32_key_map_serde.rs
@@ -36,3 +36,66 @@ where
     }
     Ok(Some(parsed))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Local wrapper so the crate-private helper can be exercised directly, without widening the
+    /// visibility of production code.
+    #[derive(Debug, Deserialize)]
+    struct Wrapper {
+        #[serde(default, deserialize_with = "deserialize_optional_i32_key_map")]
+        map: Option<HashMap<i32, String>>,
+    }
+
+    fn parse(json: &str) -> Result<Option<HashMap<i32, String>>, serde_json::Error> {
+        serde_json::from_str::<Wrapper>(json).map(|wrapper| wrapper.map)
+    }
+
+    #[test]
+    fn missing_field_and_explicit_null_both_deserialize_to_none() {
+        assert!(parse("{}").unwrap().is_none());
+        assert!(parse(r#"{"map":null}"#).unwrap().is_none());
+    }
+
+    #[test]
+    fn empty_object_deserializes_to_empty_map() {
+        let map = parse(r#"{"map":{}}"#).unwrap().expect("map should be present");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn signed_boundary_keys_deserialize_to_matching_integers() {
+        let json = format!(
+            r#"{{"map":{{"0":"zero","7":"positive","-7":"negative","{}":"min","{}":"max"}}}}"#,
+            i32::MIN,
+            i32::MAX
+        );
+        let map = parse(&json).unwrap().expect("map should be present");
+        assert_eq!(map.len(), 5);
+        assert_eq!(map[&0], "zero");
+        assert_eq!(map[&7], "positive");
+        assert_eq!(map[&-7], "negative");
+        assert_eq!(map[&i32::MIN], "min");
+        assert_eq!(map[&i32::MAX], "max");
+    }
+
+    #[test]
+    fn non_numeric_key_is_rejected_with_the_offending_key() {
+        let error = parse(r#"{"map":{"queue-1":"value"}}"#).unwrap_err().to_string();
+        assert!(error.contains("invalid i32 map key"), "unexpected error: {error}");
+        assert!(error.contains("queue-1"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn out_of_range_keys_are_rejected_instead_of_wrapping() {
+        for key in [i64::from(i32::MIN) - 1, i64::from(i32::MAX) + 1] {
+            let error = parse(&format!(r#"{{"map":{{"{key}":"value"}}}}"#))
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("invalid i32 map key"), "unexpected error: {error}");
+            assert!(error.contains(&key.to_string()), "unexpected error: {error}");
+        }
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10251

### Brief Description

Adds a `#[cfg(test)] mod tests` to `rocketmq-protocol/src/protocol/static_topic/i32_key_map_serde.rs`. The existing coverage only reaches `deserialize_optional_i32_key_map` through `TopicQueueMappingInfo` / `TopicQueueMappingDetail` round-trips with a single positive key, so the `None`, empty-map, signed-boundary and invalid-key branches were never exercised.

The tests use a local `#[derive(Deserialize)] struct Wrapper` whose field carries `#[serde(default, deserialize_with = "deserialize_optional_i32_key_map")]`, so the crate-private helper is reachable without widening production visibility. Covered cases:

- a missing field and an explicit JSON `null` both yield `None`;
- an empty JSON object yields `Some` with an empty map;
- `0`, `7`, `-7`, `i32::MIN` and `i32::MAX` string keys decode to the matching integers with values preserved;
- a non-numeric key errors with `invalid i32 map key` and the rejected key;
- keys one below `i32::MIN` and one above `i32::MAX` error instead of wrapping.

Test-only change; no production code or visibility was touched.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol --lib i32_key_map_serde` — 5 passed, 0 failed.
- `cargo fmt -p rocketmq-protocol -- --check` — clean.
- `cargo clippy -p rocketmq-protocol --tests --no-deps -- -D warnings` — clean.
- `cargo test -p rocketmq-protocol --lib static_topic` — 54 passed, 1 failed. The failure is `topic_queue_mapping_utils::tests::check_leader_in_target_brokers_requires_every_leader_broker_in_targets`, which reproduces on unmodified `main` (verified by stashing this diff) and is unrelated to these tests.

As a sanity check that the new tests are load-bearing, temporarily replacing `parse::<i32>()` with a `parse::<i64>()` + `as i32` cast made `out_of_range_keys_are_rejected_instead_of_wrapping` fail; the change was reverted before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for optional integer-keyed map deserialization, including missing or null values and empty maps.
  - Added validation for signed boundary values, non-numeric keys, and out-of-range keys.
  - Confirmed that invalid inputs produce descriptive errors and valid keys are converted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->