### PR TITLE
[ISSUE #10300]🐛Fix observability assertions and readiness contracts

### DIFF
--- a/distribution/config/architecture-production-readiness-policy.json
+++ b/distribution/config/architecture-production-readiness-policy.json
@@ -155,9 +155,20 @@
           {
             "path": "rocketmq-proxy/src/bootstrap.rs",
             "required_markers": [
-              "verify_cluster_route_and_security",
+              "ProxyAuthRuntime::from_proxy_config_with_metadata_service",
+              ".start(health_source, &service_context, lifecycle.clone())",
               "remaining_listeners",
-              "lifecycle.mark_ready"
+              ".mark_ready()"
+            ]
+          },
+          {
+            "path": "rocketmq-proxy/src/dependency_health.rs",
+            "required_markers": [
+              "source.readiness_check()",
+              "initial?;",
+              "lifecycle.set_dependency_readiness",
+              "DependencyReadiness::Ready",
+              "DependencyReadiness::Degraded"
             ]
           }
         ]
@@ -176,7 +187,7 @@
             "path": "rocketmq-ai/rocketmq-mcp/src/main.rs",
             "required_markers": [
               "prepare_mcp_bootstrap",
-              "McpApp::bootstrap_validated_typed",
+              "McpApp::bootstrap_validated(bootstrap_handoff, service_context)",
               "start_lifecycle",
               "mark_ready()"
             ]

--- a/rocketmq-observability/src/exporter/otlp.rs
+++ b/rocketmq-observability/src/exporter/otlp.rs
@@ -174,9 +174,19 @@ mod tests {
 
         let error = init_otlp_tracer_provider(&config).expect_err("invalid OTLP endpoint must fail");
 
+        assert_eq!(error.descriptor(), &rocketmq_error::OBSERVABILITY_INITIALIZATION_FAILED);
+        assert_eq!(
+            error.operation(),
+            crate::error::ObservabilityOperation::InitializeTraces
+        );
+        assert_eq!(
+            error.to_string(),
+            "observability.initialization.failed: Observability initialization failed"
+        );
         for output in [error.to_string(), format!("{error:?}")] {
             assert!(!output.contains(ENDPOINT_CANARY));
-            assert!(output.contains("OTLP trace exporter could not be built"));
+            assert!(!output.contains("OTLP trace exporter could not be built"));
+            assert!(output.contains("observability.initialization.failed"));
         }
     }
 }

--- a/rocketmq-observability/src/metrics/catalog/tests.rs
+++ b/rocketmq-observability/src/metrics/catalog/tests.rs
@@ -66,8 +66,12 @@ fn combined_catalog_contains_every_semantic_metric_once() {
         .collect::<HashSet<_>>();
 
     assert_eq!(JAVA_METRICS.len(), 94);
-    assert_eq!(RUST_METRICS.len(), 128);
-    assert_eq!(combined.len(), 222, "duplicate metric names across catalogs");
+    assert_eq!(RUST_METRICS.len(), 129);
+    assert_eq!(
+        combined.len(),
+        JAVA_METRICS.len() + RUST_METRICS.len(),
+        "duplicate metric names across catalogs"
+    );
 }
 
 #[test]

