### PR TITLE
[ISSUE #10246]🐛Align EpochEntry default with its open-ended wire default

### DIFF
--- a/rocketmq-protocol/src/protocol/body/epoch_entry_cache.rs
+++ b/rocketmq-protocol/src/protocol/body/epoch_entry_cache.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct EpochEntry {
     #[serde(default)]
@@ -27,6 +27,12 @@ pub struct EpochEntry {
     start_offset: i64,
     #[serde(default = "EpochEntry::default_end_offset")]
     end_offset: i64,
+}
+
+impl Default for EpochEntry {
+    fn default() -> Self {
+        Self::new(0, 0)
+    }
 }
 
 impl EpochEntry {
@@ -145,6 +151,27 @@ mod tests {
     use cheetah_string::CheetahString;
 
     use super::*;
+
+    #[test]
+    fn epoch_entry_default_matches_constructor_and_missing_wire_fields() {
+        let expected = EpochEntry::new(0, 0);
+        assert_eq!(expected.get_end_offset(), i64::MAX);
+        assert_eq!(EpochEntry::default(), expected);
+        assert_eq!(serde_json::from_str::<EpochEntry>("{}").unwrap(), expected);
+        assert_eq!(
+            serde_json::to_value(&expected).unwrap(),
+            serde_json::json!({
+                "epoch": 0, "startOffset": 0, "endOffset": i64::MAX
+            })
+        );
+        for end_offset in [0, 42] {
+            let value = serde_json::json!({"endOffset": end_offset});
+            assert_eq!(
+                serde_json::from_value::<EpochEntry>(value).unwrap(),
+                EpochEntry::with_end_offset(0, 0, end_offset)
+            );
+        }
+    }
 
     #[test]
     fn epoch_entry_and_cache_accessors_update_all_fields() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10246 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved default handling for epoch entries, ensuring newly created entries consistently start with zeroed values.
  - Preserved correct behavior when epoch-entry fields are omitted during deserialization.
  - Ensured serialized epoch entries accurately retain explicitly provided end offsets.

- **Tests**
  - Added coverage for default construction, missing-field deserialization, serialization output, and explicit end-offset values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->