### PR TITLE
[ISSUE #10348]🐛Clean up TUI command resources after cancellation

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/README-zh_cn.md
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/README-zh_cn.md
@@ -37,7 +37,7 @@ TUI 负责交互、状态、布局和渲染。核心管理请求、校验、RPC 
   - safe 命令直接执行；
   - mutating 命令需要输入 `confirm`；
   - dangerous 命令在可用时需要输入目标值。
-- 后台命令与 UI 事件循环运行在应用的 Tokio `LocalSet` 上；进程持有 `RuntimeOwner` 并注入共享客户端运行时。
+- 后台命令与 UI 事件循环运行在应用的 Tokio `LocalSet` 上；进程持有 `RuntimeOwner`，每次命令在应用的客户端作用域下使用独立的客户端运行时。取消命令会停止操作，TUI 随后等待任务结束并关闭其连接和后台任务；退出时也会等待清理完成。取消不会撤销 Broker 或 NameServer 已接受的请求。
 - 长时间工作流支持进度更新，例如 monitoring 和 message pull。
 - 支持以 table、key/value、JSON、text、operation summary 渲染结构化结果，并支持纵向和横向滚动。
 - 边界测试确保 `rocketmq-admin-tui -> rocketmq-admin-core`，并拒绝依赖 CLI adapter。

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/README.md
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/README.md
@@ -45,7 +45,10 @@ requests, validation, RPC orchestration, and structured results stay in
   - mutating commands require typing `confirm`;
   - dangerous commands require typing the target value when available.
 - Command futures run on the application's Tokio `LocalSet`, alongside the UI event loop.
-  The process owns a `RuntimeOwner` and an injected shared client runtime.
+  The process owns a `RuntimeOwner`; each command uses a separate client runtime beneath
+  the application's client scope. Cancelling a command stops its operation while the TUI
+  joins it and closes its connections and background tasks. Exiting waits for this cleanup.
+  Cancellation does not undo requests already accepted by a broker or NameServer.
 - Progress updates for long-running workflows such as monitoring and message
   pull operations.
 - Structured result rendering as tables, key/value rows, JSON, text, or

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
@@ -76,6 +76,13 @@ impl TuiAdminFacade {
     pub(crate) fn client_runtime(&self) -> Arc<ClientRuntime> {
         Arc::clone(&self.client_runtime)
     }
+
+    pub(crate) fn with_client_runtime(&self, client_runtime: Arc<ClientRuntime>) -> Self {
+        Self {
+            client_runtime,
+            namesrv_addr: self.namesrv_addr.clone(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::VecDeque;
+use std::future::Future;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -27,8 +28,14 @@ use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
 use ratatui::DefaultTerminal;
 use ratatui::Frame;
+use rocketmq_admin_core::client_adapter::ClientRuntime;
+use rocketmq_admin_core::client_adapter::ClientRuntimeConfig;
+use rocketmq_error::Result as CanonicalResult;
+use rocketmq_runtime::ScopeId;
 use tokio::sync::mpsc;
 use tokio::task::AbortHandle;
+use tokio::task::JoinError;
+use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
 
 use crate::action::Action;
@@ -40,6 +47,7 @@ use crate::state::AppState;
 use crate::state::CommandExecutionState;
 use crate::state::CommandTreeItem;
 use crate::state::FocusArea;
+use crate::view_model::CommandResultViewModel;
 
 pub struct RocketmqTuiApp {
     admin_facade: TuiAdminFacade,
@@ -49,6 +57,7 @@ pub struct RocketmqTuiApp {
     action_rx: mpsc::Receiver<QueuedAction>,
     action_queue_diagnostics: Arc<ActionQueueDiagnostics>,
     running_task: Option<RunningCommandTask>,
+    command_tasks: JoinSet<Option<Action>>,
 }
 
 const ACTION_QUEUE_CAPACITY: usize = 128;
@@ -94,6 +103,12 @@ struct RunningCommandTask {
     abort_handle: AbortHandle,
 }
 
+impl Drop for RunningCommandTask {
+    fn drop(&mut self) {
+        self.abort_handle.abort();
+    }
+}
+
 impl RocketmqTuiApp {
     pub fn new(client_runtime: std::sync::Arc<rocketmq_admin_core::client_adapter::ClientRuntime>) -> Self {
         Self::with_admin_facade(TuiAdminFacade::new(client_runtime))
@@ -110,6 +125,7 @@ impl RocketmqTuiApp {
             action_rx,
             action_queue_diagnostics: Arc::new(ActionQueueDiagnostics::default()),
             running_task: None,
+            command_tasks: JoinSet::new(),
         }
     }
 
@@ -197,26 +213,16 @@ fn try_send_progress(
     }
 }
 
-async fn send_required_action(
-    sender: &mpsc::Sender<QueuedAction>,
-    diagnostics: &ActionQueueDiagnostics,
-    action: Action,
-) {
-    match sender.reserve().await {
-        Ok(permit) => {
-            permit.send(diagnostics.enqueue(action));
-            diagnostics.accepted.fetch_add(1, Ordering::Relaxed);
-        }
-        Err(_) => {
-            diagnostics.rejected.fetch_add(1, Ordering::Relaxed);
-        }
-    }
-}
-
 impl RocketmqTuiApp {
     const FRAMES_PER_SECOND: f32 = 30.0;
 
     pub async fn run(mut self, mut terminal: DefaultTerminal) -> anyhow::Result<()> {
+        let result = self.run_events(&mut terminal).await;
+        self.shutdown_commands().await;
+        result
+    }
+
+    async fn run_events(&mut self, terminal: &mut DefaultTerminal) -> anyhow::Result<()> {
         let period = Duration::from_secs_f32(1.0 / Self::FRAMES_PER_SECOND);
         let mut interval = tokio::time::interval(period);
         let mut events = EventStream::new();
@@ -230,6 +236,9 @@ impl RocketmqTuiApp {
                 Some(queued) = self.action_rx.recv() => {
                     self.action_queue_diagnostics.dequeue(queued.id);
                     self.apply_action(queued.action);
+                },
+                Some(completion) = self.command_tasks.join_next(), if !self.command_tasks.is_empty() => {
+                    self.complete_command_task(completion);
                 },
             }
         }
@@ -657,39 +666,108 @@ impl RocketmqTuiApp {
             execution_id,
             command_id: command_id.clone(),
         });
+        let facade = match self.command_facade(execution_id) {
+            Ok(facade) => facade,
+            Err(error) => {
+                self.apply_action(Action::CommandFailed {
+                    execution_id,
+                    command_id,
+                    error: error.to_string(),
+                });
+                return;
+            }
+        };
+        let client_runtime = facade.client_runtime();
         let command = self.state.selected_command().clone();
         let form = self.state.form.clone();
-        let facade = self.admin_facade.clone();
-        let tx = self.action_tx.clone();
-        let diagnostics = Arc::clone(&self.action_queue_diagnostics);
-        let progress_tx = tx.clone();
-        let progress_diagnostics = Arc::clone(&diagnostics);
-        let command_id_for_task = command_id.clone();
-        let command_task = tokio::task::spawn_local(async move {
-            let result = execute_command_with_progress(&facade, &command, &form, move |message| {
+        let progress_tx = self.action_tx.clone();
+        let progress_diagnostics = Arc::clone(&self.action_queue_diagnostics);
+        let operation = async move {
+            execute_command_with_progress(&facade, &command, &form, move |message| {
                 try_send_progress(&progress_tx, &progress_diagnostics, execution_id, message);
             })
-            .await;
-            let action = match result {
+            .await
+        };
+        self.spawn_command_task(execution_id, command_id, client_runtime, operation);
+    }
+
+    fn command_facade(&self, execution_id: u64) -> CanonicalResult<TuiAdminFacade> {
+        let parent = self.admin_facade.client_runtime();
+        let scope = ScopeId::try_new(format!("command-{execution_id}"))
+            .map_err(|_| crate::errors::invariant_violated("invalid command runtime scope"))?;
+        let context = parent
+            .service_context()
+            .try_component(scope)
+            .map_err(|error| rocketmq_error::Error::caused_by(error.descriptor(), error))?;
+        let client_runtime = ClientRuntime::try_new(
+            context,
+            ClientRuntimeConfig::default(),
+            parent.telemetry_handle().clone(),
+        )
+        .map_err(|error| error.into_error())?;
+        Ok(self.admin_facade.with_client_runtime(client_runtime))
+    }
+
+    fn spawn_command_task<F>(
+        &mut self,
+        execution_id: u64,
+        command_id: String,
+        client_runtime: Arc<ClientRuntime>,
+        operation: F,
+    ) where
+        F: Future<Output = CanonicalResult<CommandResultViewModel>> + 'static,
+    {
+        let command_task = tokio::task::spawn_local(operation);
+        let abort_handle = command_task.abort_handle();
+        // The UI may abort the operation, but this owner retains its JoinHandle and
+        // drains its isolated client pool before completing. Shutdown never touches
+        // a subsequent command's connections or the application's client runtime.
+        self.command_tasks.spawn_local(async move {
+            let result = command_task.await;
+            let report = client_runtime.shutdown().await;
+            if !report.is_healthy() {
+                tracing::warn!(execution_id, report = %report.to_json(), "admin command runtime shutdown is unhealthy");
+            }
+            let result = match result {
+                Err(error) if error.is_cancelled() => return None,
+                Err(_) => Err(crate::errors::invariant_violated("admin command task failed")),
+                Ok(result) if report.is_healthy() => result,
+                Ok(_) => Err(crate::errors::invariant_violated(
+                    "admin command runtime shutdown is unhealthy",
+                )),
+            };
+            Some(match result {
                 Ok(result) => Action::CommandSucceeded {
                     execution_id,
-                    command_id: command_id_for_task,
+                    command_id,
                     result,
                 },
                 Err(error) => Action::CommandFailed {
                     execution_id,
-                    command_id: command_id_for_task,
+                    command_id,
                     error: error.to_string(),
                 },
-            };
-            send_required_action(&tx, &diagnostics, action).await;
+            })
         });
-        let abort_handle = command_task.abort_handle();
-        drop(command_task);
         self.running_task = Some(RunningCommandTask {
             execution_id,
             abort_handle,
         });
+    }
+
+    fn complete_command_task(&mut self, completion: Result<Option<Action>, JoinError>) {
+        match completion {
+            Ok(Some(action)) => self.apply_action(action),
+            Ok(None) => {}
+            Err(_) => tracing::error!("admin command cleanup task failed"),
+        }
+    }
+
+    async fn shutdown_commands(&mut self) {
+        self.abort_running_task();
+        while let Some(completion) = self.command_tasks.join_next().await {
+            self.complete_command_task(completion);
+        }
     }
 
     fn is_current_running_execution(&self, execution_id: u64) -> bool {
@@ -850,61 +928,67 @@ mod tests {
     fn starting_command_execution_builds_background_task_without_stack_overflow() {
         let local = tokio::task::LocalSet::new();
 
-        local.block_on(&tokio::runtime::Builder::new_current_thread().build().unwrap(), async {
-            let mut app = RocketmqTuiApp::new(test_client_runtime());
-            app.apply_action(Action::SearchChanged("message.decode_id".to_string()));
-            app.apply_action(Action::CommandSelected("message.decode_id".to_string()));
-            app.state.reset_form_for_selected_command();
-            app.state
-                .form
-                .set_value("message_ids", "7F0000010007D8260BF075769D36C348".to_string());
+        local.block_on(
+            &tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+            async {
+                let mut app = RocketmqTuiApp::new(test_client_runtime());
+                app.apply_action(Action::SearchChanged("message.decode_id".to_string()));
+                app.apply_action(Action::CommandSelected("message.decode_id".to_string()));
+                app.state.reset_form_for_selected_command();
+                app.state
+                    .form
+                    .set_value("message_ids", "7F0000010007D8260BF075769D36C348".to_string());
 
-            app.apply_action(Action::ExecuteRequested);
+                app.apply_action(Action::ExecuteRequested);
 
-            assert!(matches!(app.state.execution, CommandExecutionState::Running { .. }));
-            assert!(app.running_task.is_some());
-            app.abort_running_task();
-        });
+                assert!(matches!(app.state.execution, CommandExecutionState::Running { .. }));
+                assert!(app.running_task.is_some());
+                app.shutdown_commands().await;
+            },
+        );
     }
 
     #[test]
     fn cancel_execution_aborts_tracked_local_task() {
         let local = tokio::task::LocalSet::new();
 
-        local.block_on(&tokio::runtime::Builder::new_current_thread().build().unwrap(), async {
-            let aborted = Rc::new(Cell::new(false));
-            let command_task = tokio::task::spawn_local(AbortProbe {
-                aborted: aborted.clone(),
-            });
-            let abort_handle = command_task.abort_handle();
-            drop(command_task);
-
-            let mut app = RocketmqTuiApp::new(test_client_runtime());
-            app.running_task = Some(RunningCommandTask {
-                execution_id: 7,
-                abort_handle,
-            });
-            app.state.execution = CommandExecutionState::Running {
-                execution_id: 7,
-                command_id: "message.consume".to_string(),
-            };
-
-            app.apply_action(Action::CancelExecution {
-                execution_id: 7,
-                command_id: "message.consume".to_string(),
-            });
-
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
-            while !aborted.get() {
-                assert!(
-                    tokio::time::Instant::now() < deadline,
-                    "abort probe task was not dropped"
+        local.block_on(
+            &tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+            async {
+                let aborted = Rc::new(Cell::new(false));
+                let mut app = RocketmqTuiApp::new(test_client_runtime());
+                let client_runtime = app.command_facade(7).unwrap().client_runtime();
+                app.spawn_command_task(
+                    7,
+                    "message.consume".to_string(),
+                    client_runtime.clone(),
+                    AbortProbe {
+                        aborted: aborted.clone(),
+                    },
                 );
-                tokio::task::yield_now().await;
-            }
+                app.state.execution = CommandExecutionState::Running {
+                    execution_id: 7,
+                    command_id: "message.consume".to_string(),
+                };
 
-            assert!(app.running_task.is_none());
-        });
+                app.apply_action(Action::CancelExecution {
+                    execution_id: 7,
+                    command_id: "message.consume".to_string(),
+                });
+
+                app.shutdown_commands().await;
+                assert!(aborted.get());
+                assert!(client_runtime.is_shutdown());
+                assert!(app.command_tasks.is_empty());
+                assert!(app.running_task.is_none());
+            },
+        );
     }
 
     struct AbortProbe {
@@ -912,7 +996,7 @@ mod tests {
     }
 
     impl Future for AbortProbe {
-        type Output = ();
+        type Output = CanonicalResult<CommandResultViewModel>;
 
         fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
             Poll::Pending
@@ -925,3 +1009,6 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod command_lifecycle_tests;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app/command_lifecycle_tests.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app/command_lifecycle_tests.rs
@@ -1,0 +1,184 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+
+use super::*;
+use crate::admin_facade::test_client_runtime;
+
+fn run_local_test(test: impl Future<Output = ()>) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    tokio::task::LocalSet::new().block_on(&runtime, async {
+        tokio::time::timeout(Duration::from_secs(20), test)
+            .await
+            .expect("command and cleanup must finish within the test deadline");
+    });
+}
+
+async fn start_blocked_query(app: &mut RocketmqTuiApp, execution_id: u64) -> (Arc<ClientRuntime>, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let namesrv_addr = listener.local_addr().unwrap().to_string();
+    app.apply_action(Action::NamesrvChanged(namesrv_addr.clone()));
+    let facade = app.command_facade(execution_id).unwrap();
+    assert_eq!(facade.namesrv_addr(), Some(namesrv_addr.as_str()));
+    let client_runtime = facade.client_runtime();
+    app.apply_action(Action::CommandStarted {
+        execution_id,
+        command_id: "topic.list".to_string(),
+    });
+    app.spawn_command_task(
+        execution_id,
+        "topic.list".to_string(),
+        client_runtime.clone(),
+        async move {
+            let topics = facade.query_topic_list(None).await?;
+            Ok(CommandResultViewModel::from_debug("Topics", &topics))
+        },
+    );
+
+    // The request has reached a real connection. Keeping the peer silent leaves
+    // the command suspended inside its RPC rather than before session startup.
+    let (mut peer, _) = listener.accept().await.unwrap();
+    peer.read_u8().await.unwrap();
+    assert_eq!(client_runtime.pool().instance_count(), 1);
+    (client_runtime, peer)
+}
+
+async fn assert_runtime_closed(client_runtime: &ClientRuntime) {
+    assert!(client_runtime.is_shutdown());
+    assert_eq!(client_runtime.pool().instance_count(), 0);
+    assert_eq!(client_runtime.service_context().task_group().task_count(), 0);
+    let report = client_runtime.shutdown().await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+#[test]
+fn cancelling_query_releases_its_pool_without_stopping_the_next_command() {
+    run_local_test(async {
+        let parent = test_client_runtime();
+        let mut app = RocketmqTuiApp::new(parent.clone());
+        let (cancelled_runtime, _cancelled_peer) = start_blocked_query(&mut app, 1).await;
+        app.apply_action(Action::CancelExecution {
+            execution_id: 1,
+            command_id: "topic.list".to_string(),
+        });
+
+        // A new command may start while the previous command's cleanup is still
+        // queued. It must keep an independent pool and cancellation scope.
+        let (next_runtime, _next_peer) = start_blocked_query(&mut app, 2).await;
+        let completion = app.command_tasks.join_next().await.unwrap();
+        app.complete_command_task(completion);
+        assert_runtime_closed(&cancelled_runtime).await;
+        assert!(!next_runtime.is_shutdown());
+        assert_eq!(next_runtime.pool().instance_count(), 1);
+        assert!(matches!(
+            app.state.execution,
+            CommandExecutionState::Running { execution_id: 2, .. }
+        ));
+
+        app.apply_action(Action::CancelExecution {
+            execution_id: 2,
+            command_id: "topic.list".to_string(),
+        });
+        app.shutdown_commands().await;
+        assert_runtime_closed(&next_runtime).await;
+        assert!(app.command_tasks.is_empty());
+        assert!(!parent.is_shutdown());
+        assert_eq!(parent.pool().instance_count(), 0);
+        assert!(parent.shutdown().await.is_healthy());
+    });
+}
+
+#[test]
+fn quitting_awaits_cancelled_command_cleanup_even_with_a_full_action_queue() {
+    run_local_test(async {
+        let parent = test_client_runtime();
+        let mut app = RocketmqTuiApp::new(parent.clone());
+        let (client_runtime, _peer) = start_blocked_query(&mut app, 1).await;
+        for _ in 0..ACTION_QUEUE_CAPACITY {
+            try_send_progress(&app.action_tx, &app.action_queue_diagnostics, 1, "waiting".to_string());
+        }
+        assert_eq!(app.action_queue_snapshot().queued, ACTION_QUEUE_CAPACITY);
+
+        app.quit();
+        app.shutdown_commands().await;
+        assert!(app.should_quit());
+        assert!(app.running_task.is_none());
+        assert!(app.command_tasks.is_empty());
+        assert_runtime_closed(&client_runtime).await;
+        assert!(parent.shutdown().await.is_healthy());
+    });
+}
+
+#[test]
+fn a_closed_parent_rejects_execution_without_spawning_tasks() {
+    run_local_test(async {
+        let parent = test_client_runtime();
+        let mut app = RocketmqTuiApp::new(parent.clone());
+        assert!(parent.shutdown().await.is_healthy());
+
+        let error = app.command_facade(1).unwrap_err();
+        assert_eq!(error.descriptor(), &rocketmq_error::RUNTIME_CONTEXT_UNAVAILABLE);
+        app.start_execution(1, "topic.list".to_string());
+        assert!(matches!(app.state.execution, CommandExecutionState::Failed { .. }));
+        assert_eq!(app.state.last_error.as_deref(), Some(error.to_string().as_str()));
+        assert!(app.running_task.is_none());
+        assert!(app.command_tasks.is_empty());
+    });
+}
+
+#[test]
+fn command_completion_error_and_panic_all_release_owned_clients() {
+    run_local_test(async {
+        let parent = test_client_runtime();
+        let mut app = RocketmqTuiApp::new(parent.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        app.apply_action(Action::NamesrvChanged(listener.local_addr().unwrap().to_string()));
+
+        for execution_id in 1..=3 {
+            let facade = app.command_facade(execution_id).unwrap();
+            let client_runtime = facade.client_runtime();
+            let observed_runtime = client_runtime.clone();
+            app.apply_action(Action::CommandStarted {
+                execution_id,
+                command_id: "test".to_string(),
+            });
+            app.spawn_command_task(execution_id, "test".to_string(), client_runtime.clone(), async move {
+                let _session = facade.admin_builder().build_and_start().await.unwrap();
+                assert_eq!(observed_runtime.pool().instance_count(), 1);
+                match execution_id {
+                    1 => Ok(CommandResultViewModel::operation_success("Done", Vec::new())),
+                    2 => Err(crate::errors::argument_invalid("test operation failed")),
+                    _ => panic!("test command panic"),
+                }
+            });
+
+            let completion = app.command_tasks.join_next().await.unwrap();
+            app.complete_command_task(completion);
+            assert_runtime_closed(&client_runtime).await;
+            assert!(app.running_task.is_none());
+            if execution_id == 1 {
+                assert!(matches!(app.state.execution, CommandExecutionState::Succeeded { .. }));
+            } else {
+                assert!(matches!(app.state.execution, CommandExecutionState::Failed { .. }));
+            }
+        }
+        assert!(parent.shutdown().await.is_healthy());
+    });
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10348

### Brief Description

Cancelling a TUI command while its RPC is pending can skip admin-session shutdown and retain client resources until application exit. Give each command a separate ClientRuntime beneath the application's service scope, preserving its NameServer configuration and telemetry.

Retain command JoinHandles through a TUI-owned JoinSet so cancellation stops the operation while its owner closes the client pool and background tasks. Completion, failure, and panic use the same cleanup path; exiting drains outstanding cleanup without depending on progress queue capacity. Commands continue to use the existing Tokio LocalSet.

Add four lifecycle regression tests and update the English and Chinese README descriptions, including the limit that cancellation cannot undo requests already accepted by a broker or NameServer.

### How Did You Test This Change?

- `cargo test -p rocketmq-admin-tui --locked --quiet` - passed: 87 unit tests and 2 integration tests.
- `cargo clippy -p rocketmq-admin-tui --locked --all-targets --no-deps -- -D warnings` - passed.
- `cargo fmt -p rocketmq-admin-tui -- --check` - passed.
- `git -c core.safecrlf=false diff --check` - passed.

The new tests cover cancellation during a real loopback RPC, starting the next command while prior cleanup is pending, exit with a full action queue, success/error/panic cleanup, and execution after the parent runtime closes. They verify client pools are emptied, shutdown reports are healthy, and subsequent commands remain active. No external RocketMQ cluster or interactive terminal session was used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commands now run independently, improving isolation between simultaneous operations.
  * Cancelling a command stops its ongoing operation and releases its associated resources.
  * The application waits for active commands and background work to finish cleanup before exiting.
* **Documentation**
  * Updated English and Chinese documentation to explain command lifecycle, cancellation behavior, cleanup during exit, and that requests already accepted by the Broker or NameServer cannot be undone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->