### PR TITLE
[ISSUE #10285]🐛Fix admin core validation error assertions

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/topic/types.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/topic/types.rs
@@ -699,7 +699,8 @@ mod tests {
     fn topic_cluster_query_request_rejects_blank_topic() {
         let err = TopicClusterQueryRequest::try_new("   ").unwrap_err();
 
-        assert!(err.to_string().contains("topic name must not be empty"));
+        assert_eq!(err.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
+        assert_eq!(err.to_string(), "core.argument.invalid: Argument is invalid");
     }
 
     #[test]
@@ -716,7 +717,8 @@ mod tests {
     fn topic_route_query_request_rejects_blank_topic() {
         let err = TopicRouteQueryRequest::try_new("   ").unwrap_err();
 
-        assert!(err.to_string().contains("topic name must not be empty"));
+        assert_eq!(err.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
+        assert_eq!(err.to_string(), "core.argument.invalid: Argument is invalid");
     }
 
     #[test]
@@ -738,7 +740,8 @@ mod tests {
     fn topic_status_query_request_rejects_blank_topic() {
         let err = TopicStatusQueryRequest::try_new("   ").unwrap_err();
 
-        assert!(err.to_string().contains("topic name must not be empty"));
+        assert_eq!(err.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
+        assert_eq!(err.to_string(), "core.argument.invalid: Argument is invalid");
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/static_topic/planner.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/static_topic/planner.rs
@@ -195,7 +195,9 @@ mod tests {
         let error =
             StaticTopicPlanRequest::try_new("TopicA", 4, ["broker-a".to_string()], [30_000], Some(4)).unwrap_err();
 
-        assert!(error.to_string().contains("greater than existing queue count"));
+        assert_eq!(error.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
+        assert_eq!(error.field(), Some("queueCount"));
+        assert_eq!(error.to_string(), "core.argument.invalid: Argument is invalid");
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10285

### Brief Description

Four admin core tests fail because they still expect private validation details in public error display strings. Update the blank-topic cluster, route, and status query assertions and the static-topic queue-count assertion to verify `CORE_ARGUMENT_INVALID` and its canonical public message. Also verify that the planner error identifies `queueCount`.

This changes only test assertions; production validation and error rendering remain unchanged.

### How Did You Test This Change?

Passed locally on Windows:

- `cargo test -p rocketmq-admin-core --lib --features client-adapter --locked`: 310 passed.
- `cargo fmt -p rocketmq-admin-core -- --check`.
- `git diff --check`.

The complete Linux workspace CI suite was not rerun locally. The maintainer requested a squash merge without waiting for CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated validation test coverage for blank topic inputs and non-increasing queue counts.
  - Tests now verify consistent invalid-argument error descriptors, messages, and relevant field information.
  - These checks help ensure validation responses remain standardized across topic queries and static topic planning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->