### PR TITLE
[Bug🐛] Fix admin CLI commands failing with core.argument.invalid due to missing ClientRuntime

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/broker/get_broker_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/broker/get_broker_config_sub_command.rs
@@ -16,6 +16,7 @@ use clap::Parser;
 use rocketmq_error::Result as CanonicalResult;
 
 use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
 use rocketmq_admin_core::client_adapter::services::broker::BrokerConfigQueryRequest;
 use rocketmq_admin_core::client_adapter::services::broker::BrokerConfigQueryResult;
 use rocketmq_admin_core::client_adapter::services::broker::BrokerConfigSection;
@@ -29,6 +30,9 @@ use rocketmq_admin_core::client_adapter::services::broker::BrokerService;
         .args(&["broker_addr", "cluster_name"])
 ))]
 pub struct GetBrokerConfigSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
     #[arg(short = 'b', long = "brokerAddr", help = "get which broker")]
     broker_addr: Option<String>,
 
@@ -45,21 +49,27 @@ pub struct GetBrokerConfigSubCommand {
 
 impl GetBrokerConfigSubCommand {
     fn request(&self) -> CanonicalResult<BrokerConfigQueryRequest> {
-        BrokerConfigQueryRequest::try_new(
+        Ok(BrokerConfigQueryRequest::try_new(
             self.broker_addr.clone(),
             self.cluster_name.clone(),
             self.key_pattern.clone(),
-        )
+        )?
+        .with_optional_namesrv_addr(self.common_args.namesrv_addr.clone()))
     }
 }
 
 impl CommandExecute for GetBrokerConfigSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> CanonicalResult<()> {
-        let result = BrokerService::query_broker_config_by_request(self.request()?).await?;
+        let result = BrokerService::query_broker_config_by_request_with_credentials(
+            self.request()?,
+            credentials,
+            client_runtime,
+        )
+        .await?;
         print_broker_config_result(&result);
         Ok(())
     }
@@ -206,6 +216,10 @@ mod tests {
     #[test]
     fn test_invalid_key_pattern_regex_returns_error() {
         let cmd = GetBrokerConfigSubCommand {
+            common_args: CommonArgs {
+                namesrv_addr: None,
+                skip_confirm: false,
+            },
             broker_addr: Some("127.0.0.1:10911".to_string()),
             cluster_name: None,
             key_pattern: Some("[".to_string()),

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/add_write_perm_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/add_write_perm_sub_command.rs
@@ -59,10 +59,12 @@ impl AddWritePermSubCommand {
 impl CommandExecute for AddWritePermSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> CanonicalResult<()> {
-        let result = NameServerService::add_write_perm_by_request(self.request()?).await?;
+        let result =
+            NameServerService::add_write_perm_by_request_with_credentials(self.request()?, credentials, client_runtime)
+                .await?;
         Self::print_result(result);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/delete_kv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/delete_kv_config_sub_command.rs
@@ -16,11 +16,15 @@ use clap::Parser;
 use rocketmq_error::Result as CanonicalResult;
 
 use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
 use rocketmq_admin_core::client_adapter::services::namesrv::KvConfigDeleteRequest;
 use rocketmq_admin_core::client_adapter::services::namesrv::NameServerService;
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteKvConfigSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
     #[arg(short = 's', long = "namespace", required = true)]
     namespace: String,
 
@@ -30,17 +34,21 @@ pub struct DeleteKvConfigSubCommand {
 
 impl DeleteKvConfigSubCommand {
     fn request(&self) -> CanonicalResult<KvConfigDeleteRequest> {
-        KvConfigDeleteRequest::try_new(self.namespace.clone(), self.key.clone())
+        Ok(
+            KvConfigDeleteRequest::try_new(self.namespace.clone(), self.key.clone())?
+                .with_optional_namesrv_addr(self.common_args.namesrv_addr.clone()),
+        )
     }
 }
 
 impl CommandExecute for DeleteKvConfigSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> CanonicalResult<()> {
-        NameServerService::delete_kv_config_by_request(self.request()?).await?;
+        NameServerService::delete_kv_config_by_request_with_credentials(self.request()?, credentials, client_runtime)
+            .await?;
         println!("delete kv config from namespace success.");
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/get_namesrv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/get_namesrv_config_sub_command.rs
@@ -44,8 +44,8 @@ impl GetNamesrvConfigSubCommand {
 impl CommandExecute for GetNamesrvConfigSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> CanonicalResult<()> {
         let request = match self.request() {
             Ok(request) => request,
@@ -59,7 +59,9 @@ impl CommandExecute for GetNamesrvConfigSubCommand {
             return Ok(());
         }
 
-        let result = NameServerService::query_namesrv_config(request).await?;
+        let result =
+            NameServerService::query_namesrv_config_by_request_with_credentials(request, credentials, client_runtime)
+                .await?;
         display_configs_with_table(&result.configs);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/update_kv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/update_kv_config_sub_command.rs
@@ -47,10 +47,11 @@ impl UpdateKvConfigSubCommand {
 impl CommandExecute for UpdateKvConfigSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> CanonicalResult<()> {
-        NameServerService::update_kv_config_by_request(self.request()?).await?;
+        NameServerService::update_kv_config_by_request_with_credentials(self.request()?, credentials, client_runtime)
+            .await?;
         println!("update kv config in namespace success.");
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/update_namesrv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/update_namesrv_config_sub_command.rs
@@ -62,10 +62,15 @@ impl UpdateNamesrvConfigSubCommand {
 impl CommandExecute for UpdateNamesrvConfigSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> CanonicalResult<()> {
-        let result = NameServerService::update_namesrv_config_by_request(self.request()?).await?;
+        let result = NameServerService::update_namesrv_config_by_request_with_credentials(
+            self.request()?,
+            credentials,
+            client_runtime,
+        )
+        .await?;
         Self::print_result(result);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/wipe_write_perm_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/namesrv/wipe_write_perm_sub_command.rs
@@ -59,10 +59,15 @@ impl WipeWritePermSubCommand {
 impl CommandExecute for WipeWritePermSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> CanonicalResult<()> {
-        let result = NameServerService::wipe_write_perm_by_request(self.request()?).await?;
+        let result = NameServerService::wipe_write_perm_by_request_with_credentials(
+            self.request()?,
+            credentials,
+            client_runtime,
+        )
+        .await?;
         Self::print_result(result);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/allocate_mq_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/allocate_mq_sub_command.rs
@@ -70,10 +70,12 @@ impl AllocateMQSubCommand {
 impl CommandExecute for AllocateMQSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> CanonicalResult<()> {
-        let result = TopicService::query_allocated_mq_by_request(self.request()?).await?;
+        let result =
+            TopicService::query_allocated_mq_by_request_with_credentials(self.request()?, credentials, client_runtime)
+                .await?;
         Self::print_result(result);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/topic_cluster_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/topic_cluster_sub_command.rs
@@ -36,10 +36,6 @@ impl TopicClusterSubCommand {
             .with_optional_namesrv_addr(self.common_args.namesrv_addr.clone()))
     }
 
-    async fn get_topic_clusters(&self) -> CanonicalResult<TopicClusterList> {
-        TopicService::query_topic_clusters(self.request()?).await
-    }
-
     fn print_clusters(&self, result: &TopicClusterList) {
         for cluster in &result.clusters {
             println!("{}", cluster);
@@ -49,10 +45,15 @@ impl TopicClusterSubCommand {
 impl CommandExecute for TopicClusterSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> rocketmq_error::Result<()> {
-        let clusters = self.get_topic_clusters().await?;
+        let clusters = TopicService::query_topic_clusters_by_request_with_credentials(
+            self.request()?,
+            credentials,
+            client_runtime,
+        )
+        .await?;
         self.print_clusters(&clusters);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/topic_list_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/topic_list_sub_command.rs
@@ -64,10 +64,12 @@ impl TopicListSubCommand {
 impl CommandExecute for TopicListSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> rocketmq_error::Result<()> {
-        let result = TopicService::query_topic_list(self.request()).await?;
+        let result =
+            TopicService::query_topic_list_by_request_with_credentials(self.request(), credentials, client_runtime)
+                .await?;
         self.print_topics(result);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/topic_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/topic_status_sub_command.rs
@@ -39,13 +39,14 @@ pub struct TopicStatusSubCommand {
 impl CommandExecute for TopicStatusSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> rocketmq_error::Result<()> {
         let request = TopicStatusQueryRequest::try_new(self.topic.clone())?
             .with_optional_namesrv_addr(self.common_args.namesrv_addr.clone())
             .with_optional_cluster_name(self.cluster_name.clone());
-        let topic_status = TopicService::query_topic_status(request).await?;
+        let topic_status =
+            TopicService::query_topic_status_by_request_with_credentials(request, credentials, client_runtime).await?;
 
         let offset_table = topic_status.get_offset_table();
         let mut mq_list: Vec<_> = offset_table.keys().cloned().collect();

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/update_order_conf_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/update_order_conf_sub_command.rs
@@ -75,10 +75,12 @@ impl UpdateOrderConfSubCommand {
 impl CommandExecute for UpdateOrderConfSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> rocketmq_error::Result<()> {
-        let result = TopicService::apply_order_conf(self.request()?).await?;
+        let result =
+            TopicService::apply_order_conf_by_request_with_credentials(self.request()?, credentials, client_runtime)
+                .await?;
         Self::print_result(result);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/update_topic_list_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/update_topic_list_sub_command.rs
@@ -77,8 +77,8 @@ impl UpdateTopicListSubCommand {
 impl CommandExecute for UpdateTopicListSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> rocketmq_error::Result<()> {
         if !self.file.is_file() {
             return Err(crate::errors::argument_invalid(
@@ -102,7 +102,12 @@ impl CommandExecute for UpdateTopicListSubCommand {
                 return Err(crate::errors::argument_invalid("the file isn't in json or yaml format"));
             };
 
-        let result = TopicService::update_topic_config_list_by_request(self.request(topic_configs)?).await?;
+        let result = TopicService::update_topic_config_list_by_request_with_credentials(
+            self.request(topic_configs)?,
+            credentials,
+            client_runtime,
+        )
+        .await?;
         Self::print_result(&result);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/update_topic_perm_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/update_topic_perm_sub_command.rs
@@ -97,8 +97,8 @@ impl UpdateTopicPermSubCommand {
 impl CommandExecute for UpdateTopicPermSubCommand {
     async fn execute(
         &self,
-        _credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
-        _client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+        credentials: Option<rocketmq_admin_core::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
     ) -> CanonicalResult<()> {
         let validation_result = TopicValidator::validate_topic(&self.topic);
         if !validation_result.valid() {
@@ -108,7 +108,9 @@ impl CommandExecute for UpdateTopicPermSubCommand {
             )));
         }
 
-        let result = TopicService::update_topic_perm_by_request(self.request()?).await?;
+        let result =
+            TopicService::update_topic_perm_by_request_with_credentials(self.request()?, credentials, client_runtime)
+                .await?;
         Self::print_result(result);
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/broker/operations.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/broker/operations.rs
@@ -85,6 +85,20 @@ impl BrokerService {
         result
     }
 
+    /// Query broker configuration using the caller-owned runtime and optional credentials.
+    pub async fn query_broker_config_by_request_with_credentials(
+        request: BrokerConfigQueryRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<BrokerConfigQueryResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await?;
+        let result = Self::query_broker_config_with_admin(&mut admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
     pub async fn delete_expired_commit_log_by_request_with_credentials(
         request: BrokerOptionalTarget,
         credentials: Option<crate::core::security::AdminCredentials>,
@@ -719,6 +733,24 @@ impl BrokerService {
         request: BrokerConfigUpdateRequest,
     ) -> CanonicalResult<BrokerConfigUpdateApplyResult> {
         let mut admin = request.admin_builder().build_and_start().await?;
+        let result = async {
+            let plan = Self::build_broker_config_update_plan_with_admin(&mut admin, &request).await?;
+            Self::apply_broker_config_update_plan_with_admin(&admin, &plan, request.rollback_enabled()).await
+        }
+        .await;
+        admin.shutdown().await;
+        result
+    }
+
+    /// Build and apply a broker config update using the caller-owned runtime and optional credentials.
+    pub async fn apply_broker_config_update_by_request_with_credentials(
+        request: BrokerConfigUpdateRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<BrokerConfigUpdateApplyResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime.clone())
+            .build_and_start()
+            .await?;
         let result = async {
             let plan = Self::build_broker_config_update_plan_with_admin(&mut admin, &request).await?;
             Self::apply_broker_config_update_plan_with_admin(&admin, &plan, request.rollback_enabled()).await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/namesrv/operations.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/namesrv/operations.rs
@@ -32,6 +32,7 @@ use super::types::NamesrvConfigUpdateResult;
 use super::types::WritePermRequest;
 use super::types::WritePermResult;
 use super::types::WritePermResultEntry;
+use crate::client_adapter::services::admin::AdminBuilder;
 
 /// NameServer operations service
 pub struct NameServerService;
@@ -46,10 +47,47 @@ impl NameServerService {
         result
     }
 
+    /// Query NameServer configuration using the caller-owned runtime and optional credentials.
+    pub async fn query_namesrv_config_by_request_with_credentials(
+        request: NamesrvConfigQueryRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<NamesrvConfigQueryResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await?;
+        let result = Self::get_namesrv_config(&mut admin, request.namesrv_addrs())
+            .await
+            .map(|configs| NamesrvConfigQueryResult { configs });
+        admin.shutdown().await;
+        result
+    }
+
     pub async fn update_namesrv_config_by_request(
         request: NamesrvConfigUpdateRequest,
     ) -> CanonicalResult<NamesrvConfigUpdateResult> {
         let mut admin = request.admin_builder().build_and_start().await?;
+        let properties = request.properties().clone();
+        let namesrv_addrs = request.namesrv_addrs();
+        let result = Self::update_namesrv_config(&mut admin, properties.clone(), namesrv_addrs.clone())
+            .await
+            .map(|_| NamesrvConfigUpdateResult {
+                properties,
+                namesrv_addrs,
+            });
+        admin.shutdown().await;
+        result
+    }
+
+    /// Update NameServer configuration using the caller-owned runtime and optional credentials.
+    pub async fn update_namesrv_config_by_request_with_credentials(
+        request: NamesrvConfigUpdateRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<NamesrvConfigUpdateResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await?;
         let properties = request.properties().clone();
         let namesrv_addrs = request.namesrv_addrs();
         let result = Self::update_namesrv_config(&mut admin, properties.clone(), namesrv_addrs.clone())
@@ -80,8 +118,53 @@ impl NameServerService {
         result
     }
 
+    /// Create or update NameServer KV config using the caller-owned runtime and optional credentials.
+    pub async fn update_kv_config_by_request_with_credentials(
+        request: KvConfigUpdateRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<KvConfigUpdateResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await?;
+        let result = Self::create_or_update_kv_config(
+            &mut admin,
+            request.namespace().clone(),
+            request.key().clone(),
+            request.value().clone(),
+        )
+        .await
+        .map(|_| KvConfigUpdateResult {
+            namespace: request.namespace().clone(),
+            key: request.key().clone(),
+            value: Some(request.value().clone()),
+        });
+        admin.shutdown().await;
+        result
+    }
+
     pub async fn delete_kv_config_by_request(request: KvConfigDeleteRequest) -> CanonicalResult<KvConfigUpdateResult> {
         let mut admin = request.admin_builder().build_and_start().await?;
+        let result = Self::delete_kv_config(&mut admin, request.namespace().clone(), request.key().clone())
+            .await
+            .map(|_| KvConfigUpdateResult {
+                namespace: request.namespace().clone(),
+                key: request.key().clone(),
+                value: None,
+            });
+        admin.shutdown().await;
+        result
+    }
+
+    /// Delete NameServer KV config using the caller-owned runtime and optional credentials.
+    pub async fn delete_kv_config_by_request_with_credentials(
+        request: KvConfigDeleteRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<KvConfigUpdateResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await?;
         let result = Self::delete_kv_config(&mut admin, request.namespace().clone(), request.key().clone())
             .await
             .map(|_| KvConfigUpdateResult {
@@ -97,8 +180,36 @@ impl NameServerService {
         Self::apply_write_perm_by_request(request, true).await
     }
 
+    /// Add broker write permission using the caller-owned runtime and optional credentials.
+    pub async fn add_write_perm_by_request_with_credentials(
+        request: WritePermRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<WritePermResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await?;
+        let result = Self::apply_write_perm_with_admin(&mut admin, &request, true).await;
+        admin.shutdown().await;
+        result
+    }
+
     pub async fn wipe_write_perm_by_request(request: WritePermRequest) -> CanonicalResult<WritePermResult> {
         Self::apply_write_perm_by_request(request, false).await
+    }
+
+    /// Wipe broker write permission using the caller-owned runtime and optional credentials.
+    pub async fn wipe_write_perm_by_request_with_credentials(
+        request: WritePermRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<WritePermResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await?;
+        let result = Self::apply_write_perm_with_admin(&mut admin, &request, false).await;
+        admin.shutdown().await;
+        result
     }
 
     async fn apply_write_perm_by_request(
@@ -106,6 +217,16 @@ impl NameServerService {
         add_perm: bool,
     ) -> CanonicalResult<WritePermResult> {
         let mut admin = request.admin_builder().build_and_start().await?;
+        let result = Self::apply_write_perm_with_admin(&mut admin, &request, add_perm).await;
+        admin.shutdown().await;
+        result
+    }
+
+    async fn apply_write_perm_with_admin(
+        admin: &mut DefaultMQAdminExt,
+        request: &WritePermRequest,
+        add_perm: bool,
+    ) -> CanonicalResult<WritePermResult> {
         let mut namesrv_addrs = request.namesrv_addrs();
         if namesrv_addrs.is_empty() {
             namesrv_addrs = admin.get_name_server_address_list().await;
@@ -114,9 +235,9 @@ impl NameServerService {
         let mut entries = Vec::with_capacity(namesrv_addrs.len());
         for namesrv_addr in namesrv_addrs {
             let result = if add_perm {
-                Self::add_write_perm_of_broker(&mut admin, namesrv_addr.clone(), request.broker_name().clone()).await
+                Self::add_write_perm_of_broker(admin, namesrv_addr.clone(), request.broker_name().clone()).await
             } else {
-                Self::wipe_write_perm_of_broker(&mut admin, namesrv_addr.clone(), request.broker_name().clone()).await
+                Self::wipe_write_perm_of_broker(admin, namesrv_addr.clone(), request.broker_name().clone()).await
             };
 
             match result {
@@ -133,7 +254,6 @@ impl NameServerService {
             }
         }
 
-        admin.shutdown().await;
         Ok(WritePermResult {
             broker_name: request.broker_name().clone(),
             entries,
@@ -280,6 +400,18 @@ impl NameServerService {
             .map_err(|error| {
                 crate::client_adapter::services::errors::admin_operation_failed_by("wipe_write_perm_of_broker", error)
             })
+    }
+}
+
+fn admin_builder_with_credentials(
+    builder: AdminBuilder,
+    credentials: Option<crate::core::security::AdminCredentials>,
+    client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+) -> AdminBuilder {
+    let builder = builder.client_runtime(client_runtime);
+    match credentials {
+        Some(hook) => builder.credentials(hook),
+        None => builder,
     }
 }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/topic/operations.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/topic/operations.rs
@@ -93,6 +93,21 @@ impl TopicService {
         result
     }
 
+    /// Query the clusters of a topic using the caller-owned runtime and optional credentials.
+    pub async fn query_topic_clusters_by_request_with_credentials(
+        request: TopicClusterQueryRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<TopicClusterList> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await
+            .map_err(crate::IntoCanonicalError::into_canonical_error)?;
+        let result = Self::get_topic_cluster_list(&mut admin, request.topic().clone()).await;
+        admin.shutdown().await;
+        result
+    }
+
     /// Query all topics, optionally filtered by cluster, through a complete core request lifecycle.
     pub async fn query_topic_list(request: TopicListQueryRequest) -> CanonicalResult<TopicListResult> {
         let mut admin = request
@@ -100,6 +115,23 @@ impl TopicService {
             .build_and_start()
             .await
             .map_err(crate::IntoCanonicalError::into_canonical_error)?;
+        let result = Self::query_topic_list_with_admin(&mut admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
+    /// Query all topics using the caller-owned runtime and optional credentials.
+    ///
+    /// This application-facing variant keeps runtime ownership explicit and applies
+    /// the same authentication hook as the other CLI-backed topic operations.
+    pub async fn query_topic_list_by_request_with_credentials(
+        request: TopicListQueryRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<TopicListResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await?;
         let result = Self::query_topic_list_with_admin(&mut admin, &request).await;
         admin.shutdown().await;
         result
@@ -146,41 +178,59 @@ impl TopicService {
             .build_and_start()
             .await
             .map_err(crate::IntoCanonicalError::into_canonical_error)?;
-        let topic = request.topic().clone();
-        let result = async {
-            if let Some(cluster) = request.cluster_name() {
-                let topic_route_data = admin
-                    .examine_topic_route_info(cluster.clone())
-                    .await
-                    .map_err(crate::IntoCanonicalError::into_canonical_error)?;
-                let mut topic_stats_table =
-                    rocketmq_protocol::protocol::admin::topic_stats_table::TopicStatsTable::new();
-                if let Some(route_data) = &topic_route_data {
-                    let mut total_offset_table = HashMap::new();
-                    let mut topic_put_tps = 0.0;
-                    for broker_data in &route_data.broker_datas {
-                        let addr = broker_data.select_broker_addr();
-                        let stats = admin
-                            .examine_topic_stats(topic.clone(), addr)
-                            .await
-                            .map_err(crate::IntoCanonicalError::into_canonical_error)?;
-                        topic_put_tps += stats.get_topic_put_tps();
-                        total_offset_table.extend(stats.into_offset_table());
-                    }
-                    topic_stats_table.set_offset_table(total_offset_table);
-                    topic_stats_table.set_topic_put_tps(topic_put_tps);
-                }
-                Ok(topic_stats_table)
-            } else {
-                admin
-                    .examine_topic_stats(topic, None)
-                    .await
-                    .map_err(crate::IntoCanonicalError::into_canonical_error)
-            }
-        }
-        .await;
+        let result = Self::query_topic_status_with_admin(&mut admin, &request).await;
         admin.shutdown().await;
         result
+    }
+
+    /// Query topic status using the caller-owned runtime and optional credentials.
+    pub async fn query_topic_status_by_request_with_credentials(
+        request: TopicStatusQueryRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<rocketmq_protocol::protocol::admin::topic_stats_table::TopicStatsTable> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await
+            .map_err(crate::IntoCanonicalError::into_canonical_error)?;
+        let result = Self::query_topic_status_with_admin(&mut admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
+    async fn query_topic_status_with_admin(
+        admin: &mut DefaultMQAdminExt,
+        request: &TopicStatusQueryRequest,
+    ) -> CanonicalResult<rocketmq_protocol::protocol::admin::topic_stats_table::TopicStatsTable> {
+        let topic = request.topic().clone();
+        if let Some(cluster) = request.cluster_name() {
+            let topic_route_data = admin
+                .examine_topic_route_info(cluster.clone())
+                .await
+                .map_err(crate::IntoCanonicalError::into_canonical_error)?;
+            let mut topic_stats_table = rocketmq_protocol::protocol::admin::topic_stats_table::TopicStatsTable::new();
+            if let Some(route_data) = &topic_route_data {
+                let mut total_offset_table = HashMap::new();
+                let mut topic_put_tps = 0.0;
+                for broker_data in &route_data.broker_datas {
+                    let addr = broker_data.select_broker_addr();
+                    let stats = admin
+                        .examine_topic_stats(topic.clone(), addr)
+                        .await
+                        .map_err(crate::IntoCanonicalError::into_canonical_error)?;
+                    topic_put_tps += stats.get_topic_put_tps();
+                    total_offset_table.extend(stats.into_offset_table());
+                }
+                topic_stats_table.set_offset_table(total_offset_table);
+                topic_stats_table.set_topic_put_tps(topic_put_tps);
+            }
+            Ok(topic_stats_table)
+        } else {
+            admin
+                .examine_topic_stats(topic, None)
+                .await
+                .map_err(crate::IntoCanonicalError::into_canonical_error)
+        }
     }
 
     /// Apply order configuration through a complete core request lifecycle.
@@ -190,10 +240,34 @@ impl TopicService {
             .build_and_start()
             .await
             .map_err(crate::IntoCanonicalError::into_canonical_error)?;
-        let result = match request.method() {
+        let result = Self::apply_order_conf_with_admin(&mut admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
+    /// Apply order configuration using the caller-owned runtime and optional credentials.
+    pub async fn apply_order_conf_by_request_with_credentials(
+        request: OrderConfRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<OrderConfResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await
+            .map_err(crate::IntoCanonicalError::into_canonical_error)?;
+        let result = Self::apply_order_conf_with_admin(&mut admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
+    async fn apply_order_conf_with_admin(
+        admin: &mut DefaultMQAdminExt,
+        request: &OrderConfRequest,
+    ) -> CanonicalResult<OrderConfResult> {
+        match request.method() {
             OrderConfMethod::Put => {
                 let order_conf = CheetahString::from(request.order_conf().unwrap_or_default());
-                Self::create_or_update_order_conf(&mut admin, request.topic().clone(), order_conf.clone())
+                Self::create_or_update_order_conf(admin, request.topic().clone(), order_conf.clone())
                     .await
                     .map(|_| OrderConfResult {
                         topic: request.topic().clone(),
@@ -201,23 +275,23 @@ impl TopicService {
                         order_conf: Some(order_conf),
                     })
             }
-            OrderConfMethod::Get => Self::get_order_conf(&mut admin, request.topic().clone())
+            OrderConfMethod::Get => Self::get_order_conf(admin, request.topic().clone())
                 .await
                 .map(|order_conf| OrderConfResult {
                     topic: request.topic().clone(),
                     method: request.method(),
                     order_conf: Some(order_conf),
                 }),
-            OrderConfMethod::Delete => Self::delete_order_conf(&mut admin, request.topic().clone())
-                .await
-                .map(|_| OrderConfResult {
-                    topic: request.topic().clone(),
-                    method: request.method(),
-                    order_conf: None,
-                }),
-        };
-        admin.shutdown().await;
-        result
+            OrderConfMethod::Delete => {
+                Self::delete_order_conf(admin, request.topic().clone())
+                    .await
+                    .map(|_| OrderConfResult {
+                        topic: request.topic().clone(),
+                        method: request.method(),
+                        order_conf: None,
+                    })
+            }
+        }
     }
 
     /// Query message queue allocation through a complete core request lifecycle.
@@ -226,6 +300,21 @@ impl TopicService {
     ) -> CanonicalResult<AllocatedMqQueryResult> {
         let mut admin = request
             .admin_builder()
+            .build_and_start()
+            .await
+            .map_err(crate::IntoCanonicalError::into_canonical_error)?;
+        let result = Self::query_allocated_mq(&mut admin, request.topic().clone(), request.ip_list().clone()).await;
+        admin.shutdown().await;
+        result
+    }
+
+    /// Query message queue allocation using the caller-owned runtime and optional credentials.
+    pub async fn query_allocated_mq_by_request_with_credentials(
+        request: AllocateMqQueryRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<AllocatedMqQueryResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
             .build_and_start()
             .await
             .map_err(crate::IntoCanonicalError::into_canonical_error)?;
@@ -297,12 +386,55 @@ impl TopicService {
         result
     }
 
+    /// Apply a batch of topic configs using the caller-owned runtime and optional credentials.
+    pub async fn update_topic_config_list_by_request_with_credentials(
+        request: UpdateTopicListRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<UpdateTopicListResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
+            .build_and_start()
+            .await
+            .map_err(crate::IntoCanonicalError::into_canonical_error)?;
+        let target = request.target().clone();
+        let topic_configs = request.topic_configs().to_vec();
+        let result = Self::update_topic_config_list(&mut admin, target, topic_configs).await;
+        admin.shutdown().await;
+        result
+    }
+
     /// Update topic permission through a complete core request lifecycle.
     pub async fn update_topic_perm_by_request(
         request: UpdateTopicPermRequest,
     ) -> CanonicalResult<UpdateTopicPermResult> {
         let mut admin = request
             .admin_builder()
+            .build_and_start()
+            .await
+            .map_err(crate::IntoCanonicalError::into_canonical_error)?;
+        let result = Self::update_topic_perm(
+            &mut admin,
+            request.topic().clone(),
+            request.perm(),
+            request.target().clone(),
+        )
+        .await
+        .map(|_| UpdateTopicPermResult {
+            topic: request.topic().clone(),
+            target: request.target().clone(),
+            perm: request.perm(),
+        });
+        admin.shutdown().await;
+        result
+    }
+
+    /// Update topic permission using the caller-owned runtime and optional credentials.
+    pub async fn update_topic_perm_by_request_with_credentials(
+        request: UpdateTopicPermRequest,
+        credentials: Option<crate::core::security::AdminCredentials>,
+        client_runtime: std::sync::Arc<rocketmq_client_rust::ClientRuntime>,
+    ) -> CanonicalResult<UpdateTopicPermResult> {
+        let mut admin = admin_builder_with_credentials(request.admin_builder(), credentials, client_runtime)
             .build_and_start()
             .await
             .map_err(crate::IntoCanonicalError::into_canonical_error)?;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/operations.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade/operations.rs
@@ -1420,11 +1420,21 @@ impl TuiAdminFacade {
     }
 
     pub async fn query_topic_clusters(&self, topic: impl Into<String>) -> CanonicalResult<TopicClusterList> {
-        TopicService::query_topic_clusters(self.topic_cluster_request(topic)?).await
+        TopicService::query_topic_clusters_by_request_with_credentials(
+            self.topic_cluster_request(topic)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn query_topic_route(&self, topic: impl Into<String>) -> CanonicalResult<Option<TopicRouteData>> {
-        TopicService::query_topic_route(self.topic_route_request(topic)?).await
+        TopicService::query_topic_route_by_request_with_credentials(
+            self.topic_route_request(topic)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn query_topic_status(
@@ -1432,11 +1442,21 @@ impl TuiAdminFacade {
         topic: impl Into<String>,
         cluster_name: Option<String>,
     ) -> CanonicalResult<TopicStatsTable> {
-        TopicService::query_topic_status(self.topic_status_request(topic, cluster_name)?).await
+        TopicService::query_topic_status_by_request_with_credentials(
+            self.topic_status_request(topic, cluster_name)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn query_topic_list(&self, cluster_name: Option<String>) -> CanonicalResult<TopicListResult> {
-        TopicService::query_topic_list(self.topic_list_request(cluster_name)).await
+        TopicService::query_topic_list_by_request_with_credentials(
+            self.topic_list_request(cluster_name),
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn delete_topic(
@@ -1458,7 +1478,12 @@ impl TuiAdminFacade {
         method: impl AsRef<str>,
         order_conf: Option<String>,
     ) -> CanonicalResult<OrderConfResult> {
-        TopicService::apply_order_conf(self.order_conf_request(topic, method, order_conf)?).await
+        TopicService::apply_order_conf_by_request_with_credentials(
+            self.order_conf_request(topic, method, order_conf)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn query_allocated_mq(
@@ -1466,15 +1491,20 @@ impl TuiAdminFacade {
         topic: impl Into<String>,
         ip_list: impl Into<String>,
     ) -> CanonicalResult<AllocatedMqQueryResult> {
-        TopicService::query_allocated_mq_by_request(self.allocate_mq_request(topic, ip_list)?).await
+        TopicService::query_allocated_mq_by_request_with_credentials(
+            self.allocate_mq_request(topic, ip_list)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn create_or_update_topic(&self, request: UpdateTopicRequest) -> CanonicalResult<UpdateTopicResult> {
-        TopicService::create_or_update_topic_by_request(request).await
+        TopicService::create_or_update_topic_by_request_with_credentials(request, None, self.client_runtime()).await
     }
 
     pub async fn update_topic_perm(&self, request: UpdateTopicPermRequest) -> CanonicalResult<UpdateTopicPermResult> {
-        TopicService::update_topic_perm_by_request(request).await
+        TopicService::update_topic_perm_by_request_with_credentials(request, None, self.client_runtime()).await
     }
 
     pub async fn query_auth_user(
@@ -1754,7 +1784,12 @@ impl TuiAdminFacade {
     }
 
     pub async fn query_namesrv_config(&self) -> CanonicalResult<NamesrvConfigQueryResult> {
-        NameServerService::query_namesrv_config(self.namesrv_config_query_request()?).await
+        NameServerService::query_namesrv_config_by_request_with_credentials(
+            self.namesrv_config_query_request()?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn update_namesrv_config(
@@ -1762,7 +1797,12 @@ impl TuiAdminFacade {
         key: impl Into<String>,
         value: impl Into<String>,
     ) -> CanonicalResult<NamesrvConfigUpdateResult> {
-        NameServerService::update_namesrv_config_by_request(self.namesrv_config_update_request(key, value)?).await
+        NameServerService::update_namesrv_config_by_request_with_credentials(
+            self.namesrv_config_update_request(key, value)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn update_kv_config(
@@ -1771,7 +1811,12 @@ impl TuiAdminFacade {
         key: impl Into<String>,
         value: impl Into<String>,
     ) -> CanonicalResult<KvConfigUpdateResult> {
-        NameServerService::update_kv_config_by_request(self.kv_config_update_request(namespace, key, value)?).await
+        NameServerService::update_kv_config_by_request_with_credentials(
+            self.kv_config_update_request(namespace, key, value)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn delete_kv_config(
@@ -1779,15 +1824,30 @@ impl TuiAdminFacade {
         namespace: impl Into<String>,
         key: impl Into<String>,
     ) -> CanonicalResult<KvConfigUpdateResult> {
-        NameServerService::delete_kv_config_by_request(self.kv_config_delete_request(namespace, key)?).await
+        NameServerService::delete_kv_config_by_request_with_credentials(
+            self.kv_config_delete_request(namespace, key)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn add_write_perm(&self, broker_name: impl Into<String>) -> CanonicalResult<WritePermResult> {
-        NameServerService::add_write_perm_by_request(self.write_perm_request(broker_name)?).await
+        NameServerService::add_write_perm_by_request_with_credentials(
+            self.write_perm_request(broker_name)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn wipe_write_perm(&self, broker_name: impl Into<String>) -> CanonicalResult<WritePermResult> {
-        NameServerService::wipe_write_perm_by_request(self.write_perm_request(broker_name)?).await
+        NameServerService::wipe_write_perm_by_request_with_credentials(
+            self.write_perm_request(broker_name)?,
+            None,
+            self.client_runtime(),
+        )
+        .await
     }
 
     pub async fn query_broker_config(
@@ -1796,11 +1856,11 @@ impl TuiAdminFacade {
         cluster_name: Option<String>,
         key_pattern: Option<String>,
     ) -> CanonicalResult<BrokerConfigQueryResult> {
-        BrokerService::query_broker_config_by_request(self.broker_config_query_request(
-            broker_addr,
-            cluster_name,
-            key_pattern,
-        )?)
+        BrokerService::query_broker_config_by_request_with_credentials(
+            self.broker_config_query_request(broker_addr, cluster_name, key_pattern)?,
+            None,
+            self.client_runtime(),
+        )
         .await
     }
 
@@ -1808,14 +1868,16 @@ impl TuiAdminFacade {
         &self,
         request: BrokerConfigUpdateRequest,
     ) -> CanonicalResult<BrokerConfigUpdatePlanResult> {
-        BrokerService::build_broker_config_update_plan_by_request(request).await
+        BrokerService::build_broker_config_update_plan_by_request_with_credentials(request, None, self.client_runtime())
+            .await
     }
 
     pub async fn apply_broker_config_update(
         &self,
         request: BrokerConfigUpdateRequest,
     ) -> CanonicalResult<BrokerConfigUpdateApplyResult> {
-        BrokerService::apply_broker_config_update_by_request(request).await
+        BrokerService::apply_broker_config_update_by_request_with_credentials(request, None, self.client_runtime())
+            .await
     }
 
     pub async fn query_broker_runtime_stats(
@@ -1823,8 +1885,10 @@ impl TuiAdminFacade {
         broker_addr: Option<String>,
         cluster_name: Option<String>,
     ) -> CanonicalResult<BrokerRuntimeStatsResult> {
-        BrokerService::query_broker_runtime_stats_by_request(
+        BrokerService::query_broker_runtime_stats_by_request_with_credentials(
             self.broker_runtime_stats_request(broker_addr, cluster_name)?,
+            None,
+            self.client_runtime(),
         )
         .await
     }
@@ -1836,12 +1900,11 @@ impl TuiAdminFacade {
         diff_level: i64,
         is_order: bool,
     ) -> CanonicalResult<BrokerConsumeStatsResult> {
-        BrokerService::query_broker_consume_stats_by_request(self.broker_consume_stats_request(
-            broker_addr,
-            timeout_millis,
-            diff_level,
-            is_order,
-        )?)
+        BrokerService::query_broker_consume_stats_by_request_with_credentials(
+            self.broker_consume_stats_request(broker_addr, timeout_millis, diff_level, is_order)?,
+            None,
+            self.client_runtime(),
+        )
         .await
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

No tracked issue; reported while running the CLI after pulling latest `main`:

```
$ ./rocketmq-admin-cli topic topicList -n '192.168.3.21:9876' -c 'Defaultcluster'
ERROR core.argument.invalid: Argument is invalid
```

### Brief Description

- Fix #10347

After the explicit `ClientRuntime` migration (#8731), `AdminBuilder::build_and_start()` requires an injected runtime, but several admin CLI subcommands still called legacy service entry points whose request builders never set one. Every such call therefore failed immediately with `core.argument.invalid` ("AdminBuilder requires an explicit ClientRuntime"); the message is redacted by the CLI error projection, so users only saw "Argument is invalid".

Changes:

- Add runtime/credentials-aware service variants (`..._by_request_with_credentials`) in admin-core for:
  - topic: `topicList`, `topicClusterList`, `topicStatus`, `updateOrderConf`, `allocateMQ`, `updateTopicList`, `updateTopicPerm`
  - broker: `getBrokerConfig`, plus a one-shot `applyBrokerConfigUpdate` credential variant
  - namesrv: `getNamesrvConfig`, `updateNamesrvConfig`, `updateKvConfig`, `deleteKvConfig`, `addWritePerm`, `wipeWritePerm`
- Wire all affected CLI subcommands to the new entry points using the CLI-owned runtime and ACL credentials.
- Wire the admin TUI facade, which called the same broken legacy entry points.
- Add the previously missing `-n` namesrv option to `deleteKvConfig` and to cluster-mode `getBrokerConfig` (cluster mode cannot resolve brokers without a NameServer address).
- Purely local commands (`decodeMessageId`, `dumpCompactionLog`, RocksDB metadata export) intentionally remain runtime-free.
- Legacy entry points are retained for API compatibility but are no longer reachable from the CLI or TUI.

### How Did You Test This Change?

- `cargo build` for `rocketmq-admin-core`, `rocketmq-admin-cli`, `rocketmq-admin-tui`.
- `cargo fmt --check` and `cargo clippy --no-deps` clean for all three packages.
- Tests: `cargo test -p rocketmq-admin-cli`, `-p rocketmq-admin-core`, `-p rocketmq-admin-tui` all pass (227+ CLI, 62+ core, 83+ TUI, including integration suites).
- Live verification against a real cluster (`192.168.3.21:9876`): `topic topicList` (with and without `-c`), `topicClusterList`, `topicStatus`, `allocateMQ`, `updateOrderConf -m get`, `broker getBrokerConfig -c`, `nameserver getNamesrvConfig` all succeed.
- Dead-port verification for mutating commands (`updateTopicPerm`, `updateKvConfig`, `updateNamesrvConfig`, `addWritePerm`): they now reach the network layer (connection failure) instead of failing argument validation, confirming the runtime is injected. No mutations were performed against the live cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Administrative commands now support authenticated operations across broker, NameServer, and topic management tasks.
  - Broker and NameServer commands can use an optional NameServer address when making requests.
  - The administration interface consistently supports credential-aware queries, updates, permissions, and configuration changes.

- **Bug Fixes**
  - Fixed administrative operations that previously ignored supplied credentials or client connection settings.
  - Improved consistency for command-line and interactive administration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->