### PR TITLE
[ISSUE #10366]✨Add a local RocketMQ Rust cluster skill

### DIFF
--- a/.agents/skills/rocketmq-rust-local-cluster/SKILL.md
+++ b/.agents/skills/rocketmq-rust-local-cluster/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: rocketmq-rust-local-cluster
+description: Set up, start, verify, inspect, and stop local development clusters from the current rocketmq-rust checkout. Use for single-Broker development, replicated master/slave clusters, Proxy cluster/local mode, or three-node Controller HA with automatic Broker election.
+---
+
+# RocketMQ Rust Local Cluster
+
+Turn the requested topology into a running, verifiable local environment with isolated data and an explicit stop procedure. Use this checkout's manifests, configuration parsers, and entrypoints. Java RocketMQ scripts and old flat Broker configuration are not substitutes for the Rust services.
+
+## Select a topology
+
+Preserve the user's topology, paths, ports, and execution method. Otherwise default to `dev-single`, native processes, loopback addresses, and a debug build; state the assumptions and continue. For an unspecified request for HA, select `controller-ha` and explain its larger resource needs. Select `dev-ha` when the user explicitly wants ordinary master/slave replication.
+
+| Profile | Processes | Purpose and limits |
+| --- | --- | --- |
+| `dev-single` | 1 NameServer + 1 Broker | Minimum message round trip; no replica |
+| `dev-ha` | 2 NameServers + 1 master + 1 slave | Synchronous replication by default; no automatic writable-master promotion |
+| `dev-ha-2m2s` | 2 NameServers + 2 master/slave groups | Two distinct brokerName values; ordinary replication |
+| `proxy-cluster` | `dev-single` + a separate Proxy | gRPC ingress forwarding to the backend cluster |
+| `proxy-local` | 1 Proxy with an embedded Broker | Single-process development; no separate NameServer/Broker and no HA |
+| `controller-ha` | 2 NameServers + 3 Controllers + 3 Brokers in one group | Raft quorum, automatic Broker election, and replica synchronization |
+
+`--with-proxy` adds a separate Proxy to `dev-single`, `dev-ha`, `dev-ha-2m2s`, or `controller-ha`. It adds one ingress instance; Proxy redundancy needs additional instances and an endpoint strategy when requested.
+
+These are **single-host development topologies**. They do not survive loss of the host or its disks. Explain synchronous replication (`SYNC_MASTER`), disk flush (`SYNC_FLUSH`), and automatic election as separate properties.
+
+## Workflow
+
+For status, stop, or restart requests, open the existing environment manifest and process records first. Skip configuration generation and builds unless a requested restart actually needs updated binaries. Do not create another cluster while inspecting an existing one.
+
+1. Read applicable `AGENTS.md` instructions and `git status --short`. Inspect OS, toolchain, disk capacity, and port occupancy. Keep the selected Rust toolchain. Use [topology rules and source map](references/topologies.md) to check only the requested components.
+2. Generate configuration and a run manifest with the helper below. It writes files and optionally probes port availability; it does not compile, start processes, or delete data. Stop at artifacts if the user requested only a plan/configuration; continue through startup and verification when asked to set up an environment.
+3. Follow [operations and lifecycle](references/operations.md): build the necessary binaries, check configuration parsing, record process ownership, start dependency groups, and wait for readiness within a deadline. Initial compilation can dominate setup time; report actual progress.
+4. Follow [verification and troubleshooting](references/verification.md): check registration and a message round trip. For HA, inspect replication/election state. Perform disruptive failover exercises when requested, then restore the environment.
+5. Deliver the actual endpoints, configuration/data/log locations, verification results, and reusable start/status/stop commands. Leave the environment running when that is the requested outcome. Report the last completed stage on failure; generated configuration is not successful startup.
+
+## Configuration helper
+
+Run from the repository root using Python 3.11+. On Linux/macOS, `python3` may replace `python`. When using the Claude copy, replace the script prefix with `.claude/skills`.
+
+```text
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name dev --profile dev-single --check-ports
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name ha --profile dev-ha --port-offset 1000 --check-ports
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name dual --profile dev-ha-2m2s --replication async --port-offset 2000
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name proxy --profile proxy-cluster --port-offset 3000
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name local --profile proxy-local --port-offset 4000
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name controller --profile controller-ha --with-proxy --port-offset 5000 --check-ports
+```
+
+- Output defaults to ignored `.rocketmq/clusters/<name>/`. Use `--repo-root` for another checkout or `--output` for a new, dedicated environment directory.
+- `--dry-run` prints the manifest without writing files. `--check-ports` checks whether all planned loopback ports can currently bind; it does not reserve them for startup.
+- Existing output directories are rejected to preserve configuration and messages. For restart/status/stop, read the existing `manifest.json`. Prefer a new environment for topology changes.
+- `--replication async` applies only to ordinary HA profiles. Controller HA retains three replicas and a minimum of two in-sync replicas; do not lower write requirements to conceal startup or replication failures.
+- Add `--proxy-remoting` only when Remoting ingress is requested. The default Proxy ingress is gRPC.
+- Base ports: NameServer `9876/9886`; Broker remoting `10911 + 20*i`, fast channel `remoting - 2`, HA `remoting + 1`; Controller remoting `9878/9888/9898`, Raft `9879/9889/9899`; Proxy gRPC `8081`, optional remoting `8080`; health `18000 + node index`. `--port-offset` shifts all ports and their references together.
+
+## Execution boundaries
+
+- A request to set up the environment authorizes necessary local configuration, builds, startup, and non-disruptive verification without repeated confirmation. It does not authorize publication, remote-cluster changes, system services, or deleting old data.
+- The native generator uses `127.0.0.1` and `development-insecure-loopback`. Inspect conflicting inherited TLS/ACL or listener environment settings; resolve them only for these new processes. Preserve security settings of existing environments.
+- On port conflicts, choose another offset or the user's available ports. Do not terminate the current port owner. Isolate every instance's persistence and logs instead of using a shared default home-directory `store`.
+- Record PID, process creation time, executable path, arguments, and configuration path. Verify identity before stopping; a process name or stale PID file alone is insufficient.
+- Preserve data by default. For an explicitly requested reset, first resolve absolute paths, verify they remain in this environment and do not link elsewhere, and stop its processes. Delete only that environment's intended data.
+- Docker/Compose, WSL, and local Kubernetes are optional execution methods. Use the [container branch](references/operations.md#containers-and-local-kubernetes) when requested; native loopback configuration cannot be mounted unchanged into multiple containers. Local setup does not require release, performance, full-workspace Clippy, or integration fault-matrix gates.
+
+## Example requests
+
+```text
+Use $rocketmq-rust-local-cluster to start a minimal development cluster and verify one message round trip.
+Use $rocketmq-rust-local-cluster to create an asynchronous two-master/two-slave environment with port offset 2000, preserving my existing cluster.
+Use $rocketmq-rust-local-cluster to start Controller HA with Proxy and verify message delivery after automatic failover.
+Use $rocketmq-rust-local-cluster to inspect the dev environment, then stop it while preserving messages.
+```

--- a/.agents/skills/rocketmq-rust-local-cluster/agents/openai.yaml
+++ b/.agents/skills/rocketmq-rust-local-cluster/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RocketMQ Rust Local Cluster"
+  short_description: "Set up local Broker, Proxy, and Controller HA clusters"
+  default_prompt: "Use $rocketmq-rust-local-cluster to set up a local development cluster from this checkout and verify message delivery."

--- a/.agents/skills/rocketmq-rust-local-cluster/references/operations.md
+++ b/.agents/skills/rocketmq-rust-local-cluster/references/operations.md
@@ -1,0 +1,84 @@
+# Operations and Lifecycle
+
+## Build and configuration checks
+
+Inspect the selected toolchain and build prerequisites before launching anything. Proxy protobuf generation uses `protoc` on PATH or `PROTOC` (`rocketmq-proxy-core/build.rs`); Controller uses vendored protoc (`rocketmq-controller/build.rs`). Controller's default RocksDB build needs the platform's supported native C/C++ and bindgen prerequisites. Report the actual missing prerequisite, use a documented local setup path, and do not switch HA storage or upgrade dependencies to make a build pass.
+
+The generated `manifest.json` contains:
+
+- `build_commands`: argument arrays, executed with the repository root as cwd. Package and binary names differ for some components; use these arrays directly.
+- `start_groups`: dependencies in order. Start every node within a group before waiting for group readiness, especially Controllers and synchronous Brokers.
+- `nodes`: binary name, config arguments, per-process environment, cwd, log destinations, and readiness URL.
+- `ports`: all configured or reserved ports, including Broker fast and HA ports and per-process health probes.
+
+Build once, then execute the binaries directly for every replica. Reuse matching binaries only when they reflect the current source/features; existence alone is insufficient. Honor `CARGO_TARGET_DIR`, `.cargo/config.toml`, configured build target, and the selected profile when locating executables; `cargo metadata --format-version 1 --no-deps` and Cargo JSON executable artifacts can resolve nonstandard locations. Windows binaries have `.exe`. Do not run concurrent Cargo builds against the same target directory just to start replicas.
+
+For example, the minimal environment needs:
+
+```text
+cargo build -p rocketmq-namesrv --bin rocketmq-namesrv-rust
+cargo build -p rocketmq-broker --bin rocketmq-broker-rust
+cargo build -p rocketmq-admin-cli --bin rocketmq-admin-cli
+```
+
+Use each node's environment and cwd for configuration checks. Append its `print_config_flag` to its `argv`: NameServer/Broker/Controller use `-c <file> -p`, Proxy uses `-c <file> --printConfig`. Inspect `--help` if options changed. Check exit codes; printing configuration does not verify listeners, storage initialization, quorum, or message delivery. Do not publish configuration dumps containing credentials.
+
+## Start native processes
+
+Choose the platform's existing process supervisor or managed terminal sessions. When background processes are necessary, keep their ownership records under `<environment>/run/` and provide reusable start/status/stop scripts there. The configuration generator intentionally does not manage processes. Implement those environment-specific commands using the following rules, instead of claiming that it already offers a `start` or `stop` subcommand.
+
+1. Inspect the existing manifest and process records. An already-running node with matching identity should be reported/reused, not launched twice. Reject changed configuration for a live node.
+2. Execute the exact binary with the manifest's argument array, per-node cwd, and environment. Overlay only the intended variables; inspect inherited `ROCKETMQ_*`, telemetry/health bindings, `NAMESRV_ADDR`, `rocketmq.namesrv.addr`, legacy `rocketmq.rocketmq-namesrv.addr`, and `ROCKETMQ_CONTROLLER_RAFT_BIND_ADDR` for conflicts. Do not save secrets into the run manifest. Do not interpolate arguments into shell code.
+3. Redirect stdout and stderr to the corresponding node logs. Preserve earlier logs on restart through append or per-start filenames.
+4. Immediately record PID, executable path, config arguments, process creation time, and the managed session/container ID when available. Never hold only the PID from a shell wrapper.
+5. Launch each `start_groups` group, then poll its readiness with short request timeouts and an overall deadline (for example, 90 seconds after startup, extended with evidence for first initialization). Stop waiting early if a process exits. Capture its exit status and relevant log tail.
+6. After service readiness, run the topology checks in [verification](verification.md). Controller election may need additional convergence time. A timeout is a failure to diagnose, not permission to start a duplicate.
+
+PowerShell: use `Start-Process -WindowStyle Hidden -PassThru` for background launches, with `-WorkingDirectory`, separate `-RedirectStandardOutput` / `-RedirectStandardError`, and correctly quoted config paths in `-ArgumentList`. If setting process-level environment temporarily, save and restore it with `try/finally`; apply Controller bootstrap variables only to their intended nodes. `Get-Process` provides `StartTime`/`Path`; use `Get-CimInstance Win32_Process` when command-line verification is needed. Do not use `$PID`, `$HOME`, or `$CODEX_HOME` as task variables.
+
+Bash: use explicit argv or an array and a subshell to scope cwd/environment. For persistent local background work, `nohup` with stdin closed and redirected logs is an option; capture the actual executable PID (use `exec` in wrappers). Record process start time and arguments using the host's `ps`, and handle platform differences between Linux and macOS. Keep all paths quoted.
+
+For a one-node foreground check, after substituting absolute paths from the manifest:
+
+```bash
+cd "$NODE_HOME"
+ROCKETMQ_HOME="$NODE_HOME" \
+ROCKETMQ_SECURITY_PROFILE=development-insecure-loopback \
+ROCKETMQ_HEALTH_BIND_ADDR=127.0.0.1:18000 \
+"$BIN_DIR/rocketmq-namesrv-rust" -c "$CONFIG_FILE"
+```
+
+The health address above illustrates the first zero-offset NameServer only. Use each node's actual manifest values, including all Controller environment entries, for real launches. A foreground command is not the complete cluster launcher.
+
+## Status, stop, and restart
+
+Status must distinguish process existence, readiness, route registration, and topology health. `GET /livez` and `GET /readyz` are non-mutating probes. Do not probe `/drainz` during a status check: it requests shutdown.
+
+For a normal stop, verify ownership, stop Proxy ingress first, then Brokers, Controllers, and NameServers. For ordinary HA groups, stop the master before its slave so the master's final drain can retain its replica. For a full Controller HA shutdown, keep quorum available while Brokers drain. Process groups should share bounded deadlines rather than waiting forever for each individual node.
+
+The current service lifecycle supports a graceful HTTP drain, including on Windows:
+
+```powershell
+Invoke-WebRequest -UseBasicParsing -Method Post -Uri $ownedDrainUrl -TimeoutSec 3
+```
+
+```bash
+curl --fail --silent --show-error --max-time 3 --request POST "$OWNED_DRAIN_URL"
+```
+
+Derive that URL from the verified node's health endpoint by replacing `/readyz` with `/drainz`. Confirm the listener still belongs to that node before sending it. Await exit within the configured shutdown deadline (the helper uses 45 seconds), and inspect shutdown errors. A successful drain HTTP response only means the request was accepted. On Unix, SIGTERM to a verified PID is a fallback when the probe is unavailable. Windows `Stop-Process` is forceful, not equivalent to graceful drain; use it only for a requested crash exercise or a stuck owned process after a bounded graceful attempt, and report that outcome.
+
+Restart with the same configuration, data, identities, and ports. Controllers may reuse the generated bootstrap environment: existing committed state is not reinitialized. Revalidate registration, synchronization, and a message round trip. Reset is a separate destructive operation; require the user's actual reset request and never delete data as routine startup repair.
+
+## Containers and local Kubernetes
+
+Use this branch only when requested or chosen with the user's existing context. The helper generates native loopback environments, not container configuration.
+
+- Inspect `distribution/container/core-service.Dockerfile`, `distribution/helm/rocketmq-rust-core/README.md`, its values/schema/templates, and `distribution/kubernetes/README.md`. Check actual image availability and binary contents; do not invent an official image tag. Prefer building this checkout for source-based development.
+- For Compose, put every node on a named project network, use service DNS names for inter-service addresses, separate volumes, and unique host port publications bound to `127.0.0.1`. Internal ports can repeat across containers; native host ports cannot. Controller Raft peer addresses and Broker-facing discovery addresses remain distinct.
+- Loopback inside a container is that container. Choose bind and advertised addresses separately, and ensure client-visible route addresses are reachable from the user's host or client container. Publishing only NameServer or Proxy ports does not automatically make direct Broker clients work.
+- `development-insecure-loopback` rejects public binds inside containers. Choose a repository-supported container security setup and inspect the relevant guide; do not silently turn off security to force `0.0.0.0` to bind. Host-only publication alone does not change this runtime check.
+- For Kind/Helm, explicitly select the intended local Kubernetes context and namespace. Do not send an install to an inherited remote context. Adapt development values and resources for the local machine; the production chart's host-separation rules and TLS settings are not evidence of local HA.
+- Validate generated Compose/Helm configuration, then start and verify the actual workload. Do not invoke release publication, supply-chain promotion, full SLO collection, or destructive fault scripts merely to create a development cluster.
+
+WSL has its own filesystem, toolchain, processes, and network namespace. Keep binaries, data, and lifecycle ownership on one side of the boundary, and verify the endpoint the user's client actually reaches.

--- a/.agents/skills/rocketmq-rust-local-cluster/references/topologies.md
+++ b/.agents/skills/rocketmq-rust-local-cluster/references/topologies.md
@@ -1,0 +1,54 @@
+# Topology Rules and Source Map
+
+Paths below are relative to the repository root. These are targeted inspection entrypoints, not a requirement to read everything. If this checkout changes a field or behavior, adapt the environment and revalidate it.
+
+| Component | Configuration and startup sources |
+| --- | --- |
+| Build | `Cargo.toml`, `rust-toolchain.toml`, selected package manifests |
+| NameServer | `rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs`, `rocketmq-namesrv/src/config.rs` |
+| Broker | `rocketmq-broker/src/command.rs`, `rocketmq-broker/src/config/raw.rs`, `rocketmq-broker/src/config/sections.rs`, `rocketmq-broker/src/config/broker_config.rs`, `rocketmq-store/src/config/message_store_config.rs` |
+| Ordinary HA | `distribution/config/broker/1m-1s-async-one-machine/`, `distribution/config/broker/2m-2s-async/`, `scripts/interop/run_default_ha_interop.py` |
+| Proxy | `rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs`, `rocketmq-proxy/src/config.rs`, `rocketmq-proxy-local/src/config.rs`, `rocketmq-proxy/README.md` |
+| Controller | `rocketmq-controller/src/cli.rs`, `rocketmq-controller/src/config/controller_config.rs`, `rocketmq-controller/src/config/peer_endpoints.rs`, `rocketmq-controller/README.md` |
+| Controller HA composition | `distribution/helm/rocketmq-rust-core/templates/_config.tpl`; reuse field/role semantics, not container addresses |
+| Security and probes | `rocketmq-security-api/src/secure_deployment.rs`, `rocketmq-runtime/src/service_lifecycle.rs` |
+
+## NameServer and Broker
+
+NameServer uses top-level camelCase fields. `distribution/config/nameserver/namesrv.toml` contains production TLS/ACL settings and `/opt` paths; do not copy it unchanged into a minimal environment. The helper sets loopback binding, per-node `rocketmqHome`, `kvConfigPath`, and `configStorePath`, and disables embedded Controller mode.
+
+Canonical Broker TOML uses `[broker]`, `[broker.brokerIdentity]`, `[broker.brokerServerConfig]`, and `[store]`. Set the business port only through `broker.listenPort`; `broker.brokerServerConfig.listenPort` is derived and explicitly rejected in the input. Set `enableControllerMode` only in `[broker]`, not `[store]`.
+
+The two `storePathRootDir` fields must identify the same instance's storage. Isolate `storePathBrokerIdentity` as well. The helper uses 64 MiB CommitLog segments for small local messages; this is not a production capacity recommendation. Check disk and memory headroom before adding replicas instead of promising one fixed minimum for every topology.
+
+NameServer and Controller address lists use semicolons. Pass each list as one string. Clients must reach the `brokerIp1:listenPort` returned by routing; reaching only the NameServer is insufficient.
+
+## Ordinary replication
+
+- Replicas in a group share `brokerName` and `brokerClusterName`. The master has `brokerId = 0`, the slave `brokerId = 1`. Two master/slave groups have different broker names.
+- Give each instance unique remoting, fast-channel, and HA ports. Point each slave's `haMasterAddress` at its own master's **HA port**.
+- Synchronous presets use `SYNC_MASTER` / `SLAVE`, `totalReplicas = 2`, `inSyncReplicas = 2`, `minInSyncReplicas = 2`, and `SYNC_FLUSH`. Writes may wait for replicas while the master is alone; preserve this constraint.
+- Asynchronous presets use `ASYNC_MASTER`, a minimum in-sync count of 1, and `ASYNC_FLUSH`. Acknowledgment can precede replication; do not promise zero message loss after failure.
+- Maintain `1 <= minInSyncReplicas <= inSyncReplicas <= totalReplicas`. NameServer redundancy, readable slaves, and acting-master behavior do not establish automatic promotion to a writable master.
+
+## Proxy
+
+`mode = "cluster"` forwards to the backend through `[cluster].namesrvAddr`, with `brokerClusterName` matching the Brokers. Default ingress is gRPC on `8081`. `--proxy-remoting` additionally enables `8080`. Neither is a NameServer or HTTP management UI.
+
+`mode = "local"` uses `[local]` fields `brokerClusterName`, `brokerName`, `brokerIp`, `brokerListenPort`, and `storeRootDir`. The current `rocketmq-proxy-local/src/local.rs` sets the embedded Broker's `namesrv_addr` to `None`. Do not start a separate NameServer and claim registration. The helper reserves the embedded Broker identity port; check the current embedded implementation for actual network listeners.
+
+Proxy modes require matching Cargo features. Cluster-only builds use `--no-default-features --features cluster-mode`; local-only builds use `--no-default-features --features local-mode`. TLS requires the `tls` feature and certificate configuration. Adding ordinary Broker fields to Proxy's `[local]` table does not create Controller HA.
+
+## Controller HA
+
+- Start three Controller processes with `nodeId = 1/2/3`. Separate Broker-facing `listenAddr` from `raftListenAddr`, and isolate `storagePath`, `configStorePath`, and `controllerStorePath`.
+- Every file contains identical three-entry `[[raftPeers]]` and `[[controllerPeers]]` lists pointing to Raft and Remoting endpoints respectively. Broker `controllerAddr` must use Remoting endpoints. DNS-based `raftPeerEndpoints` / `controllerPeerEndpoints` are mutually exclusive with these legacy IP peer lists; the native helper uses only the latter.
+- Fresh multi-member clusters do not initialize by default. Set `ROCKETMQ_CONTROLLER_AUTO_INITIALIZE_CLUSTER=true` on the lowest-ID member for bootstrap; explicitly set it to `false` on the others. Launch the whole group before waiting for a leader. Existing committed state is not reinitialized; preserve membership and data on restart.
+- The three Brokers form one replica group, start with `brokerId = 1/2/3`, `brokerRole = "SLAVE"`, and `enableControllerMode = true`, and share the full Controller Remoting address list. Controller and persisted identity determine elected roles. Do not configure a fixed ID-zero master or static `haMasterAddress`.
+- Use `totalReplicas = 3`, `inSyncReplicas = 2`, `minInSyncReplicas = 2`, and `SYNC_FLUSH`. Keep `enableElectUncleanMaster` and `enableElectUncleanMasterLocal` false. Diagnose an insufficient sync-state set instead of bypassing acknowledgment requirements.
+- The preset retains default RocksDB storage and the `storage-rocksdb` feature. The opt-in File backend is documented in `rocketmq-controller/src/storage/file_backend.rs` for single-node development; do not silently substitute it in the HA preset to bypass native build requirements. `dev-single` enables File storage, not multi-node initialization. Memory storage is inappropriate for restart-persistent metadata.
+- Separate Controllers are the default. If the user requests embedded NameServer Controllers, additionally inspect the `embedded-controller` feature, configuration bridge, and listener mapping.
+
+## Maintaining the helper
+
+After changing configuration generation, run `python -B -m unittest discover -s .agents/skills/rocketmq-rust-local-cluster/scripts -p test_prepare_cluster.py -v` from the repository root. These tests check topology relationships, output preservation, and port conflicts; they do not replace current binary configuration checks or live-cluster verification. Keep the `.agents/skills` and `.claude/skills` copies aligned.

--- a/.agents/skills/rocketmq-rust-local-cluster/references/verification.md
+++ b/.agents/skills/rocketmq-rust-local-cluster/references/verification.md
@@ -1,0 +1,75 @@
+# Verification and Troubleshooting
+
+## Readiness and routes
+
+Check live processes, expected listeners, and each `ready_url`. Then verify route registration through **each** configured NameServer; one responsive NameServer does not prove that Brokers registered with both. Match the observed cluster name, broker names, replica IDs, and addresses to the manifest, allowing Controller-assigned persistent identity and elected roles.
+
+The Rust administrative binary is `rocketmq-admin-cli` and has command categories. Use its current `--help`; do not assume Java's flat `mqadmin` invocation or a global `-n` flag. For commands below, set `NAMESRV_ADDR` to the manifest's NameServer list in the admin process environment. Inspect conflicting Java-property-style address overrides before use. In PowerShell use `& $admin`; in Bash use `"$admin"`; examples below use the binary name for readability.
+
+```text
+rocketmq-admin-cli cluster clusterList
+rocketmq-admin-cli topic topicRoute -t LOCAL_SMOKE_TOPIC
+rocketmq-admin-cli ha haStatus -b 127.0.0.1:10911
+rocketmq-admin-cli controller getControllerMetaData -a 127.0.0.1:9878
+rocketmq-admin-cli ha getSyncStateSet -a 127.0.0.1:9878 -b broker-a
+```
+
+Replace sample endpoints with actual manifest values and the current writable Broker/Controller leader. Inspect `haStatus` for ordinary replication; Controller metadata and sync-state commands apply only to Controller HA. The zero-offset examples are not fixed requirements.
+
+## Direct Broker message round trip
+
+Use a new topic name and a unique message key/body token for this environment/run. Do not reuse an unrelated application topic or consumer group. For example, with `NAMESRV_ADDR` scoped to the selected environment:
+
+```text
+rocketmq-admin-cli topic updateTopic -c Local-dev -t LOCAL_SMOKE_TOPIC -r 1 -w 1
+rocketmq-admin-cli message sendMessage -t LOCAL_SMOKE_TOPIC -p LOCAL_RUN_TOKEN -k LOCAL_RUN_TOKEN -b broker-a -i 0
+rocketmq-admin-cli message consumeMessage -t LOCAL_SMOKE_TOPIC -b broker-a -i 0 -o 0 -c 1
+```
+
+Substitute the actual cluster name (`Local-<environment name>`), unique topic, broker name, and token. Check exit status and returned send status, message identity, and consumed token. `Consume ok`, an empty poll, or `SEND_OK` alone is insufficient. Offset zero is appropriate only for a fresh topic/queue; for retries, use the actual offset or a fresh topic. Bound the command duration and keep the test to a few messages. In two-master/two-slave mode, repeat on each broker group so success on one group does not hide a failure on the other.
+
+The `rocketmq-example` project is standalone and examples may contain hardcoded addresses, topics, or message loops. Read its local `AGENTS.md` and the selected example before using it. Do not assume a root-workspace `cargo run -p rocketmq-example` works or run an unbounded producer as a smoke test.
+
+## Proxy message round trip
+
+For cluster mode, first verify the backend Broker path, then use a RocketMQ v5 gRPC client against the actual Proxy endpoint. Query routes, send a unique normal message, receive it with a dedicated group, and acknowledge its receipt handle. For local mode, this Proxy path is the message test; no NameServer registration should be expected. Provision topic/group metadata through a supported path for the selected mode, inspecting its current behavior instead of assuming auto-creation.
+
+Useful protocol sources are `rocketmq-proxy-core/proto/service.proto` and `definition.proto`; examples of request construction are in `rocketmq-proxy/tests/grpc_ingress.rs`. Those tests launch their own fixtures and do **not** validate the user's running environment. Prefer an existing compatible SDK or generate a small bounded external smoke client using those schemas when needed. Support required session/metadata exchanges from the current implementation. A raw TCP connection, HTTP curl against the gRPC port, or a successful gRPC transport with non-OK application status does not establish message delivery.
+
+`rocketmq-proxy/examples/proxy_live_fault_driver.rs` is a fault/overload driver requiring ACL and workload environment variables. Do not run it unchanged as a basic smoke test. If a usable v5 client is unavailable, report Proxy process/readiness and backend results separately, state that ingress delivery remains unverified, and provide a concrete client setup step.
+
+If Remoting ingress was requested, additionally test a supported operation through that enabled endpoint. A direct Broker send does not validate Proxy routing.
+
+## HA checks and optional failover
+
+For ordinary HA, inspect master/slave connection state and replication offsets after sending a message. Wait within a deadline for the replica to catch up. Report whether writes use synchronous or asynchronous replication. Stopping a master does not imply automatic promotion in this topology.
+
+For Controller HA, query all Controller endpoints and establish an agreed leader and membership, then inspect each Broker group's elected master and sync-state set. All three configured processes being alive is not quorum evidence. Confirm enough synchronized replicas for the configured write requirement before declaring writable HA ready.
+
+When the user requests a failover exercise, operate only on this environment's verified processes:
+
+1. Send and consume a unique baseline message; record the elected leaders, synchronization state, and successful acknowledgment.
+2. Stop one Controller leader, retain two voters, and wait for a new leader with bounded polling. Re-query metadata and verify message delivery. Restore the stopped Controller and wait for recovery before another fault.
+3. With the Controller quorum healthy and Broker replicas caught up, stop the writable Broker. Observe a new master and route convergence; send and consume another unique message and check that the pre-failure acknowledged message remains readable.
+4. Restore the original Broker with its data intact, wait for synchronization, and verify delivery again. Leave all intended replicas running unless the user requested a degraded environment.
+
+Graceful drain and abrupt process termination exercise different behavior; label which was tested. Do not stop multiple Controller voters or combine faults unless explicitly requested. For ordinary asynchronous replication, successful recovery in one exercise does not establish an RPO guarantee. Single-host testing never proves host-level availability.
+
+## Diagnose the last failed layer
+
+| Symptom | Targeted checks |
+| --- | --- |
+| Build failure | Selected toolchain; exact package/features; native compiler, bindgen, or Proxy protoc error; no automatic dependency upgrades |
+| Config rejected | Broker section ownership; camelCase names; TOML-escaped absolute paths; `ROCKETMQ_HOME`; current `--help` |
+| Bind failure | Business, fast, HA, Raft, Proxy, health, metrics, and diagnostic ports; inherited listener overrides; actual owner |
+| Broker missing from routes | NameServer list/reachability, cluster/broker identity, registration logs, advertised IP/port; query both NameServers |
+| Writes wait/fail in sync mode | Slave connection, HA master address, lag, sync-state set, replica counts; do not reduce acknowledgment thresholds |
+| No Controller leader | Both peer lists, separate remoting/Raft ports, lowest-ID bootstrap opt-in, peer reachability, existing membership/storage |
+| Proxy ready but delivery fails | Compiled mode feature, backend clusterName, v5 protocol/TLS/client metadata, topic/group provisioning, application status |
+| Restart fails | Stale process record vs live process, locked/reused data directory, changed membership, previous forceful shutdown |
+
+Stop and report an actionable blocker after repeated identical failures with no new corrective step. Keep valid independent parts of the setup and preserve logs/data. Do not label an unavailable component as unsupported merely because a local prerequisite is missing.
+
+## Delivery
+
+Report topology and replica/ack semantics, executable/build profile, actual NameServer/Broker/Proxy/Controller endpoints, environment and log paths, reusable lifecycle commands, and what was observed. Distinguish generated, parsed, started, ready, message-verified, replication-verified, and failover-tested states. Include concrete failure reproduction details only when a stage did not pass.

--- a/.agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py
+++ b/.agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate isolated loopback cluster configs; never build, launch, or delete."""
+
+import argparse
+from contextlib import ExitStack
+import json
+from pathlib import Path
+import re
+import socket
+import sys
+import tomllib
+
+
+PROFILES = (
+    "dev-single", "dev-ha", "dev-ha-2m2s", "proxy-cluster", "proxy-local", "controller-ha",
+)
+HEADER = "# Generated local development configuration; keep per-node data isolated.\n"
+
+
+def quoted(value):
+    # JSON basic strings are valid TOML for these generated paths and identifiers.
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def table(values):
+    def scalar(value):
+        if isinstance(value, bool):
+            return str(value).lower()
+        return str(value) if isinstance(value, int) else quoted(value)
+    return "\n".join(f"{key} = {scalar(value)}" for key, value in values.items()) + "\n"
+
+
+def build_plan(repo, output, name, profile, offset=0, with_proxy=False,
+               replication=None, proxy_remoting=False):
+    if not re.fullmatch(r"[a-z][a-z0-9-]{0,39}", name):
+        raise ValueError("name must be 1-40 lowercase letters, digits or hyphens, starting with a letter")
+    if name in {"con", "prn", "aux", "nul", *(f"com{i}" for i in range(1, 10)),
+                *(f"lpt{i}" for i in range(1, 10))}:
+        raise ValueError("name is reserved on Windows")
+    if profile not in PROFILES:
+        raise ValueError("unknown profile")
+    ordinary_ha = profile in {"dev-ha", "dev-ha-2m2s"}
+    controller = profile == "controller-ha"
+    local = profile == "proxy-local"
+    proxy = profile in {"proxy-local", "proxy-cluster"} or with_proxy
+    if with_proxy and profile in {"proxy-cluster", "proxy-local"}:
+        raise ValueError("this profile already includes a Proxy")
+    if replication is not None and (not ordinary_ha or replication not in {"sync", "async"}):
+        raise ValueError("replication selection requires an ordinary HA profile")
+    if proxy_remoting and not proxy:
+        raise ValueError("proxy-remoting requires a Proxy")
+    if offset < 0:
+        raise ValueError("port-offset must not be negative")
+
+    repo, output = Path(repo).resolve(), Path(output).resolve()
+    cluster_name = f"Local-{name}"
+    files, nodes, builds, ports = {}, [], [], []
+
+    def port(base):
+        value = base + offset
+        if not 1 <= value <= 65535:
+            raise ValueError(f"port-offset produces invalid TCP port {value}")
+        return value
+
+    def endpoint(base):
+        return f"127.0.0.1:{port(base)}"
+
+    def home(node):
+        return (output / "nodes" / node).as_posix()
+
+    def add_node(node, service, content, listeners, extra_env=None):
+        config_path = output / "conf" / f"{node}.toml"
+        tomllib.loads(content)
+        files[f"conf/{node}.toml"] = HEADER + content
+        probe = endpoint(18000 + len(nodes))
+        bindings = {**listeners, "health": probe}
+        for purpose, address in bindings.items():
+            ports.append({"node": node, "purpose": purpose, "address": address})
+        env = {
+            "ROCKETMQ_HOME": home(node),
+            "ROCKETMQ_SECURITY_PROFILE": "development-insecure-loopback",
+            "ROCKETMQ_HEALTH_BIND_ADDR": probe,
+            "ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS": "45",
+            "RUST_LOG": "info",
+            **(extra_env or {}),
+        }
+        nodes.append({
+            "id": node, "service": service, "binary": f"rocketmq-{service}-rust",
+            "argv": ["-c", config_path.as_posix()],
+            "print_config_flag": "--printConfig" if service == "proxy" else "-p",
+            "cwd": home(node), "env": env, "ports": bindings,
+            "stdout": (output / "logs" / f"{node}.out.log").as_posix(),
+            "stderr": (output / "logs" / f"{node}.err.log").as_posix(),
+            "ready_url": f"http://{probe}/readyz",
+        })
+
+    namesrv_count = 0 if local else (2 if ordinary_ha or controller else 1)
+    namesrv_addr = ";".join(endpoint(9876 + i * 10) for i in range(namesrv_count))
+    for i in range(namesrv_count):
+        node = f"namesrv-{i + 1}"
+        add_node(node, "namesrv", table({
+            "rocketmqHome": home(node), "listenPort": port(9876 + i * 10),
+            "bindAddress": "127.0.0.1", "allowInsecurePublicListener": False,
+            "kvConfigPath": f"{home(node)}/data/kvConfig.json",
+            "configStorePath": f"{home(node)}/data/namesrv.properties",
+            "authenticationEnabled": False, "authorizationEnabled": False,
+            "enableControllerInNamesrv": False,
+        }), {"remoting": endpoint(9876 + i * 10)})
+
+    controller_addresses = ";".join(endpoint(9878 + i * 10) for i in range(3)) if controller else ""
+    if controller:
+        for i in range(3):
+            node = f"controller-{i + 1}"
+            content = table({
+                "rocketmqHome": home(node), "controllerType": "Raft", "nodeId": i + 1,
+                "listenAddr": endpoint(9878 + i * 10), "raftListenAddr": endpoint(9879 + i * 10),
+                "configStorePath": f"{home(node)}/data/controller.properties",
+                "controllerStorePath": f"{home(node)}/data/controller",
+                "storagePath": f"{home(node)}/data/raft",
+                "storageBackend": "RocksDB",
+                "electionTimeoutMs": 1000, "heartbeatIntervalMs": 300,
+                "enableElectUncleanMaster": False, "enableElectUncleanMasterLocal": False,
+            })
+            for field, base in (("raftPeers", 9879), ("controllerPeers", 9878)):
+                for peer in range(3):
+                    content += f"\n[[{field}]]\n" + table({"id": peer + 1, "addr": endpoint(base + peer * 10)})
+            content += '\n[observability.metrics]\nexporter = "disable"\n'
+            add_node(node, "controller", content,
+                     {"remoting": endpoint(9878 + i * 10), "raft": endpoint(9879 + i * 10)},
+                     {"ROCKETMQ_CONTROLLER_AUTO_INITIALIZE_CLUSTER": "true" if i == 0 else "false"})
+
+    broker_count = 0 if local else (3 if controller else (4 if profile == "dev-ha-2m2s" else (2 if ordinary_ha else 1)))
+    for i in range(broker_count):
+        node = f"broker-{i + 1}"
+        group = i // 2 if ordinary_ha else 0
+        replica_id = i + 1 if controller else (i % 2 if ordinary_ha else 0)
+        sync = controller or (ordinary_ha and replication != "async")
+        role = "SLAVE" if replica_id else ("SYNC_MASTER" if sync else "ASYNC_MASTER")
+        store = f"{home(node)}/store"
+        broker = {
+            "listenPort": port(10911 + i * 20), "brokerIp1": "127.0.0.1", "brokerIp2": "127.0.0.1",
+            "storePathRootDir": store, "namesrvAddr": namesrv_addr,
+            "autoCreateTopicEnable": True, "enableControllerMode": controller,
+        }
+        if controller:
+            broker["controllerAddr"] = controller_addresses
+        content = "[broker]\n" + table(broker)
+        content += "\n[broker.brokerIdentity]\n" + table({
+            "brokerName": f"broker-{chr(97 + group)}", "brokerClusterName": cluster_name, "brokerId": replica_id,
+        })
+        content += '\n[broker.brokerServerConfig]\nbindAddress = "127.0.0.1"\n'
+        store_config = {
+            "storePathRootDir": store, "storePathBrokerIdentity": f"{store}/brokerIdentity",
+            "brokerRole": role, "flushDiskType": "SYNC_FLUSH" if sync else "ASYNC_FLUSH",
+            "haListenAddress": "127.0.0.1", "haListenPort": port(10912 + i * 20),
+            "totalReplicas": 3 if controller else (2 if ordinary_ha else 1),
+            "inSyncReplicas": 2 if sync else 1, "minInSyncReplicas": 2 if sync else 1,
+            "mappedFileSizeCommitLog": 64 * 1024 * 1024,
+        }
+        if ordinary_ha and replica_id:
+            store_config["haMasterAddress"] = endpoint(10912 + (i - 1) * 20)
+        content += "\n[store]\n" + table(store_config)
+        add_node(node, "broker", content, {
+            "remoting": endpoint(10911 + i * 20), "fast": endpoint(10909 + i * 20),
+            "ha": endpoint(10912 + i * 20),
+        })
+
+    if proxy:
+        content = table({"mode": "local" if local else "cluster"})
+        content += "\n[grpc]\n" + table({"listenAddr": endpoint(8081)})
+        content += '\n[grpc.tls]\nenabled = false\n'
+        content += "\n[remoting]\n" + table({"enabled": proxy_remoting, "listenAddr": endpoint(8080)})
+        bindings = {"grpc": endpoint(8081)}
+        if proxy_remoting:
+            bindings["remoting"] = endpoint(8080)
+        if local:
+            content += "\n[local]\n" + table({
+                "brokerClusterName": cluster_name, "brokerName": "broker-local",
+                "brokerIp": "127.0.0.1", "brokerListenPort": port(10911),
+                "storeRootDir": f"{home('proxy-1')}/store",
+            })
+            bindings["embedded-broker-reserved"] = endpoint(10911)
+        else:
+            content += "\n[cluster]\n" + table({"namesrvAddr": namesrv_addr, "brokerClusterName": cluster_name})
+        add_node("proxy-1", "proxy", content, bindings)
+
+    addresses = [binding["address"] for binding in ports]
+    if len(addresses) != len(set(addresses)):
+        raise ValueError("generated ports collide")
+    for service in ("namesrv", "broker", "controller", "proxy"):
+        if not any(node["service"] == service for node in nodes):
+            continue
+        command = ["cargo", "build", "-p", f"rocketmq-{service}", "--bin", f"rocketmq-{service}-rust"]
+        if service == "proxy":
+            command += ["--no-default-features", "--features", "local-mode" if local else "cluster-mode"]
+        builds.append(command)
+    builds.append(["cargo", "build", "-p", "rocketmq-admin-cli", "--bin", "rocketmq-admin-cli"])
+    groups = [[node["id"] for node in nodes if node["service"] == service]
+              for service in ("namesrv", "controller", "broker", "proxy")]
+    manifest = {
+        "schema_version": 1, "name": name, "profile": profile, "repo_root": repo.as_posix(),
+        "output_root": output.as_posix(), "cluster_name": cluster_name, "port_offset": offset,
+        "namesrv_addr": namesrv_addr, "controller_addr": controller_addresses,
+        "proxy_grpc_addr": endpoint(8081) if proxy else None,
+        "replication": (replication or "sync") if ordinary_ha else ("controller" if controller else "none"),
+        "build_commands": builds, "start_groups": [group for group in groups if group],
+        "nodes": nodes, "ports": ports,
+        "notes": ["Generated configuration is not runtime validation.",
+                  "Start every member in a dependency group before waiting for group readiness.",
+                  "Keep data and verify process identity before stopping or restarting nodes."],
+    }
+    return manifest, files
+
+
+def check_ports(manifest):
+    with ExitStack() as stack:
+        for binding in manifest["ports"]:
+            host, port = binding["address"].rsplit(":", 1)
+            sock = stack.enter_context(socket.socket(socket.AF_INET, socket.SOCK_STREAM))
+            if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+            try:
+                sock.bind((host, int(port)))
+            except OSError as error:
+                raise ValueError(f"unavailable {binding['node']} {binding['purpose']} {binding['address']}: {error}") from error
+
+
+def write_plan(manifest, files):
+    output = Path(manifest["output_root"])
+    # Exclusive creation also rejects existing files, symlinks and reused environment roots.
+    output.mkdir(parents=True, exist_ok=False)
+    for directory in ("conf", "logs", "run"):
+        (output / directory).mkdir()
+    for node in manifest["nodes"]:
+        for directory in ("data", "store"):
+            (Path(node["cwd"]) / directory).mkdir(parents=True, exist_ok=True)
+    for relative, content in files.items():
+        with (output / relative).open("x", encoding="utf-8", newline="\n") as stream:
+            stream.write(content)
+    with (output / "manifest.json").open("x", encoding="utf-8", newline="\n") as stream:
+        json.dump(manifest, stream, ensure_ascii=False, indent=2)
+        stream.write("\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--profile", choices=PROFILES, default="dev-single")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path, help="new directory; defaults to .rocketmq/clusters/NAME")
+    parser.add_argument("--port-offset", type=int, default=0)
+    parser.add_argument("--with-proxy", action="store_true")
+    parser.add_argument("--proxy-remoting", action="store_true")
+    parser.add_argument("--replication", choices=("sync", "async"))
+    parser.add_argument("--check-ports", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    try:
+        repo = args.repo_root.resolve()
+        for required in ("Cargo.toml", "rocketmq-broker/Cargo.toml", "rocketmq-namesrv/Cargo.toml"):
+            if not (repo / required).is_file():
+                raise ValueError(f"not a rocketmq-rust checkout: missing {required}")
+        output = args.output or repo / ".rocketmq" / "clusters" / args.name
+        manifest, files = build_plan(repo, output, args.name, args.profile, args.port_offset,
+                                     args.with_proxy, args.replication, args.proxy_remoting)
+        if args.check_ports:
+            check_ports(manifest)
+        if args.dry_run:
+            print(json.dumps(manifest, ensure_ascii=False, indent=2))
+        else:
+            write_plan(manifest, files)
+            print(f"Prepared {len(manifest['nodes'])} processes: {manifest['output_root']}/manifest.json")
+            print("No processes started. Follow the skill's operations and verification references.")
+    except (OSError, ValueError) as error:
+        print(f"prepare-cluster: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/rocketmq-rust-local-cluster/scripts/test_prepare_cluster.py
+++ b/.agents/skills/rocketmq-rust-local-cluster/scripts/test_prepare_cluster.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check generated topology relationships and non-destructive preparation."""
+
+import json
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+
+from prepare_cluster import PROFILES, build_plan, check_ports, write_plan
+
+
+SCRIPT = Path(__file__).with_name("prepare_cluster.py")
+REPO = Path(__file__).resolve().parents[4]
+
+
+class PrepareClusterTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="rocketmq-skill-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.output = Path(self.temporary.name) / "environment with spaces"
+
+    def plan(self, profile, **kwargs):
+        return build_plan(REPO, self.output, "test", profile, **kwargs)
+
+    def test_all_profiles_isolate_paths_and_resolve_backend_endpoints(self):
+        for profile in PROFILES:
+            with self.subTest(profile=profile):
+                manifest, files = self.plan(profile)
+                addresses = [entry["address"] for entry in manifest["ports"]]
+                self.assertEqual(len(addresses), len(set(addresses)))
+                self.assertEqual(len(manifest["nodes"]), len({node["cwd"] for node in manifest["nodes"]}))
+                nameservers = {node["ports"]["remoting"] for node in manifest["nodes"] if node["service"] == "namesrv"}
+                for node in manifest["nodes"]:
+                    config = tomllib.loads(files[f"conf/{node['id']}.toml"])
+                    self.assertTrue(Path(node["cwd"]).is_relative_to(self.output))
+                    self.assertTrue(Path(node["argv"][1]).is_relative_to(self.output))
+                    if node["service"] == "broker":
+                        self.assertEqual(set(config["broker"]["namesrvAddr"].split(";")), nameservers)
+                        self.assertEqual(config["broker"]["storePathRootDir"], config["store"]["storePathRootDir"])
+                        self.assertTrue(Path(config["store"]["storePathBrokerIdentity"]).is_relative_to(node["cwd"]))
+                    if node["service"] == "proxy" and profile != "proxy-local":
+                        self.assertEqual(set(config["cluster"]["namesrvAddr"].split(";")), nameservers)
+                        self.assertEqual(config["cluster"]["brokerClusterName"], manifest["cluster_name"])
+
+    def test_two_replication_groups_resolve_their_own_master(self):
+        for replication in ("sync", "async"):
+            manifest, files = self.plan("dev-ha-2m2s", replication=replication)
+            brokers = [node for node in manifest["nodes"] if node["service"] == "broker"]
+            for master, slave in (brokers[:2], brokers[2:]):
+                primary = tomllib.loads(files[f"conf/{master['id']}.toml"])
+                secondary = tomllib.loads(files[f"conf/{slave['id']}.toml"])
+                self.assertEqual(secondary["store"]["haMasterAddress"], master["ports"]["ha"])
+                self.assertEqual(primary["broker"]["brokerIdentity"]["brokerName"], secondary["broker"]["brokerIdentity"]["brokerName"])
+                self.assertNotEqual(primary["broker"]["brokerIdentity"]["brokerId"], secondary["broker"]["brokerIdentity"]["brokerId"])
+                self.assertEqual(primary["store"]["minInSyncReplicas"], 2 if replication == "sync" else 1)
+
+    def test_controller_membership_bootstrap_and_broker_discovery_match(self):
+        manifest, files = self.plan("controller-ha", with_proxy=True)
+        controllers = [node for node in manifest["nodes"] if node["service"] == "controller"]
+        remoting = {node["ports"]["remoting"] for node in controllers}
+        raft = {node["ports"]["raft"] for node in controllers}
+        self.assertFalse(remoting & raft)
+        initialized = [node for node in controllers if node["env"]["ROCKETMQ_CONTROLLER_AUTO_INITIALIZE_CLUSTER"] == "true"]
+        self.assertEqual([node["id"] for node in initialized], [controllers[0]["id"]])
+        for node in controllers:
+            config = tomllib.loads(files[f"conf/{node['id']}.toml"])
+            self.assertEqual({peer["addr"] for peer in config["raftPeers"]}, raft)
+            self.assertEqual({peer["addr"] for peer in config["controllerPeers"]}, remoting)
+            self.assertEqual(next(peer["addr"] for peer in config["raftPeers"] if peer["id"] == config["nodeId"]), config["raftListenAddr"])
+        for node in manifest["nodes"]:
+            if node["service"] != "broker":
+                continue
+            config = tomllib.loads(files[f"conf/{node['id']}.toml"])
+            self.assertEqual(set(config["broker"]["controllerAddr"].split(";")), remoting)
+            self.assertGreater(config["broker"]["brokerIdentity"]["brokerId"], 0)
+            self.assertEqual(config["store"]["brokerRole"], "SLAVE")
+            self.assertNotIn("haMasterAddress", config["store"])
+            self.assertLessEqual(config["store"]["minInSyncReplicas"], config["store"]["inSyncReplicas"])
+            self.assertLessEqual(config["store"]["inSyncReplicas"], config["store"]["totalReplicas"])
+
+    def test_offset_updates_every_address_without_changing_topology(self):
+        original, _ = self.plan("controller-ha", with_proxy=True, proxy_remoting=True)
+        shifted, _ = self.plan("controller-ha", offset=2000, with_proxy=True, proxy_remoting=True)
+        for left, right in zip(original["ports"], shifted["ports"], strict=True):
+            self.assertEqual(left["node"], right["node"])
+            self.assertEqual(int(right["address"].split(":")[1]) - int(left["address"].split(":")[1]), 2000)
+
+    def test_local_proxy_has_no_external_backend_and_matching_features(self):
+        manifest, files = self.plan("proxy-local")
+        self.assertEqual([node["service"] for node in manifest["nodes"]], ["proxy"])
+        config = tomllib.loads(files["conf/proxy-1.toml"])
+        self.assertNotIn("cluster", config)
+        self.assertEqual(manifest["namesrv_addr"], "")
+        self.assertEqual(manifest["build_commands"][0][-1], "local-mode")
+
+    def test_existing_environment_is_preserved_and_new_files_parse(self):
+        manifest, files = self.plan("controller-ha")
+        write_plan(manifest, files)
+        sentinel = Path(manifest["nodes"][0]["cwd"]) / "data" / "messages"
+        sentinel.write_text("preserve me", encoding="utf-8")
+        with self.assertRaises(FileExistsError):
+            write_plan(*self.plan("dev-single"))
+        self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve me")
+        self.assertEqual(json.loads((self.output / "manifest.json").read_text(encoding="utf-8")), manifest)
+        for config in (self.output / "conf").glob("*.toml"):
+            with config.open("rb") as stream:
+                tomllib.load(stream)
+
+    def test_dry_run_has_no_filesystem_side_effects(self):
+        result = subprocess.run([sys.executable, str(SCRIPT), "--repo-root", str(REPO), "--name", "test",
+                                 "--profile", "proxy-cluster", "--output", str(self.output), "--dry-run"],
+                                capture_output=True, text=True, timeout=10, check=True)
+        self.assertEqual(json.loads(result.stdout)["profile"], "proxy-cluster")
+        self.assertFalse(self.output.exists())
+
+    def test_invalid_combinations_and_names_fail_before_writing(self):
+        for kwargs in ({"replication": "async"}, {"offset": 65535}, {"offset": -1}, {"proxy_remoting": True}):
+            with self.subTest(kwargs=kwargs), self.assertRaises(ValueError):
+                self.plan("controller-ha", **kwargs)
+        for name in ("../escape", "a/b", "CON", "nul", "com1"):
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                build_plan(REPO, self.output, name, "dev-single")
+        self.assertFalse(self.output.exists())
+
+    def test_port_conflict_is_reported_without_disturbing_owner(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as owner:
+            owner.bind(("127.0.0.1", 0))
+            owner.listen()
+            address = f"127.0.0.1:{owner.getsockname()[1]}"
+            with self.assertRaisesRegex(ValueError, "unavailable"):
+                check_ports({"ports": [{"node": "owned", "purpose": "health", "address": address}]})
+            self.assertGreater(owner.getsockname()[1], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/rocketmq-rust-local-cluster/SKILL.md
+++ b/.claude/skills/rocketmq-rust-local-cluster/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: rocketmq-rust-local-cluster
+description: Set up, start, verify, inspect, and stop local development clusters from the current rocketmq-rust checkout. Use for single-Broker development, replicated master/slave clusters, Proxy cluster/local mode, or three-node Controller HA with automatic Broker election.
+---
+
+# RocketMQ Rust Local Cluster
+
+Turn the requested topology into a running, verifiable local environment with isolated data and an explicit stop procedure. Use this checkout's manifests, configuration parsers, and entrypoints. Java RocketMQ scripts and old flat Broker configuration are not substitutes for the Rust services.
+
+## Select a topology
+
+Preserve the user's topology, paths, ports, and execution method. Otherwise default to `dev-single`, native processes, loopback addresses, and a debug build; state the assumptions and continue. For an unspecified request for HA, select `controller-ha` and explain its larger resource needs. Select `dev-ha` when the user explicitly wants ordinary master/slave replication.
+
+| Profile | Processes | Purpose and limits |
+| --- | --- | --- |
+| `dev-single` | 1 NameServer + 1 Broker | Minimum message round trip; no replica |
+| `dev-ha` | 2 NameServers + 1 master + 1 slave | Synchronous replication by default; no automatic writable-master promotion |
+| `dev-ha-2m2s` | 2 NameServers + 2 master/slave groups | Two distinct brokerName values; ordinary replication |
+| `proxy-cluster` | `dev-single` + a separate Proxy | gRPC ingress forwarding to the backend cluster |
+| `proxy-local` | 1 Proxy with an embedded Broker | Single-process development; no separate NameServer/Broker and no HA |
+| `controller-ha` | 2 NameServers + 3 Controllers + 3 Brokers in one group | Raft quorum, automatic Broker election, and replica synchronization |
+
+`--with-proxy` adds a separate Proxy to `dev-single`, `dev-ha`, `dev-ha-2m2s`, or `controller-ha`. It adds one ingress instance; Proxy redundancy needs additional instances and an endpoint strategy when requested.
+
+These are **single-host development topologies**. They do not survive loss of the host or its disks. Explain synchronous replication (`SYNC_MASTER`), disk flush (`SYNC_FLUSH`), and automatic election as separate properties.
+
+## Workflow
+
+For status, stop, or restart requests, open the existing environment manifest and process records first. Skip configuration generation and builds unless a requested restart actually needs updated binaries. Do not create another cluster while inspecting an existing one.
+
+1. Read applicable `AGENTS.md` instructions and `git status --short`. Inspect OS, toolchain, disk capacity, and port occupancy. Keep the selected Rust toolchain. Use [topology rules and source map](references/topologies.md) to check only the requested components.
+2. Generate configuration and a run manifest with the helper below. It writes files and optionally probes port availability; it does not compile, start processes, or delete data. Stop at artifacts if the user requested only a plan/configuration; continue through startup and verification when asked to set up an environment.
+3. Follow [operations and lifecycle](references/operations.md): build the necessary binaries, check configuration parsing, record process ownership, start dependency groups, and wait for readiness within a deadline. Initial compilation can dominate setup time; report actual progress.
+4. Follow [verification and troubleshooting](references/verification.md): check registration and a message round trip. For HA, inspect replication/election state. Perform disruptive failover exercises when requested, then restore the environment.
+5. Deliver the actual endpoints, configuration/data/log locations, verification results, and reusable start/status/stop commands. Leave the environment running when that is the requested outcome. Report the last completed stage on failure; generated configuration is not successful startup.
+
+## Configuration helper
+
+Run from the repository root using Python 3.11+. On Linux/macOS, `python3` may replace `python`. When using the Claude copy, replace the script prefix with `.claude/skills`.
+
+```text
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name dev --profile dev-single --check-ports
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name ha --profile dev-ha --port-offset 1000 --check-ports
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name dual --profile dev-ha-2m2s --replication async --port-offset 2000
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name proxy --profile proxy-cluster --port-offset 3000
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name local --profile proxy-local --port-offset 4000
+python .agents/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py --name controller --profile controller-ha --with-proxy --port-offset 5000 --check-ports
+```
+
+- Output defaults to ignored `.rocketmq/clusters/<name>/`. Use `--repo-root` for another checkout or `--output` for a new, dedicated environment directory.
+- `--dry-run` prints the manifest without writing files. `--check-ports` checks whether all planned loopback ports can currently bind; it does not reserve them for startup.
+- Existing output directories are rejected to preserve configuration and messages. For restart/status/stop, read the existing `manifest.json`. Prefer a new environment for topology changes.
+- `--replication async` applies only to ordinary HA profiles. Controller HA retains three replicas and a minimum of two in-sync replicas; do not lower write requirements to conceal startup or replication failures.
+- Add `--proxy-remoting` only when Remoting ingress is requested. The default Proxy ingress is gRPC.
+- Base ports: NameServer `9876/9886`; Broker remoting `10911 + 20*i`, fast channel `remoting - 2`, HA `remoting + 1`; Controller remoting `9878/9888/9898`, Raft `9879/9889/9899`; Proxy gRPC `8081`, optional remoting `8080`; health `18000 + node index`. `--port-offset` shifts all ports and their references together.
+
+## Execution boundaries
+
+- A request to set up the environment authorizes necessary local configuration, builds, startup, and non-disruptive verification without repeated confirmation. It does not authorize publication, remote-cluster changes, system services, or deleting old data.
+- The native generator uses `127.0.0.1` and `development-insecure-loopback`. Inspect conflicting inherited TLS/ACL or listener environment settings; resolve them only for these new processes. Preserve security settings of existing environments.
+- On port conflicts, choose another offset or the user's available ports. Do not terminate the current port owner. Isolate every instance's persistence and logs instead of using a shared default home-directory `store`.
+- Record PID, process creation time, executable path, arguments, and configuration path. Verify identity before stopping; a process name or stale PID file alone is insufficient.
+- Preserve data by default. For an explicitly requested reset, first resolve absolute paths, verify they remain in this environment and do not link elsewhere, and stop its processes. Delete only that environment's intended data.
+- Docker/Compose, WSL, and local Kubernetes are optional execution methods. Use the [container branch](references/operations.md#containers-and-local-kubernetes) when requested; native loopback configuration cannot be mounted unchanged into multiple containers. Local setup does not require release, performance, full-workspace Clippy, or integration fault-matrix gates.
+
+## Example requests
+
+```text
+Use $rocketmq-rust-local-cluster to start a minimal development cluster and verify one message round trip.
+Use $rocketmq-rust-local-cluster to create an asynchronous two-master/two-slave environment with port offset 2000, preserving my existing cluster.
+Use $rocketmq-rust-local-cluster to start Controller HA with Proxy and verify message delivery after automatic failover.
+Use $rocketmq-rust-local-cluster to inspect the dev environment, then stop it while preserving messages.
+```

--- a/.claude/skills/rocketmq-rust-local-cluster/agents/openai.yaml
+++ b/.claude/skills/rocketmq-rust-local-cluster/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RocketMQ Rust Local Cluster"
+  short_description: "Set up local Broker, Proxy, and Controller HA clusters"
+  default_prompt: "Use $rocketmq-rust-local-cluster to set up a local development cluster from this checkout and verify message delivery."

--- a/.claude/skills/rocketmq-rust-local-cluster/references/operations.md
+++ b/.claude/skills/rocketmq-rust-local-cluster/references/operations.md
@@ -1,0 +1,84 @@
+# Operations and Lifecycle
+
+## Build and configuration checks
+
+Inspect the selected toolchain and build prerequisites before launching anything. Proxy protobuf generation uses `protoc` on PATH or `PROTOC` (`rocketmq-proxy-core/build.rs`); Controller uses vendored protoc (`rocketmq-controller/build.rs`). Controller's default RocksDB build needs the platform's supported native C/C++ and bindgen prerequisites. Report the actual missing prerequisite, use a documented local setup path, and do not switch HA storage or upgrade dependencies to make a build pass.
+
+The generated `manifest.json` contains:
+
+- `build_commands`: argument arrays, executed with the repository root as cwd. Package and binary names differ for some components; use these arrays directly.
+- `start_groups`: dependencies in order. Start every node within a group before waiting for group readiness, especially Controllers and synchronous Brokers.
+- `nodes`: binary name, config arguments, per-process environment, cwd, log destinations, and readiness URL.
+- `ports`: all configured or reserved ports, including Broker fast and HA ports and per-process health probes.
+
+Build once, then execute the binaries directly for every replica. Reuse matching binaries only when they reflect the current source/features; existence alone is insufficient. Honor `CARGO_TARGET_DIR`, `.cargo/config.toml`, configured build target, and the selected profile when locating executables; `cargo metadata --format-version 1 --no-deps` and Cargo JSON executable artifacts can resolve nonstandard locations. Windows binaries have `.exe`. Do not run concurrent Cargo builds against the same target directory just to start replicas.
+
+For example, the minimal environment needs:
+
+```text
+cargo build -p rocketmq-namesrv --bin rocketmq-namesrv-rust
+cargo build -p rocketmq-broker --bin rocketmq-broker-rust
+cargo build -p rocketmq-admin-cli --bin rocketmq-admin-cli
+```
+
+Use each node's environment and cwd for configuration checks. Append its `print_config_flag` to its `argv`: NameServer/Broker/Controller use `-c <file> -p`, Proxy uses `-c <file> --printConfig`. Inspect `--help` if options changed. Check exit codes; printing configuration does not verify listeners, storage initialization, quorum, or message delivery. Do not publish configuration dumps containing credentials.
+
+## Start native processes
+
+Choose the platform's existing process supervisor or managed terminal sessions. When background processes are necessary, keep their ownership records under `<environment>/run/` and provide reusable start/status/stop scripts there. The configuration generator intentionally does not manage processes. Implement those environment-specific commands using the following rules, instead of claiming that it already offers a `start` or `stop` subcommand.
+
+1. Inspect the existing manifest and process records. An already-running node with matching identity should be reported/reused, not launched twice. Reject changed configuration for a live node.
+2. Execute the exact binary with the manifest's argument array, per-node cwd, and environment. Overlay only the intended variables; inspect inherited `ROCKETMQ_*`, telemetry/health bindings, `NAMESRV_ADDR`, `rocketmq.namesrv.addr`, legacy `rocketmq.rocketmq-namesrv.addr`, and `ROCKETMQ_CONTROLLER_RAFT_BIND_ADDR` for conflicts. Do not save secrets into the run manifest. Do not interpolate arguments into shell code.
+3. Redirect stdout and stderr to the corresponding node logs. Preserve earlier logs on restart through append or per-start filenames.
+4. Immediately record PID, executable path, config arguments, process creation time, and the managed session/container ID when available. Never hold only the PID from a shell wrapper.
+5. Launch each `start_groups` group, then poll its readiness with short request timeouts and an overall deadline (for example, 90 seconds after startup, extended with evidence for first initialization). Stop waiting early if a process exits. Capture its exit status and relevant log tail.
+6. After service readiness, run the topology checks in [verification](verification.md). Controller election may need additional convergence time. A timeout is a failure to diagnose, not permission to start a duplicate.
+
+PowerShell: use `Start-Process -WindowStyle Hidden -PassThru` for background launches, with `-WorkingDirectory`, separate `-RedirectStandardOutput` / `-RedirectStandardError`, and correctly quoted config paths in `-ArgumentList`. If setting process-level environment temporarily, save and restore it with `try/finally`; apply Controller bootstrap variables only to their intended nodes. `Get-Process` provides `StartTime`/`Path`; use `Get-CimInstance Win32_Process` when command-line verification is needed. Do not use `$PID`, `$HOME`, or `$CODEX_HOME` as task variables.
+
+Bash: use explicit argv or an array and a subshell to scope cwd/environment. For persistent local background work, `nohup` with stdin closed and redirected logs is an option; capture the actual executable PID (use `exec` in wrappers). Record process start time and arguments using the host's `ps`, and handle platform differences between Linux and macOS. Keep all paths quoted.
+
+For a one-node foreground check, after substituting absolute paths from the manifest:
+
+```bash
+cd "$NODE_HOME"
+ROCKETMQ_HOME="$NODE_HOME" \
+ROCKETMQ_SECURITY_PROFILE=development-insecure-loopback \
+ROCKETMQ_HEALTH_BIND_ADDR=127.0.0.1:18000 \
+"$BIN_DIR/rocketmq-namesrv-rust" -c "$CONFIG_FILE"
+```
+
+The health address above illustrates the first zero-offset NameServer only. Use each node's actual manifest values, including all Controller environment entries, for real launches. A foreground command is not the complete cluster launcher.
+
+## Status, stop, and restart
+
+Status must distinguish process existence, readiness, route registration, and topology health. `GET /livez` and `GET /readyz` are non-mutating probes. Do not probe `/drainz` during a status check: it requests shutdown.
+
+For a normal stop, verify ownership, stop Proxy ingress first, then Brokers, Controllers, and NameServers. For ordinary HA groups, stop the master before its slave so the master's final drain can retain its replica. For a full Controller HA shutdown, keep quorum available while Brokers drain. Process groups should share bounded deadlines rather than waiting forever for each individual node.
+
+The current service lifecycle supports a graceful HTTP drain, including on Windows:
+
+```powershell
+Invoke-WebRequest -UseBasicParsing -Method Post -Uri $ownedDrainUrl -TimeoutSec 3
+```
+
+```bash
+curl --fail --silent --show-error --max-time 3 --request POST "$OWNED_DRAIN_URL"
+```
+
+Derive that URL from the verified node's health endpoint by replacing `/readyz` with `/drainz`. Confirm the listener still belongs to that node before sending it. Await exit within the configured shutdown deadline (the helper uses 45 seconds), and inspect shutdown errors. A successful drain HTTP response only means the request was accepted. On Unix, SIGTERM to a verified PID is a fallback when the probe is unavailable. Windows `Stop-Process` is forceful, not equivalent to graceful drain; use it only for a requested crash exercise or a stuck owned process after a bounded graceful attempt, and report that outcome.
+
+Restart with the same configuration, data, identities, and ports. Controllers may reuse the generated bootstrap environment: existing committed state is not reinitialized. Revalidate registration, synchronization, and a message round trip. Reset is a separate destructive operation; require the user's actual reset request and never delete data as routine startup repair.
+
+## Containers and local Kubernetes
+
+Use this branch only when requested or chosen with the user's existing context. The helper generates native loopback environments, not container configuration.
+
+- Inspect `distribution/container/core-service.Dockerfile`, `distribution/helm/rocketmq-rust-core/README.md`, its values/schema/templates, and `distribution/kubernetes/README.md`. Check actual image availability and binary contents; do not invent an official image tag. Prefer building this checkout for source-based development.
+- For Compose, put every node on a named project network, use service DNS names for inter-service addresses, separate volumes, and unique host port publications bound to `127.0.0.1`. Internal ports can repeat across containers; native host ports cannot. Controller Raft peer addresses and Broker-facing discovery addresses remain distinct.
+- Loopback inside a container is that container. Choose bind and advertised addresses separately, and ensure client-visible route addresses are reachable from the user's host or client container. Publishing only NameServer or Proxy ports does not automatically make direct Broker clients work.
+- `development-insecure-loopback` rejects public binds inside containers. Choose a repository-supported container security setup and inspect the relevant guide; do not silently turn off security to force `0.0.0.0` to bind. Host-only publication alone does not change this runtime check.
+- For Kind/Helm, explicitly select the intended local Kubernetes context and namespace. Do not send an install to an inherited remote context. Adapt development values and resources for the local machine; the production chart's host-separation rules and TLS settings are not evidence of local HA.
+- Validate generated Compose/Helm configuration, then start and verify the actual workload. Do not invoke release publication, supply-chain promotion, full SLO collection, or destructive fault scripts merely to create a development cluster.
+
+WSL has its own filesystem, toolchain, processes, and network namespace. Keep binaries, data, and lifecycle ownership on one side of the boundary, and verify the endpoint the user's client actually reaches.

--- a/.claude/skills/rocketmq-rust-local-cluster/references/topologies.md
+++ b/.claude/skills/rocketmq-rust-local-cluster/references/topologies.md
@@ -1,0 +1,54 @@
+# Topology Rules and Source Map
+
+Paths below are relative to the repository root. These are targeted inspection entrypoints, not a requirement to read everything. If this checkout changes a field or behavior, adapt the environment and revalidate it.
+
+| Component | Configuration and startup sources |
+| --- | --- |
+| Build | `Cargo.toml`, `rust-toolchain.toml`, selected package manifests |
+| NameServer | `rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs`, `rocketmq-namesrv/src/config.rs` |
+| Broker | `rocketmq-broker/src/command.rs`, `rocketmq-broker/src/config/raw.rs`, `rocketmq-broker/src/config/sections.rs`, `rocketmq-broker/src/config/broker_config.rs`, `rocketmq-store/src/config/message_store_config.rs` |
+| Ordinary HA | `distribution/config/broker/1m-1s-async-one-machine/`, `distribution/config/broker/2m-2s-async/`, `scripts/interop/run_default_ha_interop.py` |
+| Proxy | `rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs`, `rocketmq-proxy/src/config.rs`, `rocketmq-proxy-local/src/config.rs`, `rocketmq-proxy/README.md` |
+| Controller | `rocketmq-controller/src/cli.rs`, `rocketmq-controller/src/config/controller_config.rs`, `rocketmq-controller/src/config/peer_endpoints.rs`, `rocketmq-controller/README.md` |
+| Controller HA composition | `distribution/helm/rocketmq-rust-core/templates/_config.tpl`; reuse field/role semantics, not container addresses |
+| Security and probes | `rocketmq-security-api/src/secure_deployment.rs`, `rocketmq-runtime/src/service_lifecycle.rs` |
+
+## NameServer and Broker
+
+NameServer uses top-level camelCase fields. `distribution/config/nameserver/namesrv.toml` contains production TLS/ACL settings and `/opt` paths; do not copy it unchanged into a minimal environment. The helper sets loopback binding, per-node `rocketmqHome`, `kvConfigPath`, and `configStorePath`, and disables embedded Controller mode.
+
+Canonical Broker TOML uses `[broker]`, `[broker.brokerIdentity]`, `[broker.brokerServerConfig]`, and `[store]`. Set the business port only through `broker.listenPort`; `broker.brokerServerConfig.listenPort` is derived and explicitly rejected in the input. Set `enableControllerMode` only in `[broker]`, not `[store]`.
+
+The two `storePathRootDir` fields must identify the same instance's storage. Isolate `storePathBrokerIdentity` as well. The helper uses 64 MiB CommitLog segments for small local messages; this is not a production capacity recommendation. Check disk and memory headroom before adding replicas instead of promising one fixed minimum for every topology.
+
+NameServer and Controller address lists use semicolons. Pass each list as one string. Clients must reach the `brokerIp1:listenPort` returned by routing; reaching only the NameServer is insufficient.
+
+## Ordinary replication
+
+- Replicas in a group share `brokerName` and `brokerClusterName`. The master has `brokerId = 0`, the slave `brokerId = 1`. Two master/slave groups have different broker names.
+- Give each instance unique remoting, fast-channel, and HA ports. Point each slave's `haMasterAddress` at its own master's **HA port**.
+- Synchronous presets use `SYNC_MASTER` / `SLAVE`, `totalReplicas = 2`, `inSyncReplicas = 2`, `minInSyncReplicas = 2`, and `SYNC_FLUSH`. Writes may wait for replicas while the master is alone; preserve this constraint.
+- Asynchronous presets use `ASYNC_MASTER`, a minimum in-sync count of 1, and `ASYNC_FLUSH`. Acknowledgment can precede replication; do not promise zero message loss after failure.
+- Maintain `1 <= minInSyncReplicas <= inSyncReplicas <= totalReplicas`. NameServer redundancy, readable slaves, and acting-master behavior do not establish automatic promotion to a writable master.
+
+## Proxy
+
+`mode = "cluster"` forwards to the backend through `[cluster].namesrvAddr`, with `brokerClusterName` matching the Brokers. Default ingress is gRPC on `8081`. `--proxy-remoting` additionally enables `8080`. Neither is a NameServer or HTTP management UI.
+
+`mode = "local"` uses `[local]` fields `brokerClusterName`, `brokerName`, `brokerIp`, `brokerListenPort`, and `storeRootDir`. The current `rocketmq-proxy-local/src/local.rs` sets the embedded Broker's `namesrv_addr` to `None`. Do not start a separate NameServer and claim registration. The helper reserves the embedded Broker identity port; check the current embedded implementation for actual network listeners.
+
+Proxy modes require matching Cargo features. Cluster-only builds use `--no-default-features --features cluster-mode`; local-only builds use `--no-default-features --features local-mode`. TLS requires the `tls` feature and certificate configuration. Adding ordinary Broker fields to Proxy's `[local]` table does not create Controller HA.
+
+## Controller HA
+
+- Start three Controller processes with `nodeId = 1/2/3`. Separate Broker-facing `listenAddr` from `raftListenAddr`, and isolate `storagePath`, `configStorePath`, and `controllerStorePath`.
+- Every file contains identical three-entry `[[raftPeers]]` and `[[controllerPeers]]` lists pointing to Raft and Remoting endpoints respectively. Broker `controllerAddr` must use Remoting endpoints. DNS-based `raftPeerEndpoints` / `controllerPeerEndpoints` are mutually exclusive with these legacy IP peer lists; the native helper uses only the latter.
+- Fresh multi-member clusters do not initialize by default. Set `ROCKETMQ_CONTROLLER_AUTO_INITIALIZE_CLUSTER=true` on the lowest-ID member for bootstrap; explicitly set it to `false` on the others. Launch the whole group before waiting for a leader. Existing committed state is not reinitialized; preserve membership and data on restart.
+- The three Brokers form one replica group, start with `brokerId = 1/2/3`, `brokerRole = "SLAVE"`, and `enableControllerMode = true`, and share the full Controller Remoting address list. Controller and persisted identity determine elected roles. Do not configure a fixed ID-zero master or static `haMasterAddress`.
+- Use `totalReplicas = 3`, `inSyncReplicas = 2`, `minInSyncReplicas = 2`, and `SYNC_FLUSH`. Keep `enableElectUncleanMaster` and `enableElectUncleanMasterLocal` false. Diagnose an insufficient sync-state set instead of bypassing acknowledgment requirements.
+- The preset retains default RocksDB storage and the `storage-rocksdb` feature. The opt-in File backend is documented in `rocketmq-controller/src/storage/file_backend.rs` for single-node development; do not silently substitute it in the HA preset to bypass native build requirements. `dev-single` enables File storage, not multi-node initialization. Memory storage is inappropriate for restart-persistent metadata.
+- Separate Controllers are the default. If the user requests embedded NameServer Controllers, additionally inspect the `embedded-controller` feature, configuration bridge, and listener mapping.
+
+## Maintaining the helper
+
+After changing configuration generation, run `python -B -m unittest discover -s .agents/skills/rocketmq-rust-local-cluster/scripts -p test_prepare_cluster.py -v` from the repository root. These tests check topology relationships, output preservation, and port conflicts; they do not replace current binary configuration checks or live-cluster verification. Keep the `.agents/skills` and `.claude/skills` copies aligned.

--- a/.claude/skills/rocketmq-rust-local-cluster/references/verification.md
+++ b/.claude/skills/rocketmq-rust-local-cluster/references/verification.md
@@ -1,0 +1,75 @@
+# Verification and Troubleshooting
+
+## Readiness and routes
+
+Check live processes, expected listeners, and each `ready_url`. Then verify route registration through **each** configured NameServer; one responsive NameServer does not prove that Brokers registered with both. Match the observed cluster name, broker names, replica IDs, and addresses to the manifest, allowing Controller-assigned persistent identity and elected roles.
+
+The Rust administrative binary is `rocketmq-admin-cli` and has command categories. Use its current `--help`; do not assume Java's flat `mqadmin` invocation or a global `-n` flag. For commands below, set `NAMESRV_ADDR` to the manifest's NameServer list in the admin process environment. Inspect conflicting Java-property-style address overrides before use. In PowerShell use `& $admin`; in Bash use `"$admin"`; examples below use the binary name for readability.
+
+```text
+rocketmq-admin-cli cluster clusterList
+rocketmq-admin-cli topic topicRoute -t LOCAL_SMOKE_TOPIC
+rocketmq-admin-cli ha haStatus -b 127.0.0.1:10911
+rocketmq-admin-cli controller getControllerMetaData -a 127.0.0.1:9878
+rocketmq-admin-cli ha getSyncStateSet -a 127.0.0.1:9878 -b broker-a
+```
+
+Replace sample endpoints with actual manifest values and the current writable Broker/Controller leader. Inspect `haStatus` for ordinary replication; Controller metadata and sync-state commands apply only to Controller HA. The zero-offset examples are not fixed requirements.
+
+## Direct Broker message round trip
+
+Use a new topic name and a unique message key/body token for this environment/run. Do not reuse an unrelated application topic or consumer group. For example, with `NAMESRV_ADDR` scoped to the selected environment:
+
+```text
+rocketmq-admin-cli topic updateTopic -c Local-dev -t LOCAL_SMOKE_TOPIC -r 1 -w 1
+rocketmq-admin-cli message sendMessage -t LOCAL_SMOKE_TOPIC -p LOCAL_RUN_TOKEN -k LOCAL_RUN_TOKEN -b broker-a -i 0
+rocketmq-admin-cli message consumeMessage -t LOCAL_SMOKE_TOPIC -b broker-a -i 0 -o 0 -c 1
+```
+
+Substitute the actual cluster name (`Local-<environment name>`), unique topic, broker name, and token. Check exit status and returned send status, message identity, and consumed token. `Consume ok`, an empty poll, or `SEND_OK` alone is insufficient. Offset zero is appropriate only for a fresh topic/queue; for retries, use the actual offset or a fresh topic. Bound the command duration and keep the test to a few messages. In two-master/two-slave mode, repeat on each broker group so success on one group does not hide a failure on the other.
+
+The `rocketmq-example` project is standalone and examples may contain hardcoded addresses, topics, or message loops. Read its local `AGENTS.md` and the selected example before using it. Do not assume a root-workspace `cargo run -p rocketmq-example` works or run an unbounded producer as a smoke test.
+
+## Proxy message round trip
+
+For cluster mode, first verify the backend Broker path, then use a RocketMQ v5 gRPC client against the actual Proxy endpoint. Query routes, send a unique normal message, receive it with a dedicated group, and acknowledge its receipt handle. For local mode, this Proxy path is the message test; no NameServer registration should be expected. Provision topic/group metadata through a supported path for the selected mode, inspecting its current behavior instead of assuming auto-creation.
+
+Useful protocol sources are `rocketmq-proxy-core/proto/service.proto` and `definition.proto`; examples of request construction are in `rocketmq-proxy/tests/grpc_ingress.rs`. Those tests launch their own fixtures and do **not** validate the user's running environment. Prefer an existing compatible SDK or generate a small bounded external smoke client using those schemas when needed. Support required session/metadata exchanges from the current implementation. A raw TCP connection, HTTP curl against the gRPC port, or a successful gRPC transport with non-OK application status does not establish message delivery.
+
+`rocketmq-proxy/examples/proxy_live_fault_driver.rs` is a fault/overload driver requiring ACL and workload environment variables. Do not run it unchanged as a basic smoke test. If a usable v5 client is unavailable, report Proxy process/readiness and backend results separately, state that ingress delivery remains unverified, and provide a concrete client setup step.
+
+If Remoting ingress was requested, additionally test a supported operation through that enabled endpoint. A direct Broker send does not validate Proxy routing.
+
+## HA checks and optional failover
+
+For ordinary HA, inspect master/slave connection state and replication offsets after sending a message. Wait within a deadline for the replica to catch up. Report whether writes use synchronous or asynchronous replication. Stopping a master does not imply automatic promotion in this topology.
+
+For Controller HA, query all Controller endpoints and establish an agreed leader and membership, then inspect each Broker group's elected master and sync-state set. All three configured processes being alive is not quorum evidence. Confirm enough synchronized replicas for the configured write requirement before declaring writable HA ready.
+
+When the user requests a failover exercise, operate only on this environment's verified processes:
+
+1. Send and consume a unique baseline message; record the elected leaders, synchronization state, and successful acknowledgment.
+2. Stop one Controller leader, retain two voters, and wait for a new leader with bounded polling. Re-query metadata and verify message delivery. Restore the stopped Controller and wait for recovery before another fault.
+3. With the Controller quorum healthy and Broker replicas caught up, stop the writable Broker. Observe a new master and route convergence; send and consume another unique message and check that the pre-failure acknowledged message remains readable.
+4. Restore the original Broker with its data intact, wait for synchronization, and verify delivery again. Leave all intended replicas running unless the user requested a degraded environment.
+
+Graceful drain and abrupt process termination exercise different behavior; label which was tested. Do not stop multiple Controller voters or combine faults unless explicitly requested. For ordinary asynchronous replication, successful recovery in one exercise does not establish an RPO guarantee. Single-host testing never proves host-level availability.
+
+## Diagnose the last failed layer
+
+| Symptom | Targeted checks |
+| --- | --- |
+| Build failure | Selected toolchain; exact package/features; native compiler, bindgen, or Proxy protoc error; no automatic dependency upgrades |
+| Config rejected | Broker section ownership; camelCase names; TOML-escaped absolute paths; `ROCKETMQ_HOME`; current `--help` |
+| Bind failure | Business, fast, HA, Raft, Proxy, health, metrics, and diagnostic ports; inherited listener overrides; actual owner |
+| Broker missing from routes | NameServer list/reachability, cluster/broker identity, registration logs, advertised IP/port; query both NameServers |
+| Writes wait/fail in sync mode | Slave connection, HA master address, lag, sync-state set, replica counts; do not reduce acknowledgment thresholds |
+| No Controller leader | Both peer lists, separate remoting/Raft ports, lowest-ID bootstrap opt-in, peer reachability, existing membership/storage |
+| Proxy ready but delivery fails | Compiled mode feature, backend clusterName, v5 protocol/TLS/client metadata, topic/group provisioning, application status |
+| Restart fails | Stale process record vs live process, locked/reused data directory, changed membership, previous forceful shutdown |
+
+Stop and report an actionable blocker after repeated identical failures with no new corrective step. Keep valid independent parts of the setup and preserve logs/data. Do not label an unavailable component as unsupported merely because a local prerequisite is missing.
+
+## Delivery
+
+Report topology and replica/ack semantics, executable/build profile, actual NameServer/Broker/Proxy/Controller endpoints, environment and log paths, reusable lifecycle commands, and what was observed. Distinguish generated, parsed, started, ready, message-verified, replication-verified, and failover-tested states. Include concrete failure reproduction details only when a stage did not pass.

--- a/.claude/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py
+++ b/.claude/skills/rocketmq-rust-local-cluster/scripts/prepare_cluster.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate isolated loopback cluster configs; never build, launch, or delete."""
+
+import argparse
+from contextlib import ExitStack
+import json
+from pathlib import Path
+import re
+import socket
+import sys
+import tomllib
+
+
+PROFILES = (
+    "dev-single", "dev-ha", "dev-ha-2m2s", "proxy-cluster", "proxy-local", "controller-ha",
+)
+HEADER = "# Generated local development configuration; keep per-node data isolated.\n"
+
+
+def quoted(value):
+    # JSON basic strings are valid TOML for these generated paths and identifiers.
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def table(values):
+    def scalar(value):
+        if isinstance(value, bool):
+            return str(value).lower()
+        return str(value) if isinstance(value, int) else quoted(value)
+    return "\n".join(f"{key} = {scalar(value)}" for key, value in values.items()) + "\n"
+
+
+def build_plan(repo, output, name, profile, offset=0, with_proxy=False,
+               replication=None, proxy_remoting=False):
+    if not re.fullmatch(r"[a-z][a-z0-9-]{0,39}", name):
+        raise ValueError("name must be 1-40 lowercase letters, digits or hyphens, starting with a letter")
+    if name in {"con", "prn", "aux", "nul", *(f"com{i}" for i in range(1, 10)),
+                *(f"lpt{i}" for i in range(1, 10))}:
+        raise ValueError("name is reserved on Windows")
+    if profile not in PROFILES:
+        raise ValueError("unknown profile")
+    ordinary_ha = profile in {"dev-ha", "dev-ha-2m2s"}
+    controller = profile == "controller-ha"
+    local = profile == "proxy-local"
+    proxy = profile in {"proxy-local", "proxy-cluster"} or with_proxy
+    if with_proxy and profile in {"proxy-cluster", "proxy-local"}:
+        raise ValueError("this profile already includes a Proxy")
+    if replication is not None and (not ordinary_ha or replication not in {"sync", "async"}):
+        raise ValueError("replication selection requires an ordinary HA profile")
+    if proxy_remoting and not proxy:
+        raise ValueError("proxy-remoting requires a Proxy")
+    if offset < 0:
+        raise ValueError("port-offset must not be negative")
+
+    repo, output = Path(repo).resolve(), Path(output).resolve()
+    cluster_name = f"Local-{name}"
+    files, nodes, builds, ports = {}, [], [], []
+
+    def port(base):
+        value = base + offset
+        if not 1 <= value <= 65535:
+            raise ValueError(f"port-offset produces invalid TCP port {value}")
+        return value
+
+    def endpoint(base):
+        return f"127.0.0.1:{port(base)}"
+
+    def home(node):
+        return (output / "nodes" / node).as_posix()
+
+    def add_node(node, service, content, listeners, extra_env=None):
+        config_path = output / "conf" / f"{node}.toml"
+        tomllib.loads(content)
+        files[f"conf/{node}.toml"] = HEADER + content
+        probe = endpoint(18000 + len(nodes))
+        bindings = {**listeners, "health": probe}
+        for purpose, address in bindings.items():
+            ports.append({"node": node, "purpose": purpose, "address": address})
+        env = {
+            "ROCKETMQ_HOME": home(node),
+            "ROCKETMQ_SECURITY_PROFILE": "development-insecure-loopback",
+            "ROCKETMQ_HEALTH_BIND_ADDR": probe,
+            "ROCKETMQ_SHUTDOWN_TIMEOUT_SECONDS": "45",
+            "RUST_LOG": "info",
+            **(extra_env or {}),
+        }
+        nodes.append({
+            "id": node, "service": service, "binary": f"rocketmq-{service}-rust",
+            "argv": ["-c", config_path.as_posix()],
+            "print_config_flag": "--printConfig" if service == "proxy" else "-p",
+            "cwd": home(node), "env": env, "ports": bindings,
+            "stdout": (output / "logs" / f"{node}.out.log").as_posix(),
+            "stderr": (output / "logs" / f"{node}.err.log").as_posix(),
+            "ready_url": f"http://{probe}/readyz",
+        })
+
+    namesrv_count = 0 if local else (2 if ordinary_ha or controller else 1)
+    namesrv_addr = ";".join(endpoint(9876 + i * 10) for i in range(namesrv_count))
+    for i in range(namesrv_count):
+        node = f"namesrv-{i + 1}"
+        add_node(node, "namesrv", table({
+            "rocketmqHome": home(node), "listenPort": port(9876 + i * 10),
+            "bindAddress": "127.0.0.1", "allowInsecurePublicListener": False,
+            "kvConfigPath": f"{home(node)}/data/kvConfig.json",
+            "configStorePath": f"{home(node)}/data/namesrv.properties",
+            "authenticationEnabled": False, "authorizationEnabled": False,
+            "enableControllerInNamesrv": False,
+        }), {"remoting": endpoint(9876 + i * 10)})
+
+    controller_addresses = ";".join(endpoint(9878 + i * 10) for i in range(3)) if controller else ""
+    if controller:
+        for i in range(3):
+            node = f"controller-{i + 1}"
+            content = table({
+                "rocketmqHome": home(node), "controllerType": "Raft", "nodeId": i + 1,
+                "listenAddr": endpoint(9878 + i * 10), "raftListenAddr": endpoint(9879 + i * 10),
+                "configStorePath": f"{home(node)}/data/controller.properties",
+                "controllerStorePath": f"{home(node)}/data/controller",
+                "storagePath": f"{home(node)}/data/raft",
+                "storageBackend": "RocksDB",
+                "electionTimeoutMs": 1000, "heartbeatIntervalMs": 300,
+                "enableElectUncleanMaster": False, "enableElectUncleanMasterLocal": False,
+            })
+            for field, base in (("raftPeers", 9879), ("controllerPeers", 9878)):
+                for peer in range(3):
+                    content += f"\n[[{field}]]\n" + table({"id": peer + 1, "addr": endpoint(base + peer * 10)})
+            content += '\n[observability.metrics]\nexporter = "disable"\n'
+            add_node(node, "controller", content,
+                     {"remoting": endpoint(9878 + i * 10), "raft": endpoint(9879 + i * 10)},
+                     {"ROCKETMQ_CONTROLLER_AUTO_INITIALIZE_CLUSTER": "true" if i == 0 else "false"})
+
+    broker_count = 0 if local else (3 if controller else (4 if profile == "dev-ha-2m2s" else (2 if ordinary_ha else 1)))
+    for i in range(broker_count):
+        node = f"broker-{i + 1}"
+        group = i // 2 if ordinary_ha else 0
+        replica_id = i + 1 if controller else (i % 2 if ordinary_ha else 0)
+        sync = controller or (ordinary_ha and replication != "async")
+        role = "SLAVE" if replica_id else ("SYNC_MASTER" if sync else "ASYNC_MASTER")
+        store = f"{home(node)}/store"
+        broker = {
+            "listenPort": port(10911 + i * 20), "brokerIp1": "127.0.0.1", "brokerIp2": "127.0.0.1",
+            "storePathRootDir": store, "namesrvAddr": namesrv_addr,
+            "autoCreateTopicEnable": True, "enableControllerMode": controller,
+        }
+        if controller:
+            broker["controllerAddr"] = controller_addresses
+        content = "[broker]\n" + table(broker)
+        content += "\n[broker.brokerIdentity]\n" + table({
+            "brokerName": f"broker-{chr(97 + group)}", "brokerClusterName": cluster_name, "brokerId": replica_id,
+        })
+        content += '\n[broker.brokerServerConfig]\nbindAddress = "127.0.0.1"\n'
+        store_config = {
+            "storePathRootDir": store, "storePathBrokerIdentity": f"{store}/brokerIdentity",
+            "brokerRole": role, "flushDiskType": "SYNC_FLUSH" if sync else "ASYNC_FLUSH",
+            "haListenAddress": "127.0.0.1", "haListenPort": port(10912 + i * 20),
+            "totalReplicas": 3 if controller else (2 if ordinary_ha else 1),
+            "inSyncReplicas": 2 if sync else 1, "minInSyncReplicas": 2 if sync else 1,
+            "mappedFileSizeCommitLog": 64 * 1024 * 1024,
+        }
+        if ordinary_ha and replica_id:
+            store_config["haMasterAddress"] = endpoint(10912 + (i - 1) * 20)
+        content += "\n[store]\n" + table(store_config)
+        add_node(node, "broker", content, {
+            "remoting": endpoint(10911 + i * 20), "fast": endpoint(10909 + i * 20),
+            "ha": endpoint(10912 + i * 20),
+        })
+
+    if proxy:
+        content = table({"mode": "local" if local else "cluster"})
+        content += "\n[grpc]\n" + table({"listenAddr": endpoint(8081)})
+        content += '\n[grpc.tls]\nenabled = false\n'
+        content += "\n[remoting]\n" + table({"enabled": proxy_remoting, "listenAddr": endpoint(8080)})
+        bindings = {"grpc": endpoint(8081)}
+        if proxy_remoting:
+            bindings["remoting"] = endpoint(8080)
+        if local:
+            content += "\n[local]\n" + table({
+                "brokerClusterName": cluster_name, "brokerName": "broker-local",
+                "brokerIp": "127.0.0.1", "brokerListenPort": port(10911),
+                "storeRootDir": f"{home('proxy-1')}/store",
+            })
+            bindings["embedded-broker-reserved"] = endpoint(10911)
+        else:
+            content += "\n[cluster]\n" + table({"namesrvAddr": namesrv_addr, "brokerClusterName": cluster_name})
+        add_node("proxy-1", "proxy", content, bindings)
+
+    addresses = [binding["address"] for binding in ports]
+    if len(addresses) != len(set(addresses)):
+        raise ValueError("generated ports collide")
+    for service in ("namesrv", "broker", "controller", "proxy"):
+        if not any(node["service"] == service for node in nodes):
+            continue
+        command = ["cargo", "build", "-p", f"rocketmq-{service}", "--bin", f"rocketmq-{service}-rust"]
+        if service == "proxy":
+            command += ["--no-default-features", "--features", "local-mode" if local else "cluster-mode"]
+        builds.append(command)
+    builds.append(["cargo", "build", "-p", "rocketmq-admin-cli", "--bin", "rocketmq-admin-cli"])
+    groups = [[node["id"] for node in nodes if node["service"] == service]
+              for service in ("namesrv", "controller", "broker", "proxy")]
+    manifest = {
+        "schema_version": 1, "name": name, "profile": profile, "repo_root": repo.as_posix(),
+        "output_root": output.as_posix(), "cluster_name": cluster_name, "port_offset": offset,
+        "namesrv_addr": namesrv_addr, "controller_addr": controller_addresses,
+        "proxy_grpc_addr": endpoint(8081) if proxy else None,
+        "replication": (replication or "sync") if ordinary_ha else ("controller" if controller else "none"),
+        "build_commands": builds, "start_groups": [group for group in groups if group],
+        "nodes": nodes, "ports": ports,
+        "notes": ["Generated configuration is not runtime validation.",
+                  "Start every member in a dependency group before waiting for group readiness.",
+                  "Keep data and verify process identity before stopping or restarting nodes."],
+    }
+    return manifest, files
+
+
+def check_ports(manifest):
+    with ExitStack() as stack:
+        for binding in manifest["ports"]:
+            host, port = binding["address"].rsplit(":", 1)
+            sock = stack.enter_context(socket.socket(socket.AF_INET, socket.SOCK_STREAM))
+            if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+            try:
+                sock.bind((host, int(port)))
+            except OSError as error:
+                raise ValueError(f"unavailable {binding['node']} {binding['purpose']} {binding['address']}: {error}") from error
+
+
+def write_plan(manifest, files):
+    output = Path(manifest["output_root"])
+    # Exclusive creation also rejects existing files, symlinks and reused environment roots.
+    output.mkdir(parents=True, exist_ok=False)
+    for directory in ("conf", "logs", "run"):
+        (output / directory).mkdir()
+    for node in manifest["nodes"]:
+        for directory in ("data", "store"):
+            (Path(node["cwd"]) / directory).mkdir(parents=True, exist_ok=True)
+    for relative, content in files.items():
+        with (output / relative).open("x", encoding="utf-8", newline="\n") as stream:
+            stream.write(content)
+    with (output / "manifest.json").open("x", encoding="utf-8", newline="\n") as stream:
+        json.dump(manifest, stream, ensure_ascii=False, indent=2)
+        stream.write("\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--profile", choices=PROFILES, default="dev-single")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path, help="new directory; defaults to .rocketmq/clusters/NAME")
+    parser.add_argument("--port-offset", type=int, default=0)
+    parser.add_argument("--with-proxy", action="store_true")
+    parser.add_argument("--proxy-remoting", action="store_true")
+    parser.add_argument("--replication", choices=("sync", "async"))
+    parser.add_argument("--check-ports", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    try:
+        repo = args.repo_root.resolve()
+        for required in ("Cargo.toml", "rocketmq-broker/Cargo.toml", "rocketmq-namesrv/Cargo.toml"):
+            if not (repo / required).is_file():
+                raise ValueError(f"not a rocketmq-rust checkout: missing {required}")
+        output = args.output or repo / ".rocketmq" / "clusters" / args.name
+        manifest, files = build_plan(repo, output, args.name, args.profile, args.port_offset,
+                                     args.with_proxy, args.replication, args.proxy_remoting)
+        if args.check_ports:
+            check_ports(manifest)
+        if args.dry_run:
+            print(json.dumps(manifest, ensure_ascii=False, indent=2))
+        else:
+            write_plan(manifest, files)
+            print(f"Prepared {len(manifest['nodes'])} processes: {manifest['output_root']}/manifest.json")
+            print("No processes started. Follow the skill's operations and verification references.")
+    except (OSError, ValueError) as error:
+        print(f"prepare-cluster: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/rocketmq-rust-local-cluster/scripts/test_prepare_cluster.py
+++ b/.claude/skills/rocketmq-rust-local-cluster/scripts/test_prepare_cluster.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check generated topology relationships and non-destructive preparation."""
+
+import json
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+
+from prepare_cluster import PROFILES, build_plan, check_ports, write_plan
+
+
+SCRIPT = Path(__file__).with_name("prepare_cluster.py")
+REPO = Path(__file__).resolve().parents[4]
+
+
+class PrepareClusterTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="rocketmq-skill-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.output = Path(self.temporary.name) / "environment with spaces"
+
+    def plan(self, profile, **kwargs):
+        return build_plan(REPO, self.output, "test", profile, **kwargs)
+
+    def test_all_profiles_isolate_paths_and_resolve_backend_endpoints(self):
+        for profile in PROFILES:
+            with self.subTest(profile=profile):
+                manifest, files = self.plan(profile)
+                addresses = [entry["address"] for entry in manifest["ports"]]
+                self.assertEqual(len(addresses), len(set(addresses)))
+                self.assertEqual(len(manifest["nodes"]), len({node["cwd"] for node in manifest["nodes"]}))
+                nameservers = {node["ports"]["remoting"] for node in manifest["nodes"] if node["service"] == "namesrv"}
+                for node in manifest["nodes"]:
+                    config = tomllib.loads(files[f"conf/{node['id']}.toml"])
+                    self.assertTrue(Path(node["cwd"]).is_relative_to(self.output))
+                    self.assertTrue(Path(node["argv"][1]).is_relative_to(self.output))
+                    if node["service"] == "broker":
+                        self.assertEqual(set(config["broker"]["namesrvAddr"].split(";")), nameservers)
+                        self.assertEqual(config["broker"]["storePathRootDir"], config["store"]["storePathRootDir"])
+                        self.assertTrue(Path(config["store"]["storePathBrokerIdentity"]).is_relative_to(node["cwd"]))
+                    if node["service"] == "proxy" and profile != "proxy-local":
+                        self.assertEqual(set(config["cluster"]["namesrvAddr"].split(";")), nameservers)
+                        self.assertEqual(config["cluster"]["brokerClusterName"], manifest["cluster_name"])
+
+    def test_two_replication_groups_resolve_their_own_master(self):
+        for replication in ("sync", "async"):
+            manifest, files = self.plan("dev-ha-2m2s", replication=replication)
+            brokers = [node for node in manifest["nodes"] if node["service"] == "broker"]
+            for master, slave in (brokers[:2], brokers[2:]):
+                primary = tomllib.loads(files[f"conf/{master['id']}.toml"])
+                secondary = tomllib.loads(files[f"conf/{slave['id']}.toml"])
+                self.assertEqual(secondary["store"]["haMasterAddress"], master["ports"]["ha"])
+                self.assertEqual(primary["broker"]["brokerIdentity"]["brokerName"], secondary["broker"]["brokerIdentity"]["brokerName"])
+                self.assertNotEqual(primary["broker"]["brokerIdentity"]["brokerId"], secondary["broker"]["brokerIdentity"]["brokerId"])
+                self.assertEqual(primary["store"]["minInSyncReplicas"], 2 if replication == "sync" else 1)
+
+    def test_controller_membership_bootstrap_and_broker_discovery_match(self):
+        manifest, files = self.plan("controller-ha", with_proxy=True)
+        controllers = [node for node in manifest["nodes"] if node["service"] == "controller"]
+        remoting = {node["ports"]["remoting"] for node in controllers}
+        raft = {node["ports"]["raft"] for node in controllers}
+        self.assertFalse(remoting & raft)
+        initialized = [node for node in controllers if node["env"]["ROCKETMQ_CONTROLLER_AUTO_INITIALIZE_CLUSTER"] == "true"]
+        self.assertEqual([node["id"] for node in initialized], [controllers[0]["id"]])
+        for node in controllers:
+            config = tomllib.loads(files[f"conf/{node['id']}.toml"])
+            self.assertEqual({peer["addr"] for peer in config["raftPeers"]}, raft)
+            self.assertEqual({peer["addr"] for peer in config["controllerPeers"]}, remoting)
+            self.assertEqual(next(peer["addr"] for peer in config["raftPeers"] if peer["id"] == config["nodeId"]), config["raftListenAddr"])
+        for node in manifest["nodes"]:
+            if node["service"] != "broker":
+                continue
+            config = tomllib.loads(files[f"conf/{node['id']}.toml"])
+            self.assertEqual(set(config["broker"]["controllerAddr"].split(";")), remoting)
+            self.assertGreater(config["broker"]["brokerIdentity"]["brokerId"], 0)
+            self.assertEqual(config["store"]["brokerRole"], "SLAVE")
+            self.assertNotIn("haMasterAddress", config["store"])
+            self.assertLessEqual(config["store"]["minInSyncReplicas"], config["store"]["inSyncReplicas"])
+            self.assertLessEqual(config["store"]["inSyncReplicas"], config["store"]["totalReplicas"])
+
+    def test_offset_updates_every_address_without_changing_topology(self):
+        original, _ = self.plan("controller-ha", with_proxy=True, proxy_remoting=True)
+        shifted, _ = self.plan("controller-ha", offset=2000, with_proxy=True, proxy_remoting=True)
+        for left, right in zip(original["ports"], shifted["ports"], strict=True):
+            self.assertEqual(left["node"], right["node"])
+            self.assertEqual(int(right["address"].split(":")[1]) - int(left["address"].split(":")[1]), 2000)
+
+    def test_local_proxy_has_no_external_backend_and_matching_features(self):
+        manifest, files = self.plan("proxy-local")
+        self.assertEqual([node["service"] for node in manifest["nodes"]], ["proxy"])
+        config = tomllib.loads(files["conf/proxy-1.toml"])
+        self.assertNotIn("cluster", config)
+        self.assertEqual(manifest["namesrv_addr"], "")
+        self.assertEqual(manifest["build_commands"][0][-1], "local-mode")
+
+    def test_existing_environment_is_preserved_and_new_files_parse(self):
+        manifest, files = self.plan("controller-ha")
+        write_plan(manifest, files)
+        sentinel = Path(manifest["nodes"][0]["cwd"]) / "data" / "messages"
+        sentinel.write_text("preserve me", encoding="utf-8")
+        with self.assertRaises(FileExistsError):
+            write_plan(*self.plan("dev-single"))
+        self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve me")
+        self.assertEqual(json.loads((self.output / "manifest.json").read_text(encoding="utf-8")), manifest)
+        for config in (self.output / "conf").glob("*.toml"):
+            with config.open("rb") as stream:
+                tomllib.load(stream)
+
+    def test_dry_run_has_no_filesystem_side_effects(self):
+        result = subprocess.run([sys.executable, str(SCRIPT), "--repo-root", str(REPO), "--name", "test",
+                                 "--profile", "proxy-cluster", "--output", str(self.output), "--dry-run"],
+                                capture_output=True, text=True, timeout=10, check=True)
+        self.assertEqual(json.loads(result.stdout)["profile"], "proxy-cluster")
+        self.assertFalse(self.output.exists())
+
+    def test_invalid_combinations_and_names_fail_before_writing(self):
+        for kwargs in ({"replication": "async"}, {"offset": 65535}, {"offset": -1}, {"proxy_remoting": True}):
+            with self.subTest(kwargs=kwargs), self.assertRaises(ValueError):
+                self.plan("controller-ha", **kwargs)
+        for name in ("../escape", "a/b", "CON", "nul", "com1"):
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                build_plan(REPO, self.output, name, "dev-single")
+        self.assertFalse(self.output.exists())
+
+    def test_port_conflict_is_reported_without_disturbing_owner(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as owner:
+            owner.bind(("127.0.0.1", 0))
+            owner.listen()
+            address = f"127.0.0.1:{owner.getsockname()[1]}"
+            with self.assertRaisesRegex(ValueError, "unavailable"):
+                check_ports({"ports": [{"node": "owned", "purpose": "health", "address": address}]})
+            self.assertGreater(owner.getsockname()[1], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10366

### Brief Description

Add an English `rocketmq-rust-local-cluster` skill with matching Codex and Claude copies. Agents can select single-Broker, ordinary master/slave, two-master/two-slave, Proxy cluster/local, or Controller HA development topologies using the current repository's configuration and startup contracts.

The Python helper generates isolated TOML configurations and a run manifest with build commands, dependency groups, per-node environment, ports, and data/log paths. It supports port offsets, optional Proxy ingress, port checks, dry-run output, and ordinary replication choices while rejecting existing environment directories. References cover startup, graceful shutdown, message verification, and optional failover exercises; process management remains part of the agent workflow rather than the generator.

### How Did You Test This Change?

- `python -B -m unittest discover -s .agents/skills/rocketmq-rust-local-cluster/scripts -p test_prepare_cluster.py -v`: 9 tests passed, covering topology relationships, Controller bootstrap/discovery, port offsets/conflicts, invalid input, dry-run behavior, and existing data preservation.
- The same unittest command against `.claude/skills/rocketmq-rust-local-cluster/scripts`: 9 tests passed.
- Skill Creator's `quick_validate.py` passed for both skill directories. File equality, English text, relative documentation links, and whitespace checks passed.
- The existing local Broker binary parsed 11 generated configurations using `rocketmq-broker-rust -c <generated-config> -p`; no service listeners were started.
- `git diff --check` and `git diff --cached --check`: passed.
- `./scripts/check-agents-routing.ps1`: failed on an existing unrelated routing gap for `rocketmq-website/examples/first-message/`, which lacks a same-directory `AGENTS.md` and a root routing entry. Those files are outside this change.

Live cluster startup, message delivery, and failover were not exercised. This PR changes skill documentation and Python configuration tooling, not Rust service implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local RocketMQ Rust cluster setup workflow supporting standalone, replicated, Proxy, and Controller HA topologies.
  * Added configuration generation with isolated data and log directories, port offsets, validation, dry-run output, and port-conflict checks.
  * Added lifecycle guidance for building, starting, monitoring, stopping, restarting, and containerizing clusters.
  * Added verification procedures for readiness, message delivery, replication, failover, and troubleshooting.

* **Tests**
  * Added coverage for topology generation, validation, isolation, port handling, dry runs, and HA configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->