### PR TITLE
[ISSUE #10362]🚀Persist Tauri sessions with expiry and account revocation

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
@@ -13,7 +13,7 @@ A RocketMQ-Rust desktop dashboard built with Tauri, React, and Rust.
 - Local embedded authentication with SQLite
 - Argon2 password hashing
 - Forced bootstrap password change on first login
-- In-memory session management with session restore while the backend process remains alive
+- Persistent sessions with fixed expiry, restart restoration, and account-wide revocation
 
 ## Authentication Quick Start
 
@@ -41,6 +41,10 @@ addresses from the previous unversioned database, which remains untouched at its
 old location. The new database bootstraps the administrator as described above.
 Unversioned or unsupported databases are rejected without deleting or rebuilding
 them; choose a new data directory to start fresh.
+
+Sessions expire after eight hours by default (`DASHBOARD_TAURI_SESSION_TTL_SECS` overrides this). Password changes revoke all sessions and require a new login. Account ¡ú Sessions lists safe identifiers and can sign out the entire account.
+
+The current fresh schema is version 2; version 1 development databases are not migrated. Select a new data directory when changing from an older format.
 
 For more detail, see [doc/AUTH_CONFIG.md](./doc/AUTH_CONFIG.md).
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUTH_CONFIG.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUTH_CONFIG.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The RocketMQ Dashboard Tauri application now uses a local embedded SQLite database for authentication.
-The backend stores users in `dashboard.db`, hashes passwords with Argon2, and keeps login sessions in memory.
+The backend stores users in `dashboard.db`, hashes passwords with Argon2, and persists SHA-256 login token digests in the same database.
 
 ## Default Administrator Bootstrap
 
@@ -50,7 +50,7 @@ them; choose a new data directory to start fresh.
 
 ## Schema
 
-The versioned database contains `dashboard_schema`, `users`, and connection configuration tables. The account table is:
+Schema version 2 contains `dashboard_schema`, `users`, `sessions`, and connection configuration tables. Version 1 development databases are not migrated; select a new data directory. The account table is:
 
 ```sql
 CREATE TABLE IF NOT EXISTS users (
@@ -67,11 +67,14 @@ CREATE TABLE IF NOT EXISTS users (
 
 ## Session Behavior
 
-- Sessions are stored only in process memory.
-- Session restore works while the Tauri backend process is still alive.
-- Restarting the desktop application clears all active sessions.
-
-This is intentional for the first version to keep the design simple and reduce local attack surface.
+- Sessions survive application restarts while their account is active and the session is neither expired nor revoked.
+- The default absolute lifetime is **8 hours**. Set `DASHBOARD_TAURI_SESSION_TTL_SECS` before launch to override it (1 to 31,536,000 seconds). Invalid values prevent startup.
+- Authorization reads the database and updates last-seen time without extending expiry. First-login sessions can change their password but cannot run business commands or manage sessions.
+- Login returns a random bearer token. SQLite stores only its SHA-256 digest and a separate random safe session ID; lists and logs never expose the bearer or digest. The frontend retains the bearer in localStorage to restore the session after restart.
+- **Changing a password revokes every existing session, including the current one. Sign in again with the new password.** Password update and revocation commit together. Concurrent logins must still match the current password hash when creating their session.
+- Account ¡ú Sessions shows creation, expiry, last visit, revocation, and current-session status with cursor pagination. Management is limited to the signed-in account; the username parameter cannot grant cross-account access. There is no local role system.
+- Signing out all sessions clears the current frontend token and returns to login. Ordinary business commands do the same when the backend reports an invalid session; late errors from an old token do not clear a newer login.
+- An application-owned cleanup runs at startup and hourly, deleting at most 500 records expired or revoked at least seven days ago per pass. Authorization rejects invalid records immediately, independent of cleanup progress. Shutdown cancels the timer and waits for accepted storage work.
 
 ## Resetting Local Authentication
 
@@ -87,7 +90,7 @@ Deleting this shared database resets the administrator and saved NameServer/Prox
 - Password hashing uses Argon2.
 - SQLite access uses parameterized queries through `rusqlite`.
 - The default admin password should be changed immediately.
-- Multi-user support, RBAC, lockout policy, and persistent session storage are not part of this first version.
+- Multi-user provisioning, RBAC, and lockout policy are not implemented.
 
 ## Tauri Commands
 
@@ -98,6 +101,9 @@ The backend currently exposes these authentication commands:
 - `restore_session`
 - `change_password`
 - `get_auth_bootstrap_status`
+- `get_current_user_profile`
+- `list_sessions`
+- `revoke_user_sessions`
 
 ## Verification
 
@@ -105,11 +111,12 @@ Backend tests:
 
 ```bash
 cd src-tauri
-cargo test
+cargo test --lib auth::
 ```
 
 Frontend build:
 
 ```bash
 npm run build
+npm test -- src/services/auth-session.test.ts src/services/invoke.test.ts
 ```

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -3839,6 +3839,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tauri",
  "tauri-build",
  "tauri-plugin-log",

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ tauri-plugin-log = "2.9"
 rusqlite         = { version = "0.32", features = ["bundled"] }
 argon2           = "0.5"
 password-hash    = "0.5"
+sha2             = "0.11"
 rand_core        = { version = "0.6", features = ["getrandom"] }
 uuid             = { version = "1", features = ["v4", "serde"] }
 chrono           = { version = "0.4", features = ["serde"] }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/commands.rs
@@ -12,247 +12,85 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::auth::service::AuthService;
-use crate::auth::session::SessionState;
-use crate::auth::types::AuthSessionResponse;
-use crate::auth::types::BootstrapStatus;
-use crate::auth::types::CommonResponse;
-use crate::auth::types::SessionUser;
-use crate::auth::types::UserProfile;
+use super::SessionState;
+use super::types::{
+    AuthSessionResponse, BootstrapStatus, CommonResponse, RevokeSessionsResponse, SessionPage, UserProfile,
+};
 use crate::error::CommandResult;
-use crate::error::DashboardError;
-use crate::error::DashboardResult;
 use tauri::State;
 
-fn load_current_user_profile(
-    session_id: &str,
-    auth_service: &AuthService,
-    session_state: &SessionState,
-) -> DashboardResult<UserProfile> {
-    let session = session_state.require_session(session_id)?;
-    match auth_service.get_user_profile(session.user_id)? {
-        Some(profile) if profile.is_active => Ok(profile),
-        _ => {
-            session_state.remove_session(session_id);
-            Err(DashboardError::Unauthenticated)
-        }
-    }
-}
-
-fn login_user(
-    username: &str,
-    password: &str,
-    auth_service: &AuthService,
-    session_state: &SessionState,
-) -> DashboardResult<AuthSessionResponse> {
-    let user = auth_service.authenticate(username, password)?;
-    auth_service.update_last_login(user.id)?;
-    let session = session_state.create_session(&user);
-
-    Ok(AuthSessionResponse {
-        session_id: session.session_id.clone(),
-        current_user: session,
-    })
-}
-
 #[tauri::command]
-pub fn login(
+pub async fn login(
     username: String,
     password: String,
-    auth_service: State<'_, AuthService>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<AuthSessionResponse> {
-    login_user(&username, &password, auth_service.inner(), session_state.inner()).map_err(Into::into)
+    session_state.login(username, password).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn logout(session_id: String, session_state: State<'_, SessionState>) -> CommandResult<CommonResponse> {
-    session_state
-        .require_session(&session_id)
-        .map_err(crate::error::CommandError::from)?;
-    session_state.remove_session(&session_id);
+pub async fn logout(session_id: String, session_state: State<'_, SessionState>) -> CommandResult<CommonResponse> {
+    session_state.logout(session_id).await?;
     Ok(CommonResponse {
-        message: "Logged out successfully".to_string(),
+        message: "Logged out successfully".into(),
     })
 }
 
-fn restore_user_session(
-    session_id: &str,
-    auth_service: &AuthService,
-    session_state: &SessionState,
-) -> DashboardResult<AuthSessionResponse> {
-    let session = session_state.require_session(session_id)?;
-    match auth_service.find_user_by_id(session.user_id)? {
-        Some(user) if user.is_active => {
-            let refreshed_session = SessionUser {
-                session_id: session.session_id,
-                user_id: user.id,
-                username: user.username,
-                must_change_password: user.must_change_password,
-                created_at: session.created_at,
-            };
-            session_state.upsert_session(refreshed_session.clone());
-            Ok(AuthSessionResponse {
-                session_id: refreshed_session.session_id.clone(),
-                current_user: refreshed_session,
-            })
-        }
-        _ => {
-            session_state.remove_session(session_id);
-            Err(DashboardError::Unauthenticated)
-        }
-    }
-}
-
 #[tauri::command]
-pub fn restore_session(
+pub async fn restore_session(
     session_id: String,
-    auth_service: State<'_, AuthService>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<AuthSessionResponse> {
-    restore_user_session(&session_id, auth_service.inner(), session_state.inner()).map_err(Into::into)
-}
-
-fn change_user_password(
-    session_id: &str,
-    old_password: &str,
-    new_password: &str,
-    auth_service: &AuthService,
-    session_state: &SessionState,
-) -> DashboardResult<CommonResponse> {
-    let session = session_state.require_session(session_id)?;
-    auth_service.change_password(session.user_id, old_password, new_password)?;
-    session_state.mark_password_changed(session_id);
-    Ok(CommonResponse {
-        message: "Password updated successfully".to_string(),
-    })
+    session_state.restore(session_id).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn change_password(
+pub async fn change_password(
     session_id: String,
     old_password: String,
     new_password: String,
-    auth_service: State<'_, AuthService>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<CommonResponse> {
-    change_user_password(
-        &session_id,
-        &old_password,
-        &new_password,
-        auth_service.inner(),
-        session_state.inner(),
-    )
-    .map_err(Into::into)
+    session_state
+        .change_password(session_id, old_password, new_password)
+        .await?;
+    Ok(CommonResponse {
+        message: "Password updated. All sessions were revoked; sign in again.".into(),
+    })
 }
 
 #[tauri::command]
-pub fn get_current_user_profile(
+pub async fn get_current_user_profile(
     session_id: String,
-    auth_service: State<'_, AuthService>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<UserProfile> {
-    load_current_user_profile(&session_id, auth_service.inner(), session_state.inner()).map_err(Into::into)
+    session_state.profile(session_id).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn get_auth_bootstrap_status(auth_service: State<'_, AuthService>) -> CommandResult<BootstrapStatus> {
-    auth_service.get_bootstrap_status().map_err(Into::into)
+pub async fn get_auth_bootstrap_status(session_state: State<'_, SessionState>) -> CommandResult<BootstrapStatus> {
+    session_state.bootstrap_status().await.map_err(Into::into)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::load_current_user_profile;
-    use super::login_user;
-    use super::restore_user_session;
-    use crate::auth::db::AuthDb;
-    use crate::auth::service::AuthService;
-    use crate::auth::session::SessionState;
-    use crate::error::CommandError;
-    use std::env;
-    use std::fs;
-    use std::path::PathBuf;
-    use uuid::Uuid;
+#[tauri::command]
+pub async fn list_sessions(
+    session_id: String,
+    username: Option<String>,
+    cursor: Option<String>,
+    limit: Option<usize>,
+    session_state: State<'_, SessionState>,
+) -> CommandResult<SessionPage> {
+    session_state
+        .list(session_id, username, cursor, limit)
+        .await
+        .map_err(Into::into)
+}
 
-    struct TestDir {
-        path: PathBuf,
-    }
-
-    impl TestDir {
-        fn new() -> Self {
-            let path = env::temp_dir().join(format!(
-                "rocketmq-dashboard-tauri-auth-command-tests-{}",
-                Uuid::new_v4()
-            ));
-            fs::create_dir_all(&path).expect("failed to create test directory");
-            Self { path }
-        }
-
-        fn db_path(&self) -> PathBuf {
-            self.path.join("dashboard.db")
-        }
-    }
-
-    impl Drop for TestDir {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.path);
-        }
-    }
-
-    struct TestContext {
-        _test_dir: TestDir,
-        auth_service: AuthService,
-        session_state: SessionState,
-    }
-
-    fn setup_context() -> TestContext {
-        let test_dir = TestDir::new();
-        let db = AuthDb::from_path(test_dir.db_path());
-        db.init().expect("database initialization should succeed");
-        let auth_service = AuthService::with_initial_password(db, "change-me-now");
-        auth_service
-            .bootstrap_default_admin()
-            .expect("bootstrap should succeed");
-
-        TestContext {
-            _test_dir: test_dir,
-            auth_service,
-            session_state: SessionState::default(),
-        }
-    }
-
-    #[test]
-    fn auth_command_matrix_enforces_session_and_password_state() {
-        let context = setup_context();
-        let missing = load_current_user_profile("missing", &context.auth_service, &context.session_state)
-            .expect_err("missing session should fail");
-        assert_eq!(CommandError::from(missing).code, "auth.session.invalid");
-
-        let login = login_user("admin", "change-me-now", &context.auth_service, &context.session_state)
-            .expect("authentication should succeed");
-        assert!(context.session_state.authorize_dashboard(&login.session_id).is_err());
-
-        context.session_state.mark_password_changed(&login.session_id);
-        assert!(context.session_state.authorize_dashboard(&login.session_id).is_ok());
-        assert!(load_current_user_profile(&login.session_id, &context.auth_service, &context.session_state).is_ok());
-    }
-
-    #[test]
-    fn authentication_failure_uses_structured_redacted_error() {
-        let context = setup_context();
-        let error = login_user("admin", "wrong-password", &context.auth_service, &context.session_state)
-            .expect_err("invalid credentials should fail");
-        let public = CommandError::from(error);
-
-        assert_eq!(public.code, "auth.credentials.invalid");
-        assert_eq!(public.message, "Authentication failed.");
-    }
-
-    #[test]
-    fn restoring_unknown_session_is_an_error() {
-        let context = setup_context();
-        let error = restore_user_session("missing", &context.auth_service, &context.session_state)
-            .expect_err("unknown session should fail");
-        assert_eq!(CommandError::from(error).code, "auth.session.invalid");
-    }
+#[tauri::command]
+pub async fn revoke_user_sessions(
+    session_id: String,
+    username: String,
+    session_state: State<'_, SessionState>,
+) -> CommandResult<RevokeSessionsResponse> {
+    session_state.revoke(session_id, username).await.map_err(Into::into)
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/service.rs
@@ -126,37 +126,6 @@ impl AuthService {
         Ok(user)
     }
 
-    pub(crate) fn change_password(&self, user_id: i64, old_password: &str, new_password: &str) -> AuthResult<()> {
-        let user = self
-            .find_user_by_id(user_id)?
-            .ok_or_else(|| DashboardError::Authentication("user not found".to_string()))?;
-
-        if !verify_password(old_password, &user.password_hash)? {
-            return Err(DashboardError::Authentication(
-                "current password is incorrect".to_string(),
-            ));
-        }
-
-        validate_new_password(old_password, new_password)?;
-
-        let new_password_hash = hash_password(new_password)?;
-        let now = Utc::now().to_rfc3339();
-        let connection = self.db.connection()?;
-
-        connection.execute(
-            "
-            UPDATE users
-            SET password_hash = ?1,
-                must_change_password = 0,
-                updated_at = ?2
-            WHERE id = ?3
-            ",
-            params![new_password_hash, now, user_id],
-        )?;
-
-        Ok(())
-    }
-
     pub(crate) fn find_user_by_id(&self, user_id: i64) -> AuthResult<Option<UserRecord>> {
         let connection = self.db.connection()?;
         connection
@@ -174,6 +143,7 @@ impl AuthService {
             .map_err(Into::into)
     }
 
+    #[cfg(test)]
     pub(crate) fn update_last_login(&self, user_id: i64) -> AuthResult<()> {
         let connection = self.db.connection()?;
         let now = Utc::now().to_rfc3339();
@@ -245,7 +215,7 @@ pub(crate) fn verify_password(password: &str, hash: &str) -> AuthResult<bool> {
     }
 }
 
-fn validate_new_password(old_password: &str, new_password: &str) -> AuthResult<()> {
+pub(crate) fn validate_new_password(old_password: &str, new_password: &str) -> AuthResult<()> {
     if new_password.len() < MIN_PASSWORD_LENGTH {
         return Err(DashboardError::Validation(format!(
             "New password must be at least {MIN_PASSWORD_LENGTH} characters long"
@@ -358,31 +328,6 @@ mod tests {
         assert!(first.created);
         assert!(!second.created);
         assert!(second.has_default_admin);
-    }
-
-    #[test]
-    fn login_and_change_password_flow_updates_flags() {
-        let context = setup_service("change-me-now");
-        let service = &context.service;
-        service.bootstrap_default_admin().expect("bootstrap should succeed");
-
-        let user = service
-            .authenticate("admin", "change-me-now")
-            .expect("login should succeed");
-        assert!(user.must_change_password);
-
-        service
-            .change_password(user.id, "change-me-now", "better-secret")
-            .expect("password change should succeed");
-
-        assert!(service.authenticate("admin", "better-secret").is_ok());
-        assert!(service.authenticate("admin", "change-me-now").is_err());
-
-        let updated_user = service
-            .find_user_by_id(user.id)
-            .expect("lookup should succeed")
-            .expect("user should exist");
-        assert!(!updated_user.must_change_password);
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session.rs
@@ -12,134 +12,350 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::auth::types::SessionUser;
-use crate::auth::types::UserRecord;
-use crate::error::DashboardError;
-use crate::error::DashboardResult;
+use super::service::{AuthService, hash_password, validate_new_password, verify_password};
+use super::types::{
+    AuthSessionResponse, BootstrapStatus, RevokeSessionsResponse, SessionPage, SessionUser, SessionView, UserProfile,
+};
+use crate::error::{DashboardError, DashboardResult};
+use crate::persistence::StorageManager;
 use chrono::Utc;
-use std::collections::HashMap;
-use std::sync::Mutex;
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::time::Duration;
 use uuid::Uuid;
 
-#[derive(Debug, Default)]
+const DEFAULT_TTL_SECS: i64 = 8 * 60 * 60;
+const RETENTION_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+const CLEANUP_BATCH: i64 = 500;
+
+#[derive(Clone)]
 pub(crate) struct SessionState {
-    sessions: Mutex<HashMap<String, SessionUser>>,
+    storage: StorageManager,
+    auth: AuthService,
+    ttl_ms: i64,
+    clock: Arc<dyn Fn() -> i64 + Send + Sync>,
 }
 
 impl SessionState {
-    pub(crate) fn create_session(&self, user: &UserRecord) -> SessionUser {
-        let session_user = SessionUser {
-            session_id: Uuid::new_v4().to_string(),
-            user_id: user.id,
-            username: user.username.clone(),
-            must_change_password: user.must_change_password,
-            created_at: Utc::now().to_rfc3339(),
-        };
-
-        let mut sessions = self.sessions.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        sessions.insert(session_user.session_id.clone(), session_user.clone());
-        session_user
+    pub(crate) fn new(storage: StorageManager, auth: AuthService) -> DashboardResult<Self> {
+        let configured = std::env::var("DASHBOARD_TAURI_SESSION_TTL_SECS")
+            .map(Some)
+            .or_else(|error| match error {
+                std::env::VarError::NotPresent => Ok(None),
+                _ => Err(DashboardError::Configuration("invalid session TTL".into())),
+            })?;
+        Ok(Self {
+            storage,
+            auth,
+            ttl_ms: ttl_millis(configured.as_deref())?,
+            clock: Arc::new(|| Utc::now().timestamp_millis()),
+        })
     }
 
-    pub(crate) fn get_session(&self, session_id: &str) -> Option<SessionUser> {
-        let sessions = self.sessions.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        sessions.get(session_id).cloned()
+    pub(crate) fn start_cleanup(&self) -> DashboardResult<()> {
+        let service = self.clone();
+        self.storage.start_background("session-cleanup", async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60 * 60));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                if service.cleanup().await.is_err() {
+                    log::warn!("Session retention cleanup could not complete");
+                }
+            }
+        })
     }
 
-    pub(crate) fn require_session(&self, session_id: &str) -> DashboardResult<SessionUser> {
-        self.get_session(session_id).ok_or(DashboardError::Unauthenticated)
+    async fn cleanup(&self) -> DashboardResult<usize> {
+        let cutoff = (self.clock)().saturating_sub(RETENTION_MS);
+        self.storage
+            .run("session-retention", move |connection| {
+                Ok(connection.execute(
+                    "DELETE FROM sessions WHERE id IN (
+                    SELECT id FROM sessions WHERE expires_at_ms <= ?1
+                    UNION SELECT id FROM sessions WHERE revoked_at_ms <= ?1 LIMIT ?2
+                )",
+                    params![cutoff, CLEANUP_BATCH],
+                )?)
+            })
+            .await
     }
 
-    pub(crate) fn authorize_dashboard(&self, session_id: &str) -> DashboardResult<SessionUser> {
-        let session = self.require_session(session_id)?;
-        if session.must_change_password {
-            return Err(DashboardError::PasswordChangeRequired);
-        }
+    pub(crate) async fn login(&self, username: String, password: String) -> DashboardResult<AuthSessionResponse> {
+        let auth = self.auth.clone();
+        let clock = self.clock.clone();
+        let ttl = self.ttl_ms;
+        self.storage
+            .run("session-login", move |connection| {
+                let user = auth.authenticate(&username, &password)?;
+                let now = clock();
+                let expires = now
+                    .checked_add(ttl)
+                    .ok_or_else(|| DashboardError::Configuration("session TTL overflow".into()))?;
+                // The safe identifier is independent of the bearer credential. Only the digest is persisted.
+                let token = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+                let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let inserted = transaction.execute(
+                    "INSERT INTO sessions(id, token_digest, user_id, created_at_ms, expires_at_ms, last_seen_at_ms)
+                 SELECT ?1, ?2, id, ?3, ?4, ?3 FROM users WHERE id = ?5 AND password_hash = ?6 AND is_active = 1",
+                    params![
+                        Uuid::new_v4().to_string(),
+                        digest(&token),
+                        now,
+                        expires,
+                        user.id,
+                        user.password_hash
+                    ],
+                )?;
+                if inserted != 1 {
+                    return Err(DashboardError::Unauthenticated);
+                }
+                transaction.execute(
+                    "UPDATE users SET last_login_at = ?1 WHERE id = ?2",
+                    params![Utc::now().to_rfc3339(), user.id],
+                )?;
+                let session = lookup(&transaction, &digest(&token), now)?;
+                transaction.commit()?;
+                Ok(AuthSessionResponse {
+                    session_id: token,
+                    current_user: session,
+                })
+            })
+            .await
+    }
+
+    pub(crate) async fn require_session(&self, token: &str) -> DashboardResult<SessionUser> {
+        let hash = digest(token);
+        let clock = self.clock.clone();
+        self.storage
+            .run("session-authorize", move |connection| {
+                let now = clock();
+                let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let session = lookup(&transaction, &hash, now)?;
+                transaction.execute(
+                    "UPDATE sessions SET last_seen_at_ms = MAX(last_seen_at_ms, ?1) WHERE token_digest = ?2",
+                    params![now, hash],
+                )?;
+                transaction.commit()?;
+                Ok(session)
+            })
+            .await
+    }
+
+    pub(crate) async fn authorize_dashboard(&self, token: &str) -> DashboardResult<SessionUser> {
+        let session = self.require_session(token).await?;
+        require_password_changed(&session)?;
         Ok(session)
     }
 
-    pub(crate) fn remove_session(&self, session_id: &str) -> bool {
-        let mut sessions = self.sessions.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        sessions.remove(session_id).is_some()
+    pub(crate) async fn restore(&self, token: String) -> DashboardResult<AuthSessionResponse> {
+        let current_user = self.require_session(&token).await?;
+        Ok(AuthSessionResponse {
+            session_id: token,
+            current_user,
+        })
     }
 
-    pub(crate) fn upsert_session(&self, session: SessionUser) {
-        let mut sessions = self.sessions.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        sessions.insert(session.session_id.clone(), session);
+    pub(crate) async fn logout(&self, token: String) -> DashboardResult<()> {
+        let hash = digest(&token);
+        let clock = self.clock.clone();
+        self.storage
+            .run("session-logout", move |connection| {
+                connection.execute(
+                    "UPDATE sessions SET revoked_at_ms = ?1 WHERE token_digest = ?2 AND revoked_at_ms IS NULL",
+                    params![clock(), hash],
+                )?;
+                Ok(())
+            })
+            .await
     }
 
-    pub(crate) fn mark_password_changed(&self, session_id: &str) -> Option<SessionUser> {
-        let mut sessions = self.sessions.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        let session = sessions.get_mut(session_id)?;
-        session.must_change_password = false;
-        Some(session.clone())
+    pub(crate) async fn profile(&self, token: String) -> DashboardResult<UserProfile> {
+        let hash = digest(&token);
+        let auth = self.auth.clone();
+        let clock = self.clock.clone();
+        self.storage
+            .run("session-profile", move |connection| {
+                let session = lookup(connection, &hash, clock())?;
+                auth.get_user_profile(session.user_id)?
+                    .filter(|user| user.is_active)
+                    .ok_or(DashboardError::Unauthenticated)
+            })
+            .await
     }
+
+    pub(crate) async fn bootstrap_status(&self) -> DashboardResult<BootstrapStatus> {
+        let auth = self.auth.clone();
+        self.storage
+            .run("auth-bootstrap-status", move |_| auth.get_bootstrap_status())
+            .await
+    }
+
+    pub(crate) async fn change_password(&self, token: String, old: String, new: String) -> DashboardResult<()> {
+        let auth = self.auth.clone();
+        let hash = digest(&token);
+        let clock = self.clock.clone();
+        self.storage
+            .run("session-change-password", move |connection| {
+                let session = lookup(connection, &hash, clock())?;
+                let user = auth
+                    .find_user_by_id(session.user_id)?
+                    .ok_or(DashboardError::Unauthenticated)?;
+                if !verify_password(&old, &user.password_hash)? {
+                    return Err(DashboardError::Authentication("invalid credentials".into()));
+                }
+                validate_new_password(&old, &new)?;
+                let password_hash = hash_password(&new)?;
+                // Hash outside the write transaction, then revalidate both credential and password snapshot.
+                let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let now = clock();
+                lookup(&transaction, &hash, now)?;
+                let changed = transaction.execute(
+                    "UPDATE users SET password_hash = ?1, must_change_password = 0, updated_at = ?2
+                 WHERE id = ?3 AND password_hash = ?4 AND is_active = 1",
+                    params![password_hash, Utc::now().to_rfc3339(), user.id, user.password_hash],
+                )?;
+                if changed != 1 {
+                    return Err(DashboardError::Unauthenticated);
+                }
+                transaction.execute(
+                    "UPDATE sessions SET revoked_at_ms = ?1 WHERE user_id = ?2 AND revoked_at_ms IS NULL",
+                    params![now, user.id],
+                )?;
+                transaction.commit()?;
+                Ok(())
+            })
+            .await
+    }
+
+    pub(crate) async fn list(
+        &self,
+        token: String,
+        username: Option<String>,
+        cursor: Option<String>,
+        limit: Option<usize>,
+    ) -> DashboardResult<SessionPage> {
+        let limit = limit.unwrap_or(25);
+        if !(1..=100).contains(&limit) || cursor.as_ref().is_some_and(|value| Uuid::parse_str(value).is_err()) {
+            return Err(DashboardError::Validation("invalid session pagination".into()));
+        }
+        let hash = digest(&token);
+        let clock = self.clock.clone();
+        self.storage
+            .run("session-list", move |connection| {
+                let transaction = connection.transaction()?;
+                let actor = lookup(&transaction, &hash, clock())?;
+                require_password_changed(&actor)?;
+                // Local accounts have no cross-account administrator role. Session management is self-service.
+                let target = username.unwrap_or_else(|| actor.username.clone());
+                if target != actor.username {
+                    return Err(DashboardError::Validation("session account mismatch".into()));
+                }
+                let mut items = {
+                    let mut query = transaction.prepare(
+                        "SELECT id, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms, token_digest = ?1
+                     FROM sessions WHERE user_id = ?2 AND (?3 IS NULL OR id > ?3) ORDER BY id LIMIT ?4",
+                    )?;
+                    query
+                        .query_map(params![hash, actor.user_id, cursor, (limit + 1) as i64], |row| {
+                            Ok(SessionView {
+                                id: row.get(0)?,
+                                username: target.clone(),
+                                created_at_ms: row.get(1)?,
+                                expires_at_ms: row.get(2)?,
+                                last_seen_at_ms: row.get(3)?,
+                                revoked_at_ms: row.get(4)?,
+                                current: row.get(5)?,
+                            })
+                        })?
+                        .collect::<Result<Vec<_>, _>>()?
+                };
+                let next_cursor = if items.len() > limit {
+                    items.truncate(limit);
+                    items.last().map(|item| item.id.clone())
+                } else {
+                    None
+                };
+                transaction.commit()?;
+                Ok(SessionPage { items, next_cursor })
+            })
+            .await
+    }
+
+    pub(crate) async fn revoke(&self, token: String, username: String) -> DashboardResult<RevokeSessionsResponse> {
+        let hash = digest(&token);
+        let clock = self.clock.clone();
+        self.storage
+            .run("session-revoke-account", move |connection| {
+                let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let now = clock();
+                let actor = lookup(&transaction, &hash, now)?;
+                require_password_changed(&actor)?;
+                if username != actor.username {
+                    return Err(DashboardError::Validation("session account mismatch".into()));
+                }
+                let revoked_count = transaction.execute(
+                    "UPDATE sessions SET revoked_at_ms = ?1 WHERE user_id = ?2 AND revoked_at_ms IS NULL",
+                    params![now, actor.user_id],
+                )?;
+                transaction.commit()?;
+                Ok(RevokeSessionsResponse {
+                    revoked_count,
+                    current_session_revoked: true,
+                })
+            })
+            .await
+    }
+}
+
+fn require_password_changed(session: &SessionUser) -> DashboardResult<()> {
+    if session.must_change_password {
+        Err(DashboardError::PasswordChangeRequired)
+    } else {
+        Ok(())
+    }
+}
+
+fn lookup(connection: &Connection, digest: &[u8], now: i64) -> DashboardResult<SessionUser> {
+    connection
+        .query_row(
+            "SELECT u.id, u.username, u.must_change_password, u.created_at FROM sessions s
+         JOIN users u ON u.id = s.user_id WHERE s.token_digest = ?1 AND s.expires_at_ms > ?2
+         AND s.revoked_at_ms IS NULL AND u.is_active = 1",
+            params![digest, now],
+            |row| {
+                Ok(SessionUser {
+                    user_id: row.get(0)?,
+                    username: row.get(1)?,
+                    must_change_password: row.get(2)?,
+                    created_at: row.get(3)?,
+                })
+            },
+        )
+        .optional()?
+        .ok_or(DashboardError::Unauthenticated)
+}
+
+fn digest(token: &str) -> Vec<u8> {
+    Sha256::digest(token.as_bytes()).to_vec()
+}
+
+fn ttl_millis(value: Option<&str>) -> DashboardResult<i64> {
+    let seconds = match value {
+        Some(value) => value
+            .parse::<i64>()
+            .map_err(|_| DashboardError::Configuration("invalid session TTL".into()))?,
+        None => DEFAULT_TTL_SECS,
+    };
+    // Bound configuration to one year, avoiding impractical lifetimes and timestamp overflow.
+    if !(1..=365 * 24 * 60 * 60).contains(&seconds) {
+        return Err(DashboardError::Configuration(
+            "session TTL outside supported range".into(),
+        ));
+    }
+    Ok(seconds * 1000)
 }
 
 #[cfg(test)]
-mod tests {
-    use super::SessionState;
-    use crate::auth::types::UserRecord;
-
-    fn test_user_record() -> UserRecord {
-        UserRecord {
-            id: 7,
-            username: "admin".to_string(),
-            password_hash: "hashed".to_string(),
-            is_active: true,
-            must_change_password: true,
-            created_at: "2026-03-15T00:00:00Z".to_string(),
-            updated_at: "2026-03-15T00:00:00Z".to_string(),
-            last_login_at: None,
-        }
-    }
-
-    #[test]
-    fn session_lifecycle_round_trip() {
-        let state = SessionState::default();
-        let user = test_user_record();
-        let session = state.create_session(&user);
-
-        let restored = state
-            .get_session(&session.session_id)
-            .expect("session should be restorable");
-        assert_eq!(restored.user_id, user.id);
-        assert_eq!(restored.username, user.username);
-        assert!(state.remove_session(&session.session_id));
-        assert!(state.get_session(&session.session_id).is_none());
-    }
-
-    #[test]
-    fn mark_password_changed_updates_session_state() {
-        let state = SessionState::default();
-        let user = test_user_record();
-        let session = state.create_session(&user);
-
-        let updated = state
-            .mark_password_changed(&session.session_id)
-            .expect("session should exist");
-
-        assert!(!updated.must_change_password);
-    }
-
-    #[test]
-    fn dashboard_authorization_rejects_missing_and_password_change_sessions() {
-        let state = SessionState::default();
-        let missing = state
-            .authorize_dashboard("missing")
-            .expect_err("missing session should be rejected");
-        assert!(matches!(missing, crate::error::DashboardError::Unauthenticated));
-
-        let session = state.create_session(&test_user_record());
-        let forced_change = state
-            .authorize_dashboard(&session.session_id)
-            .expect_err("password change session should be rejected");
-        assert!(matches!(
-            forced_change,
-            crate::error::DashboardError::PasswordChangeRequired
-        ));
-
-        state.mark_password_changed(&session.session_id);
-        assert!(state.authorize_dashboard(&session.session_id).is_ok());
-    }
-}
+mod tests;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session/tests.rs
@@ -1,0 +1,334 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use crate::auth::AuthDb;
+use crate::error::CommandError;
+use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
+use std::sync::atomic::{AtomicI64, Ordering};
+
+struct Fixture {
+    owner: Option<RuntimeOwner>,
+    storage: StorageManager,
+    service: SessionState,
+    clock: Arc<AtomicI64>,
+    directory: std::path::PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let owner = RuntimeOwner::plan(RuntimeConfig::server_default("session-test"))
+            .unwrap()
+            .build()
+            .unwrap();
+        let directory = std::env::temp_dir().join(format!("tauri-sessions-{}", Uuid::new_v4()));
+        let storage = StorageManager::new(
+            directory.join("dashboard.db"),
+            owner.root_context().component("storage"),
+        );
+        owner.block_on(storage.initialize()).unwrap();
+        let auth = AuthService::with_initial_password(AuthDb::from_path(storage.path()), "change-me-now");
+        let bootstrap = auth.clone();
+        owner
+            .block_on(storage.run("bootstrap", move |_| bootstrap.bootstrap_default_admin()))
+            .unwrap();
+        let clock = Arc::new(AtomicI64::new(1_800_000_000_000));
+        let test_clock = clock.clone();
+        let service = SessionState {
+            storage: storage.clone(),
+            auth,
+            ttl_ms: 1000,
+            clock: Arc::new(move || test_clock.load(Ordering::SeqCst)),
+        };
+        Self {
+            owner: Some(owner),
+            storage,
+            service,
+            clock,
+            directory,
+        }
+    }
+
+    async fn ready_login(&self) -> AuthSessionResponse {
+        let first = self
+            .service
+            .login("admin".into(), "change-me-now".into())
+            .await
+            .unwrap();
+        self.service
+            .change_password(first.session_id, "change-me-now".into(), "better-secret".into())
+            .await
+            .unwrap();
+        self.service
+            .login("admin".into(), "better-secret".into())
+            .await
+            .unwrap()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        if let Some(owner) = self.owner.take() {
+            assert!(owner.block_on(self.storage.shutdown(Duration::from_secs(5))));
+            let _ = owner.shutdown_runtime_blocking();
+        }
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+#[test]
+fn expiry_is_absolute_and_restoration_reads_persisted_state() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let login = fixture.ready_login().await;
+        // New facade has no session cache; it reopens the on-disk database.
+        let restored_service = SessionState {
+            storage: fixture.storage.clone(),
+            ..fixture.service.clone()
+        };
+        assert_eq!(
+            restored_service
+                .restore(login.session_id.clone())
+                .await
+                .unwrap()
+                .current_user
+                .username,
+            "admin"
+        );
+        fixture.clock.fetch_add(999, Ordering::SeqCst);
+        restored_service.authorize_dashboard(&login.session_id).await.unwrap();
+        let page = restored_service
+            .list(login.session_id.clone(), None, None, None)
+            .await
+            .unwrap();
+        let current = page.items.iter().find(|row| row.current).unwrap();
+        assert_eq!(current.expires_at_ms - current.last_seen_at_ms, 1);
+        fixture.clock.fetch_add(1, Ordering::SeqCst);
+        assert!(matches!(
+            restored_service.require_session(&login.session_id).await,
+            Err(DashboardError::Unauthenticated)
+        ));
+    });
+}
+
+#[test]
+fn password_change_revokes_every_old_token_and_enforces_initial_password() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let first = fixture
+            .service
+            .login("admin".into(), "change-me-now".into())
+            .await
+            .unwrap();
+        let second = fixture
+            .service
+            .login("admin".into(), "change-me-now".into())
+            .await
+            .unwrap();
+        assert!(
+            fixture
+                .service
+                .profile(first.session_id.clone())
+                .await
+                .unwrap()
+                .must_change_password
+        );
+        assert!(matches!(
+            fixture.service.authorize_dashboard(&first.session_id).await,
+            Err(DashboardError::PasswordChangeRequired)
+        ));
+        assert!(matches!(
+            fixture.service.list(first.session_id.clone(), None, None, None).await,
+            Err(DashboardError::PasswordChangeRequired)
+        ));
+        let failure = fixture
+            .service
+            .change_password(first.session_id.clone(), "wrong".into(), "better-secret".into())
+            .await
+            .unwrap_err();
+        assert_eq!(CommandError::from(failure).code, "auth.credentials.invalid");
+        assert!(fixture.service.require_session(&first.session_id).await.is_ok());
+        fixture
+            .service
+            .change_password(first.session_id.clone(), "change-me-now".into(), "better-secret".into())
+            .await
+            .unwrap();
+        assert!(fixture.service.require_session(&first.session_id).await.is_err());
+        assert!(fixture.service.require_session(&second.session_id).await.is_err());
+        assert!(
+            fixture
+                .service
+                .login("admin".into(), "change-me-now".into())
+                .await
+                .is_err()
+        );
+        let replacement = fixture
+            .service
+            .login("admin".into(), "better-secret".into())
+            .await
+            .unwrap();
+        assert!(!replacement.current_user.must_change_password);
+        fixture
+            .service
+            .authorize_dashboard(&replacement.session_id)
+            .await
+            .unwrap();
+    });
+}
+
+#[test]
+fn pagination_redaction_revocation_and_account_isolation() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let first = fixture.ready_login().await;
+        let second = fixture
+            .service
+            .login("admin".into(), "better-secret".into())
+            .await
+            .unwrap();
+        let mut cursor = None;
+        let mut ids = std::collections::HashSet::new();
+        let mut current_count = 0;
+        loop {
+            let page = fixture
+                .service
+                .list(first.session_id.clone(), Some("admin".into()), cursor, Some(1))
+                .await
+                .unwrap();
+            let json = serde_json::to_string(&page).unwrap();
+            assert!(!json.contains(&first.session_id));
+            assert!(!json.contains(&second.session_id));
+            assert!(!json.contains("digest"));
+            for row in page.items {
+                assert!(ids.insert(row.id));
+                current_count += usize::from(row.current);
+            }
+            cursor = page.next_cursor;
+            if cursor.is_none() {
+                break;
+            }
+        }
+        assert_eq!(ids.len(), 3);
+        assert_eq!(current_count, 1);
+        assert!(
+            fixture
+                .service
+                .list(first.session_id.clone(), Some("other".into()), None, None)
+                .await
+                .is_err()
+        );
+        assert!(
+            fixture
+                .service
+                .revoke(first.session_id.clone(), "other".into())
+                .await
+                .is_err()
+        );
+        assert!(
+            fixture
+                .service
+                .list(first.session_id.clone(), None, Some("bad cursor".into()), None)
+                .await
+                .is_err()
+        );
+        let response = fixture
+            .service
+            .revoke(first.session_id.clone(), "admin".into())
+            .await
+            .unwrap();
+        assert_eq!(response.revoked_count, 2);
+        assert!(response.current_session_revoked);
+        assert!(fixture.service.require_session(&first.session_id).await.is_err());
+        assert!(fixture.service.require_session(&second.session_id).await.is_err());
+    });
+}
+
+#[test]
+fn disabled_accounts_and_logout_are_authoritative() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let login = fixture.ready_login().await;
+        fixture
+            .storage
+            .run("disable", |connection| {
+                connection.execute("UPDATE users SET is_active = 0", [])?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert!(fixture.service.restore(login.session_id.clone()).await.is_err());
+        assert!(
+            fixture
+                .service
+                .login("admin".into(), "better-secret".into())
+                .await
+                .is_err()
+        );
+        fixture
+            .storage
+            .run("enable", |connection| {
+                connection.execute("UPDATE users SET is_active = 1", [])?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        fixture.service.logout(login.session_id.clone()).await.unwrap();
+        fixture.service.logout(login.session_id.clone()).await.unwrap();
+        assert!(fixture.service.require_session(&login.session_id).await.is_err());
+    });
+}
+
+#[test]
+fn retention_is_bounded_and_keeps_live_sessions() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let login = fixture.ready_login().await;
+        let now = fixture.clock.load(Ordering::SeqCst);
+        fixture
+            .storage
+            .run("seed-retention", move |connection| {
+                let user_id: i64 = connection.query_row("SELECT id FROM users", [], |row| row.get(0))?;
+                let transaction = connection.transaction()?;
+                for index in 0..505 {
+                    transaction.execute(
+                        "INSERT INTO sessions VALUES (?1, ?2, ?3, 0, ?4, 0, NULL)",
+                        params![
+                            format!("expired-{index}"),
+                            format!("hash-{index}"),
+                            user_id,
+                            now - RETENTION_MS
+                        ],
+                    )?;
+                }
+                transaction.commit()?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(fixture.service.cleanup().await.unwrap(), 500);
+        assert_eq!(fixture.service.cleanup().await.unwrap(), 5);
+        assert_eq!(fixture.service.cleanup().await.unwrap(), 0);
+        fixture.service.authorize_dashboard(&login.session_id).await.unwrap();
+        fixture.service.start_cleanup().unwrap();
+    });
+}
+
+#[test]
+fn ttl_configuration_is_validated_without_changing_process_environment() {
+    assert_eq!(ttl_millis(None).unwrap(), 28_800_000);
+    assert_eq!(ttl_millis(Some("60")).unwrap(), 60_000);
+    for value in ["", "0", "-1", "invalid", "9223372036854775807"] {
+        assert!(ttl_millis(Some(value)).is_err());
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/types.rs
@@ -20,8 +20,6 @@ pub(crate) type AuthResult<T> = crate::error::DashboardResult<T>;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SessionUser {
-    #[serde(skip)]
-    pub(crate) session_id: String,
     pub(crate) user_id: i64,
     pub(crate) username: String,
     pub(crate) must_change_password: bool,
@@ -72,4 +70,30 @@ pub(crate) struct UserRecord {
     pub(crate) created_at: String,
     pub(crate) updated_at: String,
     pub(crate) last_login_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SessionView {
+    pub(crate) id: String,
+    pub(crate) username: String,
+    pub(crate) created_at_ms: i64,
+    pub(crate) expires_at_ms: i64,
+    pub(crate) last_seen_at_ms: i64,
+    pub(crate) revoked_at_ms: Option<i64>,
+    pub(crate) current: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SessionPage {
+    pub(crate) items: Vec<SessionView>,
+    pub(crate) next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RevokeSessionsResponse {
+    pub(crate) revoked_count: usize,
+    pub(crate) current_session_revoked: bool,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/commands.rs
@@ -31,7 +31,7 @@ pub async fn get_cluster_home_page(
     cluster_manager: State<'_, ClusterManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ClusterHomePageResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     cluster_manager.get_cluster_home_page(request).await.map_err(Into::into)
 }
 
@@ -42,7 +42,7 @@ pub async fn get_cluster_broker_config(
     cluster_manager: State<'_, ClusterManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ClusterBrokerConfigView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     cluster_manager
         .get_cluster_broker_config(request)
         .await
@@ -56,7 +56,7 @@ pub async fn get_cluster_broker_status(
     cluster_manager: State<'_, ClusterManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ClusterBrokerStatusView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     cluster_manager
         .get_cluster_broker_status(request)
         .await

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
@@ -37,7 +37,7 @@ pub async fn query_consumer_groups(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ConsumerGroupListResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     consumer_manager
         .query_consumer_groups(request)
         .await
@@ -51,7 +51,7 @@ pub async fn refresh_consumer_group(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ConsumerGroupListItem> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     consumer_manager
         .refresh_consumer_group(request)
         .await
@@ -65,7 +65,7 @@ pub async fn refresh_all_consumer_groups(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ConsumerGroupListResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     consumer_manager
         .refresh_all_consumer_groups(request)
         .await
@@ -79,7 +79,7 @@ pub async fn query_consumer_connection(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ConsumerConnectionView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     consumer_manager
         .query_consumer_connection(request)
         .await
@@ -93,7 +93,7 @@ pub async fn query_consumer_topic_detail(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ConsumerTopicDetailView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     consumer_manager
         .query_consumer_topic_detail(request)
         .await
@@ -107,7 +107,7 @@ pub async fn query_consumer_config(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ConsumerConfigView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     consumer_manager
         .query_consumer_config(request)
         .await
@@ -121,7 +121,7 @@ pub async fn create_or_update_consumer_group(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ConsumerMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     consumer_manager
         .create_or_update_consumer_group(request)
         .await
@@ -135,7 +135,7 @@ pub async fn delete_consumer_group(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ConsumerMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     consumer_manager
         .delete_consumer_group(request)
         .await

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/commands.rs
@@ -29,7 +29,7 @@ pub async fn get_dashboard_broker_overview(
     cluster_manager: State<'_, ClusterManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<DashboardBrokerOverviewResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     service::get_dashboard_broker_overview(&cluster_manager, request)
         .await
         .map_err(Into::into)
@@ -41,7 +41,7 @@ pub async fn query_dashboard_topic_current(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<DashboardTopicCurrentResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     service::query_dashboard_topic_current(&topic_manager)
         .await
         .map_err(Into::into)

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
@@ -22,9 +22,13 @@ use thiserror::Error;
 pub(crate) type DashboardResult<T> = Result<T, DashboardError>;
 pub(crate) type CommandResult<T> = Result<T, CommandError>;
 
-pub(crate) fn authorize_command(session_id: &str, session_state: &crate::auth::SessionState) -> CommandResult<()> {
+pub(crate) async fn authorize_command(
+    session_id: &str,
+    session_state: &crate::auth::SessionState,
+) -> CommandResult<()> {
     session_state
         .authorize_dashboard(session_id)
+        .await
         .map(|_| ())
         .map_err(CommandError::from)
 }
@@ -315,7 +319,7 @@ mod tests {
                 command_count += 1;
                 assert!(command.contains("session_id: String"));
                 assert!(command.contains("State<'_, SessionState>"));
-                assert!(command.contains("authorize_command(&session_id, &session_state)?;"));
+                assert!(command.contains("authorize_command(&session_id, &session_state).await?;"));
             }
         }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -225,9 +225,10 @@ fn build_application() -> Result<DashboardApplication, i32> {
                 })
                 .map_err(|_| crate::error::DashboardError::Internal("admin lifecycle initialized twice"))?;
 
+            let sessions = auth::SessionState::new(storage.clone(), auth_service)?;
+            sessions.start_cleanup()?;
             app.manage(storage);
-            app.manage(auth_service);
-            app.manage(auth::SessionState::default());
+            app.manage(sessions);
             app.manage(nameserver_runtime);
             app.manage(nameserver_manager);
             app.manage(cluster_manager);
@@ -246,6 +247,8 @@ fn build_application() -> Result<DashboardApplication, i32> {
             auth::commands::change_password,
             auth::commands::get_current_user_profile,
             auth::commands::get_auth_bootstrap_status,
+            auth::commands::list_sessions,
+            auth::commands::revoke_user_sessions,
             nameserver::commands::get_name_server_home_page,
             nameserver::commands::add_name_server,
             nameserver::commands::switch_name_server,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
@@ -41,7 +41,7 @@ pub async fn query_message_by_topic_key(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessageSummaryListResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager
         .query_message_by_topic_key(request)
         .await
@@ -55,7 +55,7 @@ pub async fn query_message_by_id(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessageSummaryListResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager.query_message_by_id(request).await.map_err(Into::into)
 }
 
@@ -66,7 +66,7 @@ pub async fn query_message_page_by_topic(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessagePageResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager
         .query_message_page_by_topic(request)
         .await
@@ -80,7 +80,7 @@ pub async fn query_dlq_message_by_consumer_group(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessagePageResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager
         .query_dlq_message_by_consumer_group(request)
         .await
@@ -94,7 +94,7 @@ pub async fn view_message_detail(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessageDetailView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager.view_message_detail(request).await.map_err(Into::into)
 }
 
@@ -105,7 +105,7 @@ pub async fn view_dlq_message_detail(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessageDetailView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager
         .view_dlq_message_detail(request)
         .await
@@ -119,7 +119,7 @@ pub async fn resend_dlq_message(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessageResendResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager.resend_dlq_message(request).await.map_err(Into::into)
 }
 
@@ -130,7 +130,7 @@ pub async fn batch_resend_dlq_message(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessageBatchResendResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager
         .batch_resend_dlq_message(request)
         .await
@@ -144,7 +144,7 @@ pub async fn export_dlq_message(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<DlqMessageExportView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager.export_dlq_message(request).await.map_err(Into::into)
 }
 
@@ -155,7 +155,7 @@ pub async fn batch_export_dlq_message(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<DlqBatchMessageExportView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager
         .batch_export_dlq_message(request)
         .await
@@ -169,7 +169,7 @@ pub async fn consume_message_directly(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessageResendResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager
         .consume_message_directly(request)
         .await
@@ -183,7 +183,7 @@ pub async fn query_message_trace_by_id(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessageSummaryListResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager
         .query_message_trace_by_id(request)
         .await
@@ -197,7 +197,7 @@ pub async fn view_message_trace_detail(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<MessageTraceDetailView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     message_manager
         .view_message_trace_detail(request)
         .await

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
@@ -23,62 +23,62 @@ pub async fn get_name_server_home_page(
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<NameServerHomePageView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     nameserver_manager.home_page_info().await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn add_name_server(
+pub async fn add_name_server(
     session_id: String,
     address: String,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     nameserver_manager.add_name_server(&address).map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn switch_name_server(
+pub async fn switch_name_server(
     session_id: String,
     address: String,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     nameserver_manager.switch_name_server(&address).map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn delete_name_server(
+pub async fn delete_name_server(
     session_id: String,
     address: String,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     nameserver_manager.delete_name_server(&address).map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn update_vip_channel(
+pub async fn update_vip_channel(
     session_id: String,
     enabled: bool,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     nameserver_manager.update_vip_channel(enabled).map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn update_use_tls(
+pub async fn update_use_tls(
     session_id: String,
     enabled: bool,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     nameserver_manager.update_use_tls(enabled).map_err(Into::into)
 }
 use crate::auth::SessionState;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/db.rs
@@ -100,6 +100,22 @@ impl StorageManager {
         self.stats.snapshot()
     }
 
+    /// Background waiters may be cancelled; accepted I/O remains owned by `run`.
+    pub(crate) fn start_background(
+        &self,
+        name: &'static str,
+        future: impl std::future::Future<Output = ()> + Send + 'static,
+    ) -> DashboardResult<()> {
+        let accepting = self.accepting.lock().map_err(|_| DashboardError::StorageClosed)?;
+        if !*accepting {
+            return Err(DashboardError::StorageClosed);
+        }
+        self.background
+            .spawn_cancellable_service(name, future)
+            .map(|_| ())
+            .map_err(DashboardError::Persistence)
+    }
+
     /// Accepted work is owned independently of the IPC waiter. Dropping that
     /// waiter does not cancel a transaction that may already have committed.
     pub(crate) async fn run<T, F>(&self, name: &'static str, operation: F) -> DashboardResult<T>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
@@ -17,7 +17,7 @@ use crate::error::DashboardResult;
 use rusqlite::Connection;
 use rusqlite::TransactionBehavior;
 
-pub(crate) const SCHEMA_VERSION: i64 = 1;
+pub(crate) const SCHEMA_VERSION: i64 = 2;
 
 pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
     // IMMEDIATE serializes competing initializers before reading the version.
@@ -62,6 +62,18 @@ pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
                 updated_at TEXT NOT NULL,
                 last_login_at TEXT
             );
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                token_digest BLOB NOT NULL UNIQUE,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                created_at_ms INTEGER NOT NULL,
+                expires_at_ms INTEGER NOT NULL,
+                last_seen_at_ms INTEGER NOT NULL,
+                revoked_at_ms INTEGER
+            );
+            CREATE INDEX sessions_user_id ON sessions(user_id, id);
+            CREATE INDEX sessions_expiry ON sessions(expires_at_ms);
+            CREATE INDEX sessions_revoked ON sessions(revoked_at_ms) WHERE revoked_at_ms IS NOT NULL;
             CREATE TABLE IF NOT EXISTS nameserver_addresses (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 address TEXT NOT NULL UNIQUE,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/commands.rs
@@ -26,7 +26,7 @@ pub async fn get_producer_topic_options(
     producer_manager: State<'_, ProducerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ProducerTopicOptionsView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     producer_manager
         .get_producer_topic_options(request)
         .await
@@ -40,7 +40,7 @@ pub async fn query_producer_connections(
     producer_manager: State<'_, ProducerManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ProducerConnectionView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     producer_manager
         .query_producer_connections(request)
         .await

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/commands.rs
@@ -18,45 +18,45 @@ use rocketmq_dashboard_common::ProxyMutationResult;
 use tauri::State;
 
 #[tauri::command]
-pub fn get_proxy_home_page(
+pub async fn get_proxy_home_page(
     session_id: String,
     proxy_manager: State<'_, ProxyManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ProxyConfigSnapshot> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     proxy_manager.home_page_info().map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn add_proxy_addr(
+pub async fn add_proxy_addr(
     session_id: String,
     address: String,
     proxy_manager: State<'_, ProxyManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ProxyMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     proxy_manager.add_proxy_addr(&address).map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn switch_proxy_addr(
+pub async fn switch_proxy_addr(
     session_id: String,
     address: String,
     proxy_manager: State<'_, ProxyManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ProxyMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     proxy_manager.switch_proxy_addr(&address).map_err(Into::into)
 }
 
 #[tauri::command]
-pub fn delete_proxy_addr(
+pub async fn delete_proxy_addr(
     session_id: String,
     address: String,
     proxy_manager: State<'_, ProxyManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<ProxyMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     proxy_manager.delete_proxy_addr(&address).map_err(Into::into)
 }
 use crate::auth::SessionState;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
@@ -38,7 +38,7 @@ pub async fn get_topic_list(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicListResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.get_topic_list(request).await.map_err(Into::into)
 }
 
@@ -49,7 +49,7 @@ pub async fn get_topic_route(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicRouteView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.get_topic_route(request).await.map_err(Into::into)
 }
 
@@ -60,7 +60,7 @@ pub async fn get_topic_stats(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicStatusView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.get_topic_stats(request).await.map_err(Into::into)
 }
 
@@ -71,7 +71,7 @@ pub async fn get_topic_config(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicConfigView> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.get_topic_config(request).await.map_err(Into::into)
 }
 
@@ -82,7 +82,7 @@ pub async fn create_or_update_topic(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.create_or_update_topic(request).await.map_err(Into::into)
 }
 
@@ -93,7 +93,7 @@ pub async fn delete_topic(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.delete_topic(request).await.map_err(Into::into)
 }
 
@@ -104,7 +104,7 @@ pub async fn delete_topic_by_broker(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.delete_topic_by_broker(request).await.map_err(Into::into)
 }
 
@@ -115,7 +115,7 @@ pub async fn get_topic_consumer_groups(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicConsumerGroupListResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager
         .get_topic_consumer_groups(request)
         .await
@@ -129,7 +129,7 @@ pub async fn get_topic_consumers(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicConsumerInfoResponse> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.get_topic_consumers(request).await.map_err(Into::into)
 }
 
@@ -140,7 +140,7 @@ pub async fn reset_consumer_offset(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.reset_consumer_offset(request).await.map_err(Into::into)
 }
 
@@ -151,7 +151,7 @@ pub async fn skip_message_accumulate(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.skip_message_accumulate(request).await.map_err(Into::into)
 }
 
@@ -162,7 +162,7 @@ pub async fn send_topic_message(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
 ) -> CommandResult<TopicSendMessageResult> {
-    authorize_command(&session_id, &session_state)?;
+    authorize_command(&session_id, &session_state).await?;
     topic_manager.send_topic_message(request).await.map_err(Into::into)
 }
 use crate::auth::SessionState;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/components/ChangePasswordDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/components/ChangePasswordDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
+import { toast } from 'sonner@2.0.3';
 import { KeyRound, Loader2, ShieldAlert, X } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { ErrorAlert } from './ErrorAlert';
@@ -60,14 +61,13 @@ export const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = ({
         });
 
         if (result.success) {
+            toast.success('Password updated. Sign in again with your new password.');
             setOldPassword('');
             setNewPassword('');
             setConfirmPassword('');
             onPasswordChanged?.();
 
-            if (!isRequiredFlow) {
-                onOpenChange?.(false);
-            }
+            onOpenChange?.(false);
         }
     };
 
@@ -79,7 +79,7 @@ export const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = ({
     const title = isRequiredFlow ? 'Change initial password' : 'Change password';
     const description = isRequiredFlow
         ? `${currentUser?.username ?? 'Admin'} must update the bootstrap password before entering the dashboard.`
-        : 'Update the local dashboard password to keep this workstation secure.';
+        : 'Changing your password signs out all sessions, including this one.';
 
     return (
         <AnimatePresence>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/hooks/useAuth.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/hooks/useAuth.ts
@@ -9,7 +9,7 @@ export const useAuth = () => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
     const [shake, setShake] = useState(false);
-    const { clearAuthSession, markPasswordChanged, sessionId, setAuthSession } = useAppStore();
+    const { sessionId, setAuthSession } = useAppStore();
 
     const login = async (credentials: LoginCredentials) => {
         setIsLoading(true);
@@ -44,7 +44,6 @@ export const useAuth = () => {
 
         try {
             await AuthService.changePassword(payload);
-            markPasswordChanged();
             return { success: true };
         } catch (err) {
             const errorMessage = dashboardErrorMessage(err, 'Failed to update password');
@@ -63,8 +62,7 @@ export const useAuth = () => {
         } catch {
             // Local session state must still be cleared when the backend session is unavailable.
         } finally {
-            SessionStorageService.clearSessionId();
-            clearAuthSession();
+            SessionStorageService.reportAuthenticationFailure(sessionId, 'invalid');
         }
     };
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/hooks/useSessionBootstrap.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/hooks/useSessionBootstrap.ts
@@ -28,16 +28,13 @@ export const useSessionBootstrap = () => {
 
             try {
                 const result = await AuthService.restoreSession(sessionId);
-                if (!isMounted) {
+                if (!isMounted || SessionStorageService.getSessionId() !== sessionId) {
                     return;
                 }
 
                 setAuthSession(result.sessionId, result.currentUser);
             } catch (_error) {
-                SessionStorageService.clearSessionId();
-                if (isMounted) {
-                    clearAuthSession();
-                }
+                if (isMounted) SessionStorageService.reportAuthenticationFailure(sessionId, 'invalid');
             } finally {
                 if (isMounted) {
                     finishAuthBootstrap();

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/AccountPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/AccountPage.tsx
@@ -10,8 +10,8 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner@2.0.3';
 import { AuthService } from '../../services/auth.service';
-import { DashboardClientError, dashboardErrorMessage } from '../../services/invoke';
-import { SessionStorageService } from '../../services/session.storage';
+import { dashboardErrorMessage } from '../../services/invoke';
+import { SessionsPanel } from './SessionsPanel';
 import { useAppStore } from '../../stores/app.store';
 import { SignOutConfirmDialog, useAuth } from '../../features/auth';
 import { ChangePasswordDialog } from '../../features/auth/components/ChangePasswordDialog';
@@ -67,7 +67,7 @@ const DetailRow = ({
 );
 
 export const AccountPage = () => {
-    const { clearAuthSession, currentUser, sessionId } = useAppStore();
+    const { currentUser, sessionId } = useAppStore();
     const { logout } = useAuth();
     const [profile, setProfile] = useState<UserProfile | null>(null);
     const [error, setError] = useState('');
@@ -81,8 +81,6 @@ export const AccountPage = () => {
         let isMounted = true;
 
         if (!sessionId) {
-            SessionStorageService.clearSessionId();
-            clearAuthSession();
             return () => {
                 isMounted = false;
             };
@@ -105,11 +103,6 @@ export const AccountPage = () => {
                 }
 
                 setProfile(null);
-                if (loadError instanceof DashboardClientError && loadError.code === 'auth.session.invalid') {
-                    SessionStorageService.clearSessionId();
-                    clearAuthSession();
-                    return;
-                }
                 setError(dashboardErrorMessage(loadError, 'Failed to load user profile'));
             } finally {
                 if (isMounted) {
@@ -254,13 +247,14 @@ export const AccountPage = () => {
                                 />
                                 <DetailRow label="Last Login" value={profile ? formatTimestamp(profile.lastLoginAt) : unresolvedValue} />
                                 <div className="rounded-2xl border border-sky-200/70 bg-sky-500/[0.08] px-4 py-3 text-sm text-sky-700 dark:border-sky-400/15 dark:bg-sky-400/[0.08] dark:text-sky-200">
-                                    The dashboard keeps authentication local to this workstation. Password changes apply to
-                                    future sign-ins immediately.
+                                    The dashboard keeps authentication local to this workstation. Changing the password signs out all sessions immediately.
                                 </div>
                             </div>
                         </CardContent>
                     </Card>
                 </div>
+
+                <SessionsPanel key={sessionId} username={username} />
 
                 <Card className={glassCardClass}>
                     <CardHeader className="pb-4">

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/SessionsPanel.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/SessionsPanel.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react';
+import { AuthService, type SessionPage } from '../../services/auth.service';
+import { dashboardErrorMessage } from '../../services/invoke';
+import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { SignOutConfirmDialog } from '../../features/auth';
+
+const timestamp = (value: number) => new Date(value).toLocaleString();
+
+export const SessionsPanel = ({ username }: { username: string }) => {
+    const [page, setPage] = useState<SessionPage | null>(null);
+    const [cursors, setCursors] = useState<Array<string | undefined>>([undefined]);
+    const [refresh, setRefresh] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+    const [confirm, setConfirm] = useState(false);
+    const [revoking, setRevoking] = useState(false);
+    const mounted = useRef(false);
+    const cursor = cursors[cursors.length - 1];
+
+    useEffect(() => {
+        mounted.current = true;
+        return () => { mounted.current = false; };
+    }, []);
+
+    useEffect(() => {
+        let active = true;
+        setLoading(true);
+        setError('');
+        setPage(null);
+        void AuthService.listSessions(username, cursor).then((result) => {
+            if (active) setPage(result);
+        }).catch((failure: unknown) => {
+            if (active) setError(dashboardErrorMessage(failure, 'Could not load sessions.'));
+        }).finally(() => { if (active) setLoading(false); });
+        return () => { active = false; };
+    }, [username, cursor, refresh]);
+
+    const revoke = async () => {
+        setRevoking(true);
+        setError('');
+        try {
+            await AuthService.revokeUserSessions(username);
+        } catch (failure) {
+            if (mounted.current) setError(dashboardErrorMessage(failure, 'Could not revoke sessions.'));
+        } finally {
+            if (mounted.current) { setRevoking(false); setConfirm(false); }
+        }
+    };
+
+    return (
+        <Card className="ops-card account-card" id="sessions">
+            <CardHeader>
+                <CardTitle>Sessions</CardTitle>
+                <CardDescription>Sessions for {username}. Activity updates the last visit, without extending expiry.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 !pb-8">
+                <div className="flex flex-wrap gap-3">
+                    <Button variant="outline" disabled={loading || revoking} onClick={() => { setCursors([undefined]); setRefresh((value) => value + 1); }}>Refresh sessions</Button>
+                    <Button variant="outline" className="ops-button ops-button-danger" disabled={revoking} onClick={() => setConfirm(true)}>Sign out all sessions</Button>
+                </div>
+                {error && <p role="alert" className="text-sm text-red-600">{error}</p>}
+                {loading ? <p role="status">Loading sessions¡­</p> : page && (
+                    <>
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-left text-sm">
+                                <caption className="sr-only">Local account sessions for {username}</caption>
+                                <thead><tr>{['Session', 'Created', 'Expires', 'Last visit', 'Status'].map((label) => <th key={label} scope="col" className="p-3">{label}</th>)}</tr></thead>
+                                <tbody>{page.items.map((session) => (
+                                    <tr key={session.id} className="border-t border-gray-200 dark:border-gray-700">
+                                        <td className="p-3"><span className="font-mono" title={session.id}>{session.id.slice(0, 8)}</span>{session.current && <span className="ml-2 text-sky-600">Current</span>}</td>
+                                        <td className="p-3 whitespace-nowrap">{timestamp(session.createdAtMs)}</td>
+                                        <td className="p-3 whitespace-nowrap">{timestamp(session.expiresAtMs)}</td>
+                                        <td className="p-3 whitespace-nowrap">{timestamp(session.lastSeenAtMs)}</td>
+                                        <td className="p-3">{session.revokedAtMs !== null ? `Revoked ${timestamp(session.revokedAtMs)}` : session.expiresAtMs <= Date.now() ? 'Expired' : 'Active'}</td>
+                                    </tr>
+                                ))}</tbody>
+                            </table>
+                            {page.items.length === 0 && <p className="p-3">No sessions found.</p>}
+                        </div>
+                        <div className="flex items-center gap-3">
+                            <Button variant="outline" disabled={cursors.length === 1} onClick={() => setCursors((values) => values.slice(0, -1))}>Previous</Button>
+                            <span>Page {cursors.length}</span>
+                            <Button variant="outline" disabled={!page.nextCursor} onClick={() => { if (page.nextCursor) setCursors((values) => [...values, page.nextCursor!]); }}>Next</Button>
+                        </div>
+                    </>
+                )}
+                <SignOutConfirmDialog open={confirm} isSubmitting={revoking} title="Sign out all sessions?"
+                    description={`All sessions for ${username}, including this one, will be revoked. Sign in again to continue.`}
+                    onCancel={() => { if (!revoking) setConfirm(false); }} onConfirm={() => void revoke()} />
+            </CardContent>
+        </Card>
+    );
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { AuthService } from './auth.service';
+import { invokeAuthenticatedCommand } from './invoke';
+import { SessionStorageService } from './session.storage';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+const failure = (code: string) => ({ code, message: 'Authentication failed.', category: 'authentication', retryable: false });
+
+beforeEach(() => {
+    const entries = new Map<string, string>();
+    vi.stubGlobal('window', { localStorage: {
+        getItem: (key: string) => entries.get(key) ?? null,
+        setItem: (key: string, value: string) => entries.set(key, value),
+        removeItem: (key: string) => entries.delete(key),
+    } });
+    SessionStorageService.setSessionId('current-token');
+});
+afterEach(() => { vi.resetAllMocks(); vi.unstubAllGlobals(); });
+
+describe('authoritative session lifecycle', () => {
+    it('clears authentication when an ordinary business command rejects the current session', async () => {
+        const onFailure = vi.fn();
+        const unsubscribe = SessionStorageService.subscribeAuthenticationFailure(onFailure);
+        try {
+            vi.mocked(invoke).mockRejectedValue(failure('auth.session.invalid'));
+            await expect(invokeAuthenticatedCommand('get_topic_list')).rejects.toMatchObject({ code: 'auth.session.invalid' });
+            expect(SessionStorageService.getSessionId()).toBeNull();
+            expect(onFailure).toHaveBeenCalledWith('invalid');
+        } finally { unsubscribe(); }
+    });
+
+    it('a delayed old request cannot invalidate a newer login', async () => {
+        let reject!: (reason: unknown) => void;
+        vi.mocked(invoke).mockImplementation(() => new Promise((_resolve, rejectRequest) => { reject = rejectRequest; }));
+        const request = invokeAuthenticatedCommand('get_topic_list');
+        SessionStorageService.setSessionId('new-token');
+        reject(failure('auth.session.invalid'));
+        await expect(request).rejects.toMatchObject({ code: 'auth.session.invalid' });
+        expect(SessionStorageService.getSessionId()).toBe('new-token');
+    });
+
+    it('wrong credentials do not log out an otherwise valid session', async () => {
+        vi.mocked(invoke).mockRejectedValue(failure('auth.credentials.invalid'));
+        await expect(AuthService.changePassword({ oldPassword: 'wrong', newPassword: 'new-secret' })).rejects.toMatchObject({ code: 'auth.credentials.invalid' });
+        expect(SessionStorageService.getSessionId()).toBe('current-token');
+    });
+
+    it('password-required errors keep the token and request the forced password flow', async () => {
+        const onFailure = vi.fn();
+        const unsubscribe = SessionStorageService.subscribeAuthenticationFailure(onFailure);
+        try {
+            vi.mocked(invoke).mockRejectedValue(failure('auth.password_change_required'));
+            await expect(invokeAuthenticatedCommand('get_topic_list')).rejects.toBeDefined();
+            expect(onFailure).toHaveBeenCalledWith('password-change-required');
+            expect(SessionStorageService.getSessionId()).toBe('current-token');
+        } finally { unsubscribe(); }
+    });
+
+    it('revoking all current-account sessions clears the token and notifies the login gate', async () => {
+        const onFailure = vi.fn();
+        const unsubscribe = SessionStorageService.subscribeAuthenticationFailure(onFailure);
+        try {
+            vi.mocked(invoke).mockResolvedValue({ revokedCount: 2, currentSessionRevoked: true });
+            await AuthService.revokeUserSessions('admin');
+            expect(SessionStorageService.getSessionId()).toBeNull();
+            expect(onFailure).toHaveBeenCalledWith('invalid');
+            expect(invoke).toHaveBeenCalledWith('revoke_user_sessions', { username: 'admin', sessionId: 'current-token' });
+        } finally { unsubscribe(); }
+    });
+
+    it('successful password changes require a new login', async () => {
+        vi.mocked(invoke).mockResolvedValue({ message: 'Password changed' });
+        await AuthService.changePassword({ oldPassword: 'old-secret', newPassword: 'new-secret' });
+        expect(SessionStorageService.getSessionId()).toBeNull();
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth.service.ts
@@ -1,3 +1,4 @@
+import { SessionStorageService } from './session.storage';
 import { invokeAuthenticatedCommand, invokePublicCommand, invokeSessionCommand } from './invoke';
 import type {
     AuthSessionResponse,
@@ -25,17 +26,51 @@ export class AuthService {
     }
 
     static async changePassword(payload: ChangePasswordPayload): Promise<CommonResponse> {
-        return invokeAuthenticatedCommand<CommonResponse>('change_password', {
+        const sessionId = SessionStorageService.getSessionId();
+        const result = await invokeAuthenticatedCommand<CommonResponse>('change_password', {
             oldPassword: payload.oldPassword,
             newPassword: payload.newPassword,
         });
+        SessionStorageService.reportAuthenticationFailure(sessionId, 'invalid');
+        return result;
     }
 
     static async getCurrentUserProfile(): Promise<UserProfile> {
         return invokeAuthenticatedCommand<UserProfile>('get_current_user_profile');
     }
 
+    static async listSessions(username: string, cursor?: string): Promise<SessionPage> {
+        return invokeAuthenticatedCommand<SessionPage>('list_sessions', { username, cursor, limit: 25 });
+    }
+
+    static async revokeUserSessions(username: string): Promise<RevokeSessionsResponse> {
+        const sessionId = SessionStorageService.getSessionId();
+        const result = await invokeAuthenticatedCommand<RevokeSessionsResponse>('revoke_user_sessions', { username });
+        if (result.currentSessionRevoked) SessionStorageService.reportAuthenticationFailure(sessionId, 'invalid');
+        return result;
+    }
+
     static async getBootstrapStatus(): Promise<BootstrapStatus> {
         return invokePublicCommand<BootstrapStatus>('get_auth_bootstrap_status');
     }
+}
+
+export interface SessionView {
+    id: string;
+    username: string;
+    createdAtMs: number;
+    expiresAtMs: number;
+    lastSeenAtMs: number;
+    revokedAtMs: number | null;
+    current: boolean;
+}
+
+export interface SessionPage {
+    items: SessionView[];
+    nextCursor: string | null;
+}
+
+export interface RevokeSessionsResponse {
+    revokedCount: number;
+    currentSessionRevoked: boolean;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
@@ -81,11 +81,21 @@ export const invokeSessionCommand = <T>(
     command: string,
     sessionId: string,
     args?: Record<string, unknown>,
-): Promise<T> => invokeDecoded<T>(command, { ...args, sessionId });
+): Promise<T> => invokeDecoded<T>(command, { ...args, sessionId }).catch((error: unknown) => {
+    if (isDashboardClientError(error)) {
+        if (error.code === 'auth.session.invalid') {
+            SessionStorageService.reportAuthenticationFailure(sessionId, 'invalid');
+        } else if (error.code === 'auth.password_change_required') {
+            SessionStorageService.reportAuthenticationFailure(sessionId, 'password-change-required');
+        }
+    }
+    throw error;
+});
 
 export const invokeAuthenticatedCommand = <T>(command: string, args?: Record<string, unknown>): Promise<T> => {
     const sessionId = SessionStorageService.getSessionId();
     if (!sessionId) {
+        SessionStorageService.reportAuthenticationFailure(null, 'invalid');
         return Promise.reject(
             new DashboardClientError({
                 code: 'auth.session.invalid',

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/session.storage.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/session.storage.ts
@@ -1,23 +1,36 @@
 const SESSION_KEY = 'rocketmq.dashboard.session_id';
+export type AuthenticationFailure = 'invalid' | 'password-change-required';
+const listeners = new Set<(reason: AuthenticationFailure) => void>();
+let memorySession: string | null = null;
 
 export class SessionStorageService {
     static getSessionId(): string | null {
         try {
             return window.localStorage.getItem(SESSION_KEY);
         } catch {
-            return null;
+            return memorySession;
         }
     }
 
     static setSessionId(sessionId: string): void {
-        try {
-            window.localStorage.setItem(SESSION_KEY, sessionId);
-        } catch {}
+        memorySession = sessionId;
+        try { window.localStorage.setItem(SESSION_KEY, sessionId); } catch {}
     }
 
     static clearSessionId(): void {
-        try {
-            window.localStorage.removeItem(SESSION_KEY);
-        } catch {}
+        memorySession = null;
+        try { window.localStorage.removeItem(SESSION_KEY); } catch {}
+    }
+
+    static subscribeAuthenticationFailure(listener: (reason: AuthenticationFailure) => void): () => void {
+        listeners.add(listener);
+        return () => { listeners.delete(listener); };
+    }
+
+    static reportAuthenticationFailure(sessionId: string | null, reason: AuthenticationFailure): void {
+        // A late rejection from an old request must not sign out a newer login.
+        if (this.getSessionId() !== sessionId) return;
+        if (reason === 'invalid') this.clearSessionId();
+        for (const listener of listeners) listener(reason);
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { SessionStorageService } from '../services/session.storage';
 import type { SessionUser } from '../features/auth/types/auth.types';
 
 type Tab =
@@ -25,7 +26,6 @@ interface AppState {
   setActiveTab: (tab: Tab) => void;
   setAuthSession: (sessionId: string, currentUser: SessionUser) => void;
   clearAuthSession: () => void;
-  markPasswordChanged: () => void;
   startAuthBootstrap: () => void;
   finishAuthBootstrap: () => void;
   pageTitle: string;
@@ -86,17 +86,14 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     setIsLoggedIn(false);
   };
 
-  const markPasswordChanged = () => {
-    setMustChangePassword(false);
-    setCurrentUser((previousUser) =>
-      previousUser
-        ? {
-            ...previousUser,
-            mustChangePassword: false,
-          }
-        : previousUser
-    );
-  };
+  useEffect(() => SessionStorageService.subscribeAuthenticationFailure((reason) => {
+    if (reason === 'invalid') {
+      clearAuthSession();
+    } else {
+      setMustChangePassword(true);
+      setCurrentUser((user) => user ? { ...user, mustChangePassword: true } : user);
+    }
+  }), []);
 
   return (
     <AppContext.Provider
@@ -110,7 +107,6 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         setActiveTab,
         setAuthSession,
         clearAuthSession,
-        markPasswordChanged,
         startAuthBootstrap: () => setIsBootstrappingAuth(true),
         finishAuthBootstrap: () => setIsBootstrappingAuth(false),
         pageTitle: getPageTitle(activeTab),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10362

### Brief Description

Tauri sessions now survive restarts and expire after eight hours by default. Every business command awaits database-backed account/session authorization. Only random bearer digests are stored, while a separate safe ID is used in session lists. Password changes atomically revoke all account sessions, including the current session, and require another login.

Add self-service account session pagination and revocation, an Account Sessions panel, and global frontend invalidation that cannot let an old request clear a newer login. StorageManager owns the hourly bounded retention task and drains accepted I/O during shutdown. Session TTL accepts a documented environment override. Fresh schema version 2 intentionally does not migrate version 1 development databases; unsupported data remains untouched.

### How Did You Test This Change?

From the standalone Tauri backend:
- `cargo test --lib auth::`: 13 passed, including controllable-clock expiry, persisted restoration, first-password restrictions, password revocation, pagination/redaction, account isolation, disabled accounts, logout, and bounded cleanup.
- `cargo test --lib persistence::`: 7 passed.
- `cargo test --lib error::`: 5 passed, including authorization coverage of all 50 business commands.
- `cargo fmt -p rocketmq-dashboard-tauri -- --check`: passed. Package scope avoids the existing Windows command-length failure of `cargo fmt --all` across path dependencies.

From the Tauri frontend:
- `npm run build`: passed; existing large-bundle warning remains.
- `npm test -- src/services/invoke.test.ts src/services/auth-session.test.ts`: 9 passed, including sign-out after revocation/password changes and stale-token rejection isolation.
- `git diff --check`: passed.

Native desktop interaction is reserved for the final desktop smoke step. No CI result is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent login sessions that survive app restarts, with configurable expiration.
  * Added account session management to view active sessions, refresh the list, and sign out all sessions.
  * Added automatic cleanup of expired sessions.
  * Added session-aware authentication recovery and safer handling of expired or invalid sessions.

* **Bug Fixes**
  * Password changes now sign out all active sessions and provide clearer confirmation feedback.
  * Improved authorization checks across dashboard operations.

* **Documentation**
  * Updated authentication and database setup documentation for persistent sessions and schema behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->