### PR TITLE
[ISSUE #10333]📝Explain product setup and contribution boundaries

### DIFF
--- a/rocketmq-website/docs/contributing/coding-standards.md
+++ b/rocketmq-website/docs/contributing/coding-standards.md
@@ -1,552 +1,71 @@
 ---
-sidebar_position: 3
-title: Coding Standards
+title: "Coding standards"
 ---
 
-# Coding Standards
+# Coding standards
 
-Welcome to RocketMQ-Rust's coding standards! 📝
+Follow the existing implementation at the owning layer and the nearest project guide. These conventions preserve public contracts, lifecycle ownership and diagnosable failures. They summarize current repository rules rather than defining a separate contribution process.
 
-This guide will help you write clean, idiomatic Rust code that follows our project conventions. These standards ensure code consistency, maintainability, and quality across the entire codebase.
+## Rust structure and public contracts
 
-## Why Coding Standards Matter
+Use the selected toolchain, package edition, `rustfmt.toml` and `.clippy.toml`. The root defaults to Rust 2021; Admin CLI and several standalone applications use Rust 2024. Preserve those manifest choices. Use snake_case modules/functions, PascalCase types and SCREAMING_SNAKE_CASE constants, and retain the Apache 2.0 header on new Rust files.
 
-Consistent code is:
+Keep implementation modules private and exports deliberate. Prefer enums, configuration/request structs, builders and newtypes to positional flags or long argument lists. Exhaustively match project-owned compatibility-sensitive enums. Keep optional features additive and test the relevant default/disabled behavior when a change affects it.
 
-- **Easier to read** and understand
-- **Easier to maintain** and debug
-- **Easier to review** in pull requests
-- **More reliable** with fewer bugs
+Request codes, response codes, headers, Serde fields/defaults and persisted layouts are compatibility surfaces. A rename that preserves an internal Rust call can still break a wire or storage contract. Explain an intended semantic change and its migration path; consult [protocol compatibility](../reference/protocol-compatibility.md).
 
-## Rust Conventions
+Split modules by cohesive behavior when useful. File length is a review signal, not a reason to split unrelated logic into arbitrary fragments. Web backend and GPUI local guides use a flat module layout without `mod.rs`; do not impose that local rule on unrelated modules without checking their guide.
 
-### Naming
+## Errors and documentation
 
-```rust
-// Modules: snake_case
-mod message_queue;
+Use typed errors for recoverable configuration, input, I/O, transport, storage and lifecycle failures. At public boundaries, map to the established component error model and stable descriptor. Do not replace meaningful errors with a generic string or match a human-readable message to make a retry decision.
 
-// Types: PascalCase
-struct MessageQueue;
-enum ConsumeResult;
+Avoid production `todo!`, `unimplemented!` and recoverable-path `unwrap`/`expect`/panic. Test assertions are appropriate, and an intentional infallible facade needs a documented invariant or a fallible companion. Narrow any lint allowance and explain why it exists.
 
-// Functions: snake_case
-fn send_message() {}
+Rustdoc should describe non-obvious invariants and applicable `# Errors`, `# Panics` and `# Safety` contracts. Comments explain why a choice is required; do not narrate every line. Keep unsafe blocks minimal with an immediately preceding `// SAFETY:` explanation and a clear safe-wrapper or caller contract.
 
-// Constants: SCREAMING_SNAKE_CASE
-const MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+## Async execution and shutdown
 
-// Static: SCREAMING_SNAKE_CASE
-static DEFAULT_TIMEOUT: u64 = 3000;
-```
+| Concern | Required design property |
+| --- | --- |
+| Background tasks | Own work through `ServiceContext`, `TaskGroup` or the established lifecycle owner; cancel and await it during shutdown. |
+| Blocking operations | Use `BlockingExecutor` or an established top-level boundary; do not introduce raw `spawn_blocking`, nested `block_on` or ad hoc runtimes. |
+| Synchronization | Do not hold a synchronous lock guard across `.await`; keep lock scopes small. |
+| Admission | Preserve bounded task, byte and blocking budgets. Timeout does not necessarily stop underlying blocking work. |
+| Async traits | Prefer native async trait methods; do not introduce `#[async_trait]`. |
+| Completion | Distinguish accepted, written, durable, replicated and business-complete outcomes. |
 
-### Code Organization
+The [runtime design](../architecture/runtime.md) describes ownership and budget boundaries. A shutdown implementation that drops a handle without awaiting owned work is not equivalent to a completed shutdown. Runtime changes need focused cancellation/resource tests where those behaviors change, without a fingerprint or baseline ceremony.
 
-```rust
-// Imports (std, external crates, internal modules)
-use std::sync::Arc;
-use tokio::sync::Mutex;
-use crate::model::Message;
-use crate::error::{Error, Result};
+## Observability and sensitive data
 
-// Type aliases
-type MessageQueueRef = Arc<MessageQueue>;
+Prefer `#[tracing::instrument(skip_all, ...)]` with explicit low-cardinality fields. Never log credentials, ACL/TLS material, tokens, message bodies or entire request/configuration objects. Avoid unsampled per-message spans and unbounded topic/group labels.
 
-// Constants
-const MAX_RETRY: u32 = 3;
+Use the established error redaction and telemetry ownership paths. A safe `Debug` implementation on one wrapper does not make arbitrary strings safe to log. [Errors and observability](../architecture/errors-observability.md) explains signal ownership and boundary mappings.
 
-// Structs
-pub struct Producer {
-    // Private fields
-    client: Arc<Client>,
-    options: ProducerOptions,
-}
+## Frontend and desktop code
 
-// Impl blocks
-impl Producer {
-    // Associated functions ( constructors)
-    pub fn new() -> Self { }
+| Project | Local convention |
+| --- | --- |
+| Website | Docusaurus/MDX, existing components and page IDs; paired English/Chinese content and translated navigation. |
+| Web frontend | React/TypeScript/Vite, shared tokens/components and unified `src/api/` client; operational tables with loading, empty, error, search, pagination and refresh states. |
+| Web backend | Thin Axum handlers, service orchestration, separate API DTOs and internal models, explicit local error mapping; reusable logic in Dashboard common. |
+| GPUI | Deterministic render paths, state changes through Context/Window, stable element IDs, owned subscriptions and nonblocking UI work. |
+| Tauri | Frontend commands from the app root; Rust commands from `src-tauri`. Frontend asset compilation is separate from desktop packaging. |
 
-    // Methods
-    pub async fn send(&self, msg: Message) -> Result<SendResult> { }
+Preserve accessibility, focus, keyboard operation, light/dark consistency and usable resizing. Product confirmation dialogs for destructive actions remain part of the application behavior; they are unrelated to the documentation-writing workflow. Do not expose internal migration or API-parity implementation notes as user-facing product controls.
 
-    // Private methods
-    async fn do_send(&self, msg: Message) -> Result<SendResult> { }
-}
+## Select relevant checks
 
-// Trait impls
-impl Default for Producer {
-    fn default() -> Self { }
-}
-```
-
-### Error Handling
-
-RocketMQ-Rust uses the `thiserror` crate for error definitions. Always use `Result` types for operations that can fail.
-
-```rust
-// Use Result for fallible operations
-use crate::error::Result;
-
-pub async fn send_message(&self, msg: Message) -> Result<SendResult> {
-    // Use ? for error propagation - clean and idiomatic
-    let broker = resolve_broker(&msg.topic)?;
-
-    // ⚠️ Avoid unwrap() in library code - it can panic!
-    // ✅ Instead, handle errors explicitly
-    match broker.send(msg).await {
-        Ok(result) => Ok(result),
-        Err(e) => Err(Error::SendFailed(e.to_string())),
-    }
-}
-
-// Custom error types using thiserror
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Broker not found: {0}")]
-    BrokerNotFound(String),
-
-    #[error("Timeout after {0}ms")]
-    Timeout(u64),
-
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-}
-
-// ✅ Good: Explicit error handling
-pub fn parse_config(data: &str) -> Result<Config> {
-    serde_json::from_str(data)
-        .map_err(|e| Error::ConfigParse(e.to_string()))
-}
-
-// ❌ Bad: Using unwrap() - can panic!
-pub fn parse_config_bad(data: &str) -> Config {
-    serde_json::from_str(data).unwrap() // Don't do this!
-}
-```
-
-### Async/Await
-
-RocketMQ-Rust uses `tokio` as the async runtime. All I/O operations should be async.
-
-```rust
-// ✅ Use async/await for async operations
-pub async fn send(&self, msg: Message) -> Result<SendResult> {
-    let broker = resolve_broker_async().await?;
-    broker.send(msg).await
-}
-
-// ✅ Spawn tasks for concurrent operations
-pub async fn send_batch(&self, msgs: Vec<Message>) -> Result<Vec<SendResult>> {
-    let tasks: Vec<_> = msgs
-        .into_iter()
-        .map(|msg| {
-            let self_clone = self.clone();
-            tokio::spawn(async move { self_clone.send(msg).await })
-        })
-        .collect();
-
-    let results = futures::future::try_join_all(tasks).await?;
-    results.into_iter().collect::<Result<Vec<_>>>()
-}
-
-// ❌ Bad: Blocking operations in async context
-pub async fn send_bad(&self, msg: Message) -> Result<SendResult> {
-    // Don't do this - blocks the async runtime!
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    self.send(msg).await
-}
-
-// ✅ Good: Use tokio's async sleep
-pub async fn send_good(&self, msg: Message) -> Result<SendResult> {
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    self.send(msg).await
-}
-```
-
-## Documentation
-
-### Public APIs
-
-```rust
-/// A producer for sending messages to RocketMQ brokers.
-///
-/// The producer handles message routing, load balancing, and
-/// automatic retry on failure.
-///
-/// # Examples
-///
-/// ```rust
-/// use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut producer = DefaultMQProducer::builder()
-///     .producer_group("example_group")
-///     .name_server_addr("localhost:9876")
-///     .build();
-/// producer.start().await?;
-/// # Ok(())
-/// # }
-/// ```
-///
-/// # See Also
-///
-/// - [`Consumer`] for consuming messages
-/// - [`Message`] for message structure
-pub struct Producer { }
-```
-
-### Module Documentation
-
-```rust
-//! Producer module.
-//!
-//! This module provides the [`Producer`] type for sending messages
-//! to RocketMQ brokers.
-//!
-//! # Features
-//!
-//! - Asynchronous message sending
-//! - Automatic retry on failure
-//! - Load balancing across brokers
-//! - Transactional message support
-//!
-//! # Examples
-//!
-//! ```rust
-//! use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-//!
-//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let mut producer = DefaultMQProducer::builder()
-//!     .producer_group("example_group")
-//!     .name_server_addr("localhost:9876")
-//!     .build();
-//! let message = Message::builder()
-//!     .topic("TopicTest")
-//!     .body("Hello")
-//!     .build()?;
-//! producer.send(message).await?;
-//! # Ok(())
-//! # }
-//! ```
-```
-
-## Testing
-
-### Unit Tests
-
-```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_message_creation() {
-        let msg = Message::builder()
-            .topic("Test")
-            .body(vec![1, 2, 3])
-            .build()
-            .unwrap();
-        assert_eq!(msg.topic().as_str(), "Test");
-    }
-
-    #[tokio::test]
-    async fn test_async_operation() {
-        let result = async_operation().await;
-        assert!(result.is_ok());
-    }
-}
-```
-
-### Integration Tests
-
-```rust
-// tests/integration_test.rs
-#[tokio::test]
-async fn test_producer_consumer() {
-    let mut producer = DefaultMQProducer::builder()
-        .producer_group("example_group")
-        .name_server_addr("localhost:9876")
-        .build();
-    producer.start().await.unwrap();
-
-    let mut consumer = DefaultMQPushConsumer::builder()
-        .consumer_group("example_group")
-        .name_server_addr("localhost:9876")
-        .build();
-    consumer.subscribe("TestTopic", "*").await.unwrap();
-
-    // Test logic
-}
-```
-
-## Code Style
-
-### Automated Formatting
-
-We use `rustfmt` to ensure consistent code formatting across the project. **Always format your code before committing!**
+Use the smallest target that demonstrates the change. For example, a model change can use:
 
 ```bash
