### PR TITLE
[ISSUE #10254]🧪Add QueryConsumeQueueResponseBody wire-shape tests

### DIFF
--- a/rocketmq-protocol/src/protocol/body/query_consume_queue_response_body.rs
+++ b/rocketmq-protocol/src/protocol/body/query_consume_queue_response_body.rs
@@ -28,3 +28,55 @@ pub struct QueryConsumeQueueResponseBody {
     pub max_queue_index: i64,
     pub min_queue_index: i64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn populated_response_preserves_java_field_names_and_signed_indexes() {
+        let body = QueryConsumeQueueResponseBody {
+            subscription_data: Some(SubscriptionData::default()),
+            filter_data: Some("filter expression".into()),
+            queue_data: Some(vec![ConsumeQueueData::default()]),
+            max_queue_index: i64::MAX,
+            min_queue_index: -1,
+        };
+        let value = serde_json::to_value(&body).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "subscriptionData": body.subscription_data,
+                "filterData": "filter expression",
+                "queueData": body.queue_data,
+                "maxQueueIndex": i64::MAX,
+                "minQueueIndex": -1
+            })
+        );
+        let decoded: QueryConsumeQueueResponseBody = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(decoded.max_queue_index, i64::MAX);
+        assert_eq!(decoded.min_queue_index, -1);
+        assert_eq!(serde_json::to_value(decoded).unwrap(), value);
+    }
+
+    #[test]
+    fn null_optionals_remain_distinct_from_an_empty_queue_array() {
+        let value = serde_json::json!({
+            "subscriptionData": null, "filterData": null, "queueData": null,
+            "maxQueueIndex": 0, "minQueueIndex": 0
+        });
+        assert_eq!(
+            serde_json::to_value(QueryConsumeQueueResponseBody::default()).unwrap(),
+            value
+        );
+        let mut decoded: QueryConsumeQueueResponseBody = serde_json::from_value(value).unwrap();
+        assert!(decoded.subscription_data.is_none());
+        assert!(decoded.filter_data.is_none());
+        assert!(decoded.queue_data.is_none());
+        decoded.queue_data = Some(Vec::new());
+        let value = serde_json::to_value(decoded).unwrap();
+        assert_eq!(value["queueData"], serde_json::json!([]));
+        let decoded: QueryConsumeQueueResponseBody = serde_json::from_value(value).unwrap();
+        assert!(decoded.queue_data.unwrap().is_empty());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10254 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for JSON serialization and deserialization of consume-queue query responses.
  * Verified camelCase field names, signed queue indexes, optional `null` values, and the distinction between missing and empty queue lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->