### PR TITLE
[ISSUE #10271]🐛Enforce production authentication and strict TLS configuration

### DIFF
--- a/distribution/helm/rocketmq-rust-core/README.md
+++ b/distribution/helm/rocketmq-rust-core/README.md
@@ -6,6 +6,11 @@ profile with `-f values-dev-single.yaml`, `-f values-production-default-ha.yaml`
 The single-node profile is for development. Production profiles require separate
 hosts for replicas; configure storage classes and resources for the target cluster.
 
+The chart defaults to `securityProfile: production` and enables authentication and
+authorization for every service. Production rejects an override that disables
+service authentication. `values-dev-single.yaml` explicitly selects development
+and disables authentication for its local test deployment.
+
 Every StatefulSet ordinal gets its own complete TOML configuration and stable DNS
 identity. Peer addresses are internal Kubernetes addresses. Processes run without
 a shell, with retained PVCs and HTTP startup, readiness, liveness, and drain probes.
@@ -16,6 +21,26 @@ Clients need matching ACL credentials; a TLS Proxy image must include the `tls`
 feature. Secret contents are never Helm values. Mounted Secret updates do not
 reload credentials or certificates automatically; restart the affected processes
 after rotation. See `values.yaml` for key names and mount options.
+
+The default auth Secret names are `rocketmq-namesrv-auth`, `rocketmq-broker-auth`,
+`rocketmq-controller-auth`, and `rocketmq-proxy-auth`. Create the Secrets for the
+enabled services before installing the release, or override their names. Each
+contains `plain_acl.yml`. Broker and Proxy Secrets also contain `inner-client.json`
+with the Java-compatible `accessKey`, `secretKey`, and optional `securityToken`
+fields. Grant those inner-client identities the required cluster permissions in
+the receiving services' ACL files. Keep the credential values in Secrets.
+
+The chart mounts the inner credentials and sets
+`ROCKETMQ_INNER_CLIENT_CREDENTIALS_FILE`. Missing, malformed, or incomplete mounted
+credentials fail initialization. Proxy enables its cluster ACL signer when auth is
+enabled; it refuses to start with an invalid signer configuration. Existing inline
+`innerClientAuthenticationCredentials` retain precedence for non-chart deployments.
+
+The chart's `securityProfile` selects authentication defaults. The process-level
+`ROCKETMQ_SECURITY_PROFILE=secure-enforced` also requires its existing bootstrap
+materials and now rejects disabled authentication or authorization in Broker,
+Controller, and Proxy, matching NameServer. Select TLS explicitly for the traffic
+that requires encryption; the Proxy TLS preset configures its gRPC listener.
 
 Configuration changes update Pod-template checksums. NameServer, Broker, and
 Controller use `OnDelete`, so a Helm upgrade does not automatically restart them.

--- a/distribution/helm/rocketmq-rust-core/templates/_config.tpl
+++ b/distribution/helm/rocketmq-rust-core/templates/_config.tpl
@@ -81,6 +81,7 @@ inSyncReplicas = {{ $config.minInSyncReplicas }}
 minInSyncReplicas = {{ $config.minInSyncReplicas }}
 {{- else if eq $service "proxy" -}}
 mode = "cluster"
+enableAclRpcHookForClusterMode = {{ $config.auth.enabled }}
 
 [grpc]
 listenAddr = "0.0.0.0:{{ $config.port }}"

--- a/distribution/helm/rocketmq-rust-core/templates/_helpers.tpl
+++ b/distribution/helm/rocketmq-rust-core/templates/_helpers.tpl
@@ -59,6 +59,9 @@ rocketmqrust.com/distribution: unofficial-community
 {{- end -}}
 {{- range $service, $config := .Values.services -}}
 {{- if $config.enabled -}}
+{{- if and (eq $.Values.securityProfile "production") (not $config.auth.enabled) -}}
+{{- fail (printf "production profile requires services.%s.auth.enabled=true" $service) -}}
+{{- end -}}
 {{- $requestCpu := include "rocketmq-core.cpuMillis" $config.resources.requests.cpu | float64 -}}
 {{- $limitCpu := include "rocketmq-core.cpuMillis" $config.resources.limits.cpu | float64 -}}
 {{- $requestMemory := include "rocketmq-core.memoryMi" $config.resources.requests.memory | int64 -}}

--- a/distribution/helm/rocketmq-rust-core/templates/workloads.yaml
+++ b/distribution/helm/rocketmq-rust-core/templates/workloads.yaml
@@ -89,6 +89,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- if and $config.auth.enabled (or (eq $service "broker") (eq $service "proxy")) }}
+            - name: ROCKETMQ_INNER_CLIENT_CREDENTIALS_FILE
+              value: "/etc/rocketmq/acl/inner-client.json"
+            {{- end }}
             - name: ROCKETMQ_HEALTH_BIND_ADDR
               value: "0.0.0.0:{{ $.Values.runtime.healthPort }}"
             - name: ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS
@@ -179,6 +183,10 @@ spec:
             items:
               - key: {{ $config.auth.aclKey }}
                 path: plain_acl.yml
+              {{- if or (eq $service "broker") (eq $service "proxy") }}
+              - key: {{ $config.auth.credentialsKey }}
+                path: inner-client.json
+              {{- end }}
         {{- end }}
         {{- if and (eq $service "proxy") $config.tls.enabled }}
         - name: proxy-tls

--- a/distribution/helm/rocketmq-rust-core/values-dev-single.yaml
+++ b/distribution/helm/rocketmq-rust-core/values-dev-single.yaml
@@ -1,11 +1,16 @@
+securityProfile: development
 services:
   namesrv:
+    auth: {enabled: false, secretName: ""}
     enabled: true
   broker:
+    auth: {enabled: false, secretName: ""}
     enabled: true
     replicas: 1
     controllerMode: false
   controller:
+    auth: {enabled: false, secretName: ""}
     enabled: false
   proxy:
+    auth: {enabled: false, secretName: ""}
     enabled: false

