### PR TITLE
[ISSUE #10259]🐛Preserve storage outcomes and Broker request ownership

### DIFF
--- a/rocketmq-broker/src/broker/broker_pre_online_capability.rs
+++ b/rocketmq-broker/src/broker/broker_pre_online_capability.rs
@@ -293,7 +293,7 @@ impl<MS: BrokerReplicationStore> BrokerSpecialServiceCapability<MS> {
             if should_start {
                 ScheduleMessageService::start(schedule).await?;
             } else {
-                schedule.stop().await?;
+                schedule.stop_checked().await?;
             }
             if let Some(timer) = self.timer.as_ref().and_then(Weak::upgrade) {
                 timer.sync_last_read_time_ms();

--- a/rocketmq-broker/src/broker/broker_runtime_config_state.rs
+++ b/rocketmq-broker/src/broker/broker_runtime_config_state.rs
@@ -168,13 +168,6 @@ impl BrokerPermissionState {
         }
     }
 
-    pub(crate) fn runtime_snapshot(&self) -> Option<BrokerRuntimeMutationSnapshot> {
-        match &self.source {
-            BrokerPermissionSource::Runtime(runtime) => Some(runtime.snapshot().mutation_snapshot()),
-            BrokerPermissionSource::Fixed(_) => None,
-        }
-    }
-
     #[inline]
     pub(crate) fn auto_create_subscription_group(&self) -> Option<bool> {
         match &self.source {

--- a/rocketmq-broker/src/broker_runtime/composition.rs
+++ b/rocketmq-broker/src/broker_runtime/composition.rs
@@ -1031,7 +1031,7 @@ impl<MS: BrokerStorePort> BrokerRuntimeState<MS> {
                     ScheduleMessageService::start(schedule_message_service.clone()).await?;
                 }
             } else if let Some(schedule_message_service) = &self.schedule_message_service {
-                schedule_message_service.stop().await?;
+                schedule_message_service.stop_checked().await?;
             }
 
             self.is_schedule_service_start.store(should_start, Ordering::Release);

--- a/rocketmq-broker/src/broker_runtime/lifecycle.rs
+++ b/rocketmq-broker/src/broker_runtime/lifecycle.rs
@@ -279,11 +279,27 @@ impl BrokerRuntime {
         // message store is still available. Detach the service only after that owned shutdown
         // completes so in-flight delivery cannot observe a missing runtime slot.
         if let Some(schedule_message_service) = self.composition.state.schedule_message_service.as_ref().cloned() {
-            if let Err(error) = schedule_message_service.shutdown().await {
-                warn!(?error, "Failed to shutdown ScheduleMessageService cleanly");
+            let started = Instant::now();
+            if let Err(error) = schedule_message_service.shutdown_until(deadline).await {
+                shutdown_report.schedule_message = if error.descriptor() == &rocketmq_error::CORE_OPERATION_TIMED_OUT {
+                    BrokerShutdownComponentReport::timed_out("schedule_message", started.elapsed())
+                } else {
+                    BrokerShutdownComponentReport::unhealthy(
+                        "schedule_message",
+                        started.elapsed(),
+                        error.code().as_str(),
+                    )
+                };
+                shutdown_report.unfinished_components = progress.unfinished();
+                return shutdown_report;
             }
+            shutdown_report.schedule_message =
+                BrokerShutdownComponentReport::completed("schedule_message", started.elapsed());
             self.composition.state.schedule_message_service.take();
+        } else {
+            shutdown_report.schedule_message = BrokerShutdownComponentReport::skipped("schedule_message");
         }
+        progress.complete("schedule_message");
 
         // Transaction checking can create the checked-too-many-times topic and read/write the
         // message store. Stop admission, drain its owned check tasks, then stop the op batch

--- a/rocketmq-broker/src/broker_runtime/request_pipeline.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline.rs
@@ -207,7 +207,6 @@ impl BrokerRuntime {
         transactional_message_service: Arc<DefaultTransactionalMessageService<BrokerMessageStore>>,
     ) -> Result<(DefaultServerProcessor, DefaultServerProcessor), BrokerStartupError> {
         let send_message_topic_capability = Arc::new(SendMessageTopicCapability::new(
-            self.composition.state.send_message_policy_state.clone(),
             self.composition.state.topic_config_manager_handle(),
             self.composition.state.topic_config_coordinator_handle(),
             self.composition.state.topic_queue_mapping_manager_handle(),

--- a/rocketmq-broker/src/broker_runtime/shutdown_report.rs
+++ b/rocketmq-broker/src/broker_runtime/shutdown_report.rs
@@ -60,6 +60,7 @@ pub(crate) struct BrokerBasicServiceShutdownReport {
     pub(crate) service_tasks: BrokerShutdownComponentReport,
     pub(crate) observability: BrokerShutdownComponentReport,
     pub(crate) scheduled_tasks: BrokerShutdownComponentReport,
+    pub(crate) schedule_message: BrokerShutdownComponentReport,
     pub(crate) message_store: BrokerShutdownComponentReport,
     pub(crate) deferred_services: BrokerShutdownComponentReport,
     pub(crate) deferred_producer_tasks: Option<ShutdownReport>,
@@ -268,7 +269,7 @@ pub(super) fn record_message_store_shutdown_outcome(
 }
 
 impl BrokerBasicServiceShutdownReport {
-    const COMPONENT_NAMES: [&'static str; 18] = [
+    const COMPONENT_NAMES: [&'static str; 19] = [
         "remoting",
         "request_processor",
         "topic_config",
@@ -278,6 +279,7 @@ impl BrokerBasicServiceShutdownReport {
         "service_tasks",
         "observability",
         "scheduled_tasks",
+        "schedule_message",
         "message_store",
         "deferred_services",
         "transaction_services",
@@ -376,6 +378,7 @@ impl BrokerBasicServiceShutdownReport {
             &self.service_tasks,
             &self.observability,
             &self.scheduled_tasks,
+            &self.schedule_message,
             &self.message_store,
             &self.deferred_services,
             &self.transaction_services,

--- a/rocketmq-broker/src/processor/dispatcher.rs
+++ b/rocketmq-broker/src/processor/dispatcher.rs
@@ -364,6 +364,24 @@ where
 
 #[cfg(test)]
 impl<MS: BrokerStorePort, TS> BrokerRequestProcessor<BrokerProcessorType<MS, TS>> {
+    pub(crate) fn install_send_hook_for_test(
+        &mut self,
+        request_code: RequestCode,
+        hook: Box<dyn crate::mqtrace::send_message_hook::SendMessageHook>,
+    ) {
+        let code = request_code.to_i32();
+        let processor = match self.process_table.get(&code).expect("send/reply route") {
+            BrokerProcessorType::Send(processor) => {
+                BrokerProcessorType::Send(Arc::new(processor.with_hook_for_test(hook)))
+            }
+            BrokerProcessorType::Reply(processor) => {
+                BrokerProcessorType::Reply(Arc::new(processor.with_hook_for_test(hook)))
+            }
+            _ => panic!("test hook requires a send/reply route"),
+        };
+        self.register_processor(code, processor);
+    }
+
     pub(crate) fn dispatch_processor_variant_for_test(&self, request_code: RequestCode) -> Option<&'static str> {
         self.process_table
             .get(&request_code.to_i32())

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -60,6 +60,7 @@ use tracing::warn;
 
 use crate::mqtrace::send_message_context::SendMessageContext;
 use crate::processor::response_assembly::BrokerResponseParts;
+use crate::processor::send_message_processor::capability::SendMessagePolicy;
 use crate::processor::send_message_processor::capability::SendMessageProcessorContext;
 use crate::processor::send_message_processor::structured_store::append_message_with_control_reply;
 use crate::processor::send_message_processor::structured_store::StoreHookCompletion;
@@ -200,7 +201,7 @@ fn apply_reply_store_result(
         }
     };
     if let (true, Some(append_result)) = (put_ok, put_message_result.append_message_result()) {
-        response_header.set_msg_id(append_result.msg_id.clone().unwrap_or_default());
+        response_header.set_msg_id(append_result.get_message_id().unwrap_or_default());
         response_header.set_queue_id(queue_id);
         response_header.set_queue_offset(append_result.logics_offset);
     }
@@ -248,13 +249,15 @@ pub struct ReplyMessageProcessor<MS: BrokerWriteStore, TS> {
 }
 
 struct ReplyCompletionFacts {
+    policy: Arc<SendMessagePolicy>,
     owner: Option<CheetahString>,
     body_len: usize,
 }
 
 impl ReplyCompletionFacts {
-    fn capture(request: &RemotingCommand) -> Self {
+    fn capture(request: &RemotingCommand, policy: Arc<SendMessagePolicy>) -> Self {
         Self {
+            policy,
             owner: request
                 .get_ext_fields()
                 .and_then(|fields| fields.get(BrokerStatsManager::COMMERCIAL_OWNER))
@@ -268,6 +271,20 @@ impl<MS: BrokerWriteStore, TS> Clone for ReplyMessageProcessor<MS, TS> {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+#[cfg(test)]
+impl<MS: BrokerWriteStore, TS> ReplyMessageProcessor<MS, TS> {
+    pub(crate) fn with_hook_for_test(&self, hook: Box<dyn crate::mqtrace::send_message_hook::SendMessageHook>) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                send_message_hook_vec: Arc::new(vec![hook]),
+                consume_message_hook_vec: Arc::clone(&self.inner.consume_message_hook_vec),
+                transactional_message_service: Arc::clone(&self.inner.transactional_message_service),
+                context: Arc::clone(&self.inner.context),
+            }),
         }
     }
 }
@@ -388,11 +405,12 @@ where
         original_opaque: i32,
         request: &mut RemotingCommand,
     ) -> crate::broker_error::BrokerResult<HandlerOutcome> {
+        let policy = self.inner.context.policy.snapshot();
         let mut request_header = parse_request_header(request)?;
         let request_properties = MessageDecoder::string_to_message_properties(request_header.properties.as_ref());
         let mut send_message_context = self
             .inner
-            .build_msg_context_at(inbound_peer, &mut request_header, request, request_properties)
+            .build_msg_context_at(&policy, inbound_peer, &mut request_header, request, request_properties)
             .0;
         self.inner.execute_send_message_hook_before(&send_message_context);
 
@@ -402,16 +420,8 @@ where
             .command_factory
             .create_success_response_command()
             .set_opaque(original_opaque);
-        let (region_id, trace_on, start_timestamp, store_reply_message_enable) = {
-            let policy = self.inner.context.policy.snapshot();
-            (
-                policy.region_id.clone(),
-                policy.trace_on,
-                policy.start_accept_send_request_time_stamp as u64,
-                policy.store_reply_message_enable,
-            )
-        };
-        add_reply_response_metadata(&mut response, region_id.as_str(), trace_on);
+        add_reply_response_metadata(&mut response, policy.region_id.as_str(), policy.trace_on);
+        let start_timestamp = policy.start_accept_send_request_time_stamp as u64;
         if current_millis() < start_timestamp {
             response = response
                 .set_code(ResponseCode::SystemError)
@@ -420,7 +430,7 @@ where
         }
         response.set_code_mut(-1);
         self.inner
-            .msg_check_at(inbound_peer, request, &request_header, &mut response)
+            .msg_check_at(&policy, inbound_peer, request, &request_header, &mut response)
             .await;
         if response.code() != -1 {
             return self.finish_reply(response, send_message_context);
@@ -440,9 +450,11 @@ where
         if queue_id < 0 {
             queue_id = self.inner.random_queue_id(topic_config.write_queue_nums) as i32;
         }
-        let mut message = self.build_msg_inner(inbound_peer, request, &request_header, queue_id);
-        let completion_facts = ReplyCompletionFacts::capture(request);
-        let store_host = self.inner.context.policy.snapshot().store_host;
+        let mut message = self.build_msg_inner(&policy, inbound_peer, request, &request_header, queue_id);
+        let store_host = policy.store_host;
+        if !self.inner.check_broker_permission(&policy, &mut response) {
+            return self.finish_reply(response, send_message_context);
+        }
         // Outbound reply delivery uses the session-owned request capability;
         // the inbound request never carries that authority.
         let mut push_port = BrokerReplyPushPort {
@@ -454,11 +466,17 @@ where
         let mut response_header = SendMessageResponseHeader::default();
         Self::handle_push_reply_result(&mut push_result, &mut response, &mut response_header, queue_id);
 
-        if !store_reply_message_enable {
-            response = response.set_command_custom_header(response_header);
+        if !policy.store_reply_message_enable {
+            if !response_header.msg_id().is_empty() {
+                response = response.set_command_custom_header(response_header);
+            }
             return self.finish_reply(response, send_message_context);
         }
 
+        if !self.inner.check_broker_permission(&policy, &mut response) {
+            return self.finish_reply(response, send_message_context);
+        }
+        let completion_facts = ReplyCompletionFacts::capture(request, policy);
         let mut store = self.inner.context.store.clone();
         let processor = self;
         let reply = append_reply_message_with_control_reply(control, &mut store, message, move |result| match result {
@@ -472,7 +490,9 @@ where
                     TopicMessageType::Normal,
                     request_header.topic(),
                 );
-                response = response.set_command_custom_header(response_header);
+                if !response_header.msg_id().is_empty() {
+                    response = response.set_command_custom_header(response_header);
+                }
                 processor
                     .inner
                     .execute_send_message_hook_after(Some(&mut response), &mut send_message_context);
@@ -508,6 +528,7 @@ where
     // Build MessageExtBrokerInner to improve readability
     fn build_msg_inner(
         &self,
+        policy: &SendMessagePolicy,
         inbound_peer: SocketAddr,
         request: &RemotingCommand,
         request_header: &SendMessageRequestHeader,
@@ -527,7 +548,7 @@ where
         msg_inner.properties_string = request_header.properties.clone().unwrap_or_default();
         msg_inner.message_ext_inner.born_timestamp = request_header.born_timestamp;
         msg_inner.message_ext_inner.born_host = inbound_peer;
-        msg_inner.message_ext_inner.store_host = self.inner.context.policy.snapshot().store_host;
+        msg_inner.message_ext_inner.store_host = policy.store_host;
         msg_inner.message_ext_inner.reconsume_times = request_header.reconsume_times.unwrap_or(0);
         msg_inner
     }
@@ -546,12 +567,10 @@ where
             put_message_result,
             response_header,
             queue_id_int,
-            self.inner.context.policy.snapshot().max_message_size,
+            completion_facts.policy.max_message_size,
         );
-        let (commercial_size_per_msg, commercial_base_count) = {
-            let policy = self.inner.context.policy.snapshot();
-            (policy.commercial_size_per_msg, policy.commercial_base_count)
-        };
+        let commercial_size_per_msg = completion_facts.policy.commercial_size_per_msg;
+        let commercial_base_count = completion_facts.policy.commercial_base_count;
 
         if put_ok {
             // Cache append_message_result to avoid repeated unwrap

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -128,6 +128,7 @@ pub struct SendMessageProcessor<MS: BrokerWriteStore, TS> {
 }
 
 struct SendCompletionFacts {
+    policy: Arc<SendMessagePolicy>,
     opaque: i32,
     body_len: i32,
     owner: Option<CheetahString>,
@@ -137,10 +138,11 @@ struct SendCompletionFacts {
 }
 
 impl SendCompletionFacts {
-    fn capture(request: &RemotingCommand) -> Self {
+    fn capture(request: &RemotingCommand, policy: Arc<SendMessagePolicy>) -> Self {
         let binding = HashMap::new();
         let ext_fields = request.ext_fields().unwrap_or(&binding);
         Self {
+            policy,
             opaque: request.opaque(),
             body_len: request.body().as_ref().map_or(0, |body| body.len() as i32),
             owner: ext_fields.get(BrokerStatsManager::COMMERCIAL_OWNER).cloned(),
@@ -169,6 +171,21 @@ impl<MS: BrokerWriteStore, TS> Clone for SendMessageProcessor<MS, TS> {
         Self {
             inner: Arc::clone(&self.inner),
             after_hooks: Arc::clone(&self.after_hooks),
+        }
+    }
+}
+
+#[cfg(test)]
+impl<MS: BrokerWriteStore, TS> SendMessageProcessor<MS, TS> {
+    pub(crate) fn with_hook_for_test(&self, hook: Box<dyn SendMessageHook>) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                send_message_hook_vec: Arc::new(vec![hook]),
+                consume_message_hook_vec: Arc::clone(&self.inner.consume_message_hook_vec),
+                transactional_message_service: Arc::clone(&self.inner.transactional_message_service),
+                context: Arc::clone(&self.inner.context),
+            }),
+            after_hooks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -354,6 +371,9 @@ where
         request: &mut RemotingCommand,
         parsed_request: Option<ParsedSendRequest>,
     ) -> crate::broker_error::BrokerResult<HandlerOutcome> {
+        // One immutable generation follows the request through completion. Permission
+        // remains live so a configuration snapshot cannot preserve revoked access.
+        let policy = self.inner.context.policy.snapshot();
         let ParsedSendRequest {
             header: mut request_header,
             properties: parsed_properties,
@@ -380,12 +400,13 @@ where
 
         let (send_message_context, mut request_properties) =
             self.inner
-                .build_msg_context_at(inbound_peer, &mut request_header, request, parsed_properties);
+                .build_msg_context_at(&policy, inbound_peer, &mut request_header, request, parsed_properties);
         self.inner.execute_send_message_hook_before(&send_message_context);
         clear_reserved_properties(&mut request_header, &mut request_properties);
 
         if request_header.is_batch() {
             self.send_batch_message(
+                policy,
                 inbound_peer,
                 control,
                 request_id,
@@ -399,6 +420,7 @@ where
             .await
         } else {
             self.send_message(
+                policy,
                 inbound_peer,
                 control,
                 request_id,
@@ -491,6 +513,7 @@ where
     )]
     async fn send_message(
         &self,
+        policy: Arc<SendMessagePolicy>,
         inbound_peer: SocketAddr,
         control: rocketmq_transport::api::RequestControlView,
         request_id: RequestId,
@@ -501,7 +524,7 @@ where
         request_properties: HashMap<CheetahString, CheetahString>,
         mut mapping_context: TopicQueueMappingContext,
     ) -> crate::broker_error::BrokerResult<HandlerOutcome> {
-        let mut response = self.pre_send_at(inbound_peer, request, &request_header).await;
+        let mut response = self.pre_send_at(&policy, inbound_peer, request, &request_header).await;
         if response.code() != -1 {
             return BrokerResponseParts::from_command(response)?.into_handler_outcome();
         }
@@ -526,6 +549,7 @@ where
         let mut properties = request_properties;
         if !self
             .handle_retry_and_dlq(
+                &policy,
                 &request_header,
                 &mut response,
                 request,
@@ -567,7 +591,7 @@ where
         );
         message_ext.message_ext_inner.born_timestamp = request_header.born_timestamp;
         message_ext.message_ext_inner.born_host = inbound_peer;
-        message_ext.message_ext_inner.store_host = self.inner.context.policy.snapshot().store_host;
+        message_ext.message_ext_inner.store_host = policy.store_host;
         message_ext.message_ext_inner.reconsume_times = request_header.reconsume_times.unwrap_or(0);
         message_ext
             .message_ext_inner
@@ -576,7 +600,7 @@ where
             .as_map_mut()
             .insert(
                 CheetahString::from_static_str(MessageConst::PROPERTY_CLUSTER),
-                self.inner.context.policy.snapshot().broker_cluster_name.clone(),
+                policy.broker_cluster_name.clone(),
             );
         message_ext.properties_string =
             MessageDecoder::message_properties_to_string(message_ext.message_ext_inner.message.properties().as_map());
@@ -584,7 +608,6 @@ where
         let transactional = if tra_flag
             && !(message_ext.reconsume_times() > 0 && message_ext.message_ext_inner.message.delay_time_level() > 0)
         {
-            let policy = self.inner.context.policy.snapshot();
             if policy.reject_transaction_message {
                 return BrokerResponseParts::from_command(response.set_code(ResponseCode::NoPermission).set_remark(
                     format!(
@@ -603,8 +626,11 @@ where
         let topic = message_ext.topic().clone();
         let topic_message_type = crate::metrics::broker_metrics_manager::get_message_type(&request_header);
         let transaction_id = MessageClientIDSetter::get_uniq_id(&message_ext.message_ext_inner.message);
-        let recall_handle = self.build_recall_handle(&message_ext);
-        let completion_facts = SendCompletionFacts::capture(request);
+        let recall_handle = self.build_recall_handle(&policy, &message_ext);
+        if !self.inner.check_broker_permission(&policy, &mut response) {
+            return BrokerResponseParts::from_command(response)?.into_handler_outcome();
+        }
+        let completion_facts = SendCompletionFacts::capture(request, policy);
         if transactional {
             let mut store = TransactionalMessageAppender::new(self.inner.transactional_message_service.as_ref());
             let result = match await_store(StoreAwaitControl::Request(control), store.append_message(message_ext))
@@ -694,6 +720,7 @@ where
     )]
     async fn send_batch_message(
         &self,
+        policy: Arc<SendMessagePolicy>,
         inbound_peer: SocketAddr,
         control: rocketmq_transport::api::RequestControlView,
         request_id: RequestId,
@@ -704,7 +731,7 @@ where
         request_properties: HashMap<CheetahString, CheetahString>,
         mut mapping_context: TopicQueueMappingContext,
     ) -> crate::broker_error::BrokerResult<HandlerOutcome> {
-        let mut response = self.pre_send_at(inbound_peer, request, &request_header).await;
+        let mut response = self.pre_send_at(&policy, inbound_peer, request, &request_header).await;
         if response.code() != -1 {
             return BrokerResponseParts::from_command(response)?.into_handler_outcome();
         }
@@ -747,11 +774,11 @@ where
         message_ext.message_ext_inner.message.set_body(request.body().cloned());
         message_ext.message_ext_inner.born_timestamp = request_header.born_timestamp;
         message_ext.message_ext_inner.born_host = inbound_peer;
-        message_ext.message_ext_inner.store_host = self.inner.context.policy.snapshot().store_host;
+        message_ext.message_ext_inner.store_host = policy.store_host;
         message_ext.message_ext_inner.reconsume_times = request_header.reconsume_times.unwrap_or(0);
         message_ext.message_ext_inner.message.put_property(
             CheetahString::from_static_str(MessageConst::PROPERTY_CLUSTER),
-            self.inner.context.policy.snapshot().broker_cluster_name.clone(),
+            policy.broker_cluster_name.clone(),
         );
 
         let mut batch_message = MessageExtBatch {
@@ -800,7 +827,10 @@ where
             MessageClientIDSetter::get_uniq_id(&batch_message.message_ext_broker_inner.message_ext_inner.message);
         let topic = batch_message.message_ext_broker_inner.message_ext_inner.topic().clone();
         let topic_message_type = crate::metrics::broker_metrics_manager::get_message_type(&request_header);
-        let completion_facts = SendCompletionFacts::capture(request);
+        if !self.inner.check_broker_permission(&policy, &mut response) {
+            return BrokerResponseParts::from_command(response)?.into_handler_outcome();
+        }
+        let completion_facts = SendCompletionFacts::capture(request, policy);
         let processor = self;
         let reply = if is_inner_batch {
             let mut store = self.inner.context.store.clone();
@@ -1067,6 +1097,7 @@ where
     /// Update send message context for hooks
     fn update_send_context_on_success(
         &self,
+        policy: &SendMessagePolicy,
         send_message_context: &mut SendMessageContext,
         response_header: &SendMessageResponseHeader,
         append_receipt: &StoreAppendReceipt,
@@ -1075,7 +1106,6 @@ where
         owner_parent: Option<CheetahString>,
         owner_self: Option<CheetahString>,
     ) {
-        let policy = self.inner.context.policy.snapshot();
         let commercial_size_per_msg = policy.commercial_size_per_msg;
         let commercial_base_count = policy.commercial_base_count;
 
@@ -1107,6 +1137,7 @@ where
     /// Update send message context for failure case
     fn update_send_context_on_failure(
         &self,
+        policy: &SendMessagePolicy,
         send_message_context: &mut SendMessageContext,
         append_receipt: &StoreAppendReceipt,
         request_body_len: i32,
@@ -1115,7 +1146,7 @@ where
         owner_parent: Option<CheetahString>,
         owner_self: Option<CheetahString>,
     ) {
-        let commercial_size_per_msg = self.inner.context.policy.snapshot().commercial_size_per_msg;
+        let commercial_size_per_msg = policy.commercial_size_per_msg;
 
         let msg_num = append_receipt
             .result()
@@ -1158,10 +1189,18 @@ where
         _message_type: MessageType,
     ) -> (Option<RemotingCommand>, bool) {
         let send_ok = map_put_status_to_response(append_receipt.result().put_message_status(), response);
+        if response.code() != ResponseCode::Success as i32 {
+            warn!(
+                response_code = response.code(),
+                append_evidence = ?append_receipt.execution_evidence(),
+                "Store append completed without a successful send response"
+            );
+        }
 
         let has_send_message_hook = self.has_send_message_hook();
 
         if send_ok {
+            response.set_command_custom_header_ref(SendMessageResponseHeader::default());
             self.update_broker_stats_on_success(
                 topic,
                 queue_id_int,
@@ -1194,6 +1233,7 @@ where
 
                 if has_send_message_hook {
                     self.update_send_context_on_success(
+                        &completion_facts.policy,
                         send_message_context,
                         response_header,
                         &append_receipt,
@@ -1210,6 +1250,7 @@ where
         } else {
             if has_send_message_hook {
                 self.update_send_context_on_failure(
+                    &completion_facts.policy,
                     send_message_context,
                     &append_receipt,
                     completion_facts.body_len,
@@ -1223,8 +1264,11 @@ where
         }
     }
 
-    fn build_recall_handle(&self, message: &MessageExtBrokerInner) -> Option<CheetahString> {
-        let policy = self.inner.context.policy.snapshot();
+    fn build_recall_handle(
+        &self,
+        policy: &SendMessagePolicy,
+        message: &MessageExtBrokerInner,
+    ) -> Option<CheetahString> {
         let max_delay_sec = if policy.timer_store_mode == rocketmq_store_api::TimerStoreMode::ExtendedTimeline {
             u64::from(policy.timer_maximum_horizon_days).saturating_mul(86_400)
         } else {
@@ -1249,16 +1293,12 @@ where
 
     async fn pre_send_at(
         &self,
+        policy: &Arc<SendMessagePolicy>,
         inbound_peer: SocketAddr,
         request: &RemotingCommand,
         request_header: &SendMessageRequestHeader,
     ) -> RemotingCommand {
-        let mut response = self
-            .inner
-            .context
-            .command_factory
-            .create_success_response_command_with_header(SendMessageResponseHeader::default());
-        let policy = self.inner.context.policy.snapshot();
+        let mut response = self.inner.context.command_factory.create_success_response_command();
         // set opaque
         response.with_opaque(request.opaque());
         add_send_response_metadata(&mut response, policy.region_id.clone(), policy.trace_on);
@@ -1275,13 +1315,14 @@ where
         }
         response = response.set_code(-1);
         self.inner
-            .msg_check_at(inbound_peer, request, request_header, &mut response)
+            .msg_check_at(policy, inbound_peer, request, request_header, &mut response)
             .await;
         response
     }
 
     async fn handle_retry_and_dlq(
         &self,
+        policy: &Arc<SendMessagePolicy>,
         request_header: &SendMessageRequestHeader,
         response: &mut RemotingCommand,
         request: &RemotingCommand,
@@ -1344,6 +1385,7 @@ where
                     .context
                     .topics
                     .create_topic_in_send_message_back(
+                        Arc::clone(policy),
                         new_topic,
                         retry_config::DLQ_NUMS_PER_GROUP as i32,
                         PermName::PERM_WRITE | PermName::PERM_READ,
@@ -1769,6 +1811,7 @@ where
             .context
             .topics
             .create_topic_in_send_message_back(
+                Arc::clone(&policy),
                 &new_topic,
                 subscription_group_config.retry_queue_nums(),
                 PermName::PERM_WRITE | PermName::PERM_READ,
@@ -1845,6 +1888,7 @@ where
                 .context
                 .topics
                 .create_topic_in_send_message_back(
+                    Arc::clone(&policy),
                     &new_topic,
                     retry_config::DLQ_NUMS_PER_GROUP as i32,
                     PermName::PERM_WRITE | PermName::PERM_READ,
@@ -1895,6 +1939,10 @@ where
         msg_inner.properties_string = message_properties_to_string(msg_ext.get_properties());
 
         let inner_topic = msg_inner.get_topic().clone();
+        let mut response = self.context.command_factory.create_success_response_command();
+        if !self.check_broker_permission(&policy, &mut response) {
+            return Ok(Some(response));
+        }
         let put_message_result = await_store(StoreAwaitControl::Legacy, self.context.store.put_message(msg_inner))
             .await
             .map_err(map_legacy_store_wait_stopped)?
@@ -1983,13 +2031,13 @@ where
 
     pub(crate) fn build_msg_context_at(
         &self,
+        policy: &SendMessagePolicy,
         inbound_peer: SocketAddr,
         request_header: &mut SendMessageRequestHeader,
         request: &RemotingCommand,
         properties: HashMap<CheetahString, CheetahString>,
     ) -> (SendMessageContext, HashMap<CheetahString, CheetahString>) {
         let namespace = NamespaceUtil::get_namespace_from_resource(request_header.topic.as_str());
-        let policy = self.context.policy.snapshot();
         let region_id = policy.region_id.to_string();
 
         let mut send_message_context = SendMessageContext {
@@ -2035,6 +2083,7 @@ where
 
     pub(crate) async fn msg_check_at(
         &self,
+        policy: &Arc<SendMessagePolicy>,
         inbound_peer: SocketAddr,
         request: &RemotingCommand,
         request_header: &SendMessageRequestHeader,
@@ -2042,14 +2091,7 @@ where
     ) where
         MS: BrokerMasterAddressStore,
     {
-        //check broker permission
-        let policy = self.context.policy.snapshot();
-        if broker_send_permission_denied(policy.broker_permission.get()) {
-            response.with_code(ResponseCode::NoPermission);
-            response.with_remark(format!(
-                "the broker[{}] sending message is forbidden",
-                policy.broker_ip.clone()
-            ));
+        if !self.check_broker_permission(policy, response) {
             return;
         }
 
@@ -2094,6 +2136,7 @@ where
                 .context
                 .topics
                 .create_topic_in_send_message(
+                    Arc::clone(policy),
                     &request_header.topic,
                     &request_header.default_topic,
                     inbound_peer,
@@ -2107,6 +2150,7 @@ where
                     .context
                     .topics
                     .create_topic_in_send_message_back(
+                        Arc::clone(policy),
                         request_header.topic.as_ref(),
                         1,
                         PermName::PERM_WRITE | PermName::PERM_READ,
@@ -2139,6 +2183,16 @@ where
                 queue_id_int, topic_config_inner, inbound_peer
             ));
         }
+    }
+
+    // Check at admission and again after asynchronous preparation, just before append.
+    pub(crate) fn check_broker_permission(&self, policy: &SendMessagePolicy, response: &mut RemotingCommand) -> bool {
+        if broker_send_permission_denied(policy.broker_permission.get()) {
+            response.with_code(ResponseCode::NoPermission);
+            response.with_remark(format!("the broker[{}] sending message is forbidden", policy.broker_ip));
+            return false;
+        }
+        true
     }
 
     #[inline]

--- a/rocketmq-broker/src/processor/send_message_processor/capability.rs
+++ b/rocketmq-broker/src/processor/send_message_processor/capability.rs
@@ -392,7 +392,6 @@ impl MessageAppender<MessageExtBatch> for SendMessageStoreCapability {
 
 /// Topic lookup, creation, persistence, and registration boundary for send paths.
 pub(crate) struct SendMessageTopicCapability<MS: BrokerWriteStore> {
-    policy: SendMessagePolicyState,
     topic_config_manager: Arc<TopicConfigManager>,
     topic_config_coordinator: Arc<TopicConfigCoordinator>,
     topic_queue_mapping_manager: Arc<TopicQueueMappingManager>,
@@ -407,7 +406,6 @@ pub(crate) struct SendMessageTopicCapability<MS: BrokerWriteStore> {
 impl<MS: BrokerWriteStore> Clone for SendMessageTopicCapability<MS> {
     fn clone(&self) -> Self {
         Self {
-            policy: self.policy.clone(),
             topic_config_manager: Arc::clone(&self.topic_config_manager),
             topic_config_coordinator: Arc::clone(&self.topic_config_coordinator),
             topic_queue_mapping_manager: Arc::clone(&self.topic_queue_mapping_manager),
@@ -430,7 +428,6 @@ where
         reason = "constructor enumerates the complete topic creation and registration boundary"
     )]
     pub(crate) fn new(
-        policy: SendMessagePolicyState,
         topic_config_manager: Arc<TopicConfigManager>,
         topic_config_coordinator: Arc<TopicConfigCoordinator>,
         topic_queue_mapping_manager: Arc<TopicQueueMappingManager>,
@@ -442,7 +439,6 @@ where
         shutdown: Arc<AtomicBool>,
     ) -> Self {
         Self {
-            policy,
             topic_config_manager,
             topic_config_coordinator,
             topic_queue_mapping_manager,
@@ -474,6 +470,7 @@ where
 
     pub(crate) async fn create_topic_in_send_message(
         &self,
+        policy: Arc<SendMessagePolicy>,
         topic: &CheetahString,
         default_topic: &CheetahString,
         remote_address: SocketAddr,
@@ -484,14 +481,6 @@ where
         MS: BrokerMasterAddressStore,
     {
         let start_time = Instant::now();
-        let policy = self.policy.snapshot();
-        let runtime_config = policy.broker_permission.runtime_snapshot();
-        let auto_create_topic_enable = runtime_config
-            .map(|snapshot| snapshot.auto_create_topic_enable)
-            .unwrap_or(policy.auto_create_topic_enable);
-        let default_topic_queue_nums = runtime_config
-            .map(|snapshot| snapshot.default_topic_queue_nums)
-            .unwrap_or(policy.default_topic_queue_nums);
         let state_machine_version = self.message_store.state_machine_version()?;
         let creation = self.topic_config_manager.create_topic_in_send_message_method(
             topic,
@@ -500,14 +489,15 @@ where
             queue_nums,
             topic_sys_flag,
             state_machine_version,
-            auto_create_topic_enable,
-            default_topic_queue_nums,
+            policy.auto_create_topic_enable,
+            policy.default_topic_queue_nums,
         )?;
         Some(self.complete_creation(creation, start_time, policy).await)
     }
 
     pub(crate) async fn create_topic_in_send_message_back(
         &self,
+        policy: Arc<SendMessagePolicy>,
         topic: &CheetahString,
         queue_nums: i32,
         perm: u32,
@@ -518,7 +508,6 @@ where
         MS: BrokerMasterAddressStore,
     {
         let start_time = Instant::now();
-        let policy = self.policy.snapshot();
         let state_machine_version = self.message_store.state_machine_version()?;
         let creation = self.topic_config_manager.create_topic_in_send_message_back_method(
             topic,
@@ -548,21 +537,21 @@ where
             policy.async_topic_create_persist_enable,
             move |update| {
                 let registration = registration.clone();
-                async move { registration.register_update(update).await }
+                let policy = Arc::clone(&policy);
+                async move { registration.register_update(update, &policy).await }
             },
         )
         .await
     }
 
-    async fn register_update(&self, update: TopicConfigUpdate)
+    async fn register_update(&self, update: TopicConfigUpdate, policy: &SendMessagePolicy)
     where
         MS: BrokerMasterAddressStore,
     {
-        let policy = self.policy.snapshot();
         if policy.enable_single_topic_register {
-            self.register_single_topic(update.topic_config, &policy).await;
+            self.register_single_topic(update.topic_config, policy).await;
         } else {
-            self.register_incremental_topic(update, &policy).await;
+            self.register_incremental_topic(update, policy).await;
         }
     }
 

--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -58,6 +58,7 @@ use rocketmq_runtime::OperationContext;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
+use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
 use rocketmq_store::get_delay_offset_store_path;
@@ -70,6 +71,7 @@ use rocketmq_store::PutMessageResult;
 use rocketmq_store::PutMessageStatus;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
+use tokio::sync::OwnedMutexGuard;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 use tracing::info;
@@ -102,6 +104,25 @@ struct ScheduleLifecycle {
     next_generation: u64,
     run: Option<ScheduleRun>,
     finalized: bool,
+    stopping: bool,
+    finalize_requested: bool,
+    final_persist: Option<SchedulePersistFuture>,
+}
+
+type SchedulePersistFuture = Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScheduleStopStage {
+    Lifecycle,
+    PersistenceGate,
+    Drain,
+    FinalPersist,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScheduleStopOutcome {
+    Completed,
+    TimedOut { generation: u64, stage: ScheduleStopStage },
 }
 
 struct ScheduleRun {
@@ -312,7 +333,9 @@ pub struct ScheduleMessageService<MS: BrokerWriteStore> {
     escape_bridge: Weak<EscapeBridge<MS>>,
     runtime_capabilities: ScheduleRuntimeCapabilities,
     lifecycle: Mutex<ScheduleLifecycle>,
-    persistence_gate: Mutex<()>,
+    persistence_gate: Arc<Mutex<()>>,
+    #[cfg(test)]
+    before_persist_write: ParkingMutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
 fn schedule_message_service_shutdown_failed(_error: impl Display) -> SharedError {
@@ -378,8 +401,13 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
                 next_generation: 1,
                 run: None,
                 finalized: false,
+                stopping: false,
+                finalize_requested: false,
+                final_persist: None,
             }),
-            persistence_gate: Mutex::new(()),
+            persistence_gate: Arc::new(Mutex::new(())),
+            #[cfg(test)]
+            before_persist_write: ParkingMutex::new(None),
         }
     }
 
@@ -487,6 +515,11 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
         let mut lifecycle = this.lifecycle.lock().await;
         if lifecycle.finalized {
             return Err(schedule_message_service_startup_failed("service is already finalized"));
+        }
+        if lifecycle.stopping {
+            return Err(schedule_message_service_startup_failed(
+                "previous generation is still stopping",
+            ));
         }
         if lifecycle.run.is_some() {
             return Ok(());
@@ -627,56 +660,125 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
     ///
     /// Signals all tasks to stop, waits for them to complete, and persists final state.
     pub async fn shutdown(&self) -> Result<()> {
-        self.stop_inner(true).await.map(|_| ())
+        self.shutdown_until(ShutdownDeadline::after(Duration::from_millis(WAIT_FOR_SHUTDOWN)))
+            .await
+    }
+
+    pub(crate) async fn shutdown_until(&self, deadline: ShutdownDeadline) -> Result<()> {
+        let timeout_ms = u64::try_from(deadline.remaining().as_millis()).unwrap_or(u64::MAX);
+        match self.stop_until(true, deadline).await? {
+            ScheduleStopOutcome::Completed => Ok(()),
+            ScheduleStopOutcome::TimedOut { generation, stage } => {
+                warn!(
+                    generation,
+                    ?stage,
+                    "ScheduleMessageService shutdown timed out; owner retained"
+                );
+                Err(crate::broker_error::timeout(
+                    "schedule_message_service_shutdown",
+                    timeout_ms,
+                ))
+            }
+        }
     }
 
     pub async fn stop(&self) -> Result<bool> {
-        self.stop_inner(false).await
+        self.stop_inner(false)
+            .await
+            .map(|outcome| outcome == ScheduleStopOutcome::Completed)
     }
 
-    async fn stop_inner(&self, finalize: bool) -> Result<bool> {
-        let mut lifecycle = self.lifecycle.lock().await;
+    pub(crate) async fn stop_checked(&self) -> Result<()> {
+        if self.stop().await? {
+            Ok(())
+        } else {
+            Err(crate::broker_error::timeout(
+                "schedule_message_service_stop",
+                WAIT_FOR_SHUTDOWN,
+            ))
+        }
+    }
+
+    async fn stop_inner(&self, finalize: bool) -> Result<ScheduleStopOutcome> {
+        self.stop_until(
+            finalize,
+            ShutdownDeadline::after(Duration::from_millis(WAIT_FOR_SHUTDOWN)),
+        )
+        .await
+    }
+
+    async fn stop_until(&self, finalize: bool, deadline: ShutdownDeadline) -> Result<ScheduleStopOutcome> {
+        let at = tokio::time::Instant::from_std(deadline.instant());
+        let Ok(mut lifecycle) = tokio::time::timeout_at(at, self.lifecycle.lock()).await else {
+            return Ok(ScheduleStopOutcome::TimedOut {
+                generation: self.active_generation.load(Ordering::Acquire),
+                stage: ScheduleStopStage::Lifecycle,
+            });
+        };
         if lifecycle.finalized {
-            return Ok(true);
+            return Ok(ScheduleStopOutcome::Completed);
         }
 
-        let run = lifecycle.run.take();
+        lifecycle.stopping = true;
+        lifecycle.finalize_requested |= finalize;
+        let generation = lifecycle.run.as_ref().map_or(0, |run| run.generation);
+        let timed_out = |stage| ScheduleStopOutcome::TimedOut { generation, stage };
         self.started.store(false, Ordering::Release);
         self.active_generation.store(0, Ordering::Release);
 
-        if let Some(run) = run {
-            info!(
-                generation = run.generation,
-                finalize, "Stopping ScheduleMessageService generation"
-            );
-            run.operation.cancel();
-
-            // Wait for any already-submitted blocking write. Periodic writers waiting for this
-            // gate observe cancellation and leave without writing.
-            drop(self.persistence_gate.lock().await);
-            let joined = run
-                .operation
-                .cancel_and_wait(&run.task_group, Duration::from_millis(WAIT_FOR_SHUTDOWN))
-                .await
-                .map_err(schedule_message_service_shutdown_failed)?;
-            if !joined {
-                warn!(
-                    generation = run.generation,
-                    "ScheduleMessageService generation exceeded its shutdown deadline"
-                );
+        if lifecycle.final_persist.is_none() {
+            if let Some(run) = lifecycle.run.as_ref() {
+                run.operation.cancel();
             }
-            run.scheduled_tasks
-                .clear_completed()
-                .map_err(schedule_message_service_shutdown_failed)?;
+            // A submitted blocking writer owns this gate until the actual I/O
+            // exits, even if its asynchronous waiter has already timed out.
+            let Ok(guard) = tokio::time::timeout_at(at, Arc::clone(&self.persistence_gate).lock_owned()).await else {
+                return Ok(timed_out(ScheduleStopStage::PersistenceGate));
+            };
+            drop(guard);
+            if let Some(run) = lifecycle.run.as_ref() {
+                let joined = run
+                    .operation
+                    .cancel_and_wait(&run.task_group, deadline.remaining())
+                    .await
+                    .map_err(schedule_message_service_shutdown_failed)?;
+                if !joined {
+                    return Ok(timed_out(ScheduleStopStage::Drain));
+                }
+                run.scheduled_tasks
+                    .clear_completed()
+                    .map_err(schedule_message_service_shutdown_failed)?;
+            }
+            if deadline.is_expired() {
+                return Ok(timed_out(ScheduleStopStage::FinalPersist));
+            }
+            let Ok(guard) = tokio::time::timeout_at(at, Arc::clone(&self.persistence_gate).lock_owned()).await else {
+                return Ok(timed_out(ScheduleStopStage::FinalPersist));
+            };
+            lifecycle.final_persist = Some(self.persistence_future(guard));
         }
 
-        self.persist_current().await?;
-        lifecycle.finalized = finalize;
+        // Keep the future inside the stopping owner. Dropping this caller or
+        // exceeding the deadline cannot lose the in-flight final write.
+        let persist = lifecycle.final_persist.as_mut().ok_or_else(|| {
+            crate::broker_error::invariant_violated("stopping schedule generation has no final persistence")
+        })?;
+        let result = tokio::time::timeout_at(at, persist).await;
+        let Ok(result) = result else {
+            return Ok(timed_out(ScheduleStopStage::FinalPersist));
+        };
+        lifecycle.final_persist = None;
+        result?;
+        lifecycle.run = None;
+        lifecycle.stopping = false;
+        lifecycle.finalized = lifecycle.finalize_requested;
+        lifecycle.finalize_requested = false;
         info!(
-            finalize,
+            generation,
+            finalized = lifecycle.finalized,
             "ScheduleMessageService stopped after final offset persistence"
         );
-        Ok(true)
+        Ok(ScheduleStopOutcome::Completed)
     }
 
     pub fn is_started(&self) -> bool {
@@ -718,34 +820,37 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
     }
 
     async fn persist_generation(&self, run_context: &ScheduleRunContext) -> Result<()> {
-        let _guard = tokio::select! {
+        let guard = tokio::select! {
             _ = run_context.cancellation.cancelled() => return Ok(()),
-            guard = self.persistence_gate.lock() => guard,
+            guard = Arc::clone(&self.persistence_gate).lock_owned() => guard,
         };
         if !self.is_generation_active(run_context.generation) || run_context.cancellation.is_cancelled() {
             return Ok(());
         }
-        self.persist_current_locked().await
+        self.persistence_future(guard).await
     }
 
-    async fn persist_current(&self) -> Result<()> {
-        let _guard = self.persistence_gate.lock().await;
-        self.persist_current_locked().await
-    }
-
-    async fn persist_current_locked(&self) -> Result<()> {
-        let runtime_capabilities = self.runtime_capabilities();
+    fn persistence_future(&self, guard: OwnedMutexGuard<()>) -> SchedulePersistFuture {
+        let blocking = self.runtime_capabilities().blocking.clone();
         let json = self.encode_pretty(true);
         let file_name = self.config_file_path();
-        runtime_capabilities
-            .blocking
-            .spawn_io("broker.schedule.persist-delay-offset", move || {
-                file_utils::string_to_file(json.as_str(), file_name.as_str())
-            })
-            .await
-            .map_err(schedule_message_service_shutdown_failed)?
-            .map_err(schedule_message_service_shutdown_failed)?;
-        Ok(())
+        #[cfg(test)]
+        let before_write = self.before_persist_write.lock().take();
+        Box::pin(async move {
+            blocking
+                .spawn_io("broker.schedule.persist-delay-offset", move || {
+                    let _guard = guard;
+                    #[cfg(test)]
+                    if let Some(before_write) = before_write {
+                        before_write();
+                    }
+                    file_utils::string_to_file(json.as_str(), file_name.as_str())
+                })
+                .await
+                .map_err(schedule_message_service_shutdown_failed)?
+                .map_err(schedule_message_service_shutdown_failed)?;
+            Ok(())
+        })
     }
 
     pub fn get_max_delay_level(&self) -> i32 {
@@ -968,18 +1073,19 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
         snapshot: &DelayOffsetSerializeWrapper,
     ) -> Result<bool> {
         let lifecycle = self.lifecycle.lock().await;
-        if lifecycle.run.is_some() {
+        if lifecycle.run.is_some() || lifecycle.stopping {
             return Err(schedule_message_service_shutdown_failed(
                 "peer delay-offset synchronization requires a stopped delivery generation",
             ));
         }
         let runtime_capabilities = self.runtime_capabilities();
-        let _persist_guard = self.persistence_gate.lock().await;
+        let persist_guard = Arc::clone(&self.persistence_gate).lock_owned().await;
         let file_name = self.config_file_path();
         let encoded_snapshot = encoded_snapshot.to_owned();
         runtime_capabilities
             .blocking
             .spawn_io("broker.schedule.persist-peer-delay-offset", move || {
+                let _persist_guard = persist_guard;
                 file_utils::string_to_file(encoded_snapshot.as_str(), file_name.as_str())
             })
             .await
@@ -2197,6 +2303,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn schedule_stop_retains_blocked_writers_and_final_persistence_after_caller_cancel() {
+        for final_write in [false, true] {
+            let temp_dir = TempDir::new().unwrap();
+            let root = temp_dir.path().to_string_lossy().into_owned();
+            let mut runtime = BrokerRuntime::new(
+                Arc::new(BrokerConfig {
+                    store_path_root_dir: root.clone().into(),
+                    ..BrokerConfig::default()
+                }),
+                Arc::new(MessageStoreConfig {
+                    store_path_root_dir: root.into(),
+                    ..MessageStoreConfig::default()
+                }),
+            );
+            let service = runtime
+                .runtime_state_mut()
+                .schedule_message_service_for_test()
+                .unwrap()
+                .clone();
+            service.offset_state.update_offset(1, 7, 1, 0);
+            let release = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
+            let writer_release = Arc::clone(&release);
+            let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+            *service.before_persist_write.lock() = Some(Box::new(move || {
+                let _ = entered_tx.send(());
+                let (lock, ready) = &*writer_release;
+                let guard = lock.lock().unwrap();
+                drop(ready.wait_while(guard, |released| !*released).unwrap());
+            }));
+            ScheduleMessageService::start_persist_task_for_probe(
+                service.clone(),
+                if final_write {
+                    Duration::from_secs(60)
+                } else {
+                    Duration::ZERO
+                },
+            )
+            .await
+            .unwrap();
+            let generation = service.active_generation.load(Ordering::Acquire);
+            let stopping_caller = final_write.then(|| {
+                let service = service.clone();
+                tokio::spawn(async move {
+                    service
+                        .stop_until(false, ShutdownDeadline::after(Duration::from_secs(30)))
+                        .await
+                })
+            });
+            let entered = tokio::time::timeout(Duration::from_secs(5), entered_rx).await;
+            if let Some(caller) = stopping_caller {
+                caller.abort();
+                let _ = caller.await;
+            }
+            let outcome = service.stop_until(false, ShutdownDeadline::after(Duration::ZERO)).await;
+            let retained = {
+                let lifecycle = service.lifecycle.lock().await;
+                lifecycle.stopping && lifecycle.run.as_ref().is_some_and(|run| run.generation == generation)
+            };
+            let restarted =
+                ScheduleMessageService::start_persist_task_for_probe(service.clone(), Duration::from_secs(60)).await;
+            // Always release the blocking writer and await its owner before assertions.
+            let (lock, ready) = &*release;
+            *lock.lock().unwrap() = true;
+            ready.notify_all();
+            let completed = service
+                .stop_until(false, ShutdownDeadline::after(Duration::from_secs(5)))
+                .await;
+            assert!(entered.is_ok_and(|result| result.is_ok()));
+            assert_eq!(
+                outcome.unwrap(),
+                ScheduleStopOutcome::TimedOut {
+                    generation,
+                    stage: if final_write {
+                        ScheduleStopStage::FinalPersist
+                    } else {
+                        ScheduleStopStage::PersistenceGate
+                    },
+                }
+            );
+            assert!(retained);
+            assert!(restarted.is_err());
+            assert_eq!(completed.unwrap(), ScheduleStopOutcome::Completed);
+            assert_eq!(service.task_count(), 0);
+
+            ScheduleMessageService::start_persist_task_for_probe(service.clone(), Duration::from_secs(60))
+                .await
+                .unwrap();
+            assert!(service.active_generation.load(Ordering::Acquire) > generation);
+            service.offset_state.update_offset(1, 11, 1, 0);
+            service.shutdown().await.unwrap();
+            let encoded = std::fs::read_to_string(service.config_file_path()).unwrap();
+            let persisted: DelayOffsetSerializeWrapper = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(persisted.offset_table().unwrap().get(&1), Some(&11));
+        }
+    }
+
+    #[tokio::test]
     async fn broker_runtime_injects_schedule_context_before_first_start() {
         let temp_dir = TempDir::new().expect("schedule context temp dir should be created");
         let root = temp_dir.path().to_string_lossy().into_owned();
@@ -2393,7 +2596,7 @@ mod tests {
     fn schedule_message_service_uses_typed_errors() {
         let source = include_str!("schedule_message_service.rs");
 
-        assert!(source.contains("async fn persist_current(&self) -> Result<()>"));
+        assert!(source.contains("Future<Output = Result<()>>"));
         assert!(source.contains("Result<PutResultProcess<MS>>"));
         assert!(!source.contains(concat!("ArcMut<", "ScheduleMessageService")));
         assert!(!source.contains(concat!("mut_from_ref()", ".escape_bridge_mut()")));

--- a/rocketmq-broker/src/store_read.rs
+++ b/rocketmq-broker/src/store_read.rs
@@ -20,16 +20,35 @@ use rocketmq_store_api::GetStatus;
 use rocketmq_store_api::ReadOutcome;
 use tracing::error;
 
+use crate::broker_error::BrokerResult;
+
+enum DecodeFailurePolicy {
+    SkipRecord,
+    FailRead,
+}
+
 /// Decodes a backend store result into the owned store-api read boundary.
 ///
 /// The backend lease remains local to this capability and is released after every selected
 /// record has been decoded. Consumers only receive owned model messages and canonical store
 /// navigation metadata.
 pub(crate) fn decode_read_outcome(result: GetMessageResult, decompress_body: bool) -> Option<ReadOutcome<MessageExt>> {
+    decode_store_records(result, decompress_body, DecodeFailurePolicy::SkipRecord).ok()
+}
+
+pub(crate) fn decode_transaction_read_outcome(result: GetMessageResult) -> BrokerResult<ReadOutcome<MessageExt>> {
+    decode_store_records(result, false, DecodeFailurePolicy::FailRead)
+}
+
+fn decode_store_records(
+    result: GetMessageResult,
+    decompress_body: bool,
+    failure_policy: DecodeFailurePolicy,
+) -> BrokerResult<ReadOutcome<MessageExt>> {
     let canonical = get_result(result);
     let Some(status) = canonical.status else {
         error!("store read result did not include a status");
-        return None;
+        return Err(crate::broker_error::storage_read_failed());
     };
     let records = if status == GetStatus::Found {
         let mut decoded = Vec::with_capacity(canonical.records.len());
@@ -44,6 +63,9 @@ pub(crate) fn decode_read_outcome(result: GetMessageResult, decompress_body: boo
                     size = selected.size(),
                     "failed to decode selected store record"
                 );
+                if matches!(failure_policy, DecodeFailurePolicy::FailRead) {
+                    return Err(crate::broker_error::storage_read_failed());
+                }
             }
         }
         Some(decoded)
@@ -51,11 +73,50 @@ pub(crate) fn decode_read_outcome(result: GetMessageResult, decompress_body: boo
         None
     };
 
-    Some(ReadOutcome::new(
+    Ok(ReadOutcome::new(
         status,
         canonical.next_begin_offset,
         canonical.min_offset,
         canonical.max_offset,
         records,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use rocketmq_store::GetMessageStatus;
+    use rocketmq_store::SelectMappedBufferResult;
+
+    use super::*;
+
+    #[test]
+    fn transaction_decode_preserves_empty_navigation_but_rejects_missing_status() {
+        let error = decode_transaction_read_outcome(GetMessageResult::new()).unwrap_err();
+        assert_eq!(error.descriptor(), &rocketmq_error::STORAGE_READ_FAILED);
+
+        let mut empty = GetMessageResult::new();
+        empty.set_status(Some(GetMessageStatus::NoMessageInQueue));
+        empty.set_next_begin_offset(7);
+        empty.set_min_offset(7);
+        empty.set_max_offset(7);
+        let decoded = decode_transaction_read_outcome(empty).unwrap();
+        assert_eq!(decoded.status(), GetStatus::NoMessageInQueue);
+        assert_eq!(decoded.next_begin_offset(), 7);
+        assert!(decoded.records().is_none());
+    }
+
+    #[test]
+    fn transaction_decode_does_not_advance_past_a_corrupt_selected_record() {
+        let mut result = GetMessageResult::new();
+        result.set_status(Some(GetMessageStatus::Found));
+        result.set_next_begin_offset(8);
+        result.add_message(
+            SelectMappedBufferResult::from_bytes(0, Bytes::from_static(b"truncated")).unwrap(),
+            7,
+            1,
+        );
+        let error = decode_transaction_read_outcome(result).unwrap_err();
+        assert_eq!(error.descriptor(), &rocketmq_error::STORAGE_READ_FAILED);
+    }
 }

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use crate::broker_error::BrokerResult as Result;
 use crate::config::broker_config::BrokerConfig;
 use cheetah_string::CheetahString;
+use futures::StreamExt;
 use rocketmq_model::common::broker::broker_role::BrokerRole;
 use rocketmq_model::common::config::TopicConfig;
 use rocketmq_model::common::message::message_accessor::MessageAccessor;
@@ -76,6 +77,7 @@ const MAX_RETRY_TIMES_FOR_ESCAPE: i32 = 10;
 const MAX_RETRY_COUNT_WHEN_HALF_NULL: i32 = 1;
 const OP_MSG_PULL_NUMS: i32 = 32;
 const SLEEP_WHILE_NO_OP: i32 = 1000;
+const MAX_CONCURRENT_OP_WRITES: usize = 32;
 
 type TransactionReadOutcome = ReadOutcome<MessageExt>;
 
@@ -102,7 +104,7 @@ pub struct DefaultTransactionalMessageService<MS: BrokerWriteStore + BrokerMaste
     transactional_message_bridge: TransactionalMessageBridge<MS>,
     broker_config: Arc<BrokerConfig>,
     file_reserved_time_hours: i64,
-    delete_context: Arc<Mutex<HashMap<i32, MessageQueueOpContext>>>,
+    delete_context: Arc<Mutex<HashMap<i32, Arc<MessageQueueOpContext>>>>,
     transactional_op_batch_service: OnceLock<TransactionalOpBatchService<MS>>,
     op_queue_map: Arc<RwLock<HashMap<MessageQueue, MessageQueue>>>,
     transaction_metrics: TransactionMetrics,
@@ -274,100 +276,60 @@ where
         let start_time = current_millis();
         let interval = self.broker_config.transaction_op_batch_interval;
         let max_size = self.broker_config.transaction_op_msg_max_size as usize;
-        let mut over_size = false;
-        let mut first_timestamp = start_time;
-        let mut send_map = HashMap::<i32, Message>::new();
-        let ready_queues = {
-            let delete_context = self.delete_context.lock().await;
-            let mut ready_queues = Vec::new();
-            for (queue_id, mq_context) in delete_context.iter() {
-                let total_size = mq_context.get_total_size().await;
-                let last_write_timestamp = mq_context.get_last_write_timestamp().await;
-                if total_size == 0
-                    || mq_context.is_empty().await
-                    || (total_size < max_size as u32
-                        && (start_time as i64 - last_write_timestamp as i64) < interval as i64)
-                {
-                    continue;
-                }
-                ready_queues.push((*queue_id, total_size, last_write_timestamp));
-            }
-            ready_queues
-        };
+        let queues: Vec<_> = self
+            .delete_context
+            .lock()
+            .await
+            .iter()
+            .map(|(id, context)| (*id, Arc::clone(context)))
+            .collect();
+        // Futures remain owned by this scan, with one drainer per queue. A slow
+        // append cannot hold the map lock or prevent another queue from writing.
+        let ready: Vec<_> = queues
+            .into_iter()
+            .filter(|(_, context)| {
+                let size = context.get_total_size();
+                size > 0
+                    && (size >= max_size || start_time.saturating_sub(context.get_last_write_timestamp()) >= interval)
+            })
+            .collect();
+        futures::stream::iter(ready)
+            .map(|(queue_id, context)| async move { self.flush_op_queue(queue_id, &context).await })
+            .buffer_unordered(MAX_CONCURRENT_OP_WRITES)
+            .collect::<Vec<_>>()
+            .await;
 
-        for (queue_id, total_size, last_write_timestamp) in ready_queues {
-            let op_message = self.get_op_message(queue_id, None).await;
-            if op_message.is_none() {
-                continue;
-            }
-            send_map.insert(queue_id, op_message.unwrap());
-            first_timestamp = first_timestamp.min(last_write_timestamp);
-            if total_size >= max_size as u32 {
-                over_size = true;
-            }
-        }
-        for (op_queue_id, op_message) in send_map {
-            if !self
-                .transactional_message_bridge
-                .write_op(op_queue_id, op_message)
-                .await
-            {
-                error!("Transaction batch op message write failed.");
-            }
-        }
-        //wait for next batch remove
-        let wakeup_timestamp = first_timestamp + interval;
-        if !over_size && wakeup_timestamp > start_time {
-            return wakeup_timestamp;
-        }
-        0
+        // Failed batches remain owned and retry on the next interval. New full
+        // batches also wake the service through the existing enqueue path.
+        current_millis().saturating_add(interval)
     }
 
-    pub async fn get_op_message(&self, queue_id: i32, more_data: Option<String>) -> Option<Message> {
-        let topic = TransactionalMessageUtil::build_op_topic();
-        let mut delete_context = self.delete_context.lock().await;
-        let mq_context = delete_context.get_mut(&queue_id)?;
-
-        let more_data_length = if let Some(ref data) = more_data { data.len() } else { 0 };
-        let mut length = more_data_length;
-        let max_size = self.broker_config.transaction_op_msg_max_size as usize;
-        if length < max_size {
-            let sz = mq_context.get_total_size().await as usize;
-            if sz > max_size || length + sz > max_size {
-                length = max_size + 100;
-            } else {
-                length += sz;
-            }
+    async fn flush_op_queue(&self, queue_id: i32, context: &MessageQueueOpContext) {
+        let Some(batch) = context.try_take_batch(self.broker_config.transaction_op_msg_max_size as usize) else {
+            return;
+        };
+        let mut message = Message::builder()
+            .topic(TransactionalMessageUtil::build_op_topic())
+            .tags(TransactionalMessageUtil::REMOVE_TAG)
+            .build_unchecked();
+        message.set_body(Some(batch.body()));
+        let result = self
+            .transactional_message_bridge
+            .write_op_result(queue_id, message)
+            .await;
+        batch.record_append_evidence(result.execution_evidence());
+        if result.put_message_status() == PutMessageStatus::PutOk {
+            batch.complete(current_millis());
+        } else {
+            warn!(
+                queue_id,
+                append_evidence = ?batch.append_evidence(),
+                "Transaction operation batch retained for retry after append failure"
+            );
+            // These bodies contain only idempotent REMOVE offsets. Retrying an
+            // uncertain append can duplicate removal records, never a business
+            // message. Preserve the original batch and its execution evidence.
         }
-
-        let mut sb = String::with_capacity(length);
-
-        if let Some(data) = more_data {
-            sb.push_str(&data);
-        }
-
-        while !mq_context.is_empty().await {
-            if sb.len() >= max_size {
-                break;
-            }
-            {
-                if let Ok(data) = mq_context.pull().await {
-                    sb.push_str(&data);
-                }
-            }
-        }
-
-        if sb.is_empty() {
-            return None;
-        }
-
-        Some(
-            Message::builder()
-                .topic(topic)
-                .tags(TransactionalMessageUtil::REMOVE_TAG)
-                .body_slice(sb.as_bytes())
-                .build_unchecked(),
-        )
     }
 
     pub async fn shutdown(&self) {
@@ -444,10 +406,17 @@ where
             let start_time = current_millis() as i64;
             let op_queue = self.get_op_queue(&message_queue).await;
 
-            let (half_offset, op_offset) = (
+            let offsets = (
                 self.transactional_message_bridge.fetch_consume_offset(&message_queue),
                 self.transactional_message_bridge.fetch_consume_offset(&op_queue),
             );
+            let (half_offset, op_offset) = match offsets {
+                (Ok(half_offset), Ok(op_offset)) => (half_offset, op_offset),
+                (Err(error), _) | (_, Err(error)) => {
+                    warn!(queue_id = message_queue.queue_id(), code = ?error.code(), "Transaction offset read failed; retry on the next scan");
+                    continue;
+                }
+            };
 
             info!(
                 "Before check, the queue={:?} msgOffset={} opOffset={}",
@@ -477,7 +446,15 @@ where
                     &mut op_msg_map,
                     &mut done_op_offset,
                 )
-                .await?;
+                .await;
+
+            let pull_result = match pull_result {
+                Ok(result) => result,
+                Err(error) => {
+                    warn!(queue_id = message_queue.queue_id(), code = ?error.code(), "Transaction operation read failed; retry on the next scan");
+                    continue;
+                }
+            };
 
             if pull_result.is_none() {
                 error!(
@@ -488,21 +465,25 @@ where
             }
 
             // Process messages in the queue
-            self.process_message_queue(
-                &message_queue,
-                &op_queue,
-                half_offset,
-                op_offset,
-                start_time,
-                transaction_timeout,
-                transaction_check_max,
-                &mut remove_map,
-                &mut op_msg_map,
-                &mut done_op_offset,
-                pull_result,
-                listener.clone(),
-            )
-            .await?;
+            if let Err(error) = self
+                .process_message_queue(
+                    &message_queue,
+                    &op_queue,
+                    half_offset,
+                    op_offset,
+                    start_time,
+                    transaction_timeout,
+                    transaction_check_max,
+                    &mut remove_map,
+                    &mut op_msg_map,
+                    &mut done_op_offset,
+                    pull_result,
+                    listener.clone(),
+                )
+                .await
+            {
+                warn!(queue_id = message_queue.queue_id(), code = ?error.code(), "Transaction scan failed without advancing checkpoints; retry on the next scan");
+            }
         }
 
         Ok(())
@@ -532,6 +513,10 @@ where
         let mut new_offset = half_offset;
         let mut consume_half_offset = half_offset;
         let mut next_op_offset = pull_result.as_ref().map_or(0, |pr| pr.next_begin_offset());
+        let mut recovered_op_offset = pull_result
+            .as_ref()
+            .filter(|result| is_illegal_or_unmatched_offset(result.status()))
+            .map_or(op_offset, |result| result.next_begin_offset());
         let mut put_in_queue_count = 0;
         let mut escape_fail_cnt = 0;
         let listener = &mut listener;
@@ -722,6 +707,13 @@ where
                         )
                         .await?;
 
+                    if let Some(result) = pull_result
+                        .as_ref()
+                        .filter(|result| is_illegal_or_unmatched_offset(result.status()))
+                    {
+                        recovered_op_offset = result.next_begin_offset();
+                    }
+
                     if pull_result.as_ref().is_none_or(|result| {
                         is_no_new_message(result.status()) || is_illegal_or_unmatched_offset(result.status())
                     }) {
@@ -740,21 +732,20 @@ where
             consume_half_offset += 1;
         }
 
-        // Update offsets
+        let new_op_offset = self.calculate_op_offset(done_op_offset, recovered_op_offset);
+        // Log final statistics
+        let get_result = self.get_half_msg(message_queue, new_offset).await?;
+        let pull_result = self.pull_op_msg(op_queue, new_op_offset, 1).await?;
+
+        // Publish checkpoints only after all reads in this queue's scan succeed.
         if new_offset != half_offset {
             self.transactional_message_bridge
                 .update_consume_offset(message_queue, new_offset);
         }
-
-        let new_op_offset = self.calculate_op_offset(done_op_offset, op_offset);
         if new_op_offset != op_offset {
             self.transactional_message_bridge
                 .update_consume_offset(op_queue, new_op_offset);
         }
-
-        // Log final statistics
-        let get_result = self.get_half_msg(message_queue, new_offset).await?;
-        let pull_result = self.pull_op_msg(op_queue, new_op_offset, 1).await;
 
         let max_msg_offset = if let Some(ref pr) = get_result.pull_result {
             pr.max_offset()
@@ -976,7 +967,7 @@ where
     async fn get_half_msg(&self, message_queue: &MessageQueue, offset: i64) -> Result<GetResult> {
         let mut get_result = GetResult::new();
 
-        if let Some(result) = self.pull_half_msg(message_queue, offset, PULL_MSG_RETRY_NUMBER).await {
+        if let Some(result) = self.pull_half_msg(message_queue, offset, PULL_MSG_RETRY_NUMBER).await? {
             if let Some(message_exts) = result.records() {
                 if !message_exts.is_empty() {
                     get_result.set_msg(Some(message_exts[0].clone()));
@@ -989,7 +980,7 @@ where
     }
 
     /// Pull half message
-    async fn pull_half_msg(&self, mq: &MessageQueue, offset: i64, nums: i32) -> Option<TransactionReadOutcome> {
+    async fn pull_half_msg(&self, mq: &MessageQueue, offset: i64, nums: i32) -> Result<Option<TransactionReadOutcome>> {
         self.transactional_message_bridge
             .get_half_message(mq.queue_id(), offset, nums)
             .await
@@ -1026,7 +1017,7 @@ where
     ///
     /// A `Result` containing an optional store read outcome:
     /// - `Some(ReadOutcome)` if the operation messages were successfully read.
-    /// - `None` if no operation messages were found or an error occurred.
+    /// - `None` if no operation messages were found.
     ///
     /// # Errors
     ///
@@ -1041,7 +1032,7 @@ where
         op_msg_map: &mut HashMap<i64, HashSet<i64>>,
         done_op_offset: &mut Vec<i64>,
     ) -> Result<Option<TransactionReadOutcome>> {
-        let pull_result = self.pull_op_msg(op_queue, pull_offset_of_op, OP_MSG_PULL_NUMS).await;
+        let pull_result = self.pull_op_msg(op_queue, pull_offset_of_op, OP_MSG_PULL_NUMS).await?;
 
         let Some(pull_result) = pull_result else {
             return Ok(None);
@@ -1052,8 +1043,8 @@ where
                 "The miss op offset={} in queue={:?} is illegal, pullResult={:?}",
                 pull_offset_of_op, op_queue, pull_result
             );
-            self.transactional_message_bridge
-                .update_consume_offset(op_queue, pull_result.next_begin_offset());
+            // Stage offset correction in the scan; later read failures must leave
+            // both half and operation checkpoints at their original positions.
             return Ok(Some(pull_result));
         }
         if is_no_new_message(pull_result.status()) {
@@ -1132,7 +1123,7 @@ where
     }
 
     /// Pull operation message
-    async fn pull_op_msg(&self, mq: &MessageQueue, offset: i64, nums: i32) -> Option<TransactionReadOutcome> {
+    async fn pull_op_msg(&self, mq: &MessageQueue, offset: i64, nums: i32) -> Result<Option<TransactionReadOutcome>> {
         self.transactional_message_bridge
             .get_op_message(mq.queue_id(), offset, nums)
             .await
@@ -1185,8 +1176,10 @@ where
             message_ext.queue_offset,
             TransactionalMessageUtil::OFFSET_SEPARATOR
         );
-        let len = data.len();
-        let offered_total_size = {
+        if data.len() > self.broker_config.transaction_op_msg_max_size as usize {
+            return false;
+        }
+        let context = {
             let mut delete_context = self.delete_context.lock().await;
             let mq_context = match delete_context.entry(queue_id) {
                 std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
@@ -1203,17 +1196,13 @@ where
                             return false;
                         }
                     };
-                    entry.insert(context)
+                    entry.insert(Arc::new(context))
                 }
             };
-            if mq_context.offer(data.clone(), Duration::from_millis(100)).await.is_ok() {
-                Some(mq_context.total_size_add_and_get(len as u32).await)
-            } else {
-                None
-            }
+            Arc::clone(mq_context)
         };
-        if let Some(total_size) = offered_total_size {
-            if total_size > self.broker_config.transaction_op_msg_max_size as u32 {
+        if context.push(data.clone()).is_ok() {
+            if context.get_total_size() >= self.broker_config.transaction_op_msg_max_size as usize {
                 if let Some(batch_service) = self.transactional_op_batch_service.get() {
                     batch_service.wakeup();
                 } else {
@@ -1227,20 +1216,8 @@ where
             error!("Transactional op batch service not initialized");
         }
 
-        let Some(msg) = self.get_op_message(queue_id, Some(data)).await else {
-            error!(queue_id, "Transaction op message was empty after offer fallback");
-            return false;
-        };
-        if self.transactional_message_bridge.write_op(queue_id, msg).await {
-            warn!("Force add remove op data. queueId={}", queue_id);
-            true
-        } else {
-            error!(
-                "Transaction op message write failed. messageId is {}, queueId is {}",
-                message_ext.msg_id, message_ext.queue_id
-            );
-            false
-        }
+        self.flush_op_queue(queue_id, &context).await;
+        context.push(data).is_ok()
     }
 
     #[inline]
@@ -1335,6 +1312,101 @@ fn to_message_ext_broker_inner(topic_config: &TopicConfig, msg_ext: &MessageExt)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn transaction_scan_preserves_both_checkpoints_on_half_or_op_read_error() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let root = directory.path().to_string_lossy().into_owned();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let ha_port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let mut runtime = crate::broker_runtime::BrokerRuntime::new(
+            Arc::new(BrokerConfig {
+                store_path_root_dir: root.clone().into(),
+                auth_config_path: directory.path().join("auth.json").to_string_lossy().into_owned().into(),
+                ..BrokerConfig::default()
+            }),
+            Arc::new(rocketmq_store::MessageStoreConfig {
+                store_path_root_dir: root.into(),
+                ha_listen_port: usize::from(ha_port),
+                ..Default::default()
+            }),
+        );
+        runtime.initialize().await.unwrap();
+        let service = runtime
+            .runtime_state_mut()
+            .transactional_message_service()
+            .unwrap()
+            .clone();
+        let listener = runtime
+            .runtime_state_mut()
+            .transactional_message_check_listener()
+            .as_ref()
+            .unwrap()
+            .clone();
+        let half = MessageQueue::from_parts(TransactionalMessageUtil::build_half_topic(), "broker", 0);
+        let op = MessageQueue::from_parts(TransactionalMessageUtil::build_op_topic(), "broker", 0);
+        let empty = || {
+            let mut result = rocketmq_store::GetMessageResult::new();
+            result.set_status(Some(rocketmq_store::GetMessageStatus::NoMessageInQueue));
+            result.set_next_begin_offset(8);
+            result.set_max_offset(8);
+            Ok(Some(result))
+        };
+        service.transactional_message_bridge.set_read_results(vec![Ok(None)]);
+        assert!(service
+            .transactional_message_bridge
+            .get_half_message(0, 7, 1)
+            .await
+            .unwrap()
+            .is_none());
+
+        for failure in [Some("half"), Some("op"), None] {
+            service.transactional_message_bridge.update_consume_offset(&half, 7);
+            service.transactional_message_bridge.update_consume_offset(&op, 3);
+            let error = crate::broker_error::storage_read_failed();
+            let reads = match failure {
+                Some("half") => vec![Err(Arc::clone(&error))],
+                Some(_) => vec![empty(), empty(), Err(Arc::clone(&error))],
+                None => vec![empty(), empty(), empty()],
+            };
+            service.transactional_message_bridge.set_read_results(reads);
+            let result = service
+                .process_message_queue(
+                    &half,
+                    &op,
+                    7,
+                    3,
+                    current_millis() as i64,
+                    1_000,
+                    15,
+                    &mut HashMap::from([(7, 3)]),
+                    &mut HashMap::from([(3, HashSet::from([7]))]),
+                    &mut Vec::new(),
+                    None,
+                    listener.clone(),
+                )
+                .await;
+            if failure.is_some() {
+                assert!(Arc::ptr_eq(&result.unwrap_err(), &error));
+            } else {
+                result.unwrap();
+            }
+            assert_eq!(
+                service
+                    .transactional_message_bridge
+                    .fetch_consume_offset(&half)
+                    .unwrap(),
+                if failure.is_some() { 7 } else { 8 }
+            );
+            assert_eq!(
+                service.transactional_message_bridge.fetch_consume_offset(&op).unwrap(),
+                if failure.is_some() { 3 } else { 4 }
+            );
+        }
+        drop(service);
+        runtime.shutdown().await;
+    }
 
     #[test]
     fn discard_message_conversion_preserves_protocol_fields() {

--- a/rocketmq-broker/src/transaction/queue/message_queue_op_context.rs
+++ b/rocketmq-broker/src/transaction/queue/message_queue_op_context.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use crate::broker_error::BrokerResult as Result;
+use bytes::Bytes;
+use parking_lot::Mutex;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_runtime::BudgetLimit;
 use rocketmq_runtime::BudgetedQueue;
@@ -25,12 +24,71 @@ use rocketmq_runtime::FullPolicy;
 use rocketmq_runtime::QueueSnapshot;
 use rocketmq_runtime::RateLimit;
 use rocketmq_runtime::ResourceBudget;
-use tokio::time;
+use rocketmq_runtime::ResourcePermit;
+use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::MutexGuard;
 
 pub struct MessageQueueOpContext {
-    total_size: AtomicU32,
-    last_write_timestamp: AtomicU64,
+    state: Mutex<OperationQueueState>,
+    drainer: AsyncMutex<()>,
     pending_operations: BudgetedQueue<String>,
+}
+
+struct OperationQueueState {
+    total_size: usize,
+    last_write_timestamp: u64,
+    deferred: Option<(String, ResourcePermit)>,
+    pending: Option<Bytes>,
+    last_append_evidence: Option<rocketmq_store::AppendExecutionEvidence>,
+}
+
+struct OperationBody {
+    bytes: Vec<u8>,
+    _permits: Vec<ResourcePermit>,
+}
+
+impl AsRef<[u8]> for OperationBody {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+// Dropping an interrupted attempt only releases the drainer. The queue retains
+// the pending body, and every Store alias retains its resource permits as well.
+pub(crate) struct OperationBatch<'a> {
+    queue: &'a MessageQueueOpContext,
+    body: Bytes,
+    _drainer: MutexGuard<'a, ()>,
+}
+
+impl OperationBatch<'_> {
+    pub(crate) fn body(&self) -> Bytes {
+        self.body.clone()
+    }
+
+    pub(crate) fn complete(self, timestamp: u64) {
+        let mut state = self.queue.state.lock();
+        state.pending = None;
+        state.last_append_evidence = None;
+        state.total_size -= self.body.len();
+        state.last_write_timestamp = timestamp;
+    }
+
+    pub(crate) fn record_append_evidence(&self, evidence: &rocketmq_store::AppendExecutionEvidence) {
+        self.queue.state.lock().last_append_evidence = Some(evidence.clone());
+    }
+
+    pub(crate) fn append_evidence(&self) -> Option<rocketmq_store::AppendExecutionEvidence> {
+        self.queue.state.lock().last_append_evidence.clone()
+    }
+}
+
+fn retained_operation_bytes(message: &String) -> usize {
+    // Reserve the source and its eventual batch copy at admission. The payload
+    // is copied once; subsequent Store bodies share the budget-owning Bytes.
+    std::mem::size_of::<String>()
+        .saturating_add(std::mem::size_of::<ResourcePermit>())
+        .saturating_add(message.capacity().saturating_mul(2))
 }
 
 impl MessageQueueOpContext {
@@ -45,58 +103,91 @@ impl MessageQueueOpContext {
             )
             .map_err(|_error| crate::broker_error::configuration_invalid("broker.transaction.operationQueue"))?;
         Ok(Self {
-            total_size: AtomicU32::new(0),
-            last_write_timestamp: AtomicU64::new(timestamp),
+            state: Mutex::new(OperationQueueState {
+                total_size: 0,
+                last_write_timestamp: timestamp,
+                deferred: None,
+                pending: None,
+                last_append_evidence: None,
+            }),
+            drainer: AsyncMutex::new(()),
             pending_operations: BudgetedQueue::new(budget),
         })
     }
 
-    pub async fn get_total_size(&self) -> u32 {
-        self.total_size.load(Ordering::Relaxed)
+    pub fn get_total_size(&self) -> usize {
+        self.state.lock().total_size
     }
 
-    pub async fn total_size_add_and_get(&self, delta: u32) -> u32 {
-        self.total_size.fetch_add(delta, Ordering::AcqRel) + delta
+    pub fn get_last_write_timestamp(&self) -> u64 {
+        self.state.lock().last_write_timestamp
     }
 
-    pub async fn get_last_write_timestamp(&self) -> u64 {
-        self.last_write_timestamp.load(Ordering::Relaxed)
-    }
-
-    pub async fn set_last_write_timestamp(&self, timestamp: u64) {
-        self.last_write_timestamp.store(timestamp, Ordering::Release);
-    }
-
-    pub async fn push(&self, msg: String) -> Result<()> {
-        let retained_bytes = std::mem::size_of::<String>().saturating_add(msg.capacity());
+    pub fn push(&self, msg: String) -> Result<()> {
+        let retained_bytes = retained_operation_bytes(&msg);
+        let length = msg.len();
+        let mut state = self.state.lock();
         match self.pending_operations.try_push_data(msg, retained_bytes) {
             rocketmq_runtime::QueuePushOutcome::Rejected { .. } => Err(crate::broker_error::broker_operation_failed(
                 "message_queue_push",
                 ResponseCode::SystemBusy as i32,
                 "transaction operation queue is full",
             )),
-            _ => Ok(()),
+            _ => {
+                state.total_size += length;
+                Ok(())
+            }
         }
     }
-    pub async fn offer(&self, item: String, timeout: std::time::Duration) -> Result<()> {
-        if let Ok(res) = time::timeout(timeout, self.push(item)).await {
-            return res;
-        }
-        Err(crate::broker_error::timeout(
-            "message_queue_offer",
-            timeout.as_millis() as u64,
-        ))
-    }
-    pub async fn pull(&self) -> Result<String> {
-        if let Some(item) = self.pending_operations.recv().await {
-            return Ok(item);
-        }
-        Err(crate::broker_error::service_failed(
-            "transaction_operation_queue_interrupted",
-        ))
-    }
-    pub async fn is_empty(&self) -> bool {
-        self.pending_operations.is_empty()
+
+    pub(crate) fn try_take_batch(&self, max_bytes: usize) -> Option<OperationBatch<'_>> {
+        let drainer = self.drainer.try_lock().ok()?;
+        let mut state = self.state.lock();
+        let body = if let Some(body) = &state.pending {
+            body.clone()
+        } else {
+            let mut entries = Vec::new();
+            let mut length = 0;
+            while length < max_bytes {
+                let next = state.deferred.take().or_else(|| {
+                    self.pending_operations.try_pop_budgeted().map(|item| {
+                        let (message, permit, _) = item.into_parts();
+                        (message, permit)
+                    })
+                });
+                let Some((message, permit)) = next else { break };
+                if message.len() > max_bytes - length {
+                    state.deferred = Some((message, permit));
+                    break;
+                }
+                length += message.len();
+                entries.push((message, permit));
+            }
+            if entries.is_empty() {
+                return None;
+            }
+            let mut bytes = Vec::with_capacity(length);
+            let mut permits = Vec::with_capacity(entries.len());
+            for (message, permit) in entries {
+                bytes.extend_from_slice(message.as_bytes());
+                permits.push(permit);
+            }
+            let body = Bytes::from_owner(OperationBody {
+                bytes,
+                _permits: permits,
+            });
+            state.pending = Some(body.clone());
+            body
+        };
+        // Until the Store returns, dropping the attempt cannot prove whether
+        // the append worker committed. Keep that uncertainty with the batch.
+        state.last_append_evidence = Some(rocketmq_store::AppendExecutionEvidence::Unknown);
+        drop(state);
+        Some(OperationBatch {
+            queue: self,
+            body,
+            _drainer: drainer,
+        })
     }
 
     pub fn queue_snapshot(&self) -> QueueSnapshot {
@@ -106,12 +197,95 @@ impl MessageQueueOpContext {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use rocketmq_runtime::ResourceBudgetTree;
 
+    fn test_budget() -> ResourceBudget {
+        ResourceBudgetTree::new("transaction-batches", BudgetLimit::new(16, 4096, FullPolicy::Reject))
+            .unwrap()
+            .root()
+    }
+
+    #[tokio::test]
+    async fn blocked_queue_does_not_block_other_queue_and_cancel_preserves_batch() {
+        let root = test_budget();
+        let first = Arc::new(MessageQueueOpContext::try_new(0, 8, 0, &root).unwrap());
+        let second = MessageQueueOpContext::try_new(0, 8, 1, &root).unwrap();
+        first.push("123,".into()).unwrap();
+        second.push("456,".into()).unwrap();
+        let admitted_bytes = root.snapshot().current_bytes;
+        let (started, received) = tokio::sync::oneshot::channel();
+        let owner = Arc::clone(&first);
+        let attempt = tokio::spawn(async move {
+            let batch = owner.try_take_batch(32).unwrap();
+            started.send(batch.body()).unwrap();
+            std::future::pending::<()>().await;
+            batch.complete(1);
+        });
+        let store_alias = received.await.unwrap();
+        assert!(first.try_take_batch(32).is_none());
+        let other_batch = second.try_take_batch(32).unwrap();
+        assert_eq!(other_batch.body().as_ref(), b"456,");
+        assert_eq!(root.snapshot().current_bytes, admitted_bytes);
+        other_batch.complete(1);
+        assert_eq!(second.get_total_size(), 0);
+        assert_eq!(root.snapshot().current_count, 1);
+
+        attempt.abort();
+        assert!(attempt.await.unwrap_err().is_cancelled());
+        assert_eq!(first.get_total_size(), 4);
+        assert_eq!(
+            first.state.lock().last_append_evidence,
+            Some(rocketmq_store::AppendExecutionEvidence::Unknown)
+        );
+        assert_eq!(root.snapshot().current_count, 1);
+        let retry = first.try_take_batch(32).unwrap();
+        assert_eq!(retry.body(), store_alias);
+        retry.complete(2);
+        assert_eq!(first.get_total_size(), 0);
+        assert_eq!(first.get_last_write_timestamp(), 2);
+        assert!(first.try_take_batch(32).is_none());
+        assert_eq!(root.snapshot().current_count, 1);
+        drop(store_alias);
+        assert_eq!(root.snapshot().current_count, 0);
+        assert_eq!(root.snapshot().current_bytes, 0);
+    }
+
+    #[test]
+    fn bounded_batch_retries_before_draining_later_operations() {
+        let root = test_budget();
+        let queue = MessageQueueOpContext::try_new(7, 8, 0, &root).unwrap();
+        queue.push("12,".into()).unwrap();
+        queue.push("345,".into()).unwrap();
+        let batch = queue.try_take_batch(6).unwrap();
+        assert_eq!(batch.body().as_ref(), b"12,");
+        batch.record_append_evidence(&rocketmq_store::AppendExecutionEvidence::NotAppended);
+        assert_eq!(
+            batch.append_evidence(),
+            Some(rocketmq_store::AppendExecutionEvidence::NotAppended)
+        );
+        assert_eq!(queue.get_total_size(), 7);
+        assert_eq!(root.snapshot().current_count, 2);
+        drop(batch); // Append failure retains the original body for retry.
+        queue.push("6,".into()).unwrap();
+        let retry = queue.try_take_batch(6).unwrap();
+        assert_eq!(retry.body().as_ref(), b"12,");
+        retry.complete(8);
+        assert_eq!(queue.get_total_size(), 6);
+        assert_eq!(root.snapshot().current_count, 2);
+        let next = queue.try_take_batch(6).unwrap();
+        assert_eq!(next.body().as_ref(), b"345,6,");
+        next.complete(9);
+        assert_eq!(queue.get_total_size(), 0);
+        assert_eq!(root.snapshot().current_count, 0);
+        assert_eq!(root.snapshot().current_bytes, 0);
+    }
+
     #[tokio::test]
     async fn overload_rejects_excess_transaction_operations() {
-        let item_bytes = std::mem::size_of::<String>() + 1;
+        let item_bytes = retained_operation_bytes(&"a".to_owned());
         let root = ResourceBudgetTree::new(
             "broker-transaction-overload",
             BudgetLimit::new(2, item_bytes * 2, FullPolicy::Reject),
@@ -120,10 +294,10 @@ mod tests {
         .root();
         let queue = MessageQueueOpContext::try_new(0, 2, 0, &root).expect("operation queue");
 
-        assert!(queue.push("a".to_owned()).await.is_ok());
-        assert!(queue.push("b".to_owned()).await.is_ok());
-        assert!(queue.push("c".to_owned()).await.is_err());
-        assert!(queue.push("d".to_owned()).await.is_err());
+        assert!(queue.push("a".to_owned()).is_ok());
+        assert!(queue.push("b".to_owned()).is_ok());
+        assert!(queue.push("c".to_owned()).is_err());
+        assert!(queue.push("d".to_owned()).is_err());
 
         let snapshot = queue.queue_snapshot();
         assert_eq!(snapshot.depth, 2);

--- a/rocketmq-broker/src/transaction/queue/transaction_message_store.rs
+++ b/rocketmq-broker/src/transaction/queue/transaction_message_store.rs
@@ -25,17 +25,28 @@ use rocketmq_store::GetMessageResult;
 use rocketmq_store::PutMessageResult;
 use rocketmq_store::PutMessageStatus;
 
+use crate::broker_error::BrokerResult;
 use crate::failover::escape_bridge::EscapeBridge;
+
+fn transaction_store_unavailable() -> rocketmq_error::SharedError {
+    crate::broker_error::from_canonical(rocketmq_error::Error::new(
+        &rocketmq_error::STORAGE_LIFECYCLE_NOT_STARTED,
+    ))
+}
 
 /// Narrow, non-owning Store capability for the transaction subsystem.
 pub(crate) struct TransactionMessageStore<MS> {
     escape_bridge: Weak<EscapeBridge<MS>>,
+    #[cfg(test)]
+    read_results: Arc<parking_lot::Mutex<std::collections::VecDeque<BrokerResult<Option<GetMessageResult>>>>>,
 }
 
 impl<MS> Clone for TransactionMessageStore<MS> {
     fn clone(&self) -> Self {
         Self {
             escape_bridge: Weak::clone(&self.escape_bridge),
+            #[cfg(test)]
+            read_results: Arc::clone(&self.read_results),
         }
     }
 }
@@ -44,14 +55,17 @@ impl<MS: BrokerReadStore> TransactionMessageStore<MS> {
     pub(crate) fn new(escape_bridge: &Arc<EscapeBridge<MS>>) -> Self {
         Self {
             escape_bridge: Arc::downgrade(escape_bridge),
+            #[cfg(test)]
+            read_results: Arc::default(),
         }
     }
 
-    pub(crate) fn get_min_offset_in_queue(&self, topic: &CheetahString, queue_id: i32) -> i64 {
+    pub(crate) fn get_min_offset_in_queue(&self, topic: &CheetahString, queue_id: i32) -> BrokerResult<i64> {
         self.escape_bridge
             .upgrade()
-            .and_then(|provider| provider.get_min_offset_from_local_store(topic, queue_id).ok())
-            .unwrap_or(-1)
+            .ok_or_else(transaction_store_unavailable)?
+            .get_min_offset_from_local_store(topic, queue_id)
+            .map_err(|_| transaction_store_unavailable())
     }
 
     pub(crate) async fn get_message(
@@ -61,13 +75,21 @@ impl<MS: BrokerReadStore> TransactionMessageStore<MS> {
         queue_id: i32,
         offset: i64,
         nums: i32,
-    ) -> Option<GetMessageResult> {
-        let provider = self.escape_bridge.upgrade()?;
+    ) -> BrokerResult<Option<GetMessageResult>> {
+        let provider = self.escape_bridge.upgrade().ok_or_else(transaction_store_unavailable)?;
+        #[cfg(test)]
+        if let Some(result) = self.read_results.lock().pop_front() {
+            return result;
+        }
         provider
             .get_message_from_local_store(group, topic, queue_id, offset, nums)
             .await
-            .ok()
-            .flatten()
+            .map_err(|_| transaction_store_unavailable())
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_read_results(&self, results: Vec<BrokerResult<Option<GetMessageResult>>>) {
+        *self.read_results.lock() = results.into();
     }
 
     pub(crate) fn look_message_by_offset(&self, offset: i64) -> Option<MessageExt> {
@@ -118,12 +140,22 @@ mod tests {
     async fn transaction_store_fails_closed_after_provider_shutdown() {
         let store = TransactionMessageStore::<StorePorts> {
             escape_bridge: Weak::new(),
+            read_results: Arc::default(),
         };
         let topic = CheetahString::from_static_str("transaction-topic");
         let group = CheetahString::from_static_str("transaction-group");
 
-        assert_eq!(store.get_min_offset_in_queue(&topic, 0), -1);
-        assert!(store.get_message(&group, &topic, 0, 0, 1).await.is_none());
+        let offset_error = store.get_min_offset_in_queue(&topic, 0).unwrap_err();
+        let read_error = store
+            .get_message(&group, &topic, 0, 0, 1)
+            .await
+            .err()
+            .expect("provider unavailable");
+        assert_eq!(
+            offset_error.descriptor(),
+            &rocketmq_error::STORAGE_LIFECYCLE_NOT_STARTED
+        );
+        assert_eq!(read_error.descriptor(), offset_error.descriptor());
         assert!(store.look_message_by_offset(0).is_none());
         assert!(store.state_machine_version().is_none());
         assert_eq!(

--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -40,9 +40,10 @@ use rocketmq_store_api::ReadOutcome;
 use tokio::sync::Mutex;
 use tracing::error;
 
+use crate::broker_error::BrokerResult;
 use crate::failover::escape_bridge::EscapeBridge;
 use crate::offset::manager::consumer_offset_manager::ConsumerOffsetManager;
-use crate::store_read::decode_read_outcome;
+use crate::store_read::decode_transaction_read_outcome;
 use crate::transaction::queue::transaction_message_store::TransactionMessageStore;
 use crate::transaction::queue::transaction_topic_registration::TransactionTopicRegistration;
 use crate::transaction::queue::transactional_message_util::TransactionalMessageUtil;
@@ -87,15 +88,20 @@ impl<MS> TransactionalMessageBridge<MS>
 where
     MS: BrokerWriteStore,
 {
-    pub(crate) fn fetch_consume_offset(&self, mq: &MessageQueue) -> i64 {
+    pub(crate) fn fetch_consume_offset(&self, mq: &MessageQueue) -> BrokerResult<i64> {
         let group = CheetahString::from_static_str(TransactionalMessageUtil::build_consumer_group());
         let topic = mq.topic();
         let queue_id = mq.queue_id();
         let mut offset = self.consumer_offset_manager.query_offset(&group, topic, queue_id);
         if offset == -1 {
-            offset = self.message_store.get_min_offset_in_queue(topic, queue_id);
+            offset = self.message_store.get_min_offset_in_queue(topic, queue_id)?;
         }
-        offset
+        Ok(offset)
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_read_results(&self, results: Vec<BrokerResult<Option<rocketmq_store::GetMessageResult>>>) {
+        self.message_store.set_read_results(results);
     }
 
     pub async fn fetch_message_queues(&self, topic: &CheetahString) -> HashSet<MessageQueue>
@@ -123,7 +129,12 @@ where
         );
     }
 
-    pub async fn get_half_message(&self, queue_id: i32, offset: i64, nums: i32) -> Option<ReadOutcome<MessageExt>> {
+    pub async fn get_half_message(
+        &self,
+        queue_id: i32,
+        offset: i64,
+        nums: i32,
+    ) -> BrokerResult<Option<ReadOutcome<MessageExt>>> {
         self.get_message(
             &CheetahString::from_static_str(TransactionalMessageUtil::build_consumer_group()),
             &CheetahString::from_static_str(TransactionalMessageUtil::build_half_topic()),
@@ -135,7 +146,12 @@ where
         .await
     }
 
-    pub async fn get_op_message(&self, queue_id: i32, offset: i64, nums: i32) -> Option<ReadOutcome<MessageExt>> {
+    pub async fn get_op_message(
+        &self,
+        queue_id: i32,
+        offset: i64,
+        nums: i32,
+    ) -> BrokerResult<Option<ReadOutcome<MessageExt>>> {
         self.get_message(
             &CheetahString::from_static_str(TransactionalMessageUtil::build_consumer_group()),
             &CheetahString::from_static_str(TransactionalMessageUtil::build_op_topic()),
@@ -156,20 +172,20 @@ where
         nums: i32,
         _sub: Option<SubscriptionData>, /* in Java version, this is not used, so we keep it as
                                          * Option */
-    ) -> Option<ReadOutcome<MessageExt>> {
+    ) -> BrokerResult<Option<ReadOutcome<MessageExt>>> {
         let get_message_result = self
             .message_store
             .get_message(group, topic, queue_id, offset, nums)
-            .await;
+            .await?;
 
         if let Some(get_message_result) = get_message_result {
-            decode_read_outcome(get_message_result, false)
+            decode_transaction_read_outcome(get_message_result).map(Some)
         } else {
             error!(
                 "Get message from store return null. topic={}, groupId={}, requestOffset={}",
                 topic, group, offset
             );
-            None
+            Ok(None)
         }
     }
 
@@ -309,10 +325,13 @@ where
     }
 
     pub async fn write_op(&self, queue_id: i32, message: Message) -> bool {
+        self.write_op_result(queue_id, message).await.put_message_status() == PutMessageStatus::PutOk
+    }
+
+    pub(crate) async fn write_op_result(&self, queue_id: i32, message: Message) -> PutMessageResult {
         let op_queue = resolve_op_queue(&self.op_queue_map, queue_id, &self.broker_name).await;
         let inner = self.make_op_message_inner(message, &op_queue);
-        let result = self.put_message_return_result(inner).await;
-        result.put_message_status() == PutMessageStatus::PutOk
+        self.put_message_return_result(inner).await
     }
 
     pub async fn put_message_return_result(&self, message_inner: MessageExtBrokerInner) -> PutMessageResult {

--- a/rocketmq-broker/tests/broker_runtime/send_policy.rs
+++ b/rocketmq-broker/tests/broker_runtime/send_policy.rs
@@ -1,0 +1,312 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Barrier;
+
+use parking_lot::Mutex;
+use rocketmq_model::common::message::message_single::Message;
+use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
+
+use super::*;
+use crate::mqtrace::send_message_context::SendMessageContext;
+use crate::mqtrace::send_message_hook::SendMessageHook;
+
+#[derive(Default)]
+struct HookObservations {
+    before: Vec<CheetahString>,
+    after: Vec<(CheetahString, i32)>,
+}
+
+struct PolicyHook {
+    first: AtomicBool,
+    captured: Barrier,
+    resume: Barrier,
+    observations: Mutex<HookObservations>,
+}
+
+impl PolicyHook {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            first: AtomicBool::new(true),
+            captured: Barrier::new(2),
+            resume: Barrier::new(2),
+            observations: Mutex::new(HookObservations::default()),
+        })
+    }
+}
+
+impl SendMessageHook for Arc<PolicyHook> {
+    fn hook_name(&self) -> &'static str {
+        "request-policy-generation"
+    }
+
+    fn send_message_before(&self, context: &SendMessageContext) {
+        self.observations.lock().before.push(context.broker_region_id.clone());
+        if self.first.swap(false, Ordering::AcqRel) {
+            self.captured.wait();
+            self.resume.wait();
+        }
+    }
+
+    fn send_message_after(&self, context: &SendMessageContext) {
+        self.observations
+            .lock()
+            .after
+            .push((context.broker_region_id.clone(), context.commercial_send_times));
+    }
+}
+
+fn request(code: RequestCode, topic: &str, transactional: bool) -> RemotingCommand {
+    let batch = code == RequestCode::SendBatchMessage;
+    let header = SendMessageRequestHeader {
+        producer_group: "policy-producer".into(),
+        topic: topic.into(),
+        default_topic: "TBW102".into(),
+        default_topic_queue_nums: 1,
+        queue_id: 0,
+        sys_flag: 0,
+        born_timestamp: current_millis() as i64,
+        flag: 0,
+        properties: transactional.then(|| {
+            MessageDecoder::message_properties_to_string(&HashMap::from([(
+                MessageConst::PROPERTY_TRANSACTION_PREPARED.into(),
+                "true".into(),
+            )]))
+        }),
+        reconsume_times: None,
+        unit_mode: Some(false),
+        batch: Some(batch),
+        max_reconsume_times: None,
+        topic_request_header: None,
+    };
+    let body = if batch {
+        let mut message = Message::default();
+        message.set_body(Some(Bytes::from_static(b"policy-body")));
+        MessageDecoder::encode_messages(&[message])
+    } else {
+        Bytes::from_static(b"policy-body")
+    };
+    let mut command = if batch {
+        RemotingCommand::create_request_command(
+            code,
+            SendMessageRequestHeaderV2::create_send_message_request_header_v2(&header),
+        )
+    } else {
+        RemotingCommand::create_request_command(code, header)
+    }
+    .set_body(body);
+    command.make_custom_header_to_net();
+    command
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn send_policy_generation_survives_configuration_update_through_store_and_hooks() {
+    for (code, transactional) in [
+        (RequestCode::SendMessage, false),
+        (RequestCode::SendBatchMessage, false),
+        (RequestCode::SendReplyMessage, false),
+        (RequestCode::SendMessage, true),
+    ] {
+        let mut runtime = new_phase3_test_runtime(&format!("send-policy-{}-{transactional}", code.to_i32())).await;
+        let mut initial = runtime.composition.state.broker_config().as_ref().clone();
+        initial.region_id = "before-region".into();
+        initial.trace_on = false;
+        initial.broker_identity.broker_cluster_name = "before-cluster".into();
+        initial.commercial_size_per_msg = 1_048_576;
+        initial.commercial_base_count = 2;
+        initial.store_reply_message_enable = true;
+        initial.async_topic_create_persist_enable = false;
+        runtime.composition.state.set_broker_config(initial.clone()).unwrap();
+        let old_host = runtime
+            .composition
+            .state
+            .send_message_policy_state
+            .snapshot()
+            .store_host;
+        let new_host = "127.0.0.2:20911".parse().unwrap();
+        let (mut processor, _) = runtime.init_processor_checked().unwrap();
+        let hook = PolicyHook::new();
+        processor.install_send_hook_for_test(code, Box::new(Arc::clone(&hook)));
+
+        let state = runtime.composition.state.send_message_policy_state.clone();
+        let runtime_config = runtime.composition.state.config_state.clone();
+        let updater_hook = Arc::clone(&hook);
+        let updater = std::thread::spawn(move || {
+            updater_hook.captured.wait();
+            let mut updated = initial;
+            updated.region_id = "after-region".into();
+            updated.trace_on = true;
+            updated.broker_identity.broker_cluster_name = "after-cluster".into();
+            updated.commercial_base_count = 9;
+            updated.auto_create_topic_enable = false;
+            updated.reject_transaction_message = true;
+            let result = runtime_config.replace_broker(updated);
+            if let Ok(generation) = &result {
+                state.update_broker_config(generation.broker());
+                state.update_store_host(new_host);
+            }
+            updater_hook.resume.wait();
+            result.unwrap();
+        });
+        let response = process_broker_request(&processor, &mut request(code, "PolicyTopic", transactional)).await;
+        updater.join().unwrap();
+        assert_eq!(
+            response
+                .ext_fields()
+                .unwrap()
+                .get(MessageConst::PROPERTY_MSG_REGION)
+                .unwrap(),
+            "before-region"
+        );
+        assert_eq!(
+            response
+                .ext_fields()
+                .unwrap()
+                .get(MessageConst::PROPERTY_TRACE_SWITCH)
+                .unwrap(),
+            "false"
+        );
+        let header = response
+            .decode_command_custom_header::<SendMessageResponseHeader>()
+            .unwrap();
+        let id = MessageDecoder::decode_message_id(header.msg_id().as_str().split(',').next().unwrap()).unwrap();
+        let stored = runtime
+            .composition
+            .state
+            .message_store()
+            .unwrap()
+            .look_message_by_offset(id.offset)
+            .unwrap();
+        assert_eq!(stored.store_host, old_host);
+        assert_eq!(
+            stored.property(&MessageConst::PROPERTY_MSG_REGION.into()).as_deref(),
+            Some("before-region")
+        );
+        if code != RequestCode::SendReplyMessage {
+            assert_eq!(
+                stored.property(&MessageConst::PROPERTY_CLUSTER.into()).as_deref(),
+                Some("before-cluster")
+            );
+        }
+
+        let next = process_broker_request(&processor, &mut request(code, "PolicyTopic", transactional)).await;
+        assert_eq!(
+            next.ext_fields()
+                .unwrap()
+                .get(MessageConst::PROPERTY_MSG_REGION)
+                .unwrap(),
+            "after-region"
+        );
+        if transactional {
+            assert_eq!(ResponseCode::from(next.code()), ResponseCode::NoPermission);
+        } else {
+            let header = next
+                .decode_command_custom_header::<SendMessageResponseHeader>()
+                .unwrap();
+            let id = MessageDecoder::decode_message_id(header.msg_id().as_str().split(',').next().unwrap()).unwrap();
+            let stored = runtime
+                .composition
+                .state
+                .message_store()
+                .unwrap()
+                .look_message_by_offset(id.offset)
+                .unwrap();
+            assert_eq!(stored.store_host, new_host);
+            assert_eq!(
+                stored.property(&MessageConst::PROPERTY_MSG_REGION.into()).as_deref(),
+                Some("after-region")
+            );
+            if code != RequestCode::SendReplyMessage {
+                assert_eq!(
+                    stored.property(&MessageConst::PROPERTY_CLUSTER.into()).as_deref(),
+                    Some("after-cluster")
+                );
+            }
+        }
+        {
+            let observations = hook.observations.lock();
+            assert_eq!(observations.before.as_slice(), &["before-region", "after-region"]);
+            assert_eq!(observations.after[0], ("before-region".into(), 2));
+            if !transactional {
+                assert_eq!(observations.after[1], ("after-region".into(), 9));
+            }
+        }
+        let rejected = process_broker_request(&processor, &mut request(code, "NewPolicyTopic", false)).await;
+        assert_eq!(ResponseCode::from(rejected.code()), ResponseCode::TopicNotExist);
+        drop(processor);
+        runtime.shutdown().await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn send_policy_snapshot_does_not_preserve_revoked_permission() {
+    let mut runtime = new_phase3_test_runtime("send-policy-permission").await;
+    let mut initial = runtime.composition.state.broker_config().as_ref().clone();
+    initial.async_topic_create_persist_enable = false;
+    runtime.composition.state.set_broker_config(initial).unwrap();
+    let (processor, _) = runtime.init_processor_checked().unwrap();
+    let coordinator = runtime.composition.state.topic_config_coordinator_handle();
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    coordinator
+        .persist_and_register_accepted(Box::new(move || {
+            Box::pin(async move {
+                let _ = entered_tx.send(());
+                let _ = release_rx.await;
+                Ok(())
+            })
+        }))
+        .await
+        .unwrap();
+    entered_rx.await.unwrap();
+    let before = runtime.composition.state.message_store().unwrap().get_max_phy_offset();
+    let request_processor = processor.clone();
+    let sending = tokio::spawn(async move {
+        process_broker_request(
+            &request_processor,
+            &mut request(RequestCode::SendMessage, "PolicyTopic", false),
+        )
+        .await
+    });
+    // The new topic's queued persistence proves that admission has accepted this
+    // request. Revoke permission while it awaits asynchronous preparation.
+    let waiting = tokio::time::timeout(Duration::from_secs(5), async {
+        while coordinator.pending_count() < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    let mut config = runtime
+        .composition
+        .state
+        .config_state
+        .broker_snapshot()
+        .as_ref()
+        .clone();
+    config.broker_permission = PermName::PERM_READ;
+    let update = runtime.composition.state.config_state.replace_broker(config);
+    let _ = release_tx.send(());
+    let response = sending.await.unwrap();
+    waiting.unwrap();
+    update.unwrap();
+    assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
+    assert_eq!(
+        runtime.composition.state.message_store().unwrap().get_max_phy_offset(),
+        before
+    );
+    let next = process_broker_request(&processor, &mut request(RequestCode::SendMessage, "PolicyTopic", false)).await;
+    assert_eq!(ResponseCode::from(next.code()), ResponseCode::NoPermission);
+    drop(processor);
+    runtime.shutdown().await;
+}

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+
+#[path = "send_policy.rs"]
+mod send_policy;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -819,7 +822,7 @@ async fn schedule_role_status_changes_only_after_final_persistence_succeeds() {
         .change_schedule_service_status(false)
         .await
         .expect_err("invalid store root should reject the final persistence transition");
-    assert!(error.to_string().contains("ScheduleMessageService"));
+    assert_eq!(error.code(), rocketmq_error::CORE_SERVICE_FAILED.code());
     assert!(runtime
         .composition
         .state
@@ -861,6 +864,7 @@ fn broker_basic_shutdown_report_exposes_required_component_names() {
             "service_tasks",
             "observability",
             "scheduled_tasks",
+            "schedule_message",
             "message_store",
             "deferred_services",
             "transaction_services",

--- a/rocketmq-doc/en/remediation/2026-09-08-p1.md
+++ b/rocketmq-doc/en/remediation/2026-09-08-p1.md
@@ -1,0 +1,76 @@
+# Storage outcomes and Broker ownership remediation
+
+This change implements W06-W11 and W15 from the September 8 remediation plan.
+
+## Storage health, recovery, and cleanup
+
+- Disk sampling distinguishes known capacity from an unavailable observation. Active CommitLog
+  storage, allocation candidates, cleanup roots, and ConsumeQueue capacity have separate decisions.
+  A healthy spare does not authorize writes to an unhealthy active segment. Capacity recovery does
+  not clear an independent flush-related write prohibition.
+- Recovery phases report their actual `Result`, mark dependent phases skipped, and retain the
+  original failure separately from safe report metadata. ConsumeQueue workers are all awaited.
+  Legacy Boolean cleanup failures remain identified as having no supplied cause.
+- Managed cleanup reports submitted retirement work. Completion and pending age come from the
+  actual reaper; namespace removal does not claim that the filesystem has released physical space.
+
+## Request and transaction ownership
+
+- Each normal, batch, reply, and send-back request retains one `SendMessagePolicy` snapshot through
+  preparation and completion. Broker permission remains a live admission and pre-append check.
+  Error responses omit an incomplete success header. Reply completion resolves lazy Store message
+  IDs before encoding the response.
+- Transaction reads preserve operational errors separately from missing data. A queue scan publishes
+  neither half nor operation checkpoints after a failed read, including a failed final diagnostic read.
+  Corrupt selected transaction records fail the read instead of silently advancing navigation.
+- Operation queues own their pending batches and resource permits. One drainer per queue prevents
+  duplicate drain; a bounded set of concurrent writes allows another queue to proceed. Cancellation
+  retains the batch, and Store body aliases retain its budget until their final release. Retrying an
+  uncertain transaction REMOVE batch is explicitly idempotent; this is not a business-message retry.
+- Schedule shutdown uses one absolute deadline across persistence, task drain, and the final write.
+  Timeout and caller cancellation retain the stopping generation and final persistence future.
+  The actual blocking writer owns the persistence lock. Restart is rejected until the old generation
+  has drained and persisted successfully. Broker shutdown retains the service and reports failure;
+  role transitions also propagate an incomplete stop.
+- Local admission uses the existing trusted Control/Data classification with count and byte reserves.
+  This protects Local entry capacity; it does not claim to reserve every resource inside the Broker.
+
+## Append execution evidence
+
+`AppendExecutionEvidence` records `NotAppended`, a finalized local message range and watermark, or
+`Unknown`. The append worker supplies these facts before legacy status projection. Flush or replica
+timeouts and post-append lease fences preserve the facts while retaining their existing status codes.
+Legacy constructors without write-stage evidence remain `Unknown`, even when their diagnostic append
+fields resemble a successful write. Canonical receipt acceptance and durability retain their previous
+meaning; replication durability still requires its own acknowledgement evidence.
+
+No request codes, persisted message layouts, or success/timeout status mappings are changed. Java
+interoperability and deployment fault exercises remain part of W18.
+
+## Validation
+
+Focused tests cover disk sampling and independent write flags; managed/unmanaged recovery failures;
+executor failure with all ConsumeQueue workers joined; actual retirement with a retained lease;
+network sends across policy updates and permission revocation; transaction checkpoint preservation;
+per-queue drain, cancellation, and final-alias budget release; blocked periodic/final Schedule writes;
+and actual CommitLog appends followed by lease changes or flush/replica timeout.
+
+Representative commands:
+
+```text
+cargo test -p rocketmq-broker --lib broker_runtime::tests::send_policy::
+cargo test -p rocketmq-broker --lib transaction::queue::
+cargo test -p rocketmq-broker --lib schedule::schedule_message_service::tests::
+cargo test -p rocketmq-broker --lib schedule_role_status_changes_only_after_final_persistence_succeeds
+cargo test -p rocketmq-broker --lib store_read::tests::
+cargo test -p rocketmq-store --lib append_execution_evidence
+cargo test -p rocketmq-store --test capability_conformance_tests
+cargo test -p rocketmq-store --test ha_semantics_tests sync_master_without_slave_ack_returns_flush_slave_timeout
+cargo test -p rocketmq-store --test commitlog_recovery_tests
+cargo test -p rocketmq-store --test mapped_file_queue_retirement
+cargo fmt -p rocketmq-broker -p rocketmq-store -p rocketmq-store-local -p rocketmq-proxy-local -- --check
+```
+
+The broader HA target also contains an existing controller-role smoke fixture that never installs
+the required controller write lease. It returns `ServiceNotAvailable` where that fixture expects
+`PutOk`; controller admission was not relaxed. The replica-timeout and skip-HA cases pass.

--- a/rocketmq-proxy-local/src/execution.rs
+++ b/rocketmq-proxy-local/src/execution.rs
@@ -675,14 +675,17 @@ mod tests {
     }
 
     fn queued(command: LocalBrokerCommand) -> QueuedLocalBrokerCommand {
-        let count = Arc::new(Semaphore::new(1));
-        let bytes = Arc::new(Semaphore::new(1));
+        let budget = rocketmq_runtime::ResourceBudgetTree::new(
+            "test",
+            rocketmq_runtime::BudgetLimit::new(1, 1, rocketmq_runtime::FullPolicy::Reject),
+        )
+        .unwrap()
+        .root();
         QueuedLocalBrokerCommand {
             command,
             enqueued_at: Instant::now(),
             control: RequestControl::new(Instant::now(), None, None, &CancellationToken::new()).unwrap(),
-            _count_permit: count.try_acquire_owned().expect("count permit"),
-            _byte_permit: bytes.try_acquire_owned().expect("byte permit"),
+            _permit: budget.try_acquire_data(1).expect("command permit"),
         }
     }
 

--- a/rocketmq-proxy-local/src/local.rs
+++ b/rocketmq-proxy-local/src/local.rs
@@ -127,6 +127,9 @@ use rocketmq_proxy_core::UpdateOffsetRequest;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_runtime::{
+    BudgetCapacity, BudgetClass, BudgetLimit, FullPolicy, ResourceBudget, ResourceBudgetTree, ResourcePermit,
+};
 use rocketmq_transport::api::EmbeddedDispatchOutcome;
 use rocketmq_transport::api::EmbeddedResponse;
 use rocketmq_transport::api::EmbeddedResponseBody;
@@ -136,8 +139,6 @@ use rocketmq_transport::api::TopicRequestHeader;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::oneshot;
-use tokio::sync::OwnedSemaphorePermit;
-use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::command_control::RequestControl;
@@ -156,8 +157,7 @@ const LOCAL_REMOTING_RESPONSE_TIMEOUT: Duration = Duration::from_secs(3);
 #[derive(Clone)]
 pub struct LocalBrokerFacadeClient {
     sender: mpsc::Sender<QueuedLocalBrokerCommand>,
-    count_budget: Arc<Semaphore>,
-    byte_budget: Arc<Semaphore>,
+    budget: ResourceBudget,
     rejected: Arc<AtomicU64>,
     broker_name: String,
     context_deadline: Option<Instant>,
@@ -168,8 +168,7 @@ pub(crate) struct QueuedLocalBrokerCommand {
     pub(crate) command: LocalBrokerCommand,
     pub(crate) enqueued_at: Instant,
     pub(crate) control: RequestControl,
-    pub(crate) _count_permit: OwnedSemaphorePermit,
-    pub(crate) _byte_permit: OwnedSemaphorePermit,
+    pub(crate) _permit: ResourcePermit,
 }
 
 pub(crate) enum LocalBrokerCommand {
@@ -384,9 +383,9 @@ fn local_queue_overloaded() -> ProxyError {
 }
 
 fn validate_local_queue_config(config: &LocalConfig) -> ProxyResult<()> {
-    if config.command_queue_capacity == 0 {
+    if config.command_queue_capacity <= config.control_reserve {
         return Err(ProxyError::Transport {
-            message: "local command queue capacity must be greater than zero".to_owned(),
+            message: "local command queue capacity must exceed control_reserve".to_owned(),
         });
     }
     if config.command_queue_max_bytes == 0 || config.command_queue_max_bytes > u32::MAX as usize {
@@ -394,6 +393,7 @@ fn validate_local_queue_config(config: &LocalConfig) -> ProxyResult<()> {
             message: "local command queue byte budget must be in 1..=u32::MAX".to_owned(),
         });
     }
+    local_control_reserve_bytes(config)?;
     if config.command_queue_max_age().is_zero() {
         return Err(ProxyError::Transport {
             message: "local command queue maximum age must be greater than zero".to_owned(),
@@ -417,6 +417,34 @@ fn validate_local_queue_config(config: &LocalConfig) -> ProxyResult<()> {
     Ok(())
 }
 
+fn local_control_reserve_bytes(config: &LocalConfig) -> ProxyResult<usize> {
+    let reserved = config
+        .command_queue_max_bytes
+        .checked_mul(config.control_reserve)
+        .and_then(|bytes| bytes.checked_div(config.command_queue_capacity))
+        .map(|bytes| bytes.max(size_of::<LocalBrokerCommand>()))
+        .filter(|bytes| *bytes < config.command_queue_max_bytes)
+        .ok_or_else(|| ProxyError::Transport {
+            message: "local command byte budget must leave room beyond the control reserve".to_owned(),
+        })?;
+    Ok(reserved)
+}
+
+fn local_command_budget(config: &LocalConfig) -> ProxyResult<ResourceBudget> {
+    let reserve = BudgetCapacity::new(config.control_reserve, local_control_reserve_bytes(config)?);
+    ResourceBudgetTree::new(
+        "proxy-local-commands",
+        BudgetLimit::new(
+            config.command_queue_capacity,
+            config.command_queue_max_bytes,
+            FullPolicy::Reject,
+        )
+        .with_control_reserve(reserve),
+    )
+    .map(|tree| tree.root())
+    .map_err(|error| canonical::configuration_invalid_with_source("proxy.local.command_budget", error).into())
+}
+
 impl LocalBrokerFacadeClient {
     pub fn new(
         config: LocalConfig,
@@ -426,22 +454,21 @@ impl LocalBrokerFacadeClient {
         validate_local_queue_config(&config)?;
         let broker_config = build_broker_config(&config);
         let (sender, receiver) = mpsc::channel(config.command_queue_capacity);
-        let count_budget = Arc::new(Semaphore::new(config.command_queue_capacity));
-        let byte_budget = Arc::new(Semaphore::new(config.command_queue_max_bytes));
+        let budget = local_command_budget(&config)?;
         let rejected = Arc::new(AtomicU64::new(0));
         let capacity_items = config.command_queue_capacity;
         let capacity_bytes = config.command_queue_max_bytes;
-        let metric_count_budget = Arc::clone(&count_budget);
-        let metric_byte_budget = Arc::clone(&byte_budget);
+        let metric_budget = budget.clone();
         let metric_rejected = Arc::clone(&rejected);
         rocketmq_observability::metrics::resource::ResourceStabilityMetrics::from_handle(
             &telemetry_handle,
             rocketmq_observability::PROXY_METER_SCOPE,
         )
         .register_queue("proxy-local", "commands", "aggregate", move || {
+            let snapshot = metric_budget.snapshot();
             rocketmq_observability::metrics::resource::ResourceQueueSnapshot {
-                items: capacity_items.saturating_sub(metric_count_budget.available_permits()) as u64,
-                bytes: capacity_bytes.saturating_sub(metric_byte_budget.available_permits()) as u64,
+                items: snapshot.current_count as u64,
+                bytes: snapshot.current_bytes as u64,
                 capacity_items: capacity_items as u64,
                 capacity_bytes: capacity_bytes as u64,
                 active: 0,
@@ -479,8 +506,7 @@ impl LocalBrokerFacadeClient {
             .map_err(|error| ProxyError::from(canonical::transport_unavailable_with_source(error)))?;
         Ok(Self {
             sender,
-            count_budget,
-            byte_budget,
+            budget,
             rejected,
             broker_name,
             context_deadline: None,
@@ -657,19 +683,21 @@ impl LocalBrokerFacadeClient {
         )?;
         control.check()?;
         let estimated_bytes = command.estimated_bytes();
-        let count_permit = Arc::clone(&self.count_budget)
-            .try_acquire_owned()
-            .map_err(|_| self.queue_overloaded())?;
-        let byte_permits = u32::try_from(estimated_bytes).map_err(|_| self.queue_overloaded())?;
-        let byte_permit = Arc::clone(&self.byte_budget)
-            .try_acquire_many_owned(byte_permits)
+        let class = match command.execution_class() {
+            crate::execution::LocalExecutionClass::Control => BudgetClass::Control,
+            crate::execution::LocalExecutionClass::ShortData | crate::execution::LocalExecutionClass::LongPoll => {
+                BudgetClass::Data
+            }
+        };
+        let permit = self
+            .budget
+            .try_acquire(estimated_bytes, class)
             .map_err(|_| self.queue_overloaded())?;
         let queued = QueuedLocalBrokerCommand {
             command,
             enqueued_at,
             control: control.clone(),
-            _count_permit: count_permit,
-            _byte_permit: byte_permit,
+            _permit: permit,
         };
         match self.sender.try_send(queued) {
             Ok(()) => {}
@@ -1138,8 +1166,7 @@ async fn drain_local_commands(
             command,
             enqueued_at: _,
             control,
-            _count_permit,
-            _byte_permit,
+            _permit,
         } = queued;
         if let Some(message) = startup_error {
             command.reject_with_transport(message.to_owned());
@@ -2787,6 +2814,15 @@ mod tests {
         }
     }
 
+    fn test_budget(count: usize, bytes: usize) -> rocketmq_runtime::ResourceBudget {
+        rocketmq_runtime::ResourceBudgetTree::new(
+            "test",
+            rocketmq_runtime::BudgetLimit::new(count, bytes, rocketmq_runtime::FullPolicy::Reject),
+        )
+        .unwrap()
+        .root()
+    }
+
     #[test]
     fn message_id_decode_failure_keeps_typed_source() {
         let error = decode_broker_message_id("not-a-message-id").expect_err("invalid message id must fail");
@@ -3153,7 +3189,7 @@ mod tests {
         let store = tempfile::tempdir().expect("create local Broker store directory");
         let config = LocalConfig {
             command_queue_capacity: 7,
-            command_queue_max_bytes: 1,
+            command_queue_max_bytes: 4096,
             broker_listen_port: available_local_broker_port(),
             store_root_dir: store.path().to_string_lossy().into_owned(),
             ..LocalConfig::default()
@@ -3163,7 +3199,7 @@ mod tests {
         assert_eq!(client.sender.max_capacity(), 7);
 
         let error = client
-            .query_route(ResourceIdentity::new("", "TopicA"))
+            .query_route(ResourceIdentity::new("", "x".repeat(4096)))
             .await
             .expect_err("request exceeding the queue byte budget must be rejected");
         assert!(matches!(
@@ -3182,8 +3218,7 @@ mod tests {
         let (sender, _receiver) = tokio::sync::mpsc::channel(1);
         let client = LocalBrokerFacadeClient {
             sender,
-            count_budget: Arc::new(tokio::sync::Semaphore::new(1)),
-            byte_budget: Arc::new(tokio::sync::Semaphore::new(4_096)),
+            budget: test_budget(1, 4096),
             rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             broker_name: "broker-a".to_owned(),
             context_deadline: None,
@@ -3215,8 +3250,7 @@ mod tests {
         let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
         let client = LocalBrokerFacadeClient {
             sender,
-            count_budget: Arc::new(tokio::sync::Semaphore::new(1)),
-            byte_budget: Arc::new(tokio::sync::Semaphore::new(4_096)),
+            budget: test_budget(1, 4096),
             rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             broker_name: "broker-a".to_owned(),
             context_deadline: None,
@@ -3266,8 +3300,7 @@ mod tests {
         let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
         let client = LocalBrokerFacadeClient {
             sender,
-            count_budget: Arc::new(tokio::sync::Semaphore::new(1)),
-            byte_budget: Arc::new(tokio::sync::Semaphore::new(4_096)),
+            budget: test_budget(1, 4096),
             rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             broker_name: "broker-a".to_owned(),
             context_deadline: None,
@@ -3315,14 +3348,7 @@ mod tests {
     #[test]
     fn local_command_queue_rejects_expired_entries() {
         let (reply, mut receiver) = tokio::sync::oneshot::channel();
-        let byte_budget = Arc::new(tokio::sync::Semaphore::new(1));
-        let permit = byte_budget
-            .try_acquire_owned()
-            .expect("test byte permit should be available");
-        let count_budget = Arc::new(tokio::sync::Semaphore::new(1));
-        let count_permit = count_budget
-            .try_acquire_owned()
-            .expect("test count permit should be available");
+        let permit = test_budget(1, 1).try_acquire_data(1).unwrap();
         let enqueued_at = Instant::now();
         let queued = super::QueuedLocalBrokerCommand {
             command: super::LocalBrokerCommand::QueryRoute {
@@ -3337,8 +3363,7 @@ mod tests {
                 &tokio_util::sync::CancellationToken::new(),
             )
             .unwrap(),
-            _count_permit: count_permit,
-            _byte_permit: permit,
+            _permit: permit,
         };
 
         assert!(queued.is_expired(enqueued_at + Duration::from_millis(11), Duration::from_millis(10)));
@@ -3400,11 +3425,10 @@ mod tests {
     #[tokio::test]
     async fn caller_drop_cancels_envelope_but_keeps_queue_budget() {
         let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
-        let count_budget = Arc::new(tokio::sync::Semaphore::new(1));
+        let budget = test_budget(1, 4096);
         let client = LocalBrokerFacadeClient {
             sender,
-            count_budget: count_budget.clone(),
-            byte_budget: Arc::new(tokio::sync::Semaphore::new(4096)),
+            budget: budget.clone(),
             rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             broker_name: "broker-a".to_owned(),
             context_deadline: None,
@@ -3416,12 +3440,12 @@ mod tests {
         drop(call);
         assert!(queued.control.cancellation.is_cancelled());
         assert_eq!(
-            count_budget.available_permits(),
-            0,
+            budget.snapshot().current_count,
+            1,
             "caller cannot release an envelope's payload budget"
         );
         drop(queued);
-        assert_eq!(count_budget.available_permits(), 1);
+        assert_eq!(budget.snapshot().current_count, 0);
     }
 
     #[tokio::test]
@@ -3429,8 +3453,7 @@ mod tests {
         let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
         let client = LocalBrokerFacadeClient {
             sender,
-            count_budget: Arc::new(tokio::sync::Semaphore::new(1)),
-            byte_budget: Arc::new(tokio::sync::Semaphore::new(4096)),
+            budget: test_budget(1, 4096),
             rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             broker_name: "broker-a".to_owned(),
             context_deadline: Some(Instant::now()),
@@ -3469,5 +3492,166 @@ mod tests {
         assert_eq!(calls.load(std::sync::atomic::Ordering::Relaxed), 1);
         assert!(results[0].status.is_ok());
         assert!(!results[1].status.is_ok());
+    }
+    #[tokio::test]
+    async fn facade_control_commands_execute_when_data_count_or_bytes_are_full() {
+        use super::*;
+        struct Handler {
+            release_data: CancellationToken,
+        }
+        impl LocalCommandHandler for Handler {
+            async fn handle(&self, command: LocalBrokerCommand, _control: RequestControl) {
+                match command {
+                    LocalBrokerCommand::QueryRoute { reply, .. } => {
+                        let _ = reply.send(Ok(TopicRouteData::default()));
+                    }
+                    LocalBrokerCommand::ProcessRemoting { request, reply, .. }
+                        if request.code() == RequestCode::AckMessage as i32 =>
+                    {
+                        let response = RemotingResponse::command(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::Success,
+                        ))
+                        .unwrap();
+                        let _ = reply.send(Ok(EmbeddedDispatchOutcome::Reply(response)));
+                    }
+                    LocalBrokerCommand::SendMessage { reply, .. } => {
+                        self.release_data.cancelled().await;
+                        let _ = reply.send(Ok(Vec::new()));
+                    }
+                    command => command.reject_unavailable(),
+                }
+            }
+        }
+        for bytes_full in [false, true] {
+            let config = LocalConfig {
+                command_queue_capacity: 5,
+                command_queue_max_bytes: 65536,
+                control_reserve: 1,
+                io_max_inflight: 2,
+                ..Default::default()
+            };
+            let budget = local_command_budget(&config).unwrap();
+            let (sender, receiver) = mpsc::channel(config.command_queue_capacity);
+            let client = LocalBrokerFacadeClient {
+                sender,
+                budget: budget.clone(),
+                rejected: Arc::new(AtomicU64::new(0)),
+                broker_name: "test".into(),
+                context_deadline: None,
+                cancellation: CancellationToken::new(),
+            };
+            let data_bytes = config.command_queue_max_bytes - local_control_reserve_bytes(&config).unwrap();
+            let count = if bytes_full {
+                1
+            } else {
+                config.command_queue_capacity - config.control_reserve
+            };
+            let mut replies = Vec::new();
+            for _ in 0..count {
+                replies.push(
+                    client
+                        .enqueue(|reply| LocalBrokerCommand::SendMessage {
+                            request: SendMessageRequest {
+                                messages: Vec::new(),
+                                timeout: None,
+                                validate_message_type: false,
+                            },
+                            client_id: None,
+                            request_id: if bytes_full {
+                                "d".repeat(data_bytes - size_of::<LocalBrokerCommand>())
+                            } else {
+                                "data".into()
+                            },
+                            reply,
+                        })
+                        .unwrap(),
+                );
+            }
+            assert!(matches!(
+                client
+                    .send_message(
+                        SendMessageRequest {
+                            messages: Vec::new(),
+                            timeout: None,
+                            validate_message_type: false
+                        },
+                        None,
+                        "extra".into()
+                    )
+                    .await,
+                Err(ProxyError::TooManyRequests { .. })
+            ));
+            let mut route = Box::pin(client.query_route(ResourceIdentity::new("", "TopicA")));
+            tokio::select! { result = &mut route => panic!("control must reach the queue: {result:?}"), () = tokio::task::yield_now() => {} }
+            if !bytes_full {
+                assert_eq!(budget.snapshot().current_count, config.command_queue_capacity);
+                assert!(matches!(
+                    client.query_route(ResourceIdentity::new("", "TopicB")).await,
+                    Err(ProxyError::TooManyRequests { .. })
+                ));
+            } else {
+                assert!(budget.snapshot().current_bytes > data_bytes);
+                assert!(budget.snapshot().current_bytes <= config.command_queue_max_bytes);
+            }
+            let runtime = rocketmq_runtime::RuntimeContext::try_from_current("local-control-reserve-test").unwrap();
+            let service = runtime.service_context("local-control-reserve-test.service");
+            let release = CancellationToken::new();
+            let stopping = CancellationToken::new();
+            let run = run_local_execution(
+                LocalExecutionPolicy::from_config(&config),
+                receiver,
+                stopping.clone(),
+                service.clone(),
+                service.component("lanes"),
+                Arc::new(Handler {
+                    release_data: release.clone(),
+                }),
+                Duration::from_secs(1),
+            );
+            let observe = async {
+                route.as_mut().await.unwrap();
+                assert!(matches!(
+                    client
+                        .process_remoting(RemotingCommand::create_remoting_command(RequestCode::AckMessage))
+                        .await
+                        .unwrap(),
+                    EmbeddedDispatchOutcome::Reply(_)
+                ));
+                assert_eq!(
+                    budget.snapshot().current_count,
+                    count,
+                    "data owners remain charged after control completes"
+                );
+                release.cancel();
+                for (reply, _control) in replies {
+                    reply.await.unwrap().unwrap();
+                }
+                stopping.cancel();
+            };
+            tokio::join!(run, observe);
+            assert_eq!(budget.snapshot().current_count, 0);
+            assert_eq!(budget.snapshot().current_bytes, 0);
+            assert!(service.task_group().shutdown(Duration::from_secs(1)).await.is_healthy());
+        }
+    }
+
+    #[test]
+    fn local_reserve_rejects_configs_without_data_capacity() {
+        for config in [
+            LocalConfig {
+                command_queue_capacity: 2,
+                ..Default::default()
+            },
+            LocalConfig {
+                command_queue_max_bytes: size_of::<super::LocalBrokerCommand>(),
+                ..Default::default()
+            },
+            LocalConfig {
+                command_queue_max_bytes: usize::MAX,
+                ..Default::default()
+            },
+        ] {
+            assert!(validate_local_queue_config(&config).is_err());
+        }
     }
 }

--- a/rocketmq-store-local/src/message_store/cleanup.rs
+++ b/rocketmq-store-local/src/message_store/cleanup.rs
@@ -25,6 +25,7 @@ pub struct DiskCleanDecision {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DiskUsageState {
+    Unknown,
     Warning,
     Forcible,
     Reclaim,
@@ -58,11 +59,13 @@ impl CleanupPolicy {
     }
 
     pub fn classify(self, ratio: f64) -> DiskUsageState {
-        if ratio > self.disk_warning_ratio() {
+        if !ratio.is_finite() || !(0.0..=1.0).contains(&ratio) {
+            DiskUsageState::Unknown
+        } else if ratio > self.disk_warning_ratio() {
             DiskUsageState::Warning
         } else if ratio > self.disk_clean_forcibly_ratio() {
             DiskUsageState::Forcible
-        } else if ratio < 0.0 || ratio > self.disk_max_used_ratio() {
+        } else if ratio > self.disk_max_used_ratio() {
             DiskUsageState::Reclaim
         } else {
             DiskUsageState::Healthy
@@ -81,7 +84,9 @@ impl CleanupPolicy {
             };
         }
 
-        if physic == DiskUsageState::Reclaim || logic == DiskUsageState::Reclaim {
+        if matches!(physic, DiskUsageState::Reclaim | DiskUsageState::Unknown)
+            || matches!(logic, DiskUsageState::Reclaim | DiskUsageState::Unknown)
+        {
             return DiskCleanDecision {
                 should_delete: true,
                 clean_immediately: false,
@@ -133,6 +138,16 @@ mod tests {
             disk_max_used_ratio: 0.75,
             clean_file_forcibly_enabled: true,
         })
+    }
+
+    #[test]
+    fn invalid_capacity_samples_are_unknown() {
+        for ratio in [-1.0, f64::NAN, f64::INFINITY, 1.01] {
+            assert_eq!(policy().classify(ratio), DiskUsageState::Unknown);
+            let decision = policy().decide(ratio, 0.1);
+            assert!(decision.should_delete);
+            assert!(!decision.clean_immediately);
+        }
     }
 
     #[test]

--- a/rocketmq-store/src/base/message_result.rs
+++ b/rocketmq-store/src/base/message_result.rs
@@ -16,11 +16,29 @@ use crate::base::message_status_enum::PutMessageStatus;
 
 pub use rocketmq_store_local::commit_log::append::AppendMessageResult;
 
+/// Physical append facts, independent of response eligibility and durability.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum AppendExecutionEvidence {
+    /// The request was rejected before any message append could occur.
+    NotAppended,
+    /// The append worker finalized this message range in the local primary log.
+    Appended {
+        /// Exclusive range occupied by the finalized message or batch.
+        range: std::ops::Range<i64>,
+        /// Exclusive local append watermark observed by that worker.
+        local_watermark: i64,
+    },
+    /// The producer supplied no execution evidence, or completion is uncertain.
+    #[default]
+    Unknown,
+}
+
 #[derive(Default, Clone)]
 pub struct PutMessageResult {
     put_message_status: PutMessageStatus,
     append_message_result: Option<AppendMessageResult>,
     remote_put: bool,
+    execution_evidence: AppendExecutionEvidence,
 }
 
 impl PutMessageResult {
@@ -34,6 +52,7 @@ impl PutMessageResult {
             put_message_status,
             append_message_result,
             remote_put,
+            execution_evidence: AppendExecutionEvidence::Unknown,
         }
     }
 
@@ -46,6 +65,7 @@ impl PutMessageResult {
             put_message_status,
             append_message_result,
             remote_put: false,
+            execution_evidence: AppendExecutionEvidence::Unknown,
         }
     }
 
@@ -55,12 +75,27 @@ impl PutMessageResult {
             put_message_status,
             append_message_result: None,
             remote_put: false,
+            execution_evidence: AppendExecutionEvidence::Unknown,
         }
     }
 
     #[inline]
     pub fn put_message_status(&self) -> PutMessageStatus {
         self.put_message_status
+    }
+
+    pub(crate) fn rejected_before_append(status: PutMessageStatus) -> Self {
+        Self::new_default(status).with_execution_evidence(AppendExecutionEvidence::NotAppended)
+    }
+
+    pub(crate) fn with_execution_evidence(mut self, evidence: AppendExecutionEvidence) -> Self {
+        self.execution_evidence = evidence;
+        self
+    }
+
+    /// Returns write-stage evidence without interpreting the final response status.
+    pub const fn execution_evidence(&self) -> &AppendExecutionEvidence {
+        &self.execution_evidence
     }
 
     #[inline]

--- a/rocketmq-store/src/capability.rs
+++ b/rocketmq-store/src/capability.rs
@@ -744,9 +744,18 @@ pub struct StoreAppendReceipt {
     canonical: Result<AppendReceipt, StoreContractViolation>,
     appended_watermark: i64,
     durable_watermark: i64,
+    execution_evidence: crate::base::message_result::AppendExecutionEvidence,
 }
 
 impl StoreAppendReceipt {
+    /// Returns physical append evidence supplied by the write stage.
+    ///
+    /// An `Appended` result can accompany a rejected canonical receipt after a
+    /// lease fence or durability timeout. It does not authorize a success reply.
+    pub const fn execution_evidence(&self) -> &crate::base::message_result::AppendExecutionEvidence {
+        &self.execution_evidence
+    }
+
     /// Returns the backend append result.
     pub const fn result(&self) -> &PutMessageResult {
         &self.result
@@ -793,6 +802,7 @@ pub fn store_append_receipt(
         AppendReceipt::try_rejected(status, appended_watermark, durable_watermark)
     };
     StoreAppendReceipt {
+        execution_evidence: result.execution_evidence().clone(),
         result,
         canonical,
         appended_watermark,

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -672,20 +672,47 @@ where
         .then_some(mapped_file)
 }
 
-/// Narrow, cloneable capability used by background commit-log cleanup.
-///
-/// The capability owns only the atomically published mapped-file generation.
-/// It deliberately excludes the queue's allocation and runtime state so a
-/// scheduled cleanup task never needs shared access to the composition-root-owned
-/// `MappedFileQueue` facade.
+/// Submission and namespace completion are distinct cleanup outcomes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CleanupOutcome {
+    ManagedSubmitted { selected: usize, submitted: i32 },
+    LegacyCompleted { namespace_removed: i32 },
+}
+
+impl CleanupOutcome {
+    // Compatibility only: managed counts mean accepted tickets, never physical deletion.
+    fn compatibility_count(self) -> i32 {
+        match self {
+            Self::ManagedSubmitted { submitted, .. } => submitted,
+            Self::LegacyCompleted { namespace_removed } => namespace_removed,
+        }
+    }
+}
+
+/// Narrow capability for cleanup and read-only allocation eligibility probes.
 #[derive(Clone)]
 pub(crate) struct MappedFileQueueCleanupHandle {
+    commit_log_paths: Option<Arc<CommitLogPathSet>>,
     mapped_files: MappedFileGeneration,
     mapped_file_size: u64,
     runtime_state: MappedFileQueueRuntimeState,
 }
 
 impl MappedFileQueueCleanupHandle {
+    pub(crate) fn active_root(&self) -> Option<std::path::PathBuf> {
+        let files = self.mapped_files.snapshot();
+        let file = files.last().filter(|file| !file.is_full())?;
+        Path::new(file.get_file_name().as_str()).parent().map(Path::to_path_buf)
+    }
+
+    pub(crate) fn allocation_candidates(&self) -> Vec<std::path::PathBuf> {
+        // Reuse allocation eligibility; never treat a readonly/retired root as a spare.
+        self.commit_log_paths
+            .as_ref()
+            .and_then(|paths| paths.creation_candidates(StoreFaultPoint::CreateSegment).ok())
+            .unwrap_or_default()
+    }
+
     fn check_self(&self) {
         let mapped_files = self.mapped_files.snapshot();
         for_each_discontinuous_pair(
@@ -723,7 +750,7 @@ impl MappedFileQueueCleanupHandle {
         clean_immediately: bool,
         delete_file_batch_max: i32,
         pinned_file_offset: Option<u64>,
-    ) -> i32 {
+    ) -> CleanupOutcome {
         let _maintenance_guard = self.runtime_state.commit_lock().lock();
         let files = self.mapped_files.snapshot();
         self.check_self();
@@ -736,7 +763,10 @@ impl MappedFileQueueCleanupHandle {
                 pinned_file_offset,
                 || i64::try_from(current_millis()).unwrap_or(i64::MAX),
             );
-            return submit_managed_retirements(&runtime, &generation, candidates, ManagedRetirementReason::TtlExpired);
+            let selected = candidates.len();
+            let submitted =
+                submit_managed_retirements(&runtime, &generation, candidates, ManagedRetirementReason::TtlExpired);
+            return CleanupOutcome::ManagedSubmitted { selected, submitted };
         }
         let deletion = delete_expired_mapped_files_by_time_before(
             files.as_ref(),
@@ -748,7 +778,9 @@ impl MappedFileQueueCleanupHandle {
             pinned_file_offset,
             || i64::try_from(current_millis()).unwrap_or(i64::MAX),
         );
-        self.mapped_files.apply_legacy_namespace_removal(deletion)
+        CleanupOutcome::LegacyCompleted {
+            namespace_removed: self.mapped_files.apply_legacy_namespace_removal(deletion),
+        }
     }
 
     pub(crate) fn retry_delete_first_file(&self, interval_forcibly: i64) -> bool {
@@ -1172,6 +1204,7 @@ impl MappedFileQueue {
     #[inline]
     pub(crate) fn cleanup_handle(&self) -> MappedFileQueueCleanupHandle {
         MappedFileQueueCleanupHandle {
+            commit_log_paths: self.commit_log_paths.clone(),
             mapped_files: self.storage.mapped_files().clone(),
             mapped_file_size: self.storage.mapped_file_size(),
             runtime_state: self.runtime_state.clone(),
@@ -1404,7 +1437,8 @@ impl MappedFileQueue {
     /// * `delete_file_batch_max` - Maximum files to delete in one batch
     ///
     /// # Returns
-    /// Number of files deleted
+    /// Legacy namespace removals, or accepted retirement tickets in managed mode.
+    /// Neither count measures physical space released.
     pub fn delete_expired_file_by_time(
         &self,
         expired_time: i64,
@@ -1432,14 +1466,16 @@ impl MappedFileQueue {
         delete_file_batch_max: i32,
         pinned_file_offset: Option<u64>,
     ) -> i32 {
-        self.cleanup_handle().delete_expired_files_by_time_before(
-            expired_time,
-            delete_files_interval,
-            interval_forcibly,
-            clean_immediately,
-            delete_file_batch_max,
-            pinned_file_offset,
-        )
+        self.cleanup_handle()
+            .delete_expired_files_by_time_before(
+                expired_time,
+                delete_files_interval,
+                interval_forcibly,
+                clean_immediately,
+                delete_file_batch_max,
+                pinned_file_offset,
+            )
+            .compatibility_count()
     }
 
     /// Delete expired files by offset

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -211,6 +211,22 @@ fn log_abnormal_recovery_window(
     );
 }
 
+fn commitlog_recovery_failure(detail: &'static str) -> StoreError {
+    StoreError::new(&rocketmq_error::STORAGE_INTERNAL_FAILURE, StoreOperation::Load)
+        .in_component(StoreComponent::CommitLog)
+        .with_detail(detail)
+}
+
+fn commitlog_recovery_completion_result(completed: bool) -> Result<(), StoreError> {
+    if completed {
+        Ok(())
+    } else {
+        Err(commitlog_recovery_failure(
+            "destructive recovery completion is pending; legacy cleanup supplied no underlying cause",
+        ))
+    }
+}
+
 macro_rules! apply_recovery_completion {
     ($commit_log:ident, $completion:expr, $max_consume_queue_offset:expr $(,)?) => {{
         match $completion {
@@ -373,6 +389,8 @@ macro_rules! lock_active_mapped_file_parts {
 
 pub struct CommitLog {
     root: CommitLogRoot<CommitLogAdapter>,
+    #[cfg(test)]
+    after_append: parking_lot::Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
 mod adapter {
@@ -529,6 +547,8 @@ impl CommitLog {
                 .with_source(error)
         })?;
         Ok(Self {
+            #[cfg(test)]
+            after_append: parking_lot::Mutex::new(None),
             root: CommitLogRoot::new(CommitLogAdapter {
                 mapped_file_queue,
                 message_store_config: message_store_config.clone(),
@@ -1096,14 +1116,16 @@ impl CommitLog {
 
         let ha_service = self.store_context.ha_service().ok_or_else(|| {
             error!("HA Service is None");
-            PutMessageResult::new_default(PutMessageStatus::UnknownError)
+            PutMessageResult::rejected_before_append(PutMessageStatus::UnknownError)
         })?;
 
         if self.broker_config.enable_controller_mode {
             if ha_service.in_sync_replicas_nums(curr_offset as i64)
                 < self.message_store_config.min_in_sync_replicas as i32
             {
-                return Err(PutMessageResult::new_default(PutMessageStatus::InSyncReplicasNotEnough));
+                return Err(PutMessageResult::rejected_before_append(
+                    PutMessageStatus::InSyncReplicasNotEnough,
+                ));
             }
             if self.message_store_config.all_ack_in_sync_state_set {
                 need_ack_nums = mix_all::ALL_ACK_IN_SYNC_STATE_SET;
@@ -1116,7 +1138,9 @@ impl CommitLog {
                 .min(ha_service.in_sync_replicas_nums(curr_offset as i64));
             need_ack_nums = self.calc_need_ack_nums(in_sync_replicas);
             if need_ack_nums > in_sync_replicas {
-                return Err(PutMessageResult::new_default(PutMessageStatus::InSyncReplicasNotEnough));
+                return Err(PutMessageResult::rejected_before_append(
+                    PutMessageStatus::InSyncReplicasNotEnough,
+                ));
             }
             if self.message_store_config.all_ack_in_sync_state_set {
                 need_ack_nums = mix_all::ALL_ACK_IN_SYNC_STATE_SET;
@@ -1139,7 +1163,7 @@ impl CommitLog {
         let append_span = rocketmq_observability::trace::store::append_span(&self.telemetry_handle);
         let requested_lease = match self.store_context.controller_write_lease.capture() {
             Ok(lease) => lease,
-            Err(()) => return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable),
+            Err(()) => return PutMessageResult::rejected_before_append(PutMessageStatus::ServiceNotAvailable),
         };
         #[cfg(any(feature = "observability", feature = "observability-traces"))]
         rocketmq_observability::trace::record_message_properties_with_handle(
@@ -1150,7 +1174,7 @@ impl CommitLog {
         );
         let tran_type = MessageSysFlag::get_transaction_value(msg_batch.message_ext_broker_inner.sys_flag());
         if MessageSysFlag::TRANSACTION_NOT_TYPE != tran_type {
-            return PutMessageResult::new_default(PutMessageStatus::MessageIllegal);
+            return PutMessageResult::rejected_before_append(PutMessageStatus::MessageIllegal);
         }
         if msg_batch
             .message_ext_broker_inner
@@ -1159,7 +1183,7 @@ impl CommitLog {
             .delay_time_level()
             > 0
         {
-            return PutMessageResult::new_default(PutMessageStatus::MessageIllegal);
+            return PutMessageResult::rejected_before_append(PutMessageStatus::MessageIllegal);
         }
 
         //setting ip type:IPV4 OR IPV6, default is ipv4
@@ -1177,7 +1201,7 @@ impl CommitLog {
         let need_handle_ha = self.need_handle_ha(&msg_batch.message_ext_broker_inner);
         let need_ack_nums = match self.handle_ha_service(curr_offset, need_handle_ha) {
             Ok(ack_nums) => ack_nums,
-            Err(result) => return result,
+            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
         };
         msg_batch.message_ext_broker_inner.version = MessageVersion::V1;
         let auto_message_version_on_topic_len = self.message_store_config.auto_message_version_on_topic_len;
@@ -1191,7 +1215,7 @@ impl CommitLog {
             &self.message_store_config,
         ) {
             Ok(prepared) => prepared,
-            Err(result) => return result,
+            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
         };
         let sequenced = self
             .append_runtime
@@ -1216,7 +1240,7 @@ impl CommitLog {
         let append_span = rocketmq_observability::trace::store::append_span(&self.telemetry_handle);
         let requested_lease = match self.store_context.controller_write_lease.capture() {
             Ok(lease) => lease,
-            Err(()) => return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable),
+            Err(()) => return PutMessageResult::rejected_before_append(PutMessageStatus::ServiceNotAvailable),
         };
         #[cfg(any(feature = "observability", feature = "observability-traces"))]
         rocketmq_observability::trace::record_message_properties_with_handle(
@@ -1257,7 +1281,7 @@ impl CommitLog {
         let need_handle_ha = self.need_handle_ha(&msg);
         let need_ack_nums = match self.handle_ha_service(curr_offset, need_handle_ha) {
             Ok(ack_nums) => ack_nums,
-            Err(result) => return result,
+            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
         };
 
         let need_assign_offset = !(self.message_store_config.duplication_enable
@@ -1265,7 +1289,7 @@ impl CommitLog {
 
         let prepared = match message_encoder_pool::prepare_message_with_pool(&msg, &self.message_store_config) {
             Ok(prepared) => prepared,
-            Err(result) => return result,
+            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
         };
         let sequenced = self
             .append_runtime
@@ -1321,6 +1345,13 @@ impl CommitLog {
         need_handle_ha: bool,
         requested_lease: Option<WriteLeaseToken>,
     ) -> PutMessageResult {
+        #[cfg(test)]
+        {
+            let after_append = self.after_append.lock().take();
+            if let Some(after_append) = after_append {
+                after_append();
+            }
+        }
         let append_message_result = put_message_result.append_message_result().unwrap();
 
         // Use efficient branching based on actual requirements
@@ -1470,6 +1501,15 @@ impl CommitLog {
     /// Runs optimized normal recovery and reports whether destructive completion succeeded.
     #[must_use]
     pub async fn try_recover_normally_optimized(&mut self, max_phy_offset_of_consume_queue: i64) -> bool {
+        self.recover_normally_optimized_result(max_phy_offset_of_consume_queue)
+            .await
+            .is_ok()
+    }
+
+    pub(crate) async fn recover_normally_optimized_result(
+        &mut self,
+        max_phy_offset_of_consume_queue: i64,
+    ) -> Result<(), StoreError> {
         use crate::log_file::commit_log_recovery::BatchMessageIterator;
         use crate::log_file::commit_log_recovery::RecoveryContext;
 
@@ -1482,11 +1522,11 @@ impl CommitLog {
 
         if mapped_files_inner.is_empty() {
             warn!("The commitlog files are deleted, and delete the consume queue files");
-            return apply_recovery_completion!(
+            return commitlog_recovery_completion_result(apply_recovery_completion!(
                 self,
                 CommitLogRecoveryCompletion::Empty,
                 max_phy_offset_of_consume_queue,
-            );
+            ));
         }
 
         let recovery_window = plan_normal_recovery_file_window(
@@ -1504,14 +1544,14 @@ impl CommitLog {
             Ok(offset) => offset,
             Err(error) => {
                 warn!("normal optimized recovery initial offset conversion failed: {error}");
-                return false;
+                return Err(commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error));
             }
         };
         let mut normal_recovery = match NormalRecoveryState::try_new(initial_offset, NormalRecoveryPolicy::Optimized) {
             Some(state) => state,
             None => {
                 warn!("normal optimized recovery initial state rejected its offset");
-                return false;
+                return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
             }
         };
         let do_dispatch = false;
@@ -1598,29 +1638,37 @@ impl CommitLog {
                     NormalRecoveryAdapterViolation::RelativeOffsetConversion(error),
                 ) => {
                     warn!("normal optimized recovery relative offset conversion failed: {error}");
-                    break 'segments;
+                    return Err(
+                        commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                    );
                 }
                 NormalRecoverySegmentOutcome::AdapterFailed(NormalRecoveryAdapterViolation::MessageSizeConversion(
                     error,
                 )) => {
                     warn!("normal optimized recovery message size conversion failed: {error}");
-                    break 'segments;
+                    return Err(
+                        commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                    );
                 }
                 NormalRecoverySegmentOutcome::AdapterFailed(
                     NormalRecoveryAdapterViolation::FramePositionOverflow { position, size },
                 ) => {
                     warn!("normal optimized recovery frame position overflow at {position} with size {size}");
-                    break 'segments;
+                    return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                 }
                 NormalRecoverySegmentOutcome::StateFailed => {
                     warn!("normal optimized recovery offset state failed");
-                    break 'segments;
+                    return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                 }
             }
         }
 
         let completion = normal_recovery.completion(max_phy_offset_of_consume_queue);
-        let recovery_succeeded = apply_recovery_completion!(self, completion, max_phy_offset_of_consume_queue);
+        let recovery_succeeded = commitlog_recovery_completion_result(apply_recovery_completion!(
+            self,
+            completion,
+            max_phy_offset_of_consume_queue
+        ));
 
         recovery_ctx.stats.recovery_time_ms = start.elapsed().as_millis();
         recovery_ctx.stats.log_summary("Normal");
@@ -1636,6 +1684,15 @@ impl CommitLog {
     /// Runs compatibility normal recovery and reports whether destructive completion succeeded.
     #[must_use]
     pub async fn try_recover_normally(&mut self, max_phy_offset_of_consume_queue: i64) -> bool {
+        self.recover_normally_result(max_phy_offset_of_consume_queue)
+            .await
+            .is_ok()
+    }
+
+    pub(crate) async fn recover_normally_result(
+        &mut self,
+        max_phy_offset_of_consume_queue: i64,
+    ) -> Result<(), StoreError> {
         let check_crc_on_recover = self.message_store_config.check_crc_on_recover;
         let check_dup_info = self.message_store_config.duplication_enable;
         let message_store_config = self.message_store_config.clone();
@@ -1657,7 +1714,9 @@ impl CommitLog {
                 Ok(offset) => offset,
                 Err(error) => {
                     warn!("normal recovery initial offset conversion failed: {error}");
-                    return false;
+                    return Err(
+                        commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                    );
                 }
             };
             let mut normal_recovery = match NormalRecoveryState::try_new(initial_offset, NormalRecoveryPolicy::Standard)
@@ -1665,7 +1724,7 @@ impl CommitLog {
                 Some(state) => state,
                 None => {
                     warn!("normal recovery initial state rejected its offset");
-                    return false;
+                    return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                 }
             };
             let do_dispatch = false;
@@ -1765,39 +1824,47 @@ impl CommitLog {
                         NormalRecoveryAdapterViolation::FramePositionOverflow { position, size },
                     ) => {
                         warn!("normal recovery frame position overflow at {position} with size {size}");
-                        break 'segments;
+                        return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                     }
                     NormalRecoverySegmentOutcome::AdapterFailed(
                         NormalRecoveryAdapterViolation::RelativeOffsetConversion(error),
                     ) => {
                         warn!("normal recovery relative offset conversion failed: {error}");
-                        break 'segments;
+                        return Err(
+                            commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                        );
                     }
                     NormalRecoverySegmentOutcome::AdapterFailed(
                         NormalRecoveryAdapterViolation::MessageSizeConversion(error),
                     ) => {
                         warn!("normal recovery message size conversion failed: {error}");
-                        break 'segments;
+                        return Err(
+                            commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                        );
                     }
                     NormalRecoverySegmentOutcome::StateFailed => {
                         warn!("normal recovery offset state failed");
-                        break 'segments;
+                        return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                     }
                 }
             }
 
             let completion = normal_recovery.completion(max_phy_offset_of_consume_queue);
-            apply_recovery_completion!(self, completion, max_phy_offset_of_consume_queue)
+            commitlog_recovery_completion_result(apply_recovery_completion!(
+                self,
+                completion,
+                max_phy_offset_of_consume_queue
+            ))
         } else {
             warn!(
                 "The commitlog files are deleted, and delete the consume queue
                                         files"
             );
-            apply_recovery_completion!(
+            commitlog_recovery_completion_result(apply_recovery_completion!(
                 self,
                 CommitLogRecoveryCompletion::Empty,
                 max_phy_offset_of_consume_queue,
-            )
+            ))
         }
     }
 
@@ -1851,6 +1918,15 @@ impl CommitLog {
     /// Runs optimized abnormal recovery and reports whether destructive completion succeeded.
     #[must_use]
     pub async fn try_recover_abnormally_optimized(&mut self, max_phy_offset_of_consume_queue: i64) -> bool {
+        self.recover_abnormally_optimized_result(max_phy_offset_of_consume_queue)
+            .await
+            .is_ok()
+    }
+
+    pub(crate) async fn recover_abnormally_optimized_result(
+        &mut self,
+        max_phy_offset_of_consume_queue: i64,
+    ) -> Result<(), StoreError> {
         use crate::log_file::commit_log_recovery::plan_abnormal_recovery_window;
         use crate::log_file::commit_log_recovery::BatchMessageIterator;
         use crate::log_file::commit_log_recovery::RecoveryContext;
@@ -1865,11 +1941,11 @@ impl CommitLog {
 
         if mapped_files_inner.is_empty() {
             warn!("The commitlog files are deleted, and delete the consume queue files");
-            return apply_recovery_completion!(
+            return commitlog_recovery_completion_result(apply_recovery_completion!(
                 self,
                 CommitLogRecoveryCompletion::Empty,
                 max_phy_offset_of_consume_queue,
-            );
+            ));
         }
 
         let recovery_window = plan_abnormal_recovery_window(
@@ -1886,7 +1962,7 @@ impl CommitLog {
         let mut index = recovery_window.start_index;
         let Some(first_recovery_file) = mapped_files_inner.get(index) else {
             warn!("optimized abnormal recovery window starts outside mapped files: {index}");
-            return false;
+            return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
         };
         let initial_offset = if index == 0 {
             first_recovery_file.get_file_from_offset()
@@ -1898,7 +1974,7 @@ impl CommitLog {
                 Some(state) => state,
                 None => {
                     warn!("optimized abnormal recovery initial state rejected its offset");
-                    return false;
+                    return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                 }
             };
         let do_dispatch = true;
@@ -2008,45 +2084,55 @@ impl CommitLog {
                 AbnormalRecoverySegmentOutcome::StopRecovery => break 'segments,
                 AbnormalRecoverySegmentOutcome::AdapterFailed(AbnormalRecoveryAdapterViolation::ConfirmCandidate) => {
                     warn!("optimized abnormal recovery confirm candidate failed");
-                    break 'segments;
+                    return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                 }
                 AbnormalRecoverySegmentOutcome::AdapterFailed(
                     AbnormalRecoveryAdapterViolation::ConfirmLimitConversion(error),
                 ) => {
                     warn!("optimized abnormal recovery confirm limit conversion failed: {error}");
-                    break 'segments;
+                    return Err(
+                        commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                    );
                 }
                 AbnormalRecoverySegmentOutcome::AdapterFailed(
                     AbnormalRecoveryAdapterViolation::RelativeOffsetConversion(error),
                 ) => {
                     warn!("optimized abnormal recovery relative offset conversion failed: {error}");
-                    break 'segments;
+                    return Err(
+                        commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                    );
                 }
                 AbnormalRecoverySegmentOutcome::AdapterFailed(
                     AbnormalRecoveryAdapterViolation::ValidatedSizeConversion(error),
                 ) => {
                     warn!("optimized abnormal recovery validated size conversion failed: {error}");
-                    break 'segments;
+                    return Err(
+                        commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                    );
                 }
                 AbnormalRecoverySegmentOutcome::AdapterFailed(
                     AbnormalRecoveryAdapterViolation::FramePositionOverflow { position, size },
                 ) => {
                     warn!("optimized abnormal recovery frame position overflow at {position} with size {size}");
-                    break 'segments;
+                    return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                 }
                 AbnormalRecoverySegmentOutcome::StateFailed => {
                     warn!("optimized abnormal recovery offset state failed");
-                    break 'segments;
+                    return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                 }
                 AbnormalRecoverySegmentOutcome::UnexpectedAction(action) => {
                     warn!("optimized abnormal recovery unexpected action: {action:?}");
-                    break 'segments;
+                    return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                 }
             }
         }
 
         let completion = abnormal_recovery.completion(max_phy_offset_of_consume_queue);
-        let recovery_succeeded = apply_recovery_completion!(self, completion, max_phy_offset_of_consume_queue);
+        let recovery_succeeded = commitlog_recovery_completion_result(apply_recovery_completion!(
+            self,
+            completion,
+            max_phy_offset_of_consume_queue
+        ));
 
         recovery_ctx.stats.recovery_time_ms = start.elapsed().as_millis();
         recovery_ctx.stats.log_summary("Abnormal");
@@ -2062,6 +2148,15 @@ impl CommitLog {
     /// Runs compatibility abnormal recovery and reports whether destructive completion succeeded.
     #[must_use]
     pub async fn try_recover_abnormally(&mut self, max_phy_offset_of_consume_queue: i64) -> bool {
+        self.recover_abnormally_result(max_phy_offset_of_consume_queue)
+            .await
+            .is_ok()
+    }
+
+    pub(crate) async fn recover_abnormally_result(
+        &mut self,
+        max_phy_offset_of_consume_queue: i64,
+    ) -> Result<(), StoreError> {
         use crate::log_file::commit_log_recovery::plan_abnormal_recovery_window;
 
         let check_crc_on_recover = self.message_store_config.check_crc_on_recover;
@@ -2085,7 +2180,7 @@ impl CommitLog {
             let mut index = recovery_window.start_index;
             let Some(first_recovery_file) = mapped_files_inner.get(index) else {
                 warn!("standard abnormal recovery window starts outside mapped files: {index}");
-                return false;
+                return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
             };
             let initial_offset = first_recovery_file.get_file_from_offset();
             let mut abnormal_recovery =
@@ -2093,7 +2188,7 @@ impl CommitLog {
                     Some(state) => state,
                     None => {
                         warn!("standard abnormal recovery initial state rejected its offset");
-                        return false;
+                        return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                     }
                 };
             let do_dispatch = true;
@@ -2209,55 +2304,65 @@ impl CommitLog {
                         AbnormalRecoveryAdapterViolation::ConfirmCandidate,
                     ) => {
                         warn!("standard abnormal recovery confirm candidate failed");
-                        break 'segments;
+                        return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                     }
                     AbnormalRecoverySegmentOutcome::AdapterFailed(
                         AbnormalRecoveryAdapterViolation::ConfirmLimitConversion(error),
                     ) => {
                         warn!("standard abnormal recovery confirm limit conversion failed: {error}");
-                        break 'segments;
+                        return Err(
+                            commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                        );
                     }
                     AbnormalRecoverySegmentOutcome::AdapterFailed(
                         AbnormalRecoveryAdapterViolation::FramePositionOverflow { position, size },
                     ) => {
                         warn!("standard abnormal recovery frame position overflow at {position} with size {size}");
-                        break 'segments;
+                        return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                     }
                     AbnormalRecoverySegmentOutcome::AdapterFailed(
                         AbnormalRecoveryAdapterViolation::RelativeOffsetConversion(error),
                     ) => {
                         warn!("standard abnormal recovery relative offset conversion failed: {error}");
-                        break 'segments;
+                        return Err(
+                            commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                        );
                     }
                     AbnormalRecoverySegmentOutcome::AdapterFailed(
                         AbnormalRecoveryAdapterViolation::ValidatedSizeConversion(error),
                     ) => {
                         warn!("standard abnormal recovery validated size conversion failed: {error}");
-                        break 'segments;
+                        return Err(
+                            commitlog_recovery_failure("recovery offset or adapter state failed").with_source(error)
+                        );
                     }
                     AbnormalRecoverySegmentOutcome::StateFailed => {
                         warn!("standard abnormal recovery offset state failed");
-                        break 'segments;
+                        return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                     }
                     AbnormalRecoverySegmentOutcome::UnexpectedAction(action) => {
                         warn!("standard abnormal recovery unexpected action: {action:?}");
-                        break 'segments;
+                        return Err(commitlog_recovery_failure("recovery offset or adapter state failed"));
                     }
                 }
             }
 
             let completion = abnormal_recovery.completion(max_phy_offset_of_consume_queue);
-            apply_recovery_completion!(self, completion, max_phy_offset_of_consume_queue)
+            commitlog_recovery_completion_result(apply_recovery_completion!(
+                self,
+                completion,
+                max_phy_offset_of_consume_queue
+            ))
         } else {
             warn!(
                 "The commitlog files are deleted, and delete the consume queue
                                         files"
             );
-            apply_recovery_completion!(
+            commitlog_recovery_completion_result(apply_recovery_completion!(
                 self,
                 CommitLogRecoveryCompletion::Empty,
                 max_phy_offset_of_consume_queue,
-            )
+            ))
         }
     }
 
@@ -3105,6 +3210,153 @@ mod tests {
         assert_eq!(accepted.put_message_status(), PutMessageStatus::PutOk);
 
         let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn append_execution_evidence_survives_post_append_lease_fence_and_renewal() {
+        for batch in [false, true] {
+            for replace_lease in [false, true] {
+                let directory = tempfile::TempDir::new().unwrap();
+                let mut store = new_test_message_store_with_config(
+                    directory.path(),
+                    MessageStoreConfig {
+                        mapped_file_size_commit_log: 4096,
+                        ha_listen_port: 0,
+                        ..Default::default()
+                    },
+                    BrokerRole::AsyncMaster,
+                    false,
+                );
+                store.init().await.unwrap();
+                let log = store.get_commit_log();
+                let before = log.get_max_offset();
+                let denied = log.put_message(append_test_message("evidence-topic", b"denied")).await;
+                let denied = crate::store_append_receipt(denied, log.get_max_offset(), log.get_flushed_where());
+                assert_eq!(
+                    denied.execution_evidence(),
+                    &crate::AppendExecutionEvidence::NotAppended
+                );
+                assert_eq!(log.get_max_offset(), before);
+                assert!(!denied.canonical().unwrap().is_accepted());
+
+                let authority = WriteAuthority::try_new(0, MasterEpoch::try_from(1).unwrap()).unwrap();
+                let token = WriteLeaseToken::try_new(authority, 1).unwrap();
+                let next_token = WriteLeaseToken::try_new(authority, 2).unwrap();
+                assert!(log.install_controller_write_lease(token, Duration::from_secs(60)));
+                let lease = log.controller_write_lease_state();
+                *log.after_append.lock() = Some(Box::new(move || {
+                    if replace_lease {
+                        assert!(lease.install(next_token, Duration::from_secs(60)));
+                    } else {
+                        lease.fence();
+                    }
+                }));
+                let result = if batch {
+                    let mut item = rocketmq_model::common::message::message_single::Message::default();
+                    item.set_body(Some(Bytes::from_static(b"evidence")));
+                    let mut message = append_test_message("evidence-topic", b"unused");
+                    message.set_body(rocketmq_protocol::common::message::message_decoder::encode_messages(&[
+                        item,
+                    ]));
+                    log.put_messages(MessageExtBatch {
+                        message_ext_broker_inner: message,
+                        ..Default::default()
+                    })
+                    .await
+                } else {
+                    log.put_message(append_test_message("evidence-topic", b"evidence"))
+                        .await
+                };
+                let receipt = crate::store_append_receipt(result, log.get_max_offset(), log.get_flushed_where());
+                assert_eq!(
+                    receipt.result().put_message_status(),
+                    PutMessageStatus::ServiceNotAvailable
+                );
+                assert!(!receipt.canonical().unwrap().is_accepted());
+                assert_eq!(receipt.canonical().unwrap().appended_range(), None);
+                let crate::AppendExecutionEvidence::Appended { range, local_watermark } = receipt.execution_evidence()
+                else {
+                    panic!("finalized worker append must retain evidence");
+                };
+                assert_eq!(range.start, before);
+                assert_eq!(range.end, *local_watermark);
+                assert_eq!(*local_watermark, log.get_max_offset());
+                let stored = store.look_message_by_offset(range.start).unwrap();
+                assert_eq!(stored.topic(), "evidence-topic");
+                assert_eq!(stored.commit_log_offset(), range.start);
+                assert_eq!(
+                    receipt
+                        .result()
+                        .append_message_result()
+                        .unwrap()
+                        .get_message_id()
+                        .as_deref(),
+                    Some(stored.msg_id().as_str())
+                );
+
+                if !replace_lease {
+                    assert!(log.install_controller_write_lease(next_token, Duration::from_secs(60)));
+                }
+                let next = log
+                    .put_message(append_test_message("evidence-topic", b"evidence"))
+                    .await;
+                let next = crate::store_append_receipt(next, log.get_max_offset(), log.get_flushed_where());
+                assert!(next.canonical().unwrap().is_accepted());
+                let crate::AppendExecutionEvidence::Appended { range: next_range, .. } = next.execution_evidence()
+                else {
+                    panic!("next generation append should be observable");
+                };
+                assert_eq!(next_range.start, range.end);
+                assert!(store.look_message_by_offset(range.start).is_some());
+                assert!(store.look_message_by_offset(next_range.start).is_some());
+                store.shutdown().await;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn append_execution_evidence_survives_sync_flush_timeout() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let mut store = new_test_message_store_with_config(
+            directory.path(),
+            MessageStoreConfig {
+                mapped_file_size_commit_log: 4096,
+                ha_listen_port: 0,
+                flush_disk_type: FlushDiskType::SyncFlush,
+                sync_flush_timeout: 1,
+                ..Default::default()
+            },
+            BrokerRole::AsyncMaster,
+            false,
+        );
+        // The append worker is installed, but the flush worker has not started.
+        store.init().await.unwrap();
+        let log = store.get_commit_log();
+        let authority = WriteAuthority::try_new(0, MasterEpoch::try_from(1).unwrap()).unwrap();
+        assert!(log
+            .install_controller_write_lease(WriteLeaseToken::try_new(authority, 1).unwrap(), Duration::from_secs(60)));
+        let mut message = append_test_message("flush-evidence", b"stored-before-flush");
+        message.set_wait_store_msg_ok(true);
+        let result = log.put_message(message).await;
+        let receipt = crate::store_append_receipt(result, log.get_max_offset(), log.get_flushed_where());
+        assert_eq!(
+            receipt.result().put_message_status(),
+            PutMessageStatus::FlushDiskTimeout
+        );
+        let crate::AppendExecutionEvidence::Appended { range, .. } = receipt.execution_evidence() else {
+            panic!("flush timeout must retain completed append evidence");
+        };
+        assert!(store.look_message_by_offset(range.start).is_some());
+        assert_eq!(
+            receipt.canonical().unwrap().status(),
+            rocketmq_store_api::AppendStatus::FlushDiskTimeout
+        );
+        assert_eq!(receipt.canonical().unwrap().appended_range(), Some(range.clone()));
+        assert_eq!(
+            receipt.canonical().unwrap().durability(),
+            rocketmq_store_api::Durability::Memory
+        );
+        store.shutdown().await;
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/log_file/commit_log/append_sequencer.rs
+++ b/rocketmq-store/src/log_file/commit_log/append_sequencer.rs
@@ -33,8 +33,11 @@ use rocketmq_store_local::commit_log::append::sequencer::AppendSequencer;
 use rocketmq_store_local::commit_log::append::sequencer::AppendSequencerConfig;
 use rocketmq_store_local::commit_log::append::sequencer::AppendSequencerReceiver;
 use rocketmq_store_local::commit_log::append::sequencer::AppendSequencerSender;
+use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendAborted;
 use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendAttempt;
+use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendCompleted;
 use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendFailure;
+use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendOutcome;
 use rocketmq_store_local::commit_log::append_attempt::CommitLogAppendResolution;
 use tokio::sync::oneshot;
 use tracing::error;
@@ -54,6 +57,7 @@ use super::MessageStoreConfig;
 use super::PutMessageContext;
 use super::PutMessageResult;
 use super::PutMessageStatus;
+use crate::base::message_result::AppendExecutionEvidence;
 use crate::base::message_result::AppendMessageResult;
 use crate::ha::ha_service::HAService;
 
@@ -103,7 +107,7 @@ impl CommitLogAppendPort {
         };
         let retained_bytes = request.retained_bytes();
         if let AppendAdmissionOutcome::Rejected { request, reason } = self.sender.try_submit(request, retained_bytes) {
-            request.reject(PutMessageResult::new_default(Self::admission_status(reason)));
+            request.reject(PutMessageResult::rejected_before_append(Self::admission_status(reason)));
         }
         response.await.unwrap_or_else(|response_error| {
             error!(error = %response_error, "CommitLog append worker dropped a message response");
@@ -129,7 +133,7 @@ impl CommitLogAppendPort {
         };
         let retained_bytes = request.retained_bytes();
         if let AppendAdmissionOutcome::Rejected { request, reason } = self.sender.try_submit(request, retained_bytes) {
-            request.reject(PutMessageResult::new_default(Self::admission_status(reason)));
+            request.reject(PutMessageResult::rejected_before_append(Self::admission_status(reason)));
         }
         response.await.unwrap_or_else(|response_error| {
             error!(error = %response_error, "CommitLog append worker dropped a batch response");
@@ -619,13 +623,45 @@ impl CommitLogAppendProcessor {
         topic: &str,
         born_host: String,
     ) -> (PutMessageResult, Option<Arc<DefaultMappedFile>>) {
+        // Capture the worker's finalized outcome before legacy status projection.
+        // A later lease fence or flush/replication timeout cannot erase these facts.
+        let evidence = match &outcome {
+            CommitLogAppendOutcome::Completed(CommitLogAppendCompleted::PutOk { result, .. }) => {
+                match (
+                    result.wrote_offset.checked_add(i64::from(result.wrote_bytes)),
+                    i64::try_from(self.append.current_append_offset()),
+                ) {
+                    (Some(end), Ok(local_watermark))
+                        if result.wrote_offset >= 0 && result.wrote_bytes > 0 && end <= local_watermark =>
+                    {
+                        AppendExecutionEvidence::Appended {
+                            range: result.wrote_offset..end,
+                            local_watermark,
+                        }
+                    }
+                    _ => AppendExecutionEvidence::Unknown,
+                }
+            }
+            CommitLogAppendOutcome::Completed(CommitLogAppendCompleted::RetryRejected { .. })
+            | CommitLogAppendOutcome::Aborted(CommitLogAppendAborted::InitialUnknown { .. }) => {
+                AppendExecutionEvidence::Unknown
+            }
+            CommitLogAppendOutcome::Aborted(
+                CommitLogAppendAborted::InitialSegmentUnavailable
+                | CommitLogAppendAborted::InitialActiveLockFailed { .. }
+                | CommitLogAppendAborted::InitialMessageIllegal { .. }
+                | CommitLogAppendAborted::RolledSegmentUnavailable { .. }
+                | CommitLogAppendAborted::RolledActiveLockFailed { .. },
+            ) => AppendExecutionEvidence::NotAppended,
+        };
         match outcome.resolve() {
             CommitLogAppendResolution::Continue {
                 status,
                 result,
                 unlock_segment,
             } => (
-                PutMessageResult::new_append_result(CommitLog::put_message_status(status), Some(result)),
+                PutMessageResult::new_append_result(CommitLog::put_message_status(status), Some(result))
+                    .with_execution_evidence(evidence),
                 unlock_segment,
             ),
             CommitLogAppendResolution::Return {
@@ -651,7 +687,8 @@ impl CommitLogAppendProcessor {
                 }
                 drop(abandoned_segment);
                 (
-                    PutMessageResult::new_append_result(CommitLog::put_message_status(status), append_result),
+                    PutMessageResult::new_append_result(CommitLog::put_message_status(status), append_result)
+                        .with_execution_evidence(evidence),
                     None,
                 )
             }

--- a/rocketmq-store/src/log_file/commit_log/handles.rs
+++ b/rocketmq-store/src/log_file/commit_log/handles.rs
@@ -51,6 +51,14 @@ pub(crate) struct CommitLogCleanupHandle {
 }
 
 impl CommitLogCleanupHandle {
+    pub(crate) fn active_root(&self) -> Option<std::path::PathBuf> {
+        self.mapped_file_queue.active_root()
+    }
+
+    pub(crate) fn allocation_candidates(&self) -> Vec<std::path::PathBuf> {
+        self.mapped_file_queue.allocation_candidates()
+    }
+
     #[inline]
     pub(crate) fn get_min_offset(&self) -> i64 {
         self.mapped_file_queue.get_min_offset()
@@ -64,7 +72,7 @@ impl CommitLogCleanupHandle {
         clean_immediately: bool,
         delete_file_batch_max: i32,
         pinned_file_offset: Option<u64>,
-    ) -> i32 {
+    ) -> crate::consume_queue::mapped_file_queue::CleanupOutcome {
         self.mapped_file_queue.delete_expired_files_by_time_before(
             expired_time,
             delete_files_interval,
@@ -224,7 +232,7 @@ impl CommitLogInternalMessageWriteHandle {
         let append_span = rocketmq_observability::trace::store::append_span(&self.telemetry_handle);
         let requested_lease = match self.store_context.controller_write_lease.capture() {
             Ok(lease) => lease,
-            Err(()) => return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable),
+            Err(()) => return PutMessageResult::rejected_before_append(PutMessageStatus::ServiceNotAvailable),
         };
         msg.set_wait_store_msg_ok(false);
         #[cfg(any(feature = "observability", feature = "observability-traces"))]
@@ -254,7 +262,7 @@ impl CommitLogInternalMessageWriteHandle {
             && self.store_runtime_state.broker_role() != BrokerRole::Slave);
         let prepared = match message_encoder_pool::prepare_message_with_pool(&msg, &self.message_store_config) {
             Ok(prepared) => prepared,
-            Err(result) => return result,
+            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
         };
         let mut result = self
             .append_port

--- a/rocketmq-store/src/log_file/commit_log_path_set.rs
+++ b/rocketmq-store/src/log_file/commit_log_path_set.rs
@@ -229,12 +229,12 @@ impl CommitLogPathSet {
                 self.writable.contains(*root) && !state.retired.contains(*root) && !state.unhealthy.contains(*root)
             })
             .filter_map(|(index, root)| {
-                if self.fault_injector.should_fail(point, root) {
+                if !root.is_dir() || self.fault_injector.should_fail(point, root) {
                     return None;
                 }
                 let total = fs2::total_space(root).ok()?;
                 let available = fs2::available_space(root).ok()?;
-                if total == 0 || available < self.minimum_remaining_bytes {
+                if total == 0 || available > total || available < self.minimum_remaining_bytes {
                     return None;
                 }
                 let used = total.saturating_sub(available);

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -676,6 +676,9 @@ pub struct LocalFileMessageStore {
     delay_level_table: Arc<BTreeMap<i32 /* level */, i64 /* delay timeMillis */>>,
     max_delay_level: i32,
     last_recovery_report: Option<RecoveryReport>,
+    last_recovery_error: Option<StoreError>,
+    #[cfg(test)]
+    recovery_failure: Option<(RecoveryPhase, StoreError)>,
     store_root_lease_state: StoreRootLeaseState,
     store_root_mode: StoreRootMode,
     // Declared last so the verified Store-root boundary outlives every component field during

--- a/rocketmq-store/src/message_store/local_file_message_store/composition.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/composition.rs
@@ -601,6 +601,9 @@ impl LocalFileMessageStore {
             delay_level_table,
             max_delay_level,
             last_recovery_report: None,
+            last_recovery_error: None,
+            #[cfg(test)]
+            recovery_failure: None,
             store_root_lease_state: StoreRootLeaseState::Operational,
             store_root_mode,
             store_root_lease,

--- a/rocketmq-store/src/message_store/local_file_message_store/health.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/health.rs
@@ -37,6 +37,11 @@ impl LocalFileMessageStore {
         self.message_store_config.clone()
     }
 
+    /// Returns the last recovery failure with its original diagnostic source.
+    pub fn last_recovery_error(&self) -> Option<&StoreError> {
+        self.last_recovery_error.as_ref()
+    }
+
     pub fn last_recovery_report(&self) -> Option<&RecoveryReport> {
         self.last_recovery_report.as_ref()
     }
@@ -75,32 +80,127 @@ where
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+enum DiskSpaceSample {
+    Known {
+        total: u64,
+        available: u64,
+        observed_at: std::time::Instant,
+    },
+    Unknown {
+        reason: &'static str,
+        observed_at: std::time::Instant,
+    },
+}
+
+impl DiskSpaceSample {
+    fn sample(path: &Path) -> Self {
+        let observed_at = std::time::Instant::now();
+        // Windows volume probes may succeed for a missing path on an existing drive.
+        if !path.is_dir() {
+            return Self::Unknown {
+                reason: "storage root unavailable",
+                observed_at,
+            };
+        }
+        match (fs2::total_space(path), fs2::available_space(path)) {
+            (Ok(total), Ok(available)) if total > 0 && available <= total => Self::Known {
+                total,
+                available,
+                observed_at,
+            },
+            (Ok(_), Ok(_)) => Self::Unknown {
+                reason: "invalid capacity sample",
+                observed_at,
+            },
+            _ => Self::Unknown {
+                reason: "disk probe unavailable",
+                observed_at,
+            },
+        }
+    }
+
+    fn ratio(self) -> Option<f64> {
+        match self {
+            Self::Known { total, available, .. } => Some((total - available) as f64 / total as f64),
+            Self::Unknown { .. } => None,
+        }
+    }
+
+    fn state(self, policy: LocalCleanupPolicy) -> DiskUsageState {
+        match self {
+            Self::Known { observed_at, .. } => {
+                tracing::trace!(
+                    sample_age_ms = observed_at.elapsed().as_millis() as u64,
+                    "disk capacity sampled"
+                );
+                policy.classify(self.ratio().unwrap_or(f64::NAN))
+            }
+            Self::Unknown { reason, observed_at } => {
+                warn!(
+                    reason,
+                    sample_age_ms = observed_at.elapsed().as_millis() as u64,
+                    "disk capacity is unknown; retaining write protection"
+                );
+                DiskUsageState::Unknown
+            }
+        }
+    }
+}
+
+struct DiskAvailabilitySummary {
+    active: Option<DiskUsageState>,
+    allocation: Vec<DiskUsageState>,
+    cleanup: Vec<DiskUsageState>,
+    logic: DiskUsageState,
+}
+
+impl DiskAvailabilitySummary {
+    fn physical_state(&self) -> DiskUsageState {
+        // An unhealthy active segment cannot be made safe by a healthy spare.
+        // Once the segment is full, normal allocation validates the next root again.
+        self.active.unwrap_or_else(|| {
+            self.allocation
+                .iter()
+                .copied()
+                .find(|state| matches!(state, DiskUsageState::Healthy | DiskUsageState::Reclaim))
+                .or_else(|| self.allocation.first().copied())
+                .unwrap_or(DiskUsageState::Unknown)
+        })
+    }
+
+    fn apply(&self, flags: &RunningFlags) -> DiskCleanDecision {
+        match self.physical_state() {
+            DiskUsageState::Unknown | DiskUsageState::Warning => {
+                flags.get_and_make_disk_full();
+            }
+            DiskUsageState::Healthy | DiskUsageState::Reclaim => {
+                flags.get_and_make_disk_ok();
+            }
+            DiskUsageState::Forcible => {}
+        }
+        match self.logic {
+            DiskUsageState::Unknown | DiskUsageState::Warning => {
+                flags.get_and_make_logic_disk_full();
+            }
+            DiskUsageState::Healthy | DiskUsageState::Reclaim => {
+                flags.get_and_make_logic_disk_ok();
+            }
+            DiskUsageState::Forcible => {}
+        }
+        let states = self.cleanup.iter().copied().chain([self.physical_state(), self.logic]);
+        let mut decision = DiskCleanDecision::default();
+        for state in states {
+            decision.should_delete |= !matches!(state, DiskUsageState::Healthy);
+            decision.clean_immediately |= matches!(state, DiskUsageState::Warning | DiskUsageState::Forcible);
+        }
+        decision
+    }
+}
+
+// Legacy runtime-info projection only. Admission uses explicit samples above.
 pub(super) fn store_path_disk_used_ratio(path: &str) -> f64 {
-    let path = path.trim();
-    if path.is_empty() {
-        error!("Error when measuring disk space usage, path is null or empty");
-        return -1.0;
-    }
-
-    let path = Path::new(path);
-    if !path.exists() {
-        error!(
-            "Error when measuring disk space usage, file doesn't exist on this path: {}",
-            path.to_string_lossy()
-        );
-        return -1.0;
-    }
-
-    match (fs2::total_space(path), fs2::available_space(path)) {
-        (Ok(total_space), Ok(available_space)) if total_space > 0 => {
-            total_space.saturating_sub(available_space) as f64 / total_space as f64
-        }
-        (Ok(_), Ok(_)) => -1.0,
-        (Err(error), _) | (_, Err(error)) => {
-            error!("Error when measuring disk space usage, got exception: {:?}", error);
-            -1.0
-        }
-    }
+    DiskSpaceSample::sample(Path::new(path.trim())).ratio().unwrap_or(-1.0)
 }
 
 pub(super) type CommitLogWalPin = dyn Fn() -> Option<u64> + Send + Sync;
@@ -151,26 +251,33 @@ impl CleanCommitLogService {
             .minimum_pinned_wal_segment
             .as_ref()
             .and_then(|minimum_pinned_wal_segment| minimum_pinned_wal_segment());
-        let delete_count = if is_time_up || disk_decision.should_delete || is_manual_delete {
-            self.commit_log.delete_expired_files_by_time_before(
+        if is_time_up || disk_decision.should_delete || is_manual_delete {
+            let outcome = self.commit_log.delete_expired_files_by_time_before(
                 expired_time,
                 self.message_store_config.delete_commit_log_files_interval as i32,
                 self.message_store_config.destroy_mapped_file_interval_forcibly as i64,
                 clean_at_once,
                 self.message_store_config.delete_file_batch_max as i32,
                 minimum_pinned_wal_segment,
-            )
-        } else {
-            0
-        };
-        if delete_count > 0 {
-            info!(
-                "clean commit log service deleted {} expired commitlog file(s), is_time_up={}, is_space_to_delete={}, \
-                 is_manual_delete={}, clean_at_once={}",
-                delete_count, is_time_up, disk_decision.should_delete, is_manual_delete, clean_at_once
             );
-        } else if disk_decision.should_delete {
-            warn!("disk space will be full soon, but delete commitlog file failed");
+            use crate::consume_queue::mapped_file_queue::CleanupOutcome;
+            match outcome {
+                CleanupOutcome::ManagedSubmitted { selected, submitted } => {
+                    if selected > 0 {
+                        info!(
+                            selected,
+                            submitted, "commitlog retirement tickets submitted; completion belongs to the reaper"
+                        );
+                    }
+                }
+                CleanupOutcome::LegacyCompleted { namespace_removed } => {
+                    if namespace_removed > 0 {
+                        info!(namespace_removed, "expired commitlog namespace entries removed; physical free space requires a new disk sample");
+                    } else if disk_decision.should_delete {
+                        warn!("disk capacity requires reclaim; no commitlog namespace entries removed");
+                    }
+                }
+            }
         }
 
         let first_file_is_before_pin = minimum_pinned_wal_segment
@@ -214,101 +321,29 @@ impl CleanCommitLogService {
             return decision;
         }
 
-        let (min_physic_ratio, min_store_path) = self.min_physic_disk_ratio();
-
-        match self.cleanup_policy.classify(min_physic_ratio) {
-            DiskUsageState::Warning => {
-                if self.running_flags.get_and_make_disk_full() {
-                    error!(
-                        "physic disk maybe full soon {}, so mark disk full, storePathPhysic={}",
-                        min_physic_ratio,
-                        min_store_path.as_deref().unwrap_or("")
-                    );
-                }
-                return DiskCleanDecision {
-                    should_delete: true,
-                    clean_immediately: true,
-                };
-            }
-            DiskUsageState::Forcible => {
-                return DiskCleanDecision {
-                    should_delete: true,
-                    clean_immediately: true,
-                };
-            }
-            DiskUsageState::Reclaim | DiskUsageState::Healthy => {
-                if !self.running_flags.get_and_make_disk_ok() {
-                    info!(
-                        "physic disk space OK {}, so mark disk ok, storePathPhysic={}",
-                        min_physic_ratio,
-                        min_store_path.as_deref().unwrap_or("")
-                    );
-                }
-            }
+        let sample = |path: &Path| DiskSpaceSample::sample(path).state(self.cleanup_policy);
+        let active = self.commit_log.active_root().as_deref().map(sample);
+        let allocation = self
+            .commit_log
+            .allocation_candidates()
+            .iter()
+            .map(|path| sample(path))
+            .collect();
+        let commit_log_path = LocalFileMessageStore::get_store_path_physic(&self.message_store_config);
+        let cleanup = commit_log_path
+            .split(mix_all::MULTI_PATH_SPLITTER.as_str())
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(|path| sample(Path::new(path)))
+            .collect();
+        let logic_path = LocalFileMessageStore::get_store_path_logic(&self.message_store_config);
+        DiskAvailabilitySummary {
+            active,
+            allocation,
+            cleanup,
+            logic: sample(Path::new(logic_path.as_str())),
         }
-
-        let store_path_logics = LocalFileMessageStore::get_store_path_logic(&self.message_store_config);
-        let logics_ratio = store_path_disk_used_ratio(store_path_logics.as_str());
-        match self.cleanup_policy.classify(logics_ratio) {
-            DiskUsageState::Warning => {
-                if self.running_flags.get_and_make_logic_disk_full() {
-                    error!("logics disk maybe full soon {}, so mark disk full", logics_ratio);
-                }
-                return DiskCleanDecision {
-                    should_delete: true,
-                    clean_immediately: true,
-                };
-            }
-            DiskUsageState::Forcible => {
-                return DiskCleanDecision {
-                    should_delete: true,
-                    clean_immediately: true,
-                };
-            }
-            DiskUsageState::Reclaim | DiskUsageState::Healthy => {
-                if !self.running_flags.get_and_make_logic_disk_ok() {
-                    info!("logics disk space OK {}, so mark disk ok", logics_ratio);
-                }
-            }
-        }
-
-        let decision = self.cleanup_policy.decide(min_physic_ratio, logics_ratio);
-        if self.cleanup_policy.classify(min_physic_ratio) == DiskUsageState::Reclaim {
-            info!("commitLog disk maybe full soon, so reclaim space, {}", min_physic_ratio);
-            return decision;
-        }
-
-        if self.cleanup_policy.classify(logics_ratio) == DiskUsageState::Reclaim {
-            info!("consumeQueue disk maybe full soon, so reclaim space, {}", logics_ratio);
-            return decision;
-        }
-
-        decision
-    }
-
-    pub(super) fn min_physic_disk_ratio(&self) -> (f64, Option<String>) {
-        let commit_log_store_path = LocalFileMessageStore::get_store_path_physic(&self.message_store_config);
-        let mut min_ratio = f64::MAX;
-        let mut min_store_path = None;
-
-        for store_path in commit_log_store_path.split(mix_all::MULTI_PATH_SPLITTER.as_str()) {
-            let store_path = store_path.trim();
-            if store_path.is_empty() {
-                continue;
-            }
-
-            let ratio = store_path_disk_used_ratio(store_path);
-            if min_ratio > ratio {
-                min_ratio = ratio;
-                min_store_path = Some(store_path.to_string());
-            }
-        }
-
-        if min_ratio == f64::MAX {
-            (-1.0, None)
-        } else {
-            (min_ratio, min_store_path)
-        }
+        .apply(&self.running_flags)
     }
 
     pub(super) fn disk_space_warning_level_ratio(&self) -> f64 {
@@ -395,5 +430,67 @@ impl CorrectLogicOffsetService {
                     .correct_min_offset(consume_queue.as_ref(), min_commit_log_offset);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod disk_tests {
+    use super::*;
+
+    fn summary(
+        active: Option<DiskUsageState>,
+        allocation: Vec<DiskUsageState>,
+        logic: DiskUsageState,
+    ) -> DiskAvailabilitySummary {
+        DiskAvailabilitySummary {
+            active,
+            allocation,
+            cleanup: Vec::new(),
+            logic,
+        }
+    }
+
+    #[test]
+    fn warning_unknown_and_recovery_preserve_independent_write_failures() {
+        let flags = RunningFlags::new();
+        summary(Some(DiskUsageState::Warning), vec![], DiskUsageState::Healthy).apply(&flags);
+        assert!(!flags.is_writeable());
+        summary(
+            Some(DiskUsageState::Unknown),
+            vec![DiskUsageState::Healthy],
+            DiskUsageState::Healthy,
+        )
+        .apply(&flags);
+        assert!(!flags.is_writeable(), "a spare cannot clear the active segment fence");
+        summary(Some(DiskUsageState::Healthy), vec![], DiskUsageState::Unknown).apply(&flags);
+        assert!(!flags.is_writeable(), "CQ capacity is independent");
+        flags.get_and_make_not_writeable();
+        summary(Some(DiskUsageState::Healthy), vec![], DiskUsageState::Healthy).apply(&flags);
+        assert!(
+            !flags.is_writeable(),
+            "capacity recovery does not clear a flush failure"
+        );
+        flags.get_and_make_writeable();
+        assert!(flags.is_writeable());
+    }
+
+    #[test]
+    fn allocation_and_cleanup_do_not_share_a_minimum_ratio() {
+        let flags = RunningFlags::new();
+        let mut disks = summary(None, vec![DiskUsageState::Healthy], DiskUsageState::Healthy);
+        disks.cleanup = vec![DiskUsageState::Warning, DiskUsageState::Healthy];
+        let decision = disks.apply(&flags);
+        assert!(decision.clean_immediately);
+        assert!(
+            flags.is_writeable(),
+            "a full inactive root does not block a verified new-segment candidate"
+        );
+        disks.allocation.clear();
+        disks.cleanup = vec![DiskUsageState::Healthy];
+        disks.apply(&flags);
+        assert!(
+            !flags.is_writeable(),
+            "healthy readonly storage cannot authorize allocation"
+        );
     }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store/mapped_file_retirement_service.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/mapped_file_retirement_service.rs
@@ -221,6 +221,11 @@ impl<D: RetirementBatchDriver> MappedFileRetirementService<D> {
                         .await
                     {
                         Ok(report) => {
+                            if report.completed > 0 || report.attempted > 0 {
+                                tracing::info!(completed = report.completed, pending = report.pending_tickets,
+                                    pending_age_ms = report.oldest_pending_age.as_millis() as u64,
+                                    "mapped-file retirement batch finished; completion does not measure physical space released");
+                            }
                             if report.recovery_required {
                                 accepting.store(false, Ordering::Release);
                                 driver.begin_shutdown();
@@ -251,6 +256,14 @@ impl<D: RetirementBatchDriver> MappedFileRetirementService<D> {
         self.task_group = Some(task_group);
         self.scheduled_tasks = Some(scheduled_tasks);
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) async fn pause_scheduling_for_test(&mut self) {
+        self.scheduled_tasks.take();
+        if let Some(tasks) = self.task_group.take() {
+            assert!(tasks.shutdown(self.config.task_shutdown_timeout).await.is_healthy());
+        }
     }
 
     pub(super) async fn cancel_drain_and_await(&mut self) -> Result<RetirementServiceBatch, StoreError> {

--- a/rocketmq-store/src/message_store/local_file_message_store/recovery.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/recovery.rs
@@ -26,6 +26,11 @@ impl LocalFileMessageStore {
     }
 
     pub(super) async fn recover(&mut self, last_exit_ok: bool) -> bool {
+        self.last_recovery_error = self.recover_result(last_exit_ok).await.err();
+        self.last_recovery_error.is_none()
+    }
+
+    async fn recover_result(&mut self, last_exit_ok: bool) -> Result<(), StoreError> {
         let previous_state = self.lifecycle_state();
         let recover_concurrently = self.is_recover_concurrently();
         let mut recovery_plan = RecoveryPlan::new(
@@ -76,11 +81,8 @@ impl LocalFileMessageStore {
                 .local_file_parallelism
         );
         self.set_lifecycle_state(LocalStoreState::RecoveringConsumeQueue);
-        let mut consume_queue_recovered = false;
-        let recover_consume_queue = recovery_executor
-            .run_phase(RecoveryPhase::ConsumeQueue, async {
-                consume_queue_recovered = self.recover_consume_queue().await;
-            })
+        let consume_queue_result = recovery_executor
+            .run_result_phase(RecoveryPhase::ConsumeQueue, self.recover_consume_queue_result())
             .await;
         let dispatch_recovery_offset = self.get_dispatch_recovery_offset();
         recovery_executor
@@ -89,36 +91,36 @@ impl LocalFileMessageStore {
         recovery_executor
             .plan_mut()
             .set_max_consume_queue_physical_offset(dispatch_recovery_offset);
-
-        self.set_lifecycle_state(LocalStoreState::RecoveringCommitLog);
-        let mut commit_log_recovered = false;
-        let recover_commit_log = if !consume_queue_recovered {
-            error!("consume-queue recovery cleanup failed; skipping CommitLog recovery");
-            0
-        } else if last_exit_ok {
-            recovery_executor
-                .run_phase(RecoveryPhase::CommitLog, async {
-                    commit_log_recovered = self.recover_normally(dispatch_recovery_offset).await;
-                })
-                .await
-        } else {
-            recovery_executor
-                .run_phase(RecoveryPhase::CommitLog, async {
-                    commit_log_recovered = self.recover_abnormally(dispatch_recovery_offset).await;
-                })
-                .await
-        };
-
-        self.set_lifecycle_state(LocalStoreState::RecoveringTopicQueueTable);
-        let recover_topic_queue_table = if commit_log_recovered {
-            recovery_executor
-                .run_phase(RecoveryPhase::TopicQueueTable, async {
-                    self.recover_topic_queue_table();
-                })
-                .await
-        } else {
-            error!("CommitLog recovery cleanup failed; skipping topic queue table recovery");
-            0
+        let recovery_result = match consume_queue_result {
+            Err(error) => {
+                recovery_executor.skip_phase(RecoveryPhase::CommitLog);
+                recovery_executor.skip_phase(RecoveryPhase::TopicQueueTable);
+                Err(error)
+            }
+            Ok(()) => {
+                self.set_lifecycle_state(LocalStoreState::RecoveringCommitLog);
+                let commit_log_result = recovery_executor
+                    .run_result_phase(
+                        RecoveryPhase::CommitLog,
+                        self.recover_commit_log_result(last_exit_ok, dispatch_recovery_offset),
+                    )
+                    .await;
+                match commit_log_result {
+                    Err(error) => {
+                        recovery_executor.skip_phase(RecoveryPhase::TopicQueueTable);
+                        Err(error)
+                    }
+                    Ok(()) => {
+                        self.set_lifecycle_state(LocalStoreState::RecoveringTopicQueueTable);
+                        recovery_executor
+                            .run_result_phase(RecoveryPhase::TopicQueueTable, async {
+                                self.recover_topic_queue_table();
+                                Ok(())
+                            })
+                            .await
+                    }
+                }
+            }
         };
         if self.lifecycle_state() != LocalStoreState::Shutdown {
             self.set_lifecycle_state(previous_state);
@@ -137,9 +139,15 @@ impl LocalFileMessageStore {
              recoverOffsetTable: {} ms, recoveryMode: {}, lastExit: {}, dispatchRecoveryOffset: {:?}, commitLogRange: \
              {:?}-{:?}, confirmOffset: {:?}, indexSafeOffset: {:?}",
             recovery_report.total_duration_ms,
-            recover_consume_queue,
-            recover_commit_log,
-            recover_topic_queue_table,
+            recovery_report
+                .phase_duration_ms(RecoveryPhase::ConsumeQueue)
+                .unwrap_or_default(),
+            recovery_report
+                .phase_duration_ms(RecoveryPhase::CommitLog)
+                .unwrap_or_default(),
+            recovery_report
+                .phase_duration_ms(RecoveryPhase::TopicQueueTable)
+                .unwrap_or_default(),
             recovery_report.plan.mode.as_str(),
             recovery_report.plan.exit.as_str(),
             recovery_report.plan.dispatch_recovery_offset,
@@ -149,7 +157,52 @@ impl LocalFileMessageStore {
             recovery_report.plan.offsets.index_safe_offset
         );
         self.last_recovery_report = Some(recovery_report);
-        consume_queue_recovered && commit_log_recovered
+        recovery_result
+    }
+
+    async fn recover_consume_queue_result(&mut self) -> Result<(), StoreError> {
+        #[cfg(test)]
+        if self
+            .recovery_failure
+            .as_ref()
+            .is_some_and(|(phase, _)| *phase == RecoveryPhase::ConsumeQueue)
+        {
+            return Err(self.recovery_failure.take().unwrap().1);
+        }
+        let parallelism = if self.is_recover_concurrently() {
+            self.composition.config().recovery.consume_queue_parallelism
+        } else {
+            1
+        };
+        self.consume_queue_store
+            .recover_result_with_parallelism(parallelism)
+            .await
+    }
+
+    async fn recover_commit_log_result(&mut self, normal: bool, offset: i64) -> Result<(), StoreError> {
+        #[cfg(test)]
+        if self
+            .recovery_failure
+            .as_ref()
+            .is_some_and(|(phase, _)| *phase == RecoveryPhase::CommitLog)
+        {
+            return Err(self.recovery_failure.take().unwrap().1);
+        }
+        let use_optimized =
+            optimized_recovery_requested(std::env::var("ROCKETMQ_USE_OPTIMIZED_RECOVERY").ok().as_deref());
+        drive_commit_log_recovery(use_optimized, |step| async move {
+            match (normal, step) {
+                (true, CommitLogRecoveryStep::Optimized) => {
+                    self.commit_log.recover_normally_optimized_result(offset).await
+                }
+                (true, CommitLogRecoveryStep::Standard) => self.commit_log.recover_normally_result(offset).await,
+                (false, CommitLogRecoveryStep::Optimized) => {
+                    self.commit_log.recover_abnormally_optimized_result(offset).await
+                }
+                (false, CommitLogRecoveryStep::Standard) => self.commit_log.recover_abnormally_result(offset).await,
+            }
+        })
+        .await
     }
 
     pub(super) fn current_index_safe_offset(&self) -> i64 {
@@ -217,34 +270,6 @@ impl LocalFileMessageStore {
             && self
                 .message_store_config
                 .enable_local_file_consume_queue_recovery_concurrently
-    }
-
-    pub(super) async fn recover_consume_queue(&mut self) -> bool {
-        if self.broker_config.recover_concurrently && self.message_store_config.is_enable_rocksdb_store() {
-            self.consume_queue_store.recover_concurrently().await
-        } else if self.broker_config.recover_concurrently && self.is_local_file_consume_queue_recover_concurrently() {
-            let parallelism = self.composition.config().recovery.consume_queue_parallelism;
-            let summary = self
-                .consume_queue_store
-                .recover_concurrently_with_summary(parallelism)
-                .await;
-            if !summary.is_success() {
-                warn!(
-                    "local file consume queue concurrent recovery failed; aborting recovery, \
-                     parallelism={}, queues={}, success={}, failed={}, failures={}",
-                    parallelism,
-                    summary.queue_count,
-                    summary.success_count,
-                    summary.failure_count,
-                    summary.failure_description()
-                );
-                false
-            } else {
-                true
-            }
-        } else {
-            self.consume_queue_store.recover_with_outcome().await
-        }
     }
 
     pub(super) fn get_dispatch_recovery_offset(&self) -> i64 {

--- a/rocketmq-store/src/message_store/local_file_message_store/write_path.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/write_path.rs
@@ -138,7 +138,7 @@ impl LocalFileMessageStore {
     pub(crate) async fn put_message_shared(&self, mut msg: MessageExtBrokerInner) -> PutMessageResult {
         if !self.is_store_available_for_io() || !self.running_flags.is_writeable() {
             warn!("message store is unavailable for writes, so putMessage is forbidden");
-            return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable);
+            return PutMessageResult::rejected_before_append(PutMessageStatus::ServiceNotAvailable);
         }
 
         #[cfg(feature = "extended_timeline")]
@@ -150,7 +150,7 @@ impl LocalFileMessageStore {
                     | TimelineAdmissionOutcome::HorizonOverflow
                     | TimelineAdmissionOutcome::HorizonExceeded
                     | TimelineAdmissionOutcome::RecordTooLarge,
-                ) => return PutMessageResult::new_default(PutMessageStatus::WheelTimerMsgIllegal),
+                ) => return PutMessageResult::rejected_before_append(PutMessageStatus::WheelTimerMsgIllegal),
                 Ok(
                     TimelineAdmissionOutcome::RoleInactive
                     | TimelineAdmissionOutcome::MaterializationLag
@@ -159,7 +159,7 @@ impl LocalFileMessageStore {
                     | TimelineAdmissionOutcome::TenantQuota
                     | TimelineAdmissionOutcome::HotBucket
                     | TimelineAdmissionOutcome::DiskHeadroom,
-                ) => return PutMessageResult::new_default(PutMessageStatus::WheelTimerFlowControl),
+                ) => return PutMessageResult::rejected_before_append(PutMessageStatus::WheelTimerFlowControl),
                 Err(error) => {
                     warn!(
                         "Extended Timer admission failed: descriptor={}, operation={:?}, component={:?}",
@@ -167,7 +167,7 @@ impl LocalFileMessageStore {
                         error.operation(),
                         error.component()
                     );
-                    return PutMessageResult::new_default(PutMessageStatus::WheelTimerFlowControl);
+                    return PutMessageResult::rejected_before_append(PutMessageStatus::WheelTimerFlowControl);
                 }
             }
         }
@@ -180,7 +180,7 @@ impl LocalFileMessageStore {
         let lmq_dispatch_queue_keys = self.prepare_lmq_dispatch(&mut msg);
         let lmq_quota_reservation = match self.reserve_lmq_quota(&lmq_dispatch_queue_keys) {
             Some(reservation) => reservation,
-            None => return PutMessageResult::new_default(PutMessageStatus::LmqConsumeQueueNumExceeded),
+            None => return PutMessageResult::rejected_before_append(PutMessageStatus::LmqConsumeQueueNumExceeded),
         };
         let lmq_dispatch_message_num = self.get_lmq_dispatch_message_num(&msg);
 
@@ -194,14 +194,14 @@ impl LocalFileMessageStore {
                 "[BUG]The message had property {} but is not an inner batch",
                 MessageConst::PROPERTY_INNER_NUM
             );
-            return PutMessageResult::new_default(PutMessageStatus::MessageIllegal);
+            return PutMessageResult::rejected_before_append(PutMessageStatus::MessageIllegal);
         }
 
         if MessageSysFlag::check(msg.sys_flag(), MessageSysFlag::INNER_BATCH_FLAG) {
             let topic_config = self.get_topic_config(msg.topic());
             if !QueueTypeUtils::is_batch_cq_arc_mut(topic_config.as_ref()) {
                 error!("[BUG]The message is an inner batch but cq type is not batch cq");
-                return PutMessageResult::new_default(PutMessageStatus::MessageIllegal);
+                return PutMessageResult::rejected_before_append(PutMessageStatus::MessageIllegal);
             }
         }
         let begin_time = Instant::now();
@@ -237,7 +237,7 @@ impl LocalFileMessageStore {
     pub(crate) async fn put_messages_shared(&self, mut message_ext_batch: MessageExtBatch) -> PutMessageResult {
         if !self.is_store_available_for_io() || !self.running_flags.is_writeable() {
             warn!("message store is unavailable for writes, so putMessages is forbidden");
-            return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable);
+            return PutMessageResult::rejected_before_append(PutMessageStatus::ServiceNotAvailable);
         }
 
         for hook in self.put_message_hook_list.snapshot() {
@@ -248,7 +248,7 @@ impl LocalFileMessageStore {
         let lmq_dispatch_queue_keys = self.prepare_lmq_dispatch(&mut message_ext_batch.message_ext_broker_inner);
         let lmq_quota_reservation = match self.reserve_lmq_quota(&lmq_dispatch_queue_keys) {
             Some(reservation) => reservation,
-            None => return PutMessageResult::new_default(PutMessageStatus::LmqConsumeQueueNumExceeded),
+            None => return PutMessageResult::rejected_before_append(PutMessageStatus::LmqConsumeQueueNumExceeded),
         };
         let lmq_dispatch_message_num = self.get_lmq_dispatch_message_num(&message_ext_batch.message_ext_broker_inner);
 

--- a/rocketmq-store/src/message_store/recovery.rs
+++ b/rocketmq-store/src/message_store/recovery.rs
@@ -232,6 +232,7 @@ pub enum RecoveryPhaseStatus {
     Success,
     Fallback,
     Failed,
+    Skipped,
 }
 
 impl RecoveryPhaseStatus {
@@ -240,6 +241,7 @@ impl RecoveryPhaseStatus {
             Self::Success => "success",
             Self::Fallback => "fallback",
             Self::Failed => "failed",
+            Self::Skipped => "skipped",
         }
     }
 }
@@ -265,9 +267,18 @@ impl RecoveryReportStats {
     }
 }
 
+/// Safe report metadata; the original error remains with the recovery caller.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecoveryPhaseFailure {
+    pub descriptor: &'static rocketmq_error::ErrorDescriptor,
+    pub operation: crate::store_error::StoreOperation,
+    pub component: crate::store_error::StoreComponent,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecoveryPhaseReport {
     pub phase: RecoveryPhase,
+    pub failure: Option<RecoveryPhaseFailure>,
     pub duration_ms: u128,
     pub status: RecoveryPhaseStatus,
     pub stats: RecoveryReportStats,
@@ -312,6 +323,7 @@ impl RecoveryReport {
         self.stats.accumulate(stats);
         self.phases.push(RecoveryPhaseReport {
             phase,
+            failure: None,
             duration_ms,
             status,
             stats,
@@ -352,6 +364,39 @@ impl RecoveryExecutor {
 
     pub fn report(&self) -> &RecoveryReport {
         &self.report
+    }
+
+    pub(crate) async fn run_result_phase<T>(
+        &mut self,
+        phase: RecoveryPhase,
+        future: impl Future<Output = Result<T, crate::store_error::StoreError>>,
+    ) -> Result<T, crate::store_error::StoreError> {
+        let start = Instant::now();
+        let result = future.await;
+        let failure = result.as_ref().err().map(|error| RecoveryPhaseFailure {
+            descriptor: error.descriptor(),
+            operation: error.operation(),
+            component: error.component(),
+        });
+        self.report.record_phase_with_status(
+            phase,
+            start.elapsed().as_millis(),
+            if result.is_ok() {
+                RecoveryPhaseStatus::Success
+            } else {
+                RecoveryPhaseStatus::Failed
+            },
+            RecoveryReportStats::default(),
+        );
+        if let Some(report) = self.report.phases.last_mut() {
+            report.failure = failure;
+        }
+        result
+    }
+
+    pub(crate) fn skip_phase(&mut self, phase: RecoveryPhase) {
+        self.report
+            .record_phase_with_status(phase, 0, RecoveryPhaseStatus::Skipped, RecoveryReportStats::default());
     }
 
     pub async fn run_phase<F>(&mut self, phase: RecoveryPhase, future: F) -> u128

--- a/rocketmq-store/src/public_api.rs
+++ b/rocketmq-store/src/public_api.rs
@@ -33,6 +33,7 @@ pub use crate::base::message_arriving_listener::MessageArrivingListener;
 pub use crate::base::message_encoder_pool::encode_message_batch_with_pool;
 pub use crate::base::message_encoder_pool::encode_message_with_pool;
 pub use crate::base::message_encoder_pool::generate_key_with_pool;
+pub use crate::base::message_result::AppendExecutionEvidence;
 pub use crate::base::message_result::AppendMessageResult;
 pub use crate::base::message_result::PutMessageResult;
 pub use crate::base::message_status_enum::AppendMessageStatus;

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -628,6 +628,47 @@ impl ConsumeQueueStore {
         }
     }
 
+    pub(crate) async fn recover_result_with_parallelism(
+        &self,
+        parallelism: usize,
+    ) -> Result<(), crate::store_error::StoreError> {
+        use crate::store_error::{StoreComponent, StoreError, StoreOperation};
+        use futures_util::StreamExt;
+        let runtime = self.inner.runtime_scope.clone();
+        let results = futures_util::stream::iter(self.snapshot_consume_queues())
+            .map(|queue| {
+                let runtime = runtime.clone();
+                async move {
+                    let complete = crate::runtime::spawn_io(&runtime, "local-file-cq-recover-result", move || {
+                        queue.write().recover_with_outcome()
+                    })
+                    .await
+                    .map_err(|source| {
+                        StoreError::new(&rocketmq_error::STORAGE_INTERNAL_FAILURE, StoreOperation::Load)
+                            .in_component(StoreComponent::Store)
+                            .with_detail("consume queue recovery executor failed")
+                            .with_source(source)
+                    })?;
+                    if complete {
+                        Ok(())
+                    } else {
+                        Err(
+                            StoreError::new(&rocketmq_error::STORAGE_INTERNAL_FAILURE, StoreOperation::Load)
+                                .in_component(StoreComponent::Store)
+                                .with_detail(
+                                    "consume queue cleanup remains pending; legacy helper supplied no underlying cause",
+                                ),
+                        )
+                    }
+                }
+            })
+            .buffer_unordered(parallelism.max(1))
+            .collect::<Vec<_>>()
+            .await;
+        // Await every owned worker before returning the first failure to the next phase.
+        results.into_iter().collect()
+    }
+
     pub async fn recover_concurrently_with_summary(&self, parallelism: usize) -> ConsumeQueueRecoverySummary {
         let total_started = Instant::now();
         let queues = self.snapshot_consume_queues();
@@ -2115,6 +2156,18 @@ mod tests {
         assert_eq!(summary.failure_count, 0);
         assert!(summary.failures.is_empty());
         assert_eq!(summary.failure_description(), "none");
+    }
+
+    #[tokio::test]
+    async fn recovery_result_preserves_executor_failure_and_awaits_other_queues() {
+        let (store, states) = tracking_store(3, Duration::ZERO, Some(1));
+        let error = store.recover_result_with_parallelism(2).await.unwrap_err();
+        assert!(std::error::Error::source(&error).is_some());
+        assert_eq!(error.descriptor(), &rocketmq_error::STORAGE_INTERNAL_FAILURE);
+        assert!(states
+            .iter()
+            .all(|state| state.recover_count.load(Ordering::SeqCst) == 1));
+        assert_eq!(states[1].visible_max_physic_offset.load(Ordering::SeqCst), -1);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rocketmq-store/src/store/running_flags.rs
+++ b/rocketmq-store/src/store/running_flags.rs
@@ -114,11 +114,16 @@ impl RunningFlags {
 
     #[inline]
     pub fn get_and_make_not_writeable(&self) -> bool {
-        let result = self.is_writeable();
-        if result {
-            self.flag_bits.fetch_or(NOT_WRITEABLE_BIT, Ordering::SeqCst);
-        }
-        result
+        // Record this independent failure even when another fence already blocks writes.
+        let previous = self.flag_bits.fetch_or(NOT_WRITEABLE_BIT, Ordering::SeqCst);
+        previous
+            & (NOT_WRITEABLE_BIT
+                | WRITE_LOGICS_QUEUE_ERROR_BIT
+                | DISK_FULL_BIT
+                | WRITE_INDEX_FILE_ERROR_BIT
+                | FENCED_BIT
+                | LOGIC_DISK_FULL_BIT)
+            == 0
     }
 
     #[inline]

--- a/rocketmq-store/tests/capability_conformance_tests.rs
+++ b/rocketmq-store/tests/capability_conformance_tests.rs
@@ -137,6 +137,10 @@ fn rejected_outer_status_ignores_inner_append_shape_for_canonical_projection() {
             let mut diagnostics = append_result();
             diagnostics.wrote_bytes = wrote_bytes;
             let receipt = store_append_receipt(PutMessageResult::new_append_result(status, Some(diagnostics)), 80, 48);
+            assert_eq!(
+                receipt.execution_evidence(),
+                &rocketmq_store::AppendExecutionEvidence::Unknown
+            );
 
             let canonical = receipt.canonical().expect("rejected status projects without a range");
             assert_eq!(put_status_to_append_status(status), canonical.status());

--- a/rocketmq-store/tests/ha_semantics_tests.rs
+++ b/rocketmq-store/tests/ha_semantics_tests.rs
@@ -120,6 +120,22 @@ async fn sync_master_without_slave_ack_returns_flush_slave_timeout() {
     let result = store.put_message(build_message(&topic, b"phase6-ha-body")).await;
 
     assert_eq!(result.put_message_status(), PutMessageStatus::FlushSlaveTimeout);
+    let receipt = rocketmq_store::store_append_receipt(result, store.get_max_phy_offset(), store.get_flushed_where());
+    let rocketmq_store::AppendExecutionEvidence::Appended { range, local_watermark } = receipt.execution_evidence()
+    else {
+        panic!("replica timeout must retain the finalized local append");
+    };
+    assert_eq!(range.end, *local_watermark);
+    assert!(store.look_message_by_offset(range.start).is_some());
+    assert_eq!(
+        receipt.canonical().unwrap().status(),
+        rocketmq_store_api::AppendStatus::FlushReplicaTimeout
+    );
+    assert_eq!(receipt.canonical().unwrap().appended_range(), Some(range.clone()));
+    assert_ne!(
+        receipt.canonical().unwrap().durability(),
+        rocketmq_store_api::Durability::Replicated
+    );
 
     store.shutdown().await;
 }

--- a/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
+++ b/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
@@ -5201,7 +5201,7 @@ fn clean_commit_log_service_manual_delete_uses_java_retry_budget() {
 }
 
 #[test]
-fn clean_commit_log_service_uses_lowest_commitlog_path_ratio_like_java() {
+fn clean_commit_log_service_unknown_configured_root_requests_reclaim() {
     let temp_dir = tempdir().unwrap();
     let store = new_test_store(&temp_dir);
     let missing_path = temp_dir.path().join("missing-commitlog");
@@ -5227,10 +5227,8 @@ fn clean_commit_log_service_uses_lowest_commitlog_path_ratio_like_java() {
         None,
     );
 
-    let (ratio, selected_path) = service.min_physic_disk_ratio();
-
-    assert!(ratio < 0.0);
-    assert_eq!(selected_path, Some(missing_path.to_string_lossy().into_owned()));
+    let decision = service.is_space_to_delete();
+    assert!(decision.should_delete);
 }
 
 #[tokio::test]
@@ -5457,4 +5455,120 @@ async fn clean_expired_removes_trimmed_queue_directly() {
         .consume_queue_store
         .find_consume_queue_map(&expired_topic)
         .is_none());
+}
+
+#[cfg(any(target_os = "linux", windows))]
+#[tokio::test]
+async fn managed_cleanup_reports_submission_before_reaper_completion() {
+    use crate::consume_queue::mapped_file_queue::CleanupOutcome;
+    let temp_dir = tempdir().unwrap();
+    let mut store = new_configured_test_store(
+        &temp_dir,
+        MessageStoreConfig {
+            enable_mapped_file_lifecycle_wave_b: true,
+            message_index_enable: false,
+            timer_wheel_enable: false,
+            enable_consume_queue_ext: false,
+            mapped_file_size_commit_log: 512,
+            ..Default::default()
+        },
+    );
+    store.init().await.unwrap();
+    assert!(store.load().await);
+    store.start().await.unwrap();
+    store
+        .mapped_file_retirement_service
+        .as_mut()
+        .unwrap()
+        .pause_scheduling_for_test()
+        .await;
+    for offset in [0, 512, 1024] {
+        assert!(store
+            .get_commit_log_mut()
+            .append_data(offset, &[1; 512], 0, 512)
+            .await
+            .unwrap());
+    }
+    let alias = store.commit_log.get_data(0).unwrap();
+    let runtime = store.managed_lifecycle_runtime.as_ref().unwrap();
+    let outcome = store
+        .commit_log
+        .cleanup_handle()
+        .delete_expired_files_by_time_before(0, 0, 0, true, 10, None);
+    assert_eq!(
+        outcome,
+        CleanupOutcome::ManagedSubmitted {
+            selected: 2,
+            submitted: 2
+        }
+    );
+    let pending = runtime.snapshot();
+    assert_eq!(pending.completed(), 0);
+    assert!(
+        pending.pending_tickets() >= 2,
+        "the allocator may also own orphan-retirement work"
+    );
+    assert!(temp_dir.path().join("commitlog/00000000000000000000").exists());
+    assert_eq!(alias.get_buffer(), &[1; 512]);
+    drop(alias);
+    let mut completed = 0;
+    for _ in 0..8 {
+        let report = runtime.drive_batch(64);
+        completed += report.completed();
+        if report.pending_tickets() == 0 {
+            break;
+        }
+    }
+    assert!(completed >= 2);
+    assert_eq!(
+        runtime.snapshot().pending_tickets(),
+        pending.pending_tickets() - completed
+    );
+    assert!(!temp_dir.path().join("commitlog/00000000000000000000").exists());
+    assert!(
+        temp_dir.path().join("commitlog/00000000000000001024").exists(),
+        "tail is retained"
+    );
+    store.shutdown().await;
+}
+
+#[tokio::test]
+async fn load_reports_failed_and_skipped_phases_and_retains_the_original_error() {
+    for managed in [false, true] {
+        for failing in [RecoveryPhase::ConsumeQueue, RecoveryPhase::CommitLog] {
+            let temp_dir = tempdir().unwrap();
+            let mut store = new_configured_test_store(
+                &temp_dir,
+                MessageStoreConfig {
+                    enable_mapped_file_lifecycle_wave_b: managed,
+                    message_index_enable: false,
+                    timer_wheel_enable: false,
+                    ..Default::default()
+                },
+            );
+            store.init().await.unwrap();
+            store.recovery_failure = Some((
+                failing,
+                StoreError::new(&rocketmq_error::STORAGE_INTERNAL_FAILURE, StoreOperation::Load).with_source(
+                    std::io::Error::new(std::io::ErrorKind::PermissionDenied, "private-recovery-cause"),
+                ),
+            ));
+            assert!(!store.load().await);
+            let report = store.last_recovery_report().unwrap();
+            assert_eq!(report.phases.len(), 3);
+            let failed_index = if failing == RecoveryPhase::ConsumeQueue { 0 } else { 1 };
+            assert_eq!(report.phases[failed_index].status, RecoveryPhaseStatus::Failed);
+            assert!(report.phases[failed_index].failure.is_some());
+            assert!(report.phases[failed_index + 1..]
+                .iter()
+                .all(|phase| phase.status == RecoveryPhaseStatus::Skipped));
+            assert!(!format!("{report:?}").contains("private-recovery-cause"));
+            let source = std::error::Error::source(store.last_recovery_error().unwrap()).unwrap();
+            assert_eq!(
+                source.downcast_ref::<std::io::Error>().unwrap().kind(),
+                std::io::ErrorKind::PermissionDenied
+            );
+            assert!(report.phase_duration_ms(failing).is_some());
+        }
+    }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10259

### Brief Description

Preserve Store outcomes and Broker ownership across configuration changes, I/O failures, cancellation, and shutdown. Unknown disk samples remain unknown, recovery retains actual failures, and managed cleanup distinguishes submission from reaper completion. Send branches retain one policy snapshot while honoring live permission revocation; incomplete error response headers and lazy Reply message IDs are handled before encoding.

Transaction read errors preserve both checkpoints. Per-queue drain owns pending batches and their budgets, including uncertain idempotent REMOVE writes. Schedule retains its stopping generation and final persistence across timeout or caller cancellation, and Broker shutdown/role transitions propagate incomplete stops. Local command admission reserves Control count and bytes within the existing root budget.

Actual append workers supply execution evidence that survives subsequent lease fences and flush/replication timeouts. Existing wire codes, persisted layouts, canonical acceptance, and durability mappings remain unchanged. Implementation details and validation scope are recorded in `rocketmq-doc/en/remediation/2026-09-08-p1.md`.

### How Did You Test This Change?

- Broker focused tests passed: two actual network policy/revocation regressions, 22 transaction queue tests, 22 Schedule tests, the failed-final-persistence role transition, two strict transaction decoder tests, 29 send tests, 11 reply tests, and shutdown-report coverage.
- Store focused regressions passed for disk samples, independent RunningFlags, managed/unmanaged load failures, recovery worker failure and joining, retained-lease retirement, real post-append lease fences/renewal, and synchronous flush timeout.
- `cargo test -p rocketmq-store --test capability_conformance_tests`: 11 passed.
- `cargo test -p rocketmq-store --test commitlog_recovery_tests`: 20 passed.
- `cargo test -p rocketmq-store --test mapped_file_queue_retirement`: five passed.
- HA replica-timeout and skip-HA cases passed. The broader HA target has an existing controller-role fixture that omits the required write lease and expects `PutOk` instead of `ServiceNotAvailable`; production lease admission was not relaxed.
- Local admission suite and the strengthened control/data progress regression passed; Store-local cleanup policy tests passed.
- `cargo fmt -p rocketmq-broker -p rocketmq-store -p rocketmq-store-local -p rocketmq-proxy-local -- --check` and `git diff --check` passed.
- Java cluster interoperability and deployment fault/performance exercises remain scheduled for the integration work. CI is not a merge gate for this request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved broker shutdown handling with deadlines, completion status, timeout detection, and unfinished-component reporting.
  - Send requests now consistently enforce current broker permissions, including checks immediately before storage.
  - Transaction and storage failures now surface as structured errors instead of silent fallback values.

- **Storage and Recovery**
  - Improved recovery reporting, including failed and skipped phases.
  - Enhanced append-result tracking and handling of writes affected by timeouts or fencing.
  - Improved disk-capacity classification and cleanup decisions.

- **Documentation**
  - Added remediation guidance covering storage health, recovery, request handling, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->