### PR TITLE
[ISSUE #10310]🐛Fix empty topic-list validation error assertion

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/topic_list_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/topic_list_core_models.rs
@@ -42,5 +42,6 @@ fn update_topic_list_request_rejects_empty_topic_config_list() {
     )
     .unwrap_err();
 
-    assert!(error.to_string().contains("topicConfigs must not be empty"));
+    assert_eq!(error.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
+    assert_eq!(error.to_string(), "core.argument.invalid: Argument is invalid");
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10310

### Brief Description

The empty topic-list test fails because it expects a legacy validation detail in public error output. Assert the canonical `CORE_ARGUMENT_INVALID` descriptor and public message instead. Empty-list rejection and production error rendering remain unchanged.

### How Did You Test This Change?

Passed locally on Windows with this patch before transferring it to an isolated submission worktree:

- `cargo test -p rocketmq-admin-core --test topic_list_core_models --features client-adapter --locked`: 2 passed.
- `cargo fmt -p rocketmq-admin-core -- --check`.
- Scoped `git diff --check` for the changed test file.

The full workspace suite and Linux CI were not rerun locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated validation coverage to verify the standardized error descriptor and exact message returned when an empty topic configuration list is submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->