--- a/distribution/helm/rocketmq-rust-core/values.schema.json
+++ b/distribution/helm/rocketmq-rust-core/values.schema.json
@@ -1,8 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["global", "services"],
+  "required": ["securityProfile", "global", "services"],
   "properties": {
+    "securityProfile": {"enum": ["production", "development"]},
     "global": {
       "type": "object",
       "required": ["candidateVersion", "imageRegistry", "imagePullPolicy"],
@@ -85,11 +86,12 @@
     },
     "auth": {
       "type": "object",
-      "required": ["enabled", "secretName", "aclKey"],
+      "required": ["enabled", "secretName", "aclKey", "credentialsKey"],
       "properties": {
         "enabled": {"type": "boolean"},
         "secretName": {"type": "string", "pattern": "^([a-z0-9]([a-z0-9.-]*[a-z0-9])?)?$"},
-        "aclKey": {"type": "string", "pattern": "^[A-Za-z0-9_-][A-Za-z0-9_.-]*$"}
+        "aclKey": {"type": "string", "pattern": "^[A-Za-z0-9_-][A-Za-z0-9_.-]*$"},
+        "credentialsKey": {"type": "string", "pattern": "^[A-Za-z0-9_-][A-Za-z0-9_.-]*$"}
       },
       "additionalProperties": false
     },

--- a/distribution/helm/rocketmq-rust-core/values.yaml
+++ b/distribution/helm/rocketmq-rust-core/values.yaml
@@ -1,3 +1,5 @@
+securityProfile: production
+
 global:
   candidateVersion: "1.0.0"
   imageRegistry: "ghcr.io/mxsm/rocketmq-rust"
@@ -36,7 +38,7 @@ services:
     resources:
       requests: {cpu: 100m, memory: 256Mi}
       limits: {cpu: "1", memory: 512Mi}
-    auth: {enabled: false, secretName: "", aclKey: plain_acl.yml}
+    auth: {enabled: true, secretName: rocketmq-namesrv-auth, aclKey: plain_acl.yml, credentialsKey: inner-client.json}
   broker:
     enabled: true
     replicas: 1
@@ -50,7 +52,7 @@ services:
     resources:
       requests: {cpu: 500m, memory: 1Gi}
       limits: {cpu: "2", memory: 2Gi}
-    auth: {enabled: false, secretName: "", aclKey: plain_acl.yml}
+    auth: {enabled: true, secretName: rocketmq-broker-auth, aclKey: plain_acl.yml, credentialsKey: inner-client.json}
   controller:
     enabled: false
     replicas: 3
@@ -61,7 +63,7 @@ services:
     resources:
       requests: {cpu: 250m, memory: 512Mi}
       limits: {cpu: "1", memory: 1Gi}
-    auth: {enabled: false, secretName: "", aclKey: plain_acl.yml}
+    auth: {enabled: true, secretName: rocketmq-controller-auth, aclKey: plain_acl.yml, credentialsKey: inner-client.json}
   proxy:
     enabled: false
     replicas: 1
@@ -69,7 +71,7 @@ services:
     resources:
       requests: {cpu: 250m, memory: 512Mi}
       limits: {cpu: "2", memory: 1Gi}
-    auth: {enabled: false, secretName: "", aclKey: plain_acl.yml}
+    auth: {enabled: true, secretName: rocketmq-proxy-auth, aclKey: plain_acl.yml, credentialsKey: inner-client.json}
     cluster:
       ioMaxInflight: 256
       controlReserve: 32

--- a/rocketmq-auth/src/authentication/acl_client_rpc_hook.rs
+++ b/rocketmq-auth/src/authentication/acl_client_rpc_hook.rs
@@ -48,6 +48,9 @@ const ACCESS_KEY: &str = "AccessKey";
 const SECURITY_TOKEN: &str = "SecurityToken";
 const SIGNATURE: &str = "Signature";
 
+/// Optional mounted JSON credentials used when inline inner-client credentials are absent.
+pub const INNER_CLIENT_CREDENTIALS_FILE_ENV: &str = "ROCKETMQ_INNER_CLIENT_CREDENTIALS_FILE";
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct AclClientRpcHook {
     access_key: CheetahString,
@@ -89,10 +92,34 @@ impl AclClientRpcHook {
     }
 
     pub fn from_auth_config(config: &AuthConfig) -> AuthServiceResult<Option<Self>> {
-        Self::from_credentials_json(
+        if config.inner_client_authentication_credentials.trim().is_empty() {
+            if let Some(path) = std::env::var_os(INNER_CLIENT_CREDENTIALS_FILE_ENV) {
+                return Self::from_required_credentials_file(Path::new(&path), config.signature_algorithm).map(Some);
+            }
+        }
+        let signer = Self::from_credentials_json(
             config.inner_client_authentication_credentials.as_str(),
             config.signature_algorithm,
-        )
+        )?;
+        if signer.is_none() && !config.inner_client_authentication_credentials.trim().is_empty() {
+            return Err(AuthServiceError::new(
+                AuthOperation::Initialize,
+                AuthFailureKind::InvalidConfiguration,
+            ));
+        }
+        Ok(signer)
+    }
+
+    /// Loads an explicitly configured Secret file; missing or empty credentials fail startup.
+    pub fn from_required_credentials_file(
+        path: impl AsRef<Path>,
+        signature_algorithm: SignatureAlgorithm,
+    ) -> AuthServiceResult<Self> {
+        let content = fs::read_to_string(path).map_err(|error| {
+            AuthServiceError::with_source(AuthOperation::LoadSecret, AuthFailureKind::Unavailable, error)
+        })?;
+        Self::from_credentials_json(&content, signature_algorithm)?
+            .ok_or_else(|| AuthServiceError::new(AuthOperation::Initialize, AuthFailureKind::InvalidConfiguration))
     }
 
     pub fn from_credentials_json(
@@ -274,6 +301,28 @@ mod tests {
 
     fn remote_addr() -> SocketAddr {
         "127.0.0.1:9876".parse().unwrap()
+    }
+
+    #[test]
+    fn required_secret_file_rejects_missing_malformed_and_incomplete_credentials() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("inner-client.json");
+        assert!(AclClientRpcHook::from_required_credentials_file(&path, SignatureAlgorithm::HmacSha1).is_err());
+        for invalid in [
+            "",
+            "not-json",
+            r#"{"accessKey":"inner"}"#,
+            r#"{"accessKey":"inner","secretKey":" "}"#,
+        ] {
+            std::fs::write(&path, invalid).unwrap();
+            let error =
+                AclClientRpcHook::from_required_credentials_file(&path, SignatureAlgorithm::HmacSha1).unwrap_err();
+            assert!(!error.to_string().contains("not-json"));
+        }
+        std::fs::write(&path, r#"{"accessKey":"inner","secretKey":"mounted-secret"}"#).unwrap();
+        let signer = AclClientRpcHook::from_required_credentials_file(&path, SignatureAlgorithm::HmacSha1).unwrap();
+        assert_eq!(signer.access_key().as_str(), "inner");
+        assert!(!format!("{signer:?}").contains("mounted-secret"));
     }
 
     #[test]

--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -282,6 +282,11 @@ fn validate_broker_security(
     observability_config: &rocketmq_observability::ObservabilityConfig,
     probe_bind_addr: Option<SocketAddr>,
 ) -> Result<SecurityBootstrapOutcome> {
+    if security_bootstrap.requires_authentication()
+        && (!broker_config.authentication_enabled || !broker_config.authorization_enabled)
+    {
+        anyhow::bail!("secure-enforced Broker requires both authenticationEnabled and authorizationEnabled");
+    }
     if !security_bootstrap.is_enabled() {
         return security_bootstrap.validate(&[]).map_err(anyhow::Error::from);
     }
@@ -666,6 +671,28 @@ fn print_tieredstore_startup_info(message_store_config: &MessageStoreConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn secure_profile_rejects_disabled_request_protection_before_material_loading() {
+        let security =
+            SecurityBootstrap::Enabled(SecurityBootstrapConfig::new(SecurityBootstrapProfile::SecureEnforced));
+        for (authentication, authorization) in [(false, false), (true, false), (false, true)] {
+            let mut config = BrokerConfig::default();
+            config.authentication_enabled = authentication;
+            config.authorization_enabled = authorization;
+            let error = validate_broker_security(
+                &security,
+                &config,
+                &MessageStoreConfig::default(),
+                &build_broker_telemetry_bootstrap_config(&config).observability,
+                None,
+            )
+            .unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("requires both authenticationEnabled and authorizationEnabled"));
+        }
+    }
 
     #[test]
     fn disabled_security_bootstrap_allows_default_broker_listeners() {

--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -420,6 +420,11 @@ fn validate_controller_security(
     prometheus_bind_addr: Option<SocketAddr>,
     probe_bind_addr: Option<SocketAddr>,
 ) -> Result<SecurityBootstrapOutcome> {
+    if security_bootstrap.requires_authentication()
+        && (!controller_config.authentication_enabled || !controller_config.authorization_enabled)
+    {
+        anyhow::bail!("secure-enforced Controller requires both authenticationEnabled and authorizationEnabled");
+    }
     if !security_bootstrap.is_enabled() {
         return security_bootstrap.validate(&[]).map_err(anyhow::Error::from);
     }
@@ -766,6 +771,21 @@ fn parse_auto_initialize_cluster_flag(raw: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn secure_profile_rejects_disabled_request_protection_before_material_loading() {
+        let security =
+            SecurityBootstrap::Enabled(SecurityBootstrapConfig::new(SecurityBootstrapProfile::SecureEnforced));
+        for (authentication, authorization) in [(false, false), (true, false), (false, true)] {
+            let mut config = ControllerConfig::default();
+            config.authentication_enabled = authentication;
+            config.authorization_enabled = authorization;
+            let error = validate_controller_security(&security, &config, None, None).unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("requires both authenticationEnabled and authorizationEnabled"));
+        }
+    }
 
     #[test]
     fn telemetry_shutdown_aggregate_retains_both_typed_failures_with_fixed_display() {

--- a/rocketmq-doc/en/remediation/2026-09-08-security-defaults.md
+++ b/rocketmq-doc/en/remediation/2026-09-08-security-defaults.md
@@ -1,0 +1,43 @@
+# Production authentication defaults and strict TLS configuration
+
+Production Helm deployments enable authentication and authorization on every
+enabled service. Development opt-out is explicit in `values-dev-single.yaml`.
+Named Kubernetes Secrets supply ACL files and Broker/Proxy inner-client JSON
+credentials; those credentials do not enter ConfigMaps or Helm values. The chart
+enables Proxy's outbound ACL signing together with authentication.
+
+An explicitly configured signer or mounted credential file is required to be
+usable. Invalid configuration fails startup instead of silently continuing with
+unsigned requests. Inline credentials preserve their existing precedence. The
+legacy optional credential parser remains available to compatibility callers.
+
+Broker, Controller, and Proxy reject `secure-enforced` startup when either request
+authentication or authorization is disabled, before loading bootstrap materials
+or binding listeners. NameServer already enforces this requirement. The existing
+development and Java-compatible process defaults remain available; the stronger
+defaults apply to production chart deployments and explicitly selected secure
+process profiles.
+
+## TLS configuration
+
+Structured TLS deserialization and operational Java-properties loaders reject
+unknown server modes, client-auth policies, and invalid security booleans. Valid
+values remain case-insensitive;
+`required` remains an alias for `require`. Omitted fields retain their existing
+defaults. Properties files retain their comment and quoting syntax.
+
+`TlsMode::parse_strict`, `TlsClientAuth::parse_strict`,
+`TlsConfig::try_apply_java_property`, and `try_apply_java_properties_str` expose
+typed failures. Applying a full properties snapshot is atomic. Startup rejects
+invalid explicit policies even in permissive mode. A failed live reload retains
+the previous acceptor and generation; it does not weaken client authentication.
+Missing explicitly named properties files also fail; the default properties-file
+location remains optional for compatibility.
+The infallible legacy parsers retain Java fallback behavior for callers that
+explicitly need that compatibility API.
+
+The protobuf schemas, remoting request/response codes, Java ACL credential shape,
+signature algorithm, and persisted storage layouts are unchanged. TLS encryption
+is configured separately from authentication; the production Proxy TLS preset
+enables gRPC TLS. These changes do not establish end-to-end cluster encryption or
+replace deployment fault and interoperability qualification.

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -696,7 +696,7 @@ fn load_durable_desired_snapshot(
                 client_config.maintenance.idle_scan_interval =
                     (parsed > 0).then(|| std::time::Duration::from_millis(parsed));
             }
-            key if is_tls_config_key(key) => server_config.tls_config.apply_java_property(key, value.as_str()),
+            key if is_tls_config_key(key) => server_config.tls_config.try_apply_java_property(key, value.as_str())?,
             _ => bail!("unknown durable NameServer configuration key '{key}'"),
         }
     }
@@ -720,7 +720,7 @@ fn resolve_startup_log_filter(
 fn apply_tls_properties_from_file(server_config: &mut ServerConfig, config_file: PathBuf) -> Result<()> {
     let content = std::fs::read_to_string(&config_file)
         .with_context(|| format!("Failed to read TLS properties from {:?}", config_file))?;
-    server_config.tls_config.apply_java_properties_str(&content);
+    server_config.tls_config.try_apply_java_properties_str(&content)?;
     Ok(())
 }
 
@@ -1032,6 +1032,17 @@ mod tests {
     use rocketmq_protocol::code::request_code::RequestCode;
 
     use super::*;
+
+    #[test]
+    fn tls_properties_reject_invalid_policy_without_partial_updates() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("tls.properties");
+        std::fs::write(&path, "tls.server.mode=disabled\ntls.server.need.client.auth=reqiure").unwrap();
+        let mut server = ServerConfig::default();
+        let original = server.tls_config.clone();
+        assert!(apply_tls_properties_from_file(&mut server, path).is_err());
+        assert_eq!(server.tls_config, original);
+    }
 
     #[test]
     #[ignore = "requires CORE_HELM_CONFIG_DIR exported by scripts/core_helm_configs.py"]

--- a/rocketmq-namesrv/src/bootstrap/config_apply.rs
+++ b/rocketmq-namesrv/src/bootstrap/config_apply.rs
@@ -221,7 +221,10 @@ fn apply_to_snapshot(
             "listenPort" => server_config.listen_port = parse_config_value(key, value)?,
             "bindAddress" => server_config.bind_address = value.to_string(),
             key if is_tls_config_key(key) => {
-                server_config.tls_config.apply_java_property(key, value.as_str());
+                server_config
+                    .tls_config
+                    .try_apply_java_property(key, value.as_str())
+                    .map_err(|error| crate::namesrv_error::invalid_configuration_source(key, error))?;
             }
             "connectTimeoutMillis" => {
                 let timeout_millis = parse_config_value::<u64>(key, value)?;

--- a/rocketmq-proxy/src/auth.rs
+++ b/rocketmq-proxy/src/auth.rs
@@ -63,8 +63,6 @@ use rocketmq_runtime::ChildServiceContext;
 use rocketmq_security_api::Action;
 use rocketmq_security_api::AuthorizationDecision;
 use tonic::Request;
-#[cfg(feature = "cluster-mode")]
-use tracing::warn;
 
 use crate::config::ProxyAuthConfig;
 #[cfg(feature = "cluster-mode")]
@@ -91,34 +89,29 @@ use crate::service::MetadataService;
 use crate::service::ResourceIdentity;
 
 #[cfg(feature = "cluster-mode")]
-pub(crate) fn build_cluster_acl_signer(config: &ProxyConfig) -> Option<AclClientRpcHook> {
+pub(crate) fn build_cluster_acl_signer(config: &ProxyConfig) -> ProxyResult<Option<AclClientRpcHook>> {
     if !config.enable_acl_rpc_hook_for_cluster_mode {
-        return None;
+        return Ok(None);
     }
-
     let auth_config = config.auth.to_auth_config();
-    match AclClientRpcHook::from_auth_config(&auth_config) {
-        Ok(Some(rpc_hook)) => return Some(rpc_hook),
-        Ok(None) => {}
-        Err(error) => {
-            warn!("Skipping proxy cluster ACL RPC hook from inner credentials: {error}");
-            return None;
-        }
+    if let Some(signer) = AclClientRpcHook::from_auth_config(&auth_config).map_err(|error| {
+        canonical::configuration_invalid_with_source("proxy.auth.innerClientAuthenticationCredentials", error)
+    })? {
+        return Ok(Some(signer));
     }
-
     let rocketmq_home = EnvUtils::get_rocketmq_home();
     let tools_file = Path::new(&rocketmq_home).join(ACL_CONF_TOOLS_FILE.trim_start_matches('/'));
-    match AclClientRpcHook::from_tools_file(&tools_file, auth_config.signature_algorithm) {
-        Ok(Some(rpc_hook)) => Some(rpc_hook),
-        Ok(None) => None,
-        Err(error) => {
-            warn!(
-                "Skipping proxy cluster ACL RPC hook from {}: {error}",
-                tools_file.display()
-            );
-            None
-        }
-    }
+    let signer = AclClientRpcHook::from_tools_file(&tools_file, auth_config.signature_algorithm)
+        .map_err(|error| {
+            canonical::configuration_invalid_with_source("proxy.auth.innerClientAuthenticationCredentials", error)
+        })?
+        .ok_or_else(|| {
+            canonical::configuration_invalid(
+                "proxy.enableAclRpcHookForClusterMode",
+                "enabled cluster ACL signing requires inner-client credentials",
+            )
+        })?;
+    Ok(Some(signer))
 }
 
 /// Authenticated identity and authorization trust decision issued by this crate.
@@ -1120,6 +1113,28 @@ mod tests {
 
     #[cfg(feature = "cluster-mode")]
     #[test]
+    fn enabled_cluster_signing_rejects_malformed_credentials() {
+        for credentials in [
+            "invalid-secret",
+            r#"{"accessKey":"inner"}"#,
+            r#"{"accessKey":"inner","secretKey":" "}"#,
+        ] {
+            let config = ProxyConfig {
+                enable_acl_rpc_hook_for_cluster_mode: true,
+                auth: ProxyAuthConfig {
+                    inner_client_authentication_credentials: credentials.to_owned(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let error = build_cluster_acl_signer(&config).unwrap_err();
+            assert_eq!(error.descriptor(), &rocketmq_error::CORE_CONFIGURATION_INVALID);
+            assert!(!error.to_string().contains("invalid-secret"));
+        }
+    }
+
+    #[cfg(feature = "cluster-mode")]
+    #[test]
     fn build_cluster_acl_signer_uses_enabled_proxy_inner_credentials() {
         let config = ProxyConfig {
             enable_acl_rpc_hook_for_cluster_mode: true,
@@ -1130,7 +1145,9 @@ mod tests {
             },
             ..ProxyConfig::default()
         };
-        let signer = build_cluster_acl_signer(&config).expect("enabled credentials should build signer");
+        let signer = build_cluster_acl_signer(&config)
+            .expect("valid signer config")
+            .expect("enabled credentials should build signer");
         assert_eq!(signer.access_key().as_str(), "inner");
     }
 

--- a/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
+++ b/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
@@ -329,6 +329,15 @@ fn validate_proxy_security(
     prometheus_bind_addr: Option<std::net::SocketAddr>,
     probe_bind_addr: Option<std::net::SocketAddr>,
 ) -> ProxyResult<SecurityBootstrapOutcome> {
+    if security_bootstrap.requires_authentication()
+        && (!config.auth.authentication_enabled || !config.auth.authorization_enabled)
+    {
+        return Err(canonical::configuration_invalid(
+            "proxy.auth",
+            "secure-enforced Proxy requires both authenticationEnabled and authorizationEnabled",
+        )
+        .into());
+    }
     if !security_bootstrap.is_enabled() {
         return security_bootstrap.validate(&[]).map_err(proxy_security_provider_error);
     }
@@ -604,6 +613,19 @@ fn print_config(config: &ProxyConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn secure_profile_rejects_disabled_request_protection_before_material_loading() {
+        let security =
+            SecurityBootstrap::Enabled(SecurityBootstrapConfig::new(SecurityBootstrapProfile::SecureEnforced));
+        for (authentication, authorization) in [(false, false), (true, false), (false, true)] {
+            let mut config = ProxyConfig::default();
+            config.auth.authentication_enabled = authentication;
+            config.auth.authorization_enabled = authorization;
+            let error = validate_proxy_security(&security, &config, None, None).unwrap_err();
+            assert_eq!(error.descriptor(), &rocketmq_error::CORE_CONFIGURATION_INVALID);
+        }
+    }
 
     #[test]
     fn runtime_termination_errors_preserve_the_runtime_source() {

--- a/rocketmq-proxy/src/bootstrap.rs
+++ b/rocketmq-proxy/src/bootstrap.rs
@@ -752,7 +752,7 @@ fn default_service_manager_and_backend(
             if !config.auth.cluster_name.trim().is_empty() {
                 cluster_config.broker_cluster_name = config.auth.cluster_name.clone();
             }
-            let signer = build_cluster_acl_signer(config).map(|signer| signer.into_outbound_signer());
+            let signer = build_cluster_acl_signer(config)?.map(|signer| signer.into_outbound_signer());
             let cluster_context = service_context.component("cluster-backend");
             let client = Arc::new(RocketmqClusterClient::new(
                 cluster_config,

--- a/rocketmq-security-api/src/secure_deployment.rs
+++ b/rocketmq-security-api/src/secure_deployment.rs
@@ -104,6 +104,11 @@ impl SecurityBootstrap {
         matches!(self, Self::Enabled(_))
     }
 
+    /// Reports whether the selected profile requires request authentication and authorization.
+    pub const fn requires_authentication(&self) -> bool {
+        matches!(self, Self::Enabled(config) if matches!(config.profile, SecurityBootstrapProfile::SecureEnforced))
+    }
+
     /// Validates enabled security bootstrap or records that it was intentionally disabled.
     ///
     /// # Errors

--- a/rocketmq-transport/src/config.rs
+++ b/rocketmq-transport/src/config.rs
@@ -22,5 +22,6 @@ pub use socket_options::TcpKeepaliveConfig;
 pub use tls_config::TlsClientAuth;
 pub use tls_config::TlsClientConfig;
 pub use tls_config::TlsConfig;
+pub use tls_config::TlsConfigError;
 pub use tls_config::TlsMode;
 pub use tls_config::TlsServerConfig;

--- a/rocketmq-transport/src/config/tls_config.rs
+++ b/rocketmq-transport/src/config/tls_config.rs
@@ -21,6 +21,19 @@ use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
 
+pub(crate) const DEFAULT_TLS_CONFIG_FILE: &str = "/etc/rocketmq/tls.properties";
+
+/// Invalid explicit TLS configuration, without retaining the supplied value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TlsConfigError {
+    #[error("tls.server.mode must be disabled, permissive, or enforcing")]
+    ServerMode,
+    #[error("tls.server.need.client.auth must be none, optional, require, or required")]
+    ClientAuth,
+    #[error("{0} must be true or false")]
+    Boolean(&'static str),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TlsMode {
     Disabled,
@@ -30,6 +43,16 @@ pub enum TlsMode {
 }
 
 impl TlsMode {
+    /// Parses explicit configuration without the Java-compatible fallback in `FromStr`.
+    pub fn parse_strict(value: &str) -> Result<Self, TlsConfigError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "disabled" => Ok(Self::Disabled),
+            "permissive" => Ok(Self::Permissive),
+            "enforcing" => Ok(Self::Enforcing),
+            _ => Err(TlsConfigError::ServerMode),
+        }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             TlsMode::Disabled => "disabled",
@@ -73,7 +96,7 @@ impl<'de> Deserialize<'de> for TlsMode {
         D: Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        Ok(TlsMode::from_str(&value).unwrap_or_default())
+        TlsMode::parse_strict(&value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -86,6 +109,16 @@ pub enum TlsClientAuth {
 }
 
 impl TlsClientAuth {
+    /// Parses explicit configuration without weakening an unknown client-auth policy.
+    pub fn parse_strict(value: &str) -> Result<Self, TlsConfigError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "none" => Ok(Self::None),
+            "optional" => Ok(Self::Optional),
+            "require" | "required" => Ok(Self::Require),
+            _ => Err(TlsConfigError::ClientAuth),
+        }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             TlsClientAuth::None => "none",
@@ -129,7 +162,7 @@ impl<'de> Deserialize<'de> for TlsClientAuth {
         D: Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        Ok(TlsClientAuth::from_str(&value).unwrap_or_default())
+        TlsClientAuth::parse_strict(&value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -173,6 +206,48 @@ impl Default for TlsConfig {
 }
 
 impl TlsConfig {
+    /// Applies one explicit property, rejecting invalid TLS policies before mutation.
+    pub fn try_apply_java_property(&mut self, key: &str, value: &str) -> Result<(), TlsConfigError> {
+        let normalized = strip_matching_quotes(strip_inline_comment(value.trim()).trim());
+        match key.trim() {
+            "tls.enable" | "tlsEnable" => self.enable = parse_bool_strict(normalized, "tls.enable")?,
+            "tls.test.mode.enable" | "tlsTestModeEnable" => {
+                self.test_mode_enable = parse_bool_strict(normalized, "tls.test.mode.enable")?;
+            }
+            "tls.server.authClient" | "tlsServerAuthClient" => {
+                self.server.auth_client = parse_bool_strict(normalized, "tls.server.authClient")?;
+            }
+            "tls.client.authServer" | "tlsClientAuthServer" => {
+                self.client.auth_server = parse_bool_strict(normalized, "tls.client.authServer")?;
+            }
+            "tls.server.mode" | "tlsServerMode" => {
+                self.server.mode = TlsMode::parse_strict(normalized)?;
+            }
+            "tls.server.need.client.auth" | "tlsServerNeedClientAuth" => {
+                self.server.need_client_auth = TlsClientAuth::parse_strict(normalized)?;
+            }
+            _ => self.apply_java_property(key, value),
+        }
+        Ok(())
+    }
+
+    /// Applies an entire properties snapshot atomically after validating its TLS policies.
+    pub fn try_apply_java_properties_str(&mut self, content: &str) -> Result<(), TlsConfigError> {
+        let mut candidate = self.clone();
+        for raw_line in content.lines() {
+            let line = raw_line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with('!') {
+                continue;
+            }
+            if let Some((key, value)) = split_property(line) {
+                candidate.try_apply_java_property(key, value)?;
+            }
+        }
+        *self = candidate;
+        Ok(())
+    }
+
+    /// Java-compatible legacy parser. Explicit startup/reload configuration uses the fallible API.
     pub fn apply_java_property(&mut self, key: &str, value: &str) {
         let value = strip_matching_quotes(strip_inline_comment(value.trim()).trim());
         match key.trim() {
@@ -370,6 +445,16 @@ fn parse_bool(value: &str, default: bool) -> bool {
     value.parse::<bool>().unwrap_or(default)
 }
 
+fn parse_bool_strict(value: &str, key: &'static str) -> Result<bool, TlsConfigError> {
+    if value.eq_ignore_ascii_case("true") {
+        Ok(true)
+    } else if value.eq_ignore_ascii_case("false") {
+        Ok(false)
+    } else {
+        Err(TlsConfigError::Boolean(key))
+    }
+}
+
 fn non_empty(value: &str) -> Option<String> {
     if value.is_empty() {
         None
@@ -436,13 +521,57 @@ fn push_optional_entry(entries: &mut Vec<(&'static str, String)>, key: &'static 
 
 mod defaults {
     pub fn tls_config_file() -> String {
-        "/etc/rocketmq/tls.properties".to_string()
+        super::DEFAULT_TLS_CONFIG_FILE.to_string()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_tls_policy_rejects_typos_without_weakening_a_snapshot() {
+        for invalid in ["enforcng", "", "false"] {
+            assert!(serde_json::from_value::<TlsMode>(serde_json::json!(invalid)).is_err());
+            assert!(serde_json::from_value::<TlsClientAuth>(serde_json::json!(invalid)).is_err());
+        }
+        assert_eq!(
+            serde_json::from_str::<TlsClientAuth>("\" REQUIRED \"").unwrap(),
+            TlsClientAuth::Require
+        );
+        let mut config = TlsConfig::default();
+        config.server.mode = TlsMode::Enforcing;
+        config.server.need_client_auth = TlsClientAuth::Require;
+        let original = config.clone();
+        for key in [
+            "tls.enable",
+            "tls.test.mode.enable",
+            "tls.server.authClient",
+            "tls.client.authServer",
+        ] {
+            assert_eq!(
+                config.try_apply_java_property(key, "flase"),
+                Err(TlsConfigError::Boolean(key))
+            );
+            assert_eq!(config, original);
+        }
+        assert_eq!(
+            config.try_apply_java_properties_str("tls.server.mode=disabled\ntls.server.need.client.auth=reqiure"),
+            Err(TlsConfigError::ClientAuth)
+        );
+        assert_eq!(config, original);
+        assert_eq!(
+            config.try_apply_java_property("tlsServerMode", "enforcng"),
+            Err(TlsConfigError::ServerMode)
+        );
+        assert_eq!(config, original);
+        config
+            .try_apply_java_properties_str(
+                "tls.server.mode=\"Enforcing\" # comment\ntls.server.need.client.auth=required",
+            )
+            .unwrap();
+        assert_eq!(config, original);
+    }
 
     #[test]
     fn tls_mode_parse_defaults_to_permissive_like_java() {

--- a/rocketmq-transport/src/public_api.rs
+++ b/rocketmq-transport/src/public_api.rs
@@ -56,6 +56,7 @@ pub use crate::config::TcpKeepaliveConfig;
 pub use crate::config::TlsClientAuth;
 pub use crate::config::TlsClientConfig;
 pub use crate::config::TlsConfig;
+pub use crate::config::TlsConfigError;
 pub use crate::config::TlsMode;
 pub use crate::config::TlsServerConfig;
 pub use crate::config_support::network_util::NetworkUtil;

--- a/rocketmq-transport/src/tls.rs
+++ b/rocketmq-transport/src/tls.rs
@@ -200,11 +200,11 @@ impl TlsServerRuntime {
             let build_config = base_config.clone();
             let initial = blocking
                 .spawn_io("transport.tls.initialize", move || {
-                    let effective = effective_tls_config(&build_config);
-                    build_server_acceptor(&effective)
+                    let effective = effective_tls_config(&build_config)?;
+                    Ok::<_, SharedError>(build_server_acceptor_exact(&effective))
                 })
                 .await
-                .map_err(|source| connection_failed(TransportStage::EndpointValidation, source))?;
+                .map_err(|source| connection_failed(TransportStage::EndpointValidation, source))??;
             match initial {
                 Ok(initial) => acceptor.store(Some(StdArc::new(VersionedTlsAcceptor {
                     generation: 1,
@@ -372,12 +372,12 @@ impl TlsServerRuntime {
         let acceptor = self
             .blocking
             .spawn_io("transport.tls.reload", move || {
-                let effective = effective_tls_config(&base_config);
+                let effective = effective_tls_config(&base_config)?;
                 let _snapshot = file_snapshot(&effective.watched_server_paths());
                 if mode == TlsMode::Disabled {
                     Ok(None)
                 } else {
-                    build_server_acceptor(&effective).map(Some)
+                    build_server_acceptor_exact(&effective).map(Some)
                 }
             })
             .await
@@ -468,11 +468,15 @@ impl TlsServerRuntime {
             let initial_config = base_config.clone();
             let mut previous_snapshot = match blocking
                 .spawn_io("transport.tls.reload.snapshot", move || {
-                    file_snapshot(&effective_tls_config(&initial_config).watched_server_paths())
+                    effective_tls_config(&initial_config).map(|config| file_snapshot(&config.watched_server_paths()))
                 })
                 .await
             {
-                Ok(snapshot) => snapshot,
+                Ok(Ok(snapshot)) => snapshot,
+                Ok(Err(error)) => {
+                    warn!(%error, "invalid initial TLS reload configuration");
+                    Vec::new()
+                }
                 Err(error) => {
                     warn!(?error, "failed to inspect initial TLS reload snapshot");
                     Vec::new()
@@ -488,15 +492,19 @@ impl TlsServerRuntime {
                 let reload_config = base_config.clone();
                 let current_snapshot = match blocking
                     .spawn_io("transport.tls.reload", move || {
-                        let effective_config = effective_tls_config(&reload_config);
+                        let effective_config = effective_tls_config(&reload_config)?;
                         let paths = effective_config.watched_server_paths();
                         let current_snapshot = file_snapshot(&paths);
-                        let acceptor = build_server_acceptor(&effective_config);
-                        (current_snapshot, acceptor)
+                        let acceptor = build_server_acceptor_exact(&effective_config);
+                        Ok::<_, SharedError>((current_snapshot, acceptor))
                     })
                     .await
                 {
-                    Ok(value) => value,
+                    Ok(Ok(value)) => value,
+                    Ok(Err(error)) => {
+                        warn!(%error, "invalid TLS reload configuration; keeping previous acceptor");
+                        continue;
+                    }
                     Err(error) => {
                         warn!(?error, "TLS reload blocking work failed");
                         continue;
@@ -612,7 +620,7 @@ pub fn build_client_config(
         }
     }
 
-    let effective_config = effective_tls_config(tls_config);
+    let effective_config = effective_tls_config(tls_config)?;
     let protocol_versions = configured_protocol_versions(&effective_config)?;
     let client_builder = match protocol_versions.as_deref() {
         Some(versions) => tokio_rustls::rustls::ClientConfig::builder_with_protocol_versions(versions),
@@ -652,9 +660,11 @@ pub fn build_client_config(
     }
 }
 
-#[cfg(feature = "tls")]
-pub fn build_server_acceptor(tls_config: &TlsConfig) -> Result<tokio_rustls::TlsAcceptor, rocketmq_error::SharedError> {
-    let effective_config = effective_tls_config(tls_config);
+#[cfg(all(feature = "tls", any(test, feature = "test-support")))]
+pub(crate) fn build_server_acceptor(
+    tls_config: &TlsConfig,
+) -> Result<tokio_rustls::TlsAcceptor, rocketmq_error::SharedError> {
+    let effective_config = effective_tls_config(tls_config)?;
 
     build_server_acceptor_exact(&effective_config)
 }
@@ -981,20 +991,28 @@ fn configured_protocol_versions(
 }
 
 #[cfg(feature = "tls")]
-fn effective_tls_config(base_config: &TlsConfig) -> TlsConfig {
+fn effective_tls_config(base_config: &TlsConfig) -> Result<TlsConfig, SharedError> {
     let mut effective_config = base_config.clone();
     let enable = effective_config.enable;
     let server_mode = effective_config.server.mode;
     let config_file = effective_config.config_file.clone();
 
-    if let Ok(content) = fs::read_to_string(&config_file) {
-        effective_config.apply_java_properties_str(&content);
-        effective_config.enable = enable;
-        effective_config.server.mode = server_mode;
-        effective_config.config_file = config_file;
+    match fs::read_to_string(&config_file) {
+        Ok(content) => {
+            effective_config
+                .try_apply_java_properties_str(&content)
+                .map_err(|source| config_error_source("tls.config.file", source))?;
+            effective_config.enable = enable;
+            effective_config.server.mode = server_mode;
+            effective_config.config_file = config_file;
+        }
+        Err(error)
+            if error.kind() == std::io::ErrorKind::NotFound
+                && (config_file.is_empty() || config_file == crate::config::tls_config::DEFAULT_TLS_CONFIG_FILE) => {}
+        Err(error) => return Err(config_error_source("tls.config.file", error)),
     }
 
-    effective_config
+    Ok(effective_config)
 }
 
 #[cfg(feature = "tls")]
@@ -1034,6 +1052,43 @@ fn config_error_source(key: &'static str, source: impl std::error::Error + Send 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "tls")]
+    #[tokio::test]
+    async fn invalid_tls_policy_fails_startup_and_preserves_a_live_reload_generation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("tls.properties");
+        let context = rocketmq_runtime::RuntimeContext::from_current("strict-tls-policy");
+        let service = context.service_context("tls");
+        let config = TlsConfig {
+            config_file: path.to_string_lossy().into_owned(),
+            test_mode_enable: true,
+            ..Default::default()
+        };
+        fs::write(&path, "tls.server.need.client.auth=reqiure").unwrap();
+        let result = TlsServerRuntime::initialize_with_service_context(config.clone(), &service).await;
+        assert!(
+            result.is_err(),
+            "invalid explicit policy must fail even in permissive mode"
+        );
+        fs::write(&path, "tls.server.need.client.auth=none").unwrap();
+        let runtime = TlsServerRuntime::initialize_with_service_context(config, &service)
+            .await
+            .unwrap();
+        let generation = runtime.active_generation();
+        assert!(generation > 0);
+        fs::write(&path, "tls.server.need.client.auth=reqiure").unwrap();
+        assert!(runtime.reload_now_with_report().await.is_err());
+        assert_eq!(runtime.active_generation(), generation);
+        fs::remove_file(&path).unwrap();
+        assert!(runtime.reload_now_with_report().await.is_err());
+        assert_eq!(runtime.active_generation(), generation);
+        assert!(runtime
+            .shutdown_gracefully(Duration::from_secs(1))
+            .await
+            .unwrap()
+            .is_healthy());
+    }
 
     #[cfg(feature = "tls")]
     #[tokio::test]
@@ -1088,7 +1143,7 @@ mod tests {
             Err(error) => error,
         };
 
-        assert!(error.to_string().contains("tls-initialize"));
+        assert_eq!(error.descriptor(), &rocketmq_error::TRANSPORT_CONNECTION_FAILED);
     }
 
     #[cfg(feature = "tls")]
@@ -1116,7 +1171,7 @@ mod tests {
             ..Default::default()
         };
 
-        let effective = effective_tls_config(&base);
+        let effective = effective_tls_config(&base).expect("valid TLS properties");
 
         assert!(effective.enable);
         assert_eq!(effective.server.mode, TlsMode::Enforcing);
@@ -1162,7 +1217,7 @@ mod tests {
             Ok(_) => panic!("missing certs should fail"),
             Err(error) => error,
         };
-        assert!(error.to_string().contains("tls.server.certPath"));
+        assert_eq!(error.descriptor(), &rocketmq_error::CORE_CONFIGURATION_INVALID);
     }
 
     #[cfg(feature = "tls")]
@@ -1183,7 +1238,7 @@ mod tests {
 
         config.protocols = Some("TLSv1.1".to_string());
         let error = configured_protocol_versions(&config).expect_err("unsupported protocols should fail");
-        assert!(error.to_string().contains("tls.protocols"));
+        assert_eq!(error.descriptor(), &rocketmq_error::CORE_CONFIGURATION_INVALID);
     }
 
     #[cfg(feature = "tls")]

--- a/scripts/tests/test_core_helm_runtime.py
+++ b/scripts/tests/test_core_helm_runtime.py
@@ -44,6 +44,37 @@ class CoreHelmRuntimeTests(unittest.TestCase):
                     self.assertEqual("/drainz", container["lifecycle"]["preStop"]["httpGet"]["path"])
                     self.assertGreater(pod["terminationGracePeriodSeconds"], int(env["ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS"]["value"]))
 
+    def test_production_enables_auth_and_mounts_inner_client_secrets(self):
+        for profile, documents in self.profiles.items():
+            if "production" not in profile:
+                continue
+            for service, _, _, config in configurations(documents):
+                auth = config["broker"] if service == "broker" else config.get("auth", config)
+                self.assertTrue(auth["authenticationEnabled"])
+                self.assertTrue(auth["authorizationEnabled"])
+                self.assertEqual("/etc/rocketmq/acl/plain_acl.yml", auth["aclFile"])
+                if service == "proxy":
+                    self.assertTrue(config["enableAclRpcHookForClusterMode"])
+            for workload in [d for d in documents if d["kind"] in ("StatefulSet", "Deployment")]:
+                service = workload["metadata"]["labels"]["app.kubernetes.io/component"]
+                if service not in ("broker", "proxy"):
+                    continue
+                pod = workload["spec"]["template"]["spec"]
+                env = {item["name"]: item.get("value") for item in pod["containers"][0]["env"]}
+                self.assertEqual("/etc/rocketmq/acl/inner-client.json", env["ROCKETMQ_INNER_CLIENT_CREDENTIALS_FILE"])
+                acl = next(v["secret"] for v in pod["volumes"] if v["name"] == "acl")
+                self.assertIn({"key": "inner-client.json", "path": "inner-client.json"}, acl["items"])
+
+    def test_production_rejects_authentication_downgrade(self):
+        for override in ("securityProfile=null", "services.broker.auth.credentialsKey=null"):
+            with self.subTest(override=override), self.assertRaises(subprocess.CalledProcessError):
+                render("values-production-default-ha.yaml", self.helm, override)
+        for service in ("namesrv", "broker", "proxy"):
+            with self.subTest(service=service), self.assertRaises(subprocess.CalledProcessError):
+                render("values-production-proxy-tls.yaml", self.helm, f"services.{service}.auth.enabled=false")
+        with self.assertRaises(subprocess.CalledProcessError):
+            render("values-production-controller-ha.yaml", self.helm, "services.controller.auth.enabled=false")
+
     def test_controller_membership_and_broker_replication_are_real(self):
         documents = self.profiles["values-production-controller-ha.yaml"]
         configs = list(configurations(documents))


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10271

### Brief Description

Production Helm profiles now require authentication and authorization and mount named ACL Secrets. Broker and Proxy load Java-shaped inner-client credentials from a mounted Secret file, and enabled Proxy cluster signing fails startup when credentials are missing, malformed, or incomplete. The explicit development profile retains its local opt-out. Broker, Controller, and Proxy also reject `secure-enforced` startup with disabled authentication or authorization.

TLS deserialization and operational properties loaders reject invalid mode, client-auth, and security-boolean values. Properties snapshots apply atomically, explicitly named missing files fail, and failed reloads retain the active acceptor generation. Legacy optional defaults and parsing APIs remain available. Java wire schemas, request/response codes, signing formats, and persisted layouts are unchanged.

Deployment migration and credential requirements are documented in the chart README and `rocketmq-doc/en/remediation/2026-09-08-security-defaults.md`. Authentication and TLS encryption remain separately configured.

### How Did You Test This Change?

- `cargo test -p rocketmq-transport --features test-support --lib tls --quiet`: 27 passed, including strict-policy startup/reload and Java-compatible TLS values.
- `cargo test -p rocketmq-transport --no-default-features --lib config::tls_config --quiet`: 5 passed. `cargo test -p rocketmq-transport --features tls --test tls_blocking_reload --quiet`: 2 passed.
- `cargo test -p rocketmq-auth --lib acl_client_rpc_hook --quiet`: 7 passed, including Java ACL fields/signatures and mounted credentials. `cargo test -p rocketmq-proxy --lib auth::tests --quiet`: 11 passed.
- Broker, Controller, and Proxy binary test `secure_profile_rejects_disabled_request_protection_before_material_loading`: all 3 passed. NameServer binary TLS tests: 2 passed.
- Rendered 19 TOML configurations across all 4 Helm profiles with `scripts/core_helm_configs.py`; the actual Broker, Controller, Proxy, and NameServer configuration-loader tests all passed.
- `python -B -m unittest scripts.tests.test_core_helm_runtime scripts.tests.test_core_helm_rollout scripts.tests.test_package_core_helm scripts.tests.test_core_container_image_guard -q`: 18 passed, including production downgrade rejection and credential mounts.
- Affected-package `cargo fmt -- --check` and `git diff --check`: passed. Cluster deployment/fault tests were not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Production Helm deployments now enable authentication and authorization across all RocketMQ services by default.
  - Broker and Proxy support credentials supplied through Kubernetes Secrets, including inner-client credentials.
  - Development profiles can explicitly disable authentication.
  - Proxy cluster ACL signing is enabled when authentication is active.

- **Bug Fixes**
  - Invalid or incomplete security credentials now prevent startup instead of being silently ignored.
  - Strict TLS validation rejects invalid settings and preserves the previous live configuration after failed reloads.
  - Secure-enforced deployments reject configurations with disabled authentication or authorization.

- **Documentation**
  - Added guidance for security profiles, required Secrets, credentials, and TLS configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->