### PR TITLE
[ISSUE #10364]🚀Add owned Tauri audit history and truthful mutation outcomes

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
@@ -13,6 +13,7 @@ A RocketMQ-Rust desktop dashboard built with Tauri, React, and Rust.
 - Local embedded authentication with SQLite
 - Argon2 password hashing
 - Forced bootstrap password change on first login
+- Audit history with filters, cursor pagination, explicit uncertain outcomes, and persistent audit-write warnings
 - Persistent sessions with fixed expiry, restart restoration, and account-wide revocation
 
 ## Authentication Quick Start
@@ -44,7 +45,7 @@ them; choose a new data directory to start fresh.
 
 Sessions expire after eight hours by default (`DASHBOARD_TAURI_SESSION_TTL_SECS` overrides this). Password changes revoke all sessions and require a new login. Account ¡ú Sessions lists safe identifiers and can sign out the entire account.
 
-The current fresh schema is version 2; version 1 development databases are not migrated. Select a new data directory when changing from an older format.
+The current fresh schema is version 3; version 1/2 development databases are not migrated. Select a new data directory when changing from an older format.
 
 For more detail, see [doc/AUTH_CONFIG.md](./doc/AUTH_CONFIG.md).
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUDIT.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUDIT.md
@@ -1,0 +1,49 @@
+# Desktop audit history
+
+Audit records cover login, logout, password changes, account session revocation,
+NameServer/Proxy changes, Topic and Consumer mutations, sends, direct consumption,
+and DLQ resends. Read-only business queries are not recorded individually.
+
+The Audit navigation entry supports an inclusive time range, exact actor/action/
+outcome/environment filters, refresh, and cursor pagination ordered by terminal
+time and event ID. Environment IDs are absent until connection identity support
+is introduced; old records are not assigned a guessed environment.
+
+Each accepted mutation belongs to the audit service task group. Closing a page or
+dropping the IPC waiter does not drop the operation or its terminal record.
+Shutdown first stops audit admission and drains accepted mutations, then drains
+storage and closes administrative sessions. Incomplete shutdown is reported.
+
+Records contain generated event/request IDs, the authoritative authenticated actor
+(or no actor for failed authentication), action, resource type/name where known,
+outcome, terminal time, and an explicit allowlist of receipt counts and safe error
+codes. Passwords, keys, tokens, message bodies, raw errors, and complete requests or
+responses are never serialized into audit detail. Endpoint text is omitted until
+stable endpoint identifiers are available.
+
+Outcomes distinguish success, rejected, failed, partial, and unknown. Remote errors
+that do not establish a validation/authentication rejection are recorded as unknown;
+inspect the resource before deciding whether to resubmit. Batch receipts preserve
+success/failure counts rather than equating every successful IPC response with a
+fully successful operation.
+
+Account mutations commit their success record in the same SQLite transaction. If
+recording fails, the account mutation rolls back. Connection configuration still
+uses its existing store; its versioned transaction integration follows with the
+connection settings work. For separately committed configuration or remote changes,
+a failed audit write preserves the actual command result and adds `auditWarning`.
+The frontend displays a persistent, dismissible warning. It does not retry the
+operation. An operation error also remains the original error if its audit write
+fails.
+
+Retention runs at startup and hourly, deleting at most 1,000 terminal records older
+than 30 days per pass. The cleanup uses the storage-owned background task group.
+The current schema is version 3; older development schemas are rejected without
+modification. Select a fresh data directory when moving between these development
+formats.
+
+## Focused validation
+
+From `src-tauri`: `cargo test --lib audit::`, plus affected auth/storage/error tests.
+From the Tauri frontend: `npm run build` and
+`npm test -- src/services/auth-session.test.ts src/services/invoke.test.ts`.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUTH_CONFIG.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUTH_CONFIG.md
@@ -50,7 +50,7 @@ them; choose a new data directory to start fresh.
 
 ## Schema
 
-Schema version 2 contains `dashboard_schema`, `users`, `sessions`, and connection configuration tables. Version 1 development databases are not migrated; select a new data directory. The account table is:
+Schema version 3 contains `dashboard_schema`, `users`, `sessions`, `audit_events`, and connection configuration tables. Version 1/2 development databases are not migrated; select a new data directory. The account table is:
 
 ```sql
 CREATE TABLE IF NOT EXISTS users (

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit.rs
@@ -1,0 +1,20 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) mod commands;
+mod db;
+mod service;
+mod types;
+pub(crate) use service::AuditManager;
+pub(crate) use types::{AuditAccess, AuditAction, AuditContext, Audited};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/commands.rs
@@ -1,0 +1,30 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::AuditManager;
+use super::types::{AuditPage, AuditQuery};
+use crate::auth::SessionState;
+use crate::error::{CommandResult, authorize_command};
+use tauri::State;
+
+#[tauri::command]
+pub async fn query_audit_events(
+    session_id: String,
+    query: AuditQuery,
+    session_state: State<'_, SessionState>,
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<AuditPage> {
+    authorize_command(&session_id, &session_state).await?;
+    audit_manager.query(query).await.map_err(Into::into)
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/db.rs
@@ -1,0 +1,102 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::types::*;
+use crate::error::{DashboardError, DashboardResult};
+use rusqlite::{Connection, params};
+use uuid::Uuid;
+
+pub(super) fn insert(connection: &Connection, event: &AuditEvent) -> DashboardResult<()> {
+    connection.execute("INSERT INTO audit_events(event_id, request_id, actor, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10) ON CONFLICT(event_id) DO NOTHING",
+        params![event.event_id, event.request_id, event.actor, event.action, event.resource_type, event.resource_name, event.environment_id, event.outcome, serde_json::to_string(&event.detail)?, event.created_at_ms])?;
+    Ok(())
+}
+
+pub(super) fn query(connection: &Connection, query: AuditQuery) -> DashboardResult<AuditPage> {
+    let limit = query.limit.unwrap_or(50);
+    if !(1..=200).contains(&limit) || matches!((query.from_ms, query.to_ms), (Some(from), Some(to)) if from > to) {
+        return Err(DashboardError::Validation("invalid audit query".into()));
+    }
+    let cursor = query
+        .cursor
+        .as_ref()
+        .map(|value| {
+            let (time, id) = value
+                .split_once(':')
+                .ok_or_else(|| DashboardError::Validation("invalid audit cursor".into()))?;
+            let time = time
+                .parse::<i64>()
+                .map_err(|_| DashboardError::Validation("invalid audit cursor".into()))?;
+            Uuid::parse_str(id).map_err(|_| DashboardError::Validation("invalid audit cursor".into()))?;
+            Ok::<_, DashboardError>((time, id))
+        })
+        .transpose()?;
+    let mut statement = connection.prepare("SELECT event_id, request_id, actor, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms FROM audit_events
+        WHERE (?1 IS NULL OR created_at_ms >= ?1) AND (?2 IS NULL OR created_at_ms <= ?2)
+        AND (?3 IS NULL OR actor = ?3) AND (?4 IS NULL OR action = ?4)
+        AND (?5 IS NULL OR outcome = ?5) AND (?6 IS NULL OR environment_id = ?6)
+        AND (?7 IS NULL OR created_at_ms < ?7 OR (created_at_ms = ?7 AND event_id < ?8))
+        ORDER BY created_at_ms DESC, event_id DESC LIMIT ?9")?;
+    let rows = statement.query_map(
+        params![
+            query.from_ms,
+            query.to_ms,
+            query.actor,
+            query.action,
+            query.outcome.map(Outcome::as_str),
+            query.environment_id,
+            cursor.map(|(time, _)| time),
+            cursor.map(|(_, id)| id),
+            (limit + 1) as i64
+        ],
+        |row| {
+            let json: String = row.get(8)?;
+            Ok((
+                AuditEvent {
+                    event_id: row.get(0)?,
+                    request_id: row.get(1)?,
+                    actor: row.get(2)?,
+                    action: row.get(3)?,
+                    resource_type: row.get(4)?,
+                    resource_name: row.get(5)?,
+                    environment_id: row.get(6)?,
+                    outcome: row.get(7)?,
+                    detail: AuditDetail {
+                        result_unknown: false,
+                        error_code: None,
+                        success_count: None,
+                        failure_count: None,
+                    },
+                    created_at_ms: row.get(9)?,
+                },
+                json,
+            ))
+        },
+    )?;
+    let mut items = Vec::new();
+    for row in rows {
+        let (mut event, json) = row?;
+        event.detail = serde_json::from_str(&json)?;
+        items.push(event);
+    }
+    let next_cursor = if items.len() > limit {
+        items.truncate(limit);
+        items
+            .last()
+            .map(|event| format!("{}:{}", event.created_at_ms, event.event_id))
+    } else {
+        None
+    };
+    Ok(AuditPage { items, next_cursor })
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/service.rs
@@ -1,0 +1,188 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::db;
+use super::types::*;
+use crate::error::{CommandError, CommandResult, DashboardError, DashboardResult};
+use crate::persistence::StorageManager;
+use chrono::Utc;
+use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_runtime::service_context::ChildServiceContext;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+const AUDIT_WARNING: &str = "The operation completed, but its audit record could not be saved. Review the result before taking any further action.";
+
+#[derive(Clone)]
+pub(crate) struct AuditManager {
+    storage: StorageManager,
+    context: ChildServiceContext,
+    accepting: Arc<Mutex<bool>>,
+}
+
+impl AuditManager {
+    pub(crate) fn new(storage: StorageManager, context: ChildServiceContext) -> Self {
+        Self {
+            storage,
+            context,
+            accepting: Arc::new(Mutex::new(true)),
+        }
+    }
+
+    /// Once admitted, an operation and its terminal audit record outlive the IPC waiter.
+    pub(crate) async fn execute<T, F, Fut>(
+        &self,
+        access: AuditAccess,
+        action: AuditAction,
+        resource: Option<String>,
+        operation: F,
+    ) -> CommandResult<Audited<T>>
+    where
+        T: AuditReceipt + Send + 'static,
+        F: FnOnce(AuditContext) -> Fut + Send + 'static,
+        Fut: Future<Output = DashboardResult<T>> + Send + 'static,
+    {
+        let (sender, receiver) = oneshot::channel();
+        {
+            let accepting = self.accepting.lock().map_err(|_| DashboardError::StorageClosed)?;
+            if !*accepting {
+                return Err(DashboardError::StorageClosed.into());
+            }
+            let manager = self.clone();
+            self.context
+                .spawn_service("audited-mutation", async move {
+                    let result = manager.execute_accepted(access, action, resource, operation).await;
+                    let _ = sender.send(result);
+                })
+                .map_err(DashboardError::Persistence)?;
+        }
+        receiver
+            .await
+            .map_err(|_| CommandError::from(DashboardError::StorageClosed))?
+    }
+
+    async fn execute_accepted<T, F, Fut>(
+        &self,
+        access: AuditAccess,
+        action: AuditAction,
+        resource: Option<String>,
+        operation: F,
+    ) -> CommandResult<Audited<T>>
+    where
+        T: AuditReceipt,
+        F: FnOnce(AuditContext) -> Fut,
+        Fut: Future<Output = DashboardResult<T>>,
+    {
+        let context = AuditContext {
+            event_id: Uuid::new_v4().to_string(),
+            request_id: Uuid::new_v4().to_string(),
+            action,
+            resource_name: resource.filter(|name| name.len() <= 255 && !name.chars().any(char::is_control)),
+        };
+        let mut actor = None;
+        let identity = match access {
+            AuditAccess::Login => Ok(()),
+            AuditAccess::Account { sessions, token } => sessions.require_session(&token).await.map(|user| {
+                actor = Some(user.username);
+            }),
+            AuditAccess::Dashboard { sessions, token } => match sessions.require_session(&token).await {
+                Ok(user) => {
+                    actor = Some(user.username);
+                    if user.must_change_password {
+                        Err(DashboardError::PasswordChangeRequired)
+                    } else {
+                        Ok(())
+                    }
+                }
+                Err(error) => Err(error),
+            },
+        };
+        let result = match identity {
+            Ok(_) => operation(context.clone()).await.map_err(CommandError::from),
+            Err(error) => Err(CommandError::from(error)),
+        };
+        let summary = match &result {
+            Ok(receipt) => {
+                actor = actor.or_else(|| receipt.authenticated_actor());
+                receipt.summary()
+            }
+            Err(error) => Summary::error(error, action.remote()),
+        };
+        let event = context.event(actor, summary);
+        let saved = self
+            .storage
+            .run("audit-terminal", move |connection| db::insert(connection, &event))
+            .await
+            .is_ok();
+        match result {
+            Ok(result) => Ok(Audited {
+                result,
+                audit_warning: if saved { None } else { Some(AUDIT_WARNING) },
+            }),
+            Err(mut error) => {
+                if !saved {
+                    error.audit_warning =
+                        Some("The audit record could not be saved. The reported operation outcome is unchanged.");
+                }
+                Err(error)
+            }
+        }
+    }
+
+    pub(crate) async fn run_local<T: Send + 'static>(
+        &self,
+        operation: impl FnOnce() -> DashboardResult<T> + Send + 'static,
+    ) -> DashboardResult<T> {
+        self.storage.run("local-config-mutation", move |_| operation()).await
+    }
+
+    pub(crate) async fn query(&self, query: AuditQuery) -> DashboardResult<AuditPage> {
+        self.storage
+            .run("audit-query", move |connection| db::query(connection, query))
+            .await
+    }
+
+    pub(crate) fn start_cleanup(&self) -> DashboardResult<()> {
+        let storage = self.storage.clone();
+        self.storage.start_background("audit-retention", async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(3600));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                let cutoff = Utc::now().timestamp_millis() - 30 * 24 * 60 * 60 * 1000;
+                if storage.run("audit-cleanup", move |connection| {
+                    connection.execute("DELETE FROM audit_events WHERE event_id IN (SELECT event_id FROM audit_events WHERE created_at_ms < ?1 ORDER BY created_at_ms LIMIT 1000)", [cutoff])?; Ok(())
+                }).await.is_err() { log::warn!("Audit retention cleanup could not complete"); }
+            }
+        })
+    }
+
+    pub(crate) async fn shutdown(&self, timeout: Duration) -> bool {
+        match self.accepting.lock() {
+            Ok(mut accepting) => *accepting = false,
+            Err(_) => return false,
+        }
+        self.context
+            .task_group()
+            .shutdown_until(ShutdownDeadline::after(timeout))
+            .await
+            .is_healthy()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/service/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/service/tests.rs
@@ -1,0 +1,397 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use crate::auth::types::CommonResponse;
+use crate::auth::{AuthDb, AuthService, SessionState};
+use crate::message::types::{MessageBatchResendResponse, MessageResendResult};
+use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+struct Fixture {
+    owner: Option<RuntimeOwner>,
+    storage: StorageManager,
+    audit: AuditManager,
+    sessions: SessionState,
+    directory: std::path::PathBuf,
+}
+impl Fixture {
+    fn new() -> Self {
+        let owner = RuntimeOwner::plan(RuntimeConfig::server_default("audit-test"))
+            .unwrap()
+            .build()
+            .unwrap();
+        let directory = std::env::temp_dir().join(format!("tauri-audit-{}", Uuid::new_v4()));
+        let storage = StorageManager::new(
+            directory.join("dashboard.db"),
+            owner.root_context().component("storage"),
+        );
+        owner.block_on(storage.initialize()).unwrap();
+        let auth = AuthService::with_initial_password(AuthDb::from_path(storage.path()), "initial-secret");
+        let bootstrap = auth.clone();
+        owner
+            .block_on(storage.run("bootstrap", move |_| bootstrap.bootstrap_default_admin()))
+            .unwrap();
+        let sessions = SessionState::new(storage.clone(), auth).unwrap();
+        let audit = AuditManager::new(storage.clone(), owner.root_context().component("audit"));
+        Self {
+            owner: Some(owner),
+            storage,
+            audit,
+            sessions,
+            directory,
+        }
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        if let Some(owner) = self.owner.take() {
+            assert!(owner.block_on(self.audit.shutdown(Duration::from_secs(5))));
+            assert!(owner.block_on(self.storage.shutdown(Duration::from_secs(5))));
+            let _ = owner.shutdown_runtime_blocking();
+        }
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+fn result(success: bool) -> MessageResendResult {
+    MessageResendResult {
+        success,
+        message: "secret-result-text".into(),
+        consumer_group: "test-group".into(),
+        topic: "test-topic".into(),
+        msg_id: "private-id".into(),
+        consume_result: None,
+        remark: None,
+    }
+}
+
+#[test]
+fn success_rejection_partial_and_unknown_each_have_one_safe_terminal_record() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        fixture
+            .audit
+            .execute(AuditAccess::Login, AuditAction::Login, None, |_| async {
+                Ok(CommonResponse {
+                    message: "secret-response".into(),
+                })
+            })
+            .await
+            .unwrap();
+        let called = Arc::new(AtomicBool::new(false));
+        let operation_called = called.clone();
+        let rejected = fixture
+            .audit
+            .execute(
+                AuditAccess::dashboard(&fixture.sessions, "secret-invalid-token".into()),
+                AuditAction::UpsertTopic,
+                Some("topic".into()),
+                move |_| async move {
+                    operation_called.store(true, Ordering::SeqCst);
+                    Ok(result(true))
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(rejected.code, "auth.session.invalid");
+        assert!(!called.load(Ordering::SeqCst));
+        fixture
+            .audit
+            .execute(AuditAccess::Login, AuditAction::BatchResendDlq, None, |_| async {
+                Ok(MessageBatchResendResponse {
+                    items: vec![result(true), result(false)],
+                    total: 2,
+                    success_count: 1,
+                    failure_count: 1,
+                })
+            })
+            .await
+            .unwrap();
+        fixture
+            .audit
+            .execute::<CommonResponse, _, _>(AuditAccess::Login, AuditAction::SendMessage, None, |_| async {
+                Err(DashboardError::Internal("secret-network-error"))
+            })
+            .await
+            .unwrap_err();
+        let page = fixture.audit.query(AuditQuery::default()).await.unwrap();
+        assert_eq!(page.items.len(), 4);
+        let mut outcomes = page
+            .items
+            .iter()
+            .map(|event| event.outcome.as_str())
+            .collect::<Vec<_>>();
+        outcomes.sort();
+        assert_eq!(outcomes, ["partial", "rejected", "success", "unknown"]);
+        assert!(
+            page.items
+                .iter()
+                .find(|event| event.outcome == "unknown")
+                .unwrap()
+                .detail
+                .result_unknown
+        );
+        let json = serde_json::to_string(&page).unwrap();
+        for secret in [
+            "secret-response",
+            "secret-invalid-token",
+            "secret-result-text",
+            "private-id",
+            "secret-network-error",
+        ] {
+            assert!(!json.contains(secret));
+        }
+        assert!(page.items.iter().all(|event| event.environment_id.is_none()));
+    });
+}
+
+#[test]
+fn successful_remote_result_survives_audit_storage_failure_without_retry() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        fixture
+            .storage
+            .run("break-audit", |connection| {
+                connection.execute("DROP TABLE audit_events", [])?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let executed = calls.clone();
+        let response = fixture
+            .audit
+            .execute(AuditAccess::Login, AuditAction::ResendDlq, None, move |_| async move {
+                executed.fetch_add(1, Ordering::SeqCst);
+                Ok(result(true))
+            })
+            .await
+            .unwrap();
+        assert!(response.result.success);
+        assert!(response.audit_warning.is_some());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["success"], true);
+        assert!(json["auditWarning"].is_string());
+    });
+}
+
+#[test]
+fn dropped_ipc_waiter_keeps_operation_and_shutdown_waits_for_terminal_audit() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let (entered, entered_rx) = oneshot::channel();
+        let (release, release_rx) = oneshot::channel();
+        let mut waiting = Box::pin(fixture.audit.execute(
+            AuditAccess::Login,
+            AuditAction::SendMessage,
+            None,
+            move |_| async move {
+                entered.send(()).unwrap();
+                release_rx.await.unwrap();
+                Ok(result(true))
+            },
+        ));
+        tokio::select! { _ = entered_rx => {}, _ = &mut waiting => panic!("operation completed before release") }
+        drop(waiting);
+        let mut shutdown = Box::pin(fixture.audit.shutdown(Duration::from_secs(5)));
+        std::future::poll_fn(|context| {
+            assert!(shutdown.as_mut().poll(context).is_pending());
+            std::task::Poll::Ready(())
+        })
+        .await;
+        release.send(()).unwrap();
+        assert!(shutdown.await);
+        assert_eq!(fixture.audit.query(AuditQuery::default()).await.unwrap().items.len(), 1);
+        assert!(
+            fixture
+                .audit
+                .execute(AuditAccess::Login, AuditAction::Login, None, |_| async {
+                    Ok(result(true))
+                })
+                .await
+                .is_err()
+        );
+    });
+}
+
+#[test]
+fn query_filters_and_cursor_do_not_duplicate_rows_with_equal_timestamps() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        fixture
+            .storage
+            .run("seed-audit", |connection| {
+                for index in 0..4 {
+                    db::insert(
+                        connection,
+                        &AuditEvent {
+                            event_id: Uuid::new_v4().to_string(),
+                            request_id: Uuid::new_v4().to_string(),
+                            actor: Some("admin".into()),
+                            action: "topic.delete".into(),
+                            resource_type: "topic".into(),
+                            resource_name: Some(format!("topic-{index}")),
+                            environment_id: None,
+                            outcome: "success".into(),
+                            detail: Summary::count(1, 0).detail,
+                            created_at_ms: 1000,
+                        },
+                    )?;
+                }
+                Ok(())
+            })
+            .await
+            .unwrap();
+        let mut cursor = None;
+        let mut ids = std::collections::HashSet::new();
+        loop {
+            let page = fixture
+                .audit
+                .query(AuditQuery {
+                    from_ms: Some(1000),
+                    to_ms: Some(1000),
+                    actor: Some("admin".into()),
+                    action: Some("topic.delete".into()),
+                    outcome: Some(Outcome::Success),
+                    limit: Some(2),
+                    cursor,
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            for item in page.items {
+                assert!(ids.insert(item.event_id));
+            }
+            cursor = page.next_cursor;
+            if cursor.is_none() {
+                break;
+            }
+        }
+        assert_eq!(ids.len(), 4);
+        assert!(
+            fixture
+                .audit
+                .query(AuditQuery {
+                    actor: Some("other".into()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items
+                .is_empty()
+        );
+        assert!(
+            fixture
+                .audit
+                .query(AuditQuery {
+                    cursor: Some("invalid".into()),
+                    ..Default::default()
+                })
+                .await
+                .is_err()
+        );
+    });
+}
+
+#[test]
+fn account_mutations_commit_their_audit_once_and_rollback_if_recording_fails() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let sessions = fixture.sessions.clone();
+        let login = fixture
+            .audit
+            .execute(AuditAccess::Login, AuditAction::Login, None, move |audit| async move {
+                sessions
+                    .with_audit(audit)
+                    .login("admin".into(), "initial-secret".into())
+                    .await
+            })
+            .await
+            .unwrap();
+        let token = login.result.session_id;
+        let page = fixture.audit.query(AuditQuery::default()).await.unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].actor.as_deref(), Some("admin"));
+        assert!(!serde_json::to_string(&page).unwrap().contains(&token));
+        fixture
+            .audit
+            .execute(
+                AuditAccess::dashboard(&fixture.sessions, token.clone()),
+                AuditAction::DeleteTopic,
+                Some("protected".into()),
+                |_| async { Ok(result(true)) },
+            )
+            .await
+            .unwrap_err();
+        let rejected = fixture
+            .audit
+            .query(AuditQuery {
+                outcome: Some(Outcome::Rejected),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(rejected.items[0].actor.as_deref(), Some("admin"));
+        fixture
+            .storage
+            .run("break-audit", |connection| {
+                connection.execute("DROP TABLE audit_events", [])?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        let sessions = fixture.sessions.clone();
+        let change_token = token.clone();
+        let failure = fixture
+            .audit
+            .execute(
+                AuditAccess::account(&fixture.sessions, token.clone()),
+                AuditAction::ChangePassword,
+                None,
+                move |audit| async move {
+                    sessions
+                        .with_audit(audit)
+                        .change_password(change_token, "initial-secret".into(), "new-secret-password".into())
+                        .await?;
+                    Ok(CommonResponse {
+                        message: "changed".into(),
+                    })
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(failure.audit_warning.is_some());
+        assert!(
+            fixture
+                .sessions
+                .require_session(&token)
+                .await
+                .unwrap()
+                .must_change_password
+        );
+        fixture
+            .sessions
+            .login("admin".into(), "initial-secret".into())
+            .await
+            .unwrap();
+        assert!(
+            fixture
+                .sessions
+                .login("admin".into(), "new-secret-password".into())
+                .await
+                .is_err()
+        );
+    });
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
@@ -1,0 +1,326 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::auth::{SessionState, types::AuthSessionResponse};
+use crate::error::{CommandError, CommandErrorCategory};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy)]
+pub(crate) enum AuditAction {
+    Login,
+    Logout,
+    ChangePassword,
+    RevokeSessions,
+    AddNameServer,
+    SwitchNameServer,
+    DeleteNameServer,
+    UpdateVip,
+    UpdateTls,
+    AddProxy,
+    SwitchProxy,
+    DeleteProxy,
+    UpsertTopic,
+    DeleteTopic,
+    DeleteTopicByBroker,
+    ResetOffset,
+    SkipMessages,
+    SendMessage,
+    UpsertConsumer,
+    DeleteConsumer,
+    ConsumeDirectly,
+    ResendDlq,
+    BatchResendDlq,
+}
+
+impl AuditAction {
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::Login => "auth.login",
+            Self::Logout => "auth.logout",
+            Self::ChangePassword => "auth.change_password",
+            Self::RevokeSessions => "auth.revoke_sessions",
+            Self::AddNameServer => "nameserver.add",
+            Self::SwitchNameServer => "nameserver.switch",
+            Self::DeleteNameServer => "nameserver.delete",
+            Self::UpdateVip => "connection.vip",
+            Self::UpdateTls => "connection.tls",
+            Self::AddProxy => "proxy.add",
+            Self::SwitchProxy => "proxy.switch",
+            Self::DeleteProxy => "proxy.delete",
+            Self::UpsertTopic => "topic.upsert",
+            Self::DeleteTopic => "topic.delete",
+            Self::DeleteTopicByBroker => "topic.delete_broker",
+            Self::ResetOffset => "consumer.reset_offset",
+            Self::SkipMessages => "consumer.skip_messages",
+            Self::SendMessage => "message.send",
+            Self::UpsertConsumer => "consumer.upsert",
+            Self::DeleteConsumer => "consumer.delete",
+            Self::ConsumeDirectly => "message.consume_directly",
+            Self::ResendDlq => "dlq.resend",
+            Self::BatchResendDlq => "dlq.batch_resend",
+        }
+    }
+    pub(crate) fn resource_type(self) -> &'static str {
+        match self {
+            Self::Login | Self::Logout | Self::ChangePassword | Self::RevokeSessions => "account",
+            Self::AddNameServer
+            | Self::SwitchNameServer
+            | Self::DeleteNameServer
+            | Self::UpdateVip
+            | Self::UpdateTls
+            | Self::AddProxy
+            | Self::SwitchProxy
+            | Self::DeleteProxy => "connection",
+            Self::UpsertTopic | Self::DeleteTopic | Self::DeleteTopicByBroker | Self::SendMessage => "topic",
+            Self::ResetOffset
+            | Self::SkipMessages
+            | Self::UpsertConsumer
+            | Self::DeleteConsumer
+            | Self::ConsumeDirectly
+            | Self::ResendDlq
+            | Self::BatchResendDlq => "consumer_group",
+        }
+    }
+    pub(crate) fn remote(self) -> bool {
+        matches!(
+            self,
+            Self::UpsertTopic
+                | Self::DeleteTopic
+                | Self::DeleteTopicByBroker
+                | Self::ResetOffset
+                | Self::SkipMessages
+                | Self::SendMessage
+                | Self::UpsertConsumer
+                | Self::DeleteConsumer
+                | Self::ConsumeDirectly
+                | Self::ResendDlq
+                | Self::BatchResendDlq
+        )
+    }
+}
+
+pub(crate) enum AuditAccess {
+    Login,
+    Account { sessions: SessionState, token: String },
+    Dashboard { sessions: SessionState, token: String },
+}
+
+impl AuditAccess {
+    pub(crate) fn dashboard(sessions: &SessionState, token: String) -> Self {
+        Self::Dashboard {
+            sessions: sessions.clone(),
+            token,
+        }
+    }
+    pub(crate) fn account(sessions: &SessionState, token: String) -> Self {
+        Self::Account {
+            sessions: sessions.clone(),
+            token,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Outcome {
+    Success,
+    Rejected,
+    Failed,
+    Partial,
+    Unknown,
+}
+impl Outcome {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Rejected => "rejected",
+            Self::Failed => "failed",
+            Self::Partial => "partial",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Only explicit receipt metadata can be persisted. Request bodies and credentials have no field here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AuditDetail {
+    pub(crate) result_unknown: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) success_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) failure_count: Option<usize>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Summary {
+    pub(crate) outcome: Outcome,
+    pub(crate) detail: AuditDetail,
+}
+impl Summary {
+    pub(crate) fn count(success: usize, failure: usize) -> Self {
+        Self {
+            outcome: if failure == 0 {
+                Outcome::Success
+            } else if success == 0 {
+                Outcome::Failed
+            } else {
+                Outcome::Partial
+            },
+            detail: AuditDetail {
+                result_unknown: false,
+                error_code: None,
+                success_count: Some(success),
+                failure_count: Some(failure),
+            },
+        }
+    }
+    pub(crate) fn error(error: &CommandError, remote: bool) -> Self {
+        let outcome = match error.category {
+            CommandErrorCategory::Authentication | CommandErrorCategory::Validation => Outcome::Rejected,
+            _ if remote => Outcome::Unknown,
+            _ => Outcome::Failed,
+        };
+        Self {
+            outcome,
+            detail: AuditDetail {
+                result_unknown: outcome == Outcome::Unknown,
+                error_code: Some(error.code.into()),
+                success_count: None,
+                failure_count: None,
+            },
+        }
+    }
+}
+
+pub(crate) trait AuditReceipt {
+    fn summary(&self) -> Summary;
+    fn authenticated_actor(&self) -> Option<String> {
+        None
+    }
+}
+macro_rules! successful_receipt { ($($ty:ty),+ $(,)?) => { $(impl AuditReceipt for $ty { fn summary(&self) -> Summary { Summary::count(1, 0) } })+ }; }
+successful_receipt!(
+    crate::auth::types::CommonResponse,
+    crate::auth::types::RevokeSessionsResponse,
+    rocketmq_dashboard_common::NameServerMutationResult,
+    rocketmq_dashboard_common::ProxyMutationResult,
+    crate::consumer::types::ConsumerMutationResult
+);
+impl AuditReceipt for AuthSessionResponse {
+    fn summary(&self) -> Summary {
+        Summary::count(1, 0)
+    }
+    fn authenticated_actor(&self) -> Option<String> {
+        Some(self.current_user.username.clone())
+    }
+}
+impl AuditReceipt for crate::topic::types::TopicMutationResult {
+    fn summary(&self) -> Summary {
+        Summary::count(usize::from(self.success), usize::from(!self.success))
+    }
+}
+impl AuditReceipt for crate::topic::types::TopicSendMessageResult {
+    fn summary(&self) -> Summary {
+        let ok = self.send_status == "SEND_OK";
+        Summary::count(usize::from(ok), usize::from(!ok))
+    }
+}
+impl AuditReceipt for crate::message::types::MessageResendResult {
+    fn summary(&self) -> Summary {
+        Summary::count(usize::from(self.success), usize::from(!self.success))
+    }
+}
+impl AuditReceipt for crate::message::types::MessageBatchResendResponse {
+    fn summary(&self) -> Summary {
+        Summary::count(self.success_count, self.failure_count)
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Audited<T> {
+    #[serde(flatten)]
+    pub(crate) result: T,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) audit_warning: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AuditEvent {
+    pub(crate) event_id: String,
+    pub(crate) request_id: String,
+    pub(crate) actor: Option<String>,
+    pub(crate) action: String,
+    pub(crate) resource_type: String,
+    pub(crate) resource_name: Option<String>,
+    pub(crate) environment_id: Option<String>,
+    pub(crate) outcome: String,
+    pub(crate) detail: AuditDetail,
+    pub(crate) created_at_ms: i64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AuditQuery {
+    pub(crate) from_ms: Option<i64>,
+    pub(crate) to_ms: Option<i64>,
+    pub(crate) actor: Option<String>,
+    pub(crate) action: Option<String>,
+    pub(crate) outcome: Option<Outcome>,
+    pub(crate) environment_id: Option<String>,
+    pub(crate) limit: Option<usize>,
+    pub(crate) cursor: Option<String>,
+}
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AuditPage {
+    pub(crate) items: Vec<AuditEvent>,
+    pub(crate) next_cursor: Option<String>,
+}
+
+#[derive(Clone)]
+pub(crate) struct AuditContext {
+    pub(crate) event_id: String,
+    pub(crate) request_id: String,
+    pub(crate) action: AuditAction,
+    pub(crate) resource_name: Option<String>,
+}
+impl AuditContext {
+    pub(crate) fn event(&self, actor: Option<String>, summary: Summary) -> AuditEvent {
+        AuditEvent {
+            event_id: self.event_id.clone(),
+            request_id: self.request_id.clone(),
+            actor,
+            action: self.action.name().into(),
+            resource_type: self.action.resource_type().into(),
+            resource_name: self.resource_name.clone(),
+            environment_id: None,
+            outcome: summary.outcome.as_str().into(),
+            detail: summary.detail,
+            created_at_ms: chrono::Utc::now().timestamp_millis(),
+        }
+    }
+    /// Call inside the mutation's transaction so a successful account change always has its audit record.
+    pub(crate) fn record_success(
+        &self,
+        connection: &rusqlite::Connection,
+        actor: &str,
+    ) -> crate::error::DashboardResult<()> {
+        super::db::insert(connection, &self.event(Some(actor.into()), Summary::count(1, 0)))
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/commands.rs
@@ -16,6 +16,7 @@ use super::SessionState;
 use super::types::{
     AuthSessionResponse, BootstrapStatus, CommonResponse, RevokeSessionsResponse, SessionPage, UserProfile,
 };
+use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
 use crate::error::CommandResult;
 use tauri::State;
 
@@ -24,16 +25,35 @@ pub async fn login(
     username: String,
     password: String,
     session_state: State<'_, SessionState>,
-) -> CommandResult<AuthSessionResponse> {
-    session_state.login(username, password).await.map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<AuthSessionResponse>> {
+    let access = AuditAccess::Login;
+    let session_state = session_state.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::Login, None, move |audit| async move {
+            let session_state = session_state.with_audit(audit);
+            session_state.login(username, password).await
+        })
+        .await
 }
 
 #[tauri::command]
-pub async fn logout(session_id: String, session_state: State<'_, SessionState>) -> CommandResult<CommonResponse> {
-    session_state.logout(session_id).await?;
-    Ok(CommonResponse {
-        message: "Logged out successfully".into(),
-    })
+pub async fn logout(
+    session_id: String,
+    session_state: State<'_, SessionState>,
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<CommonResponse>> {
+    let access = AuditAccess::account(&session_state, session_id.clone());
+    let session_state = session_state.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::Logout, None, move |audit| async move {
+            let session_state = session_state.with_audit(audit);
+            session_state.logout(session_id).await?;
+            Ok(CommonResponse {
+                message: "Logged out successfully".into(),
+            })
+        })
+        .await
 }
 
 #[tauri::command]
@@ -50,13 +70,21 @@ pub async fn change_password(
     old_password: String,
     new_password: String,
     session_state: State<'_, SessionState>,
-) -> CommandResult<CommonResponse> {
-    session_state
-        .change_password(session_id, old_password, new_password)
-        .await?;
-    Ok(CommonResponse {
-        message: "Password updated. All sessions were revoked; sign in again.".into(),
-    })
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<CommonResponse>> {
+    let access = AuditAccess::account(&session_state, session_id.clone());
+    let session_state = session_state.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::ChangePassword, None, move |audit| async move {
+            let session_state = session_state.with_audit(audit);
+            session_state
+                .change_password(session_id, old_password, new_password)
+                .await?;
+            Ok(CommonResponse {
+                message: "Password updated. All sessions were revoked; sign in again.".into(),
+            })
+        })
+        .await
 }
 
 #[tauri::command]
@@ -91,6 +119,14 @@ pub async fn revoke_user_sessions(
     session_id: String,
     username: String,
     session_state: State<'_, SessionState>,
-) -> CommandResult<RevokeSessionsResponse> {
-    session_state.revoke(session_id, username).await.map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<RevokeSessionsResponse>> {
+    let access = AuditAccess::account(&session_state, session_id.clone());
+    let session_state = session_state.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::RevokeSessions, None, move |audit| async move {
+            let session_state = session_state.with_audit(audit);
+            session_state.revoke(session_id, username).await
+        })
+        .await
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session.rs
@@ -34,6 +34,7 @@ pub(crate) struct SessionState {
     storage: StorageManager,
     auth: AuthService,
     ttl_ms: i64,
+    audit: Option<crate::audit::AuditContext>,
     clock: Arc<dyn Fn() -> i64 + Send + Sync>,
 }
 
@@ -49,8 +50,14 @@ impl SessionState {
             storage,
             auth,
             ttl_ms: ttl_millis(configured.as_deref())?,
+            audit: None,
             clock: Arc::new(|| Utc::now().timestamp_millis()),
         })
+    }
+
+    pub(crate) fn with_audit(mut self, audit: crate::audit::AuditContext) -> Self {
+        self.audit = Some(audit);
+        self
     }
 
     pub(crate) fn start_cleanup(&self) -> DashboardResult<()> {
@@ -85,6 +92,7 @@ impl SessionState {
     pub(crate) async fn login(&self, username: String, password: String) -> DashboardResult<AuthSessionResponse> {
         let auth = self.auth.clone();
         let clock = self.clock.clone();
+        let audit = self.audit.clone();
         let ttl = self.ttl_ms;
         self.storage
             .run("session-login", move |connection| {
@@ -116,6 +124,9 @@ impl SessionState {
                     params![Utc::now().to_rfc3339(), user.id],
                 )?;
                 let session = lookup(&transaction, &digest(&token), now)?;
+                if let Some(audit) = audit {
+                    audit.record_success(&transaction, &user.username)?;
+                }
                 transaction.commit()?;
                 Ok(AuthSessionResponse {
                     session_id: token,
@@ -160,12 +171,20 @@ impl SessionState {
     pub(crate) async fn logout(&self, token: String) -> DashboardResult<()> {
         let hash = digest(&token);
         let clock = self.clock.clone();
+        let audit = self.audit.clone();
         self.storage
             .run("session-logout", move |connection| {
-                connection.execute(
+                let now = clock();
+                let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                if let Some(audit) = audit {
+                    let user = lookup(&transaction, &hash, now)?;
+                    audit.record_success(&transaction, &user.username)?;
+                }
+                transaction.execute(
                     "UPDATE sessions SET revoked_at_ms = ?1 WHERE token_digest = ?2 AND revoked_at_ms IS NULL",
-                    params![clock(), hash],
+                    params![now, hash],
                 )?;
+                transaction.commit()?;
                 Ok(())
             })
             .await
@@ -196,6 +215,7 @@ impl SessionState {
         let auth = self.auth.clone();
         let hash = digest(&token);
         let clock = self.clock.clone();
+        let audit = self.audit.clone();
         self.storage
             .run("session-change-password", move |connection| {
                 let session = lookup(connection, &hash, clock())?;
@@ -223,6 +243,9 @@ impl SessionState {
                     "UPDATE sessions SET revoked_at_ms = ?1 WHERE user_id = ?2 AND revoked_at_ms IS NULL",
                     params![now, user.id],
                 )?;
+                if let Some(audit) = audit {
+                    audit.record_success(&transaction, &user.username)?;
+                }
                 transaction.commit()?;
                 Ok(())
             })
@@ -286,6 +309,7 @@ impl SessionState {
     pub(crate) async fn revoke(&self, token: String, username: String) -> DashboardResult<RevokeSessionsResponse> {
         let hash = digest(&token);
         let clock = self.clock.clone();
+        let audit = self.audit.clone();
         self.storage
             .run("session-revoke-account", move |connection| {
                 let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
@@ -299,6 +323,9 @@ impl SessionState {
                     "UPDATE sessions SET revoked_at_ms = ?1 WHERE user_id = ?2 AND revoked_at_ms IS NULL",
                     params![now, actor.user_id],
                 )?;
+                if let Some(audit) = audit {
+                    audit.record_success(&transaction, &actor.username)?;
+                }
                 transaction.commit()?;
                 Ok(RevokeSessionsResponse {
                     revoked_count,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session/tests.rs
@@ -49,6 +49,7 @@ impl Fixture {
             storage: storage.clone(),
             auth,
             ttl_ms: 1000,
+            audit: None,
             clock: Arc::new(move || test_clock.load(Ordering::SeqCst)),
         };
         Self {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
 use crate::consumer::service::ConsumerManager;
 use crate::consumer::types::ConsumerConfigView;
 use crate::consumer::types::ConsumerConnectionView;
@@ -120,12 +121,18 @@ pub async fn create_or_update_consumer_group(
     request: ConsumerCreateOrUpdateRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<ConsumerMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    consumer_manager
-        .create_or_update_consumer_group(request)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<ConsumerMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let consumer_manager = consumer_manager.inner().clone();
+    audit_manager
+        .execute(
+            access,
+            AuditAction::UpsertConsumer,
+            Some(request.consumer_group.clone()),
+            move |_audit| async move { consumer_manager.create_or_update_consumer_group(request).await },
+        )
         .await
-        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -134,11 +141,17 @@ pub async fn delete_consumer_group(
     request: ConsumerDeleteRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<ConsumerMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    consumer_manager
-        .delete_consumer_group(request)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<ConsumerMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let consumer_manager = consumer_manager.inner().clone();
+    audit_manager
+        .execute(
+            access,
+            AuditAction::DeleteConsumer,
+            Some(request.consumer_group.clone()),
+            move |_audit| async move { consumer_manager.delete_consumer_group(request).await },
+        )
         .await
-        .map_err(Into::into)
 }
 use crate::auth::SessionState;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
@@ -157,6 +157,7 @@ impl DashboardError {
             category,
             retryable,
             field,
+            audit_warning: None,
         }
     }
 }
@@ -218,6 +219,8 @@ pub(crate) struct CommandError {
     pub(crate) retryable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) audit_warning: Option<&'static str>,
 }
 
 impl From<DashboardError> for CommandError {
@@ -319,7 +322,10 @@ mod tests {
                 command_count += 1;
                 assert!(command.contains("session_id: String"));
                 assert!(command.contains("State<'_, SessionState>"));
-                assert!(command.contains("authorize_command(&session_id, &session_state).await?;"));
+                assert!(
+                    command.contains("authorize_command(&session_id, &session_state).await?;")
+                        || command.contains("AuditAccess::dashboard(&session_state, session_id)")
+                );
             }
         }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![recursion_limit = "512"]
 
+mod audit;
 mod auth;
 mod cluster;
 mod consumer;
@@ -43,6 +44,7 @@ const CLEANUP_FAILURE_EXIT_CODE: i32 = 71;
 
 #[derive(Clone)]
 struct DashboardAdminLifecycle {
+    audit: audit::AuditManager,
     storage: persistence::StorageManager,
     cluster_manager: cluster::ClusterManager,
     consumer_manager: consumer::ConsumerManager,
@@ -60,6 +62,7 @@ struct DashboardApplication {
 
 impl DashboardAdminLifecycle {
     async fn shutdown(&self) -> bool {
+        let audit_healthy = self.audit.shutdown(ADMIN_SHUTDOWN_TIMEOUT).await;
         let storage_healthy = self.storage.shutdown(ADMIN_SHUTDOWN_TIMEOUT).await;
         tokio::join!(
             self.cluster_manager.shutdown(),
@@ -68,7 +71,7 @@ impl DashboardAdminLifecycle {
             self.producer_manager.shutdown(),
             self.topic_manager.shutdown(),
         );
-        storage_healthy
+        audit_healthy && storage_healthy
     }
 }
 
@@ -181,6 +184,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
     };
     let setup_client_runtime = client_runtime.clone();
     let storage_context = client_runtime_owner.root_context().component("dashboard-storage");
+    let audit_context = client_runtime_owner.root_context().component("dashboard-audit");
     let admin_lifecycle = Arc::new(OnceLock::new());
     let setup_lifecycle = admin_lifecycle.clone();
     let app = tauri::Builder::default()
@@ -214,8 +218,11 @@ fn build_application() -> Result<DashboardApplication, i32> {
             }))?;
             log::info!("Dashboard storage initialized: {:?}", storage.health());
 
+            let audit = audit::AuditManager::new(storage.clone(), audit_context);
+            audit.start_cleanup()?;
             setup_lifecycle
                 .set(DashboardAdminLifecycle {
+                    audit: audit.clone(),
                     storage: storage.clone(),
                     cluster_manager: cluster_manager.clone(),
                     consumer_manager: consumer_manager.clone(),
@@ -229,6 +236,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
             sessions.start_cleanup()?;
             app.manage(storage);
             app.manage(sessions);
+            app.manage(audit);
             app.manage(nameserver_runtime);
             app.manage(nameserver_manager);
             app.manage(cluster_manager);
@@ -241,6 +249,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            audit::commands::query_audit_events,
             auth::commands::login,
             auth::commands::logout,
             auth::commands::restore_session,
@@ -352,7 +361,7 @@ pub fn run() -> i32 {
     let mut cleanup_healthy = true;
     if let Some(lifecycle) = admin_lifecycle.get() {
         let shutdown = tauri::async_runtime::block_on(async {
-            tokio::time::timeout(ADMIN_SHUTDOWN_TIMEOUT * 2, lifecycle.shutdown()).await
+            tokio::time::timeout(ADMIN_SHUTDOWN_TIMEOUT * 3, lifecycle.shutdown()).await
         });
         if !matches!(shutdown, Ok(true)) {
             cleanup_healthy = false;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
 use crate::message::service::MessageManager;
 use crate::message::types::DlqBatchMessageExportView;
 use crate::message::types::DlqMessageExportView;
@@ -118,9 +119,15 @@ pub async fn resend_dlq_message(
     request: DlqResendMessageRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<MessageResendResult> {
-    authorize_command(&session_id, &session_state).await?;
-    message_manager.resend_dlq_message(request).await.map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<MessageResendResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let message_manager = message_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::ResendDlq, None, move |_audit| async move {
+            message_manager.resend_dlq_message(request).await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -129,12 +136,15 @@ pub async fn batch_resend_dlq_message(
     request: DlqBatchResendMessageRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<MessageBatchResendResponse> {
-    authorize_command(&session_id, &session_state).await?;
-    message_manager
-        .batch_resend_dlq_message(request)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<MessageBatchResendResponse>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let message_manager = message_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::BatchResendDlq, None, move |_audit| async move {
+            message_manager.batch_resend_dlq_message(request).await
+        })
         .await
-        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -168,12 +178,15 @@ pub async fn consume_message_directly(
     request: MessageDirectConsumeRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<MessageResendResult> {
-    authorize_command(&session_id, &session_state).await?;
-    message_manager
-        .consume_message_directly(request)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<MessageResendResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let message_manager = message_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::ConsumeDirectly, None, move |_audit| async move {
+            message_manager.consume_message_directly(request).await
+        })
         .await
-        .map_err(Into::into)
 }
 
 #[tauri::command]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
 use crate::nameserver::NameServerManager;
 use crate::nameserver::types::NameServerHomePageView;
 use rocketmq_dashboard_common::NameServerMutationResult;
@@ -33,9 +34,18 @@ pub async fn add_name_server(
     address: String,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    nameserver_manager.add_name_server(&address).map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<NameServerMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let nameserver_manager = nameserver_manager.inner().clone();
+    let local_audit = audit_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::AddNameServer, None, move |_audit| async move {
+            local_audit
+                .run_local(move || nameserver_manager.add_name_server(&address))
+                .await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -44,9 +54,18 @@ pub async fn switch_name_server(
     address: String,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    nameserver_manager.switch_name_server(&address).map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<NameServerMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let nameserver_manager = nameserver_manager.inner().clone();
+    let local_audit = audit_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::SwitchNameServer, None, move |_audit| async move {
+            local_audit
+                .run_local(move || nameserver_manager.switch_name_server(&address))
+                .await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -55,9 +74,18 @@ pub async fn delete_name_server(
     address: String,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    nameserver_manager.delete_name_server(&address).map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<NameServerMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let nameserver_manager = nameserver_manager.inner().clone();
+    let local_audit = audit_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::DeleteNameServer, None, move |_audit| async move {
+            local_audit
+                .run_local(move || nameserver_manager.delete_name_server(&address))
+                .await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -66,9 +94,18 @@ pub async fn update_vip_channel(
     enabled: bool,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    nameserver_manager.update_vip_channel(enabled).map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<NameServerMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let nameserver_manager = nameserver_manager.inner().clone();
+    let local_audit = audit_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::UpdateVip, None, move |_audit| async move {
+            local_audit
+                .run_local(move || nameserver_manager.update_vip_channel(enabled))
+                .await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -77,9 +114,18 @@ pub async fn update_use_tls(
     enabled: bool,
     nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<NameServerMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    nameserver_manager.update_use_tls(enabled).map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<NameServerMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let nameserver_manager = nameserver_manager.inner().clone();
+    let local_audit = audit_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::UpdateTls, None, move |_audit| async move {
+            local_audit
+                .run_local(move || nameserver_manager.update_use_tls(enabled))
+                .await
+        })
+        .await
 }
 use crate::auth::SessionState;
 use crate::error::CommandResult;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
@@ -17,7 +17,7 @@ use crate::error::DashboardResult;
 use rusqlite::Connection;
 use rusqlite::TransactionBehavior;
 
-pub(crate) const SCHEMA_VERSION: i64 = 2;
+pub(crate) const SCHEMA_VERSION: i64 = 3;
 
 pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
     // IMMEDIATE serializes competing initializers before reading the version.
@@ -62,6 +62,21 @@ pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
                 updated_at TEXT NOT NULL,
                 last_login_at TEXT
             );
+            CREATE TABLE audit_events (
+                event_id TEXT PRIMARY KEY,
+                request_id TEXT NOT NULL UNIQUE,
+                actor TEXT,
+                action TEXT NOT NULL,
+                resource_type TEXT NOT NULL,
+                resource_name TEXT,
+                environment_id TEXT,
+                outcome TEXT NOT NULL CHECK(outcome IN ('success', 'rejected', 'failed', 'partial', 'unknown')),
+                detail_json TEXT NOT NULL,
+                created_at_ms INTEGER NOT NULL
+            );
+            CREATE INDEX audit_time ON audit_events(created_at_ms DESC, event_id DESC);
+            CREATE INDEX audit_actor_time ON audit_events(actor, created_at_ms DESC, event_id DESC);
+            CREATE INDEX audit_action_time ON audit_events(action, created_at_ms DESC, event_id DESC);
             CREATE TABLE sessions (
                 id TEXT PRIMARY KEY,
                 token_digest BLOB NOT NULL UNIQUE,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
 use crate::proxy::ProxyManager;
 use rocketmq_dashboard_common::ProxyConfigSnapshot;
 use rocketmq_dashboard_common::ProxyMutationResult;
@@ -33,9 +34,18 @@ pub async fn add_proxy_addr(
     address: String,
     proxy_manager: State<'_, ProxyManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<ProxyMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    proxy_manager.add_proxy_addr(&address).map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<ProxyMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let proxy_manager = proxy_manager.inner().clone();
+    let local_audit = audit_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::AddProxy, None, move |_audit| async move {
+            local_audit
+                .run_local(move || proxy_manager.add_proxy_addr(&address))
+                .await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -44,9 +54,18 @@ pub async fn switch_proxy_addr(
     address: String,
     proxy_manager: State<'_, ProxyManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<ProxyMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    proxy_manager.switch_proxy_addr(&address).map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<ProxyMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let proxy_manager = proxy_manager.inner().clone();
+    let local_audit = audit_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::SwitchProxy, None, move |_audit| async move {
+            local_audit
+                .run_local(move || proxy_manager.switch_proxy_addr(&address))
+                .await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -55,9 +74,18 @@ pub async fn delete_proxy_addr(
     address: String,
     proxy_manager: State<'_, ProxyManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<ProxyMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    proxy_manager.delete_proxy_addr(&address).map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<ProxyMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let proxy_manager = proxy_manager.inner().clone();
+    let local_audit = audit_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::DeleteProxy, None, move |_audit| async move {
+            local_audit
+                .run_local(move || proxy_manager.delete_proxy_addr(&address))
+                .await
+        })
+        .await
 }
 use crate::auth::SessionState;
 use crate::error::CommandResult;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
 use crate::topic::service::TopicManager;
 use crate::topic::types::TopicConfigView;
 use crate::topic::types::TopicConsumerGroupListResponse;
@@ -81,9 +82,18 @@ pub async fn create_or_update_topic(
     request: TopicConfigRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    topic_manager.create_or_update_topic(request).await.map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<TopicMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let topic_manager = topic_manager.inner().clone();
+    audit_manager
+        .execute(
+            access,
+            AuditAction::UpsertTopic,
+            Some(request.topic_name.clone()),
+            move |_audit| async move { topic_manager.create_or_update_topic(request).await },
+        )
+        .await
 }
 
 #[tauri::command]
@@ -92,9 +102,18 @@ pub async fn delete_topic(
     request: DeleteTopicRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    topic_manager.delete_topic(request).await.map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<TopicMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let topic_manager = topic_manager.inner().clone();
+    audit_manager
+        .execute(
+            access,
+            AuditAction::DeleteTopic,
+            Some(request.topic.clone()),
+            move |_audit| async move { topic_manager.delete_topic(request).await },
+        )
+        .await
 }
 
 #[tauri::command]
@@ -103,9 +122,18 @@ pub async fn delete_topic_by_broker(
     request: DeleteTopicByBrokerRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    topic_manager.delete_topic_by_broker(request).await.map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<TopicMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let topic_manager = topic_manager.inner().clone();
+    audit_manager
+        .execute(
+            access,
+            AuditAction::DeleteTopicByBroker,
+            Some(request.topic.clone()),
+            move |_audit| async move { topic_manager.delete_topic_by_broker(request).await },
+        )
+        .await
 }
 
 #[tauri::command]
@@ -139,9 +167,15 @@ pub async fn reset_consumer_offset(
     request: ResetOffsetRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    topic_manager.reset_consumer_offset(request).await.map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<TopicMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let topic_manager = topic_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::ResetOffset, None, move |_audit| async move {
+            topic_manager.reset_consumer_offset(request).await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -150,9 +184,15 @@ pub async fn skip_message_accumulate(
     request: ResetOffsetRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<TopicMutationResult> {
-    authorize_command(&session_id, &session_state).await?;
-    topic_manager.skip_message_accumulate(request).await.map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<TopicMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let topic_manager = topic_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::SkipMessages, None, move |_audit| async move {
+            topic_manager.skip_message_accumulate(request).await
+        })
+        .await
 }
 
 #[tauri::command]
@@ -161,9 +201,18 @@ pub async fn send_topic_message(
     request: SendTopicMessageRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<TopicSendMessageResult> {
-    authorize_command(&session_id, &session_state).await?;
-    topic_manager.send_topic_message(request).await.map_err(Into::into)
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<TopicSendMessageResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let topic_manager = topic_manager.inner().clone();
+    audit_manager
+        .execute(
+            access,
+            AuditAction::SendMessage,
+            Some(request.topic.clone()),
+            move |_audit| async move { topic_manager.send_topic_message(request).await },
+        )
+        .await
 }
 use crate::auth::SessionState;
 use crate::error::CommandResult;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
@@ -63,7 +63,8 @@ const NAV_SECTIONS = [
     {
         title: 'Governance',
         items: [
-            {tab: 'ACL', label: 'ACL', icon: Shield}
+            {tab: 'ACL', label: 'ACL', icon: Shield},
+            {tab: 'Audit', label: 'Audit', icon: Shield}
         ]
     }
 ] as const;
@@ -80,6 +81,7 @@ const PAGE_SUMMARIES: Record<string, string> = {
     MessageTrace: 'End-to-end trace timeline for produced and consumed messages.',
     DLQ: 'Dead-letter queue search, retry context, and payload inspection.',
     ACL: 'Access-control resources, credentials, and permission posture.',
+    Audit: 'Operation history, outcomes, and audit receipts.',
     Account: 'Local administrator profile, active session, and account security.'
 };
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -14,6 +14,7 @@ import {MessageView} from '../../components/MessageView';
 import {MessageTraceView} from '../../components/MessageTraceView';
 import {DLQMessageView} from '../../components/DLQMessageView';
 import {Activity} from 'lucide-react';
+import {AuditPage} from '../../pages/audit/AuditPage';
 import {AccountPage} from '../../pages/account/AccountPage';
 
 export const AppRouter = () => {
@@ -42,6 +43,8 @@ export const AppRouter = () => {
             return <DLQMessageView/>;
         case 'ACL':
             return <ACLView/>;
+        case 'Audit':
+            return <AuditPage/>;
         case 'Account':
             return <AccountPage/>;
         default:

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditPage.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { queryAuditEvents, type AuditPage as AuditResultPage, type AuditQuery, type AuditOutcome } from '../../services/audit.service';
+import { dashboardErrorMessage } from '../../services/invoke';
+import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+
+export const AuditPage = () => {
+    const [query, setQuery] = useState<AuditQuery>({ limit: 50 });
+    const [cursors, setCursors] = useState<Array<string | undefined>>([undefined]);
+    const [refresh, setRefresh] = useState(0);
+    const [page, setPage] = useState<AuditResultPage | null>(null);
+    const [error, setError] = useState('');
+    const [loading, setLoading] = useState(true);
+    const cursor = cursors[cursors.length - 1];
+    useEffect(() => {
+        let active = true;
+        setLoading(true); setError(''); setPage(null);
+        void queryAuditEvents({ ...query, cursor }).then((result) => { if (active) setPage(result); })
+            .catch((failure: unknown) => { if (active) setError(dashboardErrorMessage(failure, 'Could not load audit events.')); })
+            .finally(() => { if (active) setLoading(false); });
+        return () => { active = false; };
+    }, [query, cursor, refresh]);
+
+    const apply = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        const data = new FormData(event.currentTarget);
+        const text = (key: string) => String(data.get(key) ?? '').trim() || undefined;
+        const from = text('from'); const to = text('to');
+        const fromMs = from ? new Date(from).getTime() : undefined;
+        const toMs = to ? new Date(to).getTime() : undefined;
+        if ((fromMs !== undefined && !Number.isFinite(fromMs)) || (toMs !== undefined && !Number.isFinite(toMs)) || (fromMs !== undefined && toMs !== undefined && fromMs > toMs)) {
+            setError('Choose a valid time range.'); return;
+        }
+        setCursors([undefined]);
+        setQuery({ fromMs, toMs, actor: text('actor'), action: text('action'), outcome: text('outcome') as AuditOutcome | undefined, environmentId: text('environmentId'), limit: 50 });
+    };
+    const inputClass = 'mt-1 w-full rounded-lg border border-gray-300 bg-transparent px-3 py-2 dark:border-gray-600';
+    return <Card className="ops-card">
+        <CardHeader><CardTitle>Audit events</CardTitle><CardDescription>Terminal outcomes of local and RocketMQ administration. Unknown means the remote result could not be confirmed; review the actual resource before resubmitting.</CardDescription></CardHeader>
+        <CardContent className="space-y-5">
+            <form onSubmit={apply} className="grid gap-3 md:grid-cols-3">
+                <label className="text-sm">From<input name="from" type="datetime-local" className={inputClass} /></label>
+                <label className="text-sm">To<input name="to" type="datetime-local" className={inputClass} /></label>
+                <label className="text-sm">Actor<input name="actor" placeholder="Exact username" className={inputClass} /></label>
+                <label className="text-sm">Action<input name="action" placeholder="e.g. topic.delete" className={inputClass} /></label>
+                <label className="text-sm">Outcome<select name="outcome" className={inputClass}><option value="">All outcomes</option>{['success', 'rejected', 'failed', 'partial', 'unknown'].map((outcome) => <option key={outcome}>{outcome}</option>)}</select></label>
+                <label className="text-sm">Environment ID<input name="environmentId" placeholder="Exact ID, if recorded" className={inputClass} /></label>
+                <div className="flex gap-3"><Button type="submit" disabled={loading}>Apply filters</Button><Button type="button" variant="outline" disabled={loading} onClick={() => { setCursors([undefined]); setRefresh((value) => value + 1); }}>Refresh</Button></div>
+            </form>
+            {error && <p role="alert" className="text-red-600">{error}</p>}
+            {loading ? <p role="status">Loading audit events¡­</p> : page && <>
+                <div className="overflow-x-auto"><table className="w-full text-left text-sm">
+                    <caption className="sr-only">Filtered audit events, newest first</caption>
+                    <thead><tr>{['Time', 'Actor', 'Action', 'Resource', 'Environment', 'Outcome', 'Details'].map((label) => <th scope="col" className="p-3" key={label}>{label}</th>)}</tr></thead>
+                    <tbody>{page.items.map((event) => <tr key={event.eventId} className="border-t border-gray-200 dark:border-gray-700">
+                        <td className="p-3 whitespace-nowrap">{new Date(event.createdAtMs).toLocaleString()}</td><td className="p-3">{event.actor ?? 'Unauthenticated'}</td><td className="p-3 font-mono">{event.action}</td>
+                        <td className="p-3">{event.resourceType}{event.resourceName && `: ${event.resourceName}`}</td><td className="p-3">{event.environmentId ?? 'Not recorded'}</td><td className="p-3 font-medium">{event.outcome}</td>
+                        <td className="p-3"><details><summary className="cursor-pointer">View receipt</summary><p className="mt-2 break-all font-mono text-xs">Request: {event.requestId}</p>{event.detail.resultUnknown && <p className="text-amber-700">Remote outcome unknown. No automatic retry was performed.</p>}{event.detail.errorCode && <p>{event.detail.errorCode}</p>}{event.detail.successCount !== undefined && <p>Succeeded: {event.detail.successCount}</p>}{event.detail.failureCount !== undefined && <p>Failed: {event.detail.failureCount}</p>}</details></td>
+                    </tr>)}</tbody>
+                </table>{page.items.length === 0 && <p className="p-3">No matching audit events.</p>}</div>
+                <div className="flex items-center gap-3"><Button variant="outline" disabled={cursors.length === 1} onClick={() => setCursors((values) => values.slice(0, -1))}>Previous</Button><span>Page {cursors.length}</span><Button variant="outline" disabled={!page.nextCursor} onClick={() => { const next = page.nextCursor; if (next) setCursors((values) => [...values, next]); }}>Next</Button></div>
+            </>}
+        </CardContent>
+    </Card>;
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/audit.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/audit.service.ts
@@ -1,0 +1,14 @@
+import { invokeAuthenticatedCommand } from './invoke';
+export type AuditOutcome = 'success' | 'rejected' | 'failed' | 'partial' | 'unknown';
+export interface AuditQuery {
+    fromMs?: number; toMs?: number; actor?: string; action?: string;
+    outcome?: AuditOutcome; environmentId?: string; cursor?: string; limit?: number;
+}
+export interface AuditEvent {
+    eventId: string; requestId: string; actor: string | null; action: string;
+    resourceType: string; resourceName: string | null; environmentId: string | null;
+    outcome: AuditOutcome; createdAtMs: number;
+    detail: { resultUnknown: boolean; errorCode?: string; successCount?: number; failureCount?: number };
+}
+export interface AuditPage { items: AuditEvent[]; nextCursor: string | null }
+export const queryAuditEvents = (query: AuditQuery) => invokeAuthenticatedCommand<AuditPage>('query_audit_events', { query });

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 import { AuthService } from './auth.service';
-import { invokeAuthenticatedCommand } from './invoke';
+import { invokeAuthenticatedCommand, subscribeAuditWarning } from './invoke';
 import { SessionStorageService } from './session.storage';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
@@ -73,5 +73,31 @@ describe('authoritative session lifecycle', () => {
         vi.mocked(invoke).mockResolvedValue({ message: 'Password changed' });
         await AuthService.changePassword({ oldPassword: 'old-secret', newPassword: 'new-secret' });
         expect(SessionStorageService.getSessionId()).toBeNull();
+    });
+});
+
+describe('audit warnings', () => {
+    it('preserves the successful receipt and reports a separate warning without retrying', async () => {
+        const warning = vi.fn();
+        const unsubscribe = subscribeAuditWarning(warning);
+        try {
+            const receipt = { success: true, messageId: 'sent-once', auditWarning: 'Audit record unavailable.' };
+            vi.mocked(invoke).mockResolvedValue(receipt);
+            const result = await invokeAuthenticatedCommand('send_topic_message');
+            expect(result).toEqual(receipt);
+            expect(warning).toHaveBeenCalledWith('Audit record unavailable.');
+            expect(invoke).toHaveBeenCalledTimes(1);
+        } finally { unsubscribe(); }
+    });
+
+    it('keeps the operation error when recording its failure also fails', async () => {
+        const warning = vi.fn();
+        const unsubscribe = subscribeAuditWarning(warning);
+        try {
+            vi.mocked(invoke).mockRejectedValue({ code: 'client.component.unavailable', category: 'unavailable', message: 'Client unavailable.', retryable: false, auditWarning: 'Audit record unavailable.' });
+            await expect(invokeAuthenticatedCommand('delete_topic')).rejects.toMatchObject({ code: 'client.component.unavailable' });
+            expect(warning).toHaveBeenCalledOnce();
+            expect(invoke).toHaveBeenCalledTimes(1);
+        } finally { unsubscribe(); }
     });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
@@ -15,6 +15,7 @@ export interface CommandErrorPayload {
     category: CommandErrorCategory;
     retryable: boolean;
     field?: string;
+    auditWarning?: string;
 }
 
 export class DashboardClientError extends Error {
@@ -66,10 +67,24 @@ export const isDashboardClientError = (error: unknown): error is DashboardClient
 export const dashboardErrorMessage = (error: unknown, fallback: string): string =>
     isDashboardClientError(error) && error.message.trim().length > 0 ? error.message : fallback;
 
+const auditWarningListeners = new Set<(message: string) => void>();
+export const subscribeAuditWarning = (listener: (message: string) => void): (() => void) => {
+    auditWarningListeners.add(listener);
+    return () => { auditWarningListeners.delete(listener); };
+};
+const reportAuditWarning = (value: unknown): void => {
+    if (value && typeof value === 'object' && 'auditWarning' in value && typeof value.auditWarning === 'string') {
+        for (const listener of auditWarningListeners) listener(value.auditWarning);
+    }
+};
+
 const invokeDecoded = async <T>(command: string, args?: Record<string, unknown>): Promise<T> => {
     try {
-        return await invoke<T>(command, args);
+        const result = await invoke<T>(command, args);
+        reportAuditWarning(result);
+        return result;
     } catch (error) {
+        if (isCommandError(error)) reportAuditWarning(error);
         throw normalizeCommandError(error);
     }
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { subscribeAuditWarning } from '../services/invoke';
 import { SessionStorageService } from '../services/session.storage';
 import type { SessionUser } from '../features/auth/types/auth.types';
 
@@ -14,7 +15,8 @@ type Tab =
   | 'MessageTrace'
   | 'DLQ'
   | 'ACL'
-  | 'Account';
+  | 'Account'
+  | 'Audit';
 
 interface AppState {
   isLoggedIn: boolean;
@@ -39,6 +41,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [currentUser, setCurrentUser] = useState<SessionUser | null>(null);
   const [mustChangePassword, setMustChangePassword] = useState(false);
+  const [auditWarning, setAuditWarning] = useState<string | null>(null);
+  useEffect(() => subscribeAuditWarning(setAuditWarning), []);
   const [activeTab, setActiveTab] = useState<Tab>('Dashboard');
 
   const getPageTitle = (tab: Tab) => {
@@ -65,6 +69,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         return 'DLQ Message Management';
       case 'ACL':
         return 'ACL Management';
+      case 'Audit':
+        return 'Audit Events';
       case 'Account':
         return 'Account Overview';
       default:
@@ -113,6 +119,9 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       }}
     >
       {children}
+      {auditWarning && <div role="alert" className="fixed bottom-4 left-4 right-4 z-[100] flex items-center justify-between gap-4 rounded-xl border border-amber-400 bg-amber-50 p-4 text-sm text-amber-950 shadow-lg">
+        <p>{auditWarning}</p><button type="button" className="font-semibold underline" onClick={() => setAuditWarning(null)}>Dismiss</button>
+      </div>}
     </AppContext.Provider>
   );
 };


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10364

### Brief Description

Add durable terminal auditing for account, connection, Topic, Consumer, message-send/direct-consume, and DLQ-resend mutations. Accepted operations outlive their IPC waiter and drain before storage shutdown. Account success records commit with their mutations; remote and existing connection-store results retain their original outcome if the separate audit write fails, with an auditWarning instead of a replay-inducing error.

The Audit page supports exact filters and stable cursor pagination. Receipt metadata is allowlisted, batch counts preserve partial outcomes, uncertain remote errors are identified, and the frontend keeps a dismissible warning without retrying. Retention is bounded to 1,000 records per hourly pass after 30 days. Fresh schema version 3 leaves older development formats untouched. Stable environment/endpoint identity and atomic connection-store integration follow in the revisioned configuration work.

### How Did You Test This Change?

Standalone Tauri backend:
- `cargo test --lib audit::`: 5 passed, covering terminal outcome/redaction, preserved remote success when audit storage fails, dropped waiters and shutdown, filtered pagination, and account transaction rollback with exactly one successful audit record.
- `cargo test --lib auth::`: 13 passed.
- `cargo test --lib error::`: 5 passed, including all 50 business command authorization paths.
- `cargo test --lib persistence::`: 7 passed.
- `cargo fmt -p rocketmq-dashboard-tauri -- --check`: passed.

Tauri frontend:
- `npm run build`: passed; existing large-bundle warning remains.
- `npm test -- src/services/invoke.test.ts src/services/auth-session.test.ts`: 11 passed, including separate audit warning handling and no automatic retries.
- `git diff --check`: passed.

Native desktop interaction remains part of the final desktop smoke step. CI was not used as a merge gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Audit Events page with filters for time range, actor, action, outcome, and environment.
  * Added refresh and cursor-based pagination for browsing audit records.
  * Recorded authentication, account, connection, topic, consumer, messaging, and configuration changes.
  * Added notifications when an operation succeeds but its audit record cannot be saved.
* **Documentation**
  * Documented audit history behavior, retention, outcomes, filtering, and data protection.
  * Updated database schema documentation to version 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->