### PR TITLE
[ISSUE #10306]📝Align auth READMEs with current APIs and security behavior

### DIFF
--- a/rocketmq-auth/README-zh_cn.md
+++ b/rocketmq-auth/README-zh_cn.md
@@ -2,117 +2,98 @@
 
 [English](README.md) | [简体中文](README-zh_cn.md)
 
-[RocketMQ-Rust](../README-zh_cn.md) 的认证、授权、ACL 迁移和 auth runtime 支持 crate。
+为 [RocketMQ-Rust](../README-zh_cn.md) 提供认证、ACL 授权以及由服务管理生命周期的认证运行时。
 
-`rocketmq-auth` 提供 RocketMQ-Rust 服务端和客户端使用的 auth 层。它聚焦 RocketMQ 兼容的 access-key 认证、
-ACL 授权、Java 风格 ACL 文件兼容、本地元数据 provider、有状态缓存以及 remoting 请求集成。
+`rocketmq-auth` 实现 RocketMQ 访问密钥签名、Java 风格 ACL 文件导入、本地用户和 ACL
+元数据管理，以及 Remoting 请求检查。它还提供需要单独接入的首次管理员注册、密钥提供程序、
+凭据轮换和维护策略适配器。构建 `AuthRuntime` 不会自动安装网络拦截器，也不会自动启用这些适配器。
 
-## 能力边界
+## 能力与边界
 
-| 领域 | 提供能力 |
+| 领域 | 当前行为 |
 |------|----------|
-| 认证 | 基于 access-key 的认证、remoting 签名解析、请求时间戳校验和可插拔认证策略。 |
-| 授权 | 基于 subject/resource/action 的 ACL 授权、allow/deny policy 判断、super-user 绕过和默认拒绝行为。 |
-| ACL 兼容 | Java 风格 `plain_acl.yml` 加载、递归 ACL 文件发现、全局/账号级 white remote address 和旧 ACL 迁移。 |
-| 运行时集成 | 面向 broker/proxy 的 `AuthRuntime`，封装 remoting 命令检查、元数据初始化、ACL reload 和缓存失效。 |
-| 元数据 | 本地认证和授权 metadata provider，并在 `authConfigPath` 下持久化快照。 |
-| 可观测性 | ACL reload、缓存命中/未命中、签名、白名单、认证和授权结果的轻量计数器。 |
+| 认证 | 访问密钥查找、用户启用状态检查、HMAC 签名验证，以及可选的时间戳偏差检查。 |
+| 授权 | 按用户、资源、操作和环境评估策略，支持超级用户绕过授权；已生成的授权上下文没有适用 ACL 时拒绝访问。 |
+| ACL 兼容 | Java 风格 YAML 文件、递归目录加载、全局和账号级 IP 白名单，以及可选的 v1 迁移。 |
+| 运行时 | 提供程序初始化、请求准入、元数据初始化、ACL 重载、指标和协调关闭。 |
+| 元数据 | 内存中的用户和 ACL，以及可选的 JSON 快照；自定义元数据提供程序组合具有明确的操作接口和生命周期接口。 |
+| 策略 | 独立的无状态和有状态评估器。运行时直接执行 Remoting 检查的服务不使用有状态策略缓存。 |
+| gRPC | 认证元数据解析和可选的 Tonic 适配器；不提供完整的 gRPC 认证授权拦截器。 |
 
-## Crate 结构
+## 公共 API 与源码结构
 
-| 模块 | 职责 |
+实现模块均为私有模块。请从 crate 根路径导入公开类型，例如使用
+`rocketmq_auth::AuthConfig`，而不是 `rocketmq_auth::config::AuthConfig`。
+
+| 源码 | 职责 |
 |------|------|
-| [`authentication`](src/authentication.rs) | 认证上下文、provider、strategy、ACL 签名和客户端 RPC hook 支持。 |
-| [`authorization`](src/authorization.rs) | 授权上下文、provider、handler、strategy、ACL model、resource 和 policy。 |
-| [`acl`](src/acl.rs) | Java ACL 文件加载、校验、存储辅助能力和 white remote address 匹配。 |
-| [`runtime`](src/runtime.rs) | 面向服务集成的 auth runtime，串联 provider、ACL 文件、reload、缓存和 remoting 检查。 |
-| [`config`](src/config.rs) | `AuthConfig`，支持 serde camelCase 字段，并在 debug 输出中隐藏密钥。 |
-| [`migration`](src/migration.rs) | 旧 ACL 模型兼容，用于从 RocketMQ v1 ACL 文件迁移。 |
-| [`observability`](src/observability.rs) | Auth metrics 快照和稳定的 metric sample 名称。 |
-| [`permission`](src/permission.rs) | ACL 迁移和 policy 生成使用的权限转换辅助能力。 |
+| [公共导出](src/lib.rs)、[配置](src/config.rs) | 支持的导入路径和 Serde 配置默认值。 |
+| [运行时](src/runtime.rs)、[Remoting 上下文](src/remoting_auth_context.rs) | 服务生命周期和可信入口信息。 |
+| [提供程序操作接口](src/provider_ports.rs)、[提供程序生命周期管理](src/provider_owner.rs) | 元数据操作、准入、初始化和清理。 |
+| [认证](src/authentication.rs)、[授权](src/authorization.rs) | 上下文构建器、提供程序、策略、签名和客户端 RPC 钩子。 |
+| [ACL](src/acl.rs)、[迁移](src/migration.rs)、[权限](src/permission.rs) | YAML 导入、旧版模型、地址匹配和权限转换。 |
+| [首次管理员注册](src/bootstrap.rs)、[密钥提供程序](src/secret_provider.rs)、[凭据轮换](src/credential_rotation.rs) | 显式接入的管理员注册和凭据管理适配器。 |
+| [维护策略](src/maintenance.rs)、[分层授权](src/layered_authorization.rs) | 策略加载和组合安全决策所需的适配器。 |
+| [认证授权指标](../rocketmq-observability/src/metrics/auth.rs) | 指标实现归属 `rocketmq-observability`；本 crate 重新导出 `AuthMetrics`、`AuthMetricsSnapshot` 和 `AuthMetricSample`。 |
 
-## 安装
-
-在当前 workspace 内使用本地路径依赖：
-
-```toml
-[dependencies]
-rocketmq-auth = { path = "../rocketmq-auth" }
-```
-
-外部项目可使用已发布的 workspace 版本：
-
-```toml
-[dependencies]
-rocketmq-auth = "1.0.0"
-```
-
-如需启用可选的 gRPC metadata 解析支持，可开启 `grpc` feature：
-
-```toml
-[dependencies]
-rocketmq-auth = { version = "1.0.0", features = ["grpc"] }
-```
-
-## 安全契约所有权与策略模型迁移
-
-运行时中立的安全契约应直接从 `rocketmq-security-api` 导入：
+与运行时无关的安全契约归属 `rocketmq-security-api`：
 
 ```rust
 use rocketmq_security_api::{Principal, Resource};
 ```
 
-`rocketmq-auth` 的策略模型应通过其规范名称导入：
+认证授权策略模型使用不同的规范名称：
 
 ```rust
 use rocketmq_auth::{AuthorizationRequest, PolicyDecision, PolicyResource};
 ```
 
-维护契约现在直接从 `rocketmq-security-api` 导入；`rocketmq-auth` 不再保留这些契约的兼容再导出。
-`MaintenanceAuthorizationDenial` 表示普通拒绝决策，`SecurityContractViolation`、
-`SecurityProviderError` 和 `AuthServiceError` 分别承载确定性契约错误和运行失败。
-该直接替换不会改变 RocketMQ remoting 数字响应码。
+根路径下的 `rocketmq_auth::Resource` 和 `RequestContext` 仍保留为策略模型的兼容别名。
+`SecurityPrincipal` 和 `SecurityResource` 已弃用，请直接使用安全 API 中的类型。
+维护契约也直接来自 `rocketmq-security-api`。普通的访问拒绝属于决策结果；
+`AuthServiceError`、`SecurityContractViolation` 和 `SecurityProviderError` 表示运行故障或契约错误。
+这些 Rust API 层面的区分不会改变 RocketMQ Remoting 的数字响应码。
+
+## 依赖
+
+对于属于本仓库工作区的包：
+
+```toml
+[dependencies]
+rocketmq-auth = { workspace = true }
+rocketmq-runtime = { workspace = true }
+tokio = { workspace = true }
+```
+
+对于与 `rocketmq-auth`、`rocketmq-runtime` 目录同级的独立包，快速开始示例使用以下依赖：
+
+```toml
+[dependencies]
+rocketmq-auth = { path = "../rocketmq-auth" }
+rocketmq-runtime = { path = "../rocketmq-runtime" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+请按实际检出目录调整相对路径。本文描述当前源码树的 API，不保证具有相同工作区版本号的
+已发布 crate 包含这里展示的全部 API。
+
+本 crate 没有默认特性。在 `rocketmq-auth` 依赖上启用 `grpc` 特性后，可通过
+`DefaultAuthenticationContextBuilder` 实现的 `AuthenticationContextBuilder::build_from_grpc`
+解析 Tonic 的 `MetadataMap`；调用时需要导入 `AuthenticationContextBuilder` trait。
+接收 `HashMap<String, String>` 的 `build_from_grpc_metadata_map` 不需要此特性。
+默认授权提供程序的 gRPC 上下文方法返回空向量，因此仅启用 `grpc` 不会对 gRPC 方法实施授权检查。
 
 ## 快速开始
 
-通过 `AuthConfig` 创建 auth runtime，并指向 RocketMQ 风格的 ACL 文件：
-
-```rust
-use cheetah_string::CheetahString;
-use rocketmq_auth::config::AuthConfig;
-use rocketmq_auth::AuthRuntimeBuilder;
-
-#[tokio::main]
-async fn main() -> rocketmq_error::Result<()> {
-    let config = AuthConfig {
-        auth_config_path: CheetahString::from_static_str("store/auth"),
-        acl_file: CheetahString::from_static_str("conf/plain_acl.yml"),
-        authentication_enabled: true,
-        authorization_enabled: true,
-        acl_file_watch_enabled: true,
-        ..AuthConfig::default()
-    };
-
-    let runtime = AuthRuntimeBuilder::new(config).build().await?;
-
-    // Broker/proxy 集成时，会在处理受保护请求前用 channel context
-    // 和 RemotingCommand 调用 check_remoting(...)。
-    let metrics = runtime.metrics_snapshot();
-    println!("auth reload attempts: {}", metrics.acl_reload_attempts);
-
-    runtime.shutdown().await?;
-    Ok(())
-}
-```
-
-最小 `plain_acl.yml` 示例：
+运行程序前，请相对于进程工作目录创建 `conf/plain_acl.yml`。
+本地示例允许 Alice 向 `TopicA` 发布消息，以及使用 `GroupA` 订阅，不配置 IP 白名单绕过。
+在本地测试之外使用时，请替换示例密钥。
 
 ```yaml
-globalWhiteRemoteAddresses:
-  - 10.10.*.*
+globalWhiteRemoteAddresses: []
 accounts:
   - accessKey: alice
-    secretKey: alice-secret
+    secretKey: replace-with-a-local-test-secret
     admin: false
     defaultTopicPerm: DENY
     defaultGroupPerm: DENY
@@ -122,30 +103,149 @@ accounts:
       - GroupA=SUB
 ```
 
-Runtime 会把该文件加载到本地认证和授权元数据中。启用 `aclFileWatchEnabled` 后，文件变化会在后台自动 reload；
-reload 失败时会保留上一份可用快照。
+认证和授权都必须显式启用。构建器需要 `rocketmq-runtime` 提供的
+`ChildServiceContext`，用于管理后台任务：
+
+```rust,no_run
+use rocketmq_auth::{AuthConfig, AuthRuntimeBuilder, AuthServiceResult};
+use rocketmq_runtime::RuntimeContext;
+
+#[tokio::main]
+async fn main() -> AuthServiceResult<()> {
+    let service_runtime = RuntimeContext::from_current("auth-example");
+    let config = AuthConfig {
+        auth_config_path: "store/auth".into(),
+        acl_file: "conf/plain_acl.yml".into(),
+        authentication_enabled: true,
+        authorization_enabled: true,
+        acl_file_watch_enabled: true,
+        ..AuthConfig::default()
+    };
+
+    let runtime = AuthRuntimeBuilder::new(config, service_runtime.service_context("auth"))
+        .build()
+        .await?;
+
+    println!("auth reload attempts: {}", runtime.metrics_snapshot().acl_reload_attempts);
+
+    runtime.shutdown().await?;
+    Ok(())
+}
+```
+
+该程序加载元数据后关闭，不接收业务请求。Broker/Proxy 接入时，必须在分发受保护请求前调用
+`runtime.check_remoting(&auth_context, &command).await?`。
+通过 `from_request(&RemotingRequest)` 从可信传输信息构建 `RemotingAuthContext`，或在可信网络入口调用
+`network(source_ip, channel_id)`。网络上下文要求来源地址和通道标识非空；嵌入式调用路径从可信的
+Broker-Proxy 调用方信息派生。
+
+如果中间件可能改写命令的操作码，应在入口保存原始操作码并使用 `check_remoting_for_code`。
+在所属运行时退出前关闭认证运行时：关闭过程停止接收新请求，等待已准入的操作完成，
+停止 ACL 监听任务，并刷新、关闭提供程序。外部注入的元数据 I/O Actor 仍由调用方管理。
 
 ## 配置
 
-`AuthConfig` 支持 camelCase 字段名的 serde 反序列化。重要字段包括：
+`AuthConfig` 使用 camelCase 格式的 Serde 字段名，省略的字段由 `Default` 补齐。
+Rust 结构体字段使用 snake_case。主要默认值及作用范围如下：
 
-| 字段 | 作用 |
-|------|------|
-| `authConfigPath` | 本地 metadata provider 持久化 users 和 ACL snapshots 的目录/文件根路径。 |
-| `aclFile` | 要加载的 Java 风格 ACL YAML 文件或目录。目录会递归搜索 `.yml` 和 `.yaml` 文件。 |
-| `aclFileWatchEnabled` | 启用后台 ACL 文件 reload。 |
-| `aclFileWatchIntervalMillis` | ACL 文件 reload 轮询间隔，默认 `5000`。 |
-| `authenticationEnabled` | 启用 `AuthenticationService` 的认证检查。 |
-| `authorizationEnabled` | 启用 `AuthorizationService` 的授权检查。 |
-| `authenticationWhitelist` | 逗号分隔的 remoting request code 列表，用于跳过认证。 |
-| `authorizationWhitelist` | 逗号分隔的 remoting request code 列表，用于跳过授权。 |
-| `signatureAlgorithm` | Java 兼容签名算法：`HmacSHA1`、`HmacSHA256` 或 `HmacMD5`。 |
-| `requestTimestampExpiredMillis` | 可选重放保护窗口。`0` 保持 Java 兼容的不校验过期行为。 |
-| `migrateAuthFromV1Enabled` | 通过 v1 plain permission manager 启用旧 ACL 迁移。 |
+| 字段 | 默认值 | 含义 |
+|------|--------|------|
+| `authenticationEnabled`、`authorizationEnabled` | `false` | 分别启用普通运行时路径中的认证和授权检查。 |
+| `authConfigPath` | 空 | 可选的本地快照根路径；为空时使用内存元数据。 |
+| `aclFile` | 空 | YAML 文件或目录；目录会递归搜索 `.yml` 和 `.yaml` 文件。 |
+| `aclFileWatchEnabled` | `false` | 同时配置 ACL 路径时才启动监听任务。 |
+| `aclFileWatchIntervalMillis` | `5000` | 轮询间隔，下限为 1 毫秒。 |
+| `authenticationWhitelist`、`authorizationWhitelist` | 空 | 逗号分隔的十进制 Remoting 请求码；各自仅绕过对应的检查。 |
+| `signatureAlgorithm` | `HmacSHA1` | 也支持 `HmacSHA256` 和 `HmacMD5`；客户端必须使用相同算法。 |
+| `requestTimestampExpiredMillis` | `0` | 可选的时间戳偏差窗口；限制见下文。 |
+| `authenticationProvider`、`authorizationProvider` | 空 | 运行时使用内置默认提供程序；不支持的配置名称会被拒绝。 |
+| `authenticationMetadataProvider`、`authorizationMetadataProvider` | 空 | 运行时构建本地提供程序；自定义实现通过 `ProviderBundle` 注入。 |
+| `authenticationStrategy`、`authorizationStrategy` | 空 | 用于工厂和评估器选择，默认无状态；不会为 `AuthRuntime::check_remoting` 选择策略。 |
+| `configName` | 空 | 未注入运行时注册表时，旧版工厂按此名称缓存实例。 |
+| `clusterName` | 空 | Remoting 授权映射使用的集群资源名称。 |
+| `initAuthenticationUser`、`innerClientAuthenticationCredentials` | 空 | 可选的启动超级用户初始数据，仅在用户不存在时创建；不用于凭据轮换。 |
+| `migrateAuthFromV1Enabled` | `false` | 通过 v1 普通权限管理器导入旧版 ACL。 |
+| `aclCacheMaxNum`、`aclCacheExpiredSecond`、`aclCacheRefreshSecond` | `1000`、`600`、`60` | 本地 ACL 查询缓存的容量、有效期和回源刷新间隔。 |
+| `userCacheMaxNum`、`userCacheExpiredSecond`、`userCacheRefreshSecond` | `1000`、`600`、`60` | 兼容性配置；当前本地用户提供程序不使用这些缓存设置。 |
+| `statefulAuthenticationCacheMaxNum`、`statefulAuthenticationCacheExpiredSecond` | `10000`、`60` | 独立有状态认证策略的容量和过期时间，时间单位为秒。 |
+| `statefulAuthorizationCacheMaxNum`、`statefulAuthorizationCacheExpiredSecond` | `10000`、`60` | 独立有状态授权策略的容量和过期时间，时间单位为秒。 |
+| `statefulAuthorizationCacheNegativeEnable` | `false` | 仅在显式启用时缓存拒绝授权的决策；不缓存错误。 |
+| `maintenanceEnabled` | `false` | 显式启用维护配置，通过 `maintenance_policy_reference()` 校验。 |
+| `maintenancePolicyPath`、`maintenancePolicyVersion`、`maintenancePolicySha256` | 空、`0`、空 | 启用维护时必须提供的策略引用，同时要求普通认证和授权开关均已启用。 |
 
-## 示例
+## 请求检查语义
 
-在 workspace 根目录运行示例：
+- 普通运行时路径依次校验入口上下文、检查全局及账号级 IP 白名单、执行认证，再执行授权。
+  命中 `globalWhiteRemoteAddresses`，或命中所选账号的 `whiteRemoteAddress` 时，
+  **认证和授权都会被绕过**。请求码白名单在 IP 检查之后分别生效。
+- 已启用的超级用户在授权时绕过 ACL 查询。除非命中适用白名单或关闭认证，否则仍需要通过认证。
+- ACL 评估优先选择匹配的自定义策略，仅在没有匹配项时回退到默认策略。
+  在选定层级内，先比较资源类型和模式的具体程度：精确名称优先于前缀，前缀优先于通配符，
+  更长的前缀优先；具体程度相同时，`DENY` 优先。拒绝规则并非无条件覆盖所有策略。
+  对于具体的请求操作，策略项只需匹配至少一个操作，无需匹配上下文中的所有操作。
+  普通授权服务要求每个已生成的上下文都允许访问。
+- 默认拒绝针对已经生成的授权上下文。Remoting 构建器将支持的请求码映射为资源和操作；
+  未映射的请求码可能不生成上下文，因此普通检查路径不会产生 ACL 决策。
+  对外提供新操作时，接入方必须检查其授权映射。受监督的变更请求码会显式拒绝缺少必要上下文的请求。
+- 时间戳窗口非零时，已提供的时间戳必须可解析，且与当前时间的过去或未来偏差不得超过窗口。
+  未提供时间戳的请求仍可通过此项检查。实现没有 nonce 或重放缓存，因此仅靠此设置不能防止重放。
+  窗口为零时，不执行时间戳检查。
+
+详细评估 API 在授权关闭时返回 `Abstain`。调用方需要按显式指定的分层要求处理该结果；
+错误仍然表示失败，不会转换为弃权。
+`authenticate_maintenance_principal` 要求认证已启用，并验证凭据，不采用普通路径的白名单绕过。
+它为独立的维护策略提供身份，本身不会授予维护操作权限。
+
+## 持久化、重载与缓存
+
+设置 `authConfigPath` 后，本地提供程序持久化 `users.json` 和 `acls.json`。
+如果路径带扩展名，实现会先去掉扩展名，再拼接这两个文件名；建议直接使用 `store/auth`
+这样的目录。用户快照以明文保存 HMAC 验证所需的密钥。Debug 脱敏不会加密 JSON 或 ACL YAML 文件。
+
+启动时加载配置的 ACL。监听任务比较文件路径和内容，跳过未变化的输入；
+`reload_acl_file().await` 强制重载并返回导入的账号数量。
+导入成功后替换内存中的地址白名单，递增共享 ACL 代数，并删除该运行时先前通过文件导入管理、
+但在新文件中已经不存在的账号。
+
+读取、解析和校验失败发生在导入之前，不会改变已导入的元数据。
+随后，本地导入器按顺序更新用户和 ACL，**整个导入过程没有统一事务或回滚**。
+如果导入期间发生元数据操作或持久化错误，可能留下部分更新。只有导入成功后才发布新的白名单和代数。
+监听任务会记录失败并在后续轮询中重试；这不代表并发请求能够观察到原子的整体快照切换。
+
+使用自定义存储时，通过 `ProviderBundle` 注入 `UserMetadataPort`、`AclMetadataPort`
+和 `ProviderControl` 实现。配置 ACL 文件导入或 v1 迁移还需要 `AclSnapshotImport`；
+缺少该能力时，构建器会在启动修改操作之前拒绝该组合。
+
+有状态评估器需要显式接入。认证策略按代数、通道和用户名缓存成功及失败结果；
+命中缓存后，该请求不再重新验证签名和时间戳。
+授权缓存键还包含主体、资源、操作和来源 IP，默认只缓存允许决策。
+将评估器绑定到运行时的 `ProviderRegistry` 或共享代数计数器，ACL 重载才能使对应缓存失效。
+独立创建的策略不会自动感知另一个运行时的重载。
+
+本地 ACL 查询缓存与上述决策缓存相互独立。刷新时读取提供程序的内存存储，不会读取外部对
+`acls.json` 的修改；文件重载由 YAML 轮询机制负责。
+运行时指标覆盖使用其指标句柄的组件。独立策略默认持有各自的指标，不会自动汇总到
+`runtime.metrics_snapshot()`。
+
+## 需要单独接入的安全适配器
+
+以下 API 均需由所属服务显式接入，`AuthRuntimeBuilder` 不会自动组装这些功能。
+
+| API | 接入边界 |
+|-----|----------|
+| `OneTimeBootstrap` | 校验受范围和有效期约束的证明材料及可信 TLS 确认，在调用 `BootstrapAdminProvisioner` 前持久化占用状态，防止重启后重复使用。传输层负责验证 TLS；管理员创建失败后，已占用的注册流程保持关闭。 |
+| `SecretProviderRegistry` | 按显式注册的提供程序 ID 查找实现。`EnvironmentSecretProvider` 仅从映射的环境变量读取密钥，且不支持写入。 |
+| `EncryptedFileSecretProvider` | 使用 AES-256-GCM、版本化文件和严格 Unix 文件权限的本地开发适配器；不会加密普通用户或 ACL 快照。 |
+| `CredentialRotationManager` | 管理经过校验的凭据快照、重叠有效期、轮换完成、回滚，以及带审计记录且有期限的紧急访问。注入的解析器负责验证证书、私钥和证明材料之间的关系；不会自动轮换访问密钥或重新配置 TLS 监听器。 |
+| `MaintenancePolicyReference::load_from` | 按显式路径、版本和固定 SHA-256 摘要加载并校验 JSON。维护策略评估归属安全 API，服务负责将其与认证组合使用。 |
+
+加密文件密钥适配器和持久化的一次性管理员注册目前在 Windows 上会拒绝运行，
+因为尚未实现等效的文件系统 ACL 校验。其 Unix 成功路径需要在 Unix 上验证；
+普通 Remoting 认证和本地 JSON 元数据属于独立功能。
+
+## 示例与验证
+
+从工作区根目录运行以下示例，了解各个独立 API：
 
 ```bash
 cargo run -p rocketmq-auth --example authentication_strategy_usage
@@ -155,45 +255,35 @@ cargo run -p rocketmq-auth --example acl_authorization_handler_usage
 cargo run -p rocketmq-auth --example metadata_provider_example
 ```
 
-## 校验
-
-针对本 crate：
+根据修改涉及的行为选择检查：
 
 ```bash
-cargo test -p rocketmq-auth
-cargo test -p rocketmq-auth --test java_alignment
+cargo fmt -p rocketmq-auth -- --check
+cargo test -p rocketmq-auth --test public_api_contract --test security_api_identity --test java_alignment
 cargo test -p rocketmq-auth --examples --no-run
+cargo check -p rocketmq-auth --features grpc
 ```
 
-`java_alignment` 集成测试覆盖 Java 可见行为，包括 remoting 签名内容、旧 `plain_acl.yml` 语义、deny 优先级、
-super-user 绕过、安全 ACL reload、factory 缓存和 request context model 字段。
+`public_api_contract` 检查导出和私有模块边界；`security_api_identity` 检查共享类型身份。
+`java_alignment` 覆盖签名内容、YAML 语义、相同资源下的拒绝优先规则、超级用户和重载行为。
+其中的无效文件重载测试不能证明存储失败时具有事务回滚能力。
+`secure_bootstrap_contract`、`secret_provider_contract`、`credential_rotation_contract`
+和 `release_checkpoint_authorization` 集成测试分别覆盖对应适配器。
+需要更广泛的 crate 测试时，可运行 `cargo test -p rocketmq-auth`。
 
-工作区级校验在仓库根目录运行：
-
-```bash
-cargo fmt --all
-cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
-```
-
-## Benchmark
-
-运行认证和授权热路径 benchmark：
+## 基准测试
 
 ```bash
 cargo bench -p rocketmq-auth --bench auth_hot_path_bench
+cargo bench -p rocketmq-auth --bench auth_acl_watcher_lifecycle_bench
 ```
 
-该 benchmark 覆盖 remoting 签名计算、white remote address 匹配、ACL policy 匹配，以及有状态认证/授权缓存命中。
-
-在 CI 或本地回归门禁中，可以先确认 benchmark target 能编译：
-
-```bash
-cargo test -p rocketmq-auth --benches --no-run
-```
-
-采集基线时，应在尽量空闲的机器上运行 benchmark，并保留 `target/criterion/auth_*` 下的 Criterion 报告。后续变更应在相同
-toolchain 和硬件上对比；涉及签名、白名单匹配、ACL policy 匹配或有状态缓存 key 的变更，如果出现 auth 热路径回归，应先排查再合入。
+第一项测量签名、IP 匹配、ACL 匹配和有状态缓存命中。
+第二项测量 ACL 重载与关闭生命周期，并将报告写入 `target/runtime-baseline/prototype`。
+只编译基准测试目标、不采集测量数据时，可使用
+`cargo test -p rocketmq-auth --benches --no-run`。
+请在相同工具链和硬件环境下比较结果，并将生成的报告保留在 `target/` 下。
 
 ## 许可证
 
-RocketMQ-Rust 使用 Apache License 2.0。详见 [../LICENSE-APACHE](../LICENSE-APACHE)。
+RocketMQ-Rust 使用 Apache License 2.0。参见 [LICENSE-APACHE](../LICENSE-APACHE)。

--- a/rocketmq-auth/README.md
+++ b/rocketmq-auth/README.md
@@ -2,118 +2,100 @@
 
 [English](README.md) | [简体中文](README-zh_cn.md)
 
-Authentication, authorization, ACL migration, and auth runtime support for [RocketMQ-Rust](../README.md).
+Authentication, ACL authorization, and service-owned auth runtime support for [RocketMQ-Rust](../README.md).
 
-`rocketmq-auth` provides the auth layer used by RocketMQ-Rust services and clients. It focuses on RocketMQ-compatible
-access-key authentication, ACL-based authorization, Java-style ACL file compatibility, local metadata providers,
-stateful cache support, and remoting request integration.
+`rocketmq-auth` implements RocketMQ access-key signatures, Java-style ACL file imports, local user and ACL
+metadata, and remoting request checks. It also exposes separately composed bootstrap, secret-provider,
+credential-rotation, and maintenance-policy adapters. Building an `AuthRuntime` does not install a network
+interceptor or enable those adapters automatically.
 
-## Capabilities
+## Capabilities and boundaries
 
-| Area | What it provides |
+| Area | Current behavior |
 |------|------------------|
-| Authentication | Access-key based authentication, remoting signature parsing, request timestamp validation, and pluggable authentication strategies. |
-| Authorization | Subject/resource/action based ACL authorization, allow/deny policy evaluation, super-user bypass, and default-deny behavior. |
-| ACL compatibility | Java-style `plain_acl.yml` loading, recursive ACL file discovery, global/account white remote address support, and legacy ACL migration. |
-| Runtime integration | `AuthRuntime` for broker/proxy integration, remoting command checks, metadata seeding, ACL reloads, and cache invalidation. |
-| Metadata | Local authentication and authorization metadata providers with persisted snapshots under `authConfigPath`. |
-| Observability | Lightweight counters for ACL reloads, cache hits/misses, signatures, whitelist checks, authentication, and authorization results. |
+| Authentication | Access-key lookup, enabled-user checks, HMAC signature verification, and optional timestamp skew checks. |
+| Authorization | User/resource/action/environment policies, super-user authorization bypass, and denial when an evaluated context has no applicable ACL. |
+| ACL compatibility | Java-style YAML files, recursive directory loading, global/account IP whitelists, and optional v1 migration. |
+| Runtime | Provider initialization, request admission, metadata seeding, ACL reloads, metrics, and coordinated shutdown. |
+| Metadata | In-memory users and ACLs with optional JSON snapshots; custom metadata bundles have explicit operation and lifecycle interfaces. |
+| Strategies | Separate stateless/stateful evaluators. Stateful caches are not used by the runtime's direct remoting services. |
+| gRPC | Authentication metadata parsing and an optional Tonic adapter; no complete gRPC authentication/authorization interceptor. |
 
-## Crate Layout
+## Public API and source layout
 
-| Module | Purpose |
-|--------|---------|
-| [`authentication`](src/authentication.rs) | Authentication contexts, providers, strategies, ACL signing, and client RPC hook support. |
-| [`authorization`](src/authorization.rs) | Authorization contexts, providers, handlers, strategies, ACL models, resources, and policies. |
-| [`acl`](src/acl.rs) | Java ACL file loading, validation, storage helpers, and white remote address matching. |
-| [`runtime`](src/runtime.rs) | Service-facing auth runtime that wires providers, ACL files, reloads, caches, and remoting checks. |
-| [`config`](src/config.rs) | `AuthConfig` with serde-compatible camelCase fields and redacted debug output for secrets. |
-| [`migration`](src/migration.rs) | Legacy ACL model compatibility used when migrating from RocketMQ v1 ACL files. |
-| [`observability`](src/observability.rs) | Auth metrics snapshots and stable metric sample names. |
-| [`permission`](src/permission.rs) | Permission conversion helpers used by ACL migration and policy generation. |
+Implementation modules are private. Import supported types from the crate root, for example
+`rocketmq_auth::AuthConfig`, rather than `rocketmq_auth::config::AuthConfig`.
 
-## Installation
+| Source | Responsibility |
+|--------|----------------|
+| [Public exports](src/lib.rs), [configuration](src/config.rs) | Supported import paths and Serde configuration defaults. |
+| [Runtime](src/runtime.rs), [remoting context](src/remoting_auth_context.rs) | Service lifecycle and trusted ingress facts. |
+| [Provider ports](src/provider_ports.rs), [provider owner](src/provider_owner.rs) | Metadata operations, admission, initialization, and cleanup. |
+| [Authentication](src/authentication.rs), [authorization](src/authorization.rs) | Context builders, providers, policies, strategies, signing, and client RPC hooks. |
+| [ACL](src/acl.rs), [migration](src/migration.rs), [permissions](src/permission.rs) | YAML imports, legacy models, address matching, and permission conversion. |
+| [Bootstrap](src/bootstrap.rs), [secret providers](src/secret_provider.rs), [rotation](src/credential_rotation.rs) | Explicit administrator enrollment and credential-management adapters. |
+| [Maintenance](src/maintenance.rs), [layered authorization](src/layered_authorization.rs) | Policy loading and adapters for composed security decisions. |
+| [Auth metrics](../rocketmq-observability/src/metrics/auth.rs) | Metrics owned by `rocketmq-observability`; `AuthMetrics`, `AuthMetricsSnapshot`, and `AuthMetricSample` are re-exported here. |
 
-Inside this workspace, use the package directly:
-
-```toml
-[dependencies]
-rocketmq-auth = { path = "../rocketmq-auth" }
-```
-
-For external consumers, use the published workspace version:
-
-```toml
-[dependencies]
-rocketmq-auth = "1.0.0"
-```
-
-Optional gRPC metadata parsing support is available through the `grpc` feature:
-
-```toml
-[dependencies]
-rocketmq-auth = { version = "1.0.0", features = ["grpc"] }
-```
-
-## Security-contract ownership and policy-model migration
-
-Import runtime-neutral security contracts directly from `rocketmq-security-api`:
+Runtime-neutral security contracts belong to `rocketmq-security-api`:
 
 ```rust
 use rocketmq_security_api::{Principal, Resource};
 ```
 
-Import `rocketmq-auth` policy models through their canonical names:
+Auth policy models have distinct canonical names:
 
 ```rust
 use rocketmq_auth::{AuthorizationRequest, PolicyDecision, PolicyResource};
 ```
 
-Import maintenance contracts directly from `rocketmq-security-api`; `rocketmq-auth` no longer carries compatibility
-re-exports for them. `MaintenanceAuthorizationDenial` represents an ordinary denied decision, while
-`SecurityContractViolation`, `SecurityProviderError`, and `AuthServiceError` cover deterministic contract and
-operational failures. This direct replacement does not change RocketMQ remoting numeric response codes.
+The root `rocketmq_auth::Resource` and `RequestContext` aliases remain for compatibility with the policy
+models. `SecurityPrincipal` and `SecurityResource` are deprecated aliases; use the security API types directly.
+Maintenance contracts also come directly from `rocketmq-security-api`. An ordinary denial is a decision;
+`AuthServiceError`, `SecurityContractViolation`, and `SecurityProviderError` represent operational or
+contract failures. These Rust API distinctions do not change RocketMQ remoting numeric response codes.
 
-## Quick Start
+## Dependencies
 
-Create an auth runtime from `AuthConfig` and point it at a RocketMQ-style ACL file:
+For a package that is a member of this repository's workspace:
 
-```rust
-use cheetah_string::CheetahString;
-use rocketmq_auth::config::AuthConfig;
-use rocketmq_auth::AuthRuntimeBuilder;
-
-#[tokio::main]
-async fn main() -> rocketmq_error::Result<()> {
-    let config = AuthConfig {
-        auth_config_path: CheetahString::from_static_str("store/auth"),
-        acl_file: CheetahString::from_static_str("conf/plain_acl.yml"),
-        authentication_enabled: true,
-        authorization_enabled: true,
-        acl_file_watch_enabled: true,
-        ..AuthConfig::default()
-    };
-
-    let runtime = AuthRuntimeBuilder::new(config).build().await?;
-
-    // Broker/proxy integrations call check_remoting(...) with a channel context
-    // and RemotingCommand before serving protected requests.
-    let metrics = runtime.metrics_snapshot();
-    println!("auth reload attempts: {}", metrics.acl_reload_attempts);
-
-    runtime.shutdown().await?;
-    Ok(())
-}
+```toml
+[dependencies]
+rocketmq-auth = { workspace = true }
+rocketmq-runtime = { workspace = true }
+tokio = { workspace = true }
 ```
 
-A minimal `plain_acl.yml`:
+For a standalone package beside `rocketmq-auth` and `rocketmq-runtime`, the quick start uses:
+
+```toml
+[dependencies]
+rocketmq-auth = { path = "../rocketmq-auth" }
+rocketmq-runtime = { path = "../rocketmq-runtime" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+Adjust relative paths to your checkout. The API described here follows this source tree; it is not a
+guarantee that a published crate with the same workspace version exposes every API shown here.
+
+There are no default features. Enable `grpc` on the `rocketmq-auth` dependency to use
+`AuthenticationContextBuilder::build_from_grpc` on `DefaultAuthenticationContextBuilder` with Tonic's
+`MetadataMap`; bring the `AuthenticationContextBuilder` trait into scope.
+The `HashMap<String, String>` adapter, `build_from_grpc_metadata_map`, is available without that feature.
+The default authorization provider's gRPC context method returns an empty vector, so enabling `grpc`
+alone does not enforce authorization for gRPC methods.
+
+## Quick start
+
+Create `conf/plain_acl.yml` relative to the process working directory before running the program.
+This local example grants Alice publishing access to `TopicA` and subscription access to `GroupA`,
+without an IP whitelist bypass. Replace the example secret before using it outside a local test.
 
 ```yaml
-globalWhiteRemoteAddresses:
-  - 10.10.*.*
+globalWhiteRemoteAddresses: []
 accounts:
   - accessKey: alice
-    secretKey: alice-secret
+    secretKey: replace-with-a-local-test-secret
     admin: false
     defaultTopicPerm: DENY
     defaultGroupPerm: DENY
@@ -123,30 +105,158 @@ accounts:
       - GroupA=SUB
 ```
 
-The runtime loads the file into local authentication and authorization metadata. When `aclFileWatchEnabled` is enabled,
-file changes are reloaded in the background; failed reloads preserve the previous working snapshot.
+Both authentication and authorization must be enabled explicitly. The builder requires a
+`ChildServiceContext` from `rocketmq-runtime` to own its background work:
+
+```rust,no_run
+use rocketmq_auth::{AuthConfig, AuthRuntimeBuilder, AuthServiceResult};
+use rocketmq_runtime::RuntimeContext;
+
+#[tokio::main]
+async fn main() -> AuthServiceResult<()> {
+    let service_runtime = RuntimeContext::from_current("auth-example");
+    let config = AuthConfig {
+        auth_config_path: "store/auth".into(),
+        acl_file: "conf/plain_acl.yml".into(),
+        authentication_enabled: true,
+        authorization_enabled: true,
+        acl_file_watch_enabled: true,
+        ..AuthConfig::default()
+    };
+
+    let runtime = AuthRuntimeBuilder::new(config, service_runtime.service_context("auth"))
+        .build()
+        .await?;
+
+    println!("auth reload attempts: {}", runtime.metrics_snapshot().acl_reload_attempts);
+
+    runtime.shutdown().await?;
+    Ok(())
+}
+```
+
+This program loads metadata and shuts down; it does not serve requests. A broker/proxy integration
+must call `runtime.check_remoting(&auth_context, &command).await?` before dispatching protected requests.
+Build `RemotingAuthContext` from trusted transport facts with `from_request(&RemotingRequest)`, or use
+`network(source_ip, channel_id)` at the trusted network ingress. Network contexts require a nonempty
+source address and channel identity. The embedded path is derived from a trusted broker-proxy caller.
+
+If middleware can rewrite a command's operation code, retain the original code at ingress and use
+`check_remoting_for_code`. Shut down the auth runtime before its owning runtime exits: shutdown closes
+request admission, drains admitted work, stops the ACL watcher, and flushes/closes providers. An injected
+metadata I/O actor remains owned by its caller.
 
 ## Configuration
 
-`AuthConfig` is serde-compatible with camelCase field names. Important fields include:
+`AuthConfig` accepts camelCase Serde field names and fills omitted fields from `Default`.
+Rust struct fields use snake_case. Selected defaults and their scope are:
 
-| Field | Purpose |
-|-------|---------|
-| `authConfigPath` | Directory/file root used by local metadata providers for persisted users and ACL snapshots. |
-| `aclFile` | Java-style ACL YAML file or directory to load. Directories are searched recursively for `.yml` and `.yaml` files. |
-| `aclFileWatchEnabled` | Enables background ACL file reloads. |
-| `aclFileWatchIntervalMillis` | Polling interval for ACL file reloads. Defaults to `5000`. |
-| `authenticationEnabled` | Enables authentication checks in `AuthenticationService`. |
-| `authorizationEnabled` | Enables authorization checks in `AuthorizationService`. |
-| `authenticationWhitelist` | Comma-separated remoting request codes that bypass authentication. |
-| `authorizationWhitelist` | Comma-separated remoting request codes that bypass authorization. |
-| `signatureAlgorithm` | Java-compatible signature algorithm: `HmacSHA1`, `HmacSHA256`, or `HmacMD5`. |
-| `requestTimestampExpiredMillis` | Optional replay-protection window. `0` keeps Java-compatible no-expiry behavior. |
-| `migrateAuthFromV1Enabled` | Enables legacy ACL migration through the v1 plain permission manager. |
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `authenticationEnabled`, `authorizationEnabled` | `false` | Independently enable the ordinary runtime checks. |
+| `authConfigPath` | empty | Optional local snapshot root; empty means in-memory metadata. |
+| `aclFile` | empty | YAML file or directory; directories are searched recursively for `.yml`/`.yaml` files. |
+| `aclFileWatchEnabled` | `false` | Start the watcher only when an ACL path is also configured. |
+| `aclFileWatchIntervalMillis` | `5000` | Poll interval, clamped to at least 1 ms. |
+| `authenticationWhitelist`, `authorizationWhitelist` | empty | Comma-separated decimal remoting request codes; each bypasses only its respective check. |
+| `signatureAlgorithm` | `HmacSHA1` | Also accepts `HmacSHA256` and `HmacMD5`; clients must use the matching algorithm. |
+| `requestTimestampExpiredMillis` | `0` | Optional timestamp skew window; see the limits below. |
+| `authenticationProvider`, `authorizationProvider` | empty | Runtime uses the built-in default providers. Unsupported configured names are rejected. |
+| `authenticationMetadataProvider`, `authorizationMetadataProvider` | empty | Runtime constructs local providers. Custom providers are supplied through a `ProviderBundle`. |
+| `authenticationStrategy`, `authorizationStrategy` | empty | Factory/evaluator selection, defaulting to stateless; does not select a strategy for `AuthRuntime::check_remoting`. |
+| `configName` | empty | Legacy factories cache instances by this name when no runtime registry is injected. |
+| `clusterName` | empty | Cluster resource used by the remoting authorization mapping. |
+| `initAuthenticationUser`, `innerClientAuthenticationCredentials` | empty | Optional startup super-user seeds, created only when absent; not a credential-rotation mechanism. |
+| `migrateAuthFromV1Enabled` | `false` | Import legacy ACLs through the v1 plain permission manager. |
+| `aclCacheMaxNum`, `aclCacheExpiredSecond`, `aclCacheRefreshSecond` | `1000`, `600`, `60` | Local ACL lookup-cache capacity, lifetime, and read-through refresh interval. |
+| `userCacheMaxNum`, `userCacheExpiredSecond`, `userCacheRefreshSecond` | `1000`, `600`, `60` | Compatibility configuration; the current local user provider does not apply these cache settings. |
+| `statefulAuthenticationCacheMaxNum`, `statefulAuthenticationCacheExpiredSecond` | `10000`, `60` | Separate stateful authentication strategy capacity and expiry in seconds. |
+| `statefulAuthorizationCacheMaxNum`, `statefulAuthorizationCacheExpiredSecond` | `10000`, `60` | Separate stateful authorization strategy capacity and expiry in seconds. |
+| `statefulAuthorizationCacheNegativeEnable` | `false` | Cache denied authorization decisions only when explicitly enabled; errors are not cached. |
+| `maintenanceEnabled` | `false` | Opt-in maintenance configuration, validated through `maintenance_policy_reference()`. |
+| `maintenancePolicyPath`, `maintenancePolicyVersion`, `maintenancePolicySha256` | empty, `0`, empty | Required policy reference when maintenance is enabled; both ordinary auth flags must also be enabled. |
 
-## Examples
+## Request-check semantics
 
-Run the focused examples from the workspace root:
+- The ordinary runtime path validates ingress context, checks global/account IP whitelists, authenticates,
+  then authorizes. A matching `globalWhiteRemoteAddresses` entry, or the selected account's
+  `whiteRemoteAddress`, bypasses **both authentication and authorization**. Request-code whitelists
+  apply independently after that IP check.
+- Enabled super users bypass ACL lookup during authorization. They still require authentication unless
+  an applicable whitelist or disabled authentication setting bypasses it.
+- ACL evaluation prefers matching custom policies and falls back to default policies only when none
+  match. Within the selected tier, resource type and pattern specificity take precedence
+  (literal before prefix before wildcard, and longer prefixes first); `DENY` wins a specificity tie.
+  Deny is not an unconditional override across all policies.
+  For concrete requested actions, a policy entry needs to match at least one action, not every action
+  in the context. The ordinary authorization service requires every generated context to allow access.
+- Default denial applies to evaluated authorization contexts. The remoting builder maps supported
+  request codes to resources/actions; unmapped codes can produce no contexts and therefore no ACL
+  decision in the ordinary check path. Integrations must review the mapping when exposing new operations.
+  Supervised mutation codes explicitly reject missing required contexts.
+- With a nonzero timestamp window, a present timestamp must parse and lie within the allowed past/future
+  skew. A request with no timestamp is still accepted by this check. There is no nonce or replay cache;
+  the setting alone does not provide replay protection. A zero window disables timestamp checks.
+
+The detailed evaluation API returns `Abstain` when authorization is disabled. Resolve it using the
+explicit layer requirement; errors remain failures rather than abstentions.
+`authenticate_maintenance_principal` requires authentication to be enabled and verifies credentials
+without the ordinary whitelist shortcuts. It returns an identity for a separate maintenance policy;
+it does not itself grant permission to perform maintenance.
+
+## Persistence, reloads, and caches
+
+Local providers persist `users.json` and `acls.json` when `authConfigPath` is set. A path with an extension
+is normalized by removing that extension before appending these names; prefer an explicit directory
+such as `store/auth`. User snapshots include the secret needed for HMAC verification in plaintext.
+Debug redaction does not encrypt JSON or the ACL YAML file.
+
+The configured ACL is loaded during startup. The watcher compares file paths and contents and skips
+unchanged inputs; `reload_acl_file().await` forces a reload and returns the imported account count.
+A successful import replaces the in-memory address whitelist, advances the shared ACL generation, and
+removes accounts that were managed by an earlier file import in that runtime but are absent from the new one.
+
+Read, parse, and validation failures happen before import and leave the imported metadata unchanged.
+The local importer then updates users and ACLs sequentially: it has **no transaction or rollback across
+the entire import**. A metadata/persistence failure during import can leave partial updates. The
+whitelist and generation are published only after import succeeds. Watcher failures are recorded and
+retried on later polls; this is not a guarantee of an atomic snapshot switch for concurrent requests.
+
+For custom storage, inject a `ProviderBundle` with `UserMetadataPort`, `AclMetadataPort`, and
+`ProviderControl` implementations. Configured ACL imports and v1 migration also require
+`AclSnapshotImport`; the builder rejects a bundle missing that capability before startup mutations.
+
+Stateful evaluators require explicit composition. Authentication caches success and failure by
+generation, channel, and username; a cache hit skips signature/timestamp revalidation for that request.
+Authorization keys also include subject, resource, actions, and source IP, and cache allow decisions
+by default. Bind evaluators to the runtime's `ProviderRegistry` or shared generation counter so ACL
+reloads invalidate their entries. Independent strategies do not automatically observe another runtime's reloads.
+
+The local ACL lookup cache is separate from those decision caches. Its refresh reads the provider's
+in-memory storage, not external edits to `acls.json`; YAML polling is the file-reload mechanism.
+Runtime metrics cover the components using its metrics handle. A standalone strategy's default metrics
+are separate and are not automatically aggregated into `runtime.metrics_snapshot()`.
+
+## Separately composed security adapters
+
+These APIs require explicit integration by the owning service; none is automatically wired by
+`AuthRuntimeBuilder`.
+
+| API | Integration boundary |
+|-----|----------------------|
+| `OneTimeBootstrap` | Validates a scoped, expiring proof and trusted TLS attestation, persists a claim before invoking `BootstrapAdminProvisioner`, and prevents reuse across restarts. The transport must verify TLS; a failed provisioning attempt leaves the claim closed. |
+| `SecretProviderRegistry` | Resolves explicitly registered provider IDs. `EnvironmentSecretProvider` reads only mapped environment variables and is read-only. |
+| `EncryptedFileSecretProvider` | Local AES-256-GCM development adapter with versioned files and restrictive Unix permissions. It does not encrypt the ordinary user/ACL snapshots. |
+| `CredentialRotationManager` | Validated credential snapshots, overlap/finalization, rollback, and bounded break-glass access with an audit sink. The injected parser owns certificate/key/proof validation; this is not automatic access-key rotation or TLS listener reconfiguration. |
+| `MaintenancePolicyReference::load_from` | Loads and validates JSON using an explicit path, version, and SHA-256 pin. The security API owns maintenance policy evaluation; the service must compose it with authentication. |
+
+The encrypted-file secret adapter and persistent one-time bootstrap currently fail closed on Windows
+because equivalent filesystem ACL verification is not implemented. Their Unix success paths require
+Unix validation; ordinary remoting authentication and local JSON metadata are separate facilities.
+
+## Examples and validation
+
+From the workspace root, the examples demonstrate individual APIs:
 
 ```bash
 cargo run -p rocketmq-auth --example authentication_strategy_usage
@@ -156,47 +266,35 @@ cargo run -p rocketmq-auth --example acl_authorization_handler_usage
 cargo run -p rocketmq-auth --example metadata_provider_example
 ```
 
-## Validation
-
-For this crate:
+Select checks appropriate to the changed behavior:
 
 ```bash
-cargo test -p rocketmq-auth
-cargo test -p rocketmq-auth --test java_alignment
+cargo fmt -p rocketmq-auth -- --check
+cargo test -p rocketmq-auth --test public_api_contract --test security_api_identity --test java_alignment
 cargo test -p rocketmq-auth --examples --no-run
+cargo check -p rocketmq-auth --features grpc
 ```
 
-The `java_alignment` integration test covers Java-visible behavior such as remoting signature content, legacy
-`plain_acl.yml` semantics, deny precedence, super-user bypass, safe ACL reloads, factory caching, and request context
-model fields.
-
-Workspace-level validation is run from the repository root:
-
-```bash
-cargo fmt --all
-cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
-```
+`public_api_contract` checks exports and private-module boundaries; `security_api_identity` checks shared
+type identity. `java_alignment` covers signing content, YAML semantics, equal-resource deny precedence,
+super users, and reload behavior. Its invalid-file reload test does not establish transactional rollback
+on storage failure. The `secure_bootstrap_contract`, `secret_provider_contract`,
+`credential_rotation_contract`, and `release_checkpoint_authorization` integration suites cover their
+respective adapters. Use `cargo test -p rocketmq-auth` for the broader crate suite.
 
 ## Benchmarks
 
-Run focused authentication and authorization hot-path benchmarks with:
-
 ```bash
 cargo bench -p rocketmq-auth --bench auth_hot_path_bench
+cargo bench -p rocketmq-auth --bench auth_acl_watcher_lifecycle_bench
 ```
 
-The benchmark covers remoting signature calculation, white remote address matching, ACL policy matching, and stateful
-authentication/authorization cache hits.
-
-For CI or local regression gating, first verify the benchmark target compiles:
-
-```bash
-cargo test -p rocketmq-auth --benches --no-run
-```
-
-When collecting a baseline, run the benchmark on an otherwise idle machine and keep the generated Criterion report under
-`target/criterion/auth_*`. Compare future changes against the same toolchain and hardware; auth hot-path regressions should be investigated before merging changes that touch signing, whitelist matching, ACL policy matching, or stateful cache keys.
+The first measures signing, IP matching, ACL matching, and stateful cache hits. The second measures ACL
+reload and shutdown lifecycle behavior and writes a report under `target/runtime-baseline/prototype`.
+To compile benchmark targets without collecting measurements, use
+`cargo test -p rocketmq-auth --benches --no-run`. Compare measurements on the same toolchain and hardware;
+keep generated reports under `target/`.
 
 ## License
 
-RocketMQ-Rust is licensed under the Apache License 2.0. See [../LICENSE-APACHE](../LICENSE-APACHE).
+RocketMQ-Rust is licensed under the Apache License 2.0. See [LICENSE-APACHE](../LICENSE-APACHE).


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10306

### Brief Description

The auth quick start uses a private import and an outdated runtime constructor, while the READMEs overstate timestamp replay protection and ACL reload guarantees. Update `rocketmq-auth/README.md` and `rocketmq-auth/README-zh_cn.md` to match the current implementation.

- Correct crate-root imports, dependency examples, source links, service-context ownership, trusted remoting integration, and shutdown instructions.
- Document default-disabled checks, whitelist bypasses, policy precedence and request mapping, plaintext metadata persistence, nontransactional imports, and explicit stateful-cache wiring.
- Explain gRPC and separately composed security adapters, including platform limits, and synchronize the examples and validation guidance in both languages. Runtime behavior is unchanged.

### How Did You Test This Change?

Validation performed during preparation on Windows with the repository's Rust 1.95.0 toolchain:

- `cargo test -p rocketmq-auth --test public_api_contract --test security_api_identity --test java_alignment`: 12 tests passed.
- `cargo test -p rocketmq-auth --examples --no-run`: all 5 example targets compiled.
- A temporary standalone consumer used repository path dependencies and included the README as crate documentation. `cargo +1.95.0 test --offline --doc --features grpc --quiet` passed all 3 README Rust doctests and compiled the optional gRPC implementation.
- In that consumer, `cargo +1.95.0 run --offline --features grpc --quiet` ran the exact quick-start Rust code with the README YAML, loaded the ACL, created `users.json` and `acls.json`, and shut down successfully.
- Checked relative links, Markdown fences, TOML examples, configuration field names, and example/benchmark targets. All 9 code blocks are identical between languages. `git diff --check` passed for the two changed READMEs.

Unix-only bootstrap and encrypted-file success paths were not executed; this PR changes documentation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized authentication and authorization documentation around capabilities, boundaries, public APIs, and source structure.
  * Added guidance on dependencies, request-check semantics, persistence, reloads, caching, and security adapter integration.
  * Updated quick-start examples and expanded configuration references with additional fields and defaults.
  * Revised validation, benchmarking, and license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->