### PR TITLE
[ISSUE #10302]📝Align macro READMEs with current derive behavior

### DIFF
--- a/rocketmq-macros/README-zh_cn.md
+++ b/rocketmq-macros/README-zh_cn.md
@@ -13,24 +13,33 @@ RocketMQ-Rust 协议类型和 Remoting Header 使用的过程宏。
 | `RequestHeaderCodecV3` | 推荐 | 生成类型化 map/source codec、wire schema、校验、键解析、兼容适配器，以及经过审查的可选直接编码。 |
 | `RequestHeaderCodecV2` | 已废弃 | 加固 V2 wire 契约的冻结兼容适配器；生产 Header 禁止新增使用。 |
 | `RequestHeaderCodec` | 已废弃 | 保留最早 Request Header quirks 的冻结兼容适配器，仅用于下游源码兼容。 |
-| `RemotingSerializable` | 工具 | 为类型生成 Remoting 序列化辅助实现。 |
+| `RemotingSerializable` | 旧版工具 | 为旧版 crate 本地序列化 trait 生成实现；与当前协议 trait 不兼容。参见[序列化](#序列化)。 |
 
-仓库中登记的全部生产请求头和响应头都已使用 V3。所有新增 request-header 代码必须使用 V3；V1 和 V2 仅是冻结的兼容适配器。旧 derive 至少保留一个发布窗口，只会在未来的破坏性版本中删除。
+仓库中登记的全部生产请求头和响应头都已使用 V3。仓库新增生产 Header 必须使用 V3；V1 和 V2 仅是冻结的兼容适配器。两个旧版请求头 derive 自 1.0.0 起已废弃，仍保留导出以兼容下游代码。它们生成 `CommandCustomHeader` 和 `FromMap` 实现，但不实现 V3 的 `HeaderCodec` 或类型化 schema。
 
 ## 快速开始
 
 V3 只把专用 `#[header(...)]` 元数据作为 RocketMQ wire 契约。Serde 属性继续独立服务 JSON/DTO，不能用于推断 Header 的 key、default、alias 或 flatten。
 
+使用方需要依赖 `rocketmq-macros` 和 `rocketmq-protocol`；以下示例还使用了 `cheetah-string`。在本仓库工作空间的成员中，可以这样声明依赖：
+
+```toml
+[dependencies]
+rocketmq-macros.workspace = true
+rocketmq-protocol.workspace = true
+cheetah-string.workspace = true
+```
+
+以下是一个小型 Rust-only 示例，并非生产 `SendMessageRequestHeader` 的完整 schema：
+
 ```rust
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV3;
+use rocketmq_protocol::{CommandCustomHeader, HeaderCodec, HeaderMap, ProtocolContractViolation};
 
 #[derive(Debug, RequestHeaderCodecV3)]
-#[header(
-    type_id = "example::SendMessageRequestHeader",
-    java_class = "org.apache.rocketmq.remoting.protocol.header.SendMessageRequestHeader"
-)]
-struct SendMessageRequestHeader {
+#[header(type_id = "example::MessageHeader")]
+struct MessageHeader {
     #[header(required)]
     producer_group: CheetahString,
     #[header(required)]
@@ -39,16 +48,42 @@ struct SendMessageRequestHeader {
     sys_flag: i32,
     batch: Option<bool>,
 }
+
+fn main() -> Result<(), ProtocolContractViolation> {
+    let header = MessageHeader {
+        producer_group: "example-producer".into(),
+        topic: "example-topic".into(),
+        sys_flag: 0,
+        batch: None,
+    };
+    let mut fields = HeaderMap::new();
+    header.try_encode_into_map(&mut fields)?;
+    assert_eq!(fields.get("producerGroup").map(|value| value.as_str()), Some("example-producer"));
+    assert_eq!(fields.get("sysFlag").map(|value| value.as_str()), Some("0"));
+    assert!(!fields.contains_key("batch"));
+
+    fields.remove("sysFlag");
+    let decoded = MessageHeader::decode_from_map(&fields)?;
+    assert_eq!(decoded.sys_flag, 0);
+    assert_eq!(decoded.topic, header.topic);
+    Ok(())
+}
 ```
 
 生成结果包括：
 
 - 带稳定类型 ID 和字段/flatten schema 的 `HeaderCodec`；
-- `CommandCustomHeader` 与 `FromMap` 兼容适配器；
+- `CommandCustomHeader` 与 `FromMap` 兼容适配器，除非指定 `legacy_shim = "manual"`；
 - canonical key 与 decode alias 的确定性解析和冲突处理；
 - 显式 required/default/validation/range 语义；
-- 输入支持时的借用式、零拷贝 field-source 解码；
-- 默认 `MapOnly` 编码，以及仅对显式审查过的 `fast` Header 生成直接编码。
+- 直接从借用的字段源解码，无需先构造 `HeaderMap`；解码后的 `String` 和 `CheetahString` 字段仍会复制文本并拥有其所有权；
+- 默认 `MapOnly` 编码；`fast` 使用生成的兼容适配器时，同时提供直接二进制和 JSON 编码。
+
+## 支持的输入
+
+V3 接受具名字段结构体，包括使用花括号的空结构体和泛型结构体。元组结构体、单元结构体、枚举和联合体均不支持。生成的实现保留泛型及 where 子句，并要求 Header 类型满足 `'static`。
+
+标量字段支持 `String`、`CheetahString`、`bool`、`i32`、`i64`、`u32`、`u64`、协议使用的 `BoundaryType`，以及这些类型的 `Option<T>`。泛型标量参数会添加 `HeaderValue` 约束；展平类型会添加 `HeaderCodec` 约束。`HeaderValue` 在 `rocketmq-protocol` 中是封闭 trait，因此不能通过泛型支持任意下游 wire value 实现。`Vec<T>`、`&str`、`usize` 和浮点数等其他具体类型不支持作为标量字段。宏根据语法判断类型，不会自动解析指向受支持类型的类型别名。
 
 ## 元数据规则
 
@@ -56,29 +91,60 @@ struct SendMessageRequestHeader {
 
 | 属性 | 含义 |
 | --- | --- |
-| `type_id = "..."` | 必填的稳定 Rust schema 标识。 |
-| `java_class = "..."` | 存在 Java 对应类型时填写 Java FQCN；Rust-only Header 不填写。 |
-| `crate = "path"` | 可选的 protocol crate 路径覆盖，支持依赖重命名。 |
-| `fast` | 只有完成正确性和性能审查后才启用生成式直接编码。 |
-| `validate = "path"` | 编码首次写入前和解码完成后执行类型化校验。 |
-| `legacy_shim = "manual"` | 已有审计过的手工兼容实现时避免生成重复实现。 |
+| `type_id = "..."` | 必填的稳定 schema 标识，使用至少包含两段的 Rust 路径，不允许以 `::` 开头或包含泛型参数。 |
+| `java_class = "..."` | Java 对应类型的 FQCN。宏检查名称语法，兼容性测试检查固定的 Java schema。Rust-only Header 不填写。 |
+| `crate = "path"` | 可选的 protocol crate 路径覆盖。V3 也会自动识别重命名后的 Cargo 依赖。 |
+| `fast` | 在生成的兼容适配器中启用直接二进制和 JSON 编码。生产使用需要正确性和性能审查；宏本身不强制检查审查结果。 |
+| `validate = "path"` | 调用返回 `Result<(), ProtocolContractViolation>` 的 `path(&self)`；在当前 Header 层写入字段前，以及解码构造该层后执行。 |
+| `legacy_shim = "generated"` 或 `"manual"` | 默认为 `generated`。`manual` 禁止生成两个兼容实现及其中的直接编码方法，由使用方提供适配器。 |
+| `lookup = "auto"`、`"scan"` 或 `"get"` | 可接受的元数据，默认为 `auto`。当前所有 V3 字段源解码器均通过 `visit_fields_while` 扫描，该选项不会切换查找算法。 |
 
 字段属性：
 
 | 属性 | 含义 |
 | --- | --- |
-| `required` | 输入缺失时报错。 |
-| `default` / `default_with = "path"` | 显式定义字段缺失行为，并同时声明 `default_semantic`。 |
-| `key = "..."` | canonical wire key；省略时使用 Rust 字段名。 |
-| `alias = "..."` | 仅用于解码的历史 key；V3 不会输出 alias。 |
-| `flatten, presence = "always|any"` | 嵌套 Header 的继承/存在性契约。 |
-| `range = "i32|i64"` | 把无符号 Rust 字段限制到对应 Java 有符号域。 |
+| `required` | 拒绝缺失的输入。具体类型为 `String` 或 `CheetahString` 的必填字段在编码和解码时还必须非空。不能用于 `Option<T>`。 |
+| `default` | 缺失时使用 `Default::default()`；必须声明 `default_semantic`。 |
+| `default_with = "path"` | 缺失时调用无参函数，其返回值为完整字段类型；必须声明 `default_semantic`。 |
+| `default_semantic = "literal:<wire-text>"` 或 `"dynamic:<semantic-id>"` | 在 schema 中描述默认值，不会计算或校验实际默认值。dynamic 标识符不能为空。 |
+| `key = "..."` | canonical wire key。省略时删除下划线并将其后字符转为大写：`producer_group` 变为 `producerGroup`。 |
+| `alias = "..."` | 可重复声明的解码专用键。编码输出 canonical key。 |
+| `alias_conflict = "error"` 或 `"prefer_canonical"` | 默认为 `error`。详见下文冲突规则。 |
+| `flatten` | 在同一字段命名空间中编码和解码嵌套的 `HeaderCodec`。 |
+| `presence = "always"` 或 `"any"` | 控制展平字段的解码。`Option<Flattened>` 必须显式声明；普通展平字段默认为 `always`。 |
+| `range = "i32"` 或 `"i64"` | 分别将 `u32` 限制到 `0..=i32::MAX`，或将 `u64` 限制到 `0..=i64::MAX`。 |
+| `binary_order = N` | `u16` 类型的编码/schema 顺序，默认为从零开始的源字段索引。本地标量字段和展平字段的最终顺序值必须唯一。不会控制 `HeaderMap` 的迭代顺序。 |
+| `java_type = "..."` | 可接受的兼容元数据，会检查类型一致性。已登记的生产 schema 要求省略该属性。 |
 
-生产字段不填写 `java_type`。V3 会根据 Rust 类型推断普通 wire kind。只有当无符号 Rust 字段受 Java 有符号 `int` 或 `long` 约束时才填写 `range`；有符号 Rust 字段和 Rust-only 无符号字段都不需要填写。
+生产字段不填写 `java_type`。V3 会根据 Rust 类型推断普通 wire kind。受 Java 有符号整数范围约束的无符号 Rust 字段使用 `range`。容器声明 `java_class` 后，每个标量 `u32` 字段都必须声明 `range = "i32"`，每个标量 `u64` 字段都必须声明 `range = "i64"`，可选字段也不例外。字段显式声明 `java_type` 时，无符号字段同样需要匹配的范围。有符号 Rust 字段禁止声明 `range`；不含 Java 元数据的 Rust-only 无符号字段可以使用完整的 Rust 数值范围。
+
+### 缺失值与默认值
+
+每个非可选标量字段必须且只能声明 `required`、`default` 或 `default_with` 中的一种策略。默认值仅用于缺失的键；已提供但格式错误的值仍会返回错误。不加注解的 `Option<T>` 在输入缺失时解码为 `None`，编码时省略 `None`。对于 `Option<T>`，`default` 生成 `Some(T::default())`；`default_with` 则返回完整的 `Option<T>`，可以返回 `None`。
+
+`default_semantic = "literal:32"` 不会使 `default` 返回 32。应通过 `default_with` 指定返回 32 的函数，并保持 schema 描述与实现一致。默认值提供函数负责返回有效值；生成的默认值不会经过 wire 文本解析。
+
+V3 暂时接受旧版 `#[required]`，但会发出弃用诊断。应使用 `#[header(required)]`；同时声明两者会报错。Serde 辅助属性需要由 Serde derive 注册；V3 本身只注册 `header` 和 `required`。
+
+### 别名与展平
+
+使用 `alias_conflict = "error"` 时，多个名称同时存在且原始文本完全相同则接受；文本不同则在值解析前返回 `ProtocolContractViolation::Conflict`。使用 `prefer_canonical` 时，canonical key 优先；若其缺失，则按声明顺序选取第一个存在的别名。未知输入键会被忽略。
+
+canonical key 和别名必须非空、不包含 NUL，并满足 ROCKETMQ 的 `u16` 字节长度限制。宏会拒绝本地标量字段中的重复名称。展平 Header 之间也应保持名称互不冲突；derive 无法检查嵌套类型中的跨 Header 冲突。
+
+对于 `Option<Flattened>`，`presence = "always"` 始终尝试嵌套解码，成功后返回 `Some`。`presence = "any"` 仅在嵌套 schema（包括其子级）拥有的 canonical key 或别名存在时解码，否则返回 `None`。只要嵌套字段存在，仍会触发全部嵌套必填字段检查。非可选展平字段始终解码，不能使用 `presence = "any"`。展平不能与标量键、别名、缺失值/默认值策略、`alias_conflict`、`java_type` 或 `range` 组合。
+
+### 校验与错误
+
+优先使用 `HeaderCodec::encode_into`、`HeaderCodec::decode_from_map` / `decode_from_source` 或 `CommandCustomHeader::try_encode_into_map`，以保留类型化的 `ProtocolContractViolation` 错误。生成的旧版 `to_map` 在失败时返回 `None`，`encode_into_map` 则丢弃错误。`FromMap` 将失败转换为 `rocketmq_error::Error`。
+
+必填字符串检查和自定义校验钩子在当前 Header 层写入前执行。范围检查在字段编码时执行，嵌套 Header 则在处理到该字段时校验。因此，`encode_into` 或 `try_encode_into_map` 失败后，目标中可能保留已写入的字段。单独调用 `validate_for_wire` / `check_fields` 不会检查全部字段范围，也不会递归校验嵌套 Header。生成的 `fast` 二进制和 JSON 适配器会在失败时恢复输出缓冲区的原始长度。
 
 ## 运行路径与回退
 
-所有登记 Header 都实现了类型化 codec 和对象安全兼容适配器，因此 V3 已是生产默认路径。普通 Header 返回 `MapOnly`，Remoting 编码器会物化 canonical extension fields，不依赖可变 `Arc` 访问。经过审查的热 Header 可以对 ROCKETMQ frame 使用 `DirectBinary`，并可提供直接 JSON fields。如果命令已经包含物化字段或动态字段，同一份类型化 schema 会负责冲突解析，map 路径仍是权威回退。
+使用生成的兼容适配器时，普通 Header 返回 `MapOnly`；`fast` Header 返回 `DirectBinary`，并支持直接输出 JSON 字段。Remoting 编码器通过共享访问使用 Header，并按命令选择编码路径。
+
+对于 ROCKETMQ 编码，与类型化 schema 不重叠的动态字段可以和直接二进制输出一起编码；与 canonical key 或别名重叠时，使用类型化字段与动态字段的 map 合并逻辑。类型化字段与动态字段的值冲突时返回 `DynamicFieldConflict`，即使字段声明了 `alias_conflict = "prefer_canonical"` 也不例外。直接 JSON 路径要求扩展字段尚不存在，且 Header 尚未物化到命令中。
 
 回退按 Header 和命令生效，不改变 wire 契约，也不会在每条消息上增加全局开关或环境变量查询。
 
@@ -90,20 +156,27 @@ V2 元数据不会被静默解释成 V3。必须对照固定 Java schema 审核�
 | --- | --- |
 | `#[required]` | `#[header(required)]` |
 | `serde(rename = "...")` | 确认是 wire key 后改为 `#[header(key = "...")]` |
-| `serde(alias = "...")` | 改为 `#[header(alias = "...")]`，必要时明确冲突策略 |
-| `serde(default)` | 改为带 `default_semantic` 的 `header(default)` 或已审查的 `default_with` |
-| `serde(flatten)` | 改为 `#[header(flatten, presence = "always|any")]` |
+| `serde(alias = "...")` | `#[header(alias = "...", alias_conflict = "prefer_canonical")]` 保留 V2 优先级；选择 `error` 应作为显式行为变更 |
+| `serde(default)` 或隐式非可选默认值 | 声明 `header(default, default_semantic = "literal:...")`；可选字段的默认值需要单独审核 |
+| `serde(default = "path")` | 使用 `#[header(default_with = "path", default_semantic = "...")]` 并描述实际默认值语义 |
+| `Option<T>` 上的 `serde(flatten)` | `#[header(flatten, presence = "always")]` 保留 V2 无条件嵌套解码行为；`any` 会改变缺失时的行为 |
+| `T` 上的 `serde(flatten)` | `#[header(flatten)]` |
+| `request_header(validate = "method")` | 改为 `#[header(validate = "Self::method")]`，并将返回类型适配为 `ProtocolContractViolation` |
 | 对应 Java `int`/`long` 的无符号字段 | `range = "i32"` / `range = "i64"` |
 
-V2 只应用于尚未完成迁移的既有下游模型。RocketMQ-Rust 新增生产 Header 必须使用 V3，并进入 checked-in schema inventory，否则 migration guard 会拒绝。
+V2 忽略容器级 `serde(rename_all)`，解码时也不使用标量 `Option<T>` 的默认值提供函数。将属性复制到 V3 前应审核这些差异。与 V2 的 `ToString`/`FromStr` 路径相比，V3 支持的标量类型范围也更窄。
 
-V1（`RequestHeaderCodec`）为源码兼容而冻结，包括其历史解析和 decode quirks。不要将其用于新代码；现有 V1 Header 应直接迁移到显式的 V3 model。
+V2 只应用于尚未完成迁移的既有下游模型。新增生产 Header 应登记到类型化 registry 和仓库内的类型清单。`request_header_codec_v3_registry` 对照 `migration.json` 和固定的 Java 契约检查该 registry。迁移生成器和 Java 提取工具已退役；当前不存在自动发现并拒绝所有新增源码 Header 的 migration guard。
+
+V1（`RequestHeaderCodec`）为源码兼容而冻结，包括其历史解析和解码特殊行为。例如，格式错误的可选基础类型值可能变为 `None`，格式错误的非必填基础类型值可能回退到 `Default`。V3 则返回转换错误。不要将 V1 用于新代码；现有 V1 Header 应直接迁移到显式的 V3 model。
 
 ## 重命名 Protocol 依赖
 
-derive 会通过 Cargo 元数据解析 `rocketmq-protocol`。生成代码或 re-export 场景可显式覆盖：
+V2 和 V3 从使用方的 Cargo manifest 解析 `rocketmq-protocol`，包括重命名为 `protocol_api` 的依赖。生成代码或 re-export 场景可显式覆盖路径。V3 示例：
 
 ```rust
+use rocketmq_macros::RequestHeaderCodecV3;
+
 #[derive(RequestHeaderCodecV3)]
 #[header(type_id = "example::Header", crate = "protocol_api")]
 struct Header {
@@ -112,7 +185,13 @@ struct Header {
 }
 ```
 
-独立项目 `tests/fixtures/renamed-consumer` 同时验证 V3 路径和保留的 V2 兼容能力。
+V2 使用 `#[request_header_codec_v2(crate = "protocol_api")]`。V1 仍生成 `crate::protocol` 路径，要求使用方保留旧版布局。独立项目 [`tests/fixtures/renamed-consumer`](tests/fixtures/renamed-consumer/) 检查 V2 和 V3 自动解析依赖名称的能力。
+
+## 序列化
+
+导出的 `RemotingSerializable` derive 仍生成历史形式 `impl crate::protocol::RemotingSerializable for Type { type Output = Self; }`。它不保留泛型、不解析协议依赖，也不生成 Serde 实现。当前协议序列化 trait 不包含 `Output` 关联类型，并要求实现序列化方法，因此该展开结果与之不兼容。
+
+当前协议类型应派生 `serde::Serialize`，并导入 `rocketmq_protocol::protocol::RemotingSerializable`，以使用 `encode`、`serialize_json` 和 `serialize_json_pretty`。协议 crate 为可序列化类型提供了 blanket implementation（泛型覆盖实现）。同样，满足拥有所有权的反序列化约束的类型会通过泛型覆盖实现获得 `RemotingDeserializable`。
 
 ## Crate 结构
 
@@ -121,20 +200,30 @@ struct Header {
 | [`src/lib.rs`](src/lib.rs) | 公开 derive 入口和共享解析辅助函数。 |
 | [`src/request_header_codec_v3/`](src/request_header_codec_v3/) | canonical V3 元数据、语义模型、profile 校验和代码生成。 |
 | [`src/request_header_codec_v3/legacy_v1.rs`](src/request_header_codec_v3/legacy_v1.rs) 与 [`legacy_v2.rs`](src/request_header_codec_v3/legacy_v2.rs) | 基于 canonical model 的冻结 V1/V2 语法适配器和兼容代码生成。 |
-| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | 已废弃的 V2 public syntax parser 和 adapter。 |
+| [`src/request_header_codec_v2.rs`](src/request_header_codec_v2.rs) 与 [`src/request_header_codec_v2/attr.rs`](src/request_header_codec_v2/attr.rs) | 已废弃的 V2 入口封装和公开语法解析器；适配逻辑位于 `legacy_v2/`。 |
 | [`src/request_header_custom.rs`](src/request_header_custom.rs) | 已废弃的 V1 parse/wrapper entry，转发到冻结兼容适配器。 |
-| [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | Remoting 序列化 derive。 |
+| [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | 历史 crate 本地序列化展开逻辑。 |
 
 Cargo 构建不会访问 Java checkout。Java schema、golden frame、请求头注册数据和基准测试输入保存在协议 crate 的[兼容性夹具目录](../rocketmq-protocol/tests/fixtures/request_header_codec/README.md)中。
 
 ## 验证
 
+从仓库根目录选择与变更相关的检查。宏 crate 的单元测试检查解析和展开逻辑；协议测试编译使用方代码并验证运行时行为。
+
 ```powershell
-cargo test -p rocketmq-protocol --test request_header_codec_v3_registry
 cargo test -p rocketmq-macros --lib
+cargo test -p rocketmq-protocol --test request_header_codec_v3_typed_map
+cargo test -p rocketmq-protocol --test request_header_codec_v3_registry
+cargo test -p rocketmq-protocol --test request_header_codec_v3_ui
+cargo test -p rocketmq-protocol --test request_header_codec_runtime_ui
+cargo test -p rocketmq-protocol --test request_header_java_compatibility
+```
+
+旧版兼容行为和依赖重命名检查：
+
+```powershell
 cargo test -p rocketmq-protocol --test request_header_codec_v1_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v1_wire_snapshot
-cargo test -p rocketmq-protocol --test request_header_codec_v3_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_wire_snapshot
 cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml

--- a/rocketmq-macros/README.md
+++ b/rocketmq-macros/README.md
@@ -14,27 +14,38 @@ or remoting crates instead of depending on it directly.
 | `RequestHeaderCodecV3` | Recommended | Generates typed map/source codecs, wire schema, validation, key resolution, compatibility adapters, and optional reviewed direct encoding. |
 | `RequestHeaderCodecV2` | Deprecated | Frozen compatibility adapter for the hardened V2 wire contract. No production header may newly adopt it. |
 | `RequestHeaderCodec` | Deprecated | Frozen compatibility adapter that preserves the original request-header quirks for downstream source compatibility. |
-| `RemotingSerializable` | Utility | Implements the remoting serialization helper for a type. |
+| `RemotingSerializable` | Legacy utility | Emits an implementation for the old crate-local serialization trait; incompatible with the current protocol trait. See [Serialization](#serialization). |
 
-All registered production request and response headers use V3. All new request-header code must use V3; V1 and V2
-are frozen compatibility adapters only. Legacy derives remain callable for at least one release window and will only
-be removed in a future breaking release.
+All registered production request and response headers use V3. New production headers in this repository must use
+V3; V1 and V2 are frozen compatibility adapters only. Both legacy request-header derives are deprecated since
+1.0.0 and remain exported for downstream compatibility. They generate `CommandCustomHeader` and `FromMap`
+implementations, but do not implement V3's `HeaderCodec` or typed schema.
 
 ## Quick start
 
 V3 uses dedicated `#[header(...)]` metadata as the only RocketMQ wire contract. Serde attributes remain independent
 and must not be used to infer header keys, defaults, aliases, or flattening.
 
+Consumers need `rocketmq-macros` and `rocketmq-protocol`; this example also uses `cheetah-string`. Within a member
+of this repository's workspace, the dependencies can be declared as follows:
+
+```toml
+[dependencies]
+rocketmq-macros.workspace = true
+rocketmq-protocol.workspace = true
+cheetah-string.workspace = true
+```
+
+This is a small Rust-only example, not the complete production `SendMessageRequestHeader` schema:
+
 ```rust
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV3;
+use rocketmq_protocol::{CommandCustomHeader, HeaderCodec, HeaderMap, ProtocolContractViolation};
 
 #[derive(Debug, RequestHeaderCodecV3)]
-#[header(
-    type_id = "example::SendMessageRequestHeader",
-    java_class = "org.apache.rocketmq.remoting.protocol.header.SendMessageRequestHeader"
-)]
-struct SendMessageRequestHeader {
+#[header(type_id = "example::MessageHeader")]
+struct MessageHeader {
     #[header(required)]
     producer_group: CheetahString,
     #[header(required)]
@@ -43,16 +54,50 @@ struct SendMessageRequestHeader {
     sys_flag: i32,
     batch: Option<bool>,
 }
+
+fn main() -> Result<(), ProtocolContractViolation> {
+    let header = MessageHeader {
+        producer_group: "example-producer".into(),
+        topic: "example-topic".into(),
+        sys_flag: 0,
+        batch: None,
+    };
+    let mut fields = HeaderMap::new();
+    header.try_encode_into_map(&mut fields)?;
+    assert_eq!(fields.get("producerGroup").map(|value| value.as_str()), Some("example-producer"));
+    assert_eq!(fields.get("sysFlag").map(|value| value.as_str()), Some("0"));
+    assert!(!fields.contains_key("batch"));
+
+    fields.remove("sysFlag");
+    let decoded = MessageHeader::decode_from_map(&fields)?;
+    assert_eq!(decoded.sys_flag, 0);
+    assert_eq!(decoded.topic, header.topic);
+    Ok(())
+}
 ```
 
 The generated implementation provides:
 
 - `HeaderCodec` with a stable type ID and typed field/flatten schema;
-- `CommandCustomHeader` and `FromMap` compatibility adapters;
+- `CommandCustomHeader` and `FromMap` compatibility adapters unless `legacy_shim = "manual"` is selected;
 - canonical-key and decode-alias resolution with deterministic conflict handling;
 - explicit required/default/validation/range behavior;
-- zero-copy borrowed field-source decoding where the input supports it;
-- `MapOnly` encoding by default and generated direct encoding only for explicitly reviewed `fast` headers.
+- decoding from borrowed field sources without first materializing a `HeaderMap`; decoded `String` and
+  `CheetahString` fields still copy text into owned values;
+- `MapOnly` encoding by default, with direct binary and JSON adapters when `fast` uses the generated shim.
+
+## Supported inputs
+
+V3 accepts named structs, including empty braced structs and structs with generics. Tuple structs, unit structs,
+enums, and unions are rejected. Generated implementations preserve generics and where clauses and require the
+header type to be `'static`.
+
+Scalar fields support `String`, `CheetahString`, `bool`, `i32`, `i64`, `u32`, `u64`, and the protocol's
+`BoundaryType`, plus `Option<T>` of those types. Generic scalar parameters receive a `HeaderValue` bound;
+flattened types receive a `HeaderCodec` bound. `HeaderValue` is sealed in `rocketmq-protocol`, so this does not
+permit arbitrary downstream wire-value implementations. Other concrete types, such as `Vec<T>`, `&str`, `usize`,
+and floats, are not supported as scalar fields. Type classification is syntactic; aliases to supported types are
+not automatically resolved by the macro.
 
 ## Metadata rules
 
@@ -60,35 +105,90 @@ Container metadata:
 
 | Attribute | Meaning |
 | --- | --- |
-| `type_id = "..."` | Required stable Rust schema identity. |
-| `java_class = "..."` | Java oracle FQCN when the Rust type has a Java peer. Omit it for Rust-only headers. |
-| `crate = "path"` | Optional protocol-crate override, including renamed dependencies. |
-| `fast` | Enables generated direct encoding only after correctness and performance review. |
-| `validate = "path"` | Runs a typed validation hook before the first encode mutation and after decode. |
-| `legacy_shim = "manual"` | Avoids duplicate compatibility impls when an audited manual adapter exists. |
+| `type_id = "..."` | Required stable schema identity, written as a Rust path with at least two segments, no leading `::`, and no generic arguments. |
+| `java_class = "..."` | Java peer FQCN. The macro checks its syntax; compatibility tests check the pinned Java schema. Omit it for Rust-only headers. |
+| `crate = "path"` | Optional protocol-crate path override. V3 also detects renamed Cargo dependencies automatically. |
+| `fast` | Enables direct binary and JSON encoding in the generated compatibility shim. Production use requires correctness and performance review; the macro does not enforce that review. |
+| `validate = "path"` | Calls `path(&self)`, returning `Result<(), ProtocolContractViolation>`, before this header layer writes fields and after constructing it during decode. |
+| `legacy_shim = "generated"` or `"manual"` | Defaults to `generated`. `manual` suppresses both compatibility impls, including their direct-encoding methods; the caller supplies the adapters. |
+| `lookup = "auto"`, `"scan"`, or `"get"` | Accepted metadata; defaults to `auto`. Currently all V3 source decoders scan via `visit_fields_while`, so this option does not select a different lookup algorithm. |
 
 Field metadata:
 
 | Attribute | Meaning |
 | --- | --- |
-| `required` | Missing input is an error. |
-| `default` / `default_with = "path"` | Explicit missing-field behavior; pair it with `default_semantic`. |
-| `key = "..."` | Canonical wire key. The Rust field name is used when omitted. |
-| `alias = "..."` | Decode-only legacy key. V3 never emits aliases. |
-| `flatten, presence = "always|any"` | Nested header inheritance/presence contract. |
-| `range = "i32|i64"` | Restricts an unsigned Rust field to the corresponding Java signed domain. |
+| `required` | Rejects missing input. Concrete required `String` and `CheetahString` fields must also be nonempty on encode and decode. Invalid on `Option<T>`. |
+| `default` | Uses `Default::default()` when absent; requires `default_semantic`. |
+| `default_with = "path"` | Calls a zero-argument function returning the full field type when absent; requires `default_semantic`. |
+| `default_semantic = "literal:<wire-text>"` or `"dynamic:<semantic-id>"` | Describes a default in the schema. It does not calculate or verify the actual default value. The dynamic identifier must be nonempty. |
+| `key = "..."` | Canonical wire key. When omitted, underscores are removed and the following character is capitalized: `producer_group` becomes `producerGroup`. |
+| `alias = "..."` | Repeatable decode-only key. Encoding emits the canonical key. |
+| `alias_conflict = "error"` or `"prefer_canonical"` | Defaults to `error`. See the conflict rules below. |
+| `flatten` | Encodes and decodes a nested `HeaderCodec` in the same field namespace. |
+| `presence = "always"` or `"any"` | Controls decoding of a flattened field. Required for `Option<Flattened>`; ordinary flattened fields default to `always`. |
+| `range = "i32"` or `"i64"` | Restricts `u32` to `0..=i32::MAX` or `u64` to `0..=i64::MAX`, respectively. |
+| `binary_order = N` | `u16` encoding/schema order, defaulting to the zero-based source field index. Effective orders must be unique across local scalar and flatten fields. Does not order `HeaderMap` iteration. |
+| `java_type = "..."` | Accepted compatibility metadata with type-consistency checks. Registered production schemas require it to be omitted. |
 
 Do not write `java_type` on production fields. V3 infers the ordinary wire kind from the Rust type. Use `range`
-only for unsigned Rust fields that are constrained by a Java signed `int` or `long`; signed Rust fields and
-Rust-only unsigned fields do not need it.
+for unsigned Rust fields constrained by Java signed integers. Declaring `java_class` on a container requires
+`range = "i32"` on each scalar `u32` field and `range = "i64"` on each scalar `u64` field, including optional
+fields. Explicit field-level `java_type` also requires the matching range on unsigned fields. Signed Rust fields
+must not declare `range`; Rust-only unsigned fields without Java metadata can use their full Rust range.
+
+### Missing values and defaults
+
+Each non-optional scalar field must declare exactly one of `required`, `default`, or `default_with`. Defaults
+apply only to absent keys; malformed present values still return an error. An unannotated `Option<T>` decodes
+missing input as `None` and omits `None` during encoding. On `Option<T>`, `default` produces
+`Some(T::default())`, whereas `default_with` returns the complete `Option<T>` and may choose `None`.
+
+`default_semantic = "literal:32"` does not make `default` return 32. Use a `default_with` function that returns
+32, and keep its schema description aligned with its implementation. Default providers are responsible for
+returning valid values; generated defaults do not pass through wire-text parsing.
+
+Legacy `#[required]` is temporarily accepted by V3 with a deprecation diagnostic. Use `#[header(required)]`;
+declaring both is an error. Serde helper attributes require a Serde derive to register them; V3 itself registers
+only `header` and `required`.
+
+### Aliases and flattening
+
+With `alias_conflict = "error"`, multiple present names are accepted if their raw text is identical; different
+text produces `ProtocolContractViolation::Conflict` before value parsing. With `prefer_canonical`, the canonical
+key wins; if absent, the first present alias in declaration order wins. Unknown input keys are ignored.
+
+Canonical keys and aliases must be nonempty, contain no NUL, and fit the ROCKETMQ `u16` byte-length limit. The
+macro rejects duplicate names among local scalar fields. Keep names disjoint across flattened headers as well;
+the derive cannot inspect nested types for cross-header collisions.
+
+For `Option<Flattened>`, `presence = "always"` always attempts nested decode and returns `Some` on success.
+`presence = "any"` decodes only when a canonical key or alias owned by the nested schema (including its children)
+is present; otherwise it returns `None`. A present nested field still triggers all nested required-field checks.
+Non-optional flattened fields always decode and cannot use `presence = "any"`. Flattening cannot be combined
+with scalar keys, aliases, missing/default policies, `alias_conflict`, `java_type`, or `range`.
+
+### Validation and errors
+
+Prefer `HeaderCodec::encode_into`, `HeaderCodec::decode_from_map` / `decode_from_source`, or
+`CommandCustomHeader::try_encode_into_map` to retain typed `ProtocolContractViolation` errors. The generated
+legacy `to_map` returns `None` on failure, and `encode_into_map` discards the error. `FromMap` converts failures
+to `rocketmq_error::Error`.
+
+Required-string checks and the custom validation hook run before writes by that header layer. Range checks run
+as fields are encoded, and nested headers validate when reached. Consequently, a failed `encode_into` or
+`try_encode_into_map` can leave earlier fields in the destination. `validate_for_wire` / `check_fields` alone
+does not check all field ranges or recursively validate nested headers. The generated `fast` binary and JSON
+adapters restore the output buffer's original length on failure.
 
 ## Runtime paths and fallback
 
-V3 is the production default because every registered header implements its typed codec and object-safe
-compatibility adapter. A normal header reports `MapOnly`; the remoting encoder materializes canonical extension
-fields without relying on mutable `Arc` access. A reviewed hot header may report `DirectBinary` for ROCKETMQ frames
-and may provide direct JSON fields. If a command already contains materialized or dynamic fields, the same typed
-schema resolves collisions and the map path remains authoritative.
+With the generated shim, a normal header reports `MapOnly`. A `fast` header reports `DirectBinary` and supports
+direct JSON fields. The remoting encoder uses shared header access and chooses the path for each command.
+
+For ROCKETMQ encoding, dynamic fields that do not overlap the typed schema can accompany direct binary output;
+overlapping canonical keys or aliases use the typed/dynamic map merge. Conflicting typed and dynamic values
+produce `DynamicFieldConflict`, even for a field with `alias_conflict = "prefer_canonical"`. The direct JSON path
+requires absent extension fields and a header that has not already been materialized into the command.
 
 This fallback is per header and per command. It does not change the wire contract, and it avoids adding a global
 branch or environment lookup to every message.
@@ -101,22 +201,36 @@ V2 metadata is not silently reinterpreted. Review it against the fixed Java sche
 | --- | --- |
 | `#[required]` | `#[header(required)]` |
 | `serde(rename = "...")` | `#[header(key = "...")]` when it is a wire key |
-| `serde(alias = "...")` | `#[header(alias = "...")]` with an explicit conflict policy when required |
-| `serde(default)` | `#[header(default, default_semantic = "literal:...")]` or reviewed `default_with` |
-| `serde(flatten)` | `#[header(flatten, presence = "always|any")]` |
+| `serde(alias = "...")` | `#[header(alias = "...", alias_conflict = "prefer_canonical")]` preserves V2 precedence; choose `error` only as an explicit behavior change |
+| `serde(default)` or an implicit non-optional default | Declare `header(default, default_semantic = "literal:...")`; review optional defaults separately |
+| `serde(default = "path")` | `#[header(default_with = "path", default_semantic = "...")]` with the actual default semantics |
+| `serde(flatten)` on `Option<T>` | `#[header(flatten, presence = "always")]` preserves V2's unconditional nested decode; `any` changes absence behavior |
+| `serde(flatten)` on `T` | `#[header(flatten)]` |
+| `request_header(validate = "method")` | `#[header(validate = "Self::method")]`, adapting the return type to `ProtocolContractViolation` |
 | unsigned field matching Java `int`/`long` | `range = "i32"` / `range = "i64"` |
 
-Keep V2 only while migrating an existing downstream model. New RocketMQ-Rust production headers are rejected by
-the migration guard unless they use V3 and are registered in the checked-in schema inventory.
+V2 ignores container-level `serde(rename_all)` and does not apply scalar `Option<T>` default providers during
+decode. Review these differences before copying attributes to V3. V3 also has a narrower set of supported
+scalar types than V2's `ToString`/`FromStr` path.
+
+Keep V2 only while migrating an existing downstream model. Register new production headers in the typed registry
+and checked-in inventory. `request_header_codec_v3_registry` compares that registry with `migration.json` and
+the pinned Java contracts. Migration generators and the Java extraction harness have been retired; there is no
+active migration guard that automatically discovers and rejects every new source header.
 
 V1 (`RequestHeaderCodec`) is frozen for source compatibility, including its historical parsing and decode quirks.
-Do not use it for new code; migrate existing V1 headers directly to the explicit V3 model.
+For example, malformed optional primitive values can become `None`, and malformed non-required primitive values
+can fall back to `Default`. V3 returns conversion errors instead. Do not use V1 for new code; migrate existing V1
+headers directly to the explicit V3 model.
 
 ## Renamed protocol dependency
 
-The derive resolves `rocketmq-protocol` through Cargo metadata. Generated/re-exported environments can override it:
+V2 and V3 resolve `rocketmq-protocol` from the consumer's Cargo manifest, including a dependency renamed to
+`protocol_api`. Generated/re-exported environments can override the path explicitly. For V3:
 
 ```rust
+use rocketmq_macros::RequestHeaderCodecV3;
+
 #[derive(RequestHeaderCodecV3)]
 #[header(type_id = "example::Header", crate = "protocol_api")]
 struct Header {
@@ -125,7 +239,21 @@ struct Header {
 }
 ```
 
-The standalone `tests/fixtures/renamed-consumer` project verifies both the V3 path and retained V2 compatibility.
+V2 uses `#[request_header_codec_v2(crate = "protocol_api")]`. V1 still emits `crate::protocol` paths and requires
+the legacy consumer layout. The standalone [`tests/fixtures/renamed-consumer`](tests/fixtures/renamed-consumer/)
+project checks automatic dependency-name resolution for V2 and V3.
+
+## Serialization
+
+The exported `RemotingSerializable` derive still emits the historical form
+`impl crate::protocol::RemotingSerializable for Type { type Output = Self; }`. It does not preserve generics,
+resolve a protocol dependency, or generate Serde implementations. The current protocol serialization trait has
+no `Output` associated type and requires serialization methods, so this expansion is incompatible with it.
+
+For current protocol types, derive `serde::Serialize` and import
+`rocketmq_protocol::protocol::RemotingSerializable` to use `encode`, `serialize_json`, and
+`serialize_json_pretty`. The protocol crate supplies a blanket implementation for serializable types.
+Likewise, owned deserializable types receive `RemotingDeserializable` through its blanket implementation.
 
 ## Crate layout
 
@@ -134,9 +262,9 @@ The standalone `tests/fixtures/renamed-consumer` project verifies both the V3 pa
 | [`src/lib.rs`](src/lib.rs) | Public derive entry points and shared parsing helpers. |
 | [`src/request_header_codec_v3/`](src/request_header_codec_v3/) | Canonical V3 metadata, semantic model, profile validation, and code generation. |
 | [`src/request_header_codec_v3/legacy_v1.rs`](src/request_header_codec_v3/legacy_v1.rs) and [`legacy_v2.rs`](src/request_header_codec_v3/legacy_v2.rs) | Frozen V1/V2 syntax adapters and compatibility code generation over the canonical model. |
-| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | Deprecated V2 public syntax parser and adapter. |
+| [`src/request_header_codec_v2.rs`](src/request_header_codec_v2.rs) and [`src/request_header_codec_v2/attr.rs`](src/request_header_codec_v2/attr.rs) | Deprecated V2 entry wrapper and public syntax parser; adaptation lives under `legacy_v2/`. |
 | [`src/request_header_custom.rs`](src/request_header_custom.rs) | Deprecated V1 parse/wrapper entry forwarding to the frozen compatibility adapter. |
-| [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | Remoting serialization derive. |
+| [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | Historical crate-local serialization expansion. |
 
 No Java checkout is accessed during Cargo builds. Java schemas, golden frames, header registry data, and
 benchmark inputs are owned by the protocol crate's
@@ -144,12 +272,23 @@ benchmark inputs are owned by the protocol crate's
 
 ## Validation
 
+Select checks relevant to the change from the repository root. The macro crate's unit tests inspect parsing and
+expansion; protocol tests compile consumers and exercise runtime behavior.
+
 ```powershell
-cargo test -p rocketmq-protocol --test request_header_codec_v3_registry
 cargo test -p rocketmq-macros --lib
+cargo test -p rocketmq-protocol --test request_header_codec_v3_typed_map
+cargo test -p rocketmq-protocol --test request_header_codec_v3_registry
+cargo test -p rocketmq-protocol --test request_header_codec_v3_ui
+cargo test -p rocketmq-protocol --test request_header_codec_runtime_ui
+cargo test -p rocketmq-protocol --test request_header_java_compatibility
+```
+
+For retained legacy behavior and renamed dependencies:
+
+```powershell
 cargo test -p rocketmq-protocol --test request_header_codec_v1_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v1_wire_snapshot
-cargo test -p rocketmq-protocol --test request_header_codec_v3_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_wire_snapshot
 cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10302

### Brief Description

The macro READMEs describe unchanged Rust field names as default wire keys, overstate zero-copy decoding, and present outdated serialization and migration guarantees. Align both English and Chinese documentation with the current derive implementations and protocol runtime.

- Add a runnable quick start and describe supported field types, metadata, defaults, aliases, flattening, and Java ranges.
- Clarify validation boundaries, partial map writes, direct-encoding rollback and fallback, and V1/V2 migration differences.
- Document the historical `RemotingSerializable` derive's incompatibility with the current trait and the supported Serde-based alternative; replace the retired migration-guard claim with the actual registry checks.

Only the two macro README files change. Macro expansion and wire behavior remain unchanged.

### How Did You Test This Change?

Passed during preparation of these documentation changes:

- `cargo test -p rocketmq-macros --lib`: 13 tests passed.
- `cargo test -p rocketmq-protocol --test request_header_codec_v3_typed_map --test request_header_codec_v3_registry`: 18 tests passed.
- `cargo test -p rocketmq-protocol --test request_header_codec_v3_ui`: all 5 passing and 8 compile-fail fixtures matched expectations.
- `request_header_codec_v1_wire_snapshot`: all 3 tests passed as part of the legacy snapshot run.
- Executed both README files with `rustdoc --test --edition 2021`, using the built macro/protocol dependencies and the renamed-consumer Cargo manifest: 2 examples passed per language.
- Checked local Markdown links and matching code blocks between translations; `git diff --check` passed for the changed files.

Existing validation limitations observed before publication:

- `cargo test -p rocketmq-protocol --test request_header_codec_v2_wire_snapshot`: 1 passed and 2 failed. The failures expect legacy error text (`Missing requestId field` and `Parse count field error`), while the current descriptor-based error conversion discards those details.
- `cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml`: blocked because the fixture lock file requires an update. Its lock file was not changed by this documentation PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated English and Chinese README guidance for the V3 request-header codec.
  - Documented supported metadata, defaults, aliases, flattening, validation, runtime behavior, and usage examples.
  - Added migration guidance for legacy V1/V2 adapters and `RemotingSerializable` compatibility.
  - Clarified dependency naming, crate structure, serialization compatibility, and validation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->