-# Format all code in the workspace
-cargo fmt --all
-
-# Check if code is formatted (used in CI)
-cargo fmt --all --check
+cargo fmt -p rocketmq-model -- --check
+cargo test -p rocketmq-model --lib
 ```
 
-**Pro tip**: Configure your IDE to format on save:
+These are examples for that package, not commands to run for every edit. Reuse a meaningful test and inspect how many tests ran. A compiling test can replace a redundant `cargo check`; add package-scoped Clippy or consumer validation when it addresses an actual concern. Do not run a mutating workspace formatter over unrelated dirty Rust files.
 
-- **VS Code**: Set `"editor.formatOnSave": true` with rust-analyzer
-- **RustRover**: Enable "Reformat code" in Settings → Tools → Actions on Save
+For rendered website changes, run `npm run build` in `rocketmq-website`. Standalone projects use their own local profiles. Full feature/platform matrices, interoperability, long-running fault tests and release qualification belong to tasks that need that evidence. Do not claim an unrun scenario passed.
 
-### Linting with Clippy
-
-We use `clippy` to catch common mistakes and non-idiomatic code. All clippy warnings must be fixed before merging.
-
-```bash
-# Run clippy on all targets and features
-cargo clippy --all-targets --all-features --workspace -- -D warnings
-
-# Auto-fix clippy suggestions (when possible)
-cargo clippy --fix --all-targets --all-features --workspace
-```
-
-**Note**: Some clippy suggestions are auto-fixable, but always review the changes before committing.
-
-### Common Patterns
-
-**Builder Pattern**:
-
-```rust
-pub struct ProducerOptions {
-    name_server_addr: String,
-    group_name: String,
-    timeout: u64,
-}
-
-impl ProducerOptions {
-    pub fn new() -> Self {
-        Self {
-            name_server_addr: "localhost:9876".to_string(),
-            group_name: "DEFAULT_PRODUCER".to_string(),
-            timeout: 3000,
-        }
-    }
-
-    pub fn name_server_addr(mut self, addr: impl Into<String>) -> Self {
-        self.name_server_addr = addr.into();
-        self
-    }
-
-    pub fn timeout(mut self, timeout: u64) -> Self {
-        self.timeout = timeout;
-        self
-    }
-}
-```
-
-**Newtype Pattern**:
-
-```rust
-/// Wrapper for message IDs with validation
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MessageId(String);
-
-impl MessageId {
-    pub fn new(id: String) -> Result<Self> {
-        if id.is_empty() {
-            return Err(Error::InvalidMessageId);
-        }
-        Ok(Self(id))
-    }
-}
-
-impl AsRef<str> for MessageId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-```
-
-## Performance Guidelines
-
-RocketMQ-Rust is designed for high performance. Follow these guidelines to maintain optimal performance.
-
-### Memory Management
-
-**Prefer borrowing over cloning** - avoid unnecessary allocations:
-
-```rust
-// ✅ Good: Use references to avoid copies
-pub fn process_message(msg: &Message) -> Result<()> {
-    let body = msg.get_body();  // Borrows, no copy
-    // Process body without cloning
-    Ok(())
-}
-
-// ❌ Bad: Unnecessary cloning
-pub fn process_message_bad(msg: Message) -> Result<()> {
-    let body = msg.get_body().clone();  // Extra allocation!
-    Ok(())
-}
-
-// ✅ Use Cow for conditional ownership
-use std::borrow::Cow;
-
-pub fn get_topic<'a>(msg: &'a Message, default: &'a str) -> Cow<'a, str> {
-    match msg.get_topic() {
-        "" => Cow::Borrowed(default),  // No allocation
-        topic => Cow::Borrowed(topic), // No allocation
-    }
-}
-```
-
-### Concurrency
-
-```rust
-// Use Arc for shared ownership
-use std::sync::Arc;
-
-let client = Arc::new(Client::new());
-
-// Use Mutex/RwLock for interior mutability
-use tokio::sync::Mutex;
-
-let state = Arc::new(Mutex::new(State::new()));
-
-// Use channels for communication
-use tokio::sync::mpsc;
-
-let (tx, mut rx) = mpsc::channel(1000);
-```
-
-## Common Mistakes to Avoid ⚠️
-
-Learn from these common pitfalls:
-
-### 1. Using `unwrap()` or `panic!()` in Library Code
-
-❌ **Bad**:
-
-```rust
-pub fn get_broker(&self) -> Broker {
-    self.brokers.get(0).unwrap()  // Can panic!
-}
-```
-
-✅ **Good**:
-
-```rust
-pub fn get_broker(&self) -> Result<&Broker> {
-    self.brokers.get(0).ok_or(Error::NoBrokerAvailable)
-}
-```
-
-### 2. Ignoring Errors
-
-❌ **Bad**:
-
-```rust
-let _ = self.send(msg).await;  // Error silently ignored!
-```
-
-✅ **Good**:
-
-```rust
-if let Err(e) = self.send(msg).await {
-    log::error!("Failed to send message: {}", e);
-    return Err(e);
-}
-```
-
-### 3. Blocking in Async Code
-
-❌ **Bad**:
-
-```rust
-pub async fn send(&self) -> Result<()> {
-    std::thread::sleep(Duration::from_secs(1));  // Blocks executor!
-}
-```
-
-✅ **Good**:
-
-```rust
-pub async fn send(&self) -> Result<()> {
-    tokio::time::sleep(Duration::from_secs(1)).await;
-}
-```
-
-### 4. Unnecessary Clones
-
-❌ **Bad**:
-
-```rust
-pub fn process(&self, data: String) -> Result<()> {
-    let copy = data.clone();  // Unnecessary!
-    process_data(&copy)
-}
-```
-
-✅ **Good**:
-
-```rust
-pub fn process(&self, data: &str) -> Result<()> {
-    process_data(data)
-}
-```
-
-### 5. Memory Leaks with Reference Cycles
-
-Be careful with `Rc`/`Arc` cycles. Use `Weak` references when needed.
-
-### 6. Overusing `unsafe`
-
-Only use `unsafe` when absolutely necessary and always document why it's safe.
-
-### 7. Not Handling All Enum Variants
-
-Avoid using `_` in match arms - be explicit to catch future enum additions.
-
-## Learning Resources 📚
-
-Want to write better Rust code? Check out these resources:
-
-### Official Rust Resources
-
-- [The Rust Book](https://doc.rust-lang.org/book/) - Comprehensive Rust guide
-- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) - API design best practices
-- [Rust by Example](https://doc.rust-lang.org/rust-by-example/) - Learn by examples
-- [Clippy Lint List](https://rust-lang.github.io/rust-clippy/master/index.html) - All clippy lints explained
-
-### Advanced Topics
-
-- [Async Book](https://rust-lang.github.io/async-book/) - Deep dive into async Rust
-- [Tokio Tutorial](https://tokio.rs/tokio/tutorial) - Async runtime guide
-- [The Rustonomicon](https://doc.rust-lang.org/nomicon/) - Unsafe Rust (advanced)
-
-### RocketMQ-Rust Specific
-
-- [Architecture Overview](/docs/architecture/overview) - Understand the codebase structure
-- [Development Guide](./development-guide) - Set up your dev environment
-- [Contributing Overview](./overview) - Start contributing today!
-
-## Summary
-
-Remember:
-
-- ✅ Write idiomatic Rust code
-- ✅ Handle errors properly with `Result`
-- ✅ Use async/await for I/O operations
-- ✅ Format code with `cargo fmt`
-- ✅ Fix clippy warnings before committing
-- ✅ Write tests for your code
-- ✅ Document public APIs
-
-Happy coding! 🚀
-
-## Next Steps
-
-- [Development Guide](./development-guide) - Set up your environment
-- [Overview](./overview) - Start contributing
-- [Report Issues](https://github.com/mxsm/rocketmq-rust/issues) - Found a bug?
+Sources: [root rules](https://github.com/mxsm/rocketmq-rust/blob/main/AGENTS.md), [Web frontend](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md), [Web backend](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md), [GPUI](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md), [Tauri](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md), [website](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-website/AGENTS.md).

--- a/rocketmq-website/docs/contributing/overview.md
+++ b/rocketmq-website/docs/contributing/overview.md
@@ -1,334 +1,68 @@
 ---
-sidebar_position: 1
-title: Overview
+title: "Contribute to RocketMQ-Rust"
 ---
 
-# Contributing Overview
+# Contribute to RocketMQ-Rust
 
-Welcome to the RocketMQ-Rust community! 🎉
+Start with a concrete user problem and the component that owns it. A useful contribution can be a reproducible report, a corrected bilingual example, a focused regression test or a behavior change. The [development guide](./development-guide.md) explains environment setup and the local feedback loop; this page explains how to choose and present the work.
 
-Thank you for your interest in contributing to RocketMQ-Rust. Whether you're fixing a bug, adding a feature, or improving documentation, every contribution makes a difference. This guide will help you get started on your contribution journey.
+## Choose an entry point
 
-## Ways to Contribute
+| Your goal | First material to read | Useful contribution |
+| --- | --- | --- |
+| Report a failure | [Troubleshooting](../operations/troubleshooting.md) and the relevant component guide | Exact operation, expected/actual result, version/features and a small reproducer |
+| Improve a tutorial or translation | [Documentation guide](./documentation.md) and both language files | Correct commands, prerequisites, expected output and a full counterpart translation |
+| Fix a core behavior | [Architecture](../architecture/overview.md) and [module map](../architecture/module-map.md) | A focused change at the owning layer with regression coverage |
+| Improve client integration | [Client configuration](../configuration/client-config.md) and [API migration](../migration/rust-api.md) | A public-API example with lifecycle and completion semantics |
+| Work on an application | [Ecosystem](../ecosystem/overview.md) and that application's local guide | Product-specific behavior, UI or service integration in its own project |
+| Improve performance | [Capacity and performance](../operations/capacity-performance.md) | A defined workload, observed bottleneck and comparable measurements |
 
-There are many ways to contribute to RocketMQ-Rust:
+Use [GitHub Issues](https://github.com/mxsm/rocketmq-rust/issues) for actionable changes and [Discussions](https://github.com/mxsm/rocketmq-rust/discussions) for usage/design questions. Inspect related work before implementing the same change. Describe the behavior you intend to improve when an issue is broad; avoid expanding a small fix into unrelated refactoring.
 
-### Code Contributions
+## Prepare the correct project
 
-- **Bug fixes**: Fix reported issues
-- **New features**: Add new functionality
-- **Performance improvements**: Optimize existing code
-- **Documentation**: Improve code documentation
-- **Tests**: Add unit and integration tests
+Clone your fork or an authorized checkout, then follow [development setup](./development-guide.md). Read `git status --short` before editing so existing changes stay intact. Use the nearest `AGENTS.md` and current manifest to choose the build root.
 
-### Non-Code Contributions
+The root Cargo workspace, standalone examples, Dashboard applications, MCP, SRE and website have different commands. A directory name is not necessarily a Cargo package name: `rocketmq-client` is selected as `rocketmq-client-rust`. [Release scope](../overview/release-scope.md) explains why workspace membership and product release membership differ.
 
-- **Bug reports**: Report bugs and issues
-- **Feature requests**: Suggest new features
-- **Documentation**: Improve user documentation
-- **Code review**: Review pull requests
-- **Community support**: Help other users
+Preserve page IDs, public APIs and serialized fields unless the change intentionally addresses that contract. Keep dependencies and configuration changes limited to what the problem requires. Do not reformat unrelated files or replace someone else's uncommitted work.
 
-## Getting Started
+## Report a problem that can be reproduced
 
-### 1. Fork and Clone
+Use the repository's issue form for the change type. Include the smallest useful description:
 
-```bash
-# Fork the repository on GitHub
-# Clone your fork
-git clone https://github.com/YOUR_USERNAME/rocketmq-rust.git
-cd rocketmq-rust
+1. Component, source or artifact version, relevant features/backend/mode and platform.
+2. Preconditions and exact operation; include a minimal example when possible.
+3. Expected behavior and actual observed behavior, including stable error codes and request identifiers.
+4. Impact and any workaround already tested.
+5. For a proposed fix, the owning files and how the changed behavior will be observed.
 
-# Add upstream remote
-git remote add upstream https://github.com/mxsm/rocketmq-rust.git
-```
+Remove credentials, bearer tokens, ACL/TLS material, message bodies and unrelated personal or production details from public reports. Preserve the shape and relevant type of a redacted input so the example remains useful. Do not infer an outage's cause solely from a generic client timeout.
 
-### 2. Set Up Development Environment
+The issue templates distinguish bugs, features, enhancements, refactoring, tests and documentation. Their current fields and title prefixes live in [.github/ISSUE_TEMPLATE](https://github.com/mxsm/rocketmq-rust/tree/main/.github/ISSUE_TEMPLATE); use the actual form instead of inventing extra mandatory fields.
 
-```bash
-# Install the repository's pinned stable toolchain and development components
-rustup toolchain install 1.95.0 --profile minimal --component rustfmt,clippy
+## Implement and check the affected behavior
 
-# Build the project
-cargo build
-```
+Keep the change small enough for a reviewer to connect cause, implementation and result. Follow [coding standards](./coding-standards.md), reuse current abstractions and put shared behavior in its owning layer.
 
-### 3. Create a Branch
+For a Rust behavior change, choose a package/target and a focused regression test. A test build that compiles the affected code can also provide compilation evidence. Add checks for directly affected consumers when a shared API or feature changes. A root all-targets build or all-features run is not automatically required for every contribution.
 
-```bash
-# Sync with upstream
-git fetch upstream
-git checkout main
-git merge upstream/main
+For website content, update English and Chinese together, retain executable examples and technical limits, and run `npm run build` in `rocketmq-website`. Documentation work does not require source fingerprints, a clean-worktree ceremony, a score or a new approval process. Use normal proofreading and the existing preview/build tools.
 
-# Create feature branch
-git checkout -b feature/your-feature-name
-```
+Record what actually ran and what it demonstrated. If an external cluster, GUI platform or optional tool is unavailable, describe the untested scenario rather than claiming it passed or modifying unrelated dependencies to bypass it.
 
-## Development Workflow
+## Submit a reviewable pull request
 
-### Making Changes
-
-1. **Write code**: Follow the coding standards
-2. **Add tests**: Ensure test coverage
-3. **Format code**: Use rustfmt
-
-    ```bash
-    cargo fmt
-    ```
-
-4. **Run linter**: Use clippy
-
-    ```bash
-    cargo clippy -- -D warnings
-    ```
-
-5. **Run tests**: Ensure all tests pass
-
-    ```bash
-    cargo test --all
-    ```
-
-### Committing Changes
-
-Use clear commit messages:
+Link the issue and use the current [pull request template](https://github.com/mxsm/rocketmq-rust/blob/main/.github/PULL_REQUEST_TEMPLATE.md). The repository convention uses an issue-linked English title, for example:
 
 ```text
