### PR TITLE
[ISSUE #10356]✨Add a local RocketMQ Rust cluster for Tauri debugging

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/README.md
@@ -1,0 +1,87 @@
+# Local RocketMQ Rust debugging cluster
+
+This Compose project runs **RocketMQ Rust binaries**, using the repository's
+`rocketmq-rust/namesrv:local`, `rocketmq-rust/broker:local`, and
+`rocketmq-rust/proxy:local` images. It contains one NameServer, two independent
+master Brokers, and a Proxy with remoting and gRPC enabled. It does not provide
+replication or failover. Use it for desktop integration and partial-result tests.
+
+## Start
+
+Docker Desktop must use Linux containers. Build images from the latest local
+source at the repository root using the existing Dockerfile (the initial build
+compiles the Rust services and can take substantial time):
+
+```powershell
+$debugSourceRevision = git rev-parse HEAD
+foreach ($debugTarget in @('broker', 'namesrv', 'proxy', 'fault-driver')) {
+    docker build -f docker/Dockerfile.base --build-arg "SOURCE_REVISION=$debugSourceRevision" `
+        --target $debugTarget -t "rocketmq-rust/${debugTarget}:local" .
+    if ($LASTEXITCODE -ne 0) { throw "Build failed: $debugTarget" }
+}
+```
+
+From this directory:
+
+```powershell
+docker compose config --quiet
+docker compose up -d --wait --wait-timeout 120
+docker compose ps
+```
+
+Readiness checks use each service's `/readyz` endpoint. Logs are rotated and
+service data uses separate named volumes. All published ports bind to host
+loopback; this is an unauthenticated local debugging fixture. ACL and TLS require
+a separately configured secured fixture before claiming authentication coverage.
+
+| Desktop setting | Address |
+| --- | --- |
+| NameServer | `127.0.0.1:9876` |
+| Broker A | `127.0.0.1:10911` |
+| Broker B | `127.0.0.1:11911` |
+| Proxy remoting | `127.0.0.1:8080` |
+| Proxy gRPC | `127.0.0.1:8081` |
+| Readiness (NameServer / A / B / Proxy) | `18088` / `18090` / `18092` / `18091` |
+
+Disable VIP and TLS in the desktop connection settings for this fixture.
+Services share the NameServer network namespace, so the loopback Broker routes
+work both inside Docker and from the desktop. Recreate the full project with
+`docker compose up -d --force-recreate --wait` when changing the NameServer's
+network settings. Existing unrelated containers are not part of this project.
+
+## Exercise real administration and messages
+
+The Rust admin CLI image can run in the same namespace. In PowerShell:
+
+```powershell
+function Invoke-DebugAdmin {
+    docker run --rm --network container:rocketmq-tauri-debug-namesrv-1 `
+        -e NAMESRV_ADDR=127.0.0.1:9876 rocketmq-rust/fault-driver:local @args
+    if ($LASTEXITCODE -ne 0) { throw 'Rust admin command failed' }
+}
+Invoke-DebugAdmin cluster clusterList
+Invoke-DebugAdmin topic updateTopic -n 127.0.0.1:9876 -c TauriDebugCluster -t TauriDebugSmoke -r 4 -w 4 -y
+Invoke-DebugAdmin topic topicRoute -n 127.0.0.1:8080 -t TauriDebugSmoke
+Invoke-DebugAdmin message sendMessage -t TauriDebugSmoke -p rocketmq-rust-tauri-smoke -b tauri-broker-a -i 0
+Invoke-DebugAdmin message sendMessage -t TauriDebugSmoke -p rocketmq-rust-tauri-smoke-b -b tauri-broker-b -i 0
+Invoke-DebugAdmin message queryMsgByOffset -t TauriDebugSmoke -b tauri-broker-a -i 0 -o 0
+Invoke-DebugAdmin message queryMsgByOffset -t TauriDebugSmoke -b tauri-broker-b -i 0 -o 0
+```
+
+Expect both Brokers in the cluster and Proxy route response, `SEND_OK` from
+each send, and the sent bodies in the read responses. On subsequent runs, offset
+zero reads the first retained message; sending appends additional messages.
+This checks remoting administration and basic message storage, not gRPC clients,
+ACL, consumer processing, scheduled messages, or failover.
+
+## Stop and inspect
+
+```powershell
+docker compose logs --tail 50
+docker compose stop
+docker compose start --wait
+docker compose down
+```
+
+`down` keeps the named volumes. Only when intentionally discarding this fixture's
+messages and configuration, run `docker compose down --volumes`.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/broker-a.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/broker-a.toml
@@ -1,0 +1,23 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+[broker]
+listenPort = 10911
+brokerIp1 = "127.0.0.1"
+storePathRootDir = "/var/lib/rocketmq/broker"
+namesrvAddr = "127.0.0.1:9876"
+autoCreateTopicEnable = false
+
+[broker.brokerIdentity]
+brokerName = "tauri-broker-a"
+brokerClusterName = "TauriDebugCluster"
+brokerId = 0
+
+[store]
+storePathRootDir = "/var/lib/rocketmq/broker"
+haListenPort = 10912
+mappedFileSizeCommitLog = 67108864
+mappedFileSizeConsumeQueue = 6000
+mappedFileSizeConsumeQueueExt = 65536
+maxHashSlotNum = 1000
+maxIndexNum = 4000
+timerWheelEnable = false

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/broker-b.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/broker-b.toml
@@ -1,0 +1,23 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+[broker]
+listenPort = 11911
+brokerIp1 = "127.0.0.1"
+storePathRootDir = "/var/lib/rocketmq/broker"
+namesrvAddr = "127.0.0.1:9876"
+autoCreateTopicEnable = false
+
+[broker.brokerIdentity]
+brokerName = "tauri-broker-b"
+brokerClusterName = "TauriDebugCluster"
+brokerId = 0
+
+[store]
+storePathRootDir = "/var/lib/rocketmq/broker"
+haListenPort = 11912
+mappedFileSizeCommitLog = 67108864
+mappedFileSizeConsumeQueue = 6000
+mappedFileSizeConsumeQueueExt = 65536
+maxHashSlotNum = 1000
+maxIndexNum = 4000
+timerWheelEnable = false

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/compose.yaml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/compose.yaml
@@ -1,0 +1,98 @@
+name: rocketmq-tauri-debug
+
+x-common: &common
+  stop_grace_period: 60s
+  logging:
+    driver: json-file
+    options:
+      max-size: "10m"
+      max-file: "3"
+  healthcheck:
+    test:
+      - CMD
+      - bash
+      - -c
+      - 'exec 3<>/dev/tcp/127.0.0.1/$${ROCKETMQ_HEALTH_BIND_ADDR##*:}; printf "GET /readyz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3; read -r status <&3; [[ "$$status" == *" 200 "* ]]'
+    interval: 5s
+    timeout: 3s
+    retries: 20
+    start_period: 10s
+
+services:
+  namesrv:
+    <<: *common
+    image: rocketmq-rust/namesrv:local
+    command: [--configFile, /etc/rocketmq/namesrv.toml]
+    environment:
+      RUST_LOG: info
+      ROCKETMQ_HEALTH_BIND_ADDR: 0.0.0.0:18088
+    volumes:
+      - ./namesrv.toml:/etc/rocketmq/namesrv.toml:ro
+      - namesrv-data:/var/lib/rocketmq
+    # Share this network namespace so advertised loopback routes work both
+    # between services and from the desktop through published ports.
+    ports:
+      - "127.0.0.1:9876:9876"
+      - "127.0.0.1:10911:10911"
+      - "127.0.0.1:10912:10912"
+      - "127.0.0.1:11911:11911"
+      - "127.0.0.1:11912:11912"
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:8081:8081"
+      - "127.0.0.1:18088:18088"
+      - "127.0.0.1:18090:18090"
+      - "127.0.0.1:18091:18091"
+      - "127.0.0.1:18092:18092"
+
+  broker-a:
+    <<: *common
+    image: rocketmq-rust/broker:local
+    network_mode: service:namesrv
+    depends_on:
+      namesrv:
+        condition: service_healthy
+    command: [--configFile, /etc/rocketmq/broker.toml]
+    environment:
+      RUST_LOG: info
+      ROCKETMQ_HEALTH_BIND_ADDR: 0.0.0.0:18090
+    volumes:
+      - ./broker-a.toml:/etc/rocketmq/broker.toml:ro
+      - broker-a-data:/var/lib/rocketmq
+
+  broker-b:
+    <<: *common
+    image: rocketmq-rust/broker:local
+    network_mode: service:namesrv
+    depends_on:
+      namesrv:
+        condition: service_healthy
+    command: [--configFile, /etc/rocketmq/broker.toml]
+    environment:
+      RUST_LOG: info
+      ROCKETMQ_HEALTH_BIND_ADDR: 0.0.0.0:18092
+    volumes:
+      - ./broker-b.toml:/etc/rocketmq/broker.toml:ro
+      - broker-b-data:/var/lib/rocketmq
+
+  proxy:
+    <<: *common
+    image: rocketmq-rust/proxy:local
+    network_mode: service:namesrv
+    depends_on:
+      broker-a:
+        condition: service_healthy
+      broker-b:
+        condition: service_healthy
+    command: [--config, /etc/rocketmq/proxy.toml]
+    environment:
+      RUST_LOG: info
+      ROCKETMQ_HEALTH_BIND_ADDR: 0.0.0.0:18091
+    volumes:
+      - ./proxy.toml:/etc/rocketmq/proxy.toml:ro
+      - proxy-data:/var/lib/rocketmq
+
+volumes:
+  namesrv-data:
+  broker-a-data:
+  broker-b-data:
+  proxy-data:

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/namesrv.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/namesrv.toml
@@ -1,0 +1,6 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+rocketmqHome = "/var/lib/rocketmq/namesrv"
+kvConfigPath = "/var/lib/rocketmq/namesrv/kvConfig.json"
+configStorePath = "/var/lib/rocketmq/namesrv/namesrv.properties"
+needWaitForService = false

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/proxy.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/proxy.toml
@@ -11,3 +11,9 @@ listenAddr = "0.0.0.0:8080"
 
 [cluster]
 namesrvAddr = "127.0.0.1:9876"
+brokerClusterName = "TauriDebugCluster"
+
+[auth]
+# Proxy bootstrap uses this cluster for metadata discovery even with ACL off.
+clusterName = "TauriDebugCluster"
+authConfigPath = "/var/lib/rocketmq/proxy/auth"

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/proxy.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/proxy.toml
@@ -1,0 +1,13 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+mode = "cluster"
+
+[grpc]
+listenAddr = "0.0.0.0:8081"
+
+[remoting]
+enabled = true
+listenAddr = "0.0.0.0:8080"
+
+[cluster]
+namesrvAddr = "127.0.0.1:9876"


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10356

### Brief Description

Add an isolated Docker Compose debugging cluster for the Tauri dashboard: one RocketMQ Rust NameServer, two independent master Brokers, and a Rust Proxy with remoting and gRPC listeners. Build the images from local repository source using the existing Dockerfile. Bind published ports to host loopback, persist service data in separate volumes, rotate logs, and wait for application readiness.

Shared networking makes advertised loopback Broker addresses reachable from both the desktop and other services. Set the Proxy's cluster and authentication metadata cluster consistently. Document builds, connection settings, real message checks, and lifecycle commands. This fixture provides no replication, failover, ACL, or TLS coverage.

### How Did You Test This Change?

- Built the Broker, NameServer, and Proxy images from the current local Rust source with `docker/Dockerfile.base`.
- `docker compose config --quiet`: passed.
- `docker compose up -d --wait --wait-timeout 120`: all four services healthy.
- Issued real RocketMQ remoting requests from the Windows host: both Broker registrations were present; created a fresh topic on both Brokers; each send returned success; pulled and verified both stored message bodies; Proxy route discovery returned both Brokers.
- `git diff --check`: passed.

The supplemental Rust fault-driver image build is still running; its documented CLI walkthrough has not yet been repeated against these rebuilt services. gRPC client and secured-cluster scenarios remain separate integration work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Docker Compose development environment for RocketMQ Dashboard’s Tauri deployment.
  - Includes a NameServer, two brokers, and a Proxy with remoting and gRPC access.
  - Added persistent service storage, health checks, readiness checks, and local service endpoints.
  - Added configurations for broker, NameServer, and Proxy services.
  - Added documentation covering startup, administration, message operations, inspection, and shutdown procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->