### PR TITLE
[ISSUE #10275]🐛Fix SRE, GPUI, and Store CI failures

### DIFF
--- a/rocketmq-ai/rocketmq-sre/config/capabilities/rocketmq-capability-catalog.v1.yaml
+++ b/rocketmq-ai/rocketmq-sre/config/capabilities/rocketmq-capability-catalog.v1.yaml
@@ -2,9 +2,9 @@
 schema_version: "rocketmq-sre.capability-catalog.v1"
 source:
   path: "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands/catalog.rs"
-  revision: "sha256:7205cf868650f438cb0c4544f0c7507cdefbb5b978dbf2b670c3695b95f01983"
-  domains: 18
-  actions: 102
+  revision: "sha256:a076560ad40c4958f1ff991e2064099f57ff96336db556fcac6da4dcc3b5cb14"
+  domains: 17
+  actions: 100
   component_surfaces: 14
 component_source_surfaces:
   - component: "NameServer"
@@ -964,42 +964,6 @@ capabilities:
     domain: "Controller"
     title: "Clean Controller Metadata"
     description: "Clean broker metadata from a controller."
-    legacy_risk: "dangerous"
-    sre_class: "R3"
-    exposure: "admin_rpc"
-    source_path: "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands/catalog.rs"
-    source_symbol: "command_catalog"
-    supported_versions: [">=1.0.0"]
-    maturity:
-      implemented_local: true
-      queryable: false
-      observable: false
-      diagnosable: false
-      plannable: false
-      executable: false
-    execution_supported: false
-  - id: "container.add_broker"
-    domain: "Container"
-    title: "Add Broker To Container"
-    description: "Add a broker to the specified broker container using a broker config path."
-    legacy_risk: "dangerous"
-    sre_class: "R3"
-    exposure: "admin_rpc"
-    source_path: "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands/catalog.rs"
-    source_symbol: "command_catalog"
-    supported_versions: [">=1.0.0"]
-    maturity:
-      implemented_local: true
-      queryable: false
-      observable: false
-      diagnosable: false
-      plannable: false
-      executable: false
-    execution_supported: false
-  - id: "container.remove_broker"
-    domain: "Container"
-    title: "Remove Broker From Container"
-    description: "Remove a broker identity from the specified broker container."
     legacy_risk: "dangerous"
     sre_class: "R3"
     exposure: "admin_rpc"

--- a/rocketmq-ai/rocketmq-sre/ui/package-lock.json
+++ b/rocketmq-ai/rocketmq-sre/ui/package-lock.json
@@ -36,7 +36,7 @@
         "globals": "^17.12.0",
         "jsdom": "^30.0.1",
         "openapi-typescript": "^7.13.0",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
         "typescript-eslint": "^8.69.0",
         "vite": "^8.2.2",
         "vitest": "^5.0.0"
@@ -133,6 +133,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -477,6 +478,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -525,6 +527,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1914,8 +1917,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1962,6 +1964,7 @@
       "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1972,6 +1975,7 @@
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1982,6 +1986,7 @@
       "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2034,346 +2039,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript/typescript-aix-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-loong64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-mips64el": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-riscv64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-s390x": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-sunos-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2450,6 +2115,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2510,7 +2176,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2620,6 +2285,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -2856,8 +2522,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.396",
@@ -2915,6 +2580,7 @@
       "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3549,6 +3215,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -3869,7 +3536,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4225,7 +3891,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4241,7 +3906,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4284,6 +3948,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4293,6 +3958,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4305,8 +3971,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -4677,38 +4342,18 @@
       }
     },
     "node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
