### PR TITLE
[ISSUE #10304]🐛Fix POP index test limit construction

### DIFF
--- a/rocketmq-broker/tests/unit/long_polling/pop_deferred/index/p1_tests.rs
+++ b/rocketmq-broker/tests/unit/long_polling/pop_deferred/index/p1_tests.rs
@@ -385,7 +385,7 @@ fn ordered_selection_filters_and_reserves_only_the_bounded_merge_prefix() {
 
 #[test]
 fn reserve_next_matching_prevents_millisecond_boundary_time_inversion() {
-    let index = PopCriteriaIndex::<i32>::new(PopCriteriaLimits::default());
+    let index = PopCriteriaIndex::<i32>::new(PopCriteriaLimits::new(nonzero(2), nonzero(2)));
     let criteria = Arc::new(PopMatchCriteria::new(None, None));
 
     let born_time = 1000;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10304

### Brief Description

The millisecond-boundary POP index regression test fails to compile because `PopCriteriaLimits` has no `Default` implementation. Construct its limits explicitly with global and per-key capacity of two, matching the two waiters used by the test. Production code is unchanged.

### How Did You Test This Change?

Passed locally on Windows before PR preparation:

- `cargo test -p rocketmq-broker --lib long_polling::pop_deferred::index --locked -- --quiet`: 8 passed.
- `cargo fmt -p rocketmq-broker -- --check`.
- `git diff --check`.

The same one-line patch was then transferred to an isolated worktree for submission. Linux CI was not rerun locally. The maintainer requested a squash merge without waiting for CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated long-polling test coverage to use explicit capacity limits.
  - Improved validation of time-boundary behavior under constrained conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->