--- a/rocketmq-observability/tests/config_resolution.rs
+++ b/rocketmq-observability/tests/config_resolution.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::error::Error as _;
 
 use rocketmq_observability::{
     LogsExporter, MetricsExporter, ObservabilityConfig, ObservabilityOverrides, OtlpProtocol, TraceExporter,
@@ -410,7 +411,7 @@ fn shared_validation_requires_canonical_prometheus_configuration() {
 }
 
 #[test]
-fn invalid_trace_sample_ratio_environment_reports_only_the_variable_name() {
+fn invalid_trace_sample_ratio_environment_retains_only_the_variable_name_in_diagnostics() {
     for invalid_value in ["-0.1", "1.1", "NaN", "inf"] {
         let environment = rocketmq_observability::TelemetryEnvironmentValues {
             trace_sample_ratio: Some(invalid_value.into()),
@@ -427,10 +428,10 @@ fn invalid_trace_sample_ratio_environment_reports_only_the_variable_name() {
             },
         )
         .expect_err("invalid trace sample ratio should fail");
-        let message = error.to_string();
+        let detail = invalid_configuration_detail(&error);
 
-        assert!(message.contains("ROCKETMQ_BROKER_TRACE_SAMPLE_RATIO"));
-        assert!(!message.contains(invalid_value));
+        assert!(detail.contains("ROCKETMQ_BROKER_TRACE_SAMPLE_RATIO"));
+        assert!(!detail.contains(invalid_value));
     }
 
     for invalid_value in ["", "   ", "secret-value"] {
@@ -439,7 +440,7 @@ fn invalid_trace_sample_ratio_environment_reports_only_the_variable_name() {
             ..rocketmq_observability::TelemetryEnvironmentValues::default()
         };
 
-        let message = rocketmq_observability::resolve_telemetry_values(
+        let error = rocketmq_observability::resolve_telemetry_values(
             "rocketmq-broker",
             rocketmq_observability::TelemetryBootstrapConfig::default(),
             &rocketmq_observability::ObservabilityOverrides::default(),
@@ -448,19 +449,18 @@ fn invalid_trace_sample_ratio_environment_reports_only_the_variable_name() {
                 trace_sample_ratio_env: Some("ROCKETMQ_BROKER_TRACE_SAMPLE_RATIO"),
             },
         )
-        .expect_err("empty or non-numeric trace sample ratio should fail")
-        .to_string();
+        .expect_err("empty or non-numeric trace sample ratio should fail");
 
         assert_eq!(
-            message,
-            "invalid observability config: ROCKETMQ_BROKER_TRACE_SAMPLE_RATIO must be a floating-point number"
+            invalid_configuration_detail(&error),
+            "ROCKETMQ_BROKER_TRACE_SAMPLE_RATIO must be a floating-point number"
         );
     }
 }
 
 #[cfg(any(unix, windows))]
 #[test]
-fn non_utf8_trace_sample_ratio_reports_only_the_variable_name() {
+fn non_utf8_trace_sample_ratio_retains_only_the_variable_name_in_diagnostics() {
     #[cfg(unix)]
     let invalid_value = {
         use std::os::unix::ffi::OsStringExt;
@@ -476,7 +476,7 @@ fn non_utf8_trace_sample_ratio_reports_only_the_variable_name() {
         ..rocketmq_observability::TelemetryEnvironmentValues::default()
     };
 
-    let message = rocketmq_observability::resolve_telemetry_values(
+    let error = rocketmq_observability::resolve_telemetry_values(
         "rocketmq-broker",
         rocketmq_observability::TelemetryBootstrapConfig::default(),
         &rocketmq_observability::ObservabilityOverrides::default(),
@@ -485,10 +485,25 @@ fn non_utf8_trace_sample_ratio_reports_only_the_variable_name() {
             trace_sample_ratio_env: Some("ROCKETMQ_BROKER_TRACE_SAMPLE_RATIO"),
         },
     )
-    .expect_err("non-UTF-8 trace sample ratio should fail")
-    .to_string();
+    .expect_err("non-UTF-8 trace sample ratio should fail");
 
-    assert!(message.contains("ROCKETMQ_BROKER_TRACE_SAMPLE_RATIO"));
+    assert_eq!(
+        invalid_configuration_detail(&error),
+        "ROCKETMQ_BROKER_TRACE_SAMPLE_RATIO must contain valid UTF-8"
+    );
+}
+
+fn invalid_configuration_detail(error: &rocketmq_observability::ObservabilityError) -> &str {
+    assert_eq!(error.descriptor(), &rocketmq_error::OBSERVABILITY_CONFIGURATION_INVALID);
+    assert_eq!(
+        error.to_string(),
+        "observability.configuration.invalid: Observability configuration is invalid"
+    );
+    error
+        .source()
+        .and_then(|source| source.downcast_ref::<rocketmq_observability::ObservabilityFailureDetail>())
+        .expect("configuration error retains typed diagnostic detail")
+        .detail()
 }
 
 #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10300

### Brief Description

Observability CI fails because test expectations and readiness source contracts no longer match the current implementation. Update the Rust metric count to 129 and compute combined uniqueness from both catalog lengths. Verify canonical configuration and OTLP trace initialization errors, retaining redaction checks and typed diagnostic detail assertions.

Align the readiness policy with current Proxy authentication, dependency-health startup and listener readiness, and the validated MCP bootstrap call. Runtime behavior and security requirements remain unchanged.

### How Did You Test This Change?

Passed locally on Windows:

- `cargo test -p rocketmq-observability --locked -- --quiet`: 267 passed, 1 existing ignored test.
- `cargo test -p rocketmq-observability --features otlp-traces --locked -- --quiet`: 284 passed, 1 existing ignored test.
- `cargo clippy -p rocketmq-observability --no-deps --all-targets --locked -- -D warnings`: default features passed.
- `cargo fmt -p rocketmq-observability -- --check`.
- `git diff --check`.

Linux CI and other optional feature combinations were not rerun locally. The maintainer requested a squash merge without waiting for CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved observability initialization errors by redacting sensitive endpoint and upstream details while presenting a consistent public error message.
  - Configuration validation now reports clearer, more specific diagnostics for invalid trace sampling ratios, including non-numeric and invalid text values.

- **Reliability**
  - Updated readiness checks to reflect authentication lifecycle, dependency availability, and explicit ready or degraded states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->