### PR TITLE
[ISSUE #10277]🐛Fix Store collector and transport telemetry registry

### DIFF
--- a/rocketmq-observability/src/metrics/catalog/generated.rs
+++ b/rocketmq-observability/src/metrics/catalog/generated.rs
@@ -388,6 +388,11 @@ const METRIC_LABELS_62: &[&str] = &[
     labels::CODE,
 ];
 
+const METRIC_LABELS_63: &[&str] = &[
+    labels::REQUEST_CODE_BUCKET,
+    labels::REASON,
+];
+
 pub const JAVA_METRICS: &[MetricDescriptor] = &[
     MetricDescriptor {
         name: metrics::PROCESSOR_WATERMARK,
@@ -1944,6 +1949,13 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         kind: MetricKind::Counter,
         unit: "{response}",
         labels: METRIC_LABELS_43,
+        source: MetricSource::Remoting,
+    },
+    MetricDescriptor {
+        name: metrics::TRANSPORT_DEFERRED_TERMINAL_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{response}",
+        labels: METRIC_LABELS_63,
         source: MetricSource::Remoting,
     },
 ];

--- a/rocketmq-observability/src/metrics/catalog/schema/rust/catalog.toml
+++ b/rocketmq-observability/src/metrics/catalog/schema/rust/catalog.toml
@@ -1029,3 +1029,11 @@ kind = "Counter"
 unit = "{response}"
 labels = ["REASON"]
 source = "Remoting"
+
+[[metric]]
+index = 222
+symbol = "TRANSPORT_DEFERRED_TERMINAL_TOTAL"
+kind = "Counter"
+unit = "{response}"
+labels = ["REQUEST_CODE_BUCKET", "REASON"]
+source = "Remoting"

--- a/rocketmq-observability/tests/fixtures/metric_catalog_descriptors.tsv
+++ b/rocketmq-observability/tests/fixtures/metric_catalog_descriptors.tsv
@@ -220,3 +220,4 @@ rust	218	"rocketmq_transport_deferred_retained_bytes"	UpDownCounter	"By"	["code"
 rust	219	"rocketmq_transport_response_queue_wait_seconds"	Histogram	"s"	[]	Remoting
 rust	220	"rocketmq_transport_response_duplicate_total"	Counter	"{response}"	["code"]	Remoting
 rust	221	"rocketmq_transport_response_abandoned_total"	Counter	"{response}"	["reason"]	Remoting
+rust	222	"rocketmq_transport_deferred_terminal_total"	Counter	"{response}"	["request_code_bucket","reason"]	Remoting

--- a/rocketmq-observability/tests/metric_catalog_contract.rs
+++ b/rocketmq-observability/tests/metric_catalog_contract.rs
@@ -23,9 +23,9 @@ use rocketmq_observability::metrics::catalog::RUST_METRICS;
 
 const FIXTURE: &str = include_str!("fixtures/metric_catalog_descriptors.tsv");
 const JAVA_DESCRIPTOR_COUNT: usize = 94;
-const RUST_DESCRIPTOR_COUNT: usize = 128;
+const RUST_DESCRIPTOR_COUNT: usize = 129;
 const TOTAL_DESCRIPTOR_COUNT: usize = JAVA_DESCRIPTOR_COUNT + RUST_DESCRIPTOR_COUNT;
-const DISTINCT_LABEL_SEQUENCE_COUNT: usize = 63;
+const DISTINCT_LABEL_SEQUENCE_COUNT: usize = 64;
 const DISTINCT_SOURCE_COUNT: usize = 14;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rocketmq-store/examples/architecture_store_performance_collector.rs
+++ b/rocketmq-store/examples/architecture_store_performance_collector.rs
@@ -71,6 +71,7 @@ use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
 use rocketmq_store::BrokerReadStore;
+use rocketmq_store::BrokerReplicationStore;
 use rocketmq_store::BrokerStorePort;
 use rocketmq_store::BrokerWriteStore;
 use rocketmq_store::FlushDiskType;

--- a/scripts/generate_metric_catalog.py
+++ b/scripts/generate_metric_catalog.py
@@ -30,7 +30,7 @@ SCHEMA_DIR = ROOT / "rocketmq-observability" / "src" / "metrics" / "catalog" / "
 GENERATED_PATH = ROOT / "rocketmq-observability" / "src" / "metrics" / "catalog" / "generated.rs"
 SEMANTIC_PATH = ROOT / "rocketmq-observability" / "src" / "semantic.rs"
 SCHEMA_VERSION = 1
-PARTITIONS = (("java", 0, 94), ("rust", 94, 128))
+PARTITIONS = (("java", 0, 94), ("rust", 94, 129))
 KIND_NAMES = {"Counter", "Gauge", "Histogram", "ObservableGauge", "UpDownCounter"}
 SOURCE_NAMES = {
     "Broker",

--- a/scripts/telemetry-semantic-guard-violations.json
+++ b/scripts/telemetry-semantic-guard-violations.json
@@ -31,7 +31,7 @@
       "operation": "set",
       "path": [
         "attributes",
-        37,
+        38,
         "default_enabled"
       ],
       "value": true,
@@ -42,7 +42,7 @@
       "operation": "delete",
       "path": [
         "signals",
-        220,
+        228,
         "sampling",
         "max_per_second"
       ],
@@ -53,7 +53,7 @@
       "operation": "set",
       "path": [
         "signals",
-        220,
+        228,
         "deprecation"
       ],
       "value": {

--- a/scripts/telemetry-semantic-registry.json
+++ b/scripts/telemetry-semantic-registry.json
@@ -96,6 +96,15 @@
       "redaction": "none"
     },
     {
+      "id": "code",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
       "id": "component",
       "cardinality": "bounded",
       "privacy": "operational",
@@ -384,6 +393,15 @@
       "redaction": "none"
     },
     {
+      "id": "mode",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
       "id": "node_id",
       "cardinality": "bounded",
       "privacy": "operational",
@@ -412,6 +430,15 @@
     },
     {
       "id": "operation_kind",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "outcome",
       "cardinality": "bounded",
       "privacy": "operational",
       "max_distinct": 10000,
@@ -529,6 +556,15 @@
     },
     {
       "id": "request_code",
+      "cardinality": "bounded",
+      "privacy": "operational",
+      "max_distinct": 10000,
+      "max_value_bytes": 256,
+      "default_enabled": true,
+      "redaction": "none"
+    },
+    {
+      "id": "request_code_bucket",
       "cardinality": "bounded",
       "privacy": "operational",
       "max_distinct": 10000,
@@ -3469,8 +3505,11 @@
       "catalog": "rust",
       "family": "request",
       "stability": "stable",
-      "attributes": [],
-      "cardinality_budget": 1,
+      "attributes": [
+        "code",
+        "outcome"
+      ],
+      "cardinality_budget": 10000,
       "privacy": "operational",
       "sampling": {
         "strategy": "aggregate"
@@ -6065,6 +6104,207 @@
       "attributes": [
         "backend",
         "state"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_request_duration_seconds",
+      "source_symbol": "TRANSPORT_REQUEST_DURATION_SECONDS",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "s",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "code",
+        "outcome"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_response_total",
+      "source_symbol": "TRANSPORT_RESPONSE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{response}",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "mode",
+        "result"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_deferred_inflight",
+      "source_symbol": "TRANSPORT_DEFERRED_INFLIGHT",
+      "signal_type": "metric",
+      "kind": "up_down_counter",
+      "unit": "{request}",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "watermark-lag",
+      "stability": "stable",
+      "attributes": [
+        "code"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_deferred_retained_bytes",
+      "source_symbol": "TRANSPORT_DEFERRED_RETAINED_BYTES",
+      "signal_type": "metric",
+      "kind": "up_down_counter",
+      "unit": "By",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [
+        "code"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_response_queue_wait_seconds",
+      "source_symbol": "TRANSPORT_RESPONSE_QUEUE_WAIT_SECONDS",
+      "signal_type": "metric",
+      "kind": "histogram",
+      "unit": "s",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_response_duplicate_total",
+      "source_symbol": "TRANSPORT_RESPONSE_DUPLICATE_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{response}",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "code"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_response_abandoned_total",
+      "source_symbol": "TRANSPORT_RESPONSE_ABANDONED_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{response}",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "reason"
+      ],
+      "cardinality_budget": 10000,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_deferred_terminal_total",
+      "source_symbol": "TRANSPORT_DEFERRED_TERMINAL_TOTAL",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "{response}",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "request",
+      "stability": "stable",
+      "attributes": [
+        "request_code_bucket",
+        "reason"
       ],
       "cardinality_budget": 10000,
       "privacy": "operational",

--- a/scripts/tests/test_telemetry_semantic_guard.py
+++ b/scripts/tests/test_telemetry_semantic_guard.py
@@ -42,10 +42,10 @@ class TelemetrySemanticGuardTest(unittest.TestCase):
 
     def test_live_registry_matches_every_rust_signal(self) -> None:
         self.assertEqual([], guard.validate_registry(self.registry, self.inventory))
-        self.assertEqual(207, len(self.inventory["metrics"]))
+        self.assertEqual(215, len(self.inventory["metrics"]))
         self.assertEqual(13, len(self.inventory["spans"]))
         self.assertEqual(10, len(self.inventory["events"]))
-        self.assertEqual(230, len(self.registry["signals"]))
+        self.assertEqual(238, len(self.registry["signals"]))
         self.assertFalse(any(signal["owner"] == "mcp" for signal in self.registry["signals"]))
 
     def test_log_filter_metrics_have_stable_registry_contracts(self) -> None:
@@ -125,7 +125,7 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
             check=False,
         )
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
-        self.assertIn("metrics=207 spans=13 logs=10", result.stdout)
+        self.assertIn("metrics=215 spans=13 logs=10", result.stdout)
 
     def test_committed_violation_fixtures_are_rejected(self) -> None:
         fixture_ids = {fixture["id"] for fixture in self.fixtures}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10277

### Brief Description

Import BrokerReplicationStore in the Store performance collector so its four get_commit_log calls resolve through the public trait.

Add the missing deferred terminal Counter descriptor with its existing response unit and request-code-bucket/reason labels. Regenerate the metric catalog and telemetry semantic registry, registering eight existing transport metrics, and synchronize literal contract fixtures, violation fixture indexes, and inventory counts. Runtime instrumentation and CI checks remain unchanged.

### How Did You Test This Change?

Passed during implementation:

- `cargo clippy -p rocketmq-store --example architecture_store_performance_collector --locked --no-deps -- -D warnings` with default features on Windows.
- `cargo fmt -p rocketmq-store -- --check` and `cargo fmt -p rocketmq-observability -- --check`.
- `python scripts/generate_metric_catalog.py --check`.
- `python scripts/telemetry_semantic_guard.py` on Windows and WSL Linux.
- `python -m unittest scripts.tests.test_telemetry_semantic_guard scripts.tests.test_generate_metric_catalog -v`: 22 tests passed on Windows and WSL Linux (Linux used quiet output).
- `cargo test -p rocketmq-observability --test metric_catalog_contract --locked`: 3 tests passed with default features.
- `cargo test -p rocketmq-observability --lib --features otel-metrics request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated --locked`: 1 test passed.
- `git diff --check`.

Full-workspace all-feature CI was not rerun. Merge is requested without waiting for CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new RocketMQ transport telemetry for request durations, response totals, queue wait times, deferred responses, duplicates, abandoned responses, and terminal outcomes.
  - Added bounded telemetry attributes including response code, request code bucket, mode, and outcome.
  - Enhanced transport request metrics with response code and outcome details.
  - Expanded the available metrics catalog and telemetry inventory to reflect these additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->