-feat: Add transaction message support
-
-- Implement TransactionMQProducer
-- Add transaction listener trait
-- Add unit tests for transaction messages
-
-Closes #123
+[ISSUE #1234]📝Clarify consumer offset completion
 ```
 
-Commit message format:
+Replace the example number with the actual issue. Describe the concrete problem and final behavior, then summarize relevant validation and limitations. For a semantic change, explain the compatibility or migration effect; for a simple documentation correction, a short description and relevant build result are sufficient.
 
-- `feat:` New feature
-- `fix:` Bug fix
-- `docs:` Documentation changes
-- `test:` Test changes
-- `refactor:` Code refactoring
-- `perf:` Performance improvement
-- `chore:` Build process or tooling
+Review feedback should improve the same scoped result. Update the description if the final implementation changes scope. Leave generated builds, logs, coverage, temporary screenshots and local test data out of the commit. Keep screenshots only when they are intentional documentation assets and accurately represent the product.
 
-### Submitting Pull Request
+A submitted PR does not imply a release or deployment. Maintainers handle integration and release decisions through the applicable project workflow. Community release identity is described in [release scope](../overview/release-scope.md).
 
-1. **Push to your fork**:
-
-    ```bash
-    git push origin feature/your-feature-name
-    ```
-
-2. **Create pull request**: On GitHub
-
-3. **Fill PR template**:
-   - Describe your changes
-   - Reference related issues
-   - Add screenshots if applicable
-
-4. **Wait for review**: Maintainers will review your PR
-
-## Code Review Process
-
-### What to Expect
-
-Our review process is designed to maintain code quality while being welcoming to contributors:
-
-1. **Automated checks** (1-5 minutes): CI runs tests, linting, and format checks
-2. **Manual review** (1-3 days): Maintainers review your code for quality and design
-3. **Feedback discussion**: Collaborative discussion to improve the code
-4. **Approval & merge**: Once approved, your PR will be merged! 🎉
-
-### Addressing Feedback
-
-Code review is a conversation, not criticism. When you receive feedback:
-
-- Respond to all review comments (even if just to acknowledge)
-- Ask questions if something is unclear
-- Make requested changes and push updates to the same branch
-- Request re-review when ready
-- Don't hesitate to discuss alternative approaches
-
-**Note**: CodeRabbit suggestions are helpful references, but the final decision is made by maintainers during code review.
-
-## Coding Standards
-
-See [Coding Standards](./coding-standards) for detailed guidelines.
-
-### Key Principles
-
-1. **Follow Rust idioms**: Write idiomatic Rust code
-2. **Error handling**: Use `Result` types properly
-3. **Documentation**: Add doc comments to public APIs
-4. **Testing**: Write comprehensive tests
-5. **Performance**: Consider performance implications
-
-### Example
-
-```rust
-//! Producer module for sending messages to RocketMQ brokers.
-
-use crate::error::{Error, Result};
-use crate::model::Message;
-
-/// A RocketMQ producer for sending messages.
-///
-/// # Examples
-///
-/// ```rust
-/// use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut producer = DefaultMQProducer::builder()
-///     .producer_group("example_group")
-///     .name_server_addr("localhost:9876")
-///     .build();
-/// producer.start().await?;
-/// # Ok(())
-/// # }
-/// ```
-pub struct Producer {
-    // Implementation
-}
-
-impl Producer {
-    /// Creates a new producer instance.
-    pub fn new() -> Self {
-        Self { /* ... */ }
-    }
-
-    /// Sends a message to the broker.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The broker is not available
-    /// - The message exceeds maximum size
-    /// - Network timeout occurs
-    pub async fn send(&self, message: Message) -> Result<SendResult> {
-        // Implementation
-    }
-}
-```
-
-## Development Guide
-
-See [Development Guide](./development-guide) for detailed information.
-
-## Testing
-
-### Running Tests
-
-```bash
-# Run all tests
-cargo test --all
-
-# Run specific test
-cargo test test_send_message
-
-# Run tests with output
-cargo test -- --nocapture
-
-# Run tests in parallel
-cargo test --all -- --test-threads=4
-```
-
-### Writing Tests
-
-```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_send_message() {
-        let mut producer = DefaultMQProducer::builder()
-            .producer_group("example_group")
-            .name_server_addr("localhost:9876")
-            .build();
-        producer.start().await.unwrap();
-
-        let message = Message::builder()
-            .topic("TestTopic")
-            .body("Test")
-            .build()
-            .unwrap();
-        let result = producer.send(message).await;
-
-        assert!(result.is_ok());
-    }
-}
-```
-
-## Documentation
-
-### Building Documentation
-
-```bash
-# Build documentation
-cargo doc --no-deps --open
-```
-
-### Writing Documentation
-
-```rust
-/// Summary (one sentence)
-///
-/// More detailed explanation.
-///
-/// # Examples
-///
-/// ```
-/// use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-/// use rocketmq_common::common::message::message_single::Message;
-///
-/// let mut producer = DefaultMQProducer::builder()
-///     .producer_group("example_group")
-///     .name_server_addr("localhost:9876")
-///     .build();
-/// let message = Message::builder().topic("TopicTest").body("hello").build().unwrap();
-/// ```
-///
-/// # Errors
-///
-/// This function will return an error if...
-///
-/// # Panics
-///
-/// This function will panic if...
-pub fn public_function() -> Result<()> {
-    // Implementation
-}
-```
-
-## Getting Help
-
-We're here to help! Feel free to reach out through:
-
-- **GitHub Issues**: [Report bugs or request features](https://github.com/mxsm/rocketmq-rust/issues)
-- **GitHub Discussions**: [Ask questions and share ideas](https://github.com/mxsm/rocketmq-rust/discussions)
-- **Email**: [mxsm@apache.org](mailto:mxsm@apache.org)
-
-## License
-
-RocketMQ-Rust is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). By contributing, you agree that your contributions will be licensed under the same license.
-
-## Code of Conduct
-
-We are committed to providing a welcoming and inclusive environment for everyone. Please:
-
-- Be respectful and considerate in your communication
-- Welcome newcomers and help them get started
-- Focus on constructive feedback
-- Assume good intentions
-- Collaborate openly and share knowledge
-
-We're all here to build great software together! 🚀
-
-## Next Steps
-
-- [Development Guide](./development-guide) - Detailed development information
-- [Coding Standards](./coding-standards) - Code style guidelines
-- [Report Issues](https://github.com/mxsm/rocketmq-rust/issues) - File a bug or feature request
+Sources: [root engineering agreement](https://github.com/mxsm/rocketmq-rust/blob/main/AGENTS.md), [website guide](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-website/AGENTS.md), [issue templates](https://github.com/mxsm/rocketmq-rust/tree/main/.github/ISSUE_TEMPLATE), [PR convention](https://github.com/mxsm/rocketmq-rust/blob/main/.agents/skills/rocketmq-rust-pr-submitter/SKILL.md).

--- a/rocketmq-website/docs/ecosystem/dashboards.md
+++ b/rocketmq-website/docs/ecosystem/dashboards.md
@@ -1,0 +1,114 @@
+---
+title: "Choose and run a Dashboard"
+---
+
+# Choose and run a Dashboard
+
+The repository has three Dashboard applications: Web, GPUI and Tauri. They share RocketMQ administration concepts and selected common code, but have separate application lifecycles, persistence and build roots. Choose by deployment model first, then confirm the operations you need in that implementation.
+
+## Product comparison
+
+| Product | User interface and execution | Persistence / connection owner | Suitable starting point |
+| --- | --- | --- | --- |
+| Web | React/TypeScript browser UI calling a separate Axum HTTP backend | Backend selects File, SQLite, MySQL or PostgreSQL; backend owns outbound RocketMQ access | A centrally operated browser service |
+| GPUI | Native GPUI/gpui-component desktop application | Desktop configuration/history/monitor stores and live admin provider | A native operator workstation with a graphical desktop |
+| Tauri | React/TypeScript UI in a Tauri desktop shell, calling Rust commands | Rust application managers and shared configuration services | A packaged desktop application using web UI components |
+| Dashboard common | Library, not a user-facing executable | Shared models, configuration and optional admin facade | Reuse of UI-independent domain behavior |
+
+Do not interpret shared terminology as complete feature parity. Query, administration, authentication, history and monitoring flows must be checked in the selected product. These applications can perform mutations; a dashboard is not equivalent to the [read-only MCP](./mcp.md) service.
+
+```mermaid
+flowchart LR
+  W[Web browser] --> H[Axum HTTP backend]
+  G[GPUI desktop] --> P[Desktop services and provider]
+  T[Tauri webview] --> C[Rust command managers]
+  H --> A[Admin and client contracts]
+  P --> A
+  C --> A
+  A --> N[NameServer discovery]
+  A --> B[Broker operations]
+  D[Dashboard common models and services] -. shared code .-> H
+  D -. shared code .-> P
+  D -. shared code .-> C
+```
+
+The applications own separate runtime and persistence lifecycles. The diagram shows shared responsibility, not one shared process or a common live database. NameServer discovery and Broker operations require reachable advertised addresses from the machine running the backend/desktop process.
+
+## Web: separate backend and frontend
+
+Run the backend from its own Cargo root:
+
+```bash
+cd rocketmq-dashboard/rocketmq-dashboard-web/backend
+cargo run --bin rocketmq-dashboard-web-backend
+```
+
+The explicit binary matters because this package also includes a storage utility. The documented backend default is `http://127.0.0.1:8082`. Set `NAMESRV_ADDR` for the intended cluster and review the backend's authentication, storage and connection configuration before exposing it beyond local development.
+
+In a second terminal starting at the repository root:
+
+```bash
+cd rocketmq-dashboard/rocketmq-dashboard-web/frontend
+npm ci
+npm run dev
+```
+
+Reuse installed dependencies on subsequent runs. Vite requests port `3003` and proxies `/api` to `http://127.0.0.1:8082` by default; `VITE_API_TARGET` changes the development proxy target. Use the URL Vite actually prints if a port is already occupied. This development proxy is not a production HTTP deployment configuration.
+
+Web persistence is selected strictly at startup. File storage uses a directory with a process-lifetime exclusive lock; SQLite uses an on-disk file. MySQL/PostgreSQL require their database URL and corresponding connectivity/TLS configuration. An unknown backend or unavailable required configuration must not be interpreted as a fallback to File storage.
+
+`GET /api/health/live` reports process liveness. `GET /api/health/ready` includes storage readiness; `/api/health` remains the readiness endpoint. These do not by themselves prove that every RocketMQ operation or downstream Broker is healthy.
+
+Build frontend assets with `npm run build` from the frontend directory. Backend deployment, durable storage, session authentication and the reverse-proxy/API origin remain separate tasks. See the [Web product README](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/README.md) for detailed environment variables and storage operation procedures.
+
+## GPUI: native desktop ownership
+
+From the repository root:
+
+```bash
+cd rocketmq-dashboard/rocketmq-dashboard-gpui
+cargo run
+```
+
+For an optimized executable, use `cargo build --release` in that directory. A graphical desktop is required. Windows needs the MSVC C++ toolchain and Windows SDK; macOS needs Xcode command-line tools; Linux needs the GUI development libraries in the [GPUI guide](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md). This is a standalone Rust 2024 workspace.
+
+Configuration defaults to `rocketmq-dashboard/gpui/config.json` beneath the OS user configuration directory. `ROCKETMQ_DASHBOARD_GPUI_CONFIG_PATH` overrides the complete file path. NameServer and connection settings are stored there.
+
+Local dashboard login and outbound RocketMQ credentials are separate. When local login is enabled, the application requires `ROCKETMQ_DASHBOARD_USERNAME` and `ROCKETMQ_DASHBOARD_PASSWORD`. When the Admin credential source is `environment`, it uses `ROCKETMQ_ADMIN_ACCESS_KEY` and `ROCKETMQ_ADMIN_SECRET_KEY`, with optional `ROCKETMQ_ADMIN_SECURITY_TOKEN`. Supply secrets using the workstation's managed environment; do not put actual values in shared screenshots or reports.
+
+The GPUI entry point initializes components and owns the application runtime. Admin and persistence work runs through injected child scopes rather than the render path. Closing the event loop triggers runtime cleanup. See [GPUI README](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-gpui/README.md).
+
+## Tauri: frontend build versus desktop package
+
+From the repository root:
+
+```bash
+cd rocketmq-dashboard/rocketmq-dashboard-tauri
+npm ci
+npm run tauri dev
+```
+
+Install the target operating system's Tauri prerequisites before this native build. The React interface calls Rust command managers; the Rust application owns a shared client runtime and closes its admin managers during shutdown. A browser-only preview does not exercise that desktop command bridge.
+
+| Command and directory | Result |
+| --- | --- |
+| `npm run build` in the Tauri app root | TypeScript/Vite frontend assets |
+| `cargo check` or `cargo build` in `src-tauri` | Rust backend checking or binary compilation |
+| `npm run tauri build` in the app root | Desktop package/bundle for the configured platform |
+
+The default bundle location is `src-tauri/target/release/bundle/` unless the target directory is overridden. Do not report a frontend build as a packaged or tested desktop application. See [Dashboard build guide](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/README.md) and [Tauri application owner](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs).
+
+## Diagnose the correct boundary
+
+| Symptom | First distinction |
+| --- | --- |
+| Web UI loads but requests fail | Browser-to-backend API/proxy/session failure versus backend-to-RocketMQ failure |
+| Login succeeds but cluster access fails | Local/product authentication versus outbound RocketMQ authentication and authorization |
+| Empty topic or consumer table | Selected cluster, actual response, loading/error state and permitted visibility; not proof that the cluster has no data |
+| Web service fails during startup | Selected storage driver, path/URL, exclusive lock and readiness; do not change backend to hide a persistence failure |
+| Native build fails | Correct standalone directory, Rust edition/toolchain, Node dependencies and OS-native prerequisites |
+| Data differs between products | Different selected cluster, sampling time, product persistence or implemented operation; common models do not synchronize application state |
+
+Start with read operations against an isolated development cluster. Inspect the target and operation effect before a metadata, offset or message mutation; retain product confirmation and authorization behavior. No Web, GPUI or Tauri application was built or launched as part of writing this overview, and no cross-platform or operation-parity result is claimed.
+
+Sources: [Dashboard common](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-common/Cargo.toml), [Web architecture](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/AGENTS.md), [Web development proxy](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/frontend/vite.config.ts), [GPUI guide](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-gpui/README.md), [Tauri scripts](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-tauri/package.json).

