### PR TITLE
add unit tests for broker address selection logic

### DIFF
--- a/rocketmq-protocol/src/protocol/route_facade.rs
+++ b/rocketmq-protocol/src/protocol/route_facade.rs
@@ -28,3 +28,68 @@ impl BrokerDataExt for BrokerData {
         select_broker_addr(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::wire_constants::MASTER_ID;
+    use std::collections::HashMap;
+
+    fn create_test_broker_data(addrs: HashMap<u64, CheetahString>) -> BrokerData {
+        BrokerData::new(
+            CheetahString::from("test_cluster"),
+            CheetahString::from("test_broker"),
+            addrs,
+            None,
+        )
+    }
+
+    fn make_addr(id: u64, addr: &str) -> (u64, CheetahString) {
+        (id, CheetahString::from(addr))
+    }
+
+    #[test]
+    fn test_empty_broker_address_map() {
+        let broker_data = create_test_broker_data(HashMap::new());
+        assert!(select_broker_addr(&broker_data).is_none());
+        assert!(broker_data.select_broker_addr().is_none())
+    }
+
+    #[test]
+    fn test_map_containing_only_one_slave() {
+        let slave_id = MASTER_ID + 1;
+        let slave_addr = CheetahString::from("192.168.1.101");
+        let mut broker_addrs = HashMap::new();
+        broker_addrs.insert(slave_id, slave_addr.clone());
+        let broker_data = create_test_broker_data(broker_addrs);
+        assert_eq!(broker_data.select_broker_addr(), Some(slave_addr.clone()));
+        assert_eq!(select_broker_addr(&broker_data), Some(slave_addr));
+    }
+
+    #[test]
+    fn test_map_containing_master_and_slaves() {
+        let master_addr = CheetahString::from("192.168.1.1");
+        let broker_addrs = HashMap::from([
+            make_addr(MASTER_ID + 1, "192.168.1.101"),
+            make_addr(MASTER_ID + 2, "192.168.1.102"),
+            (MASTER_ID, master_addr.clone()),
+        ]);
+        let broker_data = create_test_broker_data(broker_addrs);
+        assert_eq!(broker_data.select_broker_addr(), Some(master_addr.clone()));
+        assert_eq!(select_broker_addr(&broker_data), Some(master_addr));
+    }
+
+    #[test]
+    fn test_map_containing_multiple_slaves() {
+        let broker_addrs: HashMap<u64, CheetahString> = (1..=5)
+            .map(|id| (id, CheetahString::from(format!("192.168.1.10{}", id))))
+            .collect();
+        let broker_data = create_test_broker_data(broker_addrs.clone());
+        let selected = broker_data.select_broker_addr();
+        assert!(selected.is_some());
+        assert!(broker_addrs.values().any(|v| v == selected.as_ref().unwrap()));
+        let selected_free = select_broker_addr(&broker_data);
+        assert!(selected_free.is_some());
+        assert!(broker_addrs.values().any(|v| v == selected_free.as_ref().unwrap()));
+    }
+}


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10255 

### Brief Description
Add test cases covering empty address map handling, single/multiple slave nodes, and Master-preference selection for both `select_broker_addr` free function and `BrokerDataExt` trait implementation.

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
cargo test -p rocketmq-protocol route_facade


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for broker address selection across empty, single-slave, master-and-slave, and multiple-slave scenarios.
  - Verified behavior through both standalone selection and broker data interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->