### PR TITLE
[ISSUE #10289]🐛Move admin SDK error conversion into the adapter layer

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/error_conversion.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/error_conversion.rs
@@ -1,0 +1,31 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error conversion shared by the read and mutation client adapters.
+
+pub(crate) trait IntoCanonicalError {
+    fn into_canonical_error(self) -> rocketmq_error::Error;
+}
+
+impl IntoCanonicalError for rocketmq_error::Error {
+    fn into_canonical_error(self) -> rocketmq_error::Error {
+        self
+    }
+}
+
+impl IntoCanonicalError for rocketmq_client_rust::ClientError {
+    fn into_canonical_error(self) -> rocketmq_error::Error {
+        self.into_error()
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/lib.rs
@@ -24,23 +24,11 @@
 pub mod core;
 
 #[cfg(any(feature = "read-client-adapter", feature = "mutation-client-adapter"))]
-pub(crate) trait IntoCanonicalError {
-    fn into_canonical_error(self) -> rocketmq_error::Error;
-}
+#[path = "client_adapter/error_conversion.rs"]
+mod error_conversion;
 
 #[cfg(any(feature = "read-client-adapter", feature = "mutation-client-adapter"))]
-impl IntoCanonicalError for rocketmq_error::Error {
-    fn into_canonical_error(self) -> rocketmq_error::Error {
-        self
-    }
-}
-
-#[cfg(any(feature = "read-client-adapter", feature = "mutation-client-adapter"))]
-impl IntoCanonicalError for rocketmq_client_rust::ClientError {
-    fn into_canonical_error(self) -> rocketmq_error::Error {
-        self.into_error()
-    }
-}
+pub(crate) use error_conversion::IntoCanonicalError;
 
 #[cfg(feature = "read-client-adapter")]
 pub(crate) fn canonical_http_status(error: &rocketmq_error::Error) -> u16 {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10289

### Brief Description

The source boundary guard fails because `lib.rs` directly references the client SDK in the canonical error conversion implementation. Move the conversion trait and implementations to `client_adapter/error_conversion.rs`, keeping a crate-private re-export for existing callers.

The module retains the same read-or-mutation feature gate. Conversion behavior, public APIs, and boundary test rules remain unchanged.

### How Did You Test This Change?

Passed locally on Windows:

- `cargo test -p rocketmq-admin-core --test boundary_source_guard --no-default-features --locked`: 5 passed.
- `cargo check -p rocketmq-admin-core --no-default-features --features read-client-adapter --locked`.
- `cargo check -p rocketmq-admin-core --no-default-features --features mutation-client-adapter --locked`.
- `cargo test -p rocketmq-admin-core --lib --test boundary_source_guard --features client-adapter --locked -- --quiet`: 310 library tests and 5 boundary tests passed.
- `cargo fmt -p rocketmq-admin-core -- --check`.
- `git diff --check`.

The full Linux CI suite was not rerun locally. The maintainer requested a squash merge without waiting for CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized error conversion for client adapters into a shared internal component.
  * Preserved consistent conversion of client errors into the application’s standard error type.
  * No user-facing behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->