--- a/rocketmq-website/docs/ecosystem/mcp.md
+++ b/rocketmq-website/docs/ecosystem/mcp.md
@@ -1,0 +1,158 @@
+---
+title: "Read-only MCP diagnostics"
+---
+
+# Read-only MCP diagnostics
+
+`rocketmq-mcp` is a standalone Model Context Protocol server for RocketMQ queries, diagnosis and runbook prompts. It runs outside Broker, NameServer and Dashboard processes and uses Admin Core's `read-client-adapter`. Its default tools do not open mutation sessions. The optional planning feature produces proposals; it does not apply them.
+
+## Request path and ownership
+
+```mermaid
+flowchart TD
+  C[MCP client] --> T[stdio or authenticated Streamable HTTPS]
+  T --> P[Verified principal and operation policy]
+  P --> Q[Tools and Resources through QueryFacade]
+  Q --> K[Visibility-scoped cache and singleflight]
+  K --> A[Read-only Admin adapter and owned ClientRuntime]
+  A --> R[Configured RocketMQ endpoints]
+  R --> O[Typed observation and bounded output]
+  O --> S[Sanitization and shared audit pipeline]
+  S --> C
+```
+
+The MCP process owns its lifecycle, query runtime, cache and asynchronous audit writer. Shutdown closes admission, drains accepted audit records, flushes the sink and closes owned tasks against a deadline. A cached observation describes when data was observed, not a new remote read or a guarantee that the cluster has not changed.
+
+## Build the selected transport
+
+From the repository root, enter the standalone project:
+
+```bash
+cd rocketmq-ai/rocketmq-mcp
+cargo build --locked --release
+```
+
+The default features are `read-only`, `diagnose` and `stdio`. In that same directory, an HTTPS build can use:
+
+```bash
+cargo build --locked --release --features streamable-http
+```
+
+`streamable-http` includes the authentication feature; it is not an unauthenticated HTTP mode. `observability` enables in-process signals, while `otlp` selects the implemented OTLP gRPC support. `change-planning` adds five planning tools subject to runtime policy. None of these features turns Query MCP into MCP Control.
+
+The binary is `target/release/rocketmq-mcp`, or `rocketmq-mcp.exe` on Windows. Root-workspace `cargo build` does not build this standalone package. Native dependencies come from its selected dependency graph; see [features/platforms](../reference/features-platforms.md).
+
+## Prepare a local stdio configuration
+
+Copy [conf/mcp.example.toml](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml) to your own configuration file. Keeping it in the same `conf` directory preserves the example's relative permission-file path; when moving it elsewhere, also copy the policy file and deliberately resolve audit/TLS references. Choose a new filename rather than replacing an existing operator configuration.
+
+For the first-message development cluster, edit the existing cluster entry to these values instead of appending another default cluster:
+
+```toml
+[[clusters]]
+name = "local-dev"
+rocketmq_cluster_name = "DocsCluster"
+namesrv_addr = "127.0.0.1:9876"
+default = true
+```
+
+This is a replacement fragment, not a complete configuration. Remove unused sample Proxy/Controller aliases or set them to the real services you intend to query. A logical MCP cluster name can differ from the physical RocketMQ cluster name. Tools take configured logical aliases rather than arbitrary network addresses.
+
+| Setting | Checked-in example / behavior |
+| --- | --- |
+| `security.profile` | `diagnose` for local diagnosis scope |
+| `security.allow_change_planning` | `false`; compilation alone cannot allow planning calls |
+| `security.permissions_file` | `permissions.example.toml`, loaded relative to the config file |
+| `security.sanitize_output` | `true` |
+| `security.max_concurrent_requests_per_cluster` | 8 |
+| `security.rate_limit_per_minute` | 60 per principal/cluster/operation policy |
+| `audit.enabled` / `sink` | `true` / `file`; choose a writable audit path |
+| `cache.enabled` / `max_entries` | `true` / 256; per-query TTLs govern freshness |
+| `server.stdio.log_to_stderr` | `true`; stdout is reserved for MCP frames |
+
+Start from the MCP directory after editing `conf/mcp.local.toml`:
+
+```bash
+cargo run --locked -- --config conf/mcp.local.toml --transport stdio
+```
+
+Configure your local MCP client to launch the built binary with those arguments and an explicit absolute config path. Stdio is a local-development process integration; a terminal waiting for protocol input is not an HTTP server. Do not prepend shell banners or redirect diagnostic text into stdout.
+
+The config path is required through `--config` or `ROCKETMQ_MCP_CONFIG`. Permission, TLS, JWKS CA and audit paths resolve relative to the config file. The CLI currently assigns its `--transport` value after loading the file, and that argument defaults to `stdio`. Always pass `--transport streamable-http` explicitly for HTTPS; setting only `server.transport` in the file is insufficient for this CLI path. Optional `--bind` and `--endpoint` override their corresponding file values.
+
+## Streamable HTTPS and identities
+
+HTTPS requires the compiled transport, a readable certificate/private-key pair, an allowed origin policy and authentication configuration. The example listens on `127.0.0.1:8089` with endpoint `/mcp` and public base URL `https://127.0.0.1:8089`. These defaults do not supply actual certificate files or credentials.
+
+| Boundary | Identity and configuration |
+| --- | --- |
+| Local development HTTP | `development-token` is restricted to loopback development; the token is read through the configured environment reference. |
+| Production HTTP | `oauth-jwt` validates RS256 tokens with `kid`, signature, issuer, audience, expiry and required scopes against HTTPS JWKS. |
+| Private JWKS CA | Configure `jwks_ca_path` with a readable PEM trust bundle; relative paths belong to the config directory. |
+| Tool execution | Verified roles/scopes, configured clusters, cluster claims, tenant binding, rate limits and operation policy apply at their defined stages. |
+| Outbound RocketMQ | Separate request-signing credentials from configured file/environment references; the incoming bearer token is never forwarded. |
+
+Production OAuth has no static `jwt_key_env` fallback. Key refresh failures preserve an already verified generation within the configured stale window. The protected-resource metadata endpoint is intentionally available without a bearer token for discovery. The MCP endpoint itself remains authenticated.
+
+After configuring these materials, launch from the MCP directory:
+
+```bash
+cargo run --locked --features streamable-http -- --config conf/mcp.local.toml --transport streamable-http --bind 127.0.0.1:8089 --endpoint /mcp
+```
+
+An HTTP-capable MCP client connects to the HTTPS endpoint and sends its authorization header and `Accept: application/json, text/event-stream`. Certificate validation, protocol initialization and the session/stream lifecycle belong to the MCP client. A bare unauthenticated GET is not a complete tool invocation.
+
+RocketMQ signing credentials must be separate from HTTP identity. A configured YAML credential file contains `access_key`, `secret_key` and optional `security_token` and is bounded to 64 KiB. Alternatively, configure environment-variable references. Inline secret values and mixed file/environment sources are rejected. Credentials are resolved at startup and for new read sessions, supporting mounted-secret rotation. Grant the Broker identity only the required read access.
+
+## Discover and call tools
+
+The checked-in protocol version is `2025-11-25`; initialization rejects another version. After initialization, use `tools/list` for the caller-visible catalog. The source default catalog contains 24 tools, but policy can reduce discovery.
+
+| Query family | Default tool names |
+| --- | --- |
+| Cluster / inventory | `rocketmq_get_cluster_overview`, `rocketmq_list_topics`, `rocketmq_list_consumer_groups` |
+| Topic | `rocketmq_describe_topic`, `rocketmq_get_topic_route`, `rocketmq_get_topic_config_state`, `rocketmq_get_topic_stats`, `rocketmq_get_topic_config` |
+| Consumers / connections | `rocketmq_get_consumer_lag`, `rocketmq_list_consumer_connections`, `rocketmq_list_producer_connections`, `rocketmq_get_consumer_group_config_state`, `rocketmq_get_consumer_group_details`, `rocketmq_get_consumer_progress` |
+| Broker | `rocketmq_describe_broker`, `rocketmq_get_broker_diagnostics`, `rocketmq_get_broker_config_summary`, `rocketmq_get_broker_log_filter_state` |
+| Infrastructure | `rocketmq_get_proxy_drain_state`, `rocketmq_get_ha_status`, `rocketmq_get_controller_metadata`, `rocketmq_get_nameserver_config_summary` |
+| Message / diagnosis | `rocketmq_get_message_metadata`, `rocketmq_diagnose_consumer_lag` |
+
+Use a simple explicit-cluster query first. This is a `tools/call` request for an already initialized MCP session, not a standalone HTTP command:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "rocketmq_list_topics",
+    "arguments": {"cluster": "local-dev", "limit": 25}
+  }
+}
+```
+
+`limit` is 1–200 and defaults to 50. Follow the opaque `data.next_cursor` while `has_more` is true; do not invent a cursor or treat it as a queue offset. Supply the same logical target and corresponding query parameters. See the [complete Tool Reference](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/docs/tool-reference.md) for exact schemas and per-tool output.
+
+Discovery checks scopes and Tool allow/deny policy; it does not establish that a particular cluster/tenant call is authorized. The two inventory tools allow omitted clusters with a default/sole-cluster fallback; the current implementation does not run the same explicit per-cluster/tenant checks on that omitted-cluster path. Use explicit clusters in operational clients and account for this limitation in deployment policy; do not describe omission as a stronger isolation guarantee.
+
+## Interpret observations, partial data and failures
+
+Successful calls carry a `rocketmq-mcp.v2` envelope with request ID, logical cluster, observation time, freshness, cache status, partial flag, warnings and typed data. `hit`, `miss` and `bypass` distinguish query reuse. Failures are not cached. Query state and continuation cursors are separated into `standard` and `sensitive` visibility classes; state does not cross that class boundary.
+
+Output arrays are bounded to 1,000 rows and structured output to 1 MiB. Truncation and source failures can produce partial results. Inspect warnings and `partial` before presenting an observation as complete. Message metadata tools omit bodies, and connection identities are pseudonymous; missing sensitive values are not necessarily a backend failure.
+
+| Symptom/code | Next action |
+| --- | --- |
+| Missing tool | Inspect compiled feature, principal scope and Tool policy; planning additionally needs runtime permission at call time. |
+| `unauthorized_scope` / `cluster_not_allowed` / `tenant_mismatch` | Check verified identity and configured policy; changing the query alias cannot grant access. |
+| `source_unavailable` | Check the MCP process's route to configured NameServer/Broker/Proxy/Controller endpoints and outbound read credentials. |
+| `rate_limited` | Reduce query rate and respect bounded retry; avoid multiplying retries across the AI client and MCP layer. |
+| `output_too_large` or partial warning | Narrow the query, paginate where supported and preserve the warning in the diagnosis. |
+| Stale observation | Inspect observation time, TTL/cache status and selected cluster before inferring a current outage. |
+| stdio parse failure | Confirm protocol version and clean stdout; inspect stderr for redacted startup/transport diagnostics. |
+
+Planning tools, when enabled, generate create-topic, update-topic-config, update-topic-permissions, update-Broker-config and reset-offset plans. They contain no Apply mode and call no mutation API. Execution belongs to separately designed operator/control workflows, not this diagnostic process.
+
+This guide was checked against configuration, registration and protocol sources, with TOML/JSON and website rendering checks. It does not claim a live MCP-client session, OAuth/JWKS deployment or external-cluster diagnosis was tested during documentation writing.
+
+Sources: [configuration parser](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/src/config.rs), [entry point](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/src/main.rs), [tool catalog](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs), [protocol server](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/src/protocol/server.rs), [permission example](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml), [read-only boundary](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/AGENTS.md).

--- a/rocketmq-website/docs/ecosystem/overview.md
+++ b/rocketmq-website/docs/ecosystem/overview.md
@@ -8,10 +8,10 @@ The ecosystem adds human-facing administration, read-only diagnostics and separa
 
 | Product | Role | Deployment boundary | Start here |
 | --- | --- | --- | --- |
-| Web Dashboard | Browser-based cluster/resource administration | Rust HTTP backend plus React frontend and selected persistent storage | [Web guide](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/README.md) |
-| GPUI Dashboard | Native desktop administration | Standalone Rust desktop package | [GPUI project](https://github.com/mxsm/rocketmq-rust/tree/main/rocketmq-dashboard/rocketmq-dashboard-gpui) |
-| Tauri Dashboard | Desktop application with web UI | Node frontend, Rust backend and OS packaging | [Dashboard build guide](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/README.md) |
-| MCP | Bounded read-only cluster diagnostics and optional non-mutating planning | Standalone server with stdio or configured Streamable HTTP | [MCP guide](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/README.md) |
+| Web Dashboard | Browser-based cluster/resource administration | Rust HTTP backend plus React frontend and selected persistent storage | [Web guide](./dashboards.md) |
+| GPUI Dashboard | Native desktop administration | Standalone Rust desktop package | [GPUI project](./dashboards.md) |
+| Tauri Dashboard | Desktop application with web UI | Node frontend, Rust backend and OS packaging | [Dashboard build guide](./dashboards.md) |
+| MCP | Bounded read-only cluster diagnostics and optional non-mutating planning | Standalone server with stdio or configured Streamable HTTP | [MCP guide](./mcp.md) |
 | MCP Control | Typed supervised cluster mutations | Independent TLS/OAuth server, feature and policy enablement | [Control guide](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp-control/README.md) |
 | AI SRE | Evidence, diagnosis, incidents, plans and execution coordination | Separate SRE workspace, services, UI and storage | [SRE guide](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-sre/README.md) |
 

--- a/rocketmq-website/docs/overview/release-scope.md
+++ b/rocketmq-website/docs/overview/release-scope.md
@@ -1,0 +1,71 @@
+---
+title: "Release scope and distribution identity"
+---
+
+# Release scope and distribution identity
+
+RocketMQ-Rust contains more products than one core release. Use the root Cargo manifest to identify workspace members, the core scope manifest to identify release classifications, and the selected artifact's release information to identify what was actually published. These are separate sources with different purposes.
+
+## Source workspace, core release and standalone products
+
+| Set | Current source definition | What membership means |
+| --- | --- | --- |
+| Root Cargo workspace | `Cargo.toml`, 28 members | Cargo can select these packages from the repository root. |
+| Core release package set | `scripts/core-release-scope.json`, 27 packages | Packages classified for the core release process. This does not prove registry publication. |
+| Core services | NameServer, Broker, Controller, Proxy | Service products named by the core release scope. They still have different build features, configuration and launch commands. |
+| Dashboard common | A root workspace member, explicitly excluded from core release | Shared dashboard models/services can be built with the root workspace without making the desktop/Web products part of that release. |
+| Independent Cargo products | Examples, GPUI, Tauri backend, Web backend, MCP, MCP Control, SRE and specialized fixtures/fuzzing | Use each local manifest and guide; a root build does not cover them. |
+| Node projects | Website, Dashboard frontends, SRE UI and TypeScript SDK | Each has its own package manifest and commands. |
+
+The scope lists repository exclusions for Dashboard, MCP and SRE. MCP Control is also a separate project and is absent from the core package list; absence does not mean it inherits the core release's status. The [module map](../architecture/module-map.md) and [ecosystem overview](../ecosystem/overview.md) identify these owners.
+
+## Read package classifications literally
+
+| Classification | Meaning in the release model | Current examples |
+| --- | --- | --- |
+| `registry-publish` | Selected for registry package planning | Client, model, protocol, transport, runtime, security, storage, service libraries and Admin Core |
+| `binary-only` | Distributed as a binary product rather than a registry library in this classification | `rocketmq-admin-cli`, `rocketmq-admin-tui`, `rocketmq-store-inspect` |
+| `internal-only` | Allowed schema classification for internal packages | No current core entry uses it |
+| `non-publish` | Allowed schema classification for packages outside publication | No current core entry uses it |
+
+The current core list has 24 `registry-publish` and three `binary-only` entries. A service package may include a library and a binary; its classification does not remove its executable. Conversely, a package version in Cargo.toml does not tell you whether a downloadable archive or registry version exists.
+
+## Distribution identity
+
+The checked-in `distribution/release-identity.json` declares:
+
+| Field | Declared value |
+| --- | --- |
+| Distribution name | RocketMQ Rust Community Distribution |
+| Identity kind | `unofficial-community` |
+| Official Apache release | `false` |
+| Source project | `mxsm/rocketmq-rust` |
+| Registry owner / package prefix | `mxsm` / `rocketmq-` on crates.io |
+| OCI namespace | `ghcr.io/mxsm/rocketmq-rust` |
+| Helm chart name | `rocketmq-rust` |
+| License identifier | `Apache-2.0` |
+
+These are declared release destinations and identity metadata, not a statement that every image, chart or package is currently available. “Official project documentation” refers to documentation maintained for this project; it must not be read as an official Apache Software Foundation release designation. The identity file explicitly identifies an unofficial community distribution.
+
+Use artifact-specific documentation for [containers](../deployment/containers.md) and [Kubernetes](../deployment/kubernetes.md). Keep the image tag, chart values, service binary and corresponding documentation together; do not substitute an unverified “latest” artifact for a named release.
+
+## Version numbers and Next documentation
+
+The root workspace currently declares version `1.0.0`, while independent applications can declare their own versions, such as `0.1.0`. These are source manifest values. They do not establish a publication date, support period, or cross-product release lockstep.
+
+The Docusaurus current documentation is labeled **Next** and uses English plus `zh-CN` content. Next describes the current source family and can contain behavior newer than a published artifact. A Chinese page is a full counterpart with the same page ID, not a separate product version.
+
+For an incident or compatibility question, record the actual executable/package version, build features, deployment mode and relevant configuration. Then compare the matching source/API documentation. The [capability matrix](./capability-matrix.md) and [compatibility reference](../reference/protocol-compatibility.md) explain why a version string alone is insufficient.
+
+## Select the right build and delivery unit
+
+1. Find the owning package/application and its manifest.
+2. Decide whether the deliverable is a library, service binary, desktop bundle, frontend assets, chart or container.
+3. Use that product's build entry and supported feature/platform combination.
+4. Associate the result with its matching configuration, operating procedure and known limitations.
+
+For example, building the Tauri React frontend does not produce a desktop installer; building the root workspace does not build the Web Dashboard backend. Publishing core messaging packages does not publish MCP or establish its HTTP authentication configuration.
+
+This page is a source-scope reference. It does not announce a new release or assert that release workflows have run.
+
+Sources: [workspace manifest](https://github.com/mxsm/rocketmq-rust/blob/main/Cargo.toml), [core release scope](https://github.com/mxsm/rocketmq-rust/blob/main/scripts/core-release-scope.json), [distribution identity](https://github.com/mxsm/rocketmq-rust/blob/main/distribution/release-identity.json), [website version configuration](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-website/docusaurus.config.ts).

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contributing/coding-standards.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contributing/coding-standards.md
@@ -1,552 +1,71 @@
 ---
-sidebar_position: 3
-title: 编码标准
+title: "编码规范"
 ---
 
-> Runtime 所有权：示例中的 `client_runtime` 是应用持有的 `Arc<ClientRuntime>`，它从 `RuntimeOwner` 的 child scope 创建，并在进程边界显式关闭。
+# 编码规范
 
-# 编码标准
+遵循归属层现有实现及最近的工程指南。这些约定用于维护公共契约、生命周期所有权和可诊断故障，概括当前仓库规则，不另设贡献流程。
 
-欢迎来到 RocketMQ-Rust 的编码标准！📝
+## Rust 结构与公共契约
 
-本指南将帮助你编写整洁、地道的 Rust 代码，遵循项目约定。这些标准确保整个代码库的一致性、可维护性和质量。
+使用选定工具链、包 edition、`rustfmt.toml` 和 `.clippy.toml`。根目录默认 Rust 2021，Admin CLI 及部分独立应用使用 Rust 2024，应保留各自 manifest 选择。模块/函数使用 snake_case，类型使用 PascalCase，常量使用 SCREAMING_SNAKE_CASE；新 Rust 文件保留 Apache 2.0 头部。
 
-## 为什么编码标准很重要
+保持实现模块私有，显式选择公共导出。优先使用枚举、配置/请求结构体、builder 和 newtype，避免位置布尔标志及过长参数列表。穷尽匹配项目自有、兼容性敏感的枚举。可选 feature 保持增量性质，变更影响默认或关闭 feature 行为时检查对应组合。
 
-一致的代码：
+请求码、响应码、请求头、Serde 字段/默认值和持久化布局都属于兼容性表面。保留内部 Rust 调用的重命名仍可能破坏线协议或存储契约。说明有意改变的语义和迁移路径，参见[协议兼容性](../reference/protocol-compatibility.md)。
 
-- **更易于阅读**和理解
-- **更易于维护**和调试
-- **更易于审查**拉取请求
-- **更可靠**，bug 更少
+需要时按内聚行为拆分模块。文件长度是审阅信号，不应为满足数字而任意拆散无关逻辑。Web 后端和 GPUI 本地指南采用不含 `mod.rs` 的扁平模块布局，不应未经核对就把局部规则强加给其他模块。
 
-## Rust 约定
+## 错误与文档
 
-### 命名
+对可恢复的配置、输入、I/O、传输、存储和生命周期故障使用类型化错误。在公共边界映射到已有组件错误模型和稳定描述符，不以通用字符串替代有意义错误，也不匹配面向人的消息来决定重试。
 
-```rust
-// 模块：snake_case
-mod message_queue;
+避免生产环境 `todo!`、`unimplemented!` 及可恢复路径中的 `unwrap`/`expect`/panic。测试断言是适当的；有意设计的不可失败门面需要记录不变量或提供可失败的配套 API。限定 lint 豁免范围，并解释原因。
 
