### PR TITLE
[ISSUE #10354]🧪Align POP profile tests with canonical error contracts

### DIFF
--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -103,13 +103,21 @@ pub mod test_support {
     #[cfg(feature = "rocksdb_store")]
     impl PopProfileStoreProbe {
         pub fn open(root: &Path, capacity: usize) -> Result<Self, String> {
-            let rocksdb = Arc::new(
-                PopConsumerRocksDbStore::open(pop_rocksdb_path(root), 16 * 1024 * 1024, 4 * 1024 * 1024)
-                    .map_err(|error| error.to_string())?,
-            );
-            let store = Arc::new(
-                PopConsumerProfileStore::load(Arc::clone(&rocksdb), capacity).map_err(|error| error.to_string())?,
-            );
+            Self::open_with_error(root, capacity).map_err(|error| error.to_string())
+        }
+
+        /// Opens the probe while preserving canonical errors and their typed sources.
+        ///
+        /// # Errors
+        ///
+        /// Returns the storage or profile validation error if the store cannot be loaded.
+        pub fn open_with_error(root: &Path, capacity: usize) -> Result<Self, rocketmq_error::SharedError> {
+            let rocksdb = Arc::new(PopConsumerRocksDbStore::open(
+                pop_rocksdb_path(root),
+                16 * 1024 * 1024,
+                4 * 1024 * 1024,
+            )?);
+            let store = Arc::new(PopConsumerProfileStore::load(Arc::clone(&rocksdb), capacity)?);
             Ok(Self { store, rocksdb })
         }
 
@@ -135,6 +143,22 @@ pub mod test_support {
             retry_policy: PopRetryPolicy,
             last_seen: i64,
         ) -> Result<PopProfileSnapshotProbe, String> {
+            self.upsert_policy_with_error(group, topics, retry_policy, last_seen)
+                .map_err(|error| error.to_string())
+        }
+
+        /// Upserts a profile while preserving canonical errors and their typed context.
+        ///
+        /// # Errors
+        ///
+        /// Returns the validation or storage error if the profile cannot be persisted.
+        pub fn upsert_policy_with_error(
+            &self,
+            group: &str,
+            topics: &[&str],
+            retry_policy: PopRetryPolicy,
+            last_seen: i64,
+        ) -> Result<PopProfileSnapshotProbe, rocketmq_error::SharedError> {
             let subscriptions = topics
                 .iter()
                 .map(
@@ -148,7 +172,6 @@ pub mod test_support {
             self.store
                 .upsert(CheetahString::from_slice(group), subscriptions, retry_policy, last_seen)
                 .map(profile_probe)
-                .map_err(|error| error.to_string())
         }
 
         pub fn remove(&self, group: &str, last_seen: i64) -> Result<bool, String> {

--- a/rocketmq-broker/tests/pop_profile_persistence.rs
+++ b/rocketmq-broker/tests/pop_profile_persistence.rs
@@ -12,7 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::error::Error as StdError;
+
 use rocketmq_broker::test_support::PopProfileStoreProbe;
+use rocketmq_error::ViewValueRef;
+use rocketmq_error::CORE_CONFIGURATION_INVALID;
+use rocketmq_error::CORE_INTERNAL_FAILURE;
+use rocketmq_error::STORAGE_STATE_CORRUPTED;
+use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
+use rocketmq_store_api::StoreComponent;
+use rocketmq_store_api::StoreError;
+use rocketmq_store_api::StoreOperation;
 use tempfile::TempDir;
 
 #[test]
@@ -63,8 +73,15 @@ fn unknown_format_version_fails_closed() {
     let root = TempDir::new().expect("temp dir");
     PopProfileStoreProbe::write_unknown_marker(root.path(), 99).expect("write marker fixture");
 
-    let error = PopProfileStoreProbe::open(root.path(), 16).expect_err("unknown version must fail");
-    assert!(error.contains("unsupported POP consumer profile format version 99"));
+    let error = PopProfileStoreProbe::open_with_error(root.path(), 16).expect_err("unknown version must fail");
+    assert_eq!(error.descriptor(), &CORE_INTERNAL_FAILURE);
+    let source = error
+        .source()
+        .and_then(|source| source.downcast_ref::<StoreError>())
+        .expect("the broker error must preserve the typed storage failure");
+    assert_eq!(source.descriptor(), &STORAGE_STATE_CORRUPTED);
+    assert_eq!(source.operation(), StoreOperation::Admin);
+    assert_eq!(source.component(), StoreComponent::RocksDb);
 }
 
 #[test]
@@ -74,11 +91,26 @@ fn capacity_failure_does_not_advance_generation() {
     store
         .upsert("group-a", &["topic-a"], 1, 10)
         .expect("persist first profile");
+    let original = store.snapshot();
 
     let error = store
-        .upsert("group-b", &["topic-b"], 1, 11)
+        .upsert_policy_with_error("group-b", &["topic-b"], PopRetryPolicy::v1_only(0), 11)
         .expect_err("capacity must be enforced");
-    assert!(error.contains("capacity"));
+    assert_eq!(error.descriptor(), &CORE_CONFIGURATION_INVALID);
+    assert_eq!(
+        error
+            .diagnostic_view()
+            .expect("valid configuration error context")
+            .fields()
+            .find(|field| field.name() == "key")
+            .map(|field| field.value()),
+        Some(ViewValueRef::Text("capacity"))
+    );
     assert_eq!(store.generation(), 1);
-    assert_eq!(store.snapshot().len(), 1);
+    assert_eq!(store.snapshot(), original);
+    drop(store);
+
+    let reopened = PopProfileStoreProbe::open(root.path(), 1).expect("reopen profile store");
+    assert_eq!(reopened.generation(), 1);
+    assert_eq!(reopened.snapshot(), original);
 }

--- a/rocketmq-broker/tests/pop_retry_version_migration.rs
+++ b/rocketmq-broker/tests/pop_retry_version_migration.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use rocketmq_broker::test_support::PopProfileStoreProbe;
+use rocketmq_error::ViewValueRef;
+use rocketmq_error::CORE_CONFIGURATION_INVALID;
 use rocketmq_model::common::pop_retry_policy::PopRetryMigrationState;
 use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
 use rocketmq_model::PopRetryPolicyOutcome;
@@ -83,10 +85,26 @@ fn persisted_profile_rejects_a_skipped_v1_to_v2_only_transition() {
     store
         .upsert_policy("group-a", &["orders"], PopRetryPolicy::v1_only(0), 10)
         .expect("persist v1-only policy");
+    let original = store.snapshot();
 
     let error = store
-        .upsert_policy("group-a", &["orders"], PopRetryPolicy::v2_only(2), 11)
+        .upsert_policy_with_error("group-a", &["orders"], PopRetryPolicy::v2_only(2), 11)
         .expect_err("migration must not skip both dual-read states");
-    assert!(error.contains("next safe POP retry migration state"), "{error}");
+    assert_eq!(error.descriptor(), &CORE_CONFIGURATION_INVALID);
+    assert_eq!(
+        error
+            .diagnostic_view()
+            .expect("valid configuration error context")
+            .fields()
+            .find(|field| field.name() == "key")
+            .map(|field| field.value()),
+        Some(ViewValueRef::Text("retryPolicy"))
+    );
     assert_eq!(store.generation(), 1);
+    assert_eq!(store.snapshot(), original);
+    drop(store);
+
+    let reopened = PopProfileStoreProbe::open(root.path(), 16).expect("reopen profile store");
+    assert_eq!(reopened.generation(), 1);
+    assert_eq!(reopened.snapshot(), original);
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10354

### Brief Description

POP profile persistence and retry migration tests expect legacy error messages that are no longer exposed by canonical errors. Add probe methods that preserve canonical errors while retaining the existing string-returning wrappers.

Check error descriptors, configuration diagnostic keys, and the typed storage failure instead of matching message text. Strengthen capacity and retry-transition rejection tests to compare the full snapshot and generation both before and after reopening the database. Production error mapping and storage formats retain their current behavior.

### How Did You Test This Change?

Reproduced both reported failures in `pop_profile_persistence` before the fix.

- `cargo test -p rocketmq-broker --locked --features rocksdb_store,test-support --test pop_profile_persistence --test pop_profile_runtime_flow --test pop_retry_version_migration` - passed: 8 tests across 3 integration targets.
- `cargo fmt -p rocketmq-broker -- --check` - passed.
- `git -c core.safecrlf=false diff --check` - passed.

Validation used local temporary RocksDB databases on Windows. Full-workspace tests were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting for POP profile storage and retry-policy updates with structured diagnostics, including the affected operation and configuration field.
  - Failed updates now preserve the existing profile snapshot and generation across store reopenings.
  - Added clearer handling for unsupported profile format versions and invalid retry-policy transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->