### PR TITLE
[ISSUE #10287]📝Align runtime READMEs with current APIs

### DIFF
--- a/rocketmq-runtime/README-zh_cn.md
+++ b/rocketmq-runtime/README-zh_cn.md
@@ -4,69 +4,78 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](../LICENSE-APACHE)
 
 `rocketmq-runtime` 是 [rocketmq-rust](https://github.com/mxsm/rocketmq-rust)
-工作区共享的 Tokio 运行时基座。它不替代 Tokio，而是统一 RocketMQ 组件如何拥有或借用
-Tokio runtime、如何追踪长期任务、如何调度周期任务、如何隔离短时阻塞工作，以及如何用
-`ShutdownReport` 验证关闭结果。
+工作区共享的运行时基座。它基于 Tokio 提供运行时所有权、受跟踪的服务与操作任务、
+周期调度、有界阻塞执行、资源预算、元数据持久化和关闭诊断。
 
 [English](README.md)
 
-## 目标线程模型
+## 运行时模型
 
-RocketMQ Rust 只使用 Tokio 作为异步 runtime。runtime 所有权和任务生命周期必须显式：
-
-- 应用入口使用 `RuntimeOwner`；迁移和测试 harness 可在已有 Tokio runtime 中绑定 `RuntimeContext`。
-- broker、namesrv、proxy、controller 和 admin 工具入口从 owner 派生组件级 `ChildServiceContext`。
-- 长期服务任务通过 `TaskGroup` 注册和关闭。
-- 周期任务通过 `ScheduledTaskGroup` 管理。
-- 文件 IO、RocksDB、DNS、压缩等短时阻塞工作通过 `BlockingExecutor` 执行。
-- 不适合 Tokio blocking pool 的长期循环保留为 dedicated OS thread，但必须有 owner、线程名、stop signal 和 bounded join。
-- 关闭路径必须返回或记录 `ShutdownReport`。
+生产应用入口拥有 `RuntimeOwner`。库接收 `ChildServiceContext` 或更窄的能力对象，
+例如 `TaskSpawner`，不自行查找或构建独立运行时。任务所有权树负责跟踪任务直到关闭；
+资源预算树负责核算显式申请的资源，两者是不同的树。
 
 ```mermaid
 flowchart TD
-    Entry["应用入口"] --> Owner["RuntimeOwner"]
-    Entry --> Current["RuntimeContext（迁移/测试）"]
+    Entry["Application entrypoint"] --> Owner["RuntimeOwner"]
     Owner --> Root["RootServiceContext"]
-    Root --> GroupRoot["根 TaskGroup"]
-    Root --> Blocking["BlockingExecutor"]
-    Root --> Diagnostics["RuntimeDiagnostics"]
     Root --> Service["ChildServiceContext"]
-    Current --> Service
-    Service --> Group["服务 TaskGroup"]
-    Group --> Scheduled["ScheduledTaskGroup"]
-    Group --> Workers["service / worker / IO tasks"]
-    Blocking --> Reaper["blocking reaper task group"]
-    Root --> Report["ShutdownReport"]
+    Service --> Group["Component TaskGroup"]
+    Group --> Tasks["Service and operation tasks"]
+    Service --> Scheduled["ScheduledTaskGroup"]
+    Scheduled --> Jobs["Tracked drivers and runs"]
+    Root --> Blocking["Shared blocking lanes and global admission budget"]
+    Service -.-> Blocking
+    Owner --> Resources["RuntimeResources / process budget"]
+    Resources --> Budgets["Component resource budgets and permits"]
+    Group --> Report["ShutdownReport"]
     Blocking --> Report
+    Service --> Diagnostics["Diagnostics snapshot / sanitized V1 view"]
 ```
 
-## 核心类型
+图中展示生产环境的组装路径。`RuntimeContext` 是借用现有 Tokio 运行时的迁移与测试工具。
+兼容执行器和专用线程辅助工具保留各自明确的所有权边界。
 
-| 类型 | 作用 |
+## 核心架构
+
+| 类型 | 职责 |
 | --- | --- |
-| `RuntimeConfig` | 配置 Tokio worker 线程数、blocking 线程上限、线程名、可选 worker stack、keep-alive、关闭超时、IO/time driver 和 blocking policy。 |
-| `RuntimeOwner` | 持有专用 Tokio 多线程 runtime，并暴露根 service context；关闭时区分任务关闭和 runtime 释放。 |
-| `RuntimeContext` | 当前 Tokio runtime 的迁移和测试 harness。生产 composition root 使用 `RuntimeOwner`；库接收 `ChildServiceContext`。 |
-| `ChildServiceContext` | 组件级运行时视图，包含 runtime handle、服务 `TaskGroup`、blocking executor 和 diagnostics。 |
-| `TaskGroup` | 结构化任务作用域，支持任务元数据、取消、关闭、abort、child group 和健康报告。 |
-| `ScheduledTaskGroup` | 在 `TaskGroup` 下运行 fixed-delay / fixed-rate 周期任务，并记录调度指标。 |
-| `BlockingExecutor` | 有界 `spawn_blocking` 网关，提供排队超时、任务超时和仍在运行任务的 reaper 跟踪。 |
-| `ShutdownReport` | 可序列化的关闭证据，记录任务完成、取消、abort、泄漏、panic、timeout、detached task 和 blocking task。 |
-| `RocketMQRuntime` | 旧兼容 wrapper。生产 composition root 使用 `RuntimeOwner`，库接收 `ChildServiceContext`；`RuntimeContext` 仅用于迁移和测试 harness。 |
+| `RuntimeConfig` | 配置工作线程数、阻塞线程上限、线程名与栈大小、keep-alive、关闭超时、IO/time 驱动和各阻塞通道的策略。 |
+| `RuntimeOwner` / `RuntimeOwnerPlan` | 校验配置，构建并拥有 Tokio 多线程运行时，提供根上下文并协调关闭。 |
+| `RootServiceContext` | 不可克隆且没有公开构造函数的根上下文；派生组件上下文，提供共享资源与诊断。 |
+| `ChildServiceContext` / `TaskSpawner` | 组件拥有任务所需的能力。任务提交器提供任务提交和取消信号访问能力，不暴露原始运行时。 |
+| `TaskGroup` / `OperationContext` | 跟踪组件任务，提供操作级取消、截止时间和有界等待；操作不会创建新的任务组。 |
+| `ScheduledTaskGroup` | 按明确的重叠执行策略运行周期任务并记录调度指标。 |
+| `BlockingExecutor` | 通过有界通道接收短时阻塞工作，并保留其容量，直到闭包实际退出。 |
+| `RuntimeResources` / `ResourceBudget` | 共享进程预算，派生组件级数量、保留字节数和可选速率限制。 |
+| `ResourcePermit` / `BudgetedQueue` | 通过 RAII 在排队或执行中的工作之间携带资源配额，并应用明确的过载策略。 |
+| `MetadataIoActor` | 拥有有界元数据快照，合并排队中的代次，并报告持久化完成结果。 |
+| `ServiceLifecycle` / `ShutdownDeadline` | 协调就绪、存活、关闭请求和共享的绝对关闭截止时间。 |
+| `ShutdownReport` | 提供任务完成、取消、中止、失败、panic、超时和剩余工作的可序列化证据。 |
+| `RuntimeDiagnosticsSnapshot` / `RuntimeDiagnosticsViewV1` | 提供运行时内部详情，以及有界、脱敏的运维视图。 |
 
-## 使用方式
+`RuntimeHandle` 是内部实现类型，不是公开接入入口。
+常用所有权类型也可通过 `rocketmq_runtime::prelude` 导入。
 
-组件拥有独立 runtime 时使用 `RuntimeOwner`：
+## 运行时所有权与快速开始
+
+默认配置使用 `RuntimeOwner::new()?`。命名或自定义配置使用
+`RuntimeOwner::plan(config)?.build()?`。规划阶段仅校验配置，不探测系统资源或启动 Tokio；
+构建阶段执行内存限制探测和运行时创建。
+
+以下有限执行示例注册一个服务后，立即验证其协作式关闭流程：
 
 ```rust
 use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
 
-fn main() -> rocketmq_runtime::RuntimeResult<()> {
-    let owner = RuntimeOwner::new(RuntimeConfig::broker_default())?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let owner = RuntimeOwner::plan(RuntimeConfig::broker_default())?.build()?;
     let broker = owner.root_context().component("broker");
+    let cancellation = broker.task_group().cancellation_token();
 
     broker.spawn_service("heartbeat", async move {
-        // tracked service loop
+        cancellation.cancelled().await;
+        // Finish any ordered asynchronous cleanup here.
     })?;
 
     let report = owner.shutdown_runtime_blocking()?;
@@ -75,92 +84,307 @@ fn main() -> rocketmq_runtime::RuntimeResult<()> {
 }
 ```
 
-仅在迁移或测试 harness 已运行于 `#[tokio::main]` 或测试 runtime 中时使用
-`RuntimeContext::try_from_current`。这种 context 可以关闭 RocketMQ 自己登记的任务，但不会拥有或关闭宿主 Tokio runtime。
+实际应用入口通过 `owner.block_on(...)` 执行启动和服务 Future，随后在异步上下文之外
+消费 owner 并关闭运行时。与 `ServiceLifecycle` 和共享关闭截止时间的集成方式可参考
+[Broker 入口](../rocketmq-broker/src/bin/broker_bootstrap_server.rs)。
 
-## 工作区接入状态
+错误通道进行了明确区分：
 
-当前统一模型已经覆盖：
+- `RuntimeContractViolation` 表示调用方配置无效或不变量被违反，包括 `plan()` 返回的错误。
+- `RuntimeResult<T>` 使用 `RuntimeError` 表示运行故障，例如运行时构建、I/O、容量或超时错误。
+- `ScheduledTaskRegistrationOutcome::AlreadyPresent`、`BudgetRejection` 和元数据目标冲突
+  等正常结果有各自的类型。
 
-- `rocketmq-broker`：bootstrap、broker runtime、housekeeping、scheduled services、processor、auth、store/remoting integration 和 shutdown report。
-- `rocketmq-namesrv`：bootstrap、route services、batch unregister、segmented lock、remoting server/client 和 shutdown report。
-- `rocketmq-client`：producer、consumer、admin、trace、rebalance、pull、offset、delayed action、fallback runtime 和 blocking helpers。
-- `rocketmq-remoting`：client/server、connection pool、reconnect、writer task、request processing、TLS/network lifecycle。
-- `rocketmq-store` 与 `rocketmq-tieredstore`：store runtime scope、RocksDB、timer、HA、consume queue、index、compaction、dispatcher、cleanup、recovery 和 blocking IO。
-- `rocketmq-proxy`：`RuntimeOwner::new(RuntimeConfig::proxy_default())`、gRPC/remoting ingress、session/auth shutdown。
-- `rocketmq-controller`：`RuntimeOwner::new(RuntimeConfig::controller_default())`、RPC/remoting server、heartbeat、metadata/openraft scan、leadership watch。
-- `rocketmq-common`、`rocketmq-observability`、`rocketmq` 和 `rocketmq-tools/*`：helper、observability lifecycle、foundation service task/scheduler、admin CLI/TUI/store-inspect 均已分类为统一模型接入或显式兼容边界。
+`RuntimeContractViolation` 不会自动转换为 `RuntimeError`。
+示例使用能够接收两者的应用层错误类型；应用也可以定义明确的启动错误枚举。
 
-Standalone dashboard 应用保留宿主 runtime 边界：Tauri/Web backend、GPUI 和 frontend 只有在 runtime owner、admin session、diagnostics API、TypeScript type 或 UI contract 改动时，才从各自 standalone root 做额外验证。
+`RuntimeConfig::for_parallelism` 根据传入的 CPU 并行度派生工作线程数和阻塞通道限制。
+默认使用 `std::thread::available_parallelism()`，探测失败时回退到四个工作线程。
+`with_max_blocking_threads` 校验覆盖值，并限制各通道的并发上限。
 
-## 兼容边界
+仅在已运行于 Tokio 内的迁移或测试环境中使用 `RuntimeContext::try_from_current`。
+它关闭已登记的 RocketMQ 工作，但不拥有或关闭宿主运行时。其资源预算是宽松的测试预算，
+不会执行生产环境的内存探测流程。
 
-以下边界被保留并已文档化：
+## 任务作用域与取消
 
-- deprecated `RocketMQRuntime`：兼容旧同步 API 和历史调用点。
-- client shared fallback runtime：支持无 ambient runtime 的 client 调用方。
-- store static blocking executor：迁移期间支持未注入 `StoreRuntimeScope` 的调用点。
-- foundation service task helper：旧 `ServiceThread` 抽象内部已接入 `TaskGroup` 和 shutdown report。
-- dedicated OS threads：用于不适合 Tokio blocking pool 的长期循环，必须提供 stop signal 和 bounded join。
+通过 `component(...)` 创建长期组件作用域。如需在关闭或中毒状态下获得创建错误，使用
+`ChildServiceContext::try_component(...)`；当父级不再接收子组时，`component(...)`
+返回已关闭的作用域。动态名称通过 `ScopeId::try_new` 校验；字符串字面量支持静态名称转换。
 
-新增代码不得扩大未分类 legacy runtime、raw `tokio::spawn` 或隐藏 runtime owner 的使用范围。
+克隆上下文或任务组会共享同一所有者和取消令牌。创建子组则获得独立的取消范围：父级取消
+向下传播，子级取消不影响父级或兄弟组件。丢弃上下文句柄不是优雅关闭协议；活动任务可能
+继续持有其任务组。
 
-`RocketMQRuntime` 及其全部 public method 在 1.x 中仍然可用，但已弃用。其移除仅意图在未来的
-2.0 source-compatibility boundary 执行；目前尚未移除，本 crate 也没有声称已经发布 2.0。任何未来
-移除仍须经过完整发布周期、2.0 breaking window，并对每个受影响的 frozen public item 获得精确、经
-reviewed post-freeze 的 repository-owner approval。本次变更不创建 approval record，也不授予移除批准。请将构造迁移到
-`RuntimeOwner::new(RuntimeConfig { .. })?`，向库注入 `ChildServiceContext` 而非暴露 raw Tokio
-runtime 或 handle，将周期回调迁移到具有明确 overlap policy 的 `ScheduledTaskGroup`，并消费 owner
-shutdown API 返回的 `ShutdownReport`。逐方法迁移说明见 [1.0 API migration guide](../rocketmq-doc/en/release/1.0/api-migration.md)。
+| 提交 API | 取消行为 |
+| --- | --- |
+| `spawn` / `spawn_service` | 跟踪 Future；服务需要自行观察取消信号并按顺序完成清理。 |
+| `spawn_cancellable_service` | 所有者取消时丢弃服务 Future；适用于可以安全地立即取消 Future 的场景。 |
+| `spawn_operation` | 任务归属固定组件所有者，同时观察所有者取消以及操作自身的取消和截止时间。 |
+| `spawn_draining_operation` | 已接收工作可在所有者取消后继续执行，但仍受操作取消、截止时间和任务组关闭约束。 |
+| `spawn_with_handle` | 返回指定任务的 join handle，同时保留任务组跟踪。 |
 
-## 关闭语义
+有界请求或可重启工作使用 `OperationContext`，无需为每次操作创建组件组。
+`close_admission()` 停止接收新的操作任务；`wait()` 等待已登记任务完成；
+`cancel_and_wait()` 还会请求取消。等待时必须传入操作最初绑定的组件所有者，
+未完成工作会在等待截止时间到达后被中止。
 
-正常关闭顺序：
+`TaskGroup::cancel()` 只广播取消信号。
+使用 `shutdown(...)` 或 `shutdown_until(...)` 关闭任务接收并等待关闭报告。
 
-1. 关闭 task group，拒绝新任务。
-2. 广播 cancellation。
-3. 关闭 child groups。
-4. 在超时内等待 tracked tasks。
-5. abort 剩余 tracked tasks。
-6. 合并 `BlockingExecutor` snapshot。
-7. 返回 `ShutdownReport`。
+### TaskGroup 不变量
 
-`ShutdownReport::is_healthy()` 是主要正确性门槛。存在 leaked task、panic、timeout、仍在运行的 blocking task、仍在运行的 detached task 或不健康 child report 时，report 为 unhealthy。
+| 状态 | 含义 |
+| --- | --- |
+| `Open` | 可以登记新任务和子组。 |
+| `Closing` | 已开始关闭，拒绝新的登记。 |
+| `Closed` | 跟踪器已关闭，取消信号已广播。 |
+| `ShutdownCompleted` | 关闭报告已缓存供重复调用使用，但报告不一定健康。 |
+| `Poisoned` | 任务组开放期间发生受跟踪任务 panic，后续登记被拒绝。 |
 
-## 验证
+任务元数据先于 Tokio 提交完成登记。提交锁将登记与关闭状态转换串行化。
+[子组注册表](src/task_group/registry.rs) 按 `TaskGroupId` 保存弱引用；
+最后一个任务组引用释放后，子组会注销。名称只是标签，多个组可以同名而不共享身份。
 
-修改 runtime 行为后至少运行：
+## 周期任务
+
+通过 `context.scheduled_tasks("maintenance")` 派生调度器，
+并选择与重叠执行需求相符的登记方法：
+
+| 模式 | 行为 |
+| --- | --- |
+| `FixedDelay` | 执行回调，完成后等待 `period`。 |
+| `FixedRateNoOverlap` | 每个驱动周期尝试执行；上一次仍在运行时跳过。 |
+| `FixedRateAllowOverlap` | 每个驱动周期启动一次执行，不等待前次完成；没有独立的并发执行数量限制。 |
+
+当前固定频率驱动在提交尝试之间等待相对时长 `period`。预期触发时刻用于测量漂移，
+不会驱动按绝对时间追赶的循环。调用方不能依赖严格的时钟对齐或漏触发补偿。
+
+- `initial_delay` 默认为零，允许首次立即执行。
+- `max_run_time` 通过超时后丢弃 Future 限制单次回调；外部副作用仍需适当的取消协议。
+- 可控固定延迟回调通过返回 `ScheduledTaskControl::Stop` 停止驱动。
+- 同名登记返回 `AlreadyPresent`，不会替换已有驱动或指标。
+  `clear_completed()` 仅在调度器任务组没有活动任务时清空登记。
+- 驱动和执行任务归属于调度器的任务组。普通执行可在关闭期间完成；
+  支持操作上下文的登记还会观察操作自身的取消和截止时间。
+
+快照记录活动执行数、完成次数、跳过次数、重叠次数、失败次数、漂移和耗时。
+通过 `shutdown(timeout)` 或所属任务组关闭调度器。
+当前调度器不会读取 `ScheduledTaskConfig::shutdown_timeout`；实际预算由关闭调用提供。
+
+## 阻塞工作
+
+使用 `ChildServiceContext` 提供的执行器：
+
+| 访问方法 | 通道 | 典型工作 |
+| --- | --- | --- |
+| `storage_io()` | `StorageIo` | 短时存储和文件系统操作。 |
+| `metadata_io()` | `MetadataIo` | 元数据持久化。 |
+| `cpu_crypto()` | `CpuCrypto` | 有界 CPU 或密码学计算。 |
+
+同一运行时所有者的受管通道共享全局准入预算，上限为
+`RuntimeConfig::max_blocking_threads`。每个通道还有独立的并发上限和队列限制。
+空闲容量可以借用；当某通道有等待者时，其预留容量会受到保护，不再借给新的借用者。
+克隆执行器或派生上下文共享已有容量，不会创建另一个线程池。
+
+`max_queue_depth` 在准入队列已满时拒绝提交。`queue_timeout` 限制等待执行容量的时间；
+`task_timeout` 限制准入后调用方的等待时间。`spawn_until` 和 `spawn_io_until`
+还通过同一个绝对截止时间约束两个阶段。这些方法需要活动的 Tokio 上下文，
+应从所属运行时的任务中调用。
+
+超时或取消不会停止已经运行的阻塞闭包。闭包保留准入配额，直到实际退出；
+闭包内部的完成守卫在退出时移除任务记录，没有独立的回收任务。
+取消排队中的提交会移除排队记录；放弃等待已经运行的提交后，任务以
+`TimedOutStillRunning` 状态保留至完成。参见[执行器实现](src/blocking/executor.rs)。
+
+`BlockingKind::LongRunning` 会被拒绝。长期阻塞循环需要专用操作系统线程或领域服务作为
+所有者，并提供停止和等待退出协议。`BlockingExecutor::new(policy, owner_group)`
+保留为隔离的兼容构造入口：它创建独立预算，传入的任务组不会将其纳入受管根通道。
+
+## 资源预算与队列
+
+`RuntimeOwner` 拥有 `RuntimeResources`，子上下文共享其进程预算。
+通过 `context.process_budget().child(...)` 派生更窄的限制。
+需要共享进程上限时，不要让每个组件各自创建独立的 `ResourceBudgetTree`。
+
+所有者从 `ROCKETMQ_PROCESS_MEMORY_LIMIT_BYTES`、Linux cgroup 限制或宿主物理内存
+探测内存限制；也可以通过 `RuntimeOwnerPlan::with_memory_limit` 提供显式
+`ProcessMemoryLimit`。这些限制只核算通过预算 API 接收的资源，不会自动限制所有进程
+内存分配或常驻内存使用量。
+
+`ResourceBudget` 沿祖先链检查数量、保留字节数和可选速率限制。
+`ResourcePermit` 保留数量与字节配额，直到被丢弃。
+`BudgetClass::Control` 可以使用配置的控制类预留容量，数据类工作不能占用该预留容量。
+同一树中的配额重绑定在组件间转移所有权时保留公共祖先的核算。
+
+`BudgetedQueue` 支持 `Reject`、`WaitUntilDeadline`、`CoalesceLatest`、
+`DropStale` 和 `CloseSlowConsumer`。应根据工作能否等待、替换或丢弃选择策略。
+`push_until` 仅在 `WaitUntilDeadline` 策略下等待容量，并在拒绝结果中保留原始条目。
+
+出队 API 决定配额核算的生命周期：
+
+- `try_pop()` / `recv()` 返回条目，并在出队时释放配额。
+- `try_pop_budgeted()` / `recv_budgeted()` 返回 `BudgetedItem`，在处理期间保留配额。
+  `into_parts()` 显式转移配额；`into_item()` 释放配额。
+
+祖先限制、控制类预留、过载处理和配额转移示例见
+[资源预算测试](tests/resource_budget_tree.rs)。
+
+## 元数据持久化
+
+通过 `MetadataIoConfig::default().into_plan()?.start(&context)?` 启动 actor。
+它拥有受跟踪的协调任务，并使用上下文共享的 `MetadataIo` 阻塞通道。
+通过 `max_pending_operations` 和 `max_pending_bytes` 配置 actor 的准入限制；
+通过 `RuntimeConfig::blocking_lane_policies.metadata_io` 配置受管通道。
+actor 的兼容 `blocking_*` 配置不会替换共享通道策略。
+
+`submit` 和 `submit_next` 接收不可变快照，但不等待持久化完成。
+调用方需要匹配 `MetadataIoAdmissionOutcome`：`Accepted` 提供回执；当同一资源已有
+写向其他目标的待处理工作时，`TargetConflict` 返回请求。通过回执的 `wait_until`
+等待持久化，或使用 `submit_durable` / `submit_next_durable`，
+并匹配持久化代次或目标冲突结果。
+
+同一逻辑资源排队中的代次可以合并，较新的持久化代次能够满足较早的等待者。
+本地写入依次执行临时文件写入、文件同步、原子替换和受支持平台上的父目录同步，
+随后推进持久化代次。等待超时不表示底层文件系统操作已经停止。
+
+先调用 `stop_admission()` 拒绝新快照，再通过 `shutdown_until(MetadataDeadline)`
+等待已接收工作完成。除运行时任务关闭报告外，还应检查返回的 `MetadataIoShutdownReport`
+中是否存在未完成代次。参见[元数据 I/O 测试](tests/metadata_io_actor.rs)。
+
+## 服务生命周期与关闭
+
+`ServiceLifecycle` 提供 `Starting`、`Ready`、`Draining`、`Stopped` 和 `Failed` 状态。
+在组件上下文下启动它，完成服务启动后标记就绪，并单独发布依赖就绪状态。
+维护操作可以暂停就绪状态而不将进程标记为死亡。存活检查依据生命周期状态和进度更新时间，
+不以业务端口是否开放作为判断依据。
+
+使用 `ServiceLifecycle::from_env` 时，`ROCKETMQ_HEALTH_BIND_ADDR` 启用可选探针服务，
+提供 `/readyz`、`/livez` 和 `/drainz`。
+`ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS` 与 `ROCKETMQ_LIVENESS_STALE_SECONDS`
+分别配置关闭和进度窗口。未配置探针绑定地址时，关闭协调仍然有效。
+服务生命周期的默认关闭超时为 45 秒；`RuntimeConfig` 独立默认为 30 秒。
+
+首次关闭请求固定一个 `ShutdownDeadline`，重复的 pre-stop 或信号请求不会延长它。
+将同一截止时间传递给组件关闭流程及 `owner.shutdown_runtime_blocking_until(deadline)`。
+
+任务组关闭时先停止登记并广播取消，再并发执行子组关闭和本组任务等待。
+截止时间到达后中止尚未完成的受跟踪任务。报告在任务组级别缓存，
+运行时所有者另外合并其阻塞通道快照。
+
+| API | 范围与保证 |
+| --- | --- |
+| `owner.shutdown_tasks().await` / `shutdown_tasks_until(deadline).await` | 关闭并等待受跟踪任务，保留 Tokio 运行时。 |
+| `owner.shutdown_runtime_blocking()` / `shutdown_runtime_blocking_until(deadline)` | 消费所有者，先关闭受跟踪任务，再在剩余预算内释放 Tokio；必须在 Tokio 上下文之外调用，无需预先单独关闭任务。 |
+| `TaskGroup::shutdown_now()` | 立即取消和中止，不等待异步完成。 |
+| `owner.shutdown_background()` | 返回立即关闭任务的证据，并请求 Tokio 在后台关闭。 |
+| `RuntimeOwner::drop` | 未显式关闭时的紧急清理，不是优雅关闭协议。 |
+
+`ShutdownReport::is_healthy()` 要求 `leaked`、`failed`、`panicked`、`timed_out`、
+`blocking_still_running` 和 `detached_still_running` 均为零，且所有子报告健康。
+仅有 `aborted` 计数不会使报告不健康。立即关闭报告不能证明全部 Future 已完成清理。
+阻塞快照只反映采样时刻的状态，不会终止超过截止时间仍在运行的闭包。
+
+## 诊断
+
+`diagnostics_snapshot()` 提供内部详情，例如运行时和任务组身份、阻塞任务名称。
+面向已认证运维 API 时，优先使用 `diagnostics_view_v1(RuntimeComponent::...)`：
+其版本化视图聚合有界的任务类型和通道摘要，不包含原始 ID、名称、参数或配置对象。
+认证仍由调用方负责。
+
+`RuntimeDiagnosticsViewOptions` 控制摘要数量上限和长期运行阈值；
+摘要被省略时设置 `truncated`。这些诊断无需 Tokio unstable 特性或 console subscriber，
+也不能替代应用健康检查或性能测量。
+
+## 兼容边界与工作区接入
+
+`RocketMQRuntime` 已弃用，但在 1.x 中仍可使用。构造方式应迁移到
+`RuntimeOwner::plan(config)?.build()?`，向组件注入 `ChildServiceContext`，
+明确选择调度重叠策略，并检查关闭报告。未来移除属于 2.0 兼容性边界，仍须满足
+[API 迁移指南](../rocketmq-doc/en/release/1.0/api-migration.md)中的发布与所有者批准要求。
+
+`RuntimeContext` 用于迁移和测试。其他保留的辅助类型包括 `TokioExecutorService`、
+`ScheduledExecutorService`、`FuturesExecutorService`、`TaskScheduler` 和 `ActorRuntime`；
+它们承担不同的适配或专用线程职责，并非全部已弃用。
+新服务应使用前文介绍的所有权和能力 API。
+
+[Broker](../rocketmq-broker/src/bin/broker_bootstrap_server.rs)、
+[NameServer](../rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs)、
+[Proxy](../rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs) 和
+[Controller](../rocketmq-controller/src/bin/controller_bootstrap.rs) 入口构建运行时所有者，
+并使用服务生命周期截止时间。其他使用方包括 `rocketmq-client`、`rocketmq-transport`、
+`rocketmq-store`、`rocketmq-auth`、`rocketmq-observability` 和管理工具。
+客户端回退运行时及存储兼容辅助工具保留明确的适配边界；上述列表不表示所有调用点都使用
+完全相同的所有权路径。独立应用遵循各自的宿主运行时与验证指南。
+
+## 特性与验证
+
+crate 的 edition 和最低 Rust 版本继承自[工作区清单](../Cargo.toml)。
+默认 crate 特性为空；`async_fs` 启用 `common::file_utils` 中的 Tokio 文件系统辅助 API。
+核心所有权、阻塞、预算和元数据 API 不需要该特性。
+
+任务生命周期变更可以从包级检查开始：
 
 ```bash
+cargo fmt -p rocketmq-runtime -- --check
 cargo test -p rocketmq-runtime --test runtime_model
-cargo test -p rocketmq-runtime --all-targets --all-features
-cargo clippy -p rocketmq-runtime --all-targets --all-features -- -D warnings
 ```
 
-影响 workspace runtime 行为时继续运行：
+根据实际变更行为选择额外检查，无需每次编辑都执行所有测试集：
 
-```bash
-cargo fmt --all
-cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
-```
+| 范围 | 测试目标或命令 |
+| --- | --- |
+| 内部单元测试、错误通道、诊断、服务生命周期 | `cargo test -p rocketmq-runtime --lib` |
+| 资源限制与队列行为 | `cargo test -p rocketmq-runtime --test resource_budget_tree` |
+| 共享进程预算所有权 | `cargo test -p rocketmq-runtime --test runtime_resource_ownership` |
+| 元数据持久化与故障处理 | `cargo test -p rocketmq-runtime --test metadata_io_actor` |
+| 公开作用域限制 | `cargo test -p rocketmq-runtime --test service_context_scope_compile_fail` |
+| 关闭或预算的并发交错 | 使用 `cargo test -p rocketmq-runtime --test <target>` 运行 `task_group_shutdown_loom` 或 `resource_budget_loom` |
+| 迁移或大型 Future 提交 | 使用相同测试命令运行 `runtime_migration_fixture` 或 `task_submission_stack` |
+| 可选文件系统辅助 API | `cargo test -p rocketmq-runtime --features async_fs common::file_utils` |
 
-模块级迁移需要补跑对应 crate 的 `--all-targets --all-features` 测试，并在审计文档中记录无法运行的本地环境限制。
+需要时，针对受影响目标和特性运行
+`cargo clippy -p rocketmq-runtime --no-deps -- -D warnings`。
+共享行为变更需要验证直接受影响的使用方，独立项目遵循各自的本地指南。
+启用特性的检查不能替代未启用特性时的覆盖。
+
+编辑 README 时，检查本地链接，并编译、运行 Rust 代码块。
+`cargo test --doc` 验证 crate Rustdoc，不会自动包含独立 README 的代码块；
+这些示例需要使用 `rustdoc --test`，并传入已构建 crate 的 `--extern` 和依赖搜索路径。
+两种语言版本应保持一致。
+
+全工作区检查、运行时审计、Loom 模型和 Criterion 基准测试用于需要相应证据的变更，
+或对应的 CI、集成任务。基准测试提供特定运行条件下的测量结果，不构成固定性能保证。
+参见[仓库验证指南](../AGENTS.md)。
 
 ## Crate 结构
 
 ```text
 rocketmq-runtime/
-  src/config.rs           runtime 与 blocking policy 配置
-  src/owner.rs            owned Tokio runtime 生命周期
-  src/context.rs          borrowed runtime context 与 service context factory
-  src/service_context.rs  组件级 runtime 视图
-  src/handle.rs           Tokio handle wrapper
-  src/task_group.rs       结构化任务跟踪与关闭
-  src/scheduled.rs        周期任务 group 与调度指标
-  src/blocking.rs         有界 blocking executor 与 reaper 跟踪
-  src/diagnostics.rs      runtime diagnostics facade
-  src/shutdown_report.rs  可序列化关闭证据
-  src/legacy.rs           legacy RocketMQRuntime 兼容 wrapper
+  src/public_api.rs        deliberate ownership and diagnostics exports
+  src/prelude.rs           common ownership imports
+  src/config.rs            runtime and blocking-lane configuration
+  src/owner.rs             validated construction and owned runtime lifecycle
+  src/context.rs           borrowed runtime migration/test harness
+  src/service_context.rs   sealed root and child capabilities
+  src/task_spawner.rs      narrow task-submission capability
+  src/task_group.rs        task tracking, cancellation, and shutdown
+  src/task_group/          child registry and deadline coordination
+  src/operation.rs         operation-local cancellation and bounded waits
+  src/scheduled.rs         periodic drivers, runs, and metrics
+  src/blocking.rs          blocking API exports
+  src/blocking/            lane admission, execution, and snapshots
+  src/resources.rs         shared process resource capabilities
+  src/resource_budget/     resource trees, permits, queues, and memory discovery
+  src/metadata_io.rs       generation-aware metadata persistence
+  src/service_lifecycle.rs readiness, liveness, and shutdown requests
+  src/shutdown_deadline.rs shared absolute shutdown deadline
+  src/shutdown_report.rs   serializable shutdown evidence
+  src/diagnostics.rs       raw snapshots and sanitized V1 views
+  src/legacy.rs            deprecated RocketMQRuntime wrapper
+  src/executor_service.rs  retained executor adapters
+  src/schedule/            retained scheduler APIs
+  src/common/              common filesystem, time, and thread helpers
 ```
 
 ## 许可证

--- a/rocketmq-runtime/README.md
+++ b/rocketmq-runtime/README.md
@@ -3,81 +3,87 @@
 [![Crates.io](https://img.shields.io/crates/v/rocketmq-runtime.svg)](https://crates.io/crates/rocketmq-runtime)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](../LICENSE-APACHE)
 
-`rocketmq-runtime` is the shared Tokio runtime substrate for the
-[rocketmq-rust](https://github.com/mxsm/rocketmq-rust) workspace. It defines
-the project runtime ownership model, structured task lifecycle model,
-scheduled task model, bounded blocking execution model, and shutdown reporting
-surface used by RocketMQ components.
-
-The crate does not replace Tokio. It standardizes how RocketMQ components own
-or borrow Tokio runtimes, how long-running tasks are tracked, how periodic work
-is scheduled, how blocking work is isolated from async worker threads, and how
-shutdown can be verified.
+`rocketmq-runtime` is the shared runtime substrate for the
+[rocketmq-rust](https://github.com/mxsm/rocketmq-rust) workspace. It builds on
+Tokio to provide runtime ownership, tracked service and operation tasks,
+periodic scheduling, bounded blocking execution, resource budgets, metadata
+persistence, and shutdown diagnostics.
 
 [中文文档](README-zh_cn.md)
 
-## Target Thread Model
+## Runtime Model
 
-RocketMQ Rust uses Tokio as the only async runtime. Runtime ownership and task
-lifecycle are explicit:
-
-- application entrypoints create a `RuntimeOwner`; migration and test harnesses
-  may bind a `RuntimeContext` to the current Tokio runtime;
-- broker, namesrv, proxy, controller, and admin tool entrypoints derive their
-  component `ChildServiceContext` from the runtime owner;
-- every service receives a `ChildServiceContext`;
-- every long-running task is spawned through a `TaskGroup`;
-- every periodic task is registered through a `ScheduledTaskGroup`;
-- blocking work goes through `BlockingExecutor` unless it is a dedicated
-  long-running OS thread by design;
-- shutdown always produces a `ShutdownReport`.
+Production entrypoints own a `RuntimeOwner`. Libraries receive a
+`ChildServiceContext` or a narrower capability such as `TaskSpawner`; they do
+not discover or construct an independent runtime. The task ownership tree
+tracks work through shutdown. The resource-budget tree accounts for explicitly
+reserved resources; it is separate from the task tree.
 
 ```mermaid
 flowchart TD
     Entry["Application entrypoint"] --> Owner["RuntimeOwner"]
-    Entry --> Current["RuntimeContext (migration/test)"]
     Owner --> Root["RootServiceContext"]
-    Root --> GroupRoot["Root TaskGroup"]
-    Root --> Blocking["BlockingExecutor"]
-    Root --> Diagnostics["RuntimeDiagnostics"]
     Root --> Service["ChildServiceContext"]
-    Current --> Service
-    Service --> Group["Service TaskGroup"]
-    Group --> Scheduled["ScheduledTaskGroup"]
-    Group --> Workers["service / worker / IO tasks"]
-    Blocking --> Reaper["blocking reaper task group"]
-    Root --> Report["ShutdownReport"]
+    Service --> Group["Component TaskGroup"]
+    Group --> Tasks["Service and operation tasks"]
+    Service --> Scheduled["ScheduledTaskGroup"]
+    Scheduled --> Jobs["Tracked drivers and runs"]
+    Root --> Blocking["Shared blocking lanes and global admission budget"]
+    Service -.-> Blocking
+    Owner --> Resources["RuntimeResources / process budget"]
+    Resources --> Budgets["Component resource budgets and permits"]
+    Group --> Report["ShutdownReport"]
     Blocking --> Report
+    Service --> Diagnostics["Diagnostics snapshot / sanitized V1 view"]
 ```
+
+This is the production composition path. `RuntimeContext` is a migration and
+test harness for an existing Tokio runtime. Compatibility executors and
+dedicated thread helpers retain their own explicit ownership boundaries.
 
 ## Core Architecture
 
 | Type | Responsibility |
 | --- | --- |
-| `RuntimeConfig` | Configures Tokio worker threads, blocking-thread limit, thread name, optional worker stack size, keep-alive, shutdown timeout, IO/time drivers, and blocking policy. |
-| `RuntimeOwner` | Owns a dedicated Tokio multi-thread runtime and exposes a root service context. It separates async task shutdown from blocking runtime shutdown. |
-| `RuntimeContext` | Migration and test harness for a current Tokio runtime. Production composition roots use `RuntimeOwner`; libraries receive `ChildServiceContext`. |
-| `RuntimeHandle` | Lightweight wrapper around `tokio::runtime::Handle`; it is handle access, not lifecycle ownership. |
-| `ChildServiceContext` | Per-service view containing runtime handle, service task group, blocking executor, and diagnostics. |
-| `TaskGroup` | Structured task scope with task metadata, cancellation, shutdown, abort, child groups, and health reporting. |
-| `ScheduledTaskGroup` | Runs fixed-delay and fixed-rate jobs under a task group and records schedule metrics. |
-| `BlockingExecutor` | Bounded `spawn_blocking` gateway with queue timeout, task timeout, and still-running reaper tracking. |
-| `ShutdownReport` | Serializable shutdown evidence for task completion, cancellation, aborts, leaks, panics, timeouts, detached tasks, and blocking tasks. |
-| `RocketMQRuntime` | Legacy compatibility wrapper. Production composition roots use `RuntimeOwner`; libraries receive `ChildServiceContext`; `RuntimeContext` is only a migration and test harness. |
+| `RuntimeConfig` | Worker threads, blocking-thread limit, thread name and stack size, keep-alive, shutdown timeout, IO/time drivers, and per-lane blocking policies. |
+| `RuntimeOwner` / `RuntimeOwnerPlan` | Validate configuration, build and own a Tokio multi-thread runtime, expose the root context, and coordinate shutdown. |
+| `RootServiceContext` | Non-cloneable root with no public constructor; derives component contexts and exposes shared resources and diagnostics. |
+| `ChildServiceContext` / `TaskSpawner` | Component capabilities for owned work. A spawner exposes task submission and cancellation access without raw runtime access. |
+| `TaskGroup` / `OperationContext` | Track component tasks and provide operation-local cancellation, deadlines, and bounded waits. An operation does not create a new task group. |
+| `ScheduledTaskGroup` | Run periodic jobs with explicit overlap behavior and schedule metrics. |
+| `BlockingExecutor` | Admit short blocking work through a bounded lane and retain its capacity until the closure actually exits. |
+| `RuntimeResources` / `ResourceBudget` | Share the process budget and derive component limits for count, retained bytes, and optional rate control. |
+| `ResourcePermit` / `BudgetedQueue` | Carry RAII reservations through queued or in-flight work and apply explicit overload policies. |
+| `MetadataIoActor` | Own bounded metadata snapshots, coalesce queued generations, and report durable completion. |
+| `ServiceLifecycle` / `ShutdownDeadline` | Coordinate readiness, liveness, shutdown requests, and a shared absolute shutdown deadline. |
+| `ShutdownReport` | Serializable evidence of completion, cancellation, aborts, failures, panics, timeouts, and remaining work. |
+| `RuntimeDiagnosticsSnapshot` / `RuntimeDiagnosticsViewV1` | Internal runtime details and a bounded, sanitized operational view. |
 
-## Runtime Ownership
+`RuntimeHandle` is an internal implementation type, not a public integration
+entrypoint. Common ownership types are also available from
+`rocketmq_runtime::prelude`.
 
-Use `RuntimeOwner` when a component owns a dedicated Tokio runtime:
+## Runtime Ownership And Quick Start
+
+Use `RuntimeOwner::new()?` for the default profile. For a named or customized
+profile, call `RuntimeOwner::plan(config)?.build()?`. Planning validates
+configuration without discovering system resources or starting Tokio;
+building performs memory-limit discovery and runtime construction.
+
+This finite example registers a service and immediately exercises its
+cooperative shutdown path:
 
 ```rust
 use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
 
-fn main() -> rocketmq_runtime::RuntimeResult<()> {
-    let owner = RuntimeOwner::new(RuntimeConfig::broker_default())?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let owner = RuntimeOwner::plan(RuntimeConfig::broker_default())?.build()?;
     let broker = owner.root_context().component("broker");
+    let cancellation = broker.task_group().cancellation_token();
 
     broker.spawn_service("heartbeat", async move {
-        // tracked service loop
+        cancellation.cancelled().await;
+        // Finish any ordered asynchronous cleanup here.
     })?;
 
     let report = owner.shutdown_runtime_blocking()?;
@@ -86,202 +92,359 @@ fn main() -> rocketmq_runtime::RuntimeResult<()> {
 }
 ```
 
+A real entrypoint runs its startup and service future through
+`owner.block_on(...)`, then consumes the owner outside the async context to
+shut down the runtime. See the [broker entrypoint](../rocketmq-broker/src/bin/broker_bootstrap_server.rs)
+for integration with `ServiceLifecycle` and a shared shutdown deadline.
+
+The error channels are intentional:
+
+- `RuntimeContractViolation` identifies invalid caller configuration or an
+  invariant violation, including failures from `plan()`.
+- `RuntimeResult<T>` contains `RuntimeError` for operational failures such as
+  runtime construction, I/O, capacity, or timeout failures.
+- Normal outcomes such as `ScheduledTaskRegistrationOutcome::AlreadyPresent`,
+  `BudgetRejection`, and metadata target conflicts have their own types.
+
+There is no automatic conversion from `RuntimeContractViolation` to
+`RuntimeError`. The example's application-level error type accepts both;
+applications can instead define an explicit startup error enum.
+
+`RuntimeConfig::for_parallelism` derives worker and blocking-lane limits from
+the supplied CPU parallelism. The default uses
+`std::thread::available_parallelism()`, with a fallback of four workers.
+`with_max_blocking_threads` validates an override and caps lane concurrency.
+
 Use `RuntimeContext::try_from_current` only in migration or test harnesses
-that already run inside `#[tokio::main]` or a test runtime. It can shut down
-tracked RocketMQ tasks, but it does not own or close the host Tokio runtime.
+already running inside Tokio. It shuts down registered RocketMQ work without
+owning or closing the host runtime. Its resource budget is a permissive test
+budget, not the production memory-discovery path.
 
-### Legacy Compatibility Boundary
+## Task Scopes And Cancellation
 
-`RocketMQRuntime` is retained only for legacy synchronous APIs that still need
-to pass around an owned Tokio runtime. Production composition roots use
-`RuntimeOwner`, libraries receive `ChildServiceContext`, and `RuntimeContext`
-is only a migration and test harness. Runtime audit classifies remaining
-`RocketMQRuntime` references as either runtime primitives or explicit
-compatibility adapters so new unclassified legacy runtime use cannot grow
-unnoticed.
+Create long-lived component scopes through `component(...)`. Use
+`ChildServiceContext::try_component(...)` to receive a creation error during
+shutdown or poisoning; `component(...)` returns a closed scope if the parent
+no longer accepts children. Validate dynamic names with `ScopeId::try_new`;
+string literals have a static-name conversion.
 
-`RocketMQRuntime` and all of its public methods remain available, deprecated
-1.x API. Its removal is intended only for a future 2.0 source-compatibility
-boundary; it has not happened, and this crate does not claim a 2.0 release.
-Any future removal remains subject to the full release cycle, a 2.0 breaking
-window, and exact, reviewed post-freeze repository-owner approval for every
-affected frozen public item. This change creates no approval record and does
-not authorize a removal.
-Migrate construction to `RuntimeOwner::new(RuntimeConfig { .. })?`, inject a
-`ChildServiceContext` instead of exposing a raw Tokio runtime or handle, move
-periodic callbacks to `ScheduledTaskGroup` with an explicit overlap policy,
-and consume the `ShutdownReport` returned by the owner shutdown APIs. The
-full per-method migration is in the [1.0 API migration guide](../rocketmq-doc/en/release/1.0/api-migration.md).
+Cloning a context or task group shares the same owner and cancellation token.
+Creating a child gives it independent cancellation: parent cancellation
+propagates downward, while child cancellation does not cancel its parent or
+siblings. Dropping a context handle is not a graceful shutdown protocol;
+active tasks can keep their group alive.
 
-`RuntimeOwner` intentionally separates two phases:
+| Submission API | Cancellation behavior |
+| --- | --- |
+| `spawn` / `spawn_service` | Tracks the future. The service must observe its cancellation signal and perform ordered cleanup itself. |
+| `spawn_cancellable_service` | Drops the service future when the owner is cancelled. Use when immediate future cancellation is safe. |
+| `spawn_operation` | Keeps work under a fixed component owner and observes both owner cancellation and the operation's cancellation/deadline. |
+| `spawn_draining_operation` | Accepted work can continue after owner cancellation; operation cancellation/deadline and task-group shutdown still bound it. |
+| `spawn_with_handle` | Returns a join handle for a specific task while retaining group tracking. |
 
-1. `shutdown_tasks().await`: cancel, close, wait, abort, and report tracked
-   RocketMQ tasks.
-2. `shutdown_runtime_blocking(self)`: release the owned Tokio runtime outside
-   an async runtime context.
+For bounded requests or restartable work, use `OperationContext` instead of
+creating a component group for every operation. `close_admission()` stops new
+operation tasks; `wait()` drains registered tasks; `cancel_and_wait()` also
+requests cancellation. The waits require the operation's original component
+owner and abort unfinished work at their deadline.
 
-This avoids calling Tokio runtime shutdown APIs from inside async shutdown
-paths and keeps ownership boundaries explicit.
+`TaskGroup::cancel()` only broadcasts cancellation. Use `shutdown(...)` or
+`shutdown_until(...)` to close task admission and wait for shutdown evidence.
 
-## TaskGroup Model
-
-`TaskGroup` is the core structured-concurrency primitive for long-running
-RocketMQ work. It uses `CancellationToken`, `TaskTracker`, `AbortHandle`, task
-metadata, and child task groups.
-
-Lifecycle states:
+### TaskGroup Invariants
 
 | State | Meaning |
 | --- | --- |
 | `Open` | New tasks and child groups can be registered. |
-| `Closing` | Shutdown has started; new task registration is rejected. |
-| `Closed` | The group has been closed and cancellation has been broadcast. |
-| `ShutdownCompleted` | Shutdown reporting completed and the report can be reused idempotently. |
-| `Poisoned` | A tracked task panicked while the group was open. |
+| `Closing` | Shutdown has started; new registration is rejected. |
+| `Closed` | The tracker is closed and cancellation has been broadcast. |
+| `ShutdownCompleted` | The shutdown report is cached for repeated calls; it need not be healthy. |
+| `Poisoned` | A tracked task panicked while the group was open; new registration is rejected. |
 
-Important invariants:
-
-- task metadata is inserted before spawning the future, so shutdown cannot miss
-  a task that is already visible to Tokio;
-- `spawn_gate` serializes spawn/child creation with shutdown transitions;
-- children are stored as a `Vec<TaskGroup>` guarded by `Mutex`, avoiding
-  recursive `DashMap<TaskGroupId, TaskGroup>` type expansion;
-- child group identity is `TaskGroupId`; names are labels, so repeated names
-  such as `remoting.connection` are allowed;
-- `spawn_with_handle` is available for integrations that must await a specific
-  task, while the task still remains tracked by the group;
-- `DetachedTaskPolicy::AbortOnShutdown` lets compatibility tasks remain
-  detached during normal operation but still be aborted during shutdown.
+Task metadata is registered before submission to Tokio. A spawn gate
+serializes registration with shutdown transitions. The
+[child registry](src/task_group/registry.rs) uses weak references keyed by
+`TaskGroupId`; dropping the last group reference unregisters the child.
+Names are labels, so multiple groups can share a name without sharing identity.
 
 ## Scheduled Tasks
 
-`ScheduledTaskGroup` is used for periodic work that must be visible to the
-runtime lifecycle. It supports:
+Derive a scheduler with `context.scheduled_tasks("maintenance")` and select
+the registration method matching the desired overlap behavior:
 
-- `FixedDelay`: wait `period` after each run completes;
-- `FixedRateNoOverlap`: tick on a fixed cadence and skip runs while the
-  previous run is still active;
-- `FixedRateAllowOverlap`: tick on a fixed cadence and allow overlapping runs.
+| Mode | Behavior |
+| --- | --- |
+| `FixedDelay` | Run the callback, then wait `period` after completion. |
+| `FixedRateNoOverlap` | Attempt a run each driver cycle; skip when the previous run is still active. |
+| `FixedRateAllowOverlap` | Start a run each driver cycle without waiting for previous runs. There is no separate concurrent-run limit. |
 
-Each schedule records active runs, completed runs, skips, overlaps, failures,
-drift, elapsed time, and max elapsed time. Scheduled drivers and scheduled runs
-are spawned through the underlying `TaskGroup`, so shutdown drains or aborts
-them like any other tracked task.
+The fixed-rate drivers currently sleep for `period` between submission
+attempts. Their expected tick measures drift; it does not schedule an
+absolute-time catch-up loop. Do not rely on strict wall-clock alignment or
+missed-tick compensation.
+
+- `initial_delay` defaults to zero, allowing the first run immediately.
+- `max_run_time` bounds an individual callback by dropping its future on
+  timeout. External side effects still need an appropriate cancellation contract.
+- Controlled fixed-delay callbacks return `ScheduledTaskControl::Stop` to end
+  their driver.
+- Duplicate names return `AlreadyPresent` without replacing the driver or
+  metrics. `clear_completed()` clears registrations only when the scheduler's
+  group has no active tasks.
+- Drivers and runs belong to the scheduler's task group. Ordinary runs may
+  finish during shutdown; operation-aware registrations also observe their
+  operation's cancellation and deadline.
+
+Snapshots record active runs, run completions, skips, overlaps, failures,
+drift, and elapsed time. Close the scheduler through `shutdown(timeout)` or
+its owning group. `ScheduledTaskConfig::shutdown_timeout` is not currently
+read by the scheduler; the actual shutdown call supplies the budget.
 
 ## Blocking Work
 
-`BlockingExecutor` is the common gateway for short blocking IO and bounded CPU
-work. It protects Tokio worker threads by controlling how `spawn_blocking` is
-used:
+Use the executors supplied by a `ChildServiceContext`:
 
-- `max_concurrency` limits concurrent blocking operations;
-- `queue_timeout` rejects work that cannot acquire a permit in time;
-- `task_timeout` reports timeout to the caller without pretending the blocking
-  closure has stopped;
-- timed-out blocking tasks remain tracked as `TimedOutStillRunning`;
-- a detached reaper awaits the real `JoinHandle` completion and removes the
-  task from the snapshot.
+| Accessor | Lane | Typical work |
+| --- | --- | --- |
+| `storage_io()` | `StorageIo` | Short storage and filesystem operations. |
+| `metadata_io()` | `MetadataIo` | Metadata persistence. |
+| `cpu_crypto()` | `CpuCrypto` | Bounded CPU or cryptographic work. |
 
-Long-running blocking loops should not use the Tokio blocking pool. They should
-be implemented as dedicated OS threads or domain-specific services with their
-own shutdown protocol.
+Managed lanes share one global admission budget per runtime owner, bounded by
+`RuntimeConfig::max_blocking_threads`. Each lane has its own concurrency
+ceiling and queue bound. Idle capacity can be borrowed; a waiting lane's
+reservation is protected from new borrowers. Cloning an executor or deriving
+a context shares this capacity rather than creating another pool.
 
-## Shutdown Semantics
+`max_queue_depth` rejects submissions when the admission queue is full.
+`queue_timeout` bounds waiting for execution capacity; `task_timeout` bounds
+the caller's wait after admission. `spawn_until` and `spawn_io_until` also cap
+both phases with one absolute deadline. These methods require an active
+Tokio context; call them from the owning runtime's work.
 
-Normal shutdown follows this order:
+Timeout or cancellation does not stop an already-running blocking closure.
+The closure retains its admission permit until it exits. A completion guard
+inside the closure removes its task record on exit; there is no separate
+reaper task. Cancelling a queued submission removes its queued record, while
+an abandoned running submission is recorded as `TimedOutStillRunning` until
+completion. See the [executor implementation](src/blocking/executor.rs).
 
-1. close the task group and reject new spawns;
-2. broadcast cancellation;
-3. shut down child groups;
-4. wait for tracked tasks within the timeout;
-5. abort remaining tracked tasks;
-6. merge `BlockingExecutor` snapshot data;
-7. return `ShutdownReport`.
+`BlockingKind::LongRunning` is rejected. Long-running blocking loops need a
+dedicated OS-thread or domain-service owner with a stop and join protocol.
+`BlockingExecutor::new(policy, owner_group)` remains an isolated compatibility
+constructor: it creates an independent budget, and the group argument does
+not enroll it in the managed root lanes.
 
-`shutdown_now` is the synchronous compatibility path used by `Drop` or sync
-teardown code. It closes the group, cancels tasks, aborts tracked work, and
-returns a report without awaiting async task completion.
+## Resource Budgets And Queues
 
-`ShutdownReport::is_healthy()` is the main correctness gate. A report is
-unhealthy when it contains leaked tasks, panics, timeouts, still-running
-blocking tasks, still-running detached tasks, or unhealthy child reports.
+`RuntimeOwner` owns `RuntimeResources`; child contexts share its process
+budget. Derive narrower limits with `context.process_budget().child(...)`.
+Do not create an independent `ResourceBudgetTree` in each component when a
+shared process limit is required.
 
-## Component Migration Rules
+The owner detects a memory limit from `ROCKETMQ_PROCESS_MEMORY_LIMIT_BYTES`,
+Linux cgroup limits, or host physical memory. Supply an explicit
+`ProcessMemoryLimit` through `RuntimeOwnerPlan::with_memory_limit` when needed.
+These limits account for resources admitted through the budget APIs; they do
+not automatically limit every process allocation or resident-memory usage.
 
-New RocketMQ code should follow these rules:
+`ResourceBudget` checks count, retained bytes, and optional rate limits along
+the ancestor chain. A `ResourcePermit` retains count and byte reservations
+until dropped. `BudgetClass::Control` can use configured control reserves;
+data work cannot consume that reserved capacity. Same-tree permit rebinding
+keeps common-ancestor accounting while moving ownership between components.
 
-- do not create ad hoc Tokio runtimes inside business crates;
-- do not call raw `tokio::spawn` for long-running service work;
-- derive a `ChildServiceContext` and spawn through its `TaskGroup`;
-- wrap periodic loops in `ScheduledTaskGroup`;
-- route file IO, RocksDB calls, DNS resolution, and other short blocking work
-  through `BlockingExecutor`;
-- keep long-running blocking loops outside Tokio blocking pools;
-- return or log `ShutdownReport` during component shutdown;
-- do not rely on `Drop` for graceful shutdown; `Drop` may only cancel or abort
-  work as an emergency cleanup path;
-- keep diagnostics and benchmark tooling as validation artifacts rather than
-  production-critical runtime dependencies.
+`BudgetedQueue` supports `Reject`, `WaitUntilDeadline`, `CoalesceLatest`,
+`DropStale`, and `CloseSlowConsumer`. Select a policy matching whether work
+can wait, be replaced, or be discarded. `push_until` waits for capacity only
+with `WaitUntilDeadline` and preserves the rejected item in its outcome.
 
-## Workspace Integration
+The dequeue API determines the accounting lifetime:
 
-The unified model is the production entrypoint for broker, namesrv, proxy,
-controller, client fallback runtime, remoting, store, tieredstore, common
-statistics helpers, observability lifecycle, and admin tools. Standalone
-dashboard applications keep their host runtime boundary documented unless
-their runtime owner, admin session, diagnostics API, or UI contract changes.
+- `try_pop()` / `recv()` return the item and release its permit at dequeue.
+- `try_pop_budgeted()` / `recv_budgeted()` return a `BudgetedItem` retaining
+  the permit during processing. `into_parts()` transfers the permit explicitly;
+  `into_item()` releases it.
 
-Compatibility adapters that intentionally remain include the deprecated
-`RocketMQRuntime`, client fallback runtime, store static blocking executor,
-foundation service task helper, and dedicated OS-thread services with explicit
-stop and join behavior.
+See [resource-budget tests](tests/resource_budget_tree.rs) for ancestor
+limits, control reserves, overload handling, and permit transfer examples.
 
-## Diagnostics And Benchmarks
+## Metadata Persistence
 
-Runtime diagnostics are intentionally kept behind the runtime abstraction. The
-default production path should not require Tokio unstable features, console
-subscribers, or runtime metrics exporters.
+Start the actor with `MetadataIoConfig::default().into_plan()?.start(&context)?`.
+It owns a tracked coordinator and uses the context's shared `MetadataIo`
+blocking lane. Configure actor admission with `max_pending_operations` and
+`max_pending_bytes`; configure the managed lane through
+`RuntimeConfig::blocking_lane_policies.metadata_io`. The actor's compatibility
+`blocking_*` settings do not replace that shared lane policy.
 
-Benchmark and audit artifacts should be used as evidence for changes, not as
-hard-coded performance claims. The expected validation loop is:
+`submit` and `submit_next` accept immutable snapshots without waiting for
+durability. Match `MetadataIoAdmissionOutcome`: `Accepted` provides a receipt;
+`TargetConflict` returns the request when a resource already has pending work
+for a different target. Wait for persistence through the receipt's
+`wait_until`, or use `submit_durable` / `submit_next_durable` and match the
+durable-generation or target-conflict outcome.
 
-1. scan spawn, runtime, blocking, and shutdown sites;
-2. classify findings as production, compatibility, test, benchmark, or
-   tool-only;
-3. collect baseline task lifecycle and shutdown behavior;
-4. migrate to runtime primitives;
-5. rerun targeted tests, runtime audit scripts, and Criterion benchmarks.
+Queued generations for the same logical resource can coalesce; a newer durable
+generation can satisfy an earlier waiter. A local write uses a temporary file,
+file synchronization, atomic replacement, and parent-directory synchronization
+on supported platforms before advancing durable generation. A wait timeout
+does not prove that the underlying filesystem operation has stopped.
 
-Useful local checks:
+Call `stop_admission()` to reject new snapshots, then
+`shutdown_until(MetadataDeadline)` to drain accepted work. Inspect the returned
+`MetadataIoShutdownReport` for unfinished generations as well as the runtime's
+task shutdown report. See [metadata I/O tests](tests/metadata_io_actor.rs).
+
+## Service Lifecycle And Shutdown
+
+`ServiceLifecycle` exposes `Starting`, `Ready`, `Draining`, `Stopped`, and
+`Failed` states. Start it under a component context, mark readiness after
+startup, and publish dependency readiness separately. Maintenance can suspend
+readiness without marking the process dead. Liveness checks lifecycle state
+and progress freshness, not whether a business port is open.
+
+With `ServiceLifecycle::from_env`, `ROCKETMQ_HEALTH_BIND_ADDR` enables the
+optional probe server with `/readyz`, `/livez`, and `/drainz`.
+`ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS` and `ROCKETMQ_LIVENESS_STALE_SECONDS`
+configure its shutdown and progress windows. Without a probe bind address,
+shutdown coordination still works. The lifecycle shutdown timeout defaults
+to 45 seconds; `RuntimeConfig` independently defaults to 30 seconds.
+
+The first shutdown request freezes a `ShutdownDeadline`; repeated pre-stop or
+signal requests cannot extend it. Pass that deadline through component
+shutdown and `owner.shutdown_runtime_blocking_until(deadline)`.
+
+Task-group shutdown closes registration and broadcasts cancellation, then
+starts child shutdowns concurrently with waiting for the group's own tasks.
+Unfinished tracked tasks are aborted when the deadline expires. Reports are
+cached at group level; the owner additionally merges its blocking-lane snapshots.
+
+| API | Scope and guarantee |
+| --- | --- |
+| `owner.shutdown_tasks().await` / `shutdown_tasks_until(deadline).await` | Close and wait for tracked tasks, retaining the Tokio runtime. |
+| `owner.shutdown_runtime_blocking()` / `shutdown_runtime_blocking_until(deadline)` | Consume the owner, shut down tracked tasks, then release Tokio within the remaining budget. Call outside a Tokio context; a separate task-shutdown call is not required. |
+| `TaskGroup::shutdown_now()` | Cancel and abort immediately without awaiting asynchronous completion. |
+| `owner.shutdown_background()` | Return immediate task-shutdown evidence and ask Tokio to shut down in the background. |
+| `RuntimeOwner::drop` | Emergency cleanup if explicit shutdown was omitted; not a graceful-shutdown protocol. |
+
+`ShutdownReport::is_healthy()` requires zero `leaked`, `failed`, `panicked`,
+`timed_out`, `blocking_still_running`, and `detached_still_running` counts,
+and healthy child reports. An `aborted` count alone does not make the report
+unhealthy. An immediate-shutdown report is not proof that all futures completed
+their cleanup. Blocking snapshots are point-in-time evidence and do not
+terminate closures that outlive a deadline.
+
+## Diagnostics
+
+`diagnostics_snapshot()` exposes internal details such as runtime/group
+identity and blocking task names. For authenticated operational APIs, prefer
+`diagnostics_view_v1(RuntimeComponent::...)`: its versioned view aggregates
+bounded task-kind and lane summaries without raw IDs, names, arguments, or
+configuration objects. Authentication remains the caller's responsibility.
+
+`RuntimeDiagnosticsViewOptions` controls summary bounds and the long-running
+threshold; omitted summaries set `truncated`. These diagnostics do not require
+Tokio unstable features or a console subscriber, and do not replace application
+health checks or performance measurements.
+
+## Compatibility And Workspace Integration
+
+`RocketMQRuntime` remains deprecated but available in 1.x. Migrate construction
+to `RuntimeOwner::plan(config)?.build()?`, inject `ChildServiceContext`, select
+an explicit scheduling overlap policy, and inspect shutdown reports. Future
+removal belongs to a 2.0 compatibility boundary and remains subject to the
+release and owner-approval requirements in the
+[API migration guide](../rocketmq-doc/en/release/1.0/api-migration.md).
+
+`RuntimeContext` is a migration/test harness. Other retained helpers include
+`TokioExecutorService`, `ScheduledExecutorService`, `FuturesExecutorService`,
+`TaskScheduler`, and `ActorRuntime`; they have separate adapter or dedicated
+thread responsibilities and are not all deprecated. New services should use
+the ownership and capability APIs described above.
+
+The [broker](../rocketmq-broker/src/bin/broker_bootstrap_server.rs),
+[NameServer](../rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs),
+[proxy](../rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs), and
+[controller](../rocketmq-controller/src/bin/controller_bootstrap.rs) entrypoints
+build runtime owners and use service lifecycle deadlines. Other consumers
+include `rocketmq-client`, `rocketmq-transport`, `rocketmq-store`,
+`rocketmq-auth`, `rocketmq-observability`, and admin tools. Client fallback
+runtimes and store compatibility helpers retain explicit adapter boundaries;
+this list does not imply that every call site uses an identical ownership path.
+Standalone applications follow their local host-runtime and validation guides.
+
+## Features And Validation
+
+The crate inherits its edition and minimum Rust version from the
+[workspace manifest](../Cargo.toml). Default crate features are empty;
+`async_fs` enables the Tokio filesystem helpers in `common::file_utils`.
+The core ownership, blocking, budget, and metadata APIs do not require it.
+
+For task-lifecycle changes, start with package-scoped checks:
 
 ```bash
-cargo test -p rocketmq-runtime --test task_group_concurrency_model
-cargo test -p rocketmq-runtime --all-targets --all-features
-cargo clippy -p rocketmq-runtime --all-targets --all-features -- -D warnings
+cargo fmt -p rocketmq-runtime -- --check
+cargo test -p rocketmq-runtime --test runtime_model
 ```
 
-Run the full workspace validation when changes affect public runtime behavior:
+Select additional checks for the behavior being changed, rather than running
+every suite for every edit:
 
-```bash
-cargo fmt --all
-cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
-```
+| Area | Test target or command |
+| --- | --- |
+| Internal units, error channels, diagnostics, service lifecycle | `cargo test -p rocketmq-runtime --lib` |
+| Resource limits and queue behavior | `cargo test -p rocketmq-runtime --test resource_budget_tree` |
+| Shared process-budget ownership | `cargo test -p rocketmq-runtime --test runtime_resource_ownership` |
+| Metadata persistence and fault handling | `cargo test -p rocketmq-runtime --test metadata_io_actor` |
+| Public scope restrictions | `cargo test -p rocketmq-runtime --test service_context_scope_compile_fail` |
+| Shutdown or budget interleavings | `task_group_shutdown_loom` or `resource_budget_loom` via `cargo test -p rocketmq-runtime --test <target>` |
+| Migration or large-future submission | `runtime_migration_fixture` or `task_submission_stack` via the same test command |
+| Optional filesystem helpers | `cargo test -p rocketmq-runtime --features async_fs common::file_utils` |
+
+When useful, run `cargo clippy -p rocketmq-runtime --no-deps -- -D warnings`
+with the affected targets/features. Validate directly affected consumers when
+shared behavior changes; follow standalone projects' local guides where
+applicable. Feature-enabled checks do not replace feature-absence coverage.
+
+For README edits, check local links and compile/run the fenced Rust examples.
+`cargo test --doc` covers crate Rustdoc, not standalone README code blocks;
+test those explicitly with `rustdoc --test` and the built crate's `--extern`
+and dependency search path. Keep both language versions aligned.
+
+Full-workspace checks, runtime audits, Loom models, and Criterion benchmarks
+belong to changes that need that evidence or the relevant CI/integration task.
+Benchmarks provide measurements for a specific run, not hard-coded performance
+guarantees. See [repository validation guidance](../AGENTS.md).
 
 ## Crate Layout
 
 ```text
 rocketmq-runtime/
-  src/config.rs           runtime and blocking policy configuration
-  src/owner.rs            owned Tokio runtime lifecycle
-  src/context.rs          borrowed runtime context and service context factory
-  src/service_context.rs  per-service runtime view
-  src/handle.rs           Tokio handle wrapper
-  src/task_group.rs       structured task tracking and shutdown
-  src/scheduled.rs        scheduled task groups and schedule metrics
-  src/blocking.rs         bounded blocking executor and reaper tracking
-  src/diagnostics.rs      runtime diagnostics facade
-  src/shutdown_report.rs  serializable shutdown evidence
-  src/legacy.rs           legacy RocketMQRuntime compatibility wrapper
+  src/public_api.rs        deliberate ownership and diagnostics exports
+  src/prelude.rs           common ownership imports
+  src/config.rs            runtime and blocking-lane configuration
+  src/owner.rs             validated construction and owned runtime lifecycle
+  src/context.rs           borrowed runtime migration/test harness
+  src/service_context.rs   sealed root and child capabilities
+  src/task_spawner.rs      narrow task-submission capability
+  src/task_group.rs        task tracking, cancellation, and shutdown
+  src/task_group/          child registry and deadline coordination
+  src/operation.rs         operation-local cancellation and bounded waits
+  src/scheduled.rs         periodic drivers, runs, and metrics
+  src/blocking.rs          blocking API exports
+  src/blocking/            lane admission, execution, and snapshots
+  src/resources.rs         shared process resource capabilities
+  src/resource_budget/     resource trees, permits, queues, and memory discovery
+  src/metadata_io.rs       generation-aware metadata persistence
+  src/service_lifecycle.rs readiness, liveness, and shutdown requests
+  src/shutdown_deadline.rs shared absolute shutdown deadline
+  src/shutdown_report.rs   serializable shutdown evidence
+  src/diagnostics.rs       raw snapshots and sanitized V1 views
+  src/legacy.rs            deprecated RocketMQRuntime wrapper
+  src/executor_service.rs  retained executor adapters
+  src/schedule/            retained scheduler APIs
+  src/common/              common filesystem, time, and thread helpers
 ```
 
 ## License


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10287

### Brief Description

The runtime quick-start example no longer compiled, and both READMEs described outdated task registration and blocking cleanup mechanisms. Update the English and Chinese documents together with a working `plan(config)?.build()?` example and the correct separation of contract violations from operational errors.

Document task and operation cancellation, shared blocking lanes, resource-permit lifetimes, metadata durability, scheduling limitations, service lifecycle deadlines, shutdown-report guarantees, and sanitized diagnostics. Refresh compatibility guidance, source links, crate layout, and package-scoped validation commands.

### How Did You Test This Change?

- `cargo build -p rocketmq-runtime --offline --message-format=json`: passed; used the reported library artifact for the README checks.
- Direct `rustdoc --test` runs for `rocketmq-runtime/README.md` and `rocketmq-runtime/README-zh_cn.md`, with edition 2021, the built library as `--extern rocketmq_runtime`, and the dependency search path: 1 example passed in each document.
- Documentation checks: 30 local links and 48 layout entries resolve; 15 section levels align; all 4 fenced blocks match between languages; all 9 referenced integration-test targets exist.
- `git diff --check`: passed for the two README files.

This is a documentation-only change. No full-workspace, all-feature, or performance validation was run for this update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote the runtime documentation in English and Chinese to reflect the current architecture and usage flow.
  * Added guidance on ownership, task scoping, cancellation, scheduled and blocking work, resource budgets, queues, metadata persistence, lifecycle, shutdown, and diagnostics.
  * Expanded the documented runtime types and updated crate structure references.
  * Updated compatibility, workspace integration, features, and validation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->