-// 类型：PascalCase
-struct MessageQueue;
-enum ConsumeResult;
+Rustdoc 应说明不明显的不变量，以及适用的 `# Errors`、`# Panics`、`# Safety` 契约。注释解释为什么需要某种选择，不逐行复述代码。unsafe 块应尽量小，前面紧接 `// SAFETY:` 说明，并明确安全包装器或调用方契约。
 
-// 函数：snake_case
-fn send_message() {}
+## 异步执行与关闭
 
-// 常量：SCREAMING_SNAKE_CASE
-const MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+| 关注点 | 设计要求 |
+| --- | --- |
+| 后台任务 | 通过 `ServiceContext`、`TaskGroup` 或已有生命周期所有者持有工作，关闭时取消并等待完成。 |
+| 阻塞操作 | 使用 `BlockingExecutor` 或已有顶层边界，不引入原始 `spawn_blocking`、嵌套 `block_on` 或临时运行时。 |
+| 同步 | 不跨 `.await` 持有同步锁守卫，缩小锁范围。 |
+| 准入 | 保留有界任务、字节和阻塞预算；超时不一定停止底层阻塞工作。 |
+| 异步 trait | 优先原生异步 trait 方法，不引入 `#[async_trait]`。 |
+| 完成语义 | 区分已接受、已写入、已持久化、已复制和业务完成。 |
 
-// 静态变量：SCREAMING_SNAKE_CASE
-static DEFAULT_TIMEOUT: u64 = 3000;
-```
+[运行时设计](../architecture/runtime.md)说明所有权和预算边界。只丢弃句柄而不等待所属工作，不等价于完成关闭。运行时变更需要针对改变行为的取消/资源测试，无需指纹或基线仪式。
 
-### 代码组织
+## 可观测性与敏感数据
 
-```rust
-// 导入（std、外部 crate、内部模块）
-use std::sync::Arc;
-use tokio::sync::Mutex;
-use crate::model::Message;
-use crate::error::{Error, Result};
+优先使用 `#[tracing::instrument(skip_all, ...)]` 并显式列出低基数字段。不得记录凭据、ACL/TLS 材料、令牌、消息体或整个请求/配置对象。避免未采样的逐消息 span 和无界主题/消费者组标签。
 
-// 类型别名
-type MessageQueueRef = Arc<MessageQueue>;
+使用已有错误脱敏及遥测所有权路径。某个包装器具有安全 `Debug` 实现，不代表任意字符串都可安全记录。[错误与可观测性](../architecture/errors-observability.md)解释信号所有权和边界映射。
 
-// 常量
-const MAX_RETRY: u32 = 3;
+## 前端与桌面代码
 
-// 结构体
-pub struct Producer {
-    // 私有字段
-    client: Arc<Client>,
-    options: ProducerOptions,
-}
+| 工程 | 本地约定 |
+| --- | --- |
+| 网站 | Docusaurus/MDX、已有组件和页面 ID；英文/中文配对正文及导航翻译。 |
+| Web 前端 | React/TypeScript/Vite、共享设计 token/组件和统一 `src/api/` 客户端；运维表格包含加载、空、错误、搜索、分页及刷新状态。 |
+| Web 后端 | 精简 Axum handler、服务编排、分离 API DTO 与内部模型、显式本地错误映射；可复用逻辑放入 Dashboard common。 |
+| GPUI | 确定性渲染路径，通过 Context/Window 修改状态，稳定元素 ID、持有所属订阅和不阻塞 UI 的工作。 |
+| Tauri | 从应用根目录运行前端命令，从 `src-tauri` 运行 Rust 命令；前端资源编译与桌面打包分开。 |
 
-// Impl 块
-impl Producer {
-    // 关联函数（构造函数）
-    pub fn new() -> Self { }
+保留无障碍、焦点、键盘操作、明暗主题一致性和可用的窗口缩放。破坏性操作的产品确认对话框仍属于应用行为，与文档编写流程无关。不要把内部迁移或 API 对齐说明暴露为面向用户的产品控件。
 
-    // 方法
-    pub async fn send(&self, msg: Message) -> Result<SendResult> { }
+## 选择相关检查
 
-    // 私有方法
-    async fn do_send(&self, msg: Message) -> Result<SendResult> { }
-}
-
-// Trait 实现
-impl Default for Producer {
-    fn default() -> Self { }
-}
-```
-
-### 错误处理
-
-RocketMQ-Rust 使用 `thiserror` crate 定义错误。对于可能失败的操作，始终使用 `Result` 类型。
-
-```rust
-// 对可能失败的操作使用 Result
-use crate::error::Result;
-
-pub async fn send_message(&self, msg: Message) -> Result<SendResult> {
-    // 使用 ? 进行错误传播 - 简洁且地道
-    let broker = resolve_broker(&msg.topic)?;
-
-    // ⚠️ 在库代码中避免使用 unwrap() - 它可能导致 panic！
-    // ✅ 相反，应显式处理错误
-    match broker.send(msg).await {
-        Ok(result) => Ok(result),
-        Err(e) => Err(Error::SendFailed(e.to_string())),
-    }
-}
-
-// 使用 thiserror 定义自定义错误类型
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Broker not found: {0}")]
-    BrokerNotFound(String),
-
-    #[error("Timeout after {0}ms")]
-    Timeout(u64),
-
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-}
-
-// ✅ 好的做法：显式错误处理
-pub fn parse_config(data: &str) -> Result<Config> {
-    serde_json::from_str(data)
-        .map_err(|e| Error::ConfigParse(e.to_string()))
-}
-
-// ❌ 坏的做法：使用 unwrap() - 可能 panic！
-pub fn parse_config_bad(data: &str) -> Config {
-    serde_json::from_str(data).unwrap() // 不要这样做！
-}
-```
-
-### Async/Await
-
-RocketMQ-Rust 使用 `tokio` 作为异步运行时。所有 I/O 操作都应该是异步的。
-
-```rust
-// ✅ 对异步操作使用 async/await
-pub async fn send(&self, msg: Message) -> Result<SendResult> {
-    let broker = resolve_broker_async().await?;
-    broker.send(msg).await
-}
-
-// ✅ 为并发操作生成任务
-pub async fn send_batch(&self, msgs: Vec<Message>) -> Result<Vec<SendResult>> {
-    let tasks: Vec<_> = msgs
-        .into_iter()
-        .map(|msg| {
-            let self_clone = self.clone();
-            tokio::spawn(async move { self_clone.send(msg).await })
-        })
-        .collect();
-
-    let results = futures::future::try_join_all(tasks).await?;
-    results.into_iter().collect::<Result<Vec<_>>>()
-}
-
-// ❌ 坏的做法：异步上下文中的阻塞操作
-pub async fn send_bad(&self, msg: Message) -> Result<SendResult> {
-    // 不要这样做 - 会阻塞异步运行时！
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    self.send(msg).await
-}
-
-// ✅ 好的做法：使用 tokio 的异步 sleep
-pub async fn send_good(&self, msg: Message) -> Result<SendResult> {
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    self.send(msg).await
-}
-```
-
-## 文档
-
-### 公共 API
-
-```rust
-/// 向 RocketMQ broker 发送消息的生产者。
-///
-/// 生产者处理消息路由、负载均衡和失败时的自动重试。
-///
-/// # 示例
-///
-/// ```rust
-/// use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut producer = DefaultMQProducer::builder(client_runtime.clone())
-///     .producer_group("example_group")
-///     .name_server_addr("localhost:9876")
-///     .build();
-/// producer.start().await?;
-/// # Ok(())
-/// # }
-/// ```
-///
-/// # 另请参阅
-///
-/// - [`Consumer`] 用于消费消息
-/// - [`Message`] 用于消息结构
-pub struct Producer { }
-```
-
-### 模块文档
-
-```rust
-//! 生产者模块。
-//!
-//! 此模块提供 [`Producer`] 类型用于向 RocketMQ broker 发送消息。
-//!
-//! # 特性
-//!
-//! - 异步消息发送
-//! - 失败时自动重试
-//! - 跨 broker 的负载均衡
-//! - 事务消息支持
-//!
-//! # 示例
-//!
-//! ```rust
-//! use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-//!
-//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let mut producer = DefaultMQProducer::builder(client_runtime.clone())
-//!     .producer_group("example_group")
-//!     .name_server_addr("localhost:9876")
-//!     .build();
-//! let message = Message::builder()
-//!     .topic("TopicTest")
-//!     .body("Hello")
-//!     .build()?;
-//! producer.send(message).await?;
-//! # Ok(())
-//! # }
-//! //! ```
-```
-
-## 测试
-
-### 单元测试
-
-```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_message_creation() {
-        let msg = Message::builder()
-            .topic("Test")
-            .body(vec![1, 2, 3])
-            .build()
-            .unwrap();
-        assert_eq!(msg.topic().as_str(), "Test");
-    }
-
-    #[tokio::test]
-    async fn test_async_operation() {
-        let result = async_operation().await;
-        assert!(result.is_ok());
-    }
-}
-```
-
-### 集成测试
-
-```rust
-// tests/integration_test.rs
-#[tokio::test]
-async fn test_producer_consumer() {
-    let mut producer = DefaultMQProducer::builder(client_runtime.clone())
-        .producer_group("example_group")
-        .name_server_addr("localhost:9876")
-        .build();
-    producer.start().await.unwrap();
-
-    let mut consumer = DefaultMQPushConsumer::builder(client_runtime.clone())
-        .consumer_group("example_group")
-        .name_server_addr("localhost:9876")
-        .build();
-    consumer.subscribe("TestTopic", "*").await.unwrap();
-
-    // 测试逻辑
-}
-```
-
-## 代码风格
-
-### 自动格式化
-
-我们使用 `rustfmt` 确保整个项目的代码格式一致。**提交前务必格式化代码！**
+使用能够说明变更效果的最小目标，例如模型变更可以运行：
 
 ```bash
