### PR TITLE
[ISSUE #10283]🐛Fix fuzz lockfile and admin CLI validation assertions

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4773,27 +4773,27 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+checksum = "bf06bd8162af0734b344780deb55b42a2429ae430870d13fcc12f238e880fe6e"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "ae42c0555055784c70058d19ba8e275528e8a99a706684868ace5da4e716a4ab"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.1.0+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0"
 dependencies = [
  "cc",
  "pkg-config",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/broker/get_broker_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/broker/get_broker_config_sub_command.rs
@@ -125,6 +125,7 @@ fn broker_addr_for_section(section: &BrokerConfigSection) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
 
     #[test]
     fn test_no_master_placeholder_check() {
@@ -210,11 +211,15 @@ mod tests {
             key_pattern: Some("[".to_string()),
         };
 
-        let err = cmd.request();
-        assert!(err.is_err());
-
-        let err_msg = format!("{}", err.unwrap_err());
-        assert!(err_msg.contains("invalid key regex pattern"));
+        let error = cmd.request().expect_err("invalid key regex must be rejected");
+        assert_eq!(error.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
+        assert!(
+            error
+                .source()
+                .and_then(|source| source.downcast_ref::<regex::Error>())
+                .is_some()
+        );
+        assert_eq!(error.to_string(), "core.argument.invalid: Argument is invalid");
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/update_topic_perm_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/update_topic_perm_sub_command.rs
@@ -158,14 +158,12 @@ mod tests {
             perm: "6".to_string(),
         };
 
-        let result = command.execute(None, crate::commands::test_client_runtime()).await;
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Either brokerAddr (-b) or clusterName (-c) must be provided")
-        );
+        let error = command
+            .execute(None, crate::commands::test_client_runtime())
+            .await
+            .expect_err("a broker or cluster target is required");
+        assert_eq!(error.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
+        assert_eq!(error.to_string(), "core.argument.invalid: Argument is invalid");
     }
 
     #[tokio::test]
@@ -181,9 +179,12 @@ mod tests {
             perm: "6".to_string(),
         };
 
-        let result = command.execute(None, crate::commands::test_client_runtime()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Invalid topic name"));
+        let error = command
+            .execute(None, crate::commands::test_client_runtime())
+            .await
+            .expect_err("an invalid topic must be rejected");
+        assert_eq!(error.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
+        assert_eq!(error.to_string(), "core.argument.invalid: Argument is invalid");
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10283

### Brief Description

The locked fuzz build fails because its standalone lockfile still resolves zstd 0.13.3 after the shared model moved to 0.14.0. Update zstd, zstd-safe, and zstd-sys in `fuzz/Cargo.lock` to match the current dependency requirements.

Three admin CLI tests expect validation details that are no longer part of public error display. Assert the canonical `CORE_ARGUMENT_INVALID` descriptor and public message instead, and verify that invalid broker key patterns retain a typed `regex::Error` source. Production behavior is unchanged.

### How Did You Test This Change?

Passed locally on Windows:

- `cargo +nightly-2026-07-05 check --locked --manifest-path fuzz/Cargo.toml --all-targets --all-features` (all four fuzz targets).
- `cargo test -p rocketmq-admin-cli --lib --locked` (227 passed).
- `cargo fmt -p rocketmq-admin-cli -- --check`.
- `git diff --check`.

The full workspace test suite and Linux builds were not rerun locally. CI completion is not required for this merge, as requested by the maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation of error handling for invalid broker configuration patterns.
  - Updated topic permission tests to verify the standard invalid-argument error code and message.
  - Added checks confirming the underlying regular-expression error is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->