### PR TITLE
[ISSUE #10281]🐛Fix workspace Clippy and dashboard error contract tests

### DIFF
--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -677,9 +677,11 @@ mod tests {
         let security =
             SecurityBootstrap::Enabled(SecurityBootstrapConfig::new(SecurityBootstrapProfile::SecureEnforced));
         for (authentication, authorization) in [(false, false), (true, false), (false, true)] {
-            let mut config = BrokerConfig::default();
-            config.authentication_enabled = authentication;
-            config.authorization_enabled = authorization;
+            let config = BrokerConfig {
+                authentication_enabled: authentication,
+                authorization_enabled: authorization,
+                ..Default::default()
+            };
             let error = validate_broker_security(
                 &security,
                 &config,

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
@@ -468,39 +468,48 @@ mod tests {
                 StatusCode::BAD_REQUEST,
                 "core.argument.invalid",
                 "Argument is invalid",
+                serde_json::json!({}),
             ),
             (
                 AdminError::session_closed(),
                 StatusCode::CONFLICT,
                 "client.lifecycle.not_started",
                 "Client is not started",
+                serde_json::json!({}),
             ),
             (
                 AdminError::target_drift("mutation", "token=secret C:\\private\\target"),
                 StatusCode::CONFLICT,
                 "client.lifecycle.invalid_state",
                 "Client state is invalid",
+                serde_json::json!({}),
             ),
             (
                 AdminError::target_limit("query", "password=plain-text"),
                 StatusCode::BAD_REQUEST,
                 "core.argument.invalid",
                 "Argument is invalid",
+                serde_json::json!({}),
             ),
             (
                 AdminError::unavailable("query", "password=plain-text"),
                 StatusCode::SERVICE_UNAVAILABLE,
                 "client.component.unavailable",
                 "Client component is unavailable",
+                serde_json::json!({ "client_role": "admin" }),
             ),
         ];
 
-        for (error, expected_status, expected_code, expected_message) in cases {
+        for (error, expected_status, expected_code, expected_message, expected_details) in cases {
             let (status, body, bytes) = failure_response(DashboardError::from(error)).await;
             assert_eq!(status, expected_status);
             assert_eq!(body.code, expected_code);
             assert_eq!(body.message, expected_message);
-            assert!(body.details.is_empty());
+            assert_eq!(
+                serde_json::to_value(&body.details).expect("serialize public details"),
+                expected_details,
+                "unexpected public details for {expected_code}"
+            );
             let serialized = String::from_utf8(bytes).expect("UTF-8 JSON");
             assert!(!serialized.contains("plain-text"));
             assert!(!serialized.contains("token=secret"));

--- a/rocketmq-proxy/src/grpc/gzip_decode.rs
+++ b/rocketmq-proxy/src/grpc/gzip_decode.rs
@@ -164,10 +164,7 @@ impl GzipDecodePool {
                     .as_mut()
                     .and_then(|lease| lease.slot.as_mut())
                     .ok_or_else(|| ProxyError::invalid_metadata("gzip decode slot is unavailable"))?;
-                let end = used
-                    .checked_add(config.max_message_body_size)
-                    .unwrap_or(usize::MAX)
-                    .min(slot.arena.len());
+                let end = used.saturating_add(config.max_message_body_size).min(slot.arena.len());
                 let start = used;
                 let mut decoder = flate2::read::GzDecoder::new(input_body.as_ref());
                 while used < end {

--- a/rocketmq-store/tests/commitlog_recovery_tests.rs
+++ b/rocketmq-store/tests/commitlog_recovery_tests.rs
@@ -43,6 +43,7 @@ use rocketmq_runtime::RuntimeOwner;
 use rocketmq_store::get_abort_file;
 use rocketmq_store::get_store_path_consume_queue;
 use rocketmq_store::BrokerReadStore;
+use rocketmq_store::BrokerReplicationStore;
 use rocketmq_store::BrokerStorePort;
 use rocketmq_store::BrokerWriteStore;
 use rocketmq_store::FlushDiskType;

--- a/rocketmq-store/tests/rocksdb_store_semantics_tests.rs
+++ b/rocketmq-store/tests/rocksdb_store_semantics_tests.rs
@@ -33,6 +33,7 @@ use rocketmq_model::common::message::MessageTrait;
 use rocketmq_model::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_store::BrokerAdminStore;
 use rocketmq_store::BrokerReadStore;
+use rocketmq_store::BrokerReplicationStore;
 use rocketmq_store::BrokerStorePort;
 use rocketmq_store::BrokerWriteStore;
 use rocketmq_store::DispatchRequest;

--- a/rocketmq-store/tests/timer_extended_delivery_tests.rs
+++ b/rocketmq-store/tests/timer_extended_delivery_tests.rs
@@ -33,6 +33,7 @@ use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
+use rocketmq_store::BrokerAdminStore;
 use rocketmq_store::BrokerReadStore;
 use rocketmq_store::BrokerReplicationStore;
 use rocketmq_store::BrokerStorePort;

--- a/rocketmq-store/tests/timer_extended_integration_tests.rs
+++ b/rocketmq-store/tests/timer_extended_integration_tests.rs
@@ -30,7 +30,7 @@ use rocketmq_protocol::common::message::message_decoder::message_properties_to_s
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
-use rocketmq_store::BrokerReadStore;
+use rocketmq_store::BrokerAdminStore;
 use rocketmq_store::BrokerStorePort;
 use rocketmq_store::BrokerWriteStore;
 use rocketmq_store::LocalFileMessageStore;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10281

### Brief Description

Restore all-feature store test compilation by importing the replication capability in RocksDB semantics and CommitLog recovery tests, and the admin capability in extended timer tests. Remove the unused read capability import. Resolve the remaining workspace Clippy findings with direct broker test configuration initialization and saturating_add in the proxy gzip decoder; the decode bounds remain equivalent.

Correct the Dashboard admin HTTP contract test to expect exactly client_role: admin for unavailable errors and no public details for the other covered cases. Preserve status, code, message, and sensitive-data checks, including omission of diagnostic lifecycle states.

### How Did You Test This Change?

Passed locally on Windows from the repository root:

- `cargo clippy --workspace --locked --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-store --locked --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt -p rocketmq-store -p rocketmq-broker -p rocketmq-proxy -- --check`
- `git diff --check`

Passed from `rocketmq-dashboard/rocketmq-dashboard-web/backend`:

- `cargo test --locked --lib error::dashboard_error::tests --all-features` (20 passed)
- `cargo fmt -p rocketmq-dashboard-web-backend -- --check`

Linux-only code and the complete Docker storage matrix were not rerun locally. The Windows workspace Clippy result does not cover Linux-only targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gzip message handling to remain safely bounded when size calculations approach numeric limits.
  - Updated administrative error responses to provide consistent detail fields, including the administrator role where applicable.

- **Tests**
  - Refined broker security configuration test setup.
  - Expanded test coverage and compatibility checks for storage recovery, database semantics, replication, administration, and scheduled message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->