### PR TITLE
[ISSUE #10350]🧪Align Broker error assertions with canonical error contracts

### DIFF
--- a/rocketmq-broker/src/controller/replicas_manager.rs
+++ b/rocketmq-broker/src/controller/replicas_manager.rs
@@ -1101,7 +1101,7 @@ mod tests {
             )
             .expect_err("same epoch must not authorize a different master");
 
-        assert!(error.to_string().contains("conflicts with the installed authority"));
+        assert_eq!(error.descriptor(), &rocketmq_error::CORE_ARGUMENT_INVALID);
         assert_eq!(manager.write_authority(), Some(installed));
         assert_eq!(manager.master_broker_id(), Some(2));
         assert_eq!(manager.sync_state_set(), &HashSet::from([2_i64]));

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -864,7 +864,12 @@ mod tests {
             (AdminOriginFact::BrokerProxy, AdminSessionFact::Unsupported),
         ] {
             let error = trusted_admin_metadata(origin, session).expect_err("untrusted fact pair must fail closed");
-            assert!(error.to_string().contains("trusted session view"));
+            assert_eq!(error.descriptor(), &rocketmq_error::CORE_INTERNAL_FAILURE);
+            let public = error
+                .public_view()
+                .expect("invariant error context must match its descriptor");
+            assert_eq!(public.message(), "Internal error");
+            assert!(public.fields().next().is_none());
         }
     }
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
@@ -488,12 +488,15 @@ fn cq_ext_unit_response_serialize_error(error: serde_json::Error) -> rocketmq_er
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as StdError;
     use std::sync::Arc;
     use std::time::SystemTime;
 
     use crate::config::broker_config::BrokerConfig;
     use bytes::Bytes;
     use cheetah_string::CheetahString;
+    use rocketmq_error::fields;
+    use rocketmq_error::ViewValueRef;
     use rocketmq_model::common::config::TopicConfig;
     use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
     use rocketmq_model::common::message::MessageConst;
@@ -559,7 +562,21 @@ mod tests {
         let error = cq_ext_unit_response_serialize_error(serde_error);
 
         assert_eq!(error.descriptor(), &rocketmq_error::PROTOCOL_RESPONSE_FAILED);
-        assert!(error.to_string().contains("query_consume_queue.cq_ext_unit"));
+        let diagnostic = error
+            .diagnostic_view()
+            .expect("response error context must match its descriptor");
+        assert_eq!(
+            diagnostic
+                .fields()
+                .find(|field| field.name() == fields::OPERATION_DIAGNOSTIC.schema().name())
+                .map(|field| field.value()),
+            Some(ViewValueRef::Text("query_consume_queue.cq_ext_unit"))
+        );
+        assert!(!error.to_string().contains("query_consume_queue.cq_ext_unit"));
+        assert!(StdError::source(error.as_ref())
+            .expect("response error must preserve the JSON source")
+            .downcast_ref::<serde_json::Error>()
+            .is_some());
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/transaction/transaction_metrics.rs
+++ b/rocketmq-broker/src/transaction/transaction_metrics.rs
@@ -220,6 +220,9 @@ mod tests {
     use std::error::Error as StdError;
     use std::fs;
 
+    use rocketmq_error::fields;
+    use rocketmq_error::ViewValueRef;
+
     use super::read_checkpoint;
 
     #[test]
@@ -230,8 +233,26 @@ mod tests {
 
         let error = read_checkpoint(&checkpoint_path).expect_err("invalid checkpoint must fail to decode");
 
-        assert_eq!(error.to_string(), "deserialize failed (JSON)");
-        assert_eq!(error.descriptor().public_message(), "Serialization failed");
+        assert_eq!(error.descriptor(), &rocketmq_error::CORE_SERIALIZATION_FAILED);
+        assert_eq!(error.to_string(), "core.serialization.failed: Serialization failed");
+        let public = error
+            .public_view()
+            .expect("checkpoint error context must match its descriptor");
+        assert_eq!(public.message(), "Serialization failed");
+        assert!(public.fields().next().is_none());
+
+        let diagnostic = error
+            .diagnostic_view()
+            .expect("checkpoint diagnostics must match the descriptor");
+        for (key, expected) in [(fields::OPERATION_DIAGNOSTIC, "deserialize"), (fields::FORMAT, "JSON")] {
+            assert_eq!(
+                diagnostic
+                    .fields()
+                    .find(|field| field.name() == key.schema().name())
+                    .map(|field| field.value()),
+                Some(ViewValueRef::Text(expected))
+            );
+        }
         assert!(StdError::source(error.as_ref())
             .expect("outer error must preserve the source")
             .downcast_ref::<serde_json::Error>()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10350

### Brief Description

Four Broker tests still asserted legacy diagnostic text in error display output after the canonical error cutover. Align them with the current descriptor and public-message contracts, and inspect structured diagnostics for operation and format details.

The tests continue to verify rejected authority changes and fail-closed admin metadata. Serialization coverage now also checks public redaction and retained `serde_json::Error` sources. Only test code changes; production error behavior is unchanged.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check`: passed.
- `git diff --check -- rocketmq-broker`: passed.
- `cargo test -p rocketmq-broker --lib invalid_checkpoint_preserves_json_source_and_public_boundary`: passed.
- `cargo test -p rocketmq-broker --lib`: 1,094 passed, 3 ignored, 1 failed. All four cases addressed by this PR passed.
- The remaining failure is `broker_runtime::tests::blocking_shutdown_hook_cannot_extend_the_absolute_deadline`, at the `report.deadline.timed_out` assertion in `rocketmq-broker/tests/broker_runtime/unit.rs:1078`. It also failed when rerun alone with `cargo test -p rocketmq-broker --lib blocking_shutdown_hook_cannot_extend_the_absolute_deadline`. That test and its implementation are outside this change.

The maintainer requested squash merge without waiting for CI, with the remaining local test failure disclosed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for structured error reporting across broker role changes, administrative requests, response serialization, and transaction metrics.
  - Tests now verify stable error descriptors, public-facing messages, diagnostic metadata, and preservation of underlying error sources.
  - Added checks confirming sensitive operational details remain excluded from public error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->