### PR TITLE
[ISSUE #10252]🧪Complete RpcResponse error mapping and typed-header tests

### DIFF
--- a/rocketmq-protocol/src/rpc/rpc_response.rs
+++ b/rocketmq-protocol/src/rpc/rpc_response.rs
@@ -94,6 +94,94 @@ mod tests {
     use rocketmq_error::ErrorContext;
 
     use super::*;
+    use crate::protocol::header::empty_header::EmptyHeader;
+    use crate::protocol::header::get_all_topic_config_response_header::GetAllTopicConfigResponseHeader;
+
+    #[test]
+    fn exception_response_uses_zero_without_a_valid_broker_code() {
+        let empty = RpcResponse::new_exception(None);
+        assert_eq!(empty.code, 0);
+        assert!(empty.exception.is_none());
+        assert!(empty.header.is_none());
+        assert!(empty.body.is_none());
+
+        for error in [
+            crate::error::invalid_argument("invalid"),
+            Error::new(&BROKER_OPERATION_FAILED),
+        ] {
+            let descriptor = error.descriptor();
+            let response = RpcResponse::new_exception(Some(error));
+            assert_eq!(response.code, 0);
+            assert_eq!(response.exception.as_ref().unwrap().descriptor(), descriptor);
+        }
+    }
+
+    #[test]
+    fn exception_response_checks_broker_code_bounds_without_truncation() {
+        for (code, expected) in [
+            (i64::from(i32::MIN), i32::MIN),
+            (i64::from(i32::MAX), i32::MAX),
+            (i64::from(i32::MIN) - 1, 0),
+            (i64::from(i32::MAX) + 1, 0),
+        ] {
+            let error = Error::new(&BROKER_OPERATION_FAILED)
+                .with_context(ErrorContext::new().with_i64(fields::BROKER_CODE, code));
+            let response = RpcResponse::new_exception(Some(error));
+            assert_eq!(response.code, expected);
+            assert_eq!(
+                response.exception.as_ref().unwrap().descriptor(),
+                &BROKER_OPERATION_FAILED
+            );
+        }
+    }
+
+    #[test]
+    fn typed_headers_support_checked_reads_and_mutation_without_changing_body() {
+        let header = GetAllTopicConfigResponseHeader {
+            total_topic_num: Some(3),
+        };
+        let mut response = RpcResponse::new(17, Box::new(header), Some(Box::new(vec![1_u8, 2])));
+        assert_eq!(response.code, 17);
+        assert!(response.exception.is_none());
+        assert!(response.get_header::<EmptyHeader>().is_none());
+        assert!(response.get_header_mut::<EmptyHeader>().is_none());
+        assert_eq!(
+            response
+                .get_header::<GetAllTopicConfigResponseHeader>()
+                .unwrap()
+                .total_topic_num,
+            Some(3)
+        );
+        response
+            .get_header_mut::<GetAllTopicConfigResponseHeader>()
+            .unwrap()
+            .total_topic_num = Some(5);
+        assert_eq!(
+            response
+                .get_header::<GetAllTopicConfigResponseHeader>()
+                .unwrap()
+                .total_topic_num,
+            Some(5)
+        );
+        assert_eq!(
+            response.body.as_ref().unwrap().downcast_ref::<Vec<u8>>().unwrap(),
+            &vec![1, 2]
+        );
+
+        let mut without_header = RpcResponse::new_option(23, Some(Box::new("body")));
+        assert_eq!(without_header.code, 23);
+        assert!(without_header.exception.is_none());
+        assert!(without_header.get_header::<EmptyHeader>().is_none());
+        assert!(without_header.get_header_mut::<EmptyHeader>().is_none());
+        assert_eq!(
+            without_header.body.as_ref().unwrap().downcast_ref::<&str>(),
+            Some(&"body")
+        );
+        assert!(RpcResponse::new_option(0, None).body.is_none());
+        assert!(RpcResponse::new(0, Box::new(EmptyHeader::default()), None)
+            .body
+            .is_none());
+    }
 
     #[test]
     fn exception_response_retains_canonical_broker_code() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10252

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for exception responses with missing or invalid broker codes.
  * Verified correct handling of integer boundary values without truncation.
  * Added tests for typed header access, header mutation, body preservation, and responses without headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->