-        "tsc": "bin/tsc"
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {
@@ -4795,6 +4440,7 @@
       "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.69.0",
         "@typescript-eslint/types": "8.69.0",
@@ -5042,6 +4688,7 @@
       "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -5120,6 +4767,7 @@
       "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/mocker": "5.0.0",
@@ -5348,6 +4996,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/rocketmq-ai/rocketmq-sre/ui/package.json
+++ b/rocketmq-ai/rocketmq-sre/ui/package.json
@@ -45,7 +45,7 @@
     "globals": "^17.12.0",
     "jsdom": "^30.0.1",
     "openapi-typescript": "^7.13.0",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.69.0",
     "vite": "^8.2.2",
     "vitest": "^5.0.0"

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/src/infrastructure/config_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/src/infrastructure/config_store.rs
@@ -581,7 +581,7 @@ impl AtomicReplaceFailure {
 
 impl fmt::Debug for AtomicReplaceFailure {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let restore_kind = match self {
+        let restore_kind: Option<io::ErrorKind> = match self {
             #[cfg(windows)]
             Self::Recovery { restore, .. } => Some(restore.kind()),
             Self::Io(_) => None,

--- a/rocketmq-store/src/base/message_encoder_pool.rs
+++ b/rocketmq-store/src/base/message_encoder_pool.rs
@@ -36,6 +36,7 @@ use rocketmq_store_local::commit_log::append::prepared_payload::PreparedPayload;
 use tracing::error;
 
 use crate::base::message_result::PutMessageResult;
+use crate::base::message_status_enum::PutMessageStatus;
 use crate::base::put_message_context::PutMessageContext;
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::log_file::commit_log::CRC32_RESERVED_LEN;
@@ -85,10 +86,10 @@ impl MessageEncoderPool {
         &self,
         message: &MessageExtBrokerInner,
         config: &Arc<MessageStoreConfig>,
-    ) -> Result<PreparedPayload, PutMessageResult> {
+    ) -> Result<PreparedPayload, PutMessageStatus> {
         let (encode_result, bytes) = self.encode_message(message, config);
         if let Some(result) = encode_result {
-            return Err(result);
+            return Err(result.put_message_status());
         }
         let crc_trailer_bytes = if config.enabled_append_prop_crc {
             CRC32_RESERVED_LEN as usize
@@ -97,7 +98,7 @@ impl MessageEncoderPool {
         };
         PreparedPayload::try_single(bytes.freeze(), crc_trailer_bytes).ok_or_else(|| {
             error!("Message encoder produced an invalid CommitLog frame");
-            PutMessageResult::new_default(crate::base::message_status_enum::PutMessageStatus::MessageIllegal)
+            PutMessageStatus::MessageIllegal
         })
     }
 
@@ -118,10 +119,10 @@ impl MessageEncoderPool {
         batch: &MessageExtBatch,
         context: &mut PutMessageContext,
         config: &Arc<MessageStoreConfig>,
-    ) -> Result<PreparedPayload, PutMessageResult> {
-        let bytes = self.encode_message_batch(batch, context, config).ok_or_else(|| {
-            PutMessageResult::new_default(crate::base::message_status_enum::PutMessageStatus::MessageIllegal)
-        })?;
+    ) -> Result<PreparedPayload, PutMessageStatus> {
+        let bytes = self
+            .encode_message_batch(batch, context, config)
+            .ok_or(PutMessageStatus::MessageIllegal)?;
         let crc_trailer_bytes = if config.enabled_append_prop_crc {
             CRC32_RESERVED_LEN as usize
         } else {
@@ -129,7 +130,7 @@ impl MessageEncoderPool {
         };
         PreparedPayload::try_batch(bytes.freeze(), crc_trailer_bytes).ok_or_else(|| {
             error!("Batch encoder produced an invalid CommitLog frame partition");
-            PutMessageResult::new_default(crate::base::message_status_enum::PutMessageStatus::MessageIllegal)
+            PutMessageStatus::MessageIllegal
         })
     }
 
@@ -168,7 +169,7 @@ pub fn encode_message_with_pool(
 pub fn prepare_message_with_pool(
     message: &MessageExtBrokerInner,
     config: &Arc<MessageStoreConfig>,
-) -> Result<PreparedPayload, PutMessageResult> {
+) -> Result<PreparedPayload, PutMessageStatus> {
     ENCODER_POOL.with(|pool| pool.prepare_message(message, config))
 }
 
@@ -188,7 +189,7 @@ pub fn prepare_message_batch_with_pool(
     batch: &MessageExtBatch,
     context: &mut PutMessageContext,
     config: &Arc<MessageStoreConfig>,
-) -> Result<PreparedPayload, PutMessageResult> {
+) -> Result<PreparedPayload, PutMessageStatus> {
     ENCODER_POOL.with(|pool| pool.prepare_message_batch(batch, context, config))
 }
 
@@ -201,6 +202,55 @@ pub fn generate_key_with_pool(message: &MessageExtBrokerInner) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
+    use cheetah_string::CheetahString;
+    use rocketmq_model::common::message::MessageTrait;
+
+    #[test]
+    fn prepare_message_preserves_encoder_rejection_statuses_and_reuse() {
+        let config = Arc::new(MessageStoreConfig {
+            max_message_size: 1024,
+            ..MessageStoreConfig::default()
+        });
+        let pool = MessageEncoderPool::new();
+        let mut message = MessageExtBrokerInner::default();
+        message.set_topic(CheetahString::from_static_str("TopicTest"));
+        message.set_body(Bytes::from(vec![0; 1025]));
+        assert_eq!(
+            pool.prepare_message(&message, &config).unwrap_err(),
+            PutMessageStatus::MessageIllegal
+        );
+
+        message.set_body(Bytes::from_static(b"valid"));
+        assert!(pool.prepare_message(&message, &config).is_ok());
+
+        message.put_property(
+            CheetahString::from_static_str("key"),
+            CheetahString::from("x".repeat(i16::MAX as usize)),
+        );
+        assert_eq!(
+            pool.prepare_message(&message, &config).unwrap_err(),
+            PutMessageStatus::PropertiesSizeExceeded
+        );
+    }
+
+    #[test]
+    fn prepare_message_batch_rejects_missing_and_empty_payloads() {
+        let config = Arc::new(MessageStoreConfig::default());
+        let pool = MessageEncoderPool::new();
+        let mut batch = MessageExtBatch::default();
+        let mut context = PutMessageContext::default();
+        assert_eq!(
+            pool.prepare_message_batch(&batch, &mut context, &config).unwrap_err(),
+            PutMessageStatus::MessageIllegal
+        );
+
+        batch.message_ext_broker_inner.set_body(Bytes::new());
+        assert_eq!(
+            pool.prepare_message_batch(&batch, &mut context, &config).unwrap_err(),
+            PutMessageStatus::MessageIllegal
+        );
+    }
 
     #[test]
     fn test_encoder_pool_reuse() {

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -1105,9 +1105,8 @@ impl CommitLog {
     }
 
     /// Handle HA service validation and calculate need_ack_nums
-    /// Returns (need_ack_nums, should_continue) where should_continue indicates if processing can
-    /// continue
-    fn handle_ha_service(&self, curr_offset: u64, need_handle_ha: bool) -> Result<i32, PutMessageResult> {
+    /// Returns the required acknowledgement count or a rejection status before append.
+    fn handle_ha_service(&self, curr_offset: u64, need_handle_ha: bool) -> Result<i32, PutMessageStatus> {
         let mut need_ack_nums = self.message_store_config.in_sync_replicas;
 
         if !need_handle_ha {
@@ -1116,16 +1115,14 @@ impl CommitLog {
 
         let ha_service = self.store_context.ha_service().ok_or_else(|| {
             error!("HA Service is None");
-            PutMessageResult::rejected_before_append(PutMessageStatus::UnknownError)
+            PutMessageStatus::UnknownError
         })?;
 
         if self.broker_config.enable_controller_mode {
             if ha_service.in_sync_replicas_nums(curr_offset as i64)
                 < self.message_store_config.min_in_sync_replicas as i32
             {
-                return Err(PutMessageResult::rejected_before_append(
-                    PutMessageStatus::InSyncReplicasNotEnough,
-                ));
+                return Err(PutMessageStatus::InSyncReplicasNotEnough);
             }
             if self.message_store_config.all_ack_in_sync_state_set {
                 need_ack_nums = mix_all::ALL_ACK_IN_SYNC_STATE_SET;
@@ -1138,9 +1135,7 @@ impl CommitLog {
                 .min(ha_service.in_sync_replicas_nums(curr_offset as i64));
             need_ack_nums = self.calc_need_ack_nums(in_sync_replicas);
             if need_ack_nums > in_sync_replicas {
-                return Err(PutMessageResult::rejected_before_append(
-                    PutMessageStatus::InSyncReplicasNotEnough,
-                ));
+                return Err(PutMessageStatus::InSyncReplicasNotEnough);
             }
             if self.message_store_config.all_ack_in_sync_state_set {
                 need_ack_nums = mix_all::ALL_ACK_IN_SYNC_STATE_SET;
@@ -1201,7 +1196,7 @@ impl CommitLog {
         let need_handle_ha = self.need_handle_ha(&msg_batch.message_ext_broker_inner);
         let need_ack_nums = match self.handle_ha_service(curr_offset, need_handle_ha) {
             Ok(ack_nums) => ack_nums,
-            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
+            Err(status) => return PutMessageResult::rejected_before_append(status),
         };
         msg_batch.message_ext_broker_inner.version = MessageVersion::V1;
         let auto_message_version_on_topic_len = self.message_store_config.auto_message_version_on_topic_len;
@@ -1215,7 +1210,7 @@ impl CommitLog {
             &self.message_store_config,
         ) {
             Ok(prepared) => prepared,
-            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
+            Err(status) => return PutMessageResult::rejected_before_append(status),
         };
         let sequenced = self
             .append_runtime
@@ -1281,7 +1276,7 @@ impl CommitLog {
         let need_handle_ha = self.need_handle_ha(&msg);
         let need_ack_nums = match self.handle_ha_service(curr_offset, need_handle_ha) {
             Ok(ack_nums) => ack_nums,
-            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
+            Err(status) => return PutMessageResult::rejected_before_append(status),
         };
 
         let need_assign_offset = !(self.message_store_config.duplication_enable
@@ -1289,7 +1284,7 @@ impl CommitLog {
 
         let prepared = match message_encoder_pool::prepare_message_with_pool(&msg, &self.message_store_config) {
             Ok(prepared) => prepared,
-            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
+            Err(status) => return PutMessageResult::rejected_before_append(status),
         };
         let sequenced = self
             .append_runtime
@@ -3089,6 +3084,22 @@ mod tests {
             .wire_owned_root_dependencies()
             .expect("commit-log tests should wire owned Store capabilities");
         store
+    }
+
+    #[tokio::test]
+    async fn ha_validation_preserves_missing_service_rejection_and_bypass() {
+        let root = tempfile::tempdir().unwrap();
+        let store = new_test_message_store(root.path(), BrokerRole::SyncMaster, false);
+        let commit_log = store.get_commit_log();
+
+        assert_eq!(
+            commit_log.handle_ha_service(0, false),
+            Ok(commit_log.message_store_config.in_sync_replicas)
+        );
+        assert_eq!(
+            commit_log.handle_ha_service(0, true),
+            Err(PutMessageStatus::UnknownError)
+        );
     }
 
     fn new_test_mapped_file(root: &Path, offset: u64, file_size: u64) -> DefaultMappedFile {

--- a/rocketmq-store/src/log_file/commit_log/handles.rs
+++ b/rocketmq-store/src/log_file/commit_log/handles.rs
@@ -262,7 +262,7 @@ impl CommitLogInternalMessageWriteHandle {
             && self.store_runtime_state.broker_role() != BrokerRole::Slave);
         let prepared = match message_encoder_pool::prepare_message_with_pool(&msg, &self.message_store_config) {
             Ok(prepared) => prepared,
-            Err(result) => return result.with_execution_evidence(crate::AppendExecutionEvidence::NotAppended),
+            Err(status) => return PutMessageResult::rejected_before_append(status),
         };
         let mut result = self
             .append_port

--- a/scripts/generate_sre_capability_catalog.py
+++ b/scripts/generate_sre_capability_catalog.py
@@ -104,8 +104,8 @@ COMPONENT_SURFACES = (
         "Runtime",
         "rocketmq-runtime/src/diagnostics.rs",
         "RuntimeDiagnosticsViewV1",
-        "mcp_system_resource_only",
-        "add authenticated component-local diagnostics adapters",
+        "protected_component_endpoints",
+        "production-verify TLS termination, token rotation, and multi-replica endpoint discovery",
     ),
     ComponentSurface(
         "Observability",
@@ -319,8 +319,9 @@ def render(commands: list[Command], revision: str) -> str:
 
 
 def source_revision() -> str:
-    """Return a commit-independent revision for the exact catalog source."""
-    return f"sha256:{hashlib.sha256(CATALOG_SOURCE.read_bytes()).hexdigest()}"
+    """Return a commit-independent revision with normalized source line endings."""
+    source = CATALOG_SOURCE.read_text(encoding="utf-8").encode("utf-8")
+    return f"sha256:{hashlib.sha256(source).hexdigest()}"
 
 
 def validate_component_surfaces() -> list[str]:
@@ -365,9 +366,9 @@ def main() -> int:
 
     commands = parse_commands(CATALOG_SOURCE.read_text(encoding="utf-8"))
     domains = {command.domain for command in commands}
-    if len(commands) != 102 or len(domains) != 18:
+    if len(commands) != 100 or len(domains) != 17:
         print(
-            f"expected 102 commands across 18 domains, found {len(commands)} across {len(domains)}",
+            f"expected 100 commands across 17 domains, found {len(commands)} across {len(domains)}",
             file=sys.stderr,
         )
         return 1

--- a/scripts/tests/test_generate_sre_capability_catalog.py
+++ b/scripts/tests/test_generate_sre_capability_catalog.py
@@ -15,8 +15,10 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -27,14 +29,30 @@ import generate_sre_capability_catalog as generator  # noqa: E402
 
 
 class SreCapabilityCatalogGeneratorTest(unittest.TestCase):
-    def test_admin_catalog_keeps_phase00_action_and_domain_counts(self) -> None:
+    def test_admin_catalog_excludes_retired_container_commands(self) -> None:
         commands = generator.parse_commands(
             generator.CATALOG_SOURCE.read_text(encoding="utf-8")
         )
 
-        self.assertEqual(102, len(commands))
-        self.assertEqual(18, len({command.domain for command in commands}))
-        self.assertEqual(102, len({command.identifier for command in commands}))
+        identifiers = {command.identifier for command in commands}
+        domains = {command.domain for command in commands}
+        self.assertEqual(100, len(commands))
+        self.assertEqual(17, len(domains))
+        self.assertEqual(100, len(identifiers))
+        self.assertNotIn("container.add_broker", identifiers)
+        self.assertNotIn("container.remove_broker", identifiers)
+        self.assertNotIn("Container", domains)
+
+    def test_source_revision_is_portable_and_tracks_content_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "catalog.rs"
+            with patch.object(generator, "CATALOG_SOURCE", source):
+                source.write_bytes(b"fn command_catalog() {\n}\n")
+                lf_revision = generator.source_revision()
+                source.write_bytes(b"fn command_catalog() {\r\n}\r\n")
+                self.assertEqual(lf_revision, generator.source_revision())
+                source.write_bytes(b"fn changed_catalog() {\n}\n")
+                self.assertNotEqual(lf_revision, generator.source_revision())
 
     def test_component_source_surfaces_are_complete_and_resolvable(self) -> None:
         self.assertEqual([], generator.validate_component_surfaces())
@@ -60,6 +78,7 @@ class SreCapabilityCatalogGeneratorTest(unittest.TestCase):
         self.assertIn("  component_surfaces: 14\n", rendered)
         self.assertIn("component_source_surfaces:\n", rendered)
         self.assertIn('  - component: "Kubernetes"\n', rendered)
+        self.assertIn('    exposure: "protected_component_endpoints"\n', rendered)
         self.assertIn("capabilities:\n", rendered)
 
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10275

### Brief Description

Fix four reported CI failures:

- Pin SRE UI TypeScript to 5.9.3 and regenerate its lockfile to satisfy OpenAPI and ESLint peer requirements.
- Explicitly type GPUI restore_kind as Option<io::ErrorKind> so the non-Windows Debug implementation compiles.
- Synchronize the SRE capability catalog with the 100 active Admin commands across 17 domains. Remove retired Container entries, preserve the existing Runtime protected endpoint description in the generator, and normalize source line endings before deriving its revision.
- Return compact PutMessageStatus errors from Store encoding preparation and HA validation, reconstructing the unchanged public PutMessageResult at write entry points with NotAppended evidence. Add focused rejection and encoder reuse tests.

### How Did You Test This Change?

All checks below passed during implementation:

- SRE UI, on Windows with Node 24.20.0 and npm 11.19.0: npm ci --no-audit --no-fund; npm run check:api; npm run lint; npm run test -- --run (30 files, 92 tests); npm run build.
- GPUI, from its standalone directory on Windows: cargo fmt -p rocketmq-dashboard-gpui -- --check; cargo clippy --locked --all-targets --all-features --no-deps -- -D warnings. This used the existing local dependency resolution. A focused probe extracted the production error type: the original source reproduced E0282 for x86_64-unknown-linux-gnu, the corrected source compiled, and Windows error-format assertions passed.
- Capability catalog, on both Windows and WSL Linux: python scripts/generate_sre_capability_catalog.py --check; python -m unittest scripts.tests.test_generate_sre_capability_catalog -v (4 tests).
- Store: cargo fmt -p rocketmq-store -- --check; cargo test -p rocketmq-store --lib prepare_message --locked (2 tests); cargo test -p rocketmq-store --lib ha_validation_preserves_missing_service_rejection_and_bypass --locked (1 test); cargo clippy -p rocketmq-store --lib --tests --locked --no-deps -- -D warnings.
- git diff --check.

The full Linux GPUI build and full-workspace all-feature CI were not rerun. The GPUI all-package format command exceeded the Windows command-length limit; its package-scoped format check passed. Merge is requested without waiting for CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Message publication failures now preserve the original rejection status, improving error accuracy for rejected messages.
  - Invalid or missing batch payloads are rejected consistently.
  - High-availability validation now reports missing service rejections correctly while preserving supported bypass behavior.

- **Capabilities**
  - Removed broker-add and broker-removal actions from the available capability catalog.
  - Updated catalog totals and revision metadata to reflect the current supported capability set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->