### PR TITLE
[ISSUE #10338]📝Complete bilingual documentation navigation

### DIFF
--- a/rocketmq-website/docs/author.md
+++ b/rocketmq-website/docs/author.md
@@ -79,34 +79,9 @@ Building production-ready, enterprise-grade messaging middleware that combines:
 - Modern async programming patterns
 - Cross-platform compatibility (Linux, Windows, macOS)
 
-## 🎯 Project Vision
+## Project documentation and release history
 
-RocketMQ-Rust is being developed to provide:
-
-### Core Features
-- ✅ High-performance message processing with zero-cost abstractions
-- ✅ Memory safety guarantees through Rust's type system
-- ✅ Full Apache RocketMQ protocol compatibility
-- ✅ Async/await based architecture for efficient I/O
-- ✅ Cross-platform support (Linux, Windows, macOS)
-
-### Production-Ready Capabilities
-- 🔄 Transactional messages
-- 📊 Message ordering and filtering
-- 🔁 Retry mechanisms and dead letter queues
-- 📈 High availability and fault tolerance
-- 🛡️ Security and authentication
-
-## 📈 Project Milestones
-
-Since its inception, RocketMQ-Rust has achieved:
-
-- **v0.1.0** (Feb 2024): Initial release with basic messaging
-- **v0.2.0** (Apr 2024): Added transactional messages
-- **v0.3.0** (Jun 2024): Enhanced performance and stability
-- **v0.4.0** (Aug 2024): Cross-platform support
-- **v0.5.0** (Oct 2024): Production-ready features
-- **v0.6.0** (Dec 2024): Advanced routing and filtering
+Read the [capability matrix](./overview/capability-matrix.md) for implemented modes and limitations, and [release scope](./overview/release-scope.md) for the community distribution identity. Architecture and compatibility claims belong to those technical pages. The [release history](/releases) preserves version-specific announcements; Next documentation does not itself announce a release.
 
 ## 👷 Looking for Contributors
 
@@ -117,7 +92,7 @@ I am actively looking for **partner developers** to join the RocketMQ-Rust proje
 - 🌟 Looking to contribute to Apache ecosystem projects
 - 🤝 Want to collaborate on open-source development
 
-**Your contributions are welcome!** Check out our [Contributing Guide](/docs/contributing/overview) to get started.
+**Your contributions are welcome!** Check out our [Contributing Guide](./contributing/overview.md) to get started.
 
 ## 🤝 Connect & Reach Me
 
@@ -164,7 +139,7 @@ We welcome contributions from the community! Whether you're:
 - 🔧 Contributing code
 - 🌍 Translating content
 
-Check out our [Contributing Guide](/docs/contributing/overview) to get started!
+Check out our [Contributing Guide](./contributing/overview.md) to get started!
 
 ## 🙏 Acknowledgments
 
@@ -192,4 +167,3 @@ If you find RocketMQ-Rust helpful, please:
   <h3>Thank you for your interest in RocketMQ-Rust! 🎉</h3>
   <p>Together, we're building the future of messaging middleware with Rust.</p>
 </div>
-```

--- a/rocketmq-website/docs/configuration/observability.md
+++ b/rocketmq-website/docs/configuration/observability.md
@@ -244,3 +244,7 @@ Local collector examples remain under `distribution/config`:
 otelcol-contrib --config distribution/config/otel-collector-observability.yaml
 prometheus --config.file=distribution/config/prometheus-observability.yaml
 ```
+
+## Operational context
+
+This page is the configuration reference. Use [monitoring](../operations/monitoring.md) to install collectors, interpret metrics and investigate missing signals; [error and observability design](../architecture/errors-observability.md) explains ownership and shutdown.

--- a/rocketmq-website/docs/release-notes/index.md
+++ b/rocketmq-website/docs/release-notes/index.md
@@ -1,0 +1,9 @@
+---
+title: "Release notes and versions"
+---
+
+Use the [release history](/releases) for version-specific announcements and [GitHub Releases](https://github.com/mxsm/rocketmq-rust/releases) for available release artifacts. This page preserves the documentation entry; individual release posts belong to the release-history section, not this document's sidebar.
+
+The current documentation is labeled **Next** and describes development source. A source manifest version, an archive candidate and a published release are different states. Match installation instructions, configuration and API documentation to the artifact you actually use.
+
+See [release scope](../overview/release-scope.md) for the community distribution identity, [release engineering](../contributing/release-engineering.md) for candidate preparation, and [upgrade/rollback](../operations/upgrade-rollback.md) for operational compatibility. This page does not claim a latest published version or replace historical announcements.

--- a/rocketmq-website/docusaurus.config.ts
+++ b/rocketmq-website/docusaurus.config.ts
@@ -64,6 +64,7 @@ const config: Config = {
                 docs: {
                     sidebarPath: './sidebars.ts',
                     editUrl: 'https://github.com/mxsm/rocketmq-rust/tree/main/rocketmq-website/',
+                    editLocalizedFiles: true,
                     versions: {
                         current: {
                             label: 'Next',
@@ -210,7 +211,7 @@ const config: Config = {
                 <div style="display: flex; flex-direction: column; align-items: flex-start; padding: 0;">
                   <img 
                     src="/img/rocketmq-rustWeChat%20OfficialAccount.jpg" 
-                    alt="WeChat Official Account" 
+                    alt="WeChat / 微信公众号"
                     style="
                       width: 120px; 
                       height: 120px; 
@@ -226,7 +227,7 @@ const config: Config = {
                     color: var(--ifm-footer-link-color);
                     opacity: 0.8;
                   ">
-                    WeChat Official Account
+                    WeChat / 微信公众号
                   </p>
                 </div>
               `,

--- a/rocketmq-website/i18n/zh-CN/code.json
+++ b/rocketmq-website/i18n/zh-CN/code.json
@@ -75,10 +75,10 @@
     "message": "GitHub"
   },
   "homepage.announcement.title": {
-    "message": "RocketMQ-Rust v0.9.0 发布了！"
+    "message": "浏览 RocketMQ-Rust 发行历史"
   },
   "homepage.announcement.link": {
-    "message": "查看新特性 →"
+    "message": "阅读发行说明 →"
   },
   "theme.ErrorPageContent.title": {
     "message": "页面已崩溃。",
@@ -721,5 +721,14 @@
   },
   "homepage.hero.status.client.detail": {
     "message": "生产与消费"
+  },
+  "docs.development.notice": {
+    "message": "Next 文档描述开发源码。部署发行产物时，请查阅对应版本说明。"
+  },
+  "docs.development.badge": {
+    "message": "开发文档"
+  },
+  "docs.development.dismiss": {
+    "message": "关闭开发文档提示"
   }
 }

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/author.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/author.md
@@ -79,34 +79,9 @@ hide_table_of_contents: false
 - 现代异步编程模式
 - 跨平台兼容性（Linux、Windows、macOS）
 
-## 🎯 项目愿景
+## 项目文档与发行历史
 
-开发 RocketMQ-Rust 旨在提供：
-
-### 核心特性
-- ✅ 零成本抽象的高性能消息处理
-- ✅ 通过 Rust 类型系统保证内存安全
-- ✅ 完全兼容 Apache RocketMQ 协议
-- ✅ 基于 async/await 的高效 I/O 架构
-- ✅ 跨平台支持（Linux、Windows、macOS）
-
-### 生产就绪功能
-- 🔄 事务消息
-- 📊 消息顺序和过滤
-- 🔁 重试机制和死信队列
-- 📈 高可用性和容错能力
-- 🛡️ 安全和身份验证
-
-## 📈 项目里程碑
-
-自成立以来，RocketMQ-Rust 已实现：
-
-- **v0.1.0**（2024 年 2 月）：支持基本消息传递的初始版本
-- **v0.2.0**（2024 年 4 月）：添加事务消息
-- **v0.3.0**（2024 年 6 月）：增强性能和稳定性
-- **v0.4.0**（2024 年 8 月）：跨平台支持
-- **v0.5.0**（2024 年 10 月）：生产就绪功能
-- **v0.6.0**（2024 年 12 月）：高级路由和过滤
+已实现模式和限制见[能力矩阵](./overview/capability-matrix.md)，社区分发身份见[发行范围](./overview/release-scope.md)。架构与兼容性说明以对应技术页面为准。[发行历史](/releases)保留各版本公告；Next 文档本身不表示版本已发布。
 
 ## 👷 寻找贡献者
 
@@ -117,7 +92,7 @@ hide_table_of_contents: false
 - 🌟 希望为 Apache 生态系统项目做贡献
 - 🤝 想要协作进行开源开发
 
-**欢迎你的贡献！** 查看我们的[贡献指南](/docs/zh-CN/contributing/overview)以开始参与。
+**欢迎你的贡献！** 查看我们的[贡献指南](./contributing/overview.md)以开始参与。
 
 ## 🤝 联系方式
 
@@ -164,7 +139,7 @@ hide_table_of_contents: false
 - 🔧 贡献代码
 - 🌍 翻译内容
 
-查看我们的[贡献指南](/docs/zh-CN/contributing/overview)以开始参与！
+查看我们的[贡献指南](./contributing/overview.md)以开始参与！
 
 ## 🙏 致谢
 

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration/observability.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration/observability.md
@@ -227,3 +227,7 @@ metrics 标签。
 otelcol-contrib --config distribution/config/otel-collector-observability.yaml
 prometheus --config.file=distribution/config/prometheus-observability.yaml
 ```
+
+## 运维阅读入口
+
+本页保留配置参考。安装采集器、解释指标和调查信号缺失，请阅读[监控](../operations/monitoring.md)；所有权和关闭语义见[错误与可观测性设计](../architecture/errors-observability.md)。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/release-notes/index.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/release-notes/index.md
@@ -1,27 +1,9 @@
 ---
-title: 发布说明
-sidebar_label: 概述
-sidebar_position: 90
+title: "发行说明与版本"
 ---
 
-# 发布说明
+各版本公告见[发行历史](/releases)，可用发行产物见 [GitHub Releases](https://github.com/mxsm/rocketmq-rust/releases)。本页保留文档入口；单个版本文章位于发行历史栏目，不在本文档侧边栏中。
 
-本页面包含 RocketMQ-Rust 项目的发布说明。
+当前文档标记为 **Next**，描述开发源码。源码清单版本、压缩包候选和已发布版本是不同状态。安装说明、配置和 API 文档应与实际使用产物匹配。
 
-## 最新版本
-
-有关最新版本和下载，请访问我们的 [GitHub Releases](https://github.com/mxsm/rocketmq-rust/releases) 页面。
-
-## 版本历史
-
-### 即将发布的版本
-
-- **路线图**: 查看 [GitHub Project Board](https://github.com/mxsm/rocketmq-rust/projects) 了解计划的功能和改进。
-
-### 最近发布的版本
-
-请查看侧边栏了解每个版本的详细发布说明。
-
----
-
-*有关每个版本的详细信息，请参考侧边栏中的特定版本。*
+社区分发身份见[发行范围](../overview/release-scope.md)，候选准备见[发行工程](../contributing/release-engineering.md)，运维兼容性见[升级回滚](../operations/upgrade-rollback.md)。本页不声明最新已发布版本，也不替代历史公告。

--- a/rocketmq-website/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -38,5 +38,20 @@
   "copyright": {
     "message": "版权所有 © RocketMQ-Rust Community。使用 Docusaurus 构建。",
     "description": "The footer copyright"
+  },
+  "link.title.Resources": {
+    "message": "资源"
+  },
+  "link.title.Follow Us": {
+    "message": "关注我们"
+  },
+  "link.item.label.Discussions": {
+    "message": "讨论"
+  },
+  "link.item.label.Issues": {
+    "message": "问题反馈"
+  },
+  "link.item.label.Rust Official": {
+    "message": "Rust 官网"
   }
 }

--- a/rocketmq-website/i18n/zh-CN/docusaurus-theme-classic/navbar.json
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-theme-classic/navbar.json
@@ -4,7 +4,7 @@
     "description": "The title in the navbar"
   },
   "logo.alt": {
-    "message": "RocketMQ-Rust Logo",
+    "message": "RocketMQ-Rust 标志",
     "description": "The alt text of navbar logo"
   },
   "item.label.Documentation": {
@@ -26,5 +26,20 @@
   "item.label.GitHub": {
     "message": "GitHub",
     "description": "Navbar item with label GitHub"
+  },
+  "item.label.Docs": {
+    "message": "文档"
+  },
+  "item.label.Architecture": {
+    "message": "架构"
+  },
+  "item.label.Examples": {
+    "message": "示例"
+  },
+  "item.label.Community": {
+    "message": "社区"
+  },
+  "item.label.Help us translate": {
+    "message": "帮助翻译"
   }
 }

--- a/rocketmq-website/sidebars.ts
+++ b/rocketmq-website/sidebars.ts
@@ -5,6 +5,7 @@ const sidebars: SidebarsConfig = {
     'introduction',
     'overview/capability-matrix',
     'overview/release-scope',
+    'release-notes/index',
     {
       type: 'category',
       label: 'Getting Started',

--- a/rocketmq-website/src/components/AnnouncementBanner.tsx
+++ b/rocketmq-website/src/components/AnnouncementBanner.tsx
@@ -39,7 +39,7 @@ export default function AnnouncementBanner(): React.JSX.Element {
                 }}>
           {translate({
               id: 'homepage.announcement.title',
-              message: 'RocketMQ-Rust v0.8.0 is out!',
+              message: 'Explore RocketMQ-Rust release history',
           })}
         </span>
                 <span style={{fontSize: '24px'}}>🚀</span>
@@ -68,7 +68,7 @@ export default function AnnouncementBanner(): React.JSX.Element {
                 >
                     {translate({
                         id: 'homepage.announcement.link',
-                        message: 'See what\'s new →',
+                        message: 'Read release notes →',
                     })}
                 </Link>
             </div>

--- a/rocketmq-website/src/components/DevWarningBanner.tsx
+++ b/rocketmq-website/src/components/DevWarningBanner.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import {translate} from '@docusaurus/Translate';
 
 export default function DevWarningBanner(): React.JSX.Element | null {
   const [isDark, setIsDark] = useState(true);
@@ -137,8 +138,7 @@ export default function DevWarningBanner(): React.JSX.Element | null {
             letterSpacing: '0.02em',
           }}
         >
-          RocketMQ-Rust is under active development. APIs may change before the 1.0
-          release.
+          {translate({id: 'docs.development.notice', message: 'Next documents the development source. Check release-specific instructions when deploying an artifact.'})}
         </span>
 
         {/* Status badge */}
@@ -163,13 +163,13 @@ export default function DevWarningBanner(): React.JSX.Element | null {
             backdropFilter: 'blur(8px)',
           }}
         >
-          Beta
+          {translate({id: 'docs.development.badge', message: 'Development'})}
         </span>
 
         {/* Close button */}
         <button
           onClick={handleDismiss}
-          aria-label="Dismiss warning"
+          aria-label={translate({id: 'docs.development.dismiss', message: 'Dismiss development notice'})}
           style={{
             position: 'absolute',
             right: '20px',


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10338

### Brief Description

Complete bilingual documentation navigation and preserve legacy author, release and observability entry points. Correct Chinese navigation/footer labels and localized edit links, remove the author page's inaccurate release timeline and unmatched fence, and replace unsupported release-banner claims with release-history and Next documentation guidance. Add the corresponding English release entry and link configuration readers to monitoring procedures.

### How Did You Test This Change?

- `npm run build` passed for English and Chinese with no broken-link or broken-anchor warnings. The existing Browserslist data-age advisory remains.
- Confirmed all 79 planned IDs have complete English/Chinese files and sidebar entries, with 72 Mermaid blocks across the paired pages. Checked legacy fences and translation JSON.
- Inspected the six Chinese reading-path entries and the localized release page, including translated navigation, footer labels and the actual Chinese edit-file destination, in the local browser.
- `git diff --check` passed. No remote search indexing or explicit website deployment was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a release-notes index with links to release history, scope, engineering, and upgrade guidance.
  * Clarified that “Next” documentation describes development content, not a published release.
  * Added operational guidance to observability documentation.
  * Updated project and contribution documentation links.

* **User Interface**
  * Updated the announcement banner to direct visitors to release history and release notes.
  * Added a development-status notice with localized messaging and dismissal controls.
  * Added the release-notes page to the documentation sidebar.

* **Localization**
  * Expanded Chinese translations for navigation, footer links, and development notices.
  * Updated WeChat branding and accessibility labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->