-# 格式化 workspace 中的所有代码
-cargo fmt --all
-
-# 检查代码是否已格式化（在 CI 中使用）
-cargo fmt --all --check
+cargo fmt -p rocketmq-model -- --check
+cargo test -p rocketmq-model --lib
 ```
 
-**专业提示**：配置 IDE 在保存时自动格式化：
+这些是对应包的示例，不是每次编辑都要执行的命令。复用有意义测试，并查看实际测试数量。完成编译的测试可以替代重复的 `cargo check`；只有存在具体问题时才增加包级 Clippy 或消费者验证。不要在有无关 Rust 修改时执行会改写整个工作区的格式化。
 
-- **VS Code**：使用 rust-analyzer 设置 `"editor.formatOnSave": true`
-- **RustRover**：在设置 → 工具 → 保存时操作中启用"重新格式化代码"
+网站渲染内容变化时，在 `rocketmq-website` 运行 `npm run build`。独立工程采用各自本地检查配置。完整 feature/平台矩阵、互操作、长时间故障测试和发行验证属于需要对应证据的任务，不宣称未运行场景已通过。
 
-### 使用 Clippy 进行 Linting
-
-我们使用 `clippy` 来捕获常见错误和非地道代码。所有 clippy 警告必须在合并前修复。
-
-```bash
-# 对所有目标和功能运行 clippy
-cargo clippy --all-targets --all-features --workspace -- -D warnings
-
-# 自动修复 clippy 建议（如果可能）
-cargo clippy --fix --all-targets --all-features --workspace
-```
-
-**注意**：一些 clippy 建议可以自动修复，但在提交前请始终审查更改。
-
-### 常见模式
-
-**构建器模式**：
-
-```rust
-pub struct ProducerOptions {
-    name_server_addr: String,
-    group_name: String,
-    timeout: u64,
-}
-
-impl ProducerOptions {
-    pub fn new() -> Self {
-        Self {
-            name_server_addr: "localhost:9876".to_string(),
-            group_name: "DEFAULT_PRODUCER".to_string(),
-            timeout: 3000,
-        }
-    }
-
-    pub fn name_server_addr(mut self, addr: impl Into<String>) -> Self {
-        self.name_server_addr = addr.into();
-        self
-    }
-
-    pub fn timeout(mut self, timeout: u64) -> Self {
-        self.timeout = timeout;
-        self
-    }
-}
-```
-
-**Newtype 模式**：
-
-```rust
-/// 带验证的消息 ID 包装器
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MessageId(String);
-
-impl MessageId {
-    pub fn new(id: String) -> Result<Self> {
-        if id.is_empty() {
-            return Err(Error::InvalidMessageId);
-        }
-        Ok(Self(id))
-    }
-}
-
-impl AsRef<str> for MessageId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-```
-
-## 性能指南
-
-RocketMQ-Rust 专为高性能设计。遵循这些指南以保持最佳性能。
-
-### 内存管理
-
-**优先使用借用而不是克隆** - 避免不必要的分配：
-
-```rust
-// ✅ 好的做法：使用引用避免复制
-pub fn process_message(msg: &Message) -> Result<()> {
-    let body = msg.get_body();  // 借用，不复制
-    // 在不克隆的情况下处理 body
-    Ok(())
-}
-
-// ❌ 坏的做法：不必要的克隆
-pub fn process_message_bad(msg: Message) -> Result<()> {
-    let body = msg.get_body().clone();  // 额外分配！
-    Ok(())
-}
-
-// ✅ 使用 Cow 进行条件所有权
-use std::borrow::Cow;
-
-pub fn get_topic<'a>(msg: &'a Message, default: &'a str) -> Cow<'a, str> {
-    match msg.get_topic() {
-        "" => Cow::Borrowed(default),  // 无分配
-        topic => Cow::Borrowed(topic), // 无分配
-    }
-}
-```
-
-### 并发
-
-```rust
-// 使用 Arc 进行共享所有权
-use std::sync::Arc;
-
-let client = Arc::new(Client::new());
-
-// 使用 Mutex/RwLock 进行内部可变性
-use tokio::sync::Mutex;
-
-let state = Arc::new(Mutex::new(State::new()));
-
-// 使用 channel 进行通信
-use tokio::sync::mpsc;
-
-let (tx, mut rx) = mpsc::channel(1000);
-```
-
-## 需要避免的常见错误 ⚠️
-
-从这些常见陷阱中学习：
-
-### 1. 在库代码中使用 `unwrap()` 或 `panic!()`
-
-❌ **坏的做法**：
-
-```rust
-pub fn get_broker(&self) -> Broker {
-    self.brokers.get(0).unwrap()  // 可能 panic！
-}
-```
-
-✅ **好的做法**：
-
-```rust
-pub fn get_broker(&self) -> Result<&Broker> {
-    self.brokers.get(0).ok_or(Error::NoBrokerAvailable)
-}
-```
-
-### 2. 忽略错误
-
-❌ **坏的做法**：
-
-```rust
-let _ = self.send(msg).await;  // 错误被静默忽略！
-```
-
-✅ **好的做法**：
-
-```rust
-if let Err(e) = self.send(msg).await {
-    log::error!("Failed to send message: {}", e);
-    return Err(e);
-}
-```
-
-### 3. 在异步代码中阻塞
-
-❌ **坏的做法**：
-
-```rust
-pub async fn send(&self) -> Result<()> {
-    std::thread::sleep(Duration::from_secs(1));  // 阻塞执行器！
-}
-```
-
-✅ **好的做法**：
-
-```rust
-pub async fn send(&self) -> Result<()> {
-    tokio::time::sleep(Duration::from_secs(1)).await;
-}
-```
-
-### 4. 不必要的克隆
-
-❌ **坏的做法**：
-
-```rust
-pub fn process(&self, data: String) -> Result<()> {
-    let copy = data.clone();  // 不必要！
-    process_data(&copy)
-}
-```
-
-✅ **好的做法**：
-
-```rust
-pub fn process(&self, data: &str) -> Result<()> {
-    process_data(data)
-}
-```
-
-### 5. 引用循环导致的内存泄漏
-
-使用 `Rc`/`Arc` 循环时要小心。需要时使用 `Weak` 引用。
-
-### 6. 过度使用 `unsafe`
-
-只在绝对必要时使用 `unsafe`，并始终记录为什么它是安全的。
-
-### 7. 未处理所有枚举变体
-
-避免在 match 分支中使用 `_` - 要明确以捕获未来的枚举添加。
-
-## 学习资源 📚
-
-想编写更好的 Rust 代码？查看这些资源：
-
-### 官方 Rust 资源
-
-- [The Rust Book](https://doc.rust-lang.org/book/) - 全面的 Rust 指南
-- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) - API 设计最佳实践
-- [Rust by Example](https://doc.rust-lang.org/rust-by-example/) - 通过示例学习
-- [Clippy Lint List](https://rust-lang.github.io/rust-clippy/master/index.html) - 所有 clippy lints 解释
-
-### 高级主题
-
-- [Async Book](https://rust-lang.github.io/async-book/) - 深入异步 Rust
-- [Tokio Tutorial](https://tokio.rs/tokio/tutorial) - 异步运行时指南
-- [The Rustonomicon](https://doc.rust-lang.org/nomicon/) - Unsafe Rust（高级）
-
-### RocketMQ-Rust 专用
-
-- [架构概述](/docs/zh-CN/architecture/overview) - 了解代码库结构
-- [开发指南](./development-guide) - 设置开发环境
-- [贡献概述](./overview) - 立即开始贡献！
-
-## 总结
-
-请记住：
-
-- ✅ 编写地道的 Rust 代码
-- ✅ 使用 `Result` 正确处理错误
-- ✅ 对 I/O 操作使用 async/await
-- ✅ 使用 `cargo fmt` 格式化代码
-- ✅ 提交前修复 clippy 警告
-- ✅ 为代码编写测试
-- ✅ 记录公共 API
-
-祝你编码愉快！🚀
-
-## 后续步骤
-
-- [开发指南](./development-guide) - 设置环境
-- [概述](./overview) - 开始贡献
-- [报告问题](https://github.com/mxsm/rocketmq-rust/issues) - 发现 bug？
+来源：[根规则](https://github.com/mxsm/rocketmq-rust/blob/main/AGENTS.md)、[Web 前端](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md)、[Web 后端](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md)、[GPUI](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md)、[Tauri](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-tauri/AGENTS.md)、[网站](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-website/AGENTS.md)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contributing/overview.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contributing/overview.md
@@ -1,336 +1,68 @@
 ---
-sidebar_position: 1
-title: 概述
+title: "参与 RocketMQ-Rust"
 ---
 
-> Runtime 所有权：示例中的 `client_runtime` 是应用持有的 `Arc<ClientRuntime>`，它从 `RuntimeOwner` 的 child scope 创建，并在进程边界显式关闭。
+# 参与 RocketMQ-Rust
 
-# 贡献指南概述
+从具体用户问题及其归属组件开始。有价值的贡献可以是可复现报告、修正后的双语示例、聚焦回归测试或行为变更。[开发指南](./development-guide.md)说明环境搭建和本地反馈流程，本文说明如何选择并呈现工作。
 
-欢迎来到 RocketMQ-Rust 社区！🎉
+## 选择入口
 
-感谢你对 RocketMQ-Rust 项目的贡献兴趣。无论是修复 bug、添加新功能还是改进文档，每一个贡献都很重要。本指南将帮助你开始贡献之旅。
+| 目标 | 首先阅读 | 有用的交付内容 |
+| --- | --- | --- |
+| 报告故障 | [故障排查](../operations/troubleshooting.md)和对应组件指南 | 精确操作、预期/实际结果、版本/feature 和最小复现 |
+| 改善教程或翻译 | [文档指南](./documentation.md)及两种语言文件 | 正确命令、前置条件、预期输出和完整对应译文 |
+| 修复核心行为 | [架构](../architecture/overview.md)和[模块地图](../architecture/module-map.md) | 归属层内的聚焦修改及回归覆盖 |
+| 改善客户端集成 | [客户端配置](../configuration/client-config.md)和 [API 迁移](../migration/rust-api.md) | 包含生命周期和完成语义的公共 API 示例 |
+| 开发应用产品 | [生态](../ecosystem/overview.md)和该应用的本地指南 | 在独立工程内改进产品行为、界面或服务集成 |
+| 改善性能 | [容量与性能](../operations/capacity-performance.md) | 明确工作负载、观察到的瓶颈和可比较测量 |
 
-## 贡献方式
+可执行变更使用 [GitHub Issues](https://github.com/mxsm/rocketmq-rust/issues)，使用或设计问题使用 [Discussions](https://github.com/mxsm/rocketmq-rust/discussions)。实现前检查相关工作，避免重复修改。较宽泛的 issue 应先说明准备改善的具体行为，不把小修复扩展为无关重构。
 
-有很多种方式可以为 RocketMQ-Rust 做出贡献：
+## 准备正确的工程
 
-### 代码贡献
+克隆自己的 fork 或使用已授权检出，然后遵循[开发环境搭建](./development-guide.md)。编辑前查看 `git status --short`，保护已有修改。通过最近的 `AGENTS.md` 和当前 manifest 选择构建根目录。
 
-- **Bug 修复**：修复已报告的问题
-- **新功能**：添加新功能
-- **性能改进**：优化现有代码
-- **文档**：改进代码文档
-- **测试**：添加单元测试和集成测试
+根 Cargo 工作区、独立示例、Dashboard 应用、MCP、SRE 和网站的命令不同。目录名不一定是 Cargo 包名，例如 `rocketmq-client` 应以 `rocketmq-client-rust` 选择。[发行范围](../overview/release-scope.md)解释工作区成员和产品发行成员的区别。
 
-### 非代码贡献
+除非变更有意处理对应契约，否则保留页面 ID、公共 API 和序列化字段。依赖和配置修改应限于问题所需，不格式化无关文件，也不替换他人未提交工作。
 
-- **Bug 报告**：报告 bug 和问题
-- **功能请求**：建议新功能
-- **文档**：改进用户文档
-- **代码审查**：审查拉取请求
-- **社区支持**：帮助其他用户
+## 提供可复现的问题报告
 
-## 开始贡献
+使用对应类型的仓库 issue 表单，包含最少但有效的信息：
 
-### 1. Fork 和克隆
+1. 组件、源码或制品版本、相关 feature/后端/模式及平台。
+2. 前置条件和精确操作，可能时提供最小示例。
+3. 预期行为与实际观察，包括稳定错误码和请求标识。
+4. 影响及已测试的临时处理方法。
+5. 若提出修复，说明归属文件和观察变更效果的方法。
 
-```bash
-# 在 GitHub 上 Fork 仓库
-# 克隆你的 fork
-git clone https://github.com/YOUR_USERNAME/rocketmq-rust.git
-cd rocketmq-rust
+从公开报告中移除凭据、Bearer 令牌、ACL/TLS 材料、消息体及无关个人或生产细节。脱敏输入仍应保留形状和相关类型，使示例可用。不要仅凭通用客户端超时推断故障根因。
 
-# 添加 upstream 远程仓库
-git remote add upstream https://github.com/mxsm/rocketmq-rust.git
-```
+Issue 模板区分缺陷、功能、增强、重构、测试和文档。当前字段和标题前缀位于 [.github/ISSUE_TEMPLATE](https://github.com/mxsm/rocketmq-rust/tree/main/.github/ISSUE_TEMPLATE)，使用真实表单，不额外发明必填字段。
 
-### 2. 设置开发环境
+## 实现并检查受影响行为
 
-```bash
-# 安装仓库固定的 stable 工具链和开发组件
-rustup toolchain install 1.95.0 --profile minimal --component rustfmt,clippy
+保持变更足够聚焦，使审阅者能关联原因、实现与结果。遵循[编码规范](./coding-standards.md)，复用现有抽象，将共享行为放在归属层。
 
-# 构建项目
-cargo build
-```
+Rust 行为变更选择对应包/目标和聚焦回归测试。编译受影响代码的测试构建也可提供编译依据。共享 API 或 feature 变化时，增加直接受影响消费者的检查。并非每次贡献都自动要求根目录全目标或全部 feature 检查。
 
-### 3. 创建分支
+网站内容应同步修改英文和中文，保留可执行示例及技术限制，并在 `rocketmq-website` 运行 `npm run build`。文档工作不需要源码指纹、清洁工作区仪式、评分或新增审批流程，正常校对和现有预览/构建工具即可。
 
-```bash
-# 与 upstream 同步
-git fetch upstream
-git checkout main
-git merge upstream/main
+记录实际运行内容及其说明的问题。外部集群、GUI 平台或可选工具不可用时，说明未测试场景，不宣称通过，也不修改无关依赖来绕过问题。
 
-# 创建功能分支
-git checkout -b feature/your-feature-name
-```
+## 提交便于审阅的 PR
 
-## 开发工作流
-
-### 进行更改
-
-1. **编写代码**：遵循编码标准
-2. **添加测试**：确保测试覆盖率
-3. **格式化代码**：使用 rustfmt
-
-    ```bash
-    cargo fmt
-    ```
-
-4. **运行 linter**：使用 clippy
-
-    ```bash
-    cargo clippy -- -D warnings
-    ```
-
-5. **运行测试**：确保所有测试通过
-
-    ```bash
-    cargo test --all
-    ```
-
-### 提交更改
-
-使用清晰的提交信息：
+关联 issue，并使用当前 [PR 模板](https://github.com/mxsm/rocketmq-rust/blob/main/.github/PULL_REQUEST_TEMPLATE.md)。仓库约定使用关联 issue 的英文标题，例如：
 
 ```text
