### PR TITLE
[ISSUE #10325]📝Document client APIs and message completion semantics

### DIFF
--- a/rocketmq-website/docs/consumer/classic-pull-compatibility.md
+++ b/rocketmq-website/docs/consumer/classic-pull-compatibility.md
@@ -1,0 +1,94 @@
+---
+title: "Classic Pull compatibility"
+---
+
+# Classic Pull compatibility
+
+`DefaultMQPullConsumer` is deprecated for new development, but it has a functional runtime-backed compatibility path. Use [LitePull](./pull-consumer.md) for new polling applications. Keep Classic Pull when migrating code that explicitly selects a queue and offset for each request.
+
+## Runnable and detached construction
+
+| Construction | Runtime behavior |
+| --- | --- |
+| `DefaultMQPullConsumer::builder(client_runtime).consumer_group(...).build()?` | Builds a runnable facade using the supplied shared client runtime |
+| `new()`, `default()`, `with_consumer_group(...)` | Retains a detached compatibility value; operational methods return initialization errors |
+| Detached implementation marker | Does not create a fallback runtime |
+
+Changing only the group name on a detached value does not attach a runtime. Replace construction at the application boundary. The builder uses LitePull infrastructure in Classic manual mode with automatic commit disabled; it does not turn explicit pulls into normal background LitePull polling.
+
+The builder requires a group and validates its durations. By default, ordinary pull timeout is 10 seconds, Broker suspension is 20 seconds, and the client timeout for suspended requests is 30 seconds. Long-poll client timeout must exceed Broker suspension.
+
+## Perform one explicitly assigned pull
+
+The function below is a compatibility excerpt with complete facade cleanup. The caller supplies a queue it owns and the next offset it intends to read, and keeps the shared runtime alive. It returns messages to the caller without advancing business progress.
+
+```rust
+use std::sync::Arc;
+use rocketmq_client_rust::{
+    ClientResult, ClientRuntime, DefaultMQPullConsumer,
+    MessageSelector, PullOptions, PullResult,
+};
+use rocketmq_model::common::message::message_queue::MessageQueue;
+
+#[allow(deprecated)]
+async fn pull_once(
+    runtime: Arc<ClientRuntime>,
+    queue: MessageQueue,
+    next_offset: i64,
+) -> ClientResult<PullResult> {
+    let consumer = DefaultMQPullConsumer::builder(runtime)
+        .consumer_group("docs_classic_group")
+        .name_server_addr("127.0.0.1:9876")
+        .build()?;
+    let result = async {
+        consumer.start().await?;
+        let options = PullOptions::new(
+            queue, MessageSelector::by_tag("*"), next_offset, 16,
+        )?;
+        consumer.pull_with_options(options).await
+    }.await;
+    let shutdown = consumer.shutdown().await;
+    let result = result?;
+    shutdown?;
+    Ok(result)
+}
+```
+
+A long-running application should reuse one started facade and shut it down after its loop; creating a consumer per pull is not the intended throughput pattern. An error in the pull still executes shutdown here. The example does not claim automatic exclusive ownership of the supplied queue.
+
+## Interpret results before moving the cursor
+
+| `PullStatus` | Meaning and next action |
+| --- | --- |
+| `Found` | Process the returned messages; use `next_begin_offset` only after the intended batch succeeds |
+| `NoNewMsg` | No new eligible data for this request; use bounded waiting or long polling |
+| `NoMatchedMsg` | Data was scanned but did not match; the returned next offset can skip scanned non-matching positions |
+| `OffsetIllegal` | Requested position is outside the valid range; investigate retention/reset and the returned min/max/next positions |
+
+Do not increment an offset by the number of messages received: filtering and gaps can make that wrong. Do not treat `OffsetIllegal` as permission to silently discard a business recovery range.
+
+`PullOptions` validates the queue topic/Broker name, non-negative offset, positive message count and response-size bound, and valid timeouts. Enabling block-if-not-found on its ordinary defaults also requires increasing the client timeout beyond the suspension timeout. The facade's dedicated block-if-not-found methods use the corresponding builder settings.
+
+## Queue assignment and progress ownership
+
+`fetch_subscribe_message_queues` returns known queues; it does not mean this process exclusively owns all of them. Registered `MessageQueueListener` callbacks distinguish all queues from those divided to this consumer. Apply that assignment or a deliberate external ownership policy before pulling.
+
+The facade offers `update_consume_offset`, `fetch_consume_offset`, `min_offset`, `max_offset`, and `search_offset`. Offset update and remote persistence must be interpreted through the underlying offset-store path. A pull result alone never commits business progress.
+
+Complete business work before advancing the next-read position. Keep a durable business identity for replay, and stop pulling a revoked queue. The wrapper's state machine rejects repeated start, restart after failed startup, and restart after shutdown; create a new facade when restarting. Shutdown itself is idempotent.
+
+## Migrate to LitePull intentionally
+
+| Classic responsibility | LitePull decision |
+| --- | --- |
+| Explicit per-request queue and offset | Choose subscription-based assignment or explicit `assign`, then `seek` only for a deliberate position change |
+| Manual pull loop | Replace with bounded `poll`/zero-copy poll and processing |
+| Per-request selector | Configure equivalent topic subscription/selector before polling |
+| Application-owned progress | Set auto-commit deliberately and preserve processing-before-progress order |
+| Queue ownership callback | Preserve assignment/revocation behavior in the chosen mode |
+
+Do not run old and new consumers concurrently against the same group's progress without planning the handover. Record the last completed business position, stop the old owner, start the new mode, and inspect duplicates/gaps and group progress. A builder substitution alone is not an offset migration.
+
+Current LitePull `commit_all` updates client offset-store state and can internally log per-queue errors; it is not an immediate durable all-queue commit. Preserve this distinction during migration.
+
+Sources: [Classic facade](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/default_mq_pull_consumer.rs), [builder](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/default_mq_pull_consumer_builder.rs), [lifecycle and assignment adapter](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/default_mq_pull_consumer_impl.rs), [pull results](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/pull_result.rs).

--- a/rocketmq-website/docs/consumer/message-filtering.md
+++ b/rocketmq-website/docs/consumer/message-filtering.md
@@ -1,175 +1,97 @@
 ---
-sidebar_position: 4
-title: Message Filtering
+title: "Message filtering"
 ---
 
-# Message Filtering
+# Message filtering
 
-RocketMQ filtering helps consumers avoid processing irrelevant messages.
+Filtering selects messages for a subscription. It does not remove messages from the primary log, replace authorization, or guarantee that all business conditions were checked. Use tags for coarse event categories and supported SQL expressions for predicates over message properties.
 
-## Tag-based Filtering
+## Choose the layer
 
-### Basic Tag Subscription
+| Selection | Input | Boundary |
+| --- | --- | --- |
+| Tag expression | Message tag and `TagA || TagB` or `*` | Subscription filtering with a simple category model |
+| SQL92-style selector | Named string properties and a supported expression | Requires Broker property-filter support and valid subscription metadata |
+| Application predicate | Delivered message and business state | Consumes network/client capacity; application decides whether processing succeeded |
 
-```rust
-// Subscribe to one tag
-consumer.subscribe("OrderEvents", "order_created").await?;
+Keep group members' topic subscriptions and selectors consistent. A filter change is a change to what the group considers relevant; it is not a request to replay previously skipped records.
 
-// Subscribe to multiple tags
-consumer
-    .subscribe("OrderEvents", "order_created || order_paid")
-    .await?;
+## Set producer metadata
 
-// Subscribe to all tags
-consumer.subscribe("OrderEvents", "*").await?;
-```
-
-### Setting Tags on Producer
+This excerpt runs after the producer has started and the topic exists:
 
 ```rust
-use rocketmq_common::common::message::message_single::Message;
+use rocketmq_model::common::message::message_single::Message;
 
 let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
+    .topic("SqlFilterConsumerTestTopic")
     .tags("order_created")
+    .raw_property("region", "cn")?
+    .raw_property("priority", "3")?
+    .body("order event")
     .build()?;
-
-producer.send(message).await?;
+let result = producer.send_with_timeout(message, 3_000).await?;
 ```
 
-## Filtering with Message Properties
+Inspect the returned send status as described in [sending messages](../producer/sending-messages.md). Property values are strings on the message; SQL evaluation applies its supported coercion rules. A JSON field inside the body does not automatically become a filterable property.
 
-Producer can attach structured metadata to support downstream filtering logic.
+Treat tags as exact categories. `TagA || TagB` is a subscription expression, not a recommendation to put that entire expression into one message's tag.
+
+## Subscribe with a Tag or SQL selector
+
+For a started-later `DefaultMQPushConsumer` with its listener registered:
 
 ```rust
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
-    .tags("order_created")
-    .raw_property("amount", "150.00")?
-    .raw_property("region", "us-west")?
-    .raw_property("priority", "high")?
-    .build()?;
-
-producer.send(message).await?;
+consumer.subscribe("OrderEvents", "order_created || order_paid").await?;
 ```
 
-## Client-side Filtering (Property-based)
-
-When business conditions are dynamic or complex, you can do additional checks in the listener.
+For SQL, use the public `MessageSelector`:
 
 ```rust
-use cheetah_string::CheetahString;
-use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
-use rocketmq_common::common::message::MessageTrait;
+use rocketmq_client_rust::MessageSelector;
 
-consumer.register_message_listener_concurrently(|msgs, _ctx| {
-    let region_key = CheetahString::from_static_str("region");
-    let amount_key = CheetahString::from_static_str("amount");
-
-    for msg in msgs {
-        let region = msg
-            .property(&region_key)
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-
-        let amount = msg
-            .property(&amount_key)
-            .and_then(|v| v.parse::<f64>().ok())
-            .unwrap_or(0.0);
-
-        if region == "us-west" && amount > 100.0 {
-            // process_message(msg);
-        }
-    }
-
-    Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
-});
+consumer.subscribe_with_selector(
+    "SqlFilterConsumerTestTopic",
+    Some(MessageSelector::by_sql("region = 'cn' AND priority >= 3")),
+).await?;
 ```
 
-## SQL92 Notes
+Complete the lifecycle from [Push consumers](./push-consumer.md), including startup and shutdown. LitePull has its own `subscribe` and selector methods; do not copy Push method signatures into a LitePull loop.
 
-RocketMQ broker supports SQL92-based server-side filtering, but current public consumer examples in this project focus on tag-expression subscriptions and optional client-side property checks.
+The Broker's `enablePropertyFilter` defaults to false. For the canonical TOML configuration, merge this field into the existing `[broker]` table and restart the configured Broker using the normal setup procedure:
 
-If you need SQL92 at scale, verify your broker and client capability in an integration environment before adopting it in production.
-
-## Filter Performance
-
-### Tag Filtering
-
-- Performance: very fast
-- Location: broker side
-- Best for: stable event categories
-
-### Client-side Property Filtering
-
-- Performance: lower than tag filtering (messages still reach consumer)
-- Location: consumer side
-- Best for: dynamic or complex business conditions
-
-## Best Practices
-
-1. Prefer tag filtering as the first-stage filter.
-2. Keep tag taxonomy stable and business-oriented.
-3. Put frequently queried dimensions into message properties.
-4. Keep client-side filter logic lightweight.
-5. Monitor rejection rate to tune producer tagging strategy.
-
-## Examples
-
-### Order Processing
-
-```rust
-// Producer
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(order_json)
-    .tags("order_created")
-    .raw_property("region", &order.region)?
-    .raw_property("amount", order.amount.to_string())?
-    .build()?;
-producer.send(message).await?;
-
-// Consumer
-consumer.subscribe("OrderEvents", "order_created").await?;
+```toml
+[broker]
+enablePropertyFilter = true
 ```
 
-### Log Aggregation
+This is a configuration excerpt, not a complete Broker file. The non-Tag pull path rejects requests when this support is disabled, and client subscription checks compile the requested expression. All Brokers that can serve the subscription need compatible support; one enabled Broker does not configure the others.
 
-```rust
-// Producer
-let message = Message::builder()
-    .topic("ApplicationLogs")
-    .body(log_entry)
-    .tags(&log.level) // ERROR, WARN, INFO, DEBUG
-    .raw_property("service", &log.service)?
-    .raw_property("environment", &log.environment)?
-    .build()?;
-producer.send(message).await?;
+## Use the implemented expression language
 
-// Consumer
-consumer.subscribe("ApplicationLogs", "ERROR || WARN").await?;
-```
+The current SQL runtime supports logical `AND`/`OR`/`NOT`, comparisons, `IS NULL`/`IS NOT NULL`, `IN`/`NOT IN`, `BETWEEN`/`NOT BETWEEN`, and supported string predicates such as `CONTAINS`, `STARTSWITH` and `ENDSWITH`. It is a predicate language over properties, not a database `SELECT` statement with joins or arbitrary functions.
 
-### Event Routing
+Strings use single quotes and escape a quote by doubling it. Missing properties evaluate as `NULL`; the three-valued logic means a missing value is not automatically equivalent to false in every intermediate expression. Final Broker matching requires a true Boolean result. Validate missing, malformed and boundary values, not only one matching message.
 
-```rust
-// Producer
-let message = Message::builder()
-    .topic("UserEvents")
-    .body(event_json)
-    .tags(&event.event_type)
-    .raw_property("user_tier", &user.tier)?
-    .build()?;
-producer.send(message).await?;
+Numeric-looking strings can be coerced by the evaluator where required. Keep producer property schemas stable so a changed representation does not silently change matches. Do not assume every Java client or another Broker version supports identical expression extensions.
 
-// Consumer
-consumer.subscribe("UserEvents", "login || logout || purchase").await?;
-```
+## Understand prefiltering and final evaluation
 
-## Next Steps
+ConsumeQueue tag codes or optional Bloom metadata can reject candidates before loading full properties. Bloom hits are candidates, not proof of a final SQL match. The current filter falls back to later evaluation when relevant prefilter metadata is absent or unsuitable.
 
-- [Broker Configuration](../configuration/broker-config) - Configure filtering-related settings
-- [Producer Guide](../category/producer) - Set tags and properties properly
-- [Consumer Overview](./overview) - Learn consumption models and offset management
+For SQL, the Broker evaluates the compiled expression against message properties from the read path. Subscription versions and compiled filter metadata must agree. A stale subscription or missing filter metadata can fail before any message reaches a listener.
+
+Application-side filtering remains useful for decisions that require current business state. If the application intentionally ignores a delivered message and returns success, it has chosen to advance that consumer's progress. To process it later, define a replay or separate subscription rather than relying on rejection by application code.
+
+## Diagnose mismatches
+
+1. Confirm the target cluster, topic, group, starting offset and producer send result.
+2. Inspect the actual tag/property values using bounded authorized tooling; do not infer them from a message body.
+3. Check `enablePropertyFilter` and expression compilation errors for SQL.
+4. Compare the subscriptions of all group members and their versions.
+5. Test one matching, one non-matching and one missing-property event in an isolated group.
+6. Observe progress separately from delivered count: scanning filtered records can advance the next position without returning messages.
+
+From `rocketmq-example/`, `consumer-tag-filter` and `consumer-sql-filter` demonstrate their respective selectors. The SQL example uses `SqlFilterConsumerTestTopic` with `region = 'cn' AND priority >= 3`. Provision that topic/group and send matching properties; running an unrelated simple producer is insufficient.
+
+Sources: [selector API](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/message_selector.rs), [SQL language](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-filter/README.md), [Broker expression filter](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/filter/expression_message_filter.rs), [pull validation](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/processor/pull_message_processor.rs), [Broker configuration](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/config/broker_config.rs).

--- a/rocketmq-website/docs/consumer/pop.md
+++ b/rocketmq-website/docs/consumer/pop.md
@@ -1,0 +1,90 @@
+---
+title: "POP, receipts and acknowledgement"
+---
+
+# POP, receipts and acknowledgement
+
+POP temporarily makes a delivered message invisible and uses a receipt to acknowledge that delivery attempt. It differs from advancing a LitePull group's queue offset. A message whose attempt is not successfully acknowledged can become eligible for redelivery after its invisibility window.
+
+The current example uses `DefaultMQPushConsumer` with a concurrent listener and Broker-side request-mode configuration. It is not a separate public `DefaultPopConsumer` constructor.
+
+## Enable the intended path
+
+1. Create the topic and consumer group on the intended cluster, and verify ordinary routing.
+2. Use an authorized Admin operation to set that topic/group's request mode to POP.
+3. Build the Push consumer with the application's `ClientRuntime` and `client_rebalance(false)`.
+4. Register a concurrent listener and subscription, then start the consumer.
+5. Complete business work before returning success; close the facade before closing its shared runtime.
+
+`client_rebalance(false)` alone does not install the Broker's request-mode setting. The example uses `SetConsumerRequestModeRequest::try_new(topic, group, ConsumerRequestMode::Pop, 8, 3_000)` through Admin Core. The value 8 is the POP share-queue setting in that request, not an eight-second invisibility period.
+
+From `rocketmq-example/`, inspect `examples/consumer/pop_consumer.rs` before running:
+
+```bash
+cargo check --example pop-consumer
+cargo run --example pop-consumer
+```
+
+The current example changes request mode for `TopicTest` / `please_rename_unique_group_name_4` on the loopback NameServer. Rename and provision those constants for an isolated experiment. It performs a real administrative mutation; do not run it against an unrelated existing group's traffic.
+
+The example illustrates setup, but omits an explicit consumer-facade shutdown after signal handling. Use the cleanup structure in [Push consumers](./push-consumer.md) when integrating it: finish or bound current work, call `consumer.shutdown().await`, then close the shared client and process runtimes. Its full-message debug logging is also unsuitable for production data.
+
+## Understand one receipt's lifetime
+
+```mermaid
+sequenceDiagram
+    participant B as Broker POP state
+    participant C as Push POP client
+    participant A as Business handler
+    B-->>C: Messages plus delivery receipt and invisibility
+    C->>A: Invoke concurrent listener
+    alt Business succeeds within the window
+        A-->>C: ConsumeSuccess
+        C->>B: ACK successful prefix using receipts
+        B-->>C: ACK outcome
+    else Processing fails or needs retry
+        A-->>C: ReconsumeLater
+        C->>B: Change invisibility according to retry policy
+    end
+    opt Attempt remains unacknowledged at expiry
+        B-->>C: Message becomes eligible for another delivery
+    end
+```
+
+A receipt is delivery-attempt metadata, not the business event ID. It carries the information needed to address the relevant Broker/queue and POP checkpoint. Do not substitute a message key or logical offset, forge receipt fields, or reuse a receipt as authority for a different attempt.
+
+The consumer callback receives the message, while the POP service uses its associated metadata for ACK. Retain a separate stable business identity for deduplication across attempts.
+
+## Invisibility is a bounded opportunity
+
+The current Push defaults request `pop_invisible_time = 60_000` milliseconds and `pop_batch_nums = 32`. These are different from listener batch size and ordinary pull timeout. Broker validation and selected mode also constrain requests.
+
+The invisibility clock includes time spent queued before the handler starts. Increasing callback concurrency may help a queueing bottleneck, but does not make a slow downstream dependency safe. A handler can finish after the original window and then coexist with another attempt.
+
+The current concurrent POP service checks expiration before invocation and before applying its result. It does not promise automatic continuous renewal while a long-running callback executes. Size the window for bounded work, or use a documented lower-level/Proxy renewal path that owns refreshed receipt state and its failures.
+
+Changing invisibility is a remote operation with a result. A successful change affects that attempt's timing; it does not commit the business operation. Treat a timed-out renewal as uncertain and use the receipt returned by the selected API where renewal replaces it.
+
+## Listener success is not an ACK receipt
+
+The concurrent service normalizes the successful prefix and calls its batch-ACK path. Individual ACK errors are logged and rely on redelivery; the application listener's `ConsumeSuccess` cannot prove that every Broker ACK succeeded.
+
+For failed messages, the service chooses a retry delay and changes invisibility. Once the configured maximum reconsume count is reached, the current implementation also considers message age and can ACK an old message or delay it again. Do not claim that every failed POP message necessarily enters a DLQ through this client branch.
+
+If business effects commit and ACK fails, the next attempt must detect the already-completed business event. If success is returned before business commit, ACK can remove the attempt from ordinary redelivery while work is incomplete. This is the same application boundary described in [delivery and retry](../guides/delivery-and-retry.md), implemented with receipts instead of LitePull commits.
+
+## Diagnose and change modes
+
+| Symptom | First checks |
+| --- | --- |
+| POP path is not selected | Broker topic/group request mode, client rebalance setting, assignment response |
+| Duplicate delivery while handler runs | Queue wait plus handler time versus invisibility, renewal outcome |
+| Callback succeeds but message returns | ACK response/logs, receipt validity, Broker reachability |
+| Repeated failures stop appearing | Retry-count/age policy and any application recovery store; do not assume DLQ without evidence |
+| Shutdown abandons business work | Owned handler tasks, facade cleanup and remaining attempt lifetime |
+
+A change from Pull to POP changes progress semantics. Stop the old consumers, define how existing offsets and in-flight attempts will be handled, change the group mode deliberately, and observe the new assignment/acknowledgement path. Do not treat a live mode switch as a no-impact tuning option.
+
+This page describes the current concurrent Push POP implementation and the example wiring. It does not establish crash recovery, failover, ordered POP, or identical semantics across Proxy and Java clients.
+
+Sources: [POP example](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/consumer/pop_consumer.rs), [concurrent POP processing](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs), [ACK and change-invisibility adapter](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs), [Broker POP processor](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/processor/pop_message_processor.rs).

--- a/rocketmq-website/docs/consumer/push-consumer.md
+++ b/rocketmq-website/docs/consumer/push-consumer.md
@@ -1,163 +1,111 @@
 ---
-sidebar_position: 2
-title: Push Consumer
+title: "Push consumers"
 ---
 
-# Push Consumer
+# Push consumers
 
-Push consumption in RocketMQ-Rust is implemented by `DefaultMQPushConsumer`. The client pulls messages in the background and dispatches them to your listener callbacks.
+`DefaultMQPushConsumer` delivers messages to a registered listener. In ordinary Pull mode, the client performs route discovery, queue assignment and background pulls/long polling, then schedules callbacks. “Push” describes the application interface, not an unconditional Broker-initiated stream.
 
-## Creating a Push Consumer
+For a manually polled application, use [LitePull](./pull-consumer.md). For Broker-managed invisibility and receipt acknowledgement, see [POP](./pop.md); its successful listener result follows a different acknowledgement path.
 
-```rust
-use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
-use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
-use rocketmq_client_rust::ClientResult;
+## Start a consumer with a complete lifecycle
 
-#[tokio::main]
-async fn main() -> ClientResult<()> {
-    let mut consumer = DefaultMQPushConsumer::builder()
-        .consumer_group("my_consumer_group")
-        .name_server_addr("localhost:9876")
-        .consume_thread_min(2)
-        .consume_thread_max(20)
-        .build();
-
-    consumer.subscribe("TopicTest", "*").await?;
-    consumer.start().await?;
-
-    Ok(())
-}
-```
-
-## Message Listeners
-
-### Concurrent Message Listener
+Create `DocsFirstMessage` using [quick start](../getting-started/quick-start.md), and repeat its group-creation command with `-g docs_push_group` for this consumer. The following function uses the tutorial's shared `Arc<ClientRuntime>`. The listener counts messages as processed for demonstration; replace that operation with bounded, idempotent business processing before returning success.
 
 ```rust
-use rocketmq_client_rust::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
-use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
-use rocketmq_client_rust::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
-use rocketmq_common::common::message::message_ext::MessageExt;
-use rocketmq_client_rust::ClientResult;
+use std::sync::Arc;
+use rocketmq_client_rust::{
+    ClientResult, ClientRuntime, ConsumeConcurrentlyContext,
+    ConsumeConcurrentlyStatus, DefaultMQPushConsumer,
+    MessageListenerConcurrently, MQPushConsumer,
+};
+use rocketmq_model::common::message::message_ext::MessageExt;
 
-struct MyListener;
+struct CountListener;
 
-impl MessageListenerConcurrently for MyListener {
+impl MessageListenerConcurrently for CountListener {
     fn consume_message(
         &self,
         messages: &[&MessageExt],
         _context: &ConsumeConcurrentlyContext,
     ) -> ClientResult<ConsumeConcurrentlyStatus> {
-        for msg in messages {
-            println!("Processing: {:?}", msg.msg_id());
-        }
+        println!("received={}", messages.len());
         Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
     }
 }
 
-consumer.register_message_listener_concurrently(MyListener);
-```
-
-### Ordered Message Listener
-
-```rust
-use rocketmq_client_rust::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
-use rocketmq_client_rust::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
-use rocketmq_client_rust::consumer::listener::message_listener_orderly::MessageListenerOrderly;
-use rocketmq_common::common::message::message_ext::MessageExt;
-use rocketmq_client_rust::ClientResult;
-
-struct OrderListener;
-
-impl MessageListenerOrderly for OrderListener {
-    fn consume_message(
-        &self,
-        messages: &[&MessageExt],
-        context: &mut ConsumeOrderlyContext,
-    ) -> ClientResult<ConsumeOrderlyStatus> {
-        for msg in messages {
-            process_in_order(msg);
-        }
-        context.set_auto_commit(true);
-        Ok(ConsumeOrderlyStatus::Success)
-    }
+async fn consume_until_interrupt(
+    client_runtime: Arc<ClientRuntime>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut consumer = DefaultMQPushConsumer::builder(client_runtime)
+        .consumer_group("docs_push_group")
+        .name_server_addr("127.0.0.1:9876")
+        .consume_message_batch_max_size(1)
+        .build();
+    let outcome = async {
+        consumer.subscribe("DocsFirstMessage", "*").await?;
+        consumer.register_message_listener_concurrently(CountListener);
+        consumer.start().await?;
+        tokio::signal::ctrl_c().await?;
+        Ok(())
+    }.await;
+    consumer.shutdown().await;
+    outcome
 }
-
-consumer.register_message_listener_orderly(OrderListener);
 ```
 
-## Subscription Patterns
+Invoke the function on the owning RuntimeOwner, then close the shared ClientRuntime, RuntimeOwner, and telemetry. Register a listener and subscription before startup. Publish after the consumer starts when learning the default new-group behavior; an existing stored offset can override the initial-position setting.
 
-### Single Topic
+## Choose concurrency and consumption model
 
-```rust
-consumer.subscribe("TopicTest", "*").await?;
-```
+| Choice | Meaning |
+| --- | --- |
+| Concurrent listener | Different batches can run concurrently; completion order can differ from queue order |
+| Orderly listener | Serializes consumption within the relevant queue ownership/lock boundary |
+| Clustering | Group members divide work; retries use the group's configured path |
+| Broadcasting | Each instance receives its own copy; the ordinary concurrent implementation logs and drops failed deliveries rather than using clustered send-back retries |
 
-### Multiple Topics
+The listener methods are synchronous. The client dispatches them through its managed blocking boundary, but downstream calls still need their own finite timeouts and capacity. Returning success immediately after handing work to an unowned background task can advance progress before the work commits.
 
-```rust
-consumer.subscribe("TopicA", "*").await?;
-consumer.subscribe("TopicB", "tag1 || tag2").await?;
-```
+Do not mix concurrent and orderly listener contracts or inconsistent subscriptions within one logical group. Group members should agree on topic, selector, consumption model and intended ordering. A second independent business application normally needs its own consumer group.
 
-### Message Selectors
+## Translate listener outcomes into progress
 
-```rust
-use rocketmq_client_rust::consumer::message_selector::MessageSelector;
+`ConsumeSuccess` marks the successfully processed prefix; `ReconsumeLater` treats the batch as unsuccessful. The default concurrent context acknowledges all messages on success. If partial acknowledgement is used, it is a prefix index, not an arbitrary subset of the batch.
 
-let selector = MessageSelector::by_sql("amount > 100 AND region = 'us-west'");
-consumer
-    .subscribe_with_selector("OrderEvents", Some(selector))
-    .await?;
-```
+In ordinary clustered concurrent consumption, failed messages go through the send-back path. Failures to send back remain pending for a later local attempt. Completed or successfully handed-off messages can be removed from the process queue, allowing its next safe offset to advance. Offset persistence is a separate step.
 
-## Concurrency Configuration
+Consequently, business completion, listener success, progress update and persistent group progress are different events. Processing must tolerate replay after a crash in between them. Broadcasting requires an explicit application recovery policy because its failure behavior differs.
 
-```rust
-let mut consumer = DefaultMQPushConsumer::builder()
-    .consumer_group("my_consumer_group")
-    .name_server_addr("localhost:9876")
-    .consume_thread_min(2)
-    .consume_thread_max(20)
-    .pull_batch_size(32)
-    .pull_interval(0)
-    .pull_threshold_for_queue(1024)
-    .pull_threshold_for_topic(10_000)
-    .build();
-```
+For orderly consumption, use `MessageListenerOrderly` and its `ConsumeOrderlyStatus`. A failed current queue can suspend and retry; that protects local sequence at the cost of queue progress. See [ordered messages](../guides/ordered-messages.md) for send-side mapping and failure boundaries.
 
-## Offset Position
+## Rebalance and control memory
 
-```rust
-use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+Route changes or group membership changes can revoke and assign queues. Treat queue ownership as temporary. Stop work belonging to revoked ownership and keep business idempotency effective across a move to another process.
 
-let mut consumer = DefaultMQPushConsumer::builder()
-    .consumer_group("my_consumer_group")
-    .name_server_addr("localhost:9876")
-    .consume_from_where(ConsumeFromWhere::ConsumeFromLastOffset)
-    .build();
-```
+| Setting family | What it bounds or influences |
+| --- | --- |
+| `pull_batch_size` | Requested network batch size |
+| `consume_message_batch_max_size` | Messages passed to one listener invocation |
+| `consume_thread_min` / `consume_thread_max` | Managed consumption concurrency controls, not permission to block indefinitely |
+| `pull_threshold_for_queue` / `pull_threshold_size_for_queue` | Buffered queue count/size pressure |
+| Topic thresholds and `pull_interval` | Topic-level pressure and pull pacing |
+| `consume_from_where` | Initial position when no usable stored progress determines the start |
 
-## Pause and Resume
+Network batch size and callback batch size are different. Larger caches can retain message bodies and delay shutdown; increasing threads does not fix a saturated database. Choose limits from the real handler cost and observe lag, pending count, retained bytes and retry rate together.
 
-```rust
-consumer.suspend().await;
-// ...
-consumer.resume().await;
-```
+Suspension pauses intake according to the consumer path; it is not a transaction barrier that proves all callbacks finished. Use explicit shutdown when leaving the service lifecycle.
 
-## Best Practices
+## Diagnose a running consumer
 
-1. Size consume threads according to your business handler complexity.
-2. Use concurrent listener for throughput, orderly listener for strict ordering.
-3. Keep listener logic idempotent to handle retries.
-4. Tune `pull_batch_size` and pull thresholds under real load.
-5. Prefer server-side filtering to reduce unnecessary network transfer.
+| Observation | Check next |
+| --- | --- |
+| No callbacks | Topic route, group configuration, listener registration, starting offset, selector |
+| More instances but little additional throughput | Queue count/assignment and downstream bottleneck |
+| Repeated delivery | Listener failures, send-back/ACK failures, rebalance and persisted progress |
+| Lag rises while callbacks succeed | Handler latency, queue assignment, persistence and which cluster/group the metric describes |
+| Broadcast failure disappears | The broadcast branch does not provide clustered retry semantics |
 
-## Next Steps
+From `rocketmq-example/`, `consumer-cluster` demonstrates concurrent clustering and `consumer-orderly` demonstrates the orderly interface. Inspect their topic/group constants before provisioning and running them. The SQL and Tag examples have their own topics. Use [first diagnosis](../operations/first-diagnosis.md) for the cluster-side commands.
 
-- [Pull Consumer](./pull-consumer) - Learn about pull consumer
-- [Message Filtering](./message-filtering) - Advanced filtering techniques
-- [Client Configuration](../configuration/client-config) - Consumer configuration options
+Sources: [Push facade/configuration](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/default_mq_push_consumer.rs), [Push lifecycle](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs), [concurrent processing](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs), [orderly processing](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs).

--- a/rocketmq-website/docs/guides/delay-and-recall.md
+++ b/rocketmq-website/docs/guides/delay-and-recall.md
@@ -1,0 +1,103 @@
+---
+title: "Delayed delivery and recall"
+---
+
+# Delayed delivery and recall
+
+Delayed messages become eligible for delivery after a configured delay or timestamp. Eligibility is separate from actual consumer processing: dispatch backlog, consumer availability and business work add latency. A timer is not a real-time deadline guarantee.
+
+## Select one scheduling form
+
+| Message builder option | Meaning | Server-side condition |
+| --- | --- | --- |
+| `delay_level(n)` | Index into the configured delay-level table | The Broker/store's level scheduler and current `messageDelayLevel` mapping |
+| `delay_secs(n)` | Relative delay in seconds | Timer normalization and selected timer engine |
+| `delay_millis(n)` | Relative delay in milliseconds | Timer normalization and configured precision |
+| `deliver_time_ms(timestamp)` | Absolute Unix-epoch milliseconds | Clock interpretation, future timestamp and admission horizon |
+
+Use one scheduling form per message. Current timer-property precedence is seconds, then milliseconds, then absolute delivery time; relying on that precedence makes mixed-property messages harder to reason about. Do not combine delay-level and timer properties.
+
+The default level table starts at 1 second, 5 seconds and 10 seconds, so level 3 is 10 seconds with that table. The mapping is configurable. The current default timer precision is 1,000 ms and the standard maximum delay is three days; the compatible precision set is 100, 200, 500 or 1,000 ms. These defaults are source configuration, not a universal deployment guarantee.
+
+## Send and observe a timer message
+
+Use the full producer lifecycle from [sending messages](../producer/sending-messages.md). Provision `DelaySendTestTopic` and a consumer subscribed to it. The following excerpt runs after producer startup:
+
+```rust
+let message = Message::builder()
+    .topic("DelaySendTestTopic")
+    .key("reminder-1001")
+    .delay_secs(30)
+    .body("reminder")
+    .build()?;
+let send_result = producer.send_with_timeout(message, 3_000).await?;
+```
+
+Inspect the optional result and `send_status` before treating the send as acknowledged. Record the business event ID and, when present, the returned `recall_handle`. A message key is not itself a recall handle.
+
+For an absolute timestamp, calculate Unix-epoch milliseconds with checked arithmetic and synchronize the participating hosts' clocks. Normalization rejects malformed values, overflow, past timestamps and requests outside the configured horizon. The wire representation's millisecond unit does not imply millisecond delivery accuracy.
+
+The relevant standard TOML keys belong in the existing `[store]` table:
+
+```toml
+[store]
+timerWheelEnable = true
+timerPrecisionMs = 1000
+timerMaxDelaySec = 259200
+```
+
+This is an excerpt, not a complete Broker configuration. A configured timer also requires its selected backend and service lifecycle to be active. Extended timeline mode has separate RocksDB/feature and admission-horizon conditions; do not infer its availability from the standard timer example.
+
+## Recall using the returned handle
+
+Recall is intended for eligible timer messages before they become due. The current handle-generation path does not give ordinary delay-level messages the same recall handle. Require the actual `SendResult.recall_handle` instead of fabricating one from the message ID.
+
+This excerpt assumes `result` is a successfully inspected `SendResult` and the producer is still started:
+
+```rust
+if let Some(handle) = result.recall_handle.as_deref() {
+    let recalled_message_id = producer
+        .recall_message("DelaySendTestTopic", handle)
+        .await?;
+}
+```
+
+The client checks lifecycle, topic and a non-empty decodable handle, then resolves its Broker. Retry/DLQ topics are not supported by this facade. The Broker checks recall enablement, role/availability, write permission policy, topic existence, matching topic/Broker in the handle, and the remaining time window.
+
+The Broker's `recallMessageEnable` currently defaults to true, but the actual deployment's authorization still applies. Remaining time must be positive and strictly below the selected maximum recall horizon. A valid-looking handle is not authority to bypass topic permissions.
+
+## Interpret recall according to the engine
+
+In the standard path, recall appends a timer deletion marker. Its response is evidence about the marker write path, not a synchronous scan proving that no consumer ever saw the original message. Delivery and deletion processing can race.
+
+In ExtendedTimeline mode, the current processor uses a typed cancellation operation. `Cancelled` and `AlreadyCancelled` map to success; `TooLate`/`NotFound` map to an illegal operation; `Retry` maps to service unavailable; `Quarantined`/`Unsupported` map to a system error. That explicit state result is different from the standard marker path.
+
+In either mode, recall does not undo a consumer's completed external side effect. Keep business cancellation state authoritative so a late reminder can be recognized and ignored or compensated according to the application's rules.
+
+## Failure and recovery decisions
+
+| Observation | Interpretation |
+| --- | --- |
+| Send times out | Timer admission may be uncertain; reconcile before creating a second business reminder |
+| Send result has no recall handle | Do not infer recall support from a delay setting alone |
+| Recall reports topic/Broker mismatch | Check the exact original handle and target; do not edit handle fields |
+| Recall is too late | Delivery may have become eligible; use the application's cancellation policy |
+| Recall times out | The remote cancellation/marker may have succeeded; preserve the original identity when reconciling |
+| Delivery is later than requested | Inspect timer dispatch, clock, storage and consumer backlog separately |
+
+Batch validation and the transaction producer reject delayed/timer combinations in their respective paths. A delayed send also does not impose ordering relative to ordinary messages sent later to the same business topic.
+
+## Example and validation scope
+
+From `rocketmq-example/`:
+
+```bash
+cargo check --example producer-delay-send
+cargo run --example producer-delay-send
+```
+
+The example sends four messages to `DelaySendTestTopic` using level, relative seconds, relative milliseconds and absolute timestamp forms. It uses the loopback NameServer and then closes its producer. Pair it with a consumer on that exact topic and compare requested eligibility with actual receive time.
+
+The example does not invoke recall, test a near-deadline race, or demonstrate timer recovery after a crash. Those scenarios require separate observation against the chosen engine and persistence configuration.
+
+Sources: [delay example](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/producer/delay_send.rs), [timer normalization](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-model/src/common/message/timer_request.rs), [store configuration](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-store/src/config/message_store_config.rs), [handle generation](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/processor/send_message_processor/message_builder.rs), [recall processor](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/processor/recall_message_processor.rs).

--- a/rocketmq-website/docs/guides/ordered-messages.md
+++ b/rocketmq-website/docs/guides/ordered-messages.md
@@ -1,0 +1,94 @@
+---
+title: "Ordered messages"
+---
+
+# Ordered messages
+
+Ordering is a contract across producer routing, queue storage, consumer scheduling and business completion. Putting an order ID into a message key alone does not establish that contract.
+
+For one business entity, send events serially to the same queue and process that queue through the intended orderly consumer path. Independent queues can progress in parallel and have no global ordering relation.
+
+## Define the ordering scope
+
+```mermaid
+flowchart LR
+    A["Order A: created → paid → shipped"] --> Q0["Queue 0"]
+    B["Order B: created → paid → shipped"] --> Q1["Queue 1"]
+    Q0 --> C0["Serial handler for Queue 0"]
+    Q1 --> C1["Serial handler for Queue 1"]
+    C0 --> D0["Commit A effects in sequence"]
+    C1 --> D1["Commit B effects in sequence"]
+```
+
+The arrows show per-queue sequencing. There is no arrow requiring an event on Queue 0 to finish before one on Queue 1. Several entities can share a queue; one blocked entity can then hold up others on that queue.
+
+## Route related events consistently
+
+The producer selector returns a queue from the current candidates. This excerpt assumes a started producer, an existing topic and an application-defined `order_id: usize`:
+
+```rust
+let message = Message::builder()
+    .topic("OrderSendTestTopic")
+    .key(format!("order-{order_id}"))
+    .body("created")
+    .build()?;
+let result = producer.send_with_selector(
+    message,
+    |queues, _message, key: &usize| {
+        if queues.is_empty() { None }
+        else { Some(queues[*key % queues.len()].clone()) }
+    },
+    order_id,
+).await?;
+```
+
+Inspect the send result before sending the next dependent event. A queue selector controls placement; it does not serialize two concurrent producers or await downstream business work.
+
+Modulo routing is suitable for explaining the mechanism, but its mapping changes when the candidate list or queue count changes. An operational change needs a handover policy for in-flight sequences. Do not send the next event to a different queue merely because the first queue is temporarily unavailable.
+
+## Consume through the orderly interface
+
+Use `DefaultMQPushConsumer` with `MessageListenerOrderly`, a consistent group/subscription and the desired message model. In clustering mode, the client coordinates queue locks with the Broker and serializes local processing. Concurrent listeners do not provide the same ordering boundary.
+
+An orderly listener receives `&mut ConsumeOrderlyContext` and returns `ConsumeOrderlyStatus`. With automatic commit in the context, return `Success` only after the ordered business effects complete. `SuspendCurrentQueueAMoment` postpones the current queue for retry. Legacy manual commit/rollback status handling must be understood before changing the context's auto-commit behavior.
+
+Do not start independent asynchronous business work and return success immediately. The next callback may then commit its effect before the previous one. A database sequence/version check can reject duplicates and detect gaps across process restarts or ownership transfers.
+
+## Handle failure without inventing global order
+
+| Failure | Consequence |
+| --- | --- |
+| Send response is lost | The event may already exist; reconcile/retry with stable identity before advancing the business sequence |
+| Same key is sent concurrently | Broker arrival order may differ from the business intention |
+| Queue count or candidate ordering changes | Simple selector mapping may move an entity |
+| Current handler fails | Queue suspension/retry can stop later work on that queue |
+| Rebalance or lock loss | Ownership changes; external business effects still require idempotency and sequence checks |
+| Retry/discard policy eventually moves past a failed event | Application must decide how a business sequence gap is repaired |
+
+Orderly processing does not imply exactly-once effects or unlimited retry. Changing retry limits affects whether later business events can proceed after a poison event. Cross-topic workflows need application orchestration or state checks; there is no automatic order across separate topics.
+
+## Exercise the matched example pair
+
+The existing producer and orderly consumer both use `OrderSendTestTopic`. Provision that topic and `consumer_orderly_group` using the resource-creation procedure in [quick start](../getting-started/quick-start.md), substituting these names. Both examples use `127.0.0.1:9876`.
+
+From `rocketmq-example/`, compile the pair:
+
+```bash
+cargo check --example producer-order-send --example consumer-orderly
+```
+
+Start the consumer in one terminal, then the producer in a second terminal, both from that directory:
+
+```bash
+cargo run --example consumer-orderly
+```
+
+```bash
+cargo run --example producer-order-send
+```
+
+The producer emits created, paid, packed and shipped events for four order IDs. Compare queue/offset and business sequence per order; interleaving between different queues is expected. The consumer uses first-offset behavior for a new group and waits for a signal before shutdown. Existing group progress or old data changes the observed sample.
+
+These targets demonstrate one fixed-topology run. They do not prove ordering through failover, queue expansion, concurrent multi-producer sends or a consumer database crash. Keep those as separate application scenarios.
+
+Sources: [producer example](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/producer/order_send.rs), [consumer example](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/consumer/orderly_consumer.rs), [orderly service](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs), [selector send facade](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/default_mq_producer.rs).

--- a/rocketmq-website/docs/producer/sending-messages.md
+++ b/rocketmq-website/docs/producer/sending-messages.md
@@ -1,278 +1,122 @@
 ---
-sidebar_position: 2
-title: Sending Messages
+title: "Sending messages"
 ---
 
-# Sending Messages
+# Sending messages
 
-This page covers practical sending patterns using `DefaultMQProducer` and `MQProducer`.
+Choose a send method by how the application observes completion and selects a destination. All methods use an application-owned `ClientRuntime` and a started producer. Begin with [quick start](../getting-started/quick-start.md) for the complete runtime, Broker, topic, and shutdown setup.
 
-## Message Types
+## Choose the result contract
 
-### Basic Message
+“Synchronous send” here means waiting for a Broker response. The Rust call is still an asynchronous future and is awaited.
 
-```rust
-use rocketmq_common::common::message::message_single::Message;
+| API family | Result channel | Suitable use |
+| --- | --- | --- |
+| `send`, `send_with_timeout` | `ClientResult<Option<SendResult>>` | Observe the send response before continuing |
+| `send_with_callback`, `send_with_callback_timeout` | Immediate method result plus callback result/error | Keep bounded application work in flight and correlate completion |
+| `send_oneway` | `ClientResult<()>` without a Broker response | Cases where the application deliberately does not require remote acknowledgement |
+| `send_batch` and timeout variants | `ClientResult<SendResult>` | Send an explicit eligible batch |
+| `send_to_queue` and queue variants | Same completion style, chosen queue | Preserve a known destination |
+| `send_with_selector` and selector variants | Same completion style, application selects from available queues | Route related events using a stable business key |
 
-let message = Message::builder()
-    .topic("TopicTest")
-    .body("Hello, RocketMQ!")
-    .build()?;
+An `Ok` wrapper is not sufficient to count a successful acknowledged send. Inspect `SendResult.send_status`, and handle `None` explicitly where the API permits it. The direct timeout path expects a response; absence is not a successful Broker acknowledgement.
 
-producer.send(message).await?;
-```
+`SendStatus::SendOk`, `FlushDiskTimeout`, `FlushSlaveTimeout`, and `SlaveNotAvailable` have different meanings. The latter statuses can follow an accepted append. The status names retain the protocol's terminology; [storage design](../architecture/storage.md) explains the corresponding durability and replica conditions. Even `SendOk` does not mean a consumer completed its business work.
 
-### Message with Tags
+## Send one message and inspect its status
 
-```rust
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
-    .tags("order_created")
-    .build()?;
-
-producer.send(message).await?;
-```
-
-### Message with Keys
+This complete function accepts the shared runtime created in the quick-start application. Call it on that runtime and close the shared ClientRuntime and RuntimeOwner afterward. Provision `DocsFirstMessage` before calling it.
 
 ```rust
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
-    .key("order_12345")
-    .build()?;
+use std::{io, sync::Arc};
+use rocketmq_client_rust::{ClientRuntime, DefaultMQProducer, SendResult, SendStatus};
+use rocketmq_model::common::message::message_single::Message;
 
-producer.send(message).await?;
-```
-
-### Message with Properties
-
-```rust
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
-    .raw_property("region", "us-west")?
-    .raw_property("priority", "high")?
-    .raw_property("source", "mobile_app")?
-    .build()?;
-
-producer.send(message).await?;
-```
-
-## Send Strategies
-
-### Sequential Sending
-
-```rust
-for msg in messages {
-    producer.send(msg).await?;
-}
-```
-
-### Concurrent Sending
-
-```rust
-use futures::future::join_all;
-
-let tasks = messages
-    .into_iter()
-    .map(|msg| producer.send(msg))
-    .collect::<Vec<_>>();
-
-let results = join_all(tasks).await;
-```
-
-### Delayed Sending
-
-```rust
-let message = Message::builder()
-    .topic("DelayedTopic")
-    .body(body)
-    .delay_level(3) // 1=1s, 2=5s, 3=10s ...
-    .build()?;
-
-producer.send(message).await?;
-```
-
-## Message Size Management
-
-### Large Messages
-
-```rust
-let mut producer = DefaultMQProducer::builder()
-    .producer_group("my_group")
-    .name_server_addr("localhost:9876")
-    .compress_msg_body_over_howmuch(4 * 1024)
-    .build();
-
-let large_body = vec![0u8; 5 * 1024 * 1024];
-let message = Message::builder()
-    .topic("TopicTest")
-    .body(large_body)
-    .build()?;
-
-producer.send(message).await?;
-```
-
-### Splitting Large Messages
-
-```rust
-use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-use rocketmq_client_rust::producer::mq_producer::MQProducer;
-
-async fn split_and_send(
-    producer: &mut DefaultMQProducer,
-    topic: &str,
-    data: Vec<u8>,
-    chunk_size: usize,
-) -> rocketmq_client_rust::ClientResult<()> {
-    let chunks: Vec<_> = data.chunks(chunk_size).collect();
-    let total = chunks.len();
-
-    for (i, chunk) in chunks.iter().enumerate() {
+async fn send_one(
+    client_runtime: Arc<ClientRuntime>,
+) -> Result<SendResult, Box<dyn std::error::Error>> {
+    let mut producer = DefaultMQProducer::builder(client_runtime)
+        .producer_group("docs_sending_group")
+        .name_server_addr("127.0.0.1:9876")
+        .build();
+    let outcome: Result<SendResult, Box<dyn std::error::Error>> = async {
+        producer.start().await?;
         let message = Message::builder()
-            .topic(topic)
-            .body_slice(chunk)
-            .key(format!("chunk-{i}-{total}"))
+            .topic("DocsFirstMessage")
+            .key("order-1001:event-1")
+            .tags("created")
+            .body("order created")
             .build()?;
-
-        producer.send(message).await?;
-    }
-
-    Ok(())
-}
-```
-
-## Error Handling
-
-### Retry on Failure
-
-```rust
-use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-use rocketmq_client_rust::producer::mq_producer::MQProducer;
-use rocketmq_client_rust::producer::send_result::SendResult;
-
-async fn send_with_retry(
-    producer: &mut DefaultMQProducer,
-    message: Message,
-    max_retries: u32,
-) -> rocketmq_client_rust::ClientResult<Option<SendResult>> {
-    let mut retry_count = 0;
-
-    loop {
-        match producer.send(message.clone()).await {
-            Ok(result) => return Ok(result),
-            Err(e) if retry_count < max_retries => {
-                retry_count += 1;
-                tokio::time::sleep(std::time::Duration::from_millis(1_000)).await;
-                eprintln!("retry {} after error: {}", retry_count, e);
-            }
-            Err(e) => return Err(e),
+        let result = producer.send_with_timeout(message, 3_000).await?
+            .ok_or_else(|| io::Error::other("send response is absent"))?;
+        if result.send_status != SendStatus::SendOk {
+            return Err(io::Error::other(format!(
+                "send policy not satisfied: {}", result.send_status
+            )).into());
         }
-    }
+        Ok(result)
+    }.await;
+    producer.shutdown().await;
+    outcome
 }
 ```
 
-### Fallback Topic
+The key supports business correlation; setting a key does not make the Broker deduplicate sends. Persist the business event identity independently if it must survive retries or process restarts. The cleanup runs after an operation error too.
+
+## Use callbacks without losing failures
+
+Callbacks receive `Option<&SendResult>` and `Option<&ClientError>`. Those references belong to the callback invocation; copy the bounded information needed for later processing. Avoid retaining a whole request or message body in a completion record.
+
+Inspect both channels: a method can fail before submission, and completion can fail through the callback. In the current `send_with_callback` facade, some underlying submission errors are delivered to the callback and the method returns `Ok(())`. Therefore, counting only successful method returns will overcount successful sends.
+
+Keep the producer and runtime alive until the application's outstanding completion records settle or its explicit deadline expires. Bound in-flight count/bytes and callback work. A callback should not block a runtime worker or launch unowned background tasks. Shutdown is not a substitute for correlating each business operation's outcome.
+
+One-way sending has no send-result callback or Broker acknowledgement to inspect. Successful local submission cannot establish remote persistence. It should not be used when the next business step requires confirmation that the Broker accepted the event.
+
+## Send a valid batch
+
+An explicit batch is non-empty, uses one topic and a consistent `waitStoreMsgOK` value, and excludes retry-topic messages and delayed/timer messages. The current `MessageBatch` validator checks delay level, relative millisecond/second delay, and absolute delivery timestamp properties. Do not combine transaction semantics with the ordinary batch path.
+
+The following is an excerpt after producer startup:
 
 ```rust
-async fn send_with_fallback(
-    producer: &mut DefaultMQProducer,
-    message: Message,
-    fallback_topic: &str,
-) -> rocketmq_client_rust::ClientResult<Option<SendResult>> {
-    match producer.send(message.clone()).await {
-        Ok(result) => Ok(result),
-        Err(_) => {
-            let mut fallback_message = message;
-            fallback_message.set_topic(fallback_topic.into());
-            producer.send(fallback_message).await
-        }
-    }
-}
+let messages = vec![
+    Message::builder().topic("DocsFirstMessage")
+        .body("batch event 1").build()?,
+    Message::builder().topic("DocsFirstMessage")
+        .body("batch event 2").build()?,
+];
+let result = producer.send_batch_with_timeout(messages, 3_000).await?;
 ```
 
-## Monitoring Sends
+Inspect the batch's `send_status` as for a single send. A batch send is not a transaction spanning a consumer's database. Encoded aggregate size, properties and framing overhead must fit the active client/Broker limits; a message-count limit alone cannot ensure that. Split into bounded batches before submitting, and give every business event its own replay identity.
 
-```rust
-let mut success_count = 0;
-let mut failure_count = 0;
+Automatic accumulation is a separate option from explicit `send_batch`. Current `send`/some callback and queue facades can route through the accumulator when enabled, while the explicit `send_with_timeout` path directly invokes its timed send implementation. Do not assume all overloads have identical buffering behavior.
 
-for message in messages {
-    match producer.send(message).await {
-        Ok(_) => success_count += 1,
-        Err(e) => {
-            failure_count += 1;
-            eprintln!("Failed: {}", e);
-        }
-    }
-}
+## Select queues and retry deliberately
 
-println!("Success: {}, Failed: {}", success_count, failure_count);
+Fetch publish queues from the topic route rather than inventing a Broker name or queue ID. A selector receives candidate queues, the message and its argument, and returns an optional queue. Handle an empty candidate set; a modulo operation on zero queues is invalid.
+
+Keep mapping stable for related events and serialize their sends if order matters. Route changes or queue-count changes can change a simple modulo mapping. See [ordered messages](../guides/ordered-messages.md).
+
+Timeouts bound a client's wait, not the remote side effect. Separate pre-admission rejection from an uncertain post-send result, keep a bounded retry deadline, and account for retries already performed by the selected send path. Do not silently redirect a failed business event to another topic: that changes subscriptions, ordering and recovery semantics.
+
+## Example targets and observations
+
+From `rocketmq-example/`, use its standalone manifest and provision each example's actual topic first:
+
+| Target | Topic | What to inspect |
+| --- | --- | --- |
+| `producer-basic-send` | `BasicSendTestTopic` | Response, callback and one-way differences |
+| `producer-batch-send` | `BatchSendTestTopic` | Batch status and selected queue |
+| `producer-send-to-queue` | Read its constants | Explicit route selection |
+| `producer-send-with-selector` | Read its constants | Selector argument and queue mapping |
+
+```bash
+cargo check --example producer-basic-send --example producer-batch-send
+cargo run --example producer-basic-send
 ```
 
-## Common Use Cases
+These examples use loopback NameServer constants rather than a universal command-line address option. They demonstrate APIs; their debug prints are not a production logging policy. For a verified first-message sequence and full cleanup, use the website's paired tutorial application. Compilation does not establish callback loss behavior, failover, or crash recovery.
 
-### Sending Order Events
-
-```rust
-async fn send_order_event(
-    producer: &mut DefaultMQProducer,
-    order_id: &str,
-    event_type: &str,
-    order_data: &Order,
-) -> rocketmq_client_rust::ClientResult<Option<SendResult>> {
-    let body = serde_json::to_vec(order_data).map_err(|source| {
-        rocketmq_client_rust::ClientError::from_error(rocketmq_error::Error::caused_by(
-            &rocketmq_error::CORE_SERIALIZATION_FAILED,
-            source,
-        ))
-    })?;
-
-    let message = Message::builder()
-        .topic("OrderEvents")
-        .body(body)
-        .tags(event_type)
-        .key(order_id)
-        .raw_property("event_type", event_type)?
-        .raw_property("timestamp", chrono::Utc::now().to_rfc3339())?
-        .build()?;
-
-    producer.send(message).await
-}
-```
-
-### Sending Logs
-
-```rust
-async fn send_log(
-    producer: &mut DefaultMQProducer,
-    level: &str,
-    message_text: &str,
-) -> rocketmq_client_rust::ClientResult<Option<SendResult>> {
-    let message = Message::builder()
-        .topic("Logs")
-        .body(message_text)
-        .tags(level)
-        .build()?;
-
-    producer.send(message).await
-}
-```
-
-## Best Practices
-
-1. Set meaningful keys to simplify tracing and deduplication.
-2. Use tags for coarse filtering and properties for rich metadata.
-3. Apply retry with bounded attempts and visible logging.
-4. Track send success rate and latency continuously.
-5. Use batch sending when throughput is more important than per-message latency.
-6. Validate payload size before send.
-7. Keep producer-side schemas stable and versioned.
-
-## Next Steps
-
-- [Transaction Messages](./transaction-messages) - Implement transactional messaging
-- [Client Configuration](../configuration/client-config) - Configure producer settings
-- [Consumer Guide](../consumer/overview) - Learn about consuming messages
+Sources: [producer facade](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/default_mq_producer.rs), [send implementation](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/send.rs), [batch validation](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-model/src/common/message/message_batch.rs), [canonical send results](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-model/src/result.rs).

--- a/rocketmq-website/docs/producer/transaction-messages.md
+++ b/rocketmq-website/docs/producer/transaction-messages.md
@@ -1,168 +1,138 @@
 ---
-sidebar_position: 3
-title: Transaction Messages
+title: "Transaction messages"
 ---
 
-# Transaction Messages
+# Transaction messages
 
-Transaction messages are used to keep message delivery and local business state consistent.
+Transaction messages coordinate visibility of an event with a producer-side business transaction. The Broker first stores a prepared, or half, message; the producer then reports commit, rollback, or an unknown local outcome. This is not a distributed ACID transaction spanning Broker storage and the application's database.
 
-## Overview
+Use a `TransactionMQProducer` with a registered `TransactionListener` and an injected `ClientRuntime`. The ordinary producer's similarly named method is not a replacement for transaction-producer initialization. Start with the [producer lifecycle](./overview.md), and provision the intended business topic.
 
-Transaction messages ensure that:
-
-1. The half message is persisted before local business execution.
-2. The final visibility (commit/rollback) depends on local transaction state.
-3. Unknown states can be checked by broker callbacks.
-
-## Transaction Flow
+## Prepare, decide, and check
 
 ```mermaid
 sequenceDiagram
-    participant P as Producer
-    participant B as Broker
-    participant L as Local Transaction
+    participant P as Transaction producer
+    participant B as Broker transaction service
+    participant D as Business database
     participant C as Consumer
-
-    P->>B: Send half message
-    B-->>P: Ack half message
-    P->>L: Execute local transaction
-    L-->>P: Return local state
-
-    alt Commit
-        P->>B: Commit message
-        B->>C: Deliver message
-    else Rollback
-        P->>B: Rollback message
-    else Unknown
-        B->>P: Check local transaction
-        P-->>B: Return local state
+    P->>B: Send prepared message
+    B-->>P: Half-message send status
+    alt SendOk
+        P->>D: Execute local transaction and record outcome
+        D-->>P: Commit / rollback / uncertain
+        P->>B: End-transaction decision
+    else Flush or replica status is not SendOk
+        P->>B: Current client chooses rollback
     end
+    opt Broker needs to resolve a pending outcome
+        B->>P: Check local transaction
+        P->>D: Read durable business outcome
+        D-->>P: Known outcome or uncertain
+        P-->>B: Commit / rollback / unknown
+    end
+    B-->>C: Committed message becomes eligible for delivery
 ```
 
-## Creating a Transaction Producer
+The final arrow describes eligibility, not an immediate callback or proof of business processing. The half-message response inherits the configured storage/replication policy; do not label every accepted half message durably replicated.
 
-```rust
-use rocketmq_client_rust::producer::mq_producer::MQProducer;
-use rocketmq_client_rust::producer::transaction_mq_producer::TransactionMQProducer;
-use rocketmq_client_rust::ClientResult;
+In the current client, `SendOk` triggers the local listener. `FlushDiskTimeout`, `FlushSlaveTimeout`, and `SlaveNotAvailable` select rollback without executing that listener. A transport error before a usable send result returns an error instead. These branches matter because some non-success statuses can still describe an accepted log append.
 
-#[tokio::main]
-async fn main() -> ClientResult<()> {
-    let mut producer = TransactionMQProducer::builder()
-        .producer_group("transaction_producer_group")
-        .name_server_addr("localhost:9876")
-        .topics(vec!["OrderEvents"])
-        .transaction_listener(OrderTransactionListener::default())
-        .build();
+## Implement a durable decision
 
-    producer.start().await?;
-    // Send transaction messages ...
-    producer.shutdown().await;
-    Ok(())
-}
-```
+`TransactionListener` has two synchronous callbacks:
 
-## Implementing Transaction Listener
+| Callback | Responsibility |
+| --- | --- |
+| `execute_local_transaction(&dyn MessageTrait, Option<&(dyn Any + Send + Sync)>)` | Execute idempotent local business work and return `LocalTransactionState` |
+| `check_local_transaction(&MessageExt)` | Read the authoritative persisted outcome and return the same state domain |
 
-```rust
-use std::any::Any;
+Both return `CommitMessage`, `RollbackMessage`, or `Unknown`. Keep the callback bounded. The client runs local execution through its managed blocking boundary; a caller timeout or panic mapping does not roll back an already committed external transaction.
 
-use cheetah_string::CheetahString;
-use rocketmq_client_rust::producer::local_transaction_state::LocalTransactionState;
-use rocketmq_client_rust::producer::transaction_listener::TransactionListener;
-use rocketmq_common::common::message::message_ext::MessageExt;
-use rocketmq_common::common::message::MessageTrait;
-
-#[derive(Default)]
-struct OrderTransactionListener;
-
-impl TransactionListener for OrderTransactionListener {
-    fn execute_local_transaction(
-        &self,
-        msg: &dyn MessageTrait,
-        _arg: Option<&(dyn Any + Send + Sync)>,
-    ) -> LocalTransactionState {
-        // Implement your local transaction with msg body/properties.
-        let _tx_id: Option<&CheetahString> = msg.transaction_id();
-        LocalTransactionState::Unknown
-    }
-
-    fn check_local_transaction(&self, _msg: &MessageExt) -> LocalTransactionState {
-        // Query local storage and return CommitMessage / RollbackMessage / Unknown.
-        LocalTransactionState::Unknown
-    }
-}
-```
-
-## Sending Transaction Messages
-
-```rust
-use rocketmq_client_rust::producer::mq_producer::MQProducer;
-use rocketmq_common::common::message::message_single::Message;
-
-let message = Message::builder()
-    .topic("OrderEvents")
-    .tags("order_created")
-    .key("order_12345")
-    .body("{\"order_id\":\"order_12345\"}")
-    .build()?;
-
-let result = producer
-    .send_message_in_transaction(message, Some("order_12345".to_string()))
-    .await?;
-
-println!("Transaction message sent: {}", result);
-```
-
-## Local Transaction State Handling (Pseudo Code)
+The following is application pseudocode, not a complete database implementation:
 
 ```text
-execute_local_transaction(message):
-  if local business succeeds:
-    return CommitMessage
-  if local business fails permanently:
-    return RollbackMessage
-  if local result is uncertain:
-    return Unknown
+execute(message):
+    event_id = stable business identifier carried in message
+    within one local database transaction:
+        if recorded outcome exists: return it
+        apply the business change idempotently
+        persist event_id and the final business outcome
+    return CommitMessage only after commit is known
 
-check_local_transaction(message):
-  query local transaction table by transaction id
-  return CommitMessage / RollbackMessage / Unknown
+check(message):
+    read authoritative outcome using event_id
+    committed -> CommitMessage
+    definitively aborted -> RollbackMessage
+    unavailable or unresolved -> Unknown
 ```
 
-## Configuration
+Do not use a process-local map as the recovery authority. A restarted producer, or another eligible producer in the same group, must be able to answer a check from durable business state. The callback's optional in-memory argument is not sent back by the Broker as durable transaction metadata.
 
-`TransactionMQProducer::builder()` currently exposes thread-pool and check queue controls:
+Missing state needs a business policy: it may mean “not executed,” “not yet visible,” or “storage unavailable.” Returning rollback for every lookup failure can hide a committed business change. Returning unknown forever leaves unresolved work and eventually meets the Broker's configured check/discard policy.
+
+## Integrate the producer
+
+The excerpt below assumes `client_runtime` is the application's shared runtime and `listener` is a real `TransactionListener` implementation:
 
 ```rust
-let mut producer = TransactionMQProducer::builder()
-    .producer_group("transaction_producer_group")
-    .name_server_addr("localhost:9876")
-    .topics(vec!["OrderEvents"])
-    .transaction_listener(OrderTransactionListener::default())
-    .check_thread_pool_min_size(2)
-    .check_thread_pool_max_size(8)
-    .check_request_hold_max(2_000)
+let mut producer = TransactionMQProducer::builder(client_runtime.clone())
+    .producer_group("docs_transaction_group")
+    .name_server_addr("127.0.0.1:9876")
+    .topics(vec!["TransactionSendTestTopic"])
+    .transaction_listener(listener)
     .build();
 ```
 
-## Best Practices
+Start the producer before sending, and inspect both fields in the returned `TransactionSendResult`:
 
-1. Keep local transaction execution short and deterministic.
-2. Persist transaction outcome before returning commit/rollback.
-3. Implement idempotent local transaction logic.
-4. Return `Unknown` only for transient uncertainty, not for permanent errors.
-5. Monitor transaction check frequency and unknown-state duration.
+```rust
+let message = Message::builder()
+    .topic("TransactionSendTestTopic")
+    .key("order-1001:event-1")
+    .body("order created")
+    .build()?;
+let outcome = producer
+    .send_message_in_transaction::<(), _>(message, None)
+    .await?;
+```
 
-## Limitations
+`send_result` describes the prepared-message send. `local_transaction_state` describes the client's decision. **Neither field is a final Broker commit receipt.** The current implementation logs an end-transaction request failure and can still return `Ok(TransactionSendResult)`. Keep transaction checking available to reconcile that window.
 
-- Transaction messages have higher latency than normal messages.
-- Brokers hold half messages until commit/rollback is resolved.
-- Poorly designed check logic can cause long pending windows.
+Once outstanding work is resolved or handed to an explicit recovery procedure, close the transaction producer, then the shared ClientRuntime, RuntimeOwner, and telemetry. Stopping immediately after returning unknown removes this process's ability to answer later checks.
 
-## Next Steps
+## Failure windows
 
-- [Client Configuration](../configuration/client-config) - Configure producer/client options
-- [Consumer Guide](../consumer/overview) - Learn consumer-side handling
-- [Troubleshooting](../faq/troubleshooting) - Diagnose production issues
+| Window | Application consequence |
+| --- | --- |
+| Half-message outcome is uncertain | Do not assume no message exists; reconcile by stable business identity |
+| Business commits, process exits before reporting commit | Broker checks must recover the durable committed outcome |
+| End-transaction request fails | A local commit return does not establish immediate consumer visibility |
+| Check reaches a producer without shared state | The group cannot reliably resolve pending transactions |
+| Business work or check panics | Current client maps the callback failure to unknown; investigate the underlying operation |
+| Consumer commits a side effect but its progress is not persisted | The consumer can receive the committed message again |
+
+Transaction messages do not remove consumer idempotency requirements. See [delivery and retry](../guides/delivery-and-retry.md).
+
+## Bounds and supported combinations
+
+The current transaction path rejects delayed/timer properties, including delay-level, relative delay and absolute delivery timestamp properties. Do not combine the ordinary batch API with a transaction send and infer batch-transaction semantics.
+
+Check settings validate positive min/max sizes, min not greater than max, and a positive request hold limit. The implementation uses admission semaphores: max size bounds concurrent checks and hold max bounds admitted check work. The min value is validated; it is not evidence that a dedicated minimum-sized OS thread pool is created.
+
+Broker check intervals, maximum checks, transaction-service availability, and producer connectivity affect resolution. Treat them as part of the deployment; an available listener type alone does not prove the full transaction path is configured.
+
+## Inspect the example without treating it as recovery proof
+
+From `rocketmq-example/`:
+
+```bash
+cargo check --example producer-transaction-send
+cargo run --example producer-transaction-send
+```
+
+First provision `TransactionSendTestTopic` on the loopback cluster. The example alternates commit, rollback and unknown decisions in memory, then shuts down after six sends. It illustrates listener wiring and the result structure. It does not persist a business transaction log or stay alive to establish eventual resolution of every unknown message.
+
+To validate an application transaction integration, keep a checking producer available, observe only committed business events at a consumer, and separately exercise restart between local commit and end-transaction reporting. Record that scenario's actual result; compiling the example is not that test.
+
+Sources: [transaction facade](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/transaction_mq_producer.rs), [send and decision path](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/transaction.rs), [check dispatch](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/lifecycle.rs), [example](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/producer/transaction_send.rs).

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/consumer/classic-pull-compatibility.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/consumer/classic-pull-compatibility.md
@@ -1,0 +1,94 @@
+---
+title: "Classic Pull 兼容接口"
+---
+
+# Classic Pull 兼容接口
+
+`DefaultMQPullConsumer` 已不推荐用于新开发，但仍具有可运行的运行时兼容路径。新轮询应用应使用 [LitePull](./pull-consumer.md)。迁移需要为每次请求显式选择队列和偏移量的旧代码时，可以保留 Classic Pull。
+
+## 可运行构造与 detached 构造
+
+| 构造方式 | 运行行为 |
+| --- | --- |
+| `DefaultMQPullConsumer::builder(client_runtime).consumer_group(...).build()?` | 使用给定共享客户端运行时构建可运行 facade |
+| `new()`、`default()`、`with_consumer_group(...)` | 保留 detached 兼容值，运行操作返回初始化错误 |
+| detached 实现标记 | 不会创建后备运行时 |
+
+仅修改 detached 值的组名不会接入运行时，应在应用边界替换构造方式。builder 使用 Classic 手动模式下的 LitePull 基础设施，关闭自动提交；它不会把显式拉取转为普通 LitePull 后台轮询。
+
+builder 要求组名并校验时长。默认普通拉取超时为 10 秒，Broker 挂起时间为 20 秒，客户端挂起请求超时为 30 秒。长轮询的客户端超时必须大于 Broker 挂起时间。
+
+## 对显式分配的队列拉取一次
+
+以下兼容片段包含完整 facade 清理。调用方提供自己持有的队列及拟读取的下一偏移量，并保持共享运行时存活。函数将消息返回调用方，不推进业务进度。
+
+```rust
+use std::sync::Arc;
+use rocketmq_client_rust::{
+    ClientResult, ClientRuntime, DefaultMQPullConsumer,
+    MessageSelector, PullOptions, PullResult,
+};
+use rocketmq_model::common::message::message_queue::MessageQueue;
+
+#[allow(deprecated)]
+async fn pull_once(
+    runtime: Arc<ClientRuntime>,
+    queue: MessageQueue,
+    next_offset: i64,
+) -> ClientResult<PullResult> {
+    let consumer = DefaultMQPullConsumer::builder(runtime)
+        .consumer_group("docs_classic_group")
+        .name_server_addr("127.0.0.1:9876")
+        .build()?;
+    let result = async {
+        consumer.start().await?;
+        let options = PullOptions::new(
+            queue, MessageSelector::by_tag("*"), next_offset, 16,
+        )?;
+        consumer.pull_with_options(options).await
+    }.await;
+    let shutdown = consumer.shutdown().await;
+    let result = result?;
+    shutdown?;
+    Ok(result)
+}
+```
+
+长期应用应复用已启动 facade，在循环结束后关闭；每次拉取创建消费者不是吞吐场景的推荐模式。此处拉取出错仍执行关闭。示例不表示自动获得输入队列的排他所有权。
+
+## 移动游标前解释结果
+
+| `PullStatus` | 含义与后续操作 |
+| --- | --- |
+| `Found` | 处理返回消息，目标批次成功后再使用 `next_begin_offset` |
+| `NoNewMsg` | 本次请求没有新的可用数据，采用有界等待或长轮询 |
+| `NoMatchedMsg` | 已扫描数据但未匹配，返回的下一偏移量可以越过已扫描的不匹配位置 |
+| `OffsetIllegal` | 请求位置不在合法范围，应检查保留策略、重置以及返回的 min/max/next 位置 |
+
+不要用收到的消息数量直接累加偏移量，过滤与空洞可能使结果错误。也不能把 `OffsetIllegal` 当作可以静默丢弃业务恢复范围的许可。
+
+`PullOptions` 校验队列主题和 Broker 名称、非负偏移量、正消息数和响应大小限制，以及合法超时。在普通默认值上开启 block-if-not-found 时，还需要将客户端超时提高到挂起时间以上。facade 专用的 block-if-not-found 方法使用 builder 中对应设置。
+
+## 队列分配与进度所有权
+
+`fetch_subscribe_message_queues` 返回已知队列，不表示当前进程独占全部队列。注册的 `MessageQueueListener` 回调区分全部队列和分配给当前消费者的队列。拉取前应使用该分配结果，或明确的外部所有权策略。
+
+facade 提供 `update_consume_offset`、`fetch_consume_offset`、`min_offset`、`max_offset` 和 `search_offset`。偏移量更新与远端持久化应按底层偏移量存储路径理解。拉取结果本身不会提交业务进度。
+
+完成业务后再推进下一读取位置，保留用于重放的持久业务标识，停止拉取已撤销的队列。包装层状态机拒绝重复启动、启动失败后重启及关闭后重启；重新启动时应创建新 facade。关闭本身具有幂等性。
+
+## 有意识地迁移到 LitePull
+
+| Classic 职责 | LitePull 选择 |
+| --- | --- |
+| 每次请求显式指定队列与偏移量 | 选择订阅分配或显式 `assign`，仅在有意改变位置时使用 `seek` |
+| 手动拉取循环 | 替换为有界 `poll` 或零拷贝轮询与处理 |
+| 每请求选择器 | 轮询前配置等价主题订阅或选择器 |
+| 应用持有进度 | 明确设置自动提交，保留先处理后推进进度的顺序 |
+| 队列所有权回调 | 在目标模式中保留分配与撤销处理 |
+
+没有交接计划时，不要让新旧消费者同时操作同组进度。记录最后完成的业务位置，停止旧所有者，启动新模式，再检查重复、缺口和组进度。仅替换 builder 不构成偏移量迁移。
+
+当前 LitePull `commit_all` 更新客户端偏移量存储状态，并可能在内部记录逐队列错误；它不是立即持久化全部队列的提交。迁移时应保留这一认知。
+
+源码依据：[Classic facade](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/default_mq_pull_consumer.rs)、[builder](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/default_mq_pull_consumer_builder.rs)、[生命周期与分配适配](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/default_mq_pull_consumer_impl.rs)、[拉取结果](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/pull_result.rs)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/consumer/message-filtering.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/consumer/message-filtering.md
@@ -1,175 +1,97 @@
 ---
-sidebar_position: 4
-title: 消息过滤
+title: "消息过滤"
 ---
 
 # 消息过滤
 
-RocketMQ 的过滤机制可以帮助消费者减少无关消息处理。
+过滤为订阅选择消息，不会从主日志删除消息、替代授权，也不能保证所有业务条件均已检查。Tag 适合粗粒度事件分类；受支持的 SQL 表达式适合对消息属性执行条件判断。
 
-## 基于 Tag 的过滤
+## 选择过滤层
 
-### 基础 Tag 订阅
+| 选择方式 | 输入 | 边界 |
+| --- | --- | --- |
+| Tag 表达式 | 消息 Tag 与 `TagA || TagB` 或 `*` | 基于简单分类模型的订阅过滤 |
+| SQL92 风格选择器 | 命名字符串属性及受支持表达式 | 需要 Broker 属性过滤支持和有效订阅元数据 |
+| 应用条件判断 | 已投递消息及业务状态 | 消耗网络和客户端容量，由应用决定是否处理成功 |
 
-```rust
-// 订阅单个 tag
-consumer.subscribe("OrderEvents", "order_created").await?;
+同组成员的主题订阅和选择器应一致。修改过滤条件会改变该组认为相关的消息集合，不等于要求重放此前跳过的记录。
 
-// 订阅多个 tag
-consumer
-    .subscribe("OrderEvents", "order_created || order_paid")
-    .await?;
+## 设置生产者元数据
 
-// 订阅全部 tag
-consumer.subscribe("OrderEvents", "*").await?;
-```
-
-### 生产者设置 Tag
+以下片段在生产者已启动、主题已创建后执行：
 
 ```rust
-use rocketmq_common::common::message::message_single::Message;
+use rocketmq_model::common::message::message_single::Message;
 
 let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
+    .topic("SqlFilterConsumerTestTopic")
     .tags("order_created")
+    .raw_property("region", "cn")?
+    .raw_property("priority", "3")?
+    .body("order event")
     .build()?;
-
-producer.send(message).await?;
+let result = producer.send_with_timeout(message, 3_000).await?;
 ```
 
-## 使用消息属性补充过滤维度
+按照[发送消息](../producer/sending-messages.md)检查发送状态。消息中的属性值是字符串，SQL 求值时应用支持的类型转换规则。消息体内的 JSON 字段不会自动变成可过滤属性。
 
-生产者可以附加结构化属性，供下游做更细粒度判断。
+Tag 应作为精确类别使用。`TagA || TagB` 是订阅表达式，不应把整个表达式当作一条消息的 Tag。
+
+## 使用 Tag 或 SQL 选择器订阅
+
+对已注册监听器、尚待启动的 `DefaultMQPushConsumer`：
 
 ```rust
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
-    .tags("order_created")
-    .raw_property("amount", "150.00")?
-    .raw_property("region", "us-west")?
-    .raw_property("priority", "high")?
-    .build()?;
-
-producer.send(message).await?;
+consumer.subscribe("OrderEvents", "order_created || order_paid").await?;
 ```
 
-## 客户端二次过滤（属性判断）
-
-当业务规则复杂或经常变化时，可在监听器里做二次筛选。
+SQL 使用公开的 `MessageSelector`：
 
 ```rust
-use cheetah_string::CheetahString;
-use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
-use rocketmq_common::common::message::MessageTrait;
+use rocketmq_client_rust::MessageSelector;
 
-consumer.register_message_listener_concurrently(|msgs, _ctx| {
-    let region_key = CheetahString::from_static_str("region");
-    let amount_key = CheetahString::from_static_str("amount");
-
-    for msg in msgs {
-        let region = msg
-            .property(&region_key)
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-
-        let amount = msg
-            .property(&amount_key)
-            .and_then(|v| v.parse::<f64>().ok())
-            .unwrap_or(0.0);
-
-        if region == "us-west" && amount > 100.0 {
-            // process_message(msg);
-        }
-    }
-
-    Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
-});
+consumer.subscribe_with_selector(
+    "SqlFilterConsumerTestTopic",
+    Some(MessageSelector::by_sql("region = 'cn' AND priority >= 3")),
+).await?;
 ```
 
-## SQL92 说明
+按照 [Push 消费者](./push-consumer.md)补齐启动和关闭。LitePull 具有自己的 `subscribe` 和选择器方法，不要将 Push 签名直接复制到 LitePull 循环。
 
-RocketMQ Broker 支持 SQL92 服务端过滤，但当前项目的公开消费者示例主要围绕 Tag 表达式订阅与客户端属性二次过滤。
+Broker 的 `enablePropertyFilter` 默认为 false。使用标准 TOML 配置时，将该字段合入已有 `[broker]` 表，并按照正常搭建流程重启对应 Broker：
 
-如果你计划在生产环境使用 SQL92，请先结合 Broker 配置与客户端能力进行集成验证。
-
-## 过滤性能
-
-### Tag 过滤
-
-- 性能：高
-- 执行位置：Broker 侧
-- 适用：稳定的事件分类场景
-
-### 客户端属性过滤
-
-- 性能：低于 Tag 过滤（消息仍会先到消费者）
-- 执行位置：Consumer 侧
-- 适用：复杂或动态业务规则
-
-## 最佳实践
-
-1. 优先使用 Tag 作为第一层过滤。
-2. 设计稳定、可维护的 Tag 体系。
-3. 将高频查询维度放入消息属性。
-4. 客户端二次过滤逻辑保持轻量。
-5. 监控过滤后的命中率，反向优化生产者打标策略。
-
-## 示例
-
-### 订单处理
-
-```rust
-// Producer
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(order_json)
-    .tags("order_created")
-    .raw_property("region", &order.region)?
-    .raw_property("amount", order.amount.to_string())?
-    .build()?;
-producer.send(message).await?;
-
-// Consumer
-consumer.subscribe("OrderEvents", "order_created").await?;
+```toml
+[broker]
+enablePropertyFilter = true
 ```
 
-### 日志聚合
+这是配置片段，不是完整 Broker 文件。禁用支持时，非 Tag 拉取路径会拒绝请求；客户端订阅检查还会编译请求的表达式。所有可能服务该订阅的 Broker 都需要兼容支持，启用一个 Broker 不会自动配置其他节点。
 
-```rust
-// Producer
-let message = Message::builder()
-    .topic("ApplicationLogs")
-    .body(log_entry)
-    .tags(&log.level) // ERROR, WARN, INFO, DEBUG
-    .raw_property("service", &log.service)?
-    .raw_property("environment", &log.environment)?
-    .build()?;
-producer.send(message).await?;
+## 使用已实现的表达式语言
 
-// Consumer
-consumer.subscribe("ApplicationLogs", "ERROR || WARN").await?;
-```
+当前 SQL 运行时支持逻辑 `AND`/`OR`/`NOT`、比较、`IS NULL`/`IS NOT NULL`、`IN`/`NOT IN`、`BETWEEN`/`NOT BETWEEN`，以及 `CONTAINS`、`STARTSWITH`、`ENDSWITH` 等受支持字符串谓词。它是属性条件语言，不是支持连接查询和任意函数的数据库 `SELECT` 语句。
 
-### 事件路由
+字符串使用单引号，内部单引号用两个连续单引号转义。缺失属性求值为 `NULL`；三值逻辑意味着缺失值并不在所有中间表达式里都等同于 false。Broker 最终匹配要求真布尔结果。应验证缺失、格式错误和边界值，而不只测试一个匹配样本。
 
-```rust
-// Producer
-let message = Message::builder()
-    .topic("UserEvents")
-    .body(event_json)
-    .tags(&event.event_type)
-    .raw_property("user_tier", &user.tier)?
-    .build()?;
-producer.send(message).await?;
+求值器在需要时可转换数字形式的字符串。保持生产者属性模式稳定，避免表示方式变化悄悄改变匹配结果。不要假定所有 Java 客户端或其他 Broker 版本都支持相同表达式扩展。
 
-// Consumer
-consumer.subscribe("UserEvents", "login || logout || purchase").await?;
-```
+## 理解预过滤与最终求值
 
-## 下一步
+ConsumeQueue Tag 编码或可选 Bloom 元数据，可在加载完整属性之前排除候选。Bloom 命中只表示候选，不证明 SQL 最终匹配。相关预过滤元数据缺失或不适用时，当前过滤器会回退到后续求值。
 
-- [Broker 配置](../configuration/broker-config) - 配置过滤相关参数
-- [生产者指南](../producer/overview) - 正确设置 tags 与 properties
-- [消费者概览](./overview) - 理解消费模型与位点管理
+SQL 路径中，Broker 对读取路径提供的消息属性求值已编译表达式。订阅版本与已编译过滤元数据必须一致；过时订阅或缺失过滤元数据可能在消息到达监听器前就导致失败。
+
+需要当前业务状态的决策仍可使用应用过滤。应用有意忽略已投递消息并返回成功，就意味着选择推进该消费者进度。如需以后处理，应定义重放或独立订阅，不能依赖应用代码中的拒绝判断。
+
+## 排查匹配偏差
+
+1. 确认目标集群、主题、组、起始偏移量和生产者发送结果。
+2. 使用有界、已授权的工具查看实际 Tag 和属性，不能从消息体推断。
+3. SQL 场景检查 `enablePropertyFilter` 和表达式编译错误。
+4. 比较同组所有成员的订阅和版本。
+5. 在隔离组测试匹配、不匹配、属性缺失三类事件。
+6. 分别观察进度与投递数量：扫描被过滤记录可能推进下一位置，而不返回消息。
+
+`rocketmq-example/` 中的 `consumer-tag-filter` 和 `consumer-sql-filter` 分别演示对应选择器。SQL 示例使用 `SqlFilterConsumerTestTopic` 和 `region = 'cn' AND priority >= 3`。应创建对应主题和组，并发送符合条件的属性；运行无关的简单生产者不足以完成验证。
+
+源码依据：[选择器 API](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/message_selector.rs)、[SQL 语言](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-filter/README.md)、[Broker 表达式过滤](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/filter/expression_message_filter.rs)、[拉取校验](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/processor/pull_message_processor.rs)、[Broker 配置](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/config/broker_config.rs)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/consumer/pop.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/consumer/pop.md
@@ -1,0 +1,90 @@
+---
+title: "POP、回执与确认"
+---
+
+# POP、回执与确认
+
+POP 在投递后暂时使消息不可见，并使用回执确认本次投递尝试。它不同于推进 LitePull 消费者组的队列偏移量。未成功确认的尝试，在不可见窗口结束后可能重新具备投递资格。
+
+当前示例通过 `DefaultMQPushConsumer`、并发监听器和 Broker 侧请求模式配置使用 POP，不存在独立的公开 `DefaultPopConsumer` 构造流程。
+
+## 启用目标路径
+
+1. 在目标集群创建主题和消费者组，确认普通路由可用。
+2. 使用有权限的 Admin 操作，将该主题和组的请求模式设为 POP。
+3. 用应用持有的 `ClientRuntime` 构建 Push 消费者，并设置 `client_rebalance(false)`。
+4. 注册并发监听器和订阅，再启动消费者。
+5. 完成业务后返回成功；关闭共享运行时前先关闭 facade。
+
+仅设置 `client_rebalance(false)` 不会写入 Broker 请求模式。示例通过 Admin Core 使用 `SetConsumerRequestModeRequest::try_new(topic, group, ConsumerRequestMode::Pop, 8, 3_000)`。其中 8 是请求中的 POP 共享队列设置，不是八秒不可见时间。
+
+在 `rocketmq-example/` 中，先阅读 `examples/consumer/pop_consumer.rs`，再运行：
+
+```bash
+cargo check --example pop-consumer
+cargo run --example pop-consumer
+```
+
+当前示例会在回环 NameServer 对应集群中修改 `TopicTest` / `please_rename_unique_group_name_4` 的请求模式。隔离试验应重命名这些常量并创建资源。该示例执行真实管理变更，不要用它改变无关现有消费者组的流量。
+
+示例展示设置方法，但在信号处理后没有显式关闭消费者 facade。集成时应采用 [Push 消费者](./push-consumer.md)的清理结构：完成或限制当前工作，调用 `consumer.shutdown().await`，再关闭共享客户端和进程运行时。示例打印完整消息的调试日志也不适合生产数据。
+
+## 理解一份回执的生命周期
+
+```mermaid
+sequenceDiagram
+    participant B as Broker POP 状态
+    participant C as Push POP 客户端
+    participant A as 业务处理器
+    B-->>C: 消息、投递回执与不可见时间
+    C->>A: 调用并发监听器
+    alt 业务在窗口内成功
+        A-->>C: ConsumeSuccess
+        C->>B: 使用回执 ACK 成功前缀
+        B-->>C: ACK 结果
+    else 处理失败或需要重试
+        A-->>C: ReconsumeLater
+        C->>B: 根据重试策略改变不可见时间
+    end
+    opt 到期时本次尝试仍未确认
+        B-->>C: 消息重新具备投递资格
+    end
+```
+
+回执属于投递尝试元数据，不是业务事件 ID。它携带定位对应 Broker、队列和 POP 检查点所需的信息。不要用消息键或逻辑偏移量替代、伪造回执字段，也不要把某次回执用作其他尝试的操作依据。
+
+消费者回调接收消息，POP 服务使用关联元数据执行 ACK。跨尝试去重应另行保留稳定业务标识。
+
+## 不可见时间是有界处理机会
+
+当前 Push 默认请求 `pop_invisible_time = 60_000` 毫秒、`pop_batch_nums = 32`。它们不同于监听器批次大小和普通拉取超时；Broker 校验及所选模式也会约束请求。
+
+不可见计时包含处理器开始前的排队时间。增加回调并发可能缓解排队瓶颈，但不会使缓慢下游变得安全。处理器可能在原窗口结束后才完成，并与另一次尝试同时存在。
+
+当前并发 POP 服务在调用前、应用结果前检查到期状态，不承诺在长回调执行期间持续自动续期。应为有界工作设置合适窗口，或使用已说明其契约的底层或 Proxy 续期路径，明确持有更新后的回执状态并处理失败。
+
+改变不可见时间是带结果的远程操作。改变成功影响本次尝试的时限，不会提交业务。续期超时应视为结果不确定；所选 API 在续期后替换回执时，应使用它返回的新回执。
+
+## 监听器成功不等于 ACK 回执
+
+并发服务规范化成功前缀，再调用批量 ACK 路径。逐项 ACK 错误会记录日志并依赖重新投递；应用监听器返回 `ConsumeSuccess`，不能证明每个 Broker ACK 都成功。
+
+失败消息由服务选择重试延迟并修改不可见时间。达到配置的最大重消费次数后，当前实现还会考虑消息年龄，可能 ACK 较老消息，也可能再次延迟。不能宣称该客户端分支中每条失败 POP 消息都会进入死信队列。
+
+业务副作用提交后 ACK 失败，下一次尝试必须识别已完成的业务事件。业务提交前返回成功，则 ACK 可能使该尝试退出普通重投，而业务仍未完成。这与[投递与重试](../guides/delivery-and-retry.md)中的应用边界相同，只是使用回执而非 LitePull 提交实现。
+
+## 诊断与模式切换
+
+| 现象 | 优先检查 |
+| --- | --- |
+| 未选中 POP 路径 | Broker 主题和组请求模式、客户端再平衡设置、分配响应 |
+| 处理器执行期间重复投递 | 排队加处理时长与不可见时间的关系、续期结果 |
+| 回调成功但消息再次出现 | ACK 响应和日志、回执有效性、Broker 连通性 |
+| 持续失败的消息不再出现 | 次数与年龄策略、应用恢复存储；没有证据不能假定已进入死信队列 |
+| 关闭遗留业务工作 | 处理任务所有权、facade 清理、剩余尝试时间 |
+
+从 Pull 切换 POP 会改变进度语义。应停止旧消费者，明确处理已有偏移量和在途尝试的方式，有意修改组模式，再观察新的分配与确认路径。不能把在线模式切换当作无影响的调优选项。
+
+本页描述当前并发 Push POP 实现及示例接入，不证明崩溃恢复、故障转移、有序 POP，或 Proxy 与 Java 客户端的语义完全相同。
+
+源码依据：[POP 示例](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/consumer/pop_consumer.rs)、[并发 POP 处理](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs)、[ACK 与不可见时间适配](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs)、[Broker POP 处理器](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/processor/pop_message_processor.rs)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/consumer/push-consumer.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/consumer/push-consumer.md
@@ -1,165 +1,111 @@
 ---
-sidebar_position: 2
-title: 推消费者
+title: "Push 消费者"
 ---
 
-> Runtime 所有权：示例中的 `client_runtime` 是应用持有的 `Arc<ClientRuntime>`，它从 `RuntimeOwner` 的 child scope 创建，并在进程边界显式关闭。
+# Push 消费者
 
-# 推消费者
+`DefaultMQPushConsumer` 将消息交给已注册的监听器。在普通 Pull 模式中，客户端完成路由发现、队列分配、后台拉取和长轮询，然后调度回调。“Push”描述应用接口，不表示 Broker 无条件主动推送流。
 
-RocketMQ-Rust 中的推模式由 `DefaultMQPushConsumer` 实现。客户端在后台拉取消息，并将消息批次分发给你注册的监听器。
+需要应用手动轮询时，使用 [LitePull](./pull-consumer.md)。需要 Broker 管理不可见时间和回执确认时，参见 [POP](./pop.md)；其监听器成功返回后的确认路径不同。
 
-## 创建推消费者
+## 启动具有完整生命周期的消费者
 
-```rust
-use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
-use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
-use rocketmq_error::RocketMQResult;
-
-#[tokio::main]
-async fn main() -> RocketMQResult<()> {
-    let mut consumer = DefaultMQPushConsumer::builder(client_runtime.clone())
-        .consumer_group("my_consumer_group")
-        .name_server_addr("localhost:9876")
-        .consume_thread_min(2)
-        .consume_thread_max(20)
-        .build();
-
-    consumer.subscribe("TopicTest", "*").await?;
-    consumer.start().await?;
-
-    Ok(())
-}
-```
-
-## 消息监听器
-
-### 并发监听器
+按照[快速开始](../getting-started/quick-start.md)创建 `DocsFirstMessage`，再将组创建命令的参数替换为 `-g docs_push_group`，为本页消费者创建独立组。以下函数使用教程中的共享 `Arc<ClientRuntime>`。监听器仅把统计消息数作为处理演示；实际应用应在返回成功前完成有界、幂等的业务处理。
 
 ```rust
-use rocketmq_client_rust::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
-use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
-use rocketmq_client_rust::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
-use rocketmq_common::common::message::message_ext::MessageExt;
-use rocketmq_error::RocketMQResult;
+use std::sync::Arc;
+use rocketmq_client_rust::{
+    ClientResult, ClientRuntime, ConsumeConcurrentlyContext,
+    ConsumeConcurrentlyStatus, DefaultMQPushConsumer,
+    MessageListenerConcurrently, MQPushConsumer,
+};
+use rocketmq_model::common::message::message_ext::MessageExt;
 
-struct MyListener;
+struct CountListener;
 
-impl MessageListenerConcurrently for MyListener {
+impl MessageListenerConcurrently for CountListener {
     fn consume_message(
         &self,
         messages: &[&MessageExt],
         _context: &ConsumeConcurrentlyContext,
-    ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
-        for msg in messages {
-            println!("Processing: {:?}", msg.msg_id());
-        }
+    ) -> ClientResult<ConsumeConcurrentlyStatus> {
+        println!("received={}", messages.len());
         Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
     }
 }
 
-consumer.register_message_listener_concurrently(MyListener);
-```
-
-### 顺序监听器
-
-```rust
-use rocketmq_client_rust::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
-use rocketmq_client_rust::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
-use rocketmq_client_rust::consumer::listener::message_listener_orderly::MessageListenerOrderly;
-use rocketmq_common::common::message::message_ext::MessageExt;
-use rocketmq_error::RocketMQResult;
-
-struct OrderListener;
-
-impl MessageListenerOrderly for OrderListener {
-    fn consume_message(
-        &self,
-        messages: &[&MessageExt],
-        context: &mut ConsumeOrderlyContext,
-    ) -> RocketMQResult<ConsumeOrderlyStatus> {
-        for msg in messages {
-            process_in_order(msg);
-        }
-        context.set_auto_commit(true);
-        Ok(ConsumeOrderlyStatus::Success)
-    }
+async fn consume_until_interrupt(
+    client_runtime: Arc<ClientRuntime>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut consumer = DefaultMQPushConsumer::builder(client_runtime)
+        .consumer_group("docs_push_group")
+        .name_server_addr("127.0.0.1:9876")
+        .consume_message_batch_max_size(1)
+        .build();
+    let outcome = async {
+        consumer.subscribe("DocsFirstMessage", "*").await?;
+        consumer.register_message_listener_concurrently(CountListener);
+        consumer.start().await?;
+        tokio::signal::ctrl_c().await?;
+        Ok(())
+    }.await;
+    consumer.shutdown().await;
+    outcome
 }
-
-consumer.register_message_listener_orderly(OrderListener);
 ```
 
-## 订阅模式
+在持有它的 RuntimeOwner 上调用该函数，之后关闭共享 ClientRuntime、RuntimeOwner 和遥测设施。启动前注册监听器和订阅。学习默认新组行为时，先启动消费者再发送；已有存储偏移量可能覆盖初始位置设置。
 
-### 单主题
+## 选择并发方式与消费模型
 
-```rust
-consumer.subscribe("TopicTest", "*").await?;
-```
+| 选择 | 含义 |
+| --- | --- |
+| 并发监听器 | 不同批次可以并行执行，完成顺序可能不同于队列顺序 |
+| 顺序监听器 | 在对应队列所有权和锁边界内串行消费 |
+| 集群消费 Clustering | 组成员分担工作，重试遵循该组配置路径 |
+| 广播消费 Broadcasting | 每个实例接收独立副本；普通并发实现对失败投递记录日志并丢弃，不使用集群式发回重试 |
 
-### 多主题
+监听器方法是同步的。客户端通过受管理的阻塞边界调度，但下游调用仍需要自己的有限超时和容量。把工作交给无人持有的后台任务后立即返回成功，可能使进度先于业务提交推进。
 
-```rust
-consumer.subscribe("TopicA", "*").await?;
-consumer.subscribe("TopicB", "tag1 || tag2").await?;
-```
+同一逻辑组内，不应混用并发与顺序监听器契约，也不应使用不一致订阅。组成员应在主题、选择器、消费模型和顺序要求上保持一致。另一个独立业务应用通常应使用自己的消费者组。
 
-### 消息选择器
+## 从监听器结果理解进度
 
-```rust
-use rocketmq_client_rust::consumer::message_selector::MessageSelector;
+`ConsumeSuccess` 表示成功处理的前缀，`ReconsumeLater` 表示批次未成功。默认并发上下文在成功时确认全部消息。使用部分确认时，其含义是前缀索引，不是批次中的任意子集。
 
-let selector = MessageSelector::by_sql("amount > 100 AND region = 'us-west'");
-consumer
-    .subscribe_with_selector("OrderEvents", Some(selector))
-    .await?;
-```
+普通集群并发消费中，失败消息进入发回路径。发回失败的消息继续待处理，等待后续本地尝试。完成或成功移交的消息可从处理队列移除，使下一个安全偏移量推进；偏移量持久化是另一步。
 
-## 并发与拉取参数
+因此，业务完成、监听器成功、进度更新和消费者组进度持久化是不同事件。应用应容忍这些步骤之间崩溃造成的重放。广播模式的失败行为不同，需要显式应用恢复策略。
 
-```rust
-let mut consumer = DefaultMQPushConsumer::builder(client_runtime.clone())
-    .consumer_group("my_consumer_group")
-    .name_server_addr("localhost:9876")
-    .consume_thread_min(2)
-    .consume_thread_max(20)
-    .pull_batch_size(32)
-    .pull_interval(0)
-    .pull_threshold_for_queue(1024)
-    .pull_threshold_for_topic(10_000)
-    .build();
-```
+顺序消费使用 `MessageListenerOrderly` 和 `ConsumeOrderlyStatus`。当前队列失败时可以暂停并重试，以队列进度为代价保护局部顺序。发送侧映射和故障边界参见[顺序消息](../guides/ordered-messages.md)。
 
-## 消费起点
+## 再平衡与内存控制
 
-```rust
-use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+路由或组成员变化可能撤销并重新分配队列。队列所有权是临时的；应停止属于已撤销所有权的工作，并使业务幂等在转移到其他进程后仍然有效。
 
-let mut consumer = DefaultMQPushConsumer::builder(client_runtime.clone())
-    .consumer_group("my_consumer_group")
-    .name_server_addr("localhost:9876")
-    .consume_from_where(ConsumeFromWhere::ConsumeFromLastOffset)
-    .build();
-```
+| 配置类别 | 限制或影响的内容 |
+| --- | --- |
+| `pull_batch_size` | 网络请求批次大小 |
+| `consume_message_batch_max_size` | 单次监听器调用的消息数量 |
+| `consume_thread_min` / `consume_thread_max` | 受管理的消费并发控制，不代表允许无限阻塞 |
+| `pull_threshold_for_queue` / `pull_threshold_size_for_queue` | 队列缓存数量与大小压力 |
+| 主题阈值及 `pull_interval` | 主题级压力与拉取节奏 |
+| `consume_from_where` | 没有可用存储进度决定起点时的初始位置 |
 
-## 暂停与恢复
+网络批次与回调批次不同。更大的缓存可能保留消息体并延长关闭；增加线程不能修复数据库饱和。根据真实处理成本选择限制，同时观察积压、待处理数量、保留字节和重试率。
 
-```rust
-consumer.suspend().await;
-// ...
-consumer.resume().await;
-```
+暂停会按消费者路径暂停接入，但它不是证明全部回调完成的事务屏障。退出服务生命周期时应显式关闭。
 
-## 最佳实践
+## 排查运行中的消费者
 
-1. 按业务处理复杂度设置消费线程数。
-2. 吞吐优先用并发监听，严格有序用顺序监听。
-3. 监听逻辑保持幂等，适配重试语义。
-4. 基于真实流量调优 `pull_batch_size` 与阈值参数。
-5. 优先使用服务端过滤，减少无效消息传输。
+| 观察结果 | 后续检查 |
+| --- | --- |
+| 没有回调 | 主题路由、组配置、监听器注册、起始偏移量、选择器 |
+| 增加实例但吞吐提升有限 | 队列数量、分配及下游瓶颈 |
+| 重复投递 | 监听器失败、发回或 ACK 失败、再平衡和持久化进度 |
+| 回调成功但积压增加 | 处理延迟、队列分配、持久化，以及指标实际对应的集群和组 |
+| 广播失败消息消失 | 广播分支不提供集群式重试语义 |
 
-## 下一步
+在 `rocketmq-example/` 中，`consumer-cluster` 展示并发集群消费，`consumer-orderly` 展示顺序接口。创建资源和运行前，应查看各自的主题、组常量。SQL 与 Tag 示例也有独立主题。集群侧检查命令参见[首次诊断](../operations/first-diagnosis.md)。
 
-- [拉取消费者](./pull-consumer) - 了解拉模式消费
-- [消息过滤](./message-filtering) - 学习高级过滤能力
-- [客户端配置](../configuration/client-config) - 查看消费者配置项
+源码依据：[Push facade 与配置](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/default_mq_push_consumer.rs)、[Push 生命周期](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs)、[并发处理](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs)、[顺序处理](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/delay-and-recall.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/delay-and-recall.md
@@ -1,0 +1,103 @@
+---
+title: "延迟投递与召回"
+---
+
+# 延迟投递与召回
+
+延迟消息在配置的延迟或时间戳之后具备投递资格。具备资格与消费者实际处理分开，分派积压、消费者可用性和业务工作都会增加延迟。定时器不提供实时截止保证。
+
+## 选择一种调度形式
+
+| Message builder 选项 | 含义 | 服务端条件 |
+| --- | --- | --- |
+| `delay_level(n)` | 配置延迟级别表中的索引 | Broker、Store 的级别调度器及当前 `messageDelayLevel` 映射 |
+| `delay_secs(n)` | 以秒为单位的相对延迟 | 定时请求规范化与所选定时器引擎 |
+| `delay_millis(n)` | 以毫秒为单位的相对延迟 | 定时请求规范化与配置精度 |
+| `deliver_time_ms(timestamp)` | Unix 纪元绝对毫秒时间 | 时钟解释、未来时间戳与接纳范围 |
+
+每条消息使用一种调度形式。当前定时属性优先级为秒、毫秒、绝对投递时间；依赖此优先级会使混合属性消息更难理解。不要混用延迟级别与定时属性。
+
+默认级别表前三项为 1 秒、5 秒、10 秒，因此该表下级别 3 为 10 秒；映射可配置。当前默认定时精度为 1,000 ms，标准最大延迟为三天；兼容精度集合为 100、200、500、1,000 ms。这些是源码配置默认值，不是所有部署的统一保证。
+
+## 发送并观察定时消息
+
+采用[发送消息](../producer/sending-messages.md)中的完整生产者生命周期。创建 `DelaySendTestTopic` 和订阅该主题的消费者。以下片段在生产者启动后执行：
+
+```rust
+let message = Message::builder()
+    .topic("DelaySendTestTopic")
+    .key("reminder-1001")
+    .delay_secs(30)
+    .body("reminder")
+    .build()?;
+let send_result = producer.send_with_timeout(message, 3_000).await?;
+```
+
+将发送视为已确认前，应检查可选结果及 `send_status`。记录业务事件 ID，以及结果存在时返回的 `recall_handle`。消息键本身不是召回句柄。
+
+绝对时间戳应使用经过溢出检查的运算计算 Unix 纪元毫秒，并同步参与主机的时钟。规范化拒绝格式错误、溢出、过去时间戳和超出配置范围的请求。协议使用毫秒单位，不意味着毫秒级投递精度。
+
+标准 TOML 中相关键放在已有 `[store]` 表：
+
+```toml
+[store]
+timerWheelEnable = true
+timerPrecisionMs = 1000
+timerMaxDelaySec = 259200
+```
+
+这是片段，不是完整 Broker 配置。配置定时器后，还需要所选后端及服务生命周期处于活动状态。ExtendedTimeline 模式具有独立的 RocksDB、feature 和接纳时间范围条件，不能根据标准定时示例推断它已经可用。
+
+## 使用返回句柄召回
+
+召回面向到期前符合条件的定时消息。当前句柄生成路径不会为普通延迟级别消息提供相同召回句柄。应要求真实的 `SendResult.recall_handle`，不要根据消息 ID 虚构句柄。
+
+以下片段假设 `result` 是已经成功检查的 `SendResult`，且生产者仍处于启动状态：
+
+```rust
+if let Some(handle) = result.recall_handle.as_deref() {
+    let recalled_message_id = producer
+        .recall_message("DelaySendTestTopic", handle)
+        .await?;
+}
+```
+
+客户端校验生命周期、主题和非空可解码句柄，然后解析对应 Broker。该 facade 不支持重试或死信主题。Broker 检查召回开关、角色和可用性、写权限策略、主题存在性、句柄中的主题和 Broker 匹配，以及剩余时间窗口。
+
+Broker 的 `recallMessageEnable` 当前默认为 true，但仍适用实际部署的授权。剩余时间必须为正，且严格小于所选最大召回范围。看起来有效的句柄不是绕过主题权限的凭据。
+
+## 根据引擎解释召回结果
+
+标准路径通过追加定时删除标记召回。响应说明标记写入路径的结果，不是同步扫描后证明没有任何消费者见过原消息。投递与删除处理可能竞争。
+
+ExtendedTimeline 模式中，当前处理器使用类型化取消操作。`Cancelled` 和 `AlreadyCancelled` 映射成功；`TooLate`、`NotFound` 映射非法操作；`Retry` 映射服务不可用；`Quarantined`、`Unsupported` 映射系统错误。这种显式状态结果与标准标记路径不同。
+
+任何模式的召回都不会撤销消费者已经完成的外部副作用。业务取消状态应保持权威，使迟到提醒可以按应用规则识别、忽略或补偿。
+
+## 失败与恢复决策
+
+| 观察结果 | 解释 |
+| --- | --- |
+| 发送超时 | 定时接纳结果可能不确定，创建第二份业务提醒前先协调状态 |
+| 发送结果没有召回句柄 | 不能仅从延迟设置推断支持召回 |
+| 召回报告主题或 Broker 不匹配 | 检查原始句柄与目标，不要修改句柄字段 |
+| 召回过晚 | 消息可能已具备投递资格，使用应用取消策略 |
+| 召回超时 | 远端取消或标记可能成功，协调时保留原始标识 |
+| 实际投递晚于请求时间 | 分别检查定时分派、时钟、存储及消费者积压 |
+
+批次校验和事务生产者在各自路径拒绝延迟或定时组合。延迟发送也不会与后来发往同一业务主题的普通消息建立顺序关系。
+
+## 示例与验证范围
+
+在 `rocketmq-example/` 中执行：
+
+```bash
+cargo check --example producer-delay-send
+cargo run --example producer-delay-send
+```
+
+示例向 `DelaySendTestTopic` 发送四条消息，分别使用级别、相对秒、相对毫秒和绝对时间形式。它使用回环 NameServer，之后关闭生产者。应配合订阅相同主题的消费者，比较请求的可投递时间与实际接收时间。
+
+该示例不调用召回，不测试临近截止时间的竞争，也不演示崩溃后的定时器恢复。这些场景需要针对所选引擎和持久化配置单独观察。
+
+源码依据：[延迟示例](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/producer/delay_send.rs)、[定时请求规范化](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-model/src/common/message/timer_request.rs)、[存储配置](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-store/src/config/message_store_config.rs)、[句柄生成](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/processor/send_message_processor/message_builder.rs)、[召回处理器](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-broker/src/processor/recall_message_processor.rs)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/ordered-messages.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/ordered-messages.md
@@ -1,0 +1,94 @@
+---
+title: "顺序消息"
+---
+
+# 顺序消息
+
+顺序是跨生产者路由、队列存储、消费者调度与业务完成的契约。仅把订单 ID 放进消息键，不会建立该契约。
+
+对于同一业务实体，应串行发送到同一队列，并通过目标顺序消费者路径处理该队列。独立队列可以并行推进，彼此不存在全局顺序关系。
+
+## 定义顺序范围
+
+```mermaid
+flowchart LR
+    A["订单 A：创建 → 支付 → 发货"] --> Q0["队列 0"]
+    B["订单 B：创建 → 支付 → 发货"] --> Q1["队列 1"]
+    Q0 --> C0["队列 0 串行处理器"]
+    Q1 --> C1["队列 1 串行处理器"]
+    C0 --> D0["顺序提交 A 的业务效果"]
+    C1 --> D1["顺序提交 B 的业务效果"]
+```
+
+箭头表示逐队列顺序，不要求队列 0 的事件先于队列 1 的事件完成。多个实体可以共享队列，因此一个实体阻塞可能影响该队列上的其他实体。
+
+## 稳定路由相关事件
+
+生产者选择器从当前候选中返回队列。以下片段假设生产者已启动、主题已创建，并存在应用定义的 `order_id: usize`：
+
+```rust
+let message = Message::builder()
+    .topic("OrderSendTestTopic")
+    .key(format!("order-{order_id}"))
+    .body("created")
+    .build()?;
+let result = producer.send_with_selector(
+    message,
+    |queues, _message, key: &usize| {
+        if queues.is_empty() { None }
+        else { Some(queues[*key % queues.len()].clone()) }
+    },
+    order_id,
+).await?;
+```
+
+发送下一依赖事件前，应检查当前发送结果。选择器控制消息位置，不会串行化两个并发生产者，也不会等待下游业务完成。
+
+取模路由适合解释机制，但候选列表或队列数量改变时，映射也会改变。运维变更需要为在途序列制定交接策略。不能仅因第一个队列暂不可用，就把下一事件改发到其他队列。
+
+## 使用顺序消费接口
+
+使用 `DefaultMQPushConsumer`、`MessageListenerOrderly`、一致的组和订阅，以及所需消费模型。集群模式中，客户端与 Broker 协调队列锁，并串行化本地处理。并发监听器不提供相同顺序边界。
+
+顺序监听器接收 `&mut ConsumeOrderlyContext`，返回 `ConsumeOrderlyStatus`。上下文使用自动提交时，只有按序业务效果完成后才能返回 `Success`。`SuspendCurrentQueueAMoment` 推迟当前队列以便重试。修改上下文自动提交行为之前，应理解保留的手动提交和回滚状态处理。
+
+不要启动独立异步业务工作后立即返回成功，否则下一回调可能先提交业务效果。数据库序列或版本检查可以跨进程重启和所有权迁移拒绝重复、识别缺口。
+
+## 处理失败时保留真实顺序边界
+
+| 故障 | 影响 |
+| --- | --- |
+| 发送响应丢失 | 事件可能已存在；推进业务序列前，用稳定标识协调或重试 |
+| 同一键并发发送 | Broker 到达顺序可能不同于业务意图 |
+| 队列数量或候选顺序改变 | 简单选择器可能把实体映射到其他队列 |
+| 当前处理失败 | 队列暂停和重试可能阻止后续工作 |
+| 再平衡或丢失锁 | 所有权变化，外部业务效果仍需幂等和序列检查 |
+| 重试或丢弃策略最终越过失败事件 | 应用必须决定如何修复业务序列缺口 |
+
+顺序处理不意味着业务效果恰好一次，也不意味着无限重试。修改重试限制会影响毒消息之后的业务事件能否继续。跨主题流程需要应用协调或状态检查，不同主题之间不存在自动顺序。
+
+## 运行匹配的示例对
+
+现有生产者和顺序消费者均使用 `OrderSendTestTopic`。按照[快速开始](../getting-started/quick-start.md)的资源创建流程，替换名称创建该主题和 `consumer_orderly_group`。两个示例均使用 `127.0.0.1:9876`。
+
+在 `rocketmq-example/` 中编译：
+
+```bash
+cargo check --example producer-order-send --example consumer-orderly
+```
+
+在一个终端启动消费者，再在第二个终端启动生产者，两个终端均位于该目录：
+
+```bash
+cargo run --example consumer-orderly
+```
+
+```bash
+cargo run --example producer-order-send
+```
+
+生产者为四个订单 ID 依次生成 created、paid、packed、shipped 事件。应逐订单比较队列、偏移量与业务序列，不同队列交错属于预期。消费者对新组采用首偏移量策略，并等待信号后关闭。已有组进度或旧数据会改变观察结果。
+
+这些目标演示固定拓扑下的一次运行，不证明故障转移、队列扩容、多生产者并发发送或消费者数据库崩溃时的顺序。这些应作为独立应用场景验证。
+
+源码依据：[生产者示例](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/producer/order_send.rs)、[消费者示例](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/consumer/orderly_consumer.rs)、[顺序服务](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs)、[选择器发送 facade](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/default_mq_producer.rs)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/producer/sending-messages.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/producer/sending-messages.md
@@ -1,279 +1,122 @@
 ---
-sidebar_position: 2
-title: 发送消息
+title: "发送消息"
 ---
-
-> Runtime 所有权：示例中的 `client_runtime` 是应用持有的 `Arc<ClientRuntime>`，它从 `RuntimeOwner` 的 child scope 创建，并在进程边界显式关闭。
 
 # 发送消息
 
-本章介绍基于 `DefaultMQProducer` 与 `MQProducer` 的常见发送模式。
+根据应用如何观察完成结果、如何选择目标队列来选择发送方法。所有方法均使用应用持有的 `ClientRuntime` 和已启动的生产者。完整运行时、Broker、主题及关闭设置参见[快速开始](../getting-started/quick-start.md)。
 
-## 消息类型
+## 选择结果契约
 
-### 基础消息
+这里的“同步发送”表示等待 Broker 响应；Rust 调用仍是需要 await 的异步 Future。
 
-```rust
-use rocketmq_common::common::message::message_single::Message;
+| API 类型 | 结果通道 | 适用场景 |
+| --- | --- | --- |
+| `send`、`send_with_timeout` | `ClientResult<Option<SendResult>>` | 观察发送响应后再继续 |
+| `send_with_callback`、`send_with_callback_timeout` | 方法直接返回值，以及回调结果或错误 | 保持有界在途工作并关联完成结果 |
+| `send_oneway` | `ClientResult<()>`，不包含 Broker 响应 | 应用明确不要求远端确认的场景 |
+| `send_batch` 及超时变体 | `ClientResult<SendResult>` | 显式发送符合约束的批次 |
+| `send_to_queue` 及队列变体 | 相同完成方式，目标队列明确 | 保持已知目标 |
+| `send_with_selector` 及选择器变体 | 相同完成方式，由应用在可用队列中选择 | 用稳定业务键路由相关事件 |
 
-let message = Message::builder()
-    .topic("TopicTest")
-    .body("Hello, RocketMQ!")
-    .build()?;
+仅有 `Ok` 包装不足以统计一次已确认发送成功。应检查 `SendResult.send_status`，在允许可选返回值的 API 中显式处理 `None`。直接超时发送路径预期获得响应；响应缺失不等于 Broker 成功确认。
 
-producer.send(message).await?;
-```
+`SendStatus::SendOk`、`FlushDiskTimeout`、`FlushSlaveTimeout` 和 `SlaveNotAvailable` 含义不同。后三种状态可能出现在追加已被接纳之后。状态名沿用协议术语；对应持久性与副本条件参见[存储设计](../architecture/storage.md)。即使返回 `SendOk`，也不表示消费者已完成业务处理。
 
-### 带 Tag 的消息
+## 发送一条消息并检查状态
 
-```rust
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
-    .tags("order_created")
-    .build()?;
-
-producer.send(message).await?;
-```
-
-### 带 Key 的消息
+以下完整函数接收快速开始应用创建的共享运行时。在该运行时上调用它，返回后关闭共享 ClientRuntime 和 RuntimeOwner。调用前创建 `DocsFirstMessage`。
 
 ```rust
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
-    .key("order_12345")
-    .build()?;
+use std::{io, sync::Arc};
+use rocketmq_client_rust::{ClientRuntime, DefaultMQProducer, SendResult, SendStatus};
+use rocketmq_model::common::message::message_single::Message;
 
-producer.send(message).await?;
-```
-
-### 带属性的消息
-
-```rust
-let message = Message::builder()
-    .topic("OrderEvents")
-    .body(body)
-    .raw_property("region", "us-west")?
-    .raw_property("priority", "high")?
-    .raw_property("source", "mobile_app")?
-    .build()?;
-
-producer.send(message).await?;
-```
-
-## 发送策略
-
-### 顺序发送
-
-```rust
-for msg in messages {
-    producer.send(msg).await?;
-}
-```
-
-### 并发发送
-
-```rust
-use futures::future::join_all;
-
-let tasks = messages
-    .into_iter()
-    .map(|msg| producer.send(msg))
-    .collect::<Vec<_>>();
-
-let results = join_all(tasks).await;
-```
-
-### 延迟发送
-
-```rust
-let message = Message::builder()
-    .topic("DelayedTopic")
-    .body(body)
-    .delay_level(3) // 1=1s, 2=5s, 3=10s ...
-    .build()?;
-
-producer.send(message).await?;
-```
-
-## 消息大小管理
-
-### 大消息
-
-```rust
-let mut producer = DefaultMQProducer::builder(client_runtime.clone())
-    .producer_group("my_group")
-    .name_server_addr("localhost:9876")
-    .compress_msg_body_over_howmuch(4 * 1024)
-    .build();
-
-let large_body = vec![0u8; 5 * 1024 * 1024];
-let message = Message::builder()
-    .topic("TopicTest")
-    .body(large_body)
-    .build()?;
-
-producer.send(message).await?;
-```
-
-### 拆分大消息
-
-```rust
-use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-use rocketmq_client_rust::producer::mq_producer::MQProducer;
-
-async fn split_and_send(
-    producer: &mut DefaultMQProducer,
-    topic: &str,
-    data: Vec<u8>,
-    chunk_size: usize,
-) -> rocketmq_error::RocketMQResult<()> {
-    let chunks: Vec<_> = data.chunks(chunk_size).collect();
-    let total = chunks.len();
-
-    for (i, chunk) in chunks.iter().enumerate() {
+async fn send_one(
+    client_runtime: Arc<ClientRuntime>,
+) -> Result<SendResult, Box<dyn std::error::Error>> {
+    let mut producer = DefaultMQProducer::builder(client_runtime)
+        .producer_group("docs_sending_group")
+        .name_server_addr("127.0.0.1:9876")
+        .build();
+    let outcome: Result<SendResult, Box<dyn std::error::Error>> = async {
+        producer.start().await?;
         let message = Message::builder()
-            .topic(topic)
-            .body_slice(chunk)
-            .key(format!("chunk-{i}-{total}"))
+            .topic("DocsFirstMessage")
+            .key("order-1001:event-1")
+            .tags("created")
+            .body("order created")
             .build()?;
-
-        producer.send(message).await?;
-    }
-
-    Ok(())
-}
-```
-
-## 错误处理
-
-### 失败重试
-
-```rust
-use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-use rocketmq_client_rust::producer::mq_producer::MQProducer;
-use rocketmq_client_rust::producer::send_result::SendResult;
-
-async fn send_with_retry(
-    producer: &mut DefaultMQProducer,
-    message: Message,
-    max_retries: u32,
-) -> rocketmq_error::RocketMQResult<Option<SendResult>> {
-    let mut retry_count = 0;
-
-    loop {
-        match producer.send(message.clone()).await {
-            Ok(result) => return Ok(result),
-            Err(e) if retry_count < max_retries => {
-                retry_count += 1;
-                tokio::time::sleep(std::time::Duration::from_millis(1_000)).await;
-                eprintln!("retry {} after error: {}", retry_count, e);
-            }
-            Err(e) => return Err(e),
+        let result = producer.send_with_timeout(message, 3_000).await?
+            .ok_or_else(|| io::Error::other("send response is absent"))?;
+        if result.send_status != SendStatus::SendOk {
+            return Err(io::Error::other(format!(
+                "send policy not satisfied: {}", result.send_status
+            )).into());
         }
-    }
+        Ok(result)
+    }.await;
+    producer.shutdown().await;
+    outcome
 }
 ```
 
-### 回退到备用队列
+消息键用于业务关联；设置键不会使 Broker 自动去重。如果业务事件标识必须跨重试或进程重启保留，应独立持久化。上述函数在操作出错后仍会执行清理。
+
+## 使用回调时完整处理失败
+
+回调接收 `Option<&SendResult>` 和 `Option<&ClientError>`。这些引用只属于当前回调调用；后续处理需要的数据应有界复制。避免在完成记录中保留完整请求或消息体。
+
+两个结果通道都要检查：方法可能在提交前失败，完成结果也可能通过回调报告失败。当前 `send_with_callback` facade 会将部分底层提交错误交给回调，然后返回 `Ok(())`。因此，只统计方法返回成功会高估实际发送成功数。
+
+在应用持有的完成记录得到结果，或显式截止时间到达前，应保持生产者和运行时存活。限制在途数量、字节数以及回调工作。回调不应阻塞运行时工作线程，也不应启动无人持有的后台任务。关闭流程不能代替对每次业务操作结果的关联。
+
+单向发送没有可检查的发送结果回调或 Broker 确认。本地提交成功不能证明远端持久化。当后续业务步骤要求确认 Broker 已接纳事件时，不应使用单向发送。
+
+## 发送合法批次
+
+显式批次不能为空，必须使用同一主题和一致的 `waitStoreMsgOK` 值，不得包含重试主题消息或延迟、定时消息。当前 `MessageBatch` 校验器检查延迟级别、相对毫秒或秒延迟、绝对投递时间属性。不要将事务语义与普通批量路径组合。
+
+以下片段在生产者启动后执行：
 
 ```rust
-async fn send_with_fallback(
-    producer: &mut DefaultMQProducer,
-    message: Message,
-    fallback_topic: &str,
-) -> rocketmq_error::RocketMQResult<Option<SendResult>> {
-    match producer.send(message.clone()).await {
-        Ok(result) => Ok(result),
-        Err(_) => {
-            let mut fallback_message = message;
-            fallback_message.set_topic(fallback_topic.into());
-            producer.send(fallback_message).await
-        }
-    }
-}
+let messages = vec![
+    Message::builder().topic("DocsFirstMessage")
+        .body("batch event 1").build()?,
+    Message::builder().topic("DocsFirstMessage")
+        .body("batch event 2").build()?,
+];
+let result = producer.send_batch_with_timeout(messages, 3_000).await?;
 ```
 
-## 发送监控
+与单条发送一样，应检查批次的 `send_status`。批量发送不是跨消费者数据库的事务。编码后的总大小、属性和帧开销必须满足当前客户端与 Broker 限制；仅限制消息条数无法保证这一点。提交前拆为有界批次，并为每个业务事件保留独立重放标识。
 
-### 跟踪发送结果
+自动累积批量与显式 `send_batch` 是不同选项。启用累积器后，当前 `send` 以及部分回调和队列 facade 可以经过累积器，而显式 `send_with_timeout` 直接调用带超时的发送实现。不能假定所有重载具有相同缓冲行为。
 
-```rust
-let mut success_count = 0;
-let mut failure_count = 0;
+## 明确选队列与重试策略
 
-for message in messages {
-    match producer.send(message).await {
-        Ok(_) => {
-            success_count += 1;
-        }
-        Err(e) => {
-            failure_count += 1;
-            eprintln!("Failed: {}", e);
-        }
-    }
-}
+从主题路由获取可发布队列，不要虚构 Broker 名称或队列 ID。选择器接收候选队列、消息和参数，返回可选队列。应处理候选集合为空的情况；对零个队列执行取模无效。
 
-println!("Success: {}, Failed: {}", success_count, failure_count);
+相关事件需要稳定映射，要求顺序时还应串行发送。路由或队列数量变化可能改变简单取模映射。详见[顺序消息](../guides/ordered-messages.md)。
+
+超时限制客户端等待，不会取消远端副作用。区分接纳前拒绝与发送后结果不确定，采用有界重试截止时间，并考虑所选发送路径已有的内部重试。不要悄悄把失败业务事件改投其他主题，这会改变订阅、顺序和恢复语义。
+
+## 示例目标与观察结果
+
+在 `rocketmq-example/` 使用其独立清单，提前创建各示例的实际主题：
+
+| 目标 | 主题 | 观察重点 |
+| --- | --- | --- |
+| `producer-basic-send` | `BasicSendTestTopic` | 响应、回调和单向发送的区别 |
+| `producer-batch-send` | `BatchSendTestTopic` | 批次状态与所选队列 |
+| `producer-send-to-queue` | 阅读其常量 | 显式路由选择 |
+| `producer-send-with-selector` | 阅读其常量 | 选择器参数与队列映射 |
+
+```bash
+cargo check --example producer-basic-send --example producer-batch-send
+cargo run --example producer-basic-send
 ```
 
-## 常见业务场景
+这些示例使用回环 NameServer 常量，没有统一的命令行地址选项。它们演示 API，其中的调试输出不是生产日志规范。已验证的首条消息流程和完整清理见网站配套教程应用。编译成功不能证明回调丢失、故障转移或崩溃恢复行为。
 
-### 发送订单事件
-
-```rust
-async fn send_order_event(
-    producer: &mut DefaultMQProducer,
-    order_id: &str,
-    event_type: &str,
-    order_data: &Order,
-) -> rocketmq_error::RocketMQResult<Option<SendResult>> {
-    let body = serde_json::to_vec(order_data)?;
-
-    let message = Message::builder()
-        .topic("OrderEvents")
-        .body(body)
-        .tags(event_type)
-        .key(order_id)
-        .raw_property("event_type", event_type)?
-        .raw_property("timestamp", chrono::Utc::now().to_rfc3339())?
-        .build()?;
-
-    producer.send(message).await
-}
-```
-
-### 发送日志
-
-```rust
-async fn send_log(
-    producer: &mut DefaultMQProducer,
-    level: &str,
-    message_text: &str,
-) -> rocketmq_error::RocketMQResult<Option<SendResult>> {
-    let message = Message::builder()
-        .topic("Logs")
-        .body(message_text)
-        .tags(level)
-        .build()?;
-
-    producer.send(message).await
-}
-```
-
-## 最佳实践
-
-1. 业务关键消息设置可追踪 Key，便于排障与去重。
-2. Tag 用于粗粒度过滤，属性用于补充元数据。
-3. 重试需要限制次数，并记录失败日志。
-4. 持续统计发送成功率与延迟。
-5. 吞吐优先场景可使用批量发送。
-6. 发送前校验消息体大小，避免超限失败。
-7. 保持消息体 schema 稳定并进行版本化。
-
-## 下一步
-
-- [事务消息](./transaction-messages) - 实现事务消息
-- [客户端配置](../configuration/client-config) - 配置生产者相关参数
-- [消费者指南](../consumer/overview) - 了解消费者处理逻辑
+源码依据：[生产者 facade](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/default_mq_producer.rs)、[发送实现](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/send.rs)、[批次校验](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-model/src/common/message/message_batch.rs)、[统一发送结果](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-model/src/result.rs)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/producer/transaction-messages.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/producer/transaction-messages.md
@@ -1,167 +1,138 @@
 ---
-sidebar_position: 3
-title: 事务消息
+title: "事务消息"
 ---
-
-> Runtime 所有权：示例中的 `client_runtime` 是应用持有的 `Arc<ClientRuntime>`，它从 `RuntimeOwner` 的 child scope 创建，并在进程边界显式关闭。
 
 # 事务消息
 
-事务消息用于保证“本地业务状态”与“消息可见性”最终一致。
+事务消息用于协调事件可见性与生产者侧业务事务。Broker 先存储准备消息，即半消息，生产者再报告本地提交、回滚或结果未知。它不是横跨 Broker 存储和应用数据库的分布式 ACID 事务。
 
-## 概述
+使用注册了 `TransactionListener`、注入了 `ClientRuntime` 的 `TransactionMQProducer`。普通生产者上的同名方法不能替代事务生产者初始化。先阅读[生产者生命周期](./overview.md)，并创建目标业务主题。
 
-事务消息保证：
-
-1. 先持久化 half message，再执行本地事务。
-2. 消息最终可见性由本地事务状态决定（提交或回滚）。
-3. 对于未知状态，Broker 可回查生产者。
-
-## 事务流程
+## 准备、决策与回查
 
 ```mermaid
 sequenceDiagram
-    participant P as Producer
-    participant B as Broker
-    participant L as Local Transaction
-    participant C as Consumer
-
-    P->>B: 发送 half message
-    B-->>P: 返回 half ack
-    P->>L: 执行本地事务
-    L-->>P: 返回本地状态
-
-    alt Commit
-        P->>B: Commit
-        B->>C: 投递消息
-    else Rollback
-        P->>B: Rollback
-    else Unknown
-        B->>P: 发起事务回查
-        P-->>B: 返回本地状态
+    participant P as 事务生产者
+    participant B as Broker 事务服务
+    participant D as 业务数据库
+    participant C as 消费者
+    P->>B: 发送准备消息
+    B-->>P: 半消息发送状态
+    alt SendOk
+        P->>D: 执行本地事务并记录结果
+        D-->>P: 提交 / 回滚 / 不确定
+        P->>B: 结束事务决策
+    else 刷盘或副本状态不是 SendOk
+        P->>B: 当前客户端选择回滚
     end
+    opt Broker 需要解决待定结果
+        B->>P: 回查本地事务
+        P->>D: 读取持久化业务结果
+        D-->>P: 已知结果或不确定
+        P-->>B: 提交 / 回滚 / 未知
+    end
+    B-->>C: 已提交消息具备投递资格
 ```
 
-## 创建事务生产者
+最后一条箭头表示具备投递资格，不代表立即回调或业务已处理。半消息响应继承当前存储及复制策略，不能把所有已接纳半消息都描述为已持久复制。
 
-```rust
-use rocketmq_client_rust::producer::mq_producer::MQProducer;
-use rocketmq_client_rust::producer::transaction_mq_producer::TransactionMQProducer;
-use rocketmq_error::RocketMQResult;
+当前客户端仅在 `SendOk` 时执行本地监听器。`FlushDiskTimeout`、`FlushSlaveTimeout` 和 `SlaveNotAvailable` 会选择回滚，不执行该监听器。在获得可用发送结果前发生传输错误，则直接返回错误。部分非成功状态仍可能对应已接纳的日志追加，因此需要区分这些分支。
 
-#[tokio::main]
-async fn main() -> RocketMQResult<()> {
-    let mut producer = TransactionMQProducer::builder(client_runtime.clone())
-        .producer_group("transaction_producer_group")
-        .name_server_addr("localhost:9876")
-        .topics(vec!["OrderEvents"])
-        .transaction_listener(OrderTransactionListener::default())
-        .build();
+## 实现可恢复的决策
 
-    producer.start().await?;
-    // 发送事务消息...
-    producer.shutdown().await;
-    Ok(())
-}
-```
+`TransactionListener` 包含两个同步回调：
 
-## 实现事务监听器
+| 回调 | 职责 |
+| --- | --- |
+| `execute_local_transaction(&dyn MessageTrait, Option<&(dyn Any + Send + Sync)>)` | 幂等执行本地业务，返回 `LocalTransactionState` |
+| `check_local_transaction(&MessageExt)` | 读取权威持久化结果，返回同一状态域 |
 
-```rust
-use std::any::Any;
+两者均返回 `CommitMessage`、`RollbackMessage` 或 `Unknown`。回调工作应有界。客户端通过受管理的阻塞边界运行本地执行；调用者超时或 panic 映射不会回滚已经提交的外部事务。
 
-use cheetah_string::CheetahString;
-use rocketmq_client_rust::producer::local_transaction_state::LocalTransactionState;
-use rocketmq_client_rust::producer::transaction_listener::TransactionListener;
-use rocketmq_common::common::message::message_ext::MessageExt;
-use rocketmq_common::common::message::MessageTrait;
-
-#[derive(Default)]
-struct OrderTransactionListener;
-
-impl TransactionListener for OrderTransactionListener {
-    fn execute_local_transaction(
-        &self,
-        msg: &dyn MessageTrait,
-        _arg: Option<&(dyn Any + Send + Sync)>,
-    ) -> LocalTransactionState {
-        // 在这里执行本地事务逻辑
-        let _tx_id: Option<&CheetahString> = msg.transaction_id();
-        LocalTransactionState::Unknown
-    }
-
-    fn check_local_transaction(&self, _msg: &MessageExt) -> LocalTransactionState {
-        // 回查本地事务表并返回 CommitMessage / RollbackMessage / Unknown
-        LocalTransactionState::Unknown
-    }
-}
-```
-
-## 发送事务消息
-
-```rust
-use rocketmq_client_rust::producer::mq_producer::MQProducer;
-use rocketmq_common::common::message::message_single::Message;
-
-let message = Message::builder()
-    .topic("OrderEvents")
-    .tags("order_created")
-    .key("order_12345")
-    .body("{\"order_id\":\"order_12345\"}")
-    .build()?;
-
-let result = producer
-    .send_message_in_transaction(message, Some("order_12345".to_string()))
-    .await?;
-
-println!("Transaction message sent: {}", result);
-```
-
-## 本地事务状态处理（伪代码）
+以下是应用伪代码，并非完整数据库实现：
 
 ```text
-execute_local_transaction(message):
-  本地事务成功 -> CommitMessage
-  本地事务明确失败 -> RollbackMessage
-  本地状态暂不确定 -> Unknown
+execute(message):
+    event_id = 消息携带的稳定业务标识
+    在同一本地数据库事务中：
+        若已有结果记录：返回该结果
+        幂等应用业务变更
+        持久化 event_id 与最终业务结果
+    仅在确认提交后返回 CommitMessage
 
-check_local_transaction(message):
-  根据事务 ID 查询本地事务表
-  返回 CommitMessage / RollbackMessage / Unknown
+check(message):
+    使用 event_id 读取权威结果
+    已提交 -> CommitMessage
+    已确定中止 -> RollbackMessage
+    不可用或未解决 -> Unknown
 ```
 
-## 配置
+不要把进程内 map 作为恢复依据。生产者重启，或同组其他合格生产者接到回查时，必须能够通过持久化业务状态回答。回调可选的内存参数不会作为持久事务元数据由 Broker 回传。
 
-当前 `TransactionMQProducer::builder(client_runtime.clone())` 暴露了事务回查线程池与请求队列相关参数：
+状态缺失需要业务策略：它可能表示尚未执行、暂不可见或存储不可用。把所有查询失败都返回为回滚，可能隐藏已提交的业务变更；永久返回未知则会积累未解决工作，并最终受到 Broker 配置的回查或丢弃策略约束。
+
+## 集成生产者
+
+以下片段假设 `client_runtime` 是应用共享运行时，`listener` 是真实的 `TransactionListener` 实现：
 
 ```rust
 let mut producer = TransactionMQProducer::builder(client_runtime.clone())
-    .producer_group("transaction_producer_group")
-    .name_server_addr("localhost:9876")
-    .topics(vec!["OrderEvents"])
-    .transaction_listener(OrderTransactionListener::default())
-    .check_thread_pool_min_size(2)
-    .check_thread_pool_max_size(8)
-    .check_request_hold_max(2_000)
+    .producer_group("docs_transaction_group")
+    .name_server_addr("127.0.0.1:9876")
+    .topics(vec!["TransactionSendTestTopic"])
+    .transaction_listener(listener)
     .build();
 ```
 
-## 最佳实践
+发送前启动生产者，并检查返回 `TransactionSendResult` 中的两个字段：
 
-1. 本地事务尽量短、确定性强。
-2. 在返回提交/回滚前先持久化本地事务结果。
-3. 本地事务逻辑要具备幂等性。
-4. `Unknown` 仅用于短暂不确定，不应用于永久失败。
-5. 监控回查频率与 Unknown 状态持续时长。
+```rust
+let message = Message::builder()
+    .topic("TransactionSendTestTopic")
+    .key("order-1001:event-1")
+    .body("order created")
+    .build()?;
+let outcome = producer
+    .send_message_in_transaction::<(), _>(message, None)
+    .await?;
+```
 
-## 限制
+`send_result` 描述准备消息发送，`local_transaction_state` 描述客户端决策。**两个字段都不是 Broker 最终提交回执。** 当前实现会记录结束事务请求失败，但仍可能返回 `Ok(TransactionSendResult)`。应保持事务回查可用，以弥合这个故障窗口。
 
-- 相比普通消息，事务消息有更高延迟。
-- Broker 在提交/回滚前会持有 half message。
-- 回查逻辑设计不当会导致长时间 pending。
+在未完成工作已经解决，或交给明确恢复流程后，依次关闭事务生产者、共享 ClientRuntime、RuntimeOwner 和遥测设施。返回未知后立即停机，会使当前进程无法回答后续回查。
 
-## 下一步
+## 故障窗口
 
-- [客户端配置](../configuration/client-config) - 查看生产端配置
-- [消费者指南](../consumer/overview) - 了解消费端处理
-- [故障排查](../faq/troubleshooting) - 排查生产问题
+| 窗口 | 对应用的影响 |
+| --- | --- |
+| 半消息结果不确定 | 不应假定消息不存在；通过稳定业务标识协调状态 |
+| 业务已提交，报告提交前进程退出 | Broker 回查必须恢复持久化的已提交结果 |
+| 结束事务请求失败 | 本地返回提交不能证明消费者立即可见 |
+| 回查到达不共享状态的生产者 | 该组无法可靠解决待定事务 |
+| 业务执行或回查 panic | 当前客户端将回调失败映射为未知；需要排查底层操作 |
+| 消费者副作用已提交，但进度未持久化 | 消费者可能再次收到已提交消息 |
+
+事务消息不会消除消费者幂等要求，详见[投递与重试](../guides/delivery-and-retry.md)。
+
+## 限制与组合条件
+
+当前事务路径拒绝延迟或定时属性，包括延迟级别、相对延迟和绝对投递时间。不要组合普通批量 API 与事务发送，并由此推断支持批次事务。
+
+回查设置要求 min/max 均为正值、min 不大于 max、请求保留上限为正值。实现采用准入信号量：max 限制并发回查，hold max 限制已接纳回查工作。min 会被校验，但不能据此认为会创建指定最小数量的专用操作系统线程池。
+
+Broker 回查间隔、最大回查次数、事务服务可用性和生产者连通性都会影响结果解决。它们属于部署条件；只有监听器类型存在，不能证明完整事务路径已经配置。
+
+## 阅读示例时区分接口演示与恢复验证
+
+在 `rocketmq-example/` 中执行：
+
+```bash
+cargo check --example producer-transaction-send
+cargo run --example producer-transaction-send
+```
+
+先在回环集群创建 `TransactionSendTestTopic`。示例在内存中交替返回提交、回滚、未知，发送六条后关闭。它展示监听器接入和结果结构，没有持久化业务事务日志，也不会持续运行以证明所有未知消息最终解决。
+
+验证应用事务集成时，应保持可回查生产者在线，在消费者侧观察仅已提交业务事件可见，并单独演练本地提交后、报告结束事务前的重启窗口。记录该场景的真实结果；编译示例不等于完成这种验证。
+
+源码依据：[事务 facade](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/transaction_mq_producer.rs)、[发送与决策路径](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/transaction.rs)、[回查调度](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/lifecycle.rs)、[示例](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-example/examples/producer/transaction_send.rs)。

--- a/rocketmq-website/sidebars.ts
+++ b/rocketmq-website/sidebars.ts
@@ -50,6 +50,8 @@ const sidebars: SidebarsConfig = {
         'consumer/overview',
         'consumer/push-consumer',
         'consumer/pull-consumer',
+        'consumer/classic-pull-compatibility',
+        'consumer/pop',
         'consumer/message-filtering',
       ],
     },
@@ -58,7 +60,11 @@ const sidebars: SidebarsConfig = {
       label: 'Application Guides',
       collapsible: true,
       collapsed: true,
-      items: ['guides/delivery-and-retry'],
+      items: [
+        'guides/delivery-and-retry',
+        'guides/ordered-messages',
+        'guides/delay-and-recall',
+      ],
     },
     {
       type: 'category',


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10325

### Brief Description

Rewrite sending, transaction, Push and filtering guidance around current public APIs and add Classic Pull compatibility, POP, ordered-message and delay/recall guides. All eight pages have complete Chinese counterparts, matching code, source references, failure windows, lifecycle guidance and navigation.

Explain callback error delivery, transaction result versus final Broker commit, POP listener success versus ACK completion, runnable versus detached Classic Pull construction, SQL enablement, queue ordering and timer-engine-specific recall. Add paired transaction, POP and ordering diagrams and describe the actual limits of the existing examples.

### How Did You Test This Change?

- Compiled ten relevant targets from the standalone `rocketmq-example` project: basic send, batch, transaction, ordered send, delay send, concurrent cluster consumer, orderly consumer, Tag, SQL and POP.
- Extracted every new Rust code block into a temporary crate with the documented runtime/producer/consumer context and ran `cargo check` successfully.
- Ran `npm run build` in `rocketmq-website`; both languages passed.
- Checked all 16 pages for balanced code fences and existing document/source link targets, and confirmed the Chinese POP sequence rendered in the browser.
- Ran `git diff --cached --check` successfully.

Remaining site link warnings are in existing message-model, FAQ, author and coding-standards pages. No new live-cluster transaction, POP, failover, crash-recovery or timer-race result is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added consumer guides for Classic Pull compatibility and POP consumption.
  - Added guides for ordered messages, delayed delivery, and message recall.
  - Reworked filtering, push consumer, message sending, and transaction message documentation.
  - Added practical examples, lifecycle details, troubleshooting guidance, validation rules, and migration notes.
  - Updated Chinese documentation to match the new consumer and producer guidance.
  - Expanded the documentation sidebar with the new pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->