### PR TITLE
[ISSUE #10247]🐛Correct enum names and wire values in Serde errors

### DIFF
--- a/rocketmq-protocol/src/protocol/heartbeat/consume_type.rs
+++ b/rocketmq-protocol/src/protocol/heartbeat/consume_type.rs
@@ -54,7 +54,7 @@ impl<'de> Deserialize<'de> for ConsumeType {
             type Value = ConsumeType;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a string representing TopicFilterType")
+                formatter.write_str("a string representing ConsumeType")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -65,10 +65,10 @@ impl<'de> Deserialize<'de> for ConsumeType {
                     "CONSUME_ACTIVELY" => Ok(ConsumeType::ConsumeActively),
                     "CONSUME_PASSIVELY" => Ok(ConsumeType::ConsumePassively),
                     "CONSUME_POP" => Ok(ConsumeType::ConsumePop),
-                    _ => Err(serde::de::Error::unknown_variant(
-                        value,
-                        &["ConsumeActively", "ConsumePassively", "ConsumePop"],
-                    )),
+                    _ => Err(E::custom(format_args!(
+                        "ConsumeType: {}",
+                        E::unknown_variant(value, &["CONSUME_ACTIVELY", "CONSUME_PASSIVELY", "CONSUME_POP"])
+                    ))),
                 }
             }
         }
@@ -128,10 +128,17 @@ mod tests {
         for json in ["\"CONSUME_UNKNOWN\"", "\"PULL\""] {
             let message = serde_json::from_str::<ConsumeType>(json).unwrap_err().to_string();
             assert!(message.contains("unknown variant"), "{message}");
-            for variant in ["ConsumeActively", "ConsumePassively", "ConsumePop"] {
+            assert!(message.contains("ConsumeType"), "{message}");
+            for variant in ["CONSUME_ACTIVELY", "CONSUME_PASSIVELY", "CONSUME_POP"] {
                 assert!(message.contains(variant), "{message}");
             }
         }
+    }
+
+    #[test]
+    fn invalid_type_error_names_consume_type() {
+        let error = serde_json::from_str::<ConsumeType>("1").unwrap_err().to_string();
+        assert!(error.contains("a string representing ConsumeType"), "{error}");
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/heartbeat/message_model.rs
+++ b/rocketmq-protocol/src/protocol/heartbeat/message_model.rs
@@ -60,7 +60,7 @@ impl<'de> Deserialize<'de> for MessageModel {
             type Value = MessageModel;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a string representing TopicFilterType")
+                formatter.write_str("a string representing MessageModel")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -70,10 +70,10 @@ impl<'de> Deserialize<'de> for MessageModel {
                 match value {
                     "BROADCASTING" => Ok(MessageModel::Broadcasting),
                     "CLUSTERING" => Ok(MessageModel::Clustering),
-                    _ => Err(serde::de::Error::unknown_variant(
-                        value,
-                        &["BROADCASTING", "CLUSTERING"],
-                    )),
+                    _ => Err(E::custom(format_args!(
+                        "MessageModel: {}",
+                        E::unknown_variant(value, &["BROADCASTING", "CLUSTERING"])
+                    ))),
                 }
             }
         }
@@ -125,8 +125,12 @@ mod tests {
     #[test]
     fn deserialize_message_model_invalid() {
         let json = "\"INVALID\"";
-        let deserialized: Result<MessageModel, _> = serde_json::from_str(json);
-        assert!(deserialized.is_err());
+        let error = serde_json::from_str::<MessageModel>(json).unwrap_err().to_string();
+        for fragment in ["MessageModel", "unknown variant", "BROADCASTING", "CLUSTERING"] {
+            assert!(error.contains(fragment), "{error}");
+        }
+        let error = serde_json::from_str::<MessageModel>("1").unwrap_err().to_string();
+        assert!(error.contains("a string representing MessageModel"), "{error}");
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/subscription/group_retry_policy_type.rs
+++ b/rocketmq-protocol/src/protocol/subscription/group_retry_policy_type.rs
@@ -50,7 +50,7 @@ impl<'de> Deserialize<'de> for GroupRetryPolicyType {
             type Value = GroupRetryPolicyType;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a string representing GroupRetryPolicyTypeVisitor")
+                formatter.write_str("a string representing GroupRetryPolicyType")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -60,7 +60,10 @@ impl<'de> Deserialize<'de> for GroupRetryPolicyType {
                 match value {
                     "EXPONENTIAL" => Ok(GroupRetryPolicyType::Exponential),
                     "CUSTOMIZED" => Ok(GroupRetryPolicyType::Customized),
-                    _ => Err(serde::de::Error::unknown_variant(value, &["Exponential", "Customized"])),
+                    _ => Err(E::custom(format_args!(
+                        "GroupRetryPolicyType: {}",
+                        E::unknown_variant(value, &["EXPONENTIAL", "CUSTOMIZED"])
+                    ))),
                 }
             }
         }
@@ -83,6 +86,17 @@ mod group_retry_policy_type_tests {
             assert_eq!(serde_json::from_str::<GroupRetryPolicyType>(json).unwrap(), policy);
         }
 
-        assert!(serde_json::from_str::<GroupRetryPolicyType>("\"UNKNOWN\"").is_err());
+        let error = serde_json::from_str::<GroupRetryPolicyType>("\"UNKNOWN\"")
+            .unwrap_err()
+            .to_string();
+        for fragment in ["GroupRetryPolicyType", "unknown variant", "EXPONENTIAL", "CUSTOMIZED"] {
+            assert!(error.contains(fragment), "{error}");
+        }
+        assert!(!error.contains("Visitor"), "{error}");
+        let error = serde_json::from_str::<GroupRetryPolicyType>("1")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("a string representing GroupRetryPolicyType"), "{error}");
+        assert!(!error.contains("Visitor"), "{error}");
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10247 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protocol validation errors for invalid heartbeat and subscription values.
  * Error messages now identify the affected type, use the expected wire-format variant names, and clearly list valid options.
  * Corrected messages for invalid string and non-string inputs, making deserialization failures easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->