### PR TITLE
[ISSUE #10357]🚀Add owned versioned storage for the Tauri dashboard

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
@@ -27,12 +27,20 @@ On first startup the application bootstraps a local administrator account:
 After the first successful login, the user must change the password before entering the dashboard.
 
 Authentication and saved NameServer/Proxy configuration share `dashboard.db` in
-Tauri's application configuration directory (identifier `com.rocketmqrust.dashboard`):
+the `data` subdirectory of Tauri's application configuration directory (identifier `com.rocketmqrust.dashboard`):
 
-- Windows: `%APPDATA%\com.rocketmqrust.dashboard\dashboard.db`
-- macOS: `~/Library/Application Support/com.rocketmqrust.dashboard/dashboard.db`
-- Linux: `$XDG_CONFIG_HOME/com.rocketmqrust.dashboard/dashboard.db`, or
-  `~/.config/com.rocketmqrust.dashboard/dashboard.db` when unset
+- Windows: `%APPDATA%\com.rocketmqrust.dashboard\data\dashboard.db`
+- macOS: `~/Library/Application Support/com.rocketmqrust.dashboard/data/dashboard.db`
+- Linux: `$XDG_CONFIG_HOME/com.rocketmqrust.dashboard/data/dashboard.db`, or
+  `~/.config/com.rocketmqrust.dashboard/data/dashboard.db` when unset
+
+Set `DASHBOARD_TAURI_DATA_DIR` to an isolated directory to override the default;
+its database is `<configured-directory>/dashboard.db`. An empty override is rejected.
+This storage design starts with a fresh database. It does not import accounts or
+addresses from the previous unversioned database, which remains untouched at its
+old location. The new database bootstraps the administrator as described above.
+Unversioned or unsupported databases are rejected without deleting or rebuilding
+them; choose a new data directory to start fresh.
 
 For more detail, see [doc/AUTH_CONFIG.md](./doc/AUTH_CONFIG.md).
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUTH_CONFIG.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUTH_CONFIG.md
@@ -20,29 +20,37 @@ After the first successful login, the administrator must change the password bef
 
 ## Database Location
 
-Authentication and saved NameServer/Proxy configuration share `dashboard.db` in the application config directory for `com.rocketmqrust.dashboard`. On Linux, `XDG_CONFIG_HOME` overrides `~/.config`.
+Authentication and saved NameServer/Proxy configuration share `dashboard.db` in the `data` subdirectory of the application config directory for `com.rocketmqrust.dashboard`. On Linux, `XDG_CONFIG_HOME` overrides `~/.config`.
 
 ### Windows
 
 ```text
-C:\Users\<YourUsername>\AppData\Roaming\com.rocketmqrust.dashboard\dashboard.db
+C:\Users\<YourUsername>\AppData\Roaming\com.rocketmqrust.dashboard\data\dashboard.db
 ```
 
 ### macOS
 
 ```text
-~/Library/Application Support/com.rocketmqrust.dashboard/dashboard.db
+~/Library/Application Support/com.rocketmqrust.dashboard/data/dashboard.db
 ```
 
 ### Linux
 
 ```text
-~/.config/com.rocketmqrust.dashboard/dashboard.db
+~/.config/com.rocketmqrust.dashboard/data/dashboard.db
 ```
+
+Set `DASHBOARD_TAURI_DATA_DIR` to an isolated directory to override the default;
+its database is `<configured-directory>/dashboard.db`. An empty override is rejected.
+This storage design starts with a fresh database. It does not import accounts or
+addresses from the previous unversioned database, which remains untouched at its
+old location. The new database bootstraps the administrator as described above.
+Unversioned or unsupported databases are rejected without deleting or rebuilding
+them; choose a new data directory to start fresh.
 
 ## Schema
 
-The embedded database currently uses a single `users` table:
+The versioned database contains `dashboard_schema`, `users`, and connection configuration tables. The account table is:
 
 ```sql
 CREATE TABLE IF NOT EXISTS users (

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -6676,27 +6676,27 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+checksum = "bf06bd8162af0734b344780deb55b42a2429ae430870d13fcc12f238e880fe6e"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "ae42c0555055784c70058d19ba8e275528e8a99a706684868ace5da4e716a4ab"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.1.0+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0"
 dependencies = [
  "cc",
  "pkg-config",

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/db.rs
@@ -18,77 +18,34 @@
 
 use crate::auth::types::AuthResult;
 use rusqlite::Connection;
-use std::fs;
+#[cfg(test)]
 use std::path::Path;
 use std::path::PathBuf;
-use std::time::Duration;
-use tauri::AppHandle;
-use tauri::Manager;
 
-// The database layer is implemented before the Tauri setup starts using it
-// so we temporarily silence dead-code warnings during the migration.
-#[allow(dead_code)]
-const DB_FILE_NAME: &str = "dashboard.db";
-#[allow(dead_code)]
-const USERS_TABLE_SCHEMA: &str = "
-    CREATE TABLE IF NOT EXISTS users (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        username TEXT NOT NULL UNIQUE,
-        password_hash TEXT NOT NULL,
-        is_active INTEGER NOT NULL DEFAULT 1,
-        must_change_password INTEGER NOT NULL DEFAULT 1,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        last_login_at TEXT
-    );
-";
-
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) struct AuthDb {
     db_path: PathBuf,
 }
 
-#[allow(dead_code)]
 impl AuthDb {
-    pub(crate) fn new(app: &AppHandle) -> AuthResult<Self> {
-        let app_config_dir = app.path().app_config_dir()?;
-
-        Ok(Self::from_path(app_config_dir.join(DB_FILE_NAME)))
-    }
-
     pub(crate) fn from_path(db_path: impl Into<PathBuf>) -> Self {
         Self {
             db_path: db_path.into(),
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn db_path(&self) -> &Path {
         &self.db_path
     }
 
     pub(crate) fn init(&self) -> AuthResult<()> {
         let mut connection = self.connection()?;
-        let transaction = connection.transaction()?;
-        transaction.execute_batch(USERS_TABLE_SCHEMA)?;
-        transaction.commit()?;
-        Ok(())
+        crate::persistence::schema::initialize(&mut connection)
     }
 
     pub(crate) fn connection(&self) -> AuthResult<Connection> {
-        self.ensure_parent_dir()?;
-
-        let connection = Connection::open(&self.db_path)?;
-        connection.busy_timeout(Duration::from_secs(5))?;
-        Ok(connection)
-    }
-
-    fn ensure_parent_dir(&self) -> AuthResult<()> {
-        if let Some(parent) = self.db_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        Ok(())
+        crate::persistence::open_connection(&self.db_path)
     }
 }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
@@ -45,6 +45,12 @@ pub(crate) enum DashboardError {
     Io(#[from] std::io::Error),
     #[error("database operation failed")]
     Database(#[from] rusqlite::Error),
+    #[error("the database schema is not supported")]
+    UnsupportedStorageVersion,
+    #[error("dashboard storage is shutting down")]
+    StorageClosed,
+    #[error("dashboard persistence work could not complete")]
+    Persistence(#[source] rocketmq_runtime::RuntimeError),
     #[error("password processing failed")]
     PasswordHash(password_hash::Error),
     #[error("application integration failed")]
@@ -111,7 +117,21 @@ impl DashboardError {
                 automatic_recovery(error.recovery_hint()),
                 None,
             ),
-            Self::Io(_) | Self::Database(_) | Self::Tauri(_) => (
+            Self::UnsupportedStorageVersion => (
+                "dashboard.storage_version_unsupported",
+                "This database format is not supported. Select a new data directory.",
+                CommandErrorCategory::Configuration,
+                false,
+                None,
+            ),
+            Self::StorageClosed => (
+                "dashboard.storage_closed",
+                "Dashboard storage is shutting down.",
+                CommandErrorCategory::Unavailable,
+                false,
+                None,
+            ),
+            Self::Io(_) | Self::Database(_) | Self::Tauri(_) | Self::Persistence(_) => (
                 "dashboard.storage_unavailable",
                 "Dashboard storage is unavailable.",
                 CommandErrorCategory::Unavailable,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod dashboard;
 mod error;
 mod message;
 mod nameserver;
+mod persistence;
 mod producer;
 mod proxy;
 mod topic;
@@ -42,6 +43,7 @@ const CLEANUP_FAILURE_EXIT_CODE: i32 = 71;
 
 #[derive(Clone)]
 struct DashboardAdminLifecycle {
+    storage: persistence::StorageManager,
     cluster_manager: cluster::ClusterManager,
     consumer_manager: consumer::ConsumerManager,
     message_manager: message::MessageManager,
@@ -57,7 +59,8 @@ struct DashboardApplication {
 }
 
 impl DashboardAdminLifecycle {
-    async fn shutdown(&self) {
+    async fn shutdown(&self) -> bool {
+        let storage_healthy = self.storage.shutdown(ADMIN_SHUTDOWN_TIMEOUT).await;
         tokio::join!(
             self.cluster_manager.shutdown(),
             self.consumer_manager.shutdown(),
@@ -65,6 +68,7 @@ impl DashboardAdminLifecycle {
             self.producer_manager.shutdown(),
             self.topic_manager.shutdown(),
         );
+        storage_healthy
     }
 }
 
@@ -76,6 +80,70 @@ fn final_exit_code(application_exit_code: i32, cleanup_healthy: bool) -> i32 {
     } else {
         CLEANUP_FAILURE_EXIT_CODE
     }
+}
+
+struct DashboardServices {
+    auth_service: auth::AuthService,
+    nameserver_runtime: Arc<nameserver::NameServerRuntimeState>,
+    nameserver_manager: nameserver::NameServerManager,
+    cluster_manager: cluster::ClusterManager,
+    consumer_manager: consumer::ConsumerManager,
+    message_manager: message::MessageManager,
+    producer_manager: producer::ProducerManager,
+    topic_manager: topic::TopicManager,
+    proxy_manager: proxy::ProxyManager,
+}
+
+fn initialize_services(
+    database_path: &std::path::Path,
+    client_runtime: Arc<ClientRuntime>,
+) -> error::DashboardResult<DashboardServices> {
+    let auth_db = auth::AuthDb::from_path(database_path);
+    auth_db.init()?;
+    log::info!("Local auth SQLite database initialized");
+
+    let auth_service = auth::AuthService::new(auth_db);
+    let bootstrap_status = auth_service.bootstrap_default_admin()?;
+
+    if bootstrap_status.created {
+        log::warn!(
+            "Initialized local dashboard admin account `{}` with the bootstrap password. The password must be \
+             changed after login.",
+            bootstrap_status.username
+        );
+    }
+
+    let nameserver_db = nameserver::NameServerDb::from_path(database_path);
+    nameserver_db.init()?;
+    log::info!("Local NameServer SQLite tables initialized");
+
+    let nameserver_store = nameserver::SqliteNameServerStore::new(nameserver_db.clone());
+    let nameserver_runtime = Arc::new(nameserver::NameServerRuntimeState::new(
+        nameserver_store.load_snapshot()?,
+        client_runtime,
+    ));
+    let nameserver_manager = nameserver::NameServerManager::new(nameserver_db, nameserver_runtime.clone())?;
+    let cluster_manager = cluster::ClusterManager::new(nameserver_runtime.clone());
+    let consumer_manager = consumer::ConsumerManager::new(nameserver_runtime.clone());
+    let message_manager = message::MessageManager::new(nameserver_runtime.clone());
+    let producer_manager = producer::ProducerManager::new(nameserver_runtime.clone());
+    let topic_manager = topic::TopicManager::new(nameserver_runtime.clone());
+    let proxy_db = proxy::ProxyDb::from_path(database_path);
+    proxy_db.init()?;
+    log::info!("Local Proxy SQLite tables initialized");
+    let proxy_manager = proxy::ProxyManager::new(proxy_db)?;
+
+    Ok(DashboardServices {
+        auth_service,
+        nameserver_runtime,
+        nameserver_manager,
+        cluster_manager,
+        consumer_manager,
+        message_manager,
+        producer_manager,
+        topic_manager,
+        proxy_manager,
+    })
 }
 
 fn build_application() -> Result<DashboardApplication, i32> {
@@ -112,6 +180,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
         }
     };
     let setup_client_runtime = client_runtime.clone();
+    let storage_context = client_runtime_owner.root_context().component("dashboard-storage");
     let admin_lifecycle = Arc::new(OnceLock::new());
     let setup_lifecycle = admin_lifecycle.clone();
     let app = tauri::Builder::default()
@@ -124,43 +193,30 @@ fn build_application() -> Result<DashboardApplication, i32> {
                 )?;
             }
 
-            let auth_db = auth::AuthDb::new(app.handle())?;
-            auth_db.init()?;
-            log::info!("Local auth SQLite database initialized");
-
-            let auth_service = auth::AuthService::new(auth_db);
-            let bootstrap_status = auth_service.bootstrap_default_admin()?;
-
-            if bootstrap_status.created {
-                log::warn!(
-                    "Initialized local dashboard admin account `{}` with the bootstrap password. The password must be \
-                     changed after login.",
-                    bootstrap_status.username
-                );
-            }
-
-            let nameserver_db = nameserver::NameServerDb::new(app.handle())?;
-            nameserver_db.init()?;
-            log::info!("Local NameServer SQLite tables initialized");
-
-            let nameserver_store = nameserver::SqliteNameServerStore::new(nameserver_db.clone());
-            let nameserver_runtime = Arc::new(nameserver::NameServerRuntimeState::new(
-                nameserver_store.load_snapshot()?,
-                setup_client_runtime.clone(),
-            ));
-            let nameserver_manager = nameserver::NameServerManager::new(nameserver_db, nameserver_runtime.clone())?;
-            let cluster_manager = cluster::ClusterManager::new(nameserver_runtime.clone());
-            let consumer_manager = consumer::ConsumerManager::new(nameserver_runtime.clone());
-            let message_manager = message::MessageManager::new(nameserver_runtime.clone());
-            let producer_manager = producer::ProducerManager::new(nameserver_runtime.clone());
-            let topic_manager = topic::TopicManager::new(nameserver_runtime.clone());
-            let proxy_db = proxy::ProxyDb::new(app.handle())?;
-            proxy_db.init()?;
-            log::info!("Local Proxy SQLite tables initialized");
-            let proxy_manager = proxy::ProxyManager::new(proxy_db)?;
+            let storage =
+                persistence::StorageManager::new(persistence::resolve_data_path(app.handle())?, storage_context);
+            let database_path = storage.path().to_path_buf();
+            // Tauri setup is the synchronous UI composition boundary. All startup
+            // SQLite/file work executes on the owned StorageIo blocking lane.
+            tauri::async_runtime::block_on(storage.initialize())?;
+            let DashboardServices {
+                auth_service,
+                nameserver_runtime,
+                nameserver_manager,
+                cluster_manager,
+                consumer_manager,
+                message_manager,
+                producer_manager,
+                topic_manager,
+                proxy_manager,
+            } = tauri::async_runtime::block_on(storage.run("storage-bootstrap", move |_connection| {
+                initialize_services(&database_path, setup_client_runtime)
+            }))?;
+            log::info!("Dashboard storage initialized: {:?}", storage.health());
 
             setup_lifecycle
                 .set(DashboardAdminLifecycle {
+                    storage: storage.clone(),
                     cluster_manager: cluster_manager.clone(),
                     consumer_manager: consumer_manager.clone(),
                     message_manager: message_manager.clone(),
@@ -169,6 +225,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
                 })
                 .map_err(|_| crate::error::DashboardError::Internal("admin lifecycle initialized twice"))?;
 
+            app.manage(storage);
             app.manage(auth_service);
             app.manage(auth::SessionState::default());
             app.manage(nameserver_runtime);
@@ -246,7 +303,8 @@ fn build_application() -> Result<DashboardApplication, i32> {
         Ok(app) => app,
         Err(_error) => {
             eprintln!("Dashboard startup failed while building the application");
-            match client_runtime_owner.block_on(tokio::time::timeout(ADMIN_SHUTDOWN_TIMEOUT, client_runtime.shutdown()))
+            match client_runtime_owner
+                .block_on(async { tokio::time::timeout(ADMIN_SHUTDOWN_TIMEOUT, client_runtime.shutdown()).await })
             {
                 Ok(report) if !report.is_healthy() => {
                     eprintln!("Dashboard admin client cleanup was incomplete after startup failure");
@@ -290,18 +348,16 @@ pub fn run() -> i32 {
     let exit_code = app.run_return(|_, _| {});
     let mut cleanup_healthy = true;
     if let Some(lifecycle) = admin_lifecycle.get() {
-        let shutdown =
-            tauri::async_runtime::block_on(tokio::time::timeout(ADMIN_SHUTDOWN_TIMEOUT, lifecycle.shutdown()));
-        if shutdown.is_err() {
+        let shutdown = tauri::async_runtime::block_on(async {
+            tokio::time::timeout(ADMIN_SHUTDOWN_TIMEOUT * 2, lifecycle.shutdown()).await
+        });
+        if !matches!(shutdown, Ok(true)) {
             cleanup_healthy = false;
-            log::error!(
-                "Timed out after {} seconds while shutting down dashboard admin sessions",
-                ADMIN_SHUTDOWN_TIMEOUT.as_secs()
-            );
+            log::error!("Dashboard storage or admin session shutdown was incomplete");
         }
     }
-    let client_shutdown =
-        client_runtime_owner.block_on(tokio::time::timeout(ADMIN_SHUTDOWN_TIMEOUT, client_runtime.shutdown()));
+    let client_shutdown = client_runtime_owner
+        .block_on(async { tokio::time::timeout(ADMIN_SHUTDOWN_TIMEOUT, client_runtime.shutdown()).await });
     match client_shutdown {
         Ok(report) => {
             cleanup_healthy &= report.is_healthy();

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/db.rs
@@ -26,35 +26,11 @@ use rusqlite::Connection;
 use rusqlite::OptionalExtension;
 use rusqlite::Transaction;
 use rusqlite::params;
-use std::fs;
 #[cfg(test)]
 use std::path::Path;
 use std::path::PathBuf;
-use std::time::Duration;
-use tauri::AppHandle;
-use tauri::Manager;
 
-const DB_FILE_NAME: &str = "dashboard.db";
 const DEFAULT_NAMESERVER_ADDRESS: &str = "127.0.0.1:9876";
-const ADDRESSES_TABLE_SCHEMA: &str = "
-    CREATE TABLE IF NOT EXISTS nameserver_addresses (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        address TEXT NOT NULL UNIQUE,
-        is_current INTEGER NOT NULL DEFAULT 0,
-        sort_order INTEGER NOT NULL DEFAULT 0,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-    );
-";
-const SETTINGS_TABLE_SCHEMA: &str = "
-    CREATE TABLE IF NOT EXISTS nameserver_settings (
-        id INTEGER PRIMARY KEY CHECK (id = 1),
-        use_vip_channel INTEGER NOT NULL DEFAULT 1,
-        use_tls INTEGER NOT NULL DEFAULT 0,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-    );
-";
 
 #[derive(Debug, Clone)]
 pub(crate) struct NameServerDb {
@@ -62,11 +38,6 @@ pub(crate) struct NameServerDb {
 }
 
 impl NameServerDb {
-    pub(crate) fn new(app: &AppHandle) -> Result<Self> {
-        let app_config_dir = app.path().app_config_dir()?;
-        Ok(Self::from_path(app_config_dir.join(DB_FILE_NAME)))
-    }
-
     pub(crate) fn from_path(db_path: impl Into<PathBuf>) -> Self {
         Self {
             db_path: db_path.into(),
@@ -80,9 +51,8 @@ impl NameServerDb {
 
     pub(crate) fn init(&self) -> Result<()> {
         let mut connection = self.connection()?;
+        crate::persistence::schema::initialize(&mut connection)?;
         let transaction = connection.transaction()?;
-        transaction.execute_batch(ADDRESSES_TABLE_SCHEMA)?;
-        transaction.execute_batch(SETTINGS_TABLE_SCHEMA)?;
         sanitize_nameserver_rows(&transaction)?;
         repair_snapshot_tables(&transaction)?;
         transaction.commit()?;
@@ -90,19 +60,7 @@ impl NameServerDb {
     }
 
     pub(crate) fn connection(&self) -> Result<Connection> {
-        self.ensure_parent_dir()?;
-
-        let connection = Connection::open(&self.db_path)?;
-        connection.busy_timeout(Duration::from_secs(5))?;
-        Ok(connection)
-    }
-
-    fn ensure_parent_dir(&self) -> Result<()> {
-        if let Some(parent) = self.db_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        Ok(())
+        crate::persistence::open_connection(&self.db_path)
     }
 }
 
@@ -434,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    fn init_sanitizes_duplicate_addresses_after_normalization() {
+    fn init_rejects_unversioned_database() {
         let test_dir = TestDir::new();
         let db = NameServerDb::from_path(test_dir.db_path());
         {
@@ -471,13 +429,10 @@ mod tests {
                 .expect("duplicate rows should insert");
         }
 
-        db.init().expect("database initialization should sanitize duplicates");
-
-        let store = SqliteNameServerStore::new(db);
-        let snapshot = store.load_snapshot().expect("snapshot should load");
-
-        assert_eq!(snapshot.namesrv_addr_list, vec!["localhost:9876".to_string()]);
-        assert_eq!(snapshot.current_namesrv.as_deref(), Some("localhost:9876"));
+        assert!(matches!(
+            db.init(),
+            Err(crate::error::DashboardError::UnsupportedStorageVersion)
+        ));
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence.rs
@@ -1,0 +1,21 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod db;
+pub(crate) mod schema;
+mod types;
+
+pub(crate) use db::StorageManager;
+pub(crate) use db::open_connection;
+pub(crate) use db::resolve_data_path;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/db.rs
@@ -1,0 +1,176 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::schema;
+use super::types::StorageHealth;
+use super::types::StorageStats;
+use crate::error::DashboardError;
+use crate::error::DashboardResult;
+use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_runtime::service_context::ChildServiceContext;
+use rusqlite::Connection;
+use std::ffi::OsString;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use tauri::Manager;
+use tokio::sync::oneshot;
+
+pub(crate) fn resolve_data_path(app: &tauri::AppHandle) -> DashboardResult<PathBuf> {
+    data_path(std::env::var_os("DASHBOARD_TAURI_DATA_DIR"), || {
+        Ok(app.path().app_config_dir()?)
+    })
+}
+
+fn data_path(
+    configured: Option<OsString>,
+    default_directory: impl FnOnce() -> DashboardResult<PathBuf>,
+) -> DashboardResult<PathBuf> {
+    let directory = match configured {
+        Some(value) if value.is_empty() => {
+            return Err(DashboardError::Configuration("empty data directory".into()));
+        }
+        Some(value) => PathBuf::from(value),
+        None => default_directory()?.join("data"),
+    };
+    Ok(directory.join("dashboard.db"))
+}
+
+/// Called only at a blocking I/O boundary; connections remain inside that closure.
+pub(crate) fn open_connection(path: &Path) -> DashboardResult<Connection> {
+    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)?;
+    }
+    let connection = Connection::open(path)?;
+    connection.busy_timeout(Duration::from_secs(5))?;
+    connection.pragma_update(None, "foreign_keys", "ON")?;
+    Ok(connection)
+}
+
+#[derive(Clone)]
+pub(crate) struct StorageManager {
+    path: Arc<PathBuf>,
+    background: ChildServiceContext,
+    operations: ChildServiceContext,
+    accepting: Arc<Mutex<bool>>,
+    stats: Arc<StorageStats>,
+}
+
+/// Ownership travels into the actual blocking closure, including after an executor
+/// timeout. Shutdown must not mistake a timed-out waiter for completed disk I/O.
+struct ActiveOperation(Arc<StorageStats>);
+
+impl Drop for ActiveOperation {
+    fn drop(&mut self) {
+        self.0.active.fetch_sub(1, Ordering::AcqRel);
+        self.0.drained.notify_waiters();
+    }
+}
+
+impl StorageManager {
+    pub(crate) fn new(path: PathBuf, context: ChildServiceContext) -> Self {
+        Self {
+            path: Arc::new(path),
+            background: context.component("background"),
+            operations: context.component("operations"),
+            accepting: Arc::new(Mutex::new(true)),
+            stats: Arc::new(StorageStats::default()),
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        self.path.as_ref()
+    }
+
+    pub(crate) fn health(&self) -> StorageHealth {
+        self.stats.snapshot()
+    }
+
+    /// Accepted work is owned independently of the IPC waiter. Dropping that
+    /// waiter does not cancel a transaction that may already have committed.
+    pub(crate) async fn run<T, F>(&self, name: &'static str, operation: F) -> DashboardResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Connection) -> DashboardResult<T> + Send + 'static,
+    {
+        let (sender, receiver) = oneshot::channel();
+        {
+            let accepting = self.accepting.lock().map_err(|_| DashboardError::StorageClosed)?;
+            if !*accepting {
+                return Err(DashboardError::StorageClosed);
+            }
+            let path = self.path.clone();
+            let executor = self.operations.storage_io().clone();
+            let stats = self.stats.clone();
+            stats.active.fetch_add(1, Ordering::AcqRel);
+            let guard = ActiveOperation(stats.clone());
+            self.operations
+                .spawn_service(name, async move {
+                    let result = executor
+                        .spawn_io(name, move || {
+                            let _guard = guard;
+                            let result = open_connection(&path).and_then(|mut connection| operation(&mut connection));
+                            if result.is_ok() {
+                                stats.completed.fetch_add(1, Ordering::Relaxed);
+                            } else {
+                                stats.failed.fetch_add(1, Ordering::Relaxed);
+                            }
+                            result
+                        })
+                        .await
+                        .map_err(DashboardError::Persistence)
+                        .and_then(|result| result);
+                    let _ = sender.send(result);
+                })
+                .map_err(DashboardError::Persistence)?;
+        }
+        receiver.await.map_err(|_| DashboardError::StorageClosed)?
+    }
+
+    pub(crate) async fn initialize(&self) -> DashboardResult<()> {
+        self.run("storage-initialize", schema::initialize).await
+    }
+
+    pub(crate) async fn shutdown(&self, timeout: Duration) -> bool {
+        // Admission and registration share this lock, so no accepted operation
+        // can appear after shutdown begins draining the owned task groups.
+        match self.accepting.lock() {
+            Ok(mut accepting) => *accepting = false,
+            Err(_) => return false,
+        }
+        let deadline = ShutdownDeadline::after(timeout);
+        let background = self.background.task_group().shutdown_until(deadline).await;
+        let operations = self.operations.task_group().shutdown_until(deadline).await;
+        let drained = tokio::time::timeout_at(deadline.instant().into(), async {
+            loop {
+                let notified = self.stats.drained.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if self.stats.active.load(Ordering::Acquire) == 0 {
+                    break;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .is_ok();
+        background.is_healthy() && operations.is_healthy() && drained
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/db/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/db/tests.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use std::future::poll_fn;
+use std::task::Poll;
+use uuid::Uuid;
+
+struct Fixture {
+    directory: PathBuf,
+    owner: Option<RuntimeOwner>,
+    storage: StorageManager,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = std::env::temp_dir().join(format!("tauri-storage-{}", Uuid::new_v4()));
+        let owner = RuntimeOwner::plan(RuntimeConfig::server_default("storage-test"))
+            .unwrap()
+            .build()
+            .unwrap();
+        let storage = StorageManager::new(
+            directory.join("dashboard.db"),
+            owner.root_context().component("storage"),
+        );
+        Self {
+            directory,
+            owner: Some(owner),
+            storage,
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        if let Some(owner) = self.owner.take() {
+            let _ = owner.shutdown_runtime_blocking();
+        }
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+#[test]
+fn data_directory_override_is_explicit_and_does_not_resolve_default() {
+    assert_eq!(
+        data_path(Some(OsString::from("isolated")), || panic!(
+            "default should not be resolved"
+        ))
+        .unwrap(),
+        PathBuf::from("isolated").join("dashboard.db"),
+    );
+    assert!(data_path(Some(OsString::new()), || panic!("empty override is invalid")).is_err());
+    assert_eq!(
+        data_path(None, || Ok(PathBuf::from("default"))).unwrap(),
+        PathBuf::from("default/data/dashboard.db")
+    );
+}
+
+#[test]
+fn file_initialization_reopens_and_rejects_operations_after_shutdown() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        fixture.storage.initialize().await.unwrap();
+        fixture.storage.initialize().await.unwrap();
+        assert!(fixture.storage.path().is_file());
+        assert_eq!(fixture.storage.health().completed, 2);
+        assert!(fixture.storage.shutdown(Duration::from_secs(5)).await);
+        assert!(matches!(
+            fixture.storage.initialize().await,
+            Err(DashboardError::StorageClosed)
+        ));
+    });
+}
+
+#[test]
+fn dropping_waiter_preserves_accepted_transaction_and_shutdown_waits() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        fixture.storage.initialize().await.unwrap();
+        let (entered, entered_rx) = oneshot::channel();
+        let (release, release_rx) = std::sync::mpsc::channel();
+        let mut operation = Box::pin(fixture.storage.run("accepted-write", move |connection| {
+            let _ = entered.send(());
+            release_rx.recv().unwrap();
+            connection.execute("INSERT INTO users (username, password_hash, created_at, updated_at) VALUES ('accepted', 'hash', 'now', 'now')", [])?;
+            Ok(())
+        }));
+        tokio::select! {
+            result = &mut operation => panic!("operation completed before release: {result:?}"),
+            _ = entered_rx => {}
+        }
+        drop(operation);
+        assert_eq!(fixture.storage.health().active, 1);
+        let mut shutdown = Box::pin(fixture.storage.shutdown(Duration::from_secs(5)));
+        poll_fn(|context| {
+            assert!(shutdown.as_mut().poll(context).is_pending());
+            Poll::Ready(())
+        }).await;
+        release.send(()).unwrap();
+        assert!(shutdown.await);
+        assert_eq!(fixture.storage.health().active, 0);
+    });
+    let connection = open_connection(fixture.storage.path()).unwrap();
+    let username: String = connection
+        .query_row("SELECT username FROM users", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(username, "accepted");
+}
+
+#[test]
+fn shutdown_waits_for_owned_background_cleanup() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let cancellation = fixture.storage.background.task_group().cancellation_token();
+        let (cancelled, cancelled_rx) = oneshot::channel();
+        let (release, release_rx) = oneshot::channel();
+        fixture
+            .storage
+            .background
+            .spawn_service("cleanup", async move {
+                cancellation.cancelled().await;
+                let _ = cancelled.send(());
+                let _ = release_rx.await;
+            })
+            .unwrap();
+        let mut shutdown = Box::pin(fixture.storage.shutdown(Duration::from_secs(5)));
+        tokio::select! {
+            _ = &mut shutdown => panic!("shutdown did not await background cleanup"),
+            _ = cancelled_rx => {}
+        }
+        poll_fn(|context| {
+            assert!(shutdown.as_mut().poll(context).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+        release.send(()).unwrap();
+        assert!(shutdown.await);
+    });
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
@@ -1,0 +1,156 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::DashboardError;
+use crate::error::DashboardResult;
+use rusqlite::Connection;
+use rusqlite::TransactionBehavior;
+
+pub(crate) const SCHEMA_VERSION: i64 = 1;
+
+pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
+    // IMMEDIATE serializes competing initializers before reading the version.
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let has_schema: bool = transaction.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'dashboard_schema')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !has_schema {
+        let has_tables: bool = transaction.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name NOT LIKE 'sqlite_%')",
+            [],
+            |row| row.get(0),
+        )?;
+        if has_tables {
+            return Err(DashboardError::UnsupportedStorageVersion);
+        }
+    }
+    transaction.execute_batch(
+        "CREATE TABLE IF NOT EXISTS dashboard_schema (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            version INTEGER NOT NULL CHECK (version >= 0)
+        );
+        INSERT OR IGNORE INTO dashboard_schema (id, version) VALUES (1, 0);",
+    )?;
+    let version: i64 = transaction.query_row("SELECT version FROM dashboard_schema WHERE id = 1", [], |row| {
+        row.get(0)
+    })?;
+    if has_schema && version != SCHEMA_VERSION {
+        return Err(DashboardError::UnsupportedStorageVersion);
+    }
+    if version == 0 {
+        transaction.execute_batch(
+            "CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                must_change_password INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                last_login_at TEXT
+            );
+            CREATE TABLE IF NOT EXISTS nameserver_addresses (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                address TEXT NOT NULL UNIQUE,
+                is_current INTEGER NOT NULL DEFAULT 0,
+                sort_order INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS nameserver_settings (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                use_vip_channel INTEGER NOT NULL DEFAULT 1,
+                use_tls INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS proxy_addresses (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                address TEXT NOT NULL UNIQUE,
+                is_current INTEGER NOT NULL DEFAULT 0,
+                sort_order INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );",
+        )?;
+        transaction.execute(
+            "UPDATE dashboard_schema SET version = ?1 WHERE id = 1",
+            [SCHEMA_VERSION],
+        )?;
+    }
+    transaction.commit()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_schema_reopens_without_resetting_data() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        initialize(&mut connection).unwrap();
+        connection.execute("INSERT INTO users (username, password_hash, created_at, updated_at) VALUES ('saved', 'hash', 'created', 'updated')", []).unwrap();
+        initialize(&mut connection).unwrap();
+        let username: String = connection
+            .query_row("SELECT username FROM users", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(username, "saved");
+    }
+
+    #[test]
+    fn unsupported_database_is_rejected_without_modification() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch("CREATE TABLE old_data(value TEXT); INSERT INTO old_data VALUES ('keep');")
+            .unwrap();
+        assert!(matches!(
+            initialize(&mut connection),
+            Err(DashboardError::UnsupportedStorageVersion)
+        ));
+        let count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name = 'dashboard_schema'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+        let value: String = connection
+            .query_row("SELECT value FROM old_data", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(value, "keep");
+    }
+
+    #[test]
+    fn mismatched_version_is_rejected_without_reset() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        initialize(&mut connection).unwrap();
+        for version in [0, 99] {
+            connection
+                .execute("UPDATE dashboard_schema SET version = ?1", [version])
+                .unwrap();
+            assert!(matches!(
+                initialize(&mut connection),
+                Err(DashboardError::UnsupportedStorageVersion)
+            ));
+            let stored: i64 = connection
+                .query_row("SELECT version FROM dashboard_schema", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(stored, version);
+        }
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/types.rs
@@ -1,0 +1,43 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use tokio::sync::Notify;
+
+#[derive(Default)]
+pub(super) struct StorageStats {
+    pub(super) active: AtomicUsize,
+    pub(super) completed: AtomicU64,
+    pub(super) failed: AtomicU64,
+    pub(super) drained: Notify,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct StorageHealth {
+    pub(crate) active: usize,
+    pub(crate) completed: u64,
+    pub(crate) failed: u64,
+}
+
+impl StorageStats {
+    pub(super) fn snapshot(&self) -> StorageHealth {
+        StorageHealth {
+            active: self.active.load(Ordering::Acquire),
+            completed: self.completed.load(Ordering::Relaxed),
+            failed: self.failed.load(Ordering::Relaxed),
+        }
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/db.rs
@@ -21,25 +21,9 @@ use rusqlite::Connection;
 use rusqlite::OptionalExtension;
 use rusqlite::Transaction;
 use rusqlite::params;
-use std::fs;
 #[cfg(test)]
 use std::path::Path;
 use std::path::PathBuf;
-use std::time::Duration;
-use tauri::AppHandle;
-use tauri::Manager;
-
-const DB_FILE_NAME: &str = "dashboard.db";
-const PROXY_ADDRESSES_TABLE_SCHEMA: &str = "
-    CREATE TABLE IF NOT EXISTS proxy_addresses (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        address TEXT NOT NULL UNIQUE,
-        is_current INTEGER NOT NULL DEFAULT 0,
-        sort_order INTEGER NOT NULL DEFAULT 0,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-    );
-";
 
 #[derive(Debug, Clone)]
 pub(crate) struct ProxyDb {
@@ -47,11 +31,6 @@ pub(crate) struct ProxyDb {
 }
 
 impl ProxyDb {
-    pub(crate) fn new(app: &AppHandle) -> Result<Self> {
-        let app_config_dir = app.path().app_config_dir()?;
-        Ok(Self::from_path(app_config_dir.join(DB_FILE_NAME)))
-    }
-
     pub(crate) fn from_path(db_path: impl Into<PathBuf>) -> Self {
         Self {
             db_path: db_path.into(),
@@ -65,8 +44,8 @@ impl ProxyDb {
 
     pub(crate) fn init(&self) -> Result<()> {
         let mut connection = self.connection()?;
+        crate::persistence::schema::initialize(&mut connection)?;
         let transaction = connection.transaction()?;
-        transaction.execute_batch(PROXY_ADDRESSES_TABLE_SCHEMA)?;
         sanitize_proxy_rows(&transaction)?;
         repair_proxy_rows(&transaction)?;
         transaction.commit()?;
@@ -74,11 +53,7 @@ impl ProxyDb {
     }
 
     pub(crate) fn connection(&self) -> Result<Connection> {
-        self.ensure_parent_dir()?;
-
-        let connection = Connection::open(&self.db_path)?;
-        connection.busy_timeout(Duration::from_secs(5))?;
-        Ok(connection)
+        crate::persistence::open_connection(&self.db_path)
     }
 
     pub(crate) fn load_snapshot(&self) -> Result<ProxyConfigSnapshot> {
@@ -100,14 +75,6 @@ impl ProxyDb {
         save_snapshot_to_transaction(&transaction, &snapshot)?;
         transaction.commit()?;
         Ok(snapshot)
-    }
-
-    fn ensure_parent_dir(&self) -> Result<()> {
-        if let Some(parent) = self.db_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        Ok(())
     }
 }
 
@@ -321,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn init_sanitizes_duplicate_addresses_after_normalization() {
+    fn init_rejects_unversioned_database() {
         let test_dir = TestDir::new();
         let db = ProxyDb::from_path(test_dir.db_path());
         {
@@ -351,12 +318,10 @@ mod tests {
                 .expect("duplicate rows should insert");
         }
 
-        db.init().expect("database initialization should sanitize duplicates");
-
-        let snapshot = db.load_snapshot().expect("snapshot should load");
-
-        assert_eq!(snapshot.proxy_addr_list, vec!["localhost:8080".to_string()]);
-        assert_eq!(snapshot.current_proxy_addr.as_deref(), Some("localhost:8080"));
+        assert!(matches!(
+            db.init(),
+            Err(crate::error::DashboardError::UnsupportedStorageVersion)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10357

### Brief Description

Start the Tauri dashboard with a fresh versioned SQLite database in the application configuration directory's `data` subdirectory, or in `DASHBOARD_TAURI_DATA_DIR`. Accounts and connection configuration share one path and schema initializer. Unversioned and unsupported databases are rejected without migration or deletion, following the maintainer's selected storage scope.

The private StorageManager routes startup and accepted storage work through the runtime's StorageIo lane. Abandoning a waiter does not cancel an accepted transaction. Shutdown closes admission, waits for background cleanup and accepted disk work, and then closes admin sessions. Update the storage documentation and synchronize the standalone lockfile with the existing workspace dependency requirements.

### How Did You Test This Change?

From `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri`:

- `cargo test --lib persistence -- --nocapture`: 7 passed, including fresh initialization, unsupported schemas, abandoned waiters, and shutdown cleanup.
- `cargo test --lib auth::`: 14 passed.
- `cargo test --lib nameserver::db::`: 3 passed.
- `cargo test --lib proxy::db::`: 3 passed.
- `cargo test --lib error::tests`: 5 passed.
- `cargo fmt -p rocketmq-dashboard-tauri -- --check`: passed.
- `git diff --check`: passed.

The standalone `cargo fmt --all -- --check` command exceeds Windows command-line length when expanding path dependencies; package-scoped formatting was used. Full desktop and cluster acceptance remains part of the final integration run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added centralized, versioned database storage for authentication, nameserver, proxy, and dashboard configuration.
  - Added support for custom data locations through the `DASHBOARD_TAURI_DATA_DIR` environment variable.
  - Added validation that rejects empty, unversioned, or unsupported databases without modifying existing data.
  - Improved startup and shutdown handling to wait for active storage operations to complete.

- **Documentation**
  - Updated storage locations, platform-specific paths, configuration overrides, schema details, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->