-feat: 添加事务消息支持
-
-- 实现 TransactionMQProducer
-- 添加事务监听器 trait
-- 为事务消息添加单元测试
-
-Closes #123
+[ISSUE #1234]📝Clarify consumer offset completion
 ```
 
-提交信息格式：
+将示例编号替换为实际 issue。先描述具体问题和最终行为，再总结相关验证及限制。语义变更解释兼容性或迁移影响；简单文档修正只需简短描述和相关构建结果。
 
-- `feat:` 新功能
-- `fix:` Bug 修复
-- `docs:` 文档更改
-- `test:` 测试更改
-- `refactor:` 代码重构
-- `perf:` 性能改进
-- `chore:` 构建过程或工具
+根据评审反馈改进同一范围的结果，最终实现范围变化时同步更新描述。不要提交生成构建、日志、覆盖率、临时截图和本地测试数据。仅在截图属于有意交付的文档资源且准确反映产品时保留。
 
-### 提交拉取请求
+提交 PR 不意味着发布或部署。维护者按照对应项目流程处理集成和发行决策。社区分发身份见[发行范围](../overview/release-scope.md)。
 
-1. **推送到你的 fork**：
-
-    ```bash
-    git push origin feature/your-feature-name
-    ```
-
-2. **创建拉取请求**：在 GitHub 上
-
-3. **填写 PR 模板**：
-   - 描述你的更改
-   - 引用相关问题
-   - 如果适用，添加截图
-
-4. **等待审查**：维护者将审查你的 PR
-
-## 代码审查流程
-
-### 预期情况
-
-我们的审查流程旨在保持代码质量，同时对贡献者友好：
-
-1. **自动检查**（1-5 分钟）：CI 运行测试、linting 和格式检查
-2. **人工审查**（1-3 天）：维护者审查你的代码质量和设计
-3. **反馈讨论**：协作讨论以改进代码
-4. **批准和合并**：一旦批准，你的 PR 将被合并！🎉
-
-### 处理反馈
-
-代码审查是对话，而非批评。当你收到反馈时：
-
-- 回应所有审查意见（即使是确认收到）
-- 如果有不清楚的地方，请提问
-- 做出请求的更改并推送到同一分支
-- 准备好后请求重新审查
-- 不要犹豫讨论替代方案
-
-**注意**：CodeRabbit 的建议是有帮助的参考，但最终决定由维护者在代码审查期间做出。
-
-## 编码标准
-
-详见 [编码标准](./coding-standards) 获取详细指南。
-
-### 核心原则
-
-1. **遵循 Rust 惯用语**：编写地道的 Rust 代码
-2. **错误处理**：正确使用 `Result` 类型
-3. **文档**：为公共 API 添加文档注释
-4. **测试**：编写全面的测试
-5. **性能**：考虑性能影响
-
-### 示例
-
-```rust
-//! 向 RocketMQ broker 发送消息的生产者模块。
-
-use crate::error::{Error, Result};
-use crate::model::Message;
-
-/// 用于发送消息的 RocketMQ 生产者。
-///
-/// # 示例
-///
-/// ```rust
-/// use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut producer = DefaultMQProducer::builder(client_runtime.clone())
-///     .producer_group("example_group")
-///     .name_server_addr("localhost:9876")
-///     .build();
-/// producer.start().await?;
-/// # Ok(())
-/// # }
-/// ```
-pub struct Producer {
-    // 实现
-}
-
-impl Producer {
-    /// 创建新的生产者实例。
-    pub fn new() -> Self {
-        Self { /* ... */ }
-    }
-
-    /// 向 broker 发送消息。
-    ///
-    /// # 错误
-    ///
-    /// 以下情况将返回错误：
-    /// - broker 不可用
-    /// - 消息超过最大大小
-    /// - 发生网络超时
-    pub async fn send(&self, message: Message) -> Result<SendResult> {
-        // 实现
-    }
-}
-```
-
-## 开发指南
-
-详见 [开发指南](./development-guide) 获取详细信息。
-
-## 测试
-
-### 运行测试
-
-```bash
-# 运行所有测试
-cargo test --all
-
-# 运行特定测试
-cargo test test_send_message
-
-# 带输出运行测试
-cargo test -- --nocapture
-
-# 并行运行测试
-cargo test --all -- --test-threads=4
-```
-
-### 编写测试
-
-```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_send_message() {
-        let mut producer = DefaultMQProducer::builder(client_runtime.clone())
-            .producer_group("example_group")
-            .name_server_addr("localhost:9876")
-            .build();
-        producer.start().await.unwrap();
-
-        let message = Message::builder()
-            .topic("TestTopic")
-            .body("Test")
-            .build()
-            .unwrap();
-        let result = producer.send(message).await;
-
-        assert!(result.is_ok());
-    }
-}
-```
-
-## 文档
-
-### 构建文档
-
-```bash
-# 构建文档
-cargo doc --no-deps --open
-```
-
-### 编写文档
-
-```rust
-/// 简要说明（一句话）
-///
-/// 更详细的解释。
-///
-/// # 示例
-///
-/// ```
-/// use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
-/// use rocketmq_common::common::message::message_single::Message;
-///
-/// let mut producer = DefaultMQProducer::builder(client_runtime.clone())
-///     .producer_group("example_group")
-///     .name_server_addr("localhost:9876")
-///     .build();
-/// let message = Message::builder().topic("TopicTest").body("hello").build().unwrap();
-/// ```
-///
-/// # 错误
-///
-/// 以下情况此函数将返回错误...
-///
-/// # Panics
-///
-/// 以下情况此函数将 panic...
-pub fn public_function() -> Result<()> {
-    // 实现
-}
-```
-
-## 获取帮助
-
-我们随时提供帮助！请通过以下方式联系：
-
-- **GitHub Issues**：[报告 bug 或请求功能](https://github.com/mxsm/rocketmq-rust/issues)
-- **GitHub Discussions**：[提问和分享想法](https://github.com/mxsm/rocketmq-rust/discussions)
-- **邮件**：[mxsm@apache.org](mailto:mxsm@apache.org)
-
-## 许可证
-
-RocketMQ-Rust 采用 [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) 许可。通过贡献，你同意你的贡献将使用相同的许可证。
-
-## 行为准则
-
-我们致力于为每个人提供一个友好和包容的环境。请：
-
-- 在交流中保持尊重和体贴
-- 欢迎新来者并帮助他们入门
-- 专注于建设性反馈
-- 假设良好的意图
-- 开放协作并分享知识
-
-我们都在这里一起构建优秀的软件！🚀
-
-## 后续步骤
-
-- [开发指南](./development-guide) - 详细的开发信息
-- [编码标准](./coding-standards) - 代码风格指南
-- [报告问题](https://github.com/mxsm/rocketmq-rust/issues) - 提交 bug 或功能请求
+来源：[根工程约定](https://github.com/mxsm/rocketmq-rust/blob/main/AGENTS.md)、[网站指南](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-website/AGENTS.md)、[Issue 模板](https://github.com/mxsm/rocketmq-rust/tree/main/.github/ISSUE_TEMPLATE)、[PR 约定](https://github.com/mxsm/rocketmq-rust/blob/main/.agents/skills/rocketmq-rust-pr-submitter/SKILL.md)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/ecosystem/dashboards.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/ecosystem/dashboards.md
@@ -1,0 +1,114 @@
+---
+title: "选择与运行 Dashboard"
+---
+
+# 选择与运行 Dashboard
+
+仓库包含 Web、GPUI、Tauri 三个 Dashboard 应用。它们共享 RocketMQ 管理概念及部分公共代码，但应用生命周期、持久化和构建根目录独立。先按部署方式选择，再确认所需操作在该实现中的支持情况。
+
+## 产品对比
+
+| 产品 | 界面与执行方式 | 持久化 / 连接所有者 | 适合的起点 |
+| --- | --- | --- | --- |
+| Web | React/TypeScript 浏览器界面调用独立 Axum HTTP 后端 | 后端选择 File、SQLite、MySQL 或 PostgreSQL，并持有出站 RocketMQ 访问 | 集中运维的浏览器服务 |
+| GPUI | 原生 GPUI/gpui-component 桌面应用 | 桌面配置/历史/监控存储及实时管理 provider | 具有图形桌面的原生操作工作站 |
+| Tauri | Tauri 桌面外壳中的 React/TypeScript 界面调用 Rust 命令 | Rust 应用管理器及共享配置服务 | 使用 Web 界面组件的桌面安装包 |
+| Dashboard common | 库，不是面向用户的可执行文件 | 共享模型、配置及可选管理门面 | 复用独立于 UI 的领域行为 |
+
+共同术语不代表功能完全对等。查询、管理、认证、历史和监控流程应在选定产品中核对。这些应用可以执行变更，Dashboard 不等同于[只读 MCP](./mcp.md) 服务。
+
+```mermaid
+flowchart LR
+  W[Web 浏览器] --> H[Axum HTTP 后端]
+  G[GPUI 桌面] --> P[桌面服务和 provider]
+  T[Tauri webview] --> C[Rust 命令管理器]
+  H --> A[Admin 与客户端契约]
+  P --> A
+  C --> A
+  A --> N[NameServer 发现]
+  A --> B[Broker 操作]
+  D[Dashboard common 模型和服务] -. 共享代码 .-> H
+  D -. 共享代码 .-> P
+  D -. 共享代码 .-> C
+```
+
+各应用独立持有运行时和持久化生命周期。图中表示共享职责，不表示同一进程或公共在线数据库。执行后端或桌面进程的机器必须能够访问 NameServer 发现结果及 Broker 广播地址。
+
+## Web：独立后端与前端
+
+从后端自身 Cargo 根目录运行：
+
+```bash
+cd rocketmq-dashboard/rocketmq-dashboard-web/backend
+cargo run --bin rocketmq-dashboard-web-backend
+```
+
+必须明确二进制，因为该包还包含存储工具。文档中的后端默认地址为 `http://127.0.0.1:8082`。为目标集群设置 `NAMESRV_ADDR`，超出本地开发范围前检查后端认证、存储和连接配置。
+
+在第二个终端中，从仓库根目录执行：
+
+```bash
+cd rocketmq-dashboard/rocketmq-dashboard-web/frontend
+npm ci
+npm run dev
+```
+
+后续运行复用已安装依赖。Vite 请求端口 `3003`，默认将 `/api` 代理到 `http://127.0.0.1:8082`；`VITE_API_TARGET` 可修改开发代理目标。端口被占用时，以 Vite 实际打印地址为准。开发代理不等同于生产 HTTP 部署配置。
+
+Web 持久化在启动时严格选择。File 使用进程生命周期独占锁保护的目录，SQLite 使用磁盘文件。MySQL/PostgreSQL 需要数据库 URL 和相应连接/TLS 配置。未知后端或缺少必需配置不能被解释为自动回退到 File 存储。
+
+`GET /api/health/live` 报告进程存活，`GET /api/health/ready` 包含存储就绪状态，`/api/health` 仍为就绪端点。这些接口本身不能证明每个 RocketMQ 操作或下游 Broker 都健康。
+
+在前端目录执行 `npm run build` 生成前端资源。后端部署、持久存储、会话认证和反向代理/API origin 仍是独立工作。详细环境变量及存储操作见 [Web 产品 README](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/README.md)。
+
+## GPUI：原生桌面所有权
+
+从仓库根目录执行：
+
+```bash
+cd rocketmq-dashboard/rocketmq-dashboard-gpui
+cargo run
+```
+
+在该目录使用 `cargo build --release` 构建优化后的可执行文件。运行需要图形桌面。Windows 需要 MSVC C++ 工具链和 Windows SDK，macOS 需要 Xcode 命令行工具，Linux 需要 [GPUI 指南](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-gpui/AGENTS.md)中的 GUI 开发库。该工程是独立 Rust 2024 工作区。
+
+配置默认位于操作系统用户配置目录下的 `rocketmq-dashboard/gpui/config.json`。`ROCKETMQ_DASHBOARD_GPUI_CONFIG_PATH` 覆盖完整文件路径，其中保存 NameServer 和连接设置。
+
+本地 Dashboard 登录与出站 RocketMQ 凭据相互独立。启用本地登录时需要 `ROCKETMQ_DASHBOARD_USERNAME`、`ROCKETMQ_DASHBOARD_PASSWORD`。Admin 凭据来源选择 `environment` 时，使用 `ROCKETMQ_ADMIN_ACCESS_KEY`、`ROCKETMQ_ADMIN_SECRET_KEY` 及可选 `ROCKETMQ_ADMIN_SECURITY_TOKEN`。通过工作站受管理环境提供密钥，不把真实值放入共享截图或报告。
+
+GPUI 入口初始化组件并持有应用运行时。Admin 和持久化工作通过注入的子作用域执行，不在渲染路径执行。事件循环退出后触发运行时清理，参见 [GPUI README](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-gpui/README.md)。
+
+## Tauri：前端构建与桌面打包
+
+从仓库根目录执行：
+
+```bash
+cd rocketmq-dashboard/rocketmq-dashboard-tauri
+npm ci
+npm run tauri dev
+```
+
+原生构建前安装目标操作系统的 Tauri 前置依赖。React 界面调用 Rust 命令管理器，Rust 应用持有共享客户端运行时，并在关闭时清理管理器。仅在浏览器预览不会执行桌面命令桥接。
+
+| 命令与目录 | 结果 |
+| --- | --- |
+| Tauri 应用根目录中的 `npm run build` | TypeScript/Vite 前端资源 |
+| `src-tauri` 中的 `cargo check` 或 `cargo build` | Rust 后端检查或二进制编译 |
+| 应用根目录中的 `npm run tauri build` | 所配置平台的桌面安装包/bundle |
+
+未覆盖 target 目录时，默认 bundle 位于 `src-tauri/target/release/bundle/`。不要把前端构建成功表述为桌面应用已打包或测试。参见 [Dashboard 构建指南](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/README.md)和 [Tauri 应用所有者](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs)。
+
+## 定位正确边界
+
+| 现象 | 首先区分 |
+| --- | --- |
+| Web UI 加载但请求失败 | 浏览器到后端的 API/代理/会话问题，还是后端到 RocketMQ 的问题 |
+| 登录成功但无法访问集群 | 本地/产品认证，还是出站 RocketMQ 认证和授权 |
+| 主题或消费者表为空 | 所选集群、实际响应、加载/错误状态和可见权限；不能直接认定集群没有数据 |
+| Web 服务启动失败 | 所选存储驱动、路径/URL、独占锁和就绪状态；不要切换后端来掩盖持久化故障 |
+| 原生构建失败 | 独立目录是否正确、Rust edition/工具链、Node 依赖及操作系统原生前置条件 |
+| 不同产品显示数据不同 | 所选集群、采样时间、产品持久化或实际操作不同；公共模型不会同步应用状态 |
+
+先在隔离开发集群执行查询。变更元数据、偏移量或消息前检查目标和操作影响，保留产品确认及授权行为。编写本概览时没有构建或启动 Web、GPUI、Tauri 应用，不宣称跨平台或操作功能对等已经验证。
+
+来源：[Dashboard common](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-common/Cargo.toml)、[Web 架构](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/AGENTS.md)、[Web 开发代理](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/frontend/vite.config.ts)、[GPUI 指南](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-gpui/README.md)、[Tauri 脚本](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-tauri/package.json)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/ecosystem/mcp.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/ecosystem/mcp.md
@@ -1,0 +1,158 @@
+---
+title: "只读 MCP 诊断服务"
+---
+
+# 只读 MCP 诊断服务
+
+`rocketmq-mcp` 是用于 RocketMQ 查询、诊断和运行手册提示词的独立 Model Context Protocol 服务。它运行在 Broker、NameServer、Dashboard 进程之外，使用 Admin Core 的 `read-client-adapter`。默认工具不打开变更会话；可选规划 feature 生成建议，不执行建议。
+
+## 请求路径与所有权
+
+```mermaid
+flowchart TD
+  C[MCP 客户端] --> T[stdio 或已认证 Streamable HTTPS]
+  T --> P[已验证主体和操作策略]
+  P --> Q[Tools 和 Resources 通过 QueryFacade]
+  Q --> K[按可见性隔离的缓存和 singleflight]
+  K --> A[只读 Admin 适配器及自有 ClientRuntime]
+  A --> R[已配置 RocketMQ 端点]
+  R --> O[类型化观察与有界输出]
+  O --> S[脱敏和共享审计路径]
+  S --> C
+```
+
+MCP 进程持有生命周期、查询运行时、缓存和异步审计写入器。关闭时停止准入，排空已接受审计记录、刷出 sink，并在截止时间内关闭所属任务。缓存观察反映数据被观察的时间，不表示新的远程读取，也不保证集群未发生变化。
+
+## 构建所选传输方式
+
+从仓库根目录进入独立工程：
+
+```bash
+cd rocketmq-ai/rocketmq-mcp
+cargo build --locked --release
+```
+
+默认 feature 为 `read-only`、`diagnose`、`stdio`。在同一目录可构建 HTTPS 支持：
+
+```bash
+cargo build --locked --release --features streamable-http
+```
+
+`streamable-http` 包含认证 feature，不是无认证 HTTP 模式。`observability` 启用进程内信号，`otlp` 选择已实现的 OTLP gRPC 支持。`change-planning` 增加五个受运行时策略约束的规划工具。这些 feature 都不会将 Query MCP 变为 MCP Control。
+
+二进制位于 `target/release/rocketmq-mcp`，Windows 为 `rocketmq-mcp.exe`。根工作区的 `cargo build` 不构建该独立包。原生依赖来自所选依赖图，参见 [features/平台](../reference/features-platforms.md)。
+
+## 准备本地 stdio 配置
+
+将 [conf/mcp.example.toml](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/conf/mcp.example.toml)复制为自己的配置文件。放在同一 `conf` 目录可以保留示例权限文件的相对路径；移动到其他位置时，同时复制策略文件，并明确解析审计/TLS 引用。选择新文件名，不替换已有运维配置。
+
+对第一条消息开发集群，将已有集群条目改为以下值，不要追加另一个默认集群：
+
+```toml
+[[clusters]]
+name = "local-dev"
+rocketmq_cluster_name = "DocsCluster"
+namesrv_addr = "127.0.0.1:9876"
+default = true
+```
+
+这是替换片段，不是完整配置。删除未使用的 Proxy/Controller 示例别名，或将其设置为实际需要查询的服务。MCP 逻辑集群名可以与物理 RocketMQ 集群名不同。工具接受配置中的逻辑别名，不接受任意网络地址。
+
+| 设置 | 仓库示例 / 行为 |
+| --- | --- |
+| `security.profile` | `diagnose`，用于本地诊断权限范围 |
+| `security.allow_change_planning` | `false`，仅编译不能允许规划调用 |
+| `security.permissions_file` | `permissions.example.toml`，相对配置文件加载 |
+| `security.sanitize_output` | `true` |
+| `security.max_concurrent_requests_per_cluster` | 8 |
+| `security.rate_limit_per_minute` | 按主体/集群/操作策略每分钟 60 次 |
+| `audit.enabled` / `sink` | `true` / `file`，应选择可写审计路径 |
+| `cache.enabled` / `max_entries` | `true` / 256，按查询类型的 TTL 决定新鲜度 |
+| `server.stdio.log_to_stderr` | `true`，stdout 保留给 MCP 协议帧 |
+
+编辑 `conf/mcp.local.toml` 后，从 MCP 目录启动：
+
+```bash
+cargo run --locked -- --config conf/mcp.local.toml --transport stdio
+```
+
+配置本地 MCP 客户端，以这些参数和明确的绝对配置路径启动已构建二进制。Stdio 是本地开发进程集成；等待协议输入的终端不是 HTTP 服务。不要在 stdout 前添加 Shell 欢迎信息，也不要将诊断文本重定向到 stdout。
+
+必须通过 `--config` 或 `ROCKETMQ_MCP_CONFIG` 提供配置路径。权限、TLS、JWKS CA 和审计路径相对配置文件解析。CLI 当前在加载文件后赋值 `--transport`，该参数默认 `stdio`。HTTPS 必须显式传入 `--transport streamable-http`；只设置文件中的 `server.transport` 对此 CLI 路径不够。可选 `--bind`、`--endpoint` 覆盖对应文件值。
+
+## Streamable HTTPS 与身份
+
+HTTPS 需要编译传输支持、可读证书/私钥对、允许的 Origin 策略和认证配置。示例监听 `127.0.0.1:8089`，端点 `/mcp`，公开基础 URL 为 `https://127.0.0.1:8089`。这些默认值不会提供真实证书文件或凭据。
+
+| 边界 | 身份与配置 |
+| --- | --- |
+| 本地开发 HTTP | `development-token` 限于环回开发，通过配置的环境引用读取令牌。 |
+| 生产 HTTP | `oauth-jwt` 通过 HTTPS JWKS 验证带 `kid` 的 RS256 令牌签名、issuer、audience、过期时间和必需 scope。 |
+| 私有 JWKS CA | 用 `jwks_ca_path` 配置可读 PEM 信任包，相对路径归配置目录所有。 |
+| 工具执行 | 已验证角色/scope、配置集群、集群声明、租户绑定、速率限制和操作策略在各自定义阶段生效。 |
+| 出站 RocketMQ | 通过配置的文件/环境引用提供独立签名凭据；不转发入站 Bearer 令牌。 |
+
+生产 OAuth 没有静态 `jwt_key_env` 回退。密钥刷新失败时，在配置的陈旧窗口内保留已验证代际。受保护资源元数据端点有意允许无 Bearer 令牌访问以支持发现，MCP 端点本身仍要求认证。
+
+配置材料后，从 MCP 目录启动：
+
+```bash
+cargo run --locked --features streamable-http -- --config conf/mcp.local.toml --transport streamable-http --bind 127.0.0.1:8089 --endpoint /mcp
+```
+
+支持 HTTP 的 MCP 客户端连接 HTTPS 端点，发送认证头及 `Accept: application/json, text/event-stream`。证书验证、协议初始化和会话/流生命周期由 MCP 客户端处理。单次无认证 GET 不是完整工具调用。
+
+RocketMQ 签名凭据必须与 HTTP 身份分离。配置的 YAML 凭据文件包含 `access_key`、`secret_key` 和可选 `security_token`，大小限制为 64 KiB；也可配置环境变量引用。内联密钥值和混合文件/环境来源会被拒绝。启动及新建读取会话时解析凭据，以支持挂载密钥轮换。Broker 身份只授予所需读取权限。
+
+## 发现并调用工具
+
+仓库协议版本为 `2025-11-25`，初始化拒绝其他版本。初始化后使用 `tools/list` 获取调用方可见目录。源码默认目录包含 24 个工具，但策略可以缩小发现结果。
+
+| 查询类型 | 默认工具名称 |
+| --- | --- |
+| 集群 / 清单 | `rocketmq_get_cluster_overview`、`rocketmq_list_topics`、`rocketmq_list_consumer_groups` |
+| 主题 | `rocketmq_describe_topic`、`rocketmq_get_topic_route`、`rocketmq_get_topic_config_state`、`rocketmq_get_topic_stats`、`rocketmq_get_topic_config` |
+| 消费者 / 连接 | `rocketmq_get_consumer_lag`、`rocketmq_list_consumer_connections`、`rocketmq_list_producer_connections`、`rocketmq_get_consumer_group_config_state`、`rocketmq_get_consumer_group_details`、`rocketmq_get_consumer_progress` |
+| Broker | `rocketmq_describe_broker`、`rocketmq_get_broker_diagnostics`、`rocketmq_get_broker_config_summary`、`rocketmq_get_broker_log_filter_state` |
+| 基础设施 | `rocketmq_get_proxy_drain_state`、`rocketmq_get_ha_status`、`rocketmq_get_controller_metadata`、`rocketmq_get_nameserver_config_summary` |
+| 消息 / 诊断 | `rocketmq_get_message_metadata`、`rocketmq_diagnose_consumer_lag` |
+
+先使用明确指定集群的简单查询。下列 `tools/call` 请求用于已初始化 MCP 会话，不是独立 HTTP 命令：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "rocketmq_list_topics",
+    "arguments": {"cluster": "local-dev", "limit": 25}
+  }
+}
+```
+
+`limit` 范围 1–200，默认 50。`has_more` 为 true 时使用不透明的 `data.next_cursor` 继续，不自行构造游标，也不将其当作队列偏移量。提供相同逻辑目标和对应查询参数。精确模式和逐工具输出见[完整工具参考](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/docs/tool-reference.md)。
+
+发现阶段检查 scope 和工具允许/拒绝策略，不代表某个集群/租户调用一定获准。两个清单工具允许省略集群并使用默认/唯一集群回退；当前实现对该省略路径不执行与显式路径相同的逐集群/租户检查。运维客户端应显式提供集群，并在部署策略中考虑此限制，不把省略参数表述为更强隔离保证。
+
+## 理解观察、部分结果和故障
+
+成功调用携带 `rocketmq-mcp.v2` 封装，包括请求 ID、逻辑集群、观察时间、新鲜度、缓存状态、部分结果标志、警告及类型化数据。`hit`、`miss`、`bypass` 区分查询复用，失败不会缓存。查询状态和继续游标按 `standard`、`sensitive` 可见性类别隔离，不跨类别共享。
+
+输出数组限制为 1,000 行，结构化输出限制为 1 MiB。截断和来源失败可能产生部分结果，将观察描述为完整前应检查 warnings 和 `partial`。消息元数据工具不返回消息体，连接身份使用化名；敏感字段缺失不一定是后端故障。
+
+| 现象/错误码 | 后续操作 |
+| --- | --- |
+| 工具缺失 | 检查编译 feature、主体 scope 和工具策略；规划还需在调用时满足运行时权限。 |
+| `unauthorized_scope` / `cluster_not_allowed` / `tenant_mismatch` | 检查已验证身份和配置策略，修改查询别名不能授予权限。 |
+| `source_unavailable` | 检查 MCP 进程到配置 NameServer/Broker/Proxy/Controller 的网络路径及出站读取凭据。 |
+| `rate_limited` | 降低查询速率并采用有界重试，避免 AI 客户端与 MCP 层叠加重试。 |
+| `output_too_large` 或部分结果警告 | 缩小查询，支持时分页，并在诊断中保留警告。 |
+| 观察过旧 | 检查观察时间、TTL/缓存状态和所选集群，再推断当前故障。 |
+| stdio 解析失败 | 确认协议版本和纯净 stdout，在 stderr 查看脱敏启动/传输诊断。 |
+
+启用规划工具后，可以生成创建主题、更新主题配置、更新主题权限、更新 Broker 配置和重置偏移量方案。工具没有 Apply 模式，也不调用变更 API。执行属于独立设计的运维/控制流程，不属于这个诊断进程。
+
+本文核对了配置、注册和协议源码，并完成 TOML/JSON 及网站渲染检查；不宣称编写文档时测试过真实 MCP 客户端会话、OAuth/JWKS 部署或外部集群诊断。
+
+来源：[配置解析器](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/src/config.rs)、[入口](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/src/main.rs)、[工具目录](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/src/tools/catalog.rs)、[协议服务](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/src/protocol/server.rs)、[权限示例](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/conf/permissions.example.toml)、[只读边界](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/AGENTS.md)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/ecosystem/overview.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/ecosystem/overview.md
@@ -8,10 +8,10 @@ title: "Dashboard、MCP 与 AI SRE"
 
 | 产品 | 角色 | 部署边界 | 起点 |
 | --- | --- | --- | --- |
-| Web Dashboard | 浏览器集群/资源管理 | Rust HTTP 后端、React 前端及所选持久存储 | [Web 指南](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/rocketmq-dashboard-web/README.md) |
-| GPUI Dashboard | 原生桌面管理 | 独立 Rust 桌面包 | [GPUI 工程](https://github.com/mxsm/rocketmq-rust/tree/main/rocketmq-dashboard/rocketmq-dashboard-gpui) |
-| Tauri Dashboard | 使用 Web UI 的桌面应用 | Node 前端、Rust 后端和操作系统打包 | [Dashboard 构建指南](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-dashboard/README.md) |
-| MCP | 有界只读集群诊断及可选非变更计划 | 使用 stdio 或已配置 Streamable HTTP 的独立服务 | [MCP 指南](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp/README.md) |
+| Web Dashboard | 浏览器集群/资源管理 | Rust HTTP 后端、React 前端及所选持久存储 | [Web 指南](./dashboards.md) |
+| GPUI Dashboard | 原生桌面管理 | 独立 Rust 桌面包 | [GPUI 工程](./dashboards.md) |
+| Tauri Dashboard | 使用 Web UI 的桌面应用 | Node 前端、Rust 后端和操作系统打包 | [Dashboard 构建指南](./dashboards.md) |
+| MCP | 有界只读集群诊断及可选非变更计划 | 使用 stdio 或已配置 Streamable HTTP 的独立服务 | [MCP 指南](./mcp.md) |
 | MCP Control | 类型化、受监督的集群变更 | 独立 TLS/OAuth 服务、feature 与策略启用 | [Control 指南](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-mcp-control/README.md) |
 | AI SRE | 证据、诊断、事件、计划与执行协调 | 独立 SRE workspace、服务、UI 和存储 | [SRE 指南](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-ai/rocketmq-sre/README.md) |
 

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/overview/release-scope.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/overview/release-scope.md
@@ -1,0 +1,71 @@
+---
+title: "发行范围与分发身份"
+---
+
+# 发行范围与分发身份
+
+RocketMQ-Rust 包含的产品多于一次核心发行。使用根 Cargo manifest 确认工作区成员、核心范围清单确认发行分类、所选制品的发布信息确认实际发布内容。这些来源各有用途，不能相互替代。
+
+## 源码工作区、核心发行与独立产品
+
+| 集合 | 当前源码定义 | 属于该集合意味着什么 |
+| --- | --- | --- |
+| 根 Cargo 工作区 | `Cargo.toml`，28 个成员 | 可从仓库根目录通过 Cargo 选择这些包。 |
+| 核心发行包集合 | `scripts/core-release-scope.json`，27 个包 | 已纳入核心发行流程分类，不代表已在 registry 发布。 |
+| 核心服务 | NameServer、Broker、Controller、Proxy | 核心范围命名的服务产品，仍有不同构建 feature、配置和启动命令。 |
+| Dashboard common | 根工作区成员，明确排除在核心发行外 | 可随根工作区构建共享 Dashboard 模型/服务，但桌面和 Web 产品不因此属于核心发行。 |
+| 独立 Cargo 产品 | Examples、GPUI、Tauri 后端、Web 后端、MCP、MCP Control、SRE 及专用测试 fixture/fuzzing | 使用各自 manifest 和指南，根构建不覆盖它们。 |
+| Node 项目 | 网站、Dashboard 前端、SRE UI 和 TypeScript SDK | 各自拥有 package manifest 和命令。 |
+
+范围文件列出了 Dashboard、MCP、SRE 的仓库排除项。MCP Control 同样是独立项目，未列入核心包清单；没有列入不意味着继承核心发行状态。[模块地图](../architecture/module-map.md)和[生态概览](../ecosystem/overview.md)说明这些归属。
+
+## 按定义理解包分类
+
+| 分类 | 在发行模型中的含义 | 当前示例 |
+| --- | --- | --- |
+| `registry-publish` | 纳入 registry 包规划 | 客户端、模型、协议、传输、运行时、安全、存储、服务库和 Admin Core |
+| `binary-only` | 在该分类中作为二进制产品分发，而非 registry 库 | `rocketmq-admin-cli`、`rocketmq-admin-tui`、`rocketmq-store-inspect` |
+| `internal-only` | 模式允许的内部包分类 | 当前核心条目未使用 |
+| `non-publish` | 模式允许的不发布包分类 | 当前核心条目未使用 |
+
+当前核心清单包含 24 个 `registry-publish` 和三个 `binary-only` 条目。服务包可以同时包含库和二进制，分类不会移除可执行文件。反过来，Cargo.toml 中的包版本不能证明下载归档或 registry 版本已经存在。
+
+## 分发身份
+
+仓库中的 `distribution/release-identity.json` 声明：
+
+| 字段 | 声明值 |
+| --- | --- |
+| 分发名称 | RocketMQ Rust Community Distribution |
+| 身份类型 | `unofficial-community` |
+| 是否为 Apache 官方发行 | `false` |
+| 源码项目 | `mxsm/rocketmq-rust` |
+| Registry 所有者 / 包前缀 | crates.io 上的 `mxsm` / `rocketmq-` |
+| OCI 命名空间 | `ghcr.io/mxsm/rocketmq-rust` |
+| Helm chart 名称 | `rocketmq-rust` |
+| 许可证标识 | `Apache-2.0` |
+
+这些是声明的发行目标和身份元数据，不代表所有镜像、chart 或包当前均可获取。“项目官方文档”指为本项目维护的文档，不能解释为 Apache Software Foundation 官方发行身份。身份文件明确将其定义为非官方社区分发。
+
+制品使用方式见[容器](../deployment/containers.md)和 [Kubernetes](../deployment/kubernetes.md)。保持镜像 tag、chart values、服务二进制与相应文档配套，不用未经核实的“latest”制品替代指定发行版。
+
+## 版本号与 Next 文档
+
+根工作区当前声明版本 `1.0.0`，独立应用可以声明自身版本，例如 `0.1.0`。这些是源码 manifest 数值，不能据此推断发布日期、支持周期或跨产品同步发布。
+
+Docusaurus 当前文档标记为 **Next**，提供英文和 `zh-CN` 内容。Next 描述当前源码系列，可能包含晚于已发布制品的行为。中文页是相同页面 ID 的完整对应正文，不是另一产品版本。
+
+定位事故或兼容性问题时，记录实际二进制/包版本、构建 feature、部署模式及相关配置，再核对匹配的源码/API 文档。[能力矩阵](./capability-matrix.md)和[兼容性参考](../reference/protocol-compatibility.md)解释了为何仅有版本字符串不足以判断行为。
+
+## 选择正确的构建与交付单元
+
+1. 找到归属包/应用及其 manifest。
+2. 明确交付物是库、服务二进制、桌面安装包、前端资源、chart 还是容器。
+3. 使用该产品的构建入口及支持的 feature/平台组合。
+4. 将产物与匹配配置、操作流程和已知限制关联。
+
+例如，构建 Tauri React 前端不会生成桌面安装包，构建根工作区不会构建 Web Dashboard 后端。发布核心消息包不会发布 MCP，也不会为其配置 HTTP 认证。
+
+本文是源码范围参考，不是新的发布公告，也不宣称发行工作流已经运行。
+
+来源：[工作区 manifest](https://github.com/mxsm/rocketmq-rust/blob/main/Cargo.toml)、[核心发行范围](https://github.com/mxsm/rocketmq-rust/blob/main/scripts/core-release-scope.json)、[分发身份](https://github.com/mxsm/rocketmq-rust/blob/main/distribution/release-identity.json)、[网站版本配置](https://github.com/mxsm/rocketmq-rust/blob/main/rocketmq-website/docusaurus.config.ts)。

--- a/rocketmq-website/sidebars.ts
+++ b/rocketmq-website/sidebars.ts
@@ -4,6 +4,7 @@ const sidebars: SidebarsConfig = {
   docsSidebar: [
     'introduction',
     'overview/capability-matrix',
+    'overview/release-scope',
     {
       type: 'category',
       label: 'Getting Started',
@@ -145,7 +146,7 @@ const sidebars: SidebarsConfig = {
       label: 'Ecosystem',
       collapsible: true,
       collapsed: true,
-      items: ['ecosystem/overview'],
+      items: ['ecosystem/overview', 'ecosystem/dashboards', 'ecosystem/mcp'],
     },
     {
       type: 'category',


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10333

### Brief Description

Add bilingual release-scope, Dashboard selection and read-only MCP guides, and replace outdated contribution/coding pages with current project conventions. Readers can identify the correct build root, distinguish frontend assets from desktop bundles, configure MCP transports explicitly and interpret tool discovery, authorization and partial observations accurately.

The five paired pages include two new diagram groups, updated ecosystem links and release-scope navigation. Distribution identity is described as community metadata, not a new release announcement.

### How Did You Test This Change?

- `npm run build` in `rocketmq-website`: both locales passed. The rewritten coding page removes its old broken link; one existing Chinese author-page link remains for the final site cleanup.
- Checked 12 changed content files for fences, source/relative targets, matching bilingual executable blocks and TOML/JSON parsing; checked release counts against current manifests.
- Previewed the Chinese MCP page, confirmed its SVG diagram, navigation, code and table rendering.
- `git diff --cached --check` passed.
- No Dashboard build/launch, cross-platform GUI trial, live MCP client session, OAuth/JWKS deployment or external-cluster diagnosis was performed for this documentation-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for selecting and running RocketMQ Dashboard Web, GPUI, and Tauri applications.
  - Added documentation for the read-only RocketMQ MCP diagnostic service, including transports, authentication, tools, and troubleshooting.
  - Added a release scope and distribution identity reference.
  - Reworked contribution workflow and coding standards into concise, project-specific references.
  - Updated ecosystem links to point to local documentation and expanded the documentation sidebar.
  - Added corresponding Chinese documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->