### PR TITLE
[ISSUE #10368]🚀Version Tauri connection settings and preserve endpoint identities

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
@@ -6,6 +6,7 @@ A RocketMQ-Rust desktop dashboard built with Tauri, React, and Rust.
 
 - Live cluster, broker, topic, consumer, producer and message inspection, with
   explicit topic/consumer administration and message actions
+- Revisioned NameServer and Proxy configuration with stable endpoint/environment identities
 - Saved NameServer and Proxy address configuration (Proxy entries do not control
   Proxy server processes)
 - Native desktop packaging with a web UI
@@ -45,7 +46,7 @@ them; choose a new data directory to start fresh.
 
 Sessions expire after eight hours by default (`DASHBOARD_TAURI_SESSION_TTL_SECS` overrides this). Password changes revoke all sessions and require a new login. Account ¡ú Sessions lists safe identifiers and can sign out the entire account.
 
-The current fresh schema is version 3; version 1/2 development databases are not migrated. Select a new data directory when changing from an older format.
+The current fresh schema is version 4; version 1/2/3 development databases are not migrated. Select a new data directory when changing from an older format.
 
 For more detail, see [doc/AUTH_CONFIG.md](./doc/AUTH_CONFIG.md).
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUDIT.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUDIT.md
@@ -6,8 +6,9 @@ and DLQ resends. Read-only business queries are not recorded individually.
 
 The Audit navigation entry supports an inclusive time range, exact actor/action/
 outcome/environment filters, refresh, and cursor pagination ordered by terminal
-time and event ID. Environment IDs are absent until connection identity support
-is introduced; old records are not assigned a guessed environment.
+time and event ID. Configuration and accepted remote mutations use the stable current environment ID.
+Account events and requests rejected before resolving an environment leave it absent;
+old records are never assigned a guessed identity.
 
 Each accepted mutation belongs to the audit service task group. Closing a page or
 dropping the IPC waiter does not drop the operation or its terminal record.
@@ -27,10 +28,8 @@ inspect the resource before deciding whether to resubmit. Batch receipts preserv
 success/failure counts rather than equating every successful IPC response with a
 fully successful operation.
 
-Account mutations commit their success record in the same SQLite transaction. If
-recording fails, the account mutation rolls back. Connection configuration still
-uses its existing store; its versioned transaction integration follows with the
-connection settings work. For separately committed configuration or remote changes,
+Account and connection mutations commit their success record in the same SQLite
+transaction. If recording fails, the local mutation rolls back. For remote changes,
 a failed audit write preserves the actual command result and adds `auditWarning`.
 The frontend displays a persistent, dismissible warning. It does not retry the
 operation. An operation error also remains the original error if its audit write
@@ -38,7 +37,7 @@ fails.
 
 Retention runs at startup and hourly, deleting at most 1,000 terminal records older
 than 30 days per pass. The cleanup uses the storage-owned background task group.
-The current schema is version 3; older development schemas are rejected without
+The current schema is version 4; older development schemas are rejected without
 modification. Select a fresh data directory when moving between these development
 formats.
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUTH_CONFIG.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUTH_CONFIG.md
@@ -50,7 +50,7 @@ them; choose a new data directory to start fresh.
 
 ## Schema
 
-Schema version 3 contains `dashboard_schema`, `users`, `sessions`, `audit_events`, and connection configuration tables. Version 1/2 development databases are not migrated; select a new data directory. The account table is:
+Schema version 4 contains `dashboard_schema`, `users`, `sessions`, `audit_events`, and connection configuration tables. Version 1/2/3 development databases are not migrated; select a new data directory. The account table is:
 
 ```sql
 CREATE TABLE IF NOT EXISTS users (

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONNECTION_SETTINGS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONNECTION_SETTINGS.md
@@ -1,0 +1,60 @@
+# Revisioned desktop connection settings
+
+All exported NameServer/Proxy additions, switches, deletions, VIP/TLS changes,
+and full NameServer replacement share one transaction manager. Read the current
+`ConnectionSettingsView` with `get_connection_settings`. It includes revision,
+stable endpoints, current endpoint IDs, environment ID, and NameServer/Proxy
+snapshots. It contains no RocketMQ credentials.
+
+Every configuration mutation requires `expectedRevision`; replacement carries it
+inside `request`. The transaction compares the stored revision, validates the full
+candidate configuration, writes both snapshots and stable identities, records the
+successful audit, increments the revision, and commits. Runtime publication occurs
+once after commit. Conflicting drafts are rejected with
+`dashboard.configuration_conflict`; the frontend asks the user to refresh and
+review instead of resubmitting automatically.
+
+Endpoint UUIDs are associated with `(kind, canonical address)` and survive removal
+and later readdition. Each saved logical NameServer address group has its own UUID
+environment. Switching groups changes environment; VIP/TLS or Proxy changes do
+not. No address hashing or guessing that different groups belong to the same
+cluster is involved.
+
+Accepted remote mutations carry the frontend's revision and hold a read lease
+through the RPC. A configuration switch waits for those mutations. A stale mutation
+is rejected before RPC dispatch. Read commands check revision before and after
+querying; the frontend also rejects old results and remounts business views when
+the shared revision changes. A completed write receipt is preserved even if the
+user changes views. Configuration pages retain drafts and require review when a
+poll detects a newer revision.
+
+## Atomic NameServer replacement (A03)
+
+The backend command and typed frontend service are implemented. A bulk editor is
+an optional follow-up UI; the command is registered and available to import tools.
+
+```typescript
+await replaceNameServers(
+    ['127.0.0.1:9876', '127.0.0.2:9876'],
+    { kind: 'address', value: '127.0.0.2:9876' },
+    settings.revision,
+);
+```
+
+`currentEndpoint` can also be `{ kind: 'existing_id', value: endpointId }`. Empty
+entries are removed and canonical duplicates are collapsed. Every nonempty entry
+must be valid and the selected endpoint must belong to the replacement list.
+Replacing with an empty list requires `currentEndpoint: null`. An intentionally
+empty configuration stays empty after restart. Each list accepts at most 256
+entries.
+
+The fresh database format is schema version 4. Older development databases are
+rejected without modification; use a new `DASHBOARD_TAURI_DATA_DIR` as needed.
+
+## Validation
+
+From the standalone backend: `cargo test --lib connection::`, plus affected
+NameServer, Proxy, audit, and error tests. Tests cover competing revisions, invalid
+replacement rollback, stable IDs, empty-list reopening, write leases, and atomic
+audit failure. From the frontend: `npm run build` and the focused auth/session
+service tests, including stale reads and preservation of completed writes.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/service.rs
@@ -87,7 +87,9 @@ impl AuditManager {
         F: FnOnce(AuditContext) -> Fut,
         Fut: Future<Output = DashboardResult<T>>,
     {
-        let context = AuditContext {
+        let mut context = AuditContext {
+            actor: None,
+            environment: Arc::new(Mutex::new(None)),
             event_id: Uuid::new_v4().to_string(),
             request_id: Uuid::new_v4().to_string(),
             action,
@@ -111,6 +113,7 @@ impl AuditManager {
                 Err(error) => Err(error),
             },
         };
+        context.actor = actor.clone();
         let result = match identity {
             Ok(_) => operation(context.clone()).await.map_err(CommandError::from),
             Err(error) => Err(CommandError::from(error)),
@@ -141,13 +144,6 @@ impl AuditManager {
                 Err(error)
             }
         }
-    }
-
-    pub(crate) async fn run_local<T: Send + 'static>(
-        &self,
-        operation: impl FnOnce() -> DashboardResult<T> + Send + 'static,
-    ) -> DashboardResult<T> {
-        self.storage.run("local-config-mutation", move |_| operation()).await
     }
 
     pub(crate) async fn query(&self, query: AuditQuery) -> DashboardResult<AuditPage> {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
@@ -25,6 +25,7 @@ pub(crate) enum AuditAction {
     AddNameServer,
     SwitchNameServer,
     DeleteNameServer,
+    ReplaceNameServers,
     UpdateVip,
     UpdateTls,
     AddProxy,
@@ -53,6 +54,7 @@ impl AuditAction {
             Self::AddNameServer => "nameserver.add",
             Self::SwitchNameServer => "nameserver.switch",
             Self::DeleteNameServer => "nameserver.delete",
+            Self::ReplaceNameServers => "nameserver.replace",
             Self::UpdateVip => "connection.vip",
             Self::UpdateTls => "connection.tls",
             Self::AddProxy => "proxy.add",
@@ -77,6 +79,7 @@ impl AuditAction {
             Self::AddNameServer
             | Self::SwitchNameServer
             | Self::DeleteNameServer
+            | Self::ReplaceNameServers
             | Self::UpdateVip
             | Self::UpdateTls
             | Self::AddProxy
@@ -295,6 +298,8 @@ pub(crate) struct AuditPage {
 
 #[derive(Clone)]
 pub(crate) struct AuditContext {
+    pub(crate) actor: Option<String>,
+    pub(crate) environment: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     pub(crate) event_id: String,
     pub(crate) request_id: String,
     pub(crate) action: AuditAction,
@@ -309,11 +314,29 @@ impl AuditContext {
             action: self.action.name().into(),
             resource_type: self.action.resource_type().into(),
             resource_name: self.resource_name.clone(),
-            environment_id: None,
+            environment_id: self
+                .environment
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone(),
             outcome: summary.outcome.as_str().into(),
             detail: summary.detail,
             created_at_ms: chrono::Utc::now().timestamp_millis(),
         }
+    }
+    pub(crate) fn set_environment(&self, environment: Option<String>) -> crate::error::DashboardResult<()> {
+        *self
+            .environment
+            .lock()
+            .map_err(|_| crate::error::DashboardError::Internal("audit scope poisoned"))? = environment;
+        Ok(())
+    }
+    pub(crate) fn record_local_success(&self, connection: &rusqlite::Connection) -> crate::error::DashboardResult<()> {
+        let actor = self
+            .actor
+            .as_deref()
+            .ok_or(crate::error::DashboardError::Unauthenticated)?;
+        self.record_success(connection, actor)
     }
     /// Call inside the mutation's transaction so a successful account change always has its audit record.
     pub(crate) fn record_success(

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/commands.rs
@@ -17,6 +17,7 @@ use crate::cluster::service::ClusterManager;
 use crate::cluster::types::ClusterBrokerConfigView;
 use crate::cluster::types::ClusterBrokerStatusView;
 use crate::cluster::types::ClusterHomePageResponse;
+use crate::connection::ConnectionManager;
 use crate::error::CommandResult;
 use crate::error::authorize_command;
 use rocketmq_dashboard_common::ClusterBrokerConfigRequest;
@@ -30,9 +31,14 @@ pub async fn get_cluster_home_page(
     request: ClusterHomePageRequest,
     cluster_manager: State<'_, ClusterManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ClusterHomePageResponse> {
     authorize_command(&session_id, &session_state).await?;
-    cluster_manager.get_cluster_home_page(request).await.map_err(Into::into)
+    connection_manager.check_revision(expected_revision)?;
+    let result = cluster_manager.get_cluster_home_page(request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -41,12 +47,17 @@ pub async fn get_cluster_broker_config(
     request: ClusterBrokerConfigRequest,
     cluster_manager: State<'_, ClusterManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ClusterBrokerConfigView> {
     authorize_command(&session_id, &session_state).await?;
-    cluster_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = cluster_manager
         .get_cluster_broker_config(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -55,10 +66,15 @@ pub async fn get_cluster_broker_status(
     request: ClusterBrokerStatusRequest,
     cluster_manager: State<'_, ClusterManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ClusterBrokerStatusView> {
     authorize_command(&session_id, &session_state).await?;
-    cluster_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = cluster_manager
         .get_cluster_broker_status(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection.rs
@@ -15,6 +15,6 @@
 pub(crate) mod commands;
 mod db;
 mod service;
-pub(crate) mod types;
-pub(crate) use service::AuditManager;
-pub(crate) use types::{AuditAccess, AuditAction, AuditContext, Audited};
+mod types;
+pub(crate) use service::ConnectionManager;
+pub(crate) use types::*;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/commands.rs
@@ -1,0 +1,57 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{
+    ConnectionChange, ConnectionManager, ConnectionMutationResult, ConnectionSettingsView, ReplaceNameServersRequest,
+};
+use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
+use crate::auth::SessionState;
+use crate::error::{CommandResult, authorize_command};
+use tauri::State;
+
+#[tauri::command]
+pub async fn get_connection_settings(
+    session_id: String,
+    session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
+) -> CommandResult<ConnectionSettingsView> {
+    authorize_command(&session_id, &session_state).await?;
+    connection_manager.snapshot().map_err(Into::into)
+}
+
+#[tauri::command]
+pub async fn replace_name_servers(
+    session_id: String,
+    request: ReplaceNameServersRequest,
+    session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<ConnectionMutationResult>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let manager = connection_manager.inner().clone();
+    audit_manager
+        .execute(access, AuditAction::ReplaceNameServers, None, move |audit| async move {
+            manager
+                .change(
+                    request.expected_revision,
+                    ConnectionChange::Replace {
+                        addresses: request.addresses,
+                        current_endpoint: request.current_endpoint,
+                    },
+                    audit,
+                )
+                .await
+        })
+        .await
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/db.rs
@@ -1,0 +1,184 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::types::*;
+use crate::error::{DashboardError, DashboardResult};
+use rocketmq_dashboard_common::{normalize_nameserver_address, normalize_proxy_address};
+use rusqlite::{Connection, params};
+use uuid::Uuid;
+
+pub(super) fn ensure_identities(connection: &Connection) -> DashboardResult<()> {
+    let nameserver = crate::nameserver::db::load_snapshot_from_connection(connection)?;
+    let proxy = crate::proxy::db::load_snapshot_from_connection(connection)?;
+    for (kind, addresses) in [
+        (EndpointKind::NameServer, nameserver.namesrv_addr_list),
+        (EndpointKind::Proxy, proxy.proxy_addr_list),
+    ] {
+        for address in addresses {
+            connection.execute("INSERT INTO endpoint_identity(kind, address, endpoint_id, environment_id) VALUES (?1, ?2, ?3, ?4) ON CONFLICT(kind, address) DO NOTHING", params![kind.as_str(), address, Uuid::new_v4().to_string(), if kind == EndpointKind::NameServer { Some(Uuid::new_v4().to_string()) } else { None }])?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn load(connection: &Connection) -> DashboardResult<ConnectionSettingsView> {
+    let revision = connection.query_row("SELECT revision FROM connection_metadata WHERE id = 1", [], |row| {
+        row.get(0)
+    })?;
+    let nameserver = crate::nameserver::db::load_snapshot_from_connection(connection)?;
+    let proxy = crate::proxy::db::load_snapshot_from_connection(connection)?;
+    let mut endpoints = Vec::new();
+    for (kind, addresses) in [
+        (EndpointKind::NameServer, &nameserver.namesrv_addr_list),
+        (EndpointKind::Proxy, &proxy.proxy_addr_list),
+    ] {
+        for address in addresses {
+            let item = connection.query_row(
+                "SELECT endpoint_id, environment_id FROM endpoint_identity WHERE kind = ?1 AND address = ?2",
+                params![kind.as_str(), address],
+                |row| {
+                    Ok(EndpointView {
+                        endpoint_id: row.get(0)?,
+                        environment_id: row.get(1)?,
+                        kind,
+                        address: address.clone(),
+                    })
+                },
+            )?;
+            endpoints.push(item);
+        }
+    }
+    let selected = endpoints.iter().find(|endpoint| {
+        endpoint.kind == EndpointKind::NameServer && Some(&endpoint.address) == nameserver.current_namesrv.as_ref()
+    });
+    let current_nameserver_id = selected.map(|endpoint| endpoint.endpoint_id.clone());
+    let environment_id = selected.and_then(|endpoint| endpoint.environment_id.clone());
+    let current_proxy_id = endpoints
+        .iter()
+        .find(|endpoint| {
+            endpoint.kind == EndpointKind::Proxy && Some(&endpoint.address) == proxy.current_proxy_addr.as_ref()
+        })
+        .map(|endpoint| endpoint.endpoint_id.clone());
+    Ok(ConnectionSettingsView {
+        revision,
+        endpoints,
+        current_nameserver_id,
+        current_proxy_id,
+        environment_id,
+        nameserver,
+        proxy,
+    })
+}
+
+fn normalize(kind: EndpointKind, address: &str) -> DashboardResult<String> {
+    Ok(match kind {
+        EndpointKind::NameServer => normalize_nameserver_address(address)?,
+        EndpointKind::Proxy => normalize_proxy_address(address)?,
+    })
+}
+
+pub(super) fn apply(view: &mut ConnectionSettingsView, change: ConnectionChange) -> DashboardResult<()> {
+    match change {
+        ConnectionChange::Vip(enabled) => view.nameserver.use_vip_channel = enabled,
+        ConnectionChange::Tls(enabled) => view.nameserver.use_tls = enabled,
+        ConnectionChange::Replace {
+            addresses,
+            current_endpoint,
+        } => {
+            let mut normalized = Vec::new();
+            if addresses.len() > 256 {
+                return Err(DashboardError::Validation("too many endpoints".into()));
+            }
+            for address in addresses {
+                if address.trim().is_empty() {
+                    continue;
+                }
+                let address = normalize(EndpointKind::NameServer, &address)?;
+                if !normalized.contains(&address) {
+                    normalized.push(address);
+                }
+            }
+            let current = current_endpoint
+                .map(|selection| match selection {
+                    NameServerSelection::ExistingId(id) => view
+                        .endpoints
+                        .iter()
+                        .find(|endpoint| endpoint.kind == EndpointKind::NameServer && endpoint.endpoint_id == id)
+                        .map(|endpoint| endpoint.address.clone())
+                        .ok_or_else(|| DashboardError::Validation("unknown current endpoint".into())),
+                    NameServerSelection::Address(address) => normalize(EndpointKind::NameServer, &address),
+                })
+                .transpose()?;
+            if current.as_ref().is_some_and(|address| !normalized.contains(address))
+                || (current.is_none() && !normalized.is_empty())
+            {
+                return Err(DashboardError::Validation(
+                    "current endpoint must belong to the replacement list".into(),
+                ));
+            }
+            view.nameserver.namesrv_addr_list = normalized;
+            view.nameserver.current_namesrv = current;
+        }
+        change => {
+            let (kind, address) = match &change {
+                ConnectionChange::Add { kind, address }
+                | ConnectionChange::Switch { kind, address }
+                | ConnectionChange::Delete { kind, address } => (*kind, normalize(*kind, address)?),
+                ConnectionChange::Vip(_) | ConnectionChange::Tls(_) | ConnectionChange::Replace { .. } => {
+                    return Err(DashboardError::Internal("invalid connection operation"));
+                }
+            };
+            let (addresses, current) = match kind {
+                EndpointKind::NameServer => (
+                    &mut view.nameserver.namesrv_addr_list,
+                    &mut view.nameserver.current_namesrv,
+                ),
+                EndpointKind::Proxy => (&mut view.proxy.proxy_addr_list, &mut view.proxy.current_proxy_addr),
+            };
+            match change {
+                ConnectionChange::Add { .. } => {
+                    if addresses.contains(&address) {
+                        return Err(DashboardError::Validation("endpoint already exists".into()));
+                    }
+                    if addresses.len() >= 256 {
+                        return Err(DashboardError::Validation("too many endpoints".into()));
+                    }
+                    addresses.push(address.clone());
+                    if current.is_none() {
+                        *current = Some(address);
+                    }
+                }
+                ConnectionChange::Switch { .. } => {
+                    if !addresses.contains(&address) {
+                        return Err(DashboardError::Validation("endpoint does not exist".into()));
+                    }
+                    *current = Some(address);
+                }
+                ConnectionChange::Delete { .. } => {
+                    if !addresses.contains(&address) {
+                        return Err(DashboardError::Validation("endpoint does not exist".into()));
+                    }
+                    addresses.retain(|item| item != &address);
+                    if current.as_ref() == Some(&address) {
+                        *current = addresses.first().cloned();
+                    }
+                }
+                ConnectionChange::Vip(_) | ConnectionChange::Tls(_) | ConnectionChange::Replace { .. } => {
+                    return Err(DashboardError::Internal("invalid connection operation"));
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/service.rs
@@ -1,0 +1,128 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::db;
+use super::types::*;
+use crate::audit::AuditContext;
+use crate::error::{DashboardError, DashboardResult};
+use crate::nameserver::NameServerRuntimeState;
+use crate::persistence::StorageManager;
+use rocketmq_dashboard_common::NameServerRuntimeAdapter;
+use rusqlite::TransactionBehavior;
+use std::sync::{Arc, Mutex};
+use tokio::sync::{OwnedRwLockReadGuard, RwLock};
+
+#[derive(Clone)]
+pub(crate) struct ConnectionManager {
+    storage: StorageManager,
+    runtime: Arc<NameServerRuntimeState>,
+    current: Arc<Mutex<ConnectionSettingsView>>,
+    gate: Arc<RwLock<()>>,
+}
+impl ConnectionManager {
+    pub(crate) async fn initialize(
+        storage: StorageManager,
+        runtime: Arc<NameServerRuntimeState>,
+    ) -> DashboardResult<Self> {
+        let view = storage
+            .run("connection-initialize", |connection| {
+                let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                db::ensure_identities(&transaction)?;
+                let view = db::load(&transaction)?;
+                transaction.commit()?;
+                Ok(view)
+            })
+            .await?;
+        Ok(Self {
+            storage,
+            runtime,
+            current: Arc::new(Mutex::new(view)),
+            gate: Arc::new(RwLock::new(())),
+        })
+    }
+
+    pub(crate) fn snapshot(&self) -> DashboardResult<ConnectionSettingsView> {
+        self.current
+            .lock()
+            .map(|view| view.clone())
+            .map_err(|_| DashboardError::Internal("connection snapshot poisoned"))
+    }
+
+    pub(crate) fn check_revision(&self, revision: i64) -> DashboardResult<()> {
+        if self.snapshot()?.revision != revision {
+            return Err(DashboardError::ConfigurationConflict);
+        }
+        Ok(())
+    }
+
+    /// Remote mutations hold this read lease through their RPC. A switch waits for already accepted writes.
+    pub(crate) async fn mutation_lease(
+        &self,
+        revision: i64,
+        audit: &AuditContext,
+    ) -> DashboardResult<OwnedRwLockReadGuard<()>> {
+        let guard = self.gate.clone().read_owned().await;
+        let view = self.snapshot()?;
+        if view.revision != revision {
+            return Err(DashboardError::ConfigurationConflict);
+        }
+        audit.set_environment(view.environment_id)?;
+        Ok(guard)
+    }
+
+    pub(crate) async fn change(
+        &self,
+        expected_revision: i64,
+        change: ConnectionChange,
+        audit: AuditContext,
+    ) -> DashboardResult<ConnectionMutationResult> {
+        let _guard = self.gate.write().await;
+        let runtime = self.runtime.clone();
+        let current = self.current.clone();
+        self.storage
+            .run("connection-change", move |connection| {
+                let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let mut view = db::load(&transaction)?;
+                if view.revision != expected_revision {
+                    return Err(DashboardError::ConfigurationConflict);
+                }
+                db::apply(&mut view, change)?;
+                crate::nameserver::db::save_snapshot_to_transaction(&transaction, &view.nameserver)?;
+                crate::proxy::db::save_snapshot_to_transaction(&transaction, &view.proxy)?;
+                db::ensure_identities(&transaction)?;
+                transaction.execute(
+                    "UPDATE connection_metadata SET revision = revision + 1 WHERE id = 1",
+                    [],
+                )?;
+                let view = db::load(&transaction)?;
+                audit.set_environment(view.environment_id.clone())?;
+                audit.record_local_success(&transaction)?;
+                // Lock publication before committing; a poisoned state must not commit an invisible configuration.
+                let mut published = current
+                    .lock()
+                    .map_err(|_| DashboardError::Internal("connection snapshot poisoned"))?;
+                transaction.commit()?;
+                runtime.apply_snapshot(&view.nameserver)?;
+                *published = view.clone();
+                Ok(ConnectionMutationResult {
+                    message: "Connection settings saved",
+                    settings: view,
+                })
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/service/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/service/tests.rs
@@ -1,0 +1,260 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use crate::audit::types::{AuditAction, AuditContext};
+use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
+use std::time::Duration;
+use uuid::Uuid;
+
+struct Fixture {
+    owner: Option<RuntimeOwner>,
+    storage: StorageManager,
+    manager: ConnectionManager,
+    directory: std::path::PathBuf,
+}
+impl Fixture {
+    fn new() -> Self {
+        let owner = RuntimeOwner::plan(RuntimeConfig::server_default("connection-test"))
+            .unwrap()
+            .build()
+            .unwrap();
+        let directory = std::env::temp_dir().join(format!("tauri-connection-{}", Uuid::new_v4()));
+        let storage = StorageManager::new(
+            directory.join("dashboard.db"),
+            owner.root_context().component("storage"),
+        );
+        let manager = owner.block_on(async {
+            storage.initialize().await.unwrap();
+            let path = storage.path().to_path_buf();
+            let snapshot = storage
+                .run("bootstrap", move |connection| {
+                    crate::nameserver::NameServerDb::from_path(path).init()?;
+                    Ok(crate::nameserver::db::load_snapshot_from_connection(connection)?)
+                })
+                .await
+                .unwrap();
+            let runtime = Arc::new(NameServerRuntimeState::new(
+                snapshot,
+                crate::nameserver::runtime::test_client_runtime(),
+            ));
+            ConnectionManager::initialize(storage.clone(), runtime).await.unwrap()
+        });
+        Self {
+            owner: Some(owner),
+            storage,
+            manager,
+            directory,
+        }
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        if let Some(owner) = self.owner.take() {
+            assert!(owner.block_on(self.storage.shutdown(Duration::from_secs(5))));
+            let _ = owner.shutdown_runtime_blocking();
+        }
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+fn audit() -> AuditContext {
+    AuditContext {
+        actor: Some("admin".into()),
+        environment: Arc::new(Mutex::new(None)),
+        event_id: Uuid::new_v4().to_string(),
+        request_id: Uuid::new_v4().to_string(),
+        action: AuditAction::ReplaceNameServers,
+        resource_name: None,
+    }
+}
+
+#[test]
+fn concurrent_saves_with_the_same_revision_have_one_winner() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let (first, second) = tokio::join!(
+            fixture.manager.change(0, ConnectionChange::Vip(false), audit()),
+            fixture.manager.change(0, ConnectionChange::Tls(true), audit())
+        );
+        assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+        let loser = first.err().or_else(|| second.err()).unwrap();
+        assert!(matches!(loser, DashboardError::ConfigurationConflict));
+        assert_eq!(fixture.manager.snapshot().unwrap().revision, 1);
+        let count = fixture
+            .storage
+            .run("audit-count", |connection| {
+                Ok(connection.query_row::<i64, _, _>("SELECT COUNT(*) FROM audit_events", [], |row| row.get(0))?)
+            })
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+    });
+}
+
+#[test]
+fn invalid_replacement_rolls_back_and_valid_new_selection_is_atomic() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let before = fixture.manager.snapshot().unwrap();
+        let invalid = ConnectionChange::Replace {
+            addresses: vec!["127.0.0.1:9876".into(), "invalid".into()],
+            current_endpoint: before
+                .current_nameserver_id
+                .clone()
+                .map(NameServerSelection::ExistingId),
+        };
+        assert!(fixture.manager.change(0, invalid, audit()).await.is_err());
+        assert_eq!(fixture.manager.snapshot().unwrap(), before);
+        let result = fixture
+            .manager
+            .change(
+                0,
+                ConnectionChange::Replace {
+                    addresses: vec![" 127.0.0.2:9876 ".into(), "".into(), "127.0.0.2:9876".into()],
+                    current_endpoint: Some(NameServerSelection::Address("127.0.0.2:9876".into())),
+                },
+                audit(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.settings.nameserver.namesrv_addr_list, ["127.0.0.2:9876"]);
+        assert_ne!(result.settings.environment_id, before.environment_id);
+        assert_eq!(fixture.manager.runtime.snapshot(), result.settings.nameserver);
+    });
+}
+
+#[test]
+fn endpoint_and_environment_ids_survive_settings_changes_and_readdition() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let initial = fixture.manager.snapshot().unwrap();
+        let settings = fixture
+            .manager
+            .change(0, ConnectionChange::Vip(false), audit())
+            .await
+            .unwrap()
+            .settings;
+        assert_eq!(settings.environment_id, initial.environment_id);
+        assert_eq!(settings.current_nameserver_id, initial.current_nameserver_id);
+        fixture
+            .manager
+            .change(
+                1,
+                ConnectionChange::Delete {
+                    kind: EndpointKind::NameServer,
+                    address: "127.0.0.1:9876".into(),
+                },
+                audit(),
+            )
+            .await
+            .unwrap();
+        let path = fixture.storage.path().to_path_buf();
+        fixture
+            .storage
+            .run("reopen", move |_| {
+                crate::nameserver::NameServerDb::from_path(path).init()
+            })
+            .await
+            .unwrap();
+        let stored = fixture
+            .storage
+            .run("read", |connection| db::load(connection))
+            .await
+            .unwrap();
+        assert!(stored.nameserver.namesrv_addr_list.is_empty());
+        let restored = fixture
+            .manager
+            .change(
+                2,
+                ConnectionChange::Add {
+                    kind: EndpointKind::NameServer,
+                    address: "127.0.0.1:9876".into(),
+                },
+                audit(),
+            )
+            .await
+            .unwrap()
+            .settings;
+        assert_eq!(restored.current_nameserver_id, initial.current_nameserver_id);
+        assert_eq!(restored.environment_id, initial.environment_id);
+        let proxy = fixture
+            .manager
+            .change(
+                3,
+                ConnectionChange::Add {
+                    kind: EndpointKind::Proxy,
+                    address: "127.0.0.1:8080".into(),
+                },
+                audit(),
+            )
+            .await
+            .unwrap()
+            .settings;
+        assert_eq!(proxy.environment_id, initial.environment_id);
+        assert!(proxy.current_proxy_id.is_some());
+    });
+}
+
+#[test]
+fn configuration_switch_waits_for_accepted_remote_mutations_and_rejects_stale_ones() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let lease = fixture.manager.mutation_lease(0, &audit()).await.unwrap();
+        let mut switch = Box::pin(fixture.manager.change(0, ConnectionChange::Vip(false), audit()));
+        std::future::poll_fn(|context| {
+            assert!(switch.as_mut().poll(context).is_pending());
+            std::task::Poll::Ready(())
+        })
+        .await;
+        drop(lease);
+        switch.await.unwrap();
+        assert!(matches!(
+            fixture.manager.mutation_lease(0, &audit()).await,
+            Err(DashboardError::ConfigurationConflict)
+        ));
+    });
+}
+
+#[test]
+fn audit_failure_prevents_config_commit_and_runtime_publication() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let before = fixture.manager.snapshot().unwrap();
+        fixture
+            .storage
+            .run("break-audit", |connection| {
+                connection.execute("DROP TABLE audit_events", [])?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert!(
+            fixture
+                .manager
+                .change(0, ConnectionChange::Vip(false), audit())
+                .await
+                .is_err()
+        );
+        assert_eq!(fixture.manager.snapshot().unwrap(), before);
+        assert_eq!(
+            fixture
+                .storage
+                .run("read", |connection| db::load(connection))
+                .await
+                .unwrap(),
+            before
+        );
+        assert_eq!(fixture.manager.runtime.generation(), 0);
+    });
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/types.rs
@@ -1,0 +1,108 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_dashboard_common::{NameServerConfigSnapshot, ProxyConfigSnapshot};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum EndpointKind {
+    NameServer,
+    Proxy,
+}
+impl EndpointKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::NameServer => "nameserver",
+            Self::Proxy => "proxy",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EndpointView {
+    pub(crate) endpoint_id: String,
+    pub(crate) kind: EndpointKind,
+    pub(crate) address: String,
+    pub(crate) environment_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConnectionSettingsView {
+    pub(crate) revision: i64,
+    pub(crate) endpoints: Vec<EndpointView>,
+    pub(crate) current_nameserver_id: Option<String>,
+    pub(crate) current_proxy_id: Option<String>,
+    pub(crate) environment_id: Option<String>,
+    pub(crate) nameserver: NameServerConfigSnapshot,
+    pub(crate) proxy: ProxyConfigSnapshot,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReplaceNameServersRequest {
+    pub(crate) addresses: Vec<String>,
+    pub(crate) current_endpoint: Option<NameServerSelection>,
+    pub(crate) expected_revision: i64,
+}
+
+pub(crate) enum ConnectionChange {
+    Add {
+        kind: EndpointKind,
+        address: String,
+    },
+    Switch {
+        kind: EndpointKind,
+        address: String,
+    },
+    Delete {
+        kind: EndpointKind,
+        address: String,
+    },
+    Vip(bool),
+    Tls(bool),
+    Replace {
+        addresses: Vec<String>,
+        current_endpoint: Option<NameServerSelection>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConnectionMutationResult {
+    pub(crate) message: &'static str,
+    pub(crate) settings: ConnectionSettingsView,
+}
+impl crate::audit::types::AuditReceipt for ConnectionMutationResult {
+    fn summary(&self) -> crate::audit::types::Summary {
+        crate::audit::types::Summary::count(1, 0)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub(crate) enum NameServerSelection {
+    ExistingId(String),
+    Address(String),
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConnectionProjection<T> {
+    #[serde(flatten)]
+    pub(crate) value: T,
+    pub(crate) settings: ConnectionSettingsView,
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
+use crate::connection::ConnectionManager;
 use crate::consumer::service::ConsumerManager;
 use crate::consumer::types::ConsumerConfigView;
 use crate::consumer::types::ConsumerConnectionView;
@@ -37,12 +38,17 @@ pub async fn query_consumer_groups(
     request: ConsumerGroupListRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ConsumerGroupListResponse> {
     authorize_command(&session_id, &session_state).await?;
-    consumer_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = consumer_manager
         .query_consumer_groups(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -51,12 +57,17 @@ pub async fn refresh_consumer_group(
     request: ConsumerGroupRefreshRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ConsumerGroupListItem> {
     authorize_command(&session_id, &session_state).await?;
-    consumer_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = consumer_manager
         .refresh_consumer_group(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -65,12 +76,17 @@ pub async fn refresh_all_consumer_groups(
     request: ConsumerGroupListRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ConsumerGroupListResponse> {
     authorize_command(&session_id, &session_state).await?;
-    consumer_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = consumer_manager
         .refresh_all_consumer_groups(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -79,12 +95,17 @@ pub async fn query_consumer_connection(
     request: ConsumerConnectionQueryRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ConsumerConnectionView> {
     authorize_command(&session_id, &session_state).await?;
-    consumer_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = consumer_manager
         .query_consumer_connection(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -93,12 +114,17 @@ pub async fn query_consumer_topic_detail(
     request: ConsumerTopicDetailQueryRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ConsumerTopicDetailView> {
     authorize_command(&session_id, &session_state).await?;
-    consumer_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = consumer_manager
         .query_consumer_topic_detail(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -107,12 +133,17 @@ pub async fn query_consumer_config(
     request: ConsumerConfigQueryRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ConsumerConfigView> {
     authorize_command(&session_id, &session_state).await?;
-    consumer_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = consumer_manager
         .query_consumer_config(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -122,7 +153,10 @@ pub async fn create_or_update_consumer_group(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<ConsumerMutationResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let consumer_manager = consumer_manager.inner().clone();
     audit_manager
@@ -130,7 +164,10 @@ pub async fn create_or_update_consumer_group(
             access,
             AuditAction::UpsertConsumer,
             Some(request.consumer_group.clone()),
-            move |_audit| async move { consumer_manager.create_or_update_consumer_group(request).await },
+            move |audit| async move {
+                let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
+                consumer_manager.create_or_update_consumer_group(request).await
+            },
         )
         .await
 }
@@ -142,7 +179,10 @@ pub async fn delete_consumer_group(
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<ConsumerMutationResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let consumer_manager = consumer_manager.inner().clone();
     audit_manager
@@ -150,7 +190,10 @@ pub async fn delete_consumer_group(
             access,
             AuditAction::DeleteConsumer,
             Some(request.consumer_group.clone()),
-            move |_audit| async move { consumer_manager.delete_consumer_group(request).await },
+            move |audit| async move {
+                let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
+                consumer_manager.delete_consumer_group(request).await
+            },
         )
         .await
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/commands.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::cluster::service::ClusterManager;
+use crate::connection::ConnectionManager;
 use crate::dashboard::service;
 use crate::dashboard::types::DashboardBrokerOverviewResponse;
 use crate::dashboard::types::DashboardTopicCurrentResponse;
@@ -28,11 +29,16 @@ pub async fn get_dashboard_broker_overview(
     request: DashboardBrokerOverviewRequest,
     cluster_manager: State<'_, ClusterManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<DashboardBrokerOverviewResponse> {
     authorize_command(&session_id, &session_state).await?;
-    service::get_dashboard_broker_overview(&cluster_manager, request)
+    connection_manager.check_revision(expected_revision)?;
+    let result = service::get_dashboard_broker_overview(&cluster_manager, request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -40,10 +46,15 @@ pub async fn query_dashboard_topic_current(
     session_id: String,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<DashboardTopicCurrentResponse> {
     authorize_command(&session_id, &session_state).await?;
-    service::query_dashboard_topic_current(&topic_manager)
+    connection_manager.check_revision(expected_revision)?;
+    let result = service::query_dashboard_topic_current(&topic_manager)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 use crate::auth::SessionState;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
@@ -45,6 +45,8 @@ pub(crate) enum DashboardError {
     Unauthenticated,
     #[error("the account password must be changed before dashboard access")]
     PasswordChangeRequired,
+    #[error("connection settings changed; review the current configuration")]
+    ConfigurationConflict,
     #[error("I/O operation failed")]
     Io(#[from] std::io::Error),
     #[error("database operation failed")]
@@ -75,6 +77,13 @@ impl DashboardError {
             Self::Validation(_) => (
                 "dashboard.invalid_argument",
                 "The request is invalid.",
+                CommandErrorCategory::Validation,
+                false,
+                None,
+            ),
+            Self::ConfigurationConflict => (
+                "dashboard.configuration_conflict",
+                "Connection settings changed. Refresh and review your changes before saving again.",
                 CommandErrorCategory::Validation,
                 false,
                 None,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@
 mod audit;
 mod auth;
 mod cluster;
+mod connection;
 mod consumer;
 mod dashboard;
 mod error;
@@ -94,7 +95,6 @@ struct DashboardServices {
     message_manager: message::MessageManager,
     producer_manager: producer::ProducerManager,
     topic_manager: topic::TopicManager,
-    proxy_manager: proxy::ProxyManager,
 }
 
 fn initialize_services(
@@ -134,7 +134,6 @@ fn initialize_services(
     let proxy_db = proxy::ProxyDb::from_path(database_path);
     proxy_db.init()?;
     log::info!("Local Proxy SQLite tables initialized");
-    let proxy_manager = proxy::ProxyManager::new(proxy_db)?;
 
     Ok(DashboardServices {
         auth_service,
@@ -145,7 +144,6 @@ fn initialize_services(
         message_manager,
         producer_manager,
         topic_manager,
-        proxy_manager,
     })
 }
 
@@ -212,12 +210,15 @@ fn build_application() -> Result<DashboardApplication, i32> {
                 message_manager,
                 producer_manager,
                 topic_manager,
-                proxy_manager,
             } = tauri::async_runtime::block_on(storage.run("storage-bootstrap", move |_connection| {
                 initialize_services(&database_path, setup_client_runtime)
             }))?;
             log::info!("Dashboard storage initialized: {:?}", storage.health());
 
+            let connections = tauri::async_runtime::block_on(connection::ConnectionManager::initialize(
+                storage.clone(),
+                nameserver_runtime.clone(),
+            ))?;
             let audit = audit::AuditManager::new(storage.clone(), audit_context);
             audit.start_cleanup()?;
             setup_lifecycle
@@ -237,18 +238,20 @@ fn build_application() -> Result<DashboardApplication, i32> {
             app.manage(storage);
             app.manage(sessions);
             app.manage(audit);
+            app.manage(connections);
             app.manage(nameserver_runtime);
             app.manage(nameserver_manager);
             app.manage(cluster_manager);
             app.manage(consumer_manager);
             app.manage(message_manager);
             app.manage(producer_manager);
-            app.manage(proxy_manager);
             app.manage(topic_manager);
 
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            connection::commands::get_connection_settings,
+            connection::commands::replace_name_servers,
             audit::commands::query_audit_events,
             auth::commands::login,
             auth::commands::logout,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
+use crate::connection::ConnectionManager;
 use crate::message::service::MessageManager;
 use crate::message::types::DlqBatchMessageExportView;
 use crate::message::types::DlqMessageExportView;
@@ -41,12 +42,17 @@ pub async fn query_message_by_topic_key(
     request: MessageKeyQueryRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<MessageSummaryListResponse> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager
         .query_message_by_topic_key(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -55,9 +61,14 @@ pub async fn query_message_by_id(
     request: MessageIdQueryRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<MessageSummaryListResponse> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager.query_message_by_id(request).await.map_err(Into::into)
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager.query_message_by_id(request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -66,12 +77,17 @@ pub async fn query_message_page_by_topic(
     request: MessagePageQueryRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<MessagePageResponse> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager
         .query_message_page_by_topic(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -80,12 +96,17 @@ pub async fn query_dlq_message_by_consumer_group(
     request: DlqMessagePageQueryRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<MessagePageResponse> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager
         .query_dlq_message_by_consumer_group(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -94,9 +115,14 @@ pub async fn view_message_detail(
     request: ViewMessageRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<MessageDetailView> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager.view_message_detail(request).await.map_err(Into::into)
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager.view_message_detail(request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -105,12 +131,17 @@ pub async fn view_dlq_message_detail(
     request: DlqViewMessageRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<MessageDetailView> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager
         .view_dlq_message_detail(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -120,11 +151,15 @@ pub async fn resend_dlq_message(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<MessageResendResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let message_manager = message_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::ResendDlq, None, move |_audit| async move {
+        .execute(access, AuditAction::ResendDlq, None, move |audit| async move {
+            let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
             message_manager.resend_dlq_message(request).await
         })
         .await
@@ -137,11 +172,15 @@ pub async fn batch_resend_dlq_message(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<MessageBatchResendResponse>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let message_manager = message_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::BatchResendDlq, None, move |_audit| async move {
+        .execute(access, AuditAction::BatchResendDlq, None, move |audit| async move {
+            let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
             message_manager.batch_resend_dlq_message(request).await
         })
         .await
@@ -153,9 +192,14 @@ pub async fn export_dlq_message(
     request: DlqViewMessageRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<DlqMessageExportView> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager.export_dlq_message(request).await.map_err(Into::into)
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager.export_dlq_message(request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -164,12 +208,17 @@ pub async fn batch_export_dlq_message(
     request: DlqBatchExportMessageRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<DlqBatchMessageExportView> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager
         .batch_export_dlq_message(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -179,11 +228,15 @@ pub async fn consume_message_directly(
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<MessageResendResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let message_manager = message_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::ConsumeDirectly, None, move |_audit| async move {
+        .execute(access, AuditAction::ConsumeDirectly, None, move |audit| async move {
+            let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
             message_manager.consume_message_directly(request).await
         })
         .await
@@ -195,12 +248,17 @@ pub async fn query_message_trace_by_id(
     request: MessageTraceQueryRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<MessageSummaryListResponse> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager
         .query_message_trace_by_id(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -209,12 +267,17 @@ pub async fn view_message_trace_detail(
     request: MessageTraceQueryRequest,
     message_manager: State<'_, MessageManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<MessageTraceDetailView> {
     authorize_command(&session_id, &session_state).await?;
-    message_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = message_manager
         .view_message_trace_detail(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 use crate::auth::SessionState;
 use crate::error::CommandResult;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The RocketMQ Rust Authors
+// Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,36 +13,51 @@
 // limitations under the License.
 
 use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
-use crate::nameserver::NameServerManager;
-use crate::nameserver::types::NameServerHomePageView;
-use rocketmq_dashboard_common::NameServerMutationResult;
+use crate::auth::SessionState;
+use crate::connection::{
+    ConnectionChange, ConnectionManager, ConnectionMutationResult, ConnectionProjection, EndpointKind,
+};
+use crate::error::{CommandResult, authorize_command};
+use crate::nameserver::{NameServerManager, types::NameServerHomePageView};
 use tauri::State;
 
 #[tauri::command]
 pub async fn get_name_server_home_page(
     session_id: String,
-    nameserver_manager: State<'_, NameServerManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<NameServerHomePageView> {
+    nameserver_manager: State<'_, NameServerManager>,
+    connection_manager: State<'_, ConnectionManager>,
+) -> CommandResult<ConnectionProjection<NameServerHomePageView>> {
     authorize_command(&session_id, &session_state).await?;
-    nameserver_manager.home_page_info().await.map_err(Into::into)
+    let settings = connection_manager.snapshot()?;
+    let value = nameserver_manager
+        .home_page_for_snapshot(settings.nameserver.clone())
+        .await?;
+    Ok(ConnectionProjection { value, settings })
 }
 
 #[tauri::command]
 pub async fn add_name_server(
     session_id: String,
     address: String,
-    nameserver_manager: State<'_, NameServerManager>,
+    expected_revision: i64,
     session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
     audit_manager: State<'_, AuditManager>,
-) -> CommandResult<Audited<NameServerMutationResult>> {
+) -> CommandResult<Audited<ConnectionMutationResult>> {
     let access = AuditAccess::dashboard(&session_state, session_id);
-    let nameserver_manager = nameserver_manager.inner().clone();
-    let local_audit = audit_manager.inner().clone();
+    let manager = connection_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::AddNameServer, None, move |_audit| async move {
-            local_audit
-                .run_local(move || nameserver_manager.add_name_server(&address))
+        .execute(access, AuditAction::AddNameServer, None, move |audit| async move {
+            manager
+                .change(
+                    expected_revision,
+                    ConnectionChange::Add {
+                        kind: EndpointKind::NameServer,
+                        address,
+                    },
+                    audit,
+                )
                 .await
         })
         .await
@@ -52,17 +67,24 @@ pub async fn add_name_server(
 pub async fn switch_name_server(
     session_id: String,
     address: String,
-    nameserver_manager: State<'_, NameServerManager>,
+    expected_revision: i64,
     session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
     audit_manager: State<'_, AuditManager>,
-) -> CommandResult<Audited<NameServerMutationResult>> {
+) -> CommandResult<Audited<ConnectionMutationResult>> {
     let access = AuditAccess::dashboard(&session_state, session_id);
-    let nameserver_manager = nameserver_manager.inner().clone();
-    let local_audit = audit_manager.inner().clone();
+    let manager = connection_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::SwitchNameServer, None, move |_audit| async move {
-            local_audit
-                .run_local(move || nameserver_manager.switch_name_server(&address))
+        .execute(access, AuditAction::SwitchNameServer, None, move |audit| async move {
+            manager
+                .change(
+                    expected_revision,
+                    ConnectionChange::Switch {
+                        kind: EndpointKind::NameServer,
+                        address,
+                    },
+                    audit,
+                )
                 .await
         })
         .await
@@ -72,17 +94,24 @@ pub async fn switch_name_server(
 pub async fn delete_name_server(
     session_id: String,
     address: String,
-    nameserver_manager: State<'_, NameServerManager>,
+    expected_revision: i64,
     session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
     audit_manager: State<'_, AuditManager>,
-) -> CommandResult<Audited<NameServerMutationResult>> {
+) -> CommandResult<Audited<ConnectionMutationResult>> {
     let access = AuditAccess::dashboard(&session_state, session_id);
-    let nameserver_manager = nameserver_manager.inner().clone();
-    let local_audit = audit_manager.inner().clone();
+    let manager = connection_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::DeleteNameServer, None, move |_audit| async move {
-            local_audit
-                .run_local(move || nameserver_manager.delete_name_server(&address))
+        .execute(access, AuditAction::DeleteNameServer, None, move |audit| async move {
+            manager
+                .change(
+                    expected_revision,
+                    ConnectionChange::Delete {
+                        kind: EndpointKind::NameServer,
+                        address,
+                    },
+                    audit,
+                )
                 .await
         })
         .await
@@ -92,17 +121,17 @@ pub async fn delete_name_server(
 pub async fn update_vip_channel(
     session_id: String,
     enabled: bool,
-    nameserver_manager: State<'_, NameServerManager>,
+    expected_revision: i64,
     session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
     audit_manager: State<'_, AuditManager>,
-) -> CommandResult<Audited<NameServerMutationResult>> {
+) -> CommandResult<Audited<ConnectionMutationResult>> {
     let access = AuditAccess::dashboard(&session_state, session_id);
-    let nameserver_manager = nameserver_manager.inner().clone();
-    let local_audit = audit_manager.inner().clone();
+    let manager = connection_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::UpdateVip, None, move |_audit| async move {
-            local_audit
-                .run_local(move || nameserver_manager.update_vip_channel(enabled))
+        .execute(access, AuditAction::UpdateVip, None, move |audit| async move {
+            manager
+                .change(expected_revision, ConnectionChange::Vip(enabled), audit)
                 .await
         })
         .await
@@ -112,21 +141,18 @@ pub async fn update_vip_channel(
 pub async fn update_use_tls(
     session_id: String,
     enabled: bool,
-    nameserver_manager: State<'_, NameServerManager>,
+    expected_revision: i64,
     session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
     audit_manager: State<'_, AuditManager>,
-) -> CommandResult<Audited<NameServerMutationResult>> {
+) -> CommandResult<Audited<ConnectionMutationResult>> {
     let access = AuditAccess::dashboard(&session_state, session_id);
-    let nameserver_manager = nameserver_manager.inner().clone();
-    let local_audit = audit_manager.inner().clone();
+    let manager = connection_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::UpdateTls, None, move |_audit| async move {
-            local_audit
-                .run_local(move || nameserver_manager.update_use_tls(enabled))
+        .execute(access, AuditAction::UpdateTls, None, move |audit| async move {
+            manager
+                .change(expected_revision, ConnectionChange::Tls(enabled), audit)
                 .await
         })
         .await
 }
-use crate::auth::SessionState;
-use crate::error::CommandResult;
-use crate::error::authorize_command;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/db.rs
@@ -113,7 +113,9 @@ impl NameServerConfigStore for SqliteNameServerStore {
     }
 }
 
-fn load_snapshot_from_connection(connection: &Connection) -> DashboardCommonResult<NameServerConfigSnapshot> {
+pub(crate) fn load_snapshot_from_connection(
+    connection: &Connection,
+) -> DashboardCommonResult<NameServerConfigSnapshot> {
     let mut statement = connection
         .prepare(
             "
@@ -159,7 +161,7 @@ fn load_snapshot_from_connection(connection: &Connection) -> DashboardCommonResu
     })
 }
 
-fn save_snapshot_to_transaction(
+pub(crate) fn save_snapshot_to_transaction(
     transaction: &Transaction<'_>,
     snapshot: &NameServerConfigSnapshot,
 ) -> DashboardCommonResult<()> {
@@ -217,7 +219,10 @@ fn repair_snapshot_tables(transaction: &Transaction<'_>) -> Result<()> {
     let address_count: i64 =
         transaction.query_row("SELECT COUNT(*) FROM nameserver_addresses", [], |row| row.get(0))?;
 
-    if address_count == 0 {
+    let revision: i64 = transaction.query_row("SELECT revision FROM connection_metadata WHERE id = 1", [], |row| {
+        row.get(0)
+    })?;
+    if address_count == 0 && revision == 0 {
         transaction.execute(
             "
             INSERT INTO nameserver_addresses (address, is_current, sort_order, created_at, updated_at)

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
@@ -14,13 +14,16 @@
 
 use crate::error::DashboardResult as Result;
 use crate::nameserver::db::NameServerDb;
+#[cfg(test)]
 use crate::nameserver::db::SqliteNameServerStore;
 use crate::nameserver::runtime::NameServerRuntimeState;
 use crate::nameserver::types::NameServerHomePageView;
 use crate::nameserver::types::NameServerStatusItem;
 use rocketmq_admin_core::client_adapter::AdminBuilder;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
+#[cfg(test)]
 use rocketmq_dashboard_common::NameServerMutationResult;
+#[cfg(test)]
 use rocketmq_dashboard_common::NameServerService;
 use std::future::Future;
 use std::pin::Pin;
@@ -81,6 +84,7 @@ impl NameServerProbe for DefaultNameServerProbe {
 
 #[derive(Clone)]
 pub(crate) struct NameServerManager {
+    #[cfg(test)]
     service: Arc<NameServerService<SqliteNameServerStore, NameServerRuntimeState>>,
     #[cfg_attr(not(test), allow(dead_code))]
     runtime: Arc<NameServerRuntimeState>,
@@ -100,60 +104,65 @@ impl NameServerManager {
         runtime: Arc<NameServerRuntimeState>,
         probe: Arc<dyn NameServerProbe>,
     ) -> Result<Self> {
+        #[cfg(test)]
         let store = Arc::new(SqliteNameServerStore::new(db));
+        #[cfg(test)]
         let service = Arc::new(NameServerService::new(store, runtime.clone()));
 
+        #[cfg(not(test))]
+        let _ = db;
         Ok(Self {
+            #[cfg(test)]
             service,
             runtime,
             probe,
         })
     }
 
+    #[cfg(test)]
     pub(crate) async fn home_page_info(&self) -> Result<NameServerHomePageView> {
-        let home_page = self.service.home_page_info()?;
-        let snapshot = NameServerConfigSnapshot {
-            current_namesrv: home_page.current_namesrv.clone(),
-            namesrv_addr_list: home_page.namesrv_addr_list.clone(),
-            use_vip_channel: home_page.use_vip_channel,
-            use_tls: home_page.use_tls,
-        };
+        self.home_page_for_snapshot(self.runtime.snapshot()).await
+    }
 
-        let mut servers = Vec::with_capacity(home_page.namesrv_addr_list.len());
-        for address in &home_page.namesrv_addr_list {
+    pub(crate) async fn home_page_for_snapshot(
+        &self,
+        snapshot: NameServerConfigSnapshot,
+    ) -> Result<NameServerHomePageView> {
+        let mut servers = Vec::with_capacity(snapshot.namesrv_addr_list.len());
+        for address in &snapshot.namesrv_addr_list {
             let is_alive = self.probe.probe(&snapshot, address).await;
             servers.push(NameServerStatusItem {
                 address: address.clone(),
-                is_current: home_page.current_namesrv.as_deref() == Some(address.as_str()),
+                is_current: snapshot.current_namesrv.as_deref() == Some(address.as_str()),
                 is_alive,
             });
         }
 
         Ok(NameServerHomePageView {
-            current_namesrv: home_page.current_namesrv,
-            namesrv_addr_list: home_page.namesrv_addr_list,
-            use_vip_channel: home_page.use_vip_channel,
-            use_tls: home_page.use_tls,
+            current_namesrv: snapshot.current_namesrv,
+            namesrv_addr_list: snapshot.namesrv_addr_list,
+            use_vip_channel: snapshot.use_vip_channel,
+            use_tls: snapshot.use_tls,
             servers,
         })
     }
 
+    #[cfg(test)]
     pub(crate) fn add_name_server(&self, address: &str) -> Result<NameServerMutationResult> {
         Ok(self.service.add_nameserver(address)?)
     }
 
+    #[cfg(test)]
     pub(crate) fn switch_name_server(&self, address: &str) -> Result<NameServerMutationResult> {
         Ok(self.service.update_current_nameserver(address)?)
     }
 
-    pub(crate) fn delete_name_server(&self, address: &str) -> Result<NameServerMutationResult> {
-        Ok(self.service.delete_nameserver(address)?)
-    }
-
+    #[cfg(test)]
     pub(crate) fn update_vip_channel(&self, enabled: bool) -> Result<NameServerMutationResult> {
         Ok(self.service.update_use_vip_channel(enabled)?)
     }
 
+    #[cfg(test)]
     pub(crate) fn update_use_tls(&self, enabled: bool) -> Result<NameServerMutationResult> {
         Ok(self.service.update_use_tls(enabled)?)
     }
@@ -174,6 +183,7 @@ mod tests {
     use super::NameServerManager;
     use super::NameServerProbe;
     use crate::nameserver::db::NameServerDb;
+    #[cfg(test)]
     use crate::nameserver::db::SqliteNameServerStore;
     use crate::nameserver::runtime::NameServerRuntimeState;
     use crate::nameserver::runtime::test_client_runtime;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
@@ -17,7 +17,7 @@ use crate::error::DashboardResult;
 use rusqlite::Connection;
 use rusqlite::TransactionBehavior;
 
-pub(crate) const SCHEMA_VERSION: i64 = 3;
+pub(crate) const SCHEMA_VERSION: i64 = 4;
 
 pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
     // IMMEDIATE serializes competing initializers before reading the version.
@@ -61,6 +61,15 @@ pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
                 created_at TEXT NOT NULL,
                 updated_at TEXT NOT NULL,
                 last_login_at TEXT
+            );
+            CREATE TABLE connection_metadata (id INTEGER PRIMARY KEY CHECK(id = 1), revision INTEGER NOT NULL CHECK(revision >= 0 AND revision < 9007199254740991));
+            INSERT INTO connection_metadata(id, revision) VALUES (1, 0);
+            CREATE TABLE endpoint_identity (
+                kind TEXT NOT NULL CHECK(kind IN ('nameserver', 'proxy')),
+                address TEXT NOT NULL,
+                endpoint_id TEXT NOT NULL UNIQUE,
+                environment_id TEXT UNIQUE,
+                PRIMARY KEY(kind, address)
             );
             CREATE TABLE audit_events (
                 event_id TEXT PRIMARY KEY,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::connection::ConnectionManager;
 use crate::producer::service::ProducerManager;
 use crate::producer::types::ProducerConnectionView;
 use crate::producer::types::ProducerTopicOptionsView;
@@ -25,12 +26,17 @@ pub async fn get_producer_topic_options(
     request: ProducerTopicOptionsRequest,
     producer_manager: State<'_, ProducerManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ProducerTopicOptionsView> {
     authorize_command(&session_id, &session_state).await?;
-    producer_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = producer_manager
         .get_producer_topic_options(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -39,12 +45,17 @@ pub async fn query_producer_connections(
     request: ProducerConnectionQueryRequest,
     producer_manager: State<'_, ProducerManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<ProducerConnectionView> {
     authorize_command(&session_id, &session_state).await?;
-    producer_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = producer_manager
         .query_producer_connections(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 use crate::auth::SessionState;
 use crate::error::CommandResult;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 pub(crate) mod commands;
-mod db;
+pub(crate) mod db;
+#[cfg(test)]
 mod service;
 
 pub(crate) use db::ProxyDb;
-pub(crate) use service::ProxyManager;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/commands.rs
@@ -13,36 +13,50 @@
 // limitations under the License.
 
 use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
-use crate::proxy::ProxyManager;
+use crate::auth::SessionState;
+use crate::connection::{
+    ConnectionChange, ConnectionManager, ConnectionMutationResult, ConnectionProjection, EndpointKind,
+};
+use crate::error::{CommandResult, authorize_command};
 use rocketmq_dashboard_common::ProxyConfigSnapshot;
-use rocketmq_dashboard_common::ProxyMutationResult;
 use tauri::State;
 
 #[tauri::command]
 pub async fn get_proxy_home_page(
     session_id: String,
-    proxy_manager: State<'_, ProxyManager>,
     session_state: State<'_, SessionState>,
-) -> CommandResult<ProxyConfigSnapshot> {
+    connection_manager: State<'_, ConnectionManager>,
+) -> CommandResult<ConnectionProjection<ProxyConfigSnapshot>> {
     authorize_command(&session_id, &session_state).await?;
-    proxy_manager.home_page_info().map_err(Into::into)
+    let settings = connection_manager.snapshot()?;
+    Ok(ConnectionProjection {
+        value: settings.proxy.clone(),
+        settings,
+    })
 }
 
 #[tauri::command]
 pub async fn add_proxy_addr(
     session_id: String,
     address: String,
-    proxy_manager: State<'_, ProxyManager>,
+    expected_revision: i64,
     session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
     audit_manager: State<'_, AuditManager>,
-) -> CommandResult<Audited<ProxyMutationResult>> {
+) -> CommandResult<Audited<ConnectionMutationResult>> {
     let access = AuditAccess::dashboard(&session_state, session_id);
-    let proxy_manager = proxy_manager.inner().clone();
-    let local_audit = audit_manager.inner().clone();
+    let manager = connection_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::AddProxy, None, move |_audit| async move {
-            local_audit
-                .run_local(move || proxy_manager.add_proxy_addr(&address))
+        .execute(access, AuditAction::AddProxy, None, move |audit| async move {
+            manager
+                .change(
+                    expected_revision,
+                    ConnectionChange::Add {
+                        kind: EndpointKind::Proxy,
+                        address,
+                    },
+                    audit,
+                )
                 .await
         })
         .await
@@ -52,17 +66,24 @@ pub async fn add_proxy_addr(
 pub async fn switch_proxy_addr(
     session_id: String,
     address: String,
-    proxy_manager: State<'_, ProxyManager>,
+    expected_revision: i64,
     session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
     audit_manager: State<'_, AuditManager>,
-) -> CommandResult<Audited<ProxyMutationResult>> {
+) -> CommandResult<Audited<ConnectionMutationResult>> {
     let access = AuditAccess::dashboard(&session_state, session_id);
-    let proxy_manager = proxy_manager.inner().clone();
-    let local_audit = audit_manager.inner().clone();
+    let manager = connection_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::SwitchProxy, None, move |_audit| async move {
-            local_audit
-                .run_local(move || proxy_manager.switch_proxy_addr(&address))
+        .execute(access, AuditAction::SwitchProxy, None, move |audit| async move {
+            manager
+                .change(
+                    expected_revision,
+                    ConnectionChange::Switch {
+                        kind: EndpointKind::Proxy,
+                        address,
+                    },
+                    audit,
+                )
                 .await
         })
         .await
@@ -72,21 +93,25 @@ pub async fn switch_proxy_addr(
 pub async fn delete_proxy_addr(
     session_id: String,
     address: String,
-    proxy_manager: State<'_, ProxyManager>,
+    expected_revision: i64,
     session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
     audit_manager: State<'_, AuditManager>,
-) -> CommandResult<Audited<ProxyMutationResult>> {
+) -> CommandResult<Audited<ConnectionMutationResult>> {
     let access = AuditAccess::dashboard(&session_state, session_id);
-    let proxy_manager = proxy_manager.inner().clone();
-    let local_audit = audit_manager.inner().clone();
+    let manager = connection_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::DeleteProxy, None, move |_audit| async move {
-            local_audit
-                .run_local(move || proxy_manager.delete_proxy_addr(&address))
+        .execute(access, AuditAction::DeleteProxy, None, move |audit| async move {
+            manager
+                .change(
+                    expected_revision,
+                    ConnectionChange::Delete {
+                        kind: EndpointKind::Proxy,
+                        address,
+                    },
+                    audit,
+                )
                 .await
         })
         .await
 }
-use crate::auth::SessionState;
-use crate::error::CommandResult;
-use crate::error::authorize_command;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/db.rs
@@ -56,11 +56,13 @@ impl ProxyDb {
         crate::persistence::open_connection(&self.db_path)
     }
 
+    #[cfg(test)]
     pub(crate) fn load_snapshot(&self) -> Result<ProxyConfigSnapshot> {
         let connection = self.connection()?;
         load_snapshot_from_connection(&connection)
     }
 
+    #[cfg(test)]
     pub(crate) fn update_snapshot<F>(&self, operation: F) -> Result<ProxyConfigSnapshot>
     where
         F: FnOnce(&mut ProxyConfigSnapshot) -> Result<()>,
@@ -78,7 +80,7 @@ impl ProxyDb {
     }
 }
 
-fn load_snapshot_from_connection(connection: &Connection) -> Result<ProxyConfigSnapshot> {
+pub(crate) fn load_snapshot_from_connection(connection: &Connection) -> Result<ProxyConfigSnapshot> {
     let mut statement = connection.prepare(
         "
         SELECT address, is_current
@@ -105,7 +107,10 @@ fn load_snapshot_from_connection(connection: &Connection) -> Result<ProxyConfigS
     })?)
 }
 
-fn save_snapshot_to_transaction(transaction: &Transaction<'_>, snapshot: &ProxyConfigSnapshot) -> Result<()> {
+pub(crate) fn save_snapshot_to_transaction(
+    transaction: &Transaction<'_>,
+    snapshot: &ProxyConfigSnapshot,
+) -> Result<()> {
     let snapshot = canonicalize_proxy_snapshot(snapshot)?;
     let now = Utc::now().to_rfc3339();
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/proxy/service.rs
@@ -15,7 +15,6 @@
 use crate::error::DashboardError;
 use crate::error::DashboardResult as Result;
 use crate::proxy::db::ProxyDb;
-use rocketmq_dashboard_common::ProxyConfigSnapshot;
 use rocketmq_dashboard_common::ProxyMutationResult;
 use rocketmq_dashboard_common::normalize_proxy_address;
 
@@ -27,10 +26,6 @@ pub(crate) struct ProxyManager {
 impl ProxyManager {
     pub(crate) fn new(db: ProxyDb) -> Result<Self> {
         Ok(Self { db })
-    }
-
-    pub(crate) fn home_page_info(&self) -> Result<ProxyConfigSnapshot> {
-        self.db.load_snapshot()
     }
 
     pub(crate) fn add_proxy_addr(&self, address: &str) -> Result<ProxyMutationResult> {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
+use crate::connection::ConnectionManager;
 use crate::topic::service::TopicManager;
 use crate::topic::types::TopicConfigView;
 use crate::topic::types::TopicConsumerGroupListResponse;
@@ -38,9 +39,14 @@ pub async fn get_topic_list(
     request: TopicListRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<TopicListResponse> {
     authorize_command(&session_id, &session_state).await?;
-    topic_manager.get_topic_list(request).await.map_err(Into::into)
+    connection_manager.check_revision(expected_revision)?;
+    let result = topic_manager.get_topic_list(request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -49,9 +55,14 @@ pub async fn get_topic_route(
     request: TopicQueryRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<TopicRouteView> {
     authorize_command(&session_id, &session_state).await?;
-    topic_manager.get_topic_route(request).await.map_err(Into::into)
+    connection_manager.check_revision(expected_revision)?;
+    let result = topic_manager.get_topic_route(request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -60,9 +71,14 @@ pub async fn get_topic_stats(
     request: TopicQueryRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<TopicStatusView> {
     authorize_command(&session_id, &session_state).await?;
-    topic_manager.get_topic_stats(request).await.map_err(Into::into)
+    connection_manager.check_revision(expected_revision)?;
+    let result = topic_manager.get_topic_stats(request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -71,9 +87,14 @@ pub async fn get_topic_config(
     request: TopicConfigQueryRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<TopicConfigView> {
     authorize_command(&session_id, &session_state).await?;
-    topic_manager.get_topic_config(request).await.map_err(Into::into)
+    connection_manager.check_revision(expected_revision)?;
+    let result = topic_manager.get_topic_config(request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -83,7 +104,10 @@ pub async fn create_or_update_topic(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<TopicMutationResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let topic_manager = topic_manager.inner().clone();
     audit_manager
@@ -91,7 +115,10 @@ pub async fn create_or_update_topic(
             access,
             AuditAction::UpsertTopic,
             Some(request.topic_name.clone()),
-            move |_audit| async move { topic_manager.create_or_update_topic(request).await },
+            move |audit| async move {
+                let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
+                topic_manager.create_or_update_topic(request).await
+            },
         )
         .await
 }
@@ -103,7 +130,10 @@ pub async fn delete_topic(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<TopicMutationResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let topic_manager = topic_manager.inner().clone();
     audit_manager
@@ -111,7 +141,10 @@ pub async fn delete_topic(
             access,
             AuditAction::DeleteTopic,
             Some(request.topic.clone()),
-            move |_audit| async move { topic_manager.delete_topic(request).await },
+            move |audit| async move {
+                let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
+                topic_manager.delete_topic(request).await
+            },
         )
         .await
 }
@@ -123,7 +156,10 @@ pub async fn delete_topic_by_broker(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<TopicMutationResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let topic_manager = topic_manager.inner().clone();
     audit_manager
@@ -131,7 +167,10 @@ pub async fn delete_topic_by_broker(
             access,
             AuditAction::DeleteTopicByBroker,
             Some(request.topic.clone()),
-            move |_audit| async move { topic_manager.delete_topic_by_broker(request).await },
+            move |audit| async move {
+                let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
+                topic_manager.delete_topic_by_broker(request).await
+            },
         )
         .await
 }
@@ -142,12 +181,17 @@ pub async fn get_topic_consumer_groups(
     request: TopicQueryRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<TopicConsumerGroupListResponse> {
     authorize_command(&session_id, &session_state).await?;
-    topic_manager
+    connection_manager.check_revision(expected_revision)?;
+    let result = topic_manager
         .get_topic_consumer_groups(request)
         .await
-        .map_err(Into::into)
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -156,9 +200,14 @@ pub async fn get_topic_consumers(
     request: TopicQueryRequest,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
 ) -> CommandResult<TopicConsumerInfoResponse> {
     authorize_command(&session_id, &session_state).await?;
-    topic_manager.get_topic_consumers(request).await.map_err(Into::into)
+    connection_manager.check_revision(expected_revision)?;
+    let result = topic_manager.get_topic_consumers(request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
 }
 
 #[tauri::command]
@@ -168,11 +217,15 @@ pub async fn reset_consumer_offset(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<TopicMutationResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let topic_manager = topic_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::ResetOffset, None, move |_audit| async move {
+        .execute(access, AuditAction::ResetOffset, None, move |audit| async move {
+            let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
             topic_manager.reset_consumer_offset(request).await
         })
         .await
@@ -185,11 +238,15 @@ pub async fn skip_message_accumulate(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<TopicMutationResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let topic_manager = topic_manager.inner().clone();
     audit_manager
-        .execute(access, AuditAction::SkipMessages, None, move |_audit| async move {
+        .execute(access, AuditAction::SkipMessages, None, move |audit| async move {
+            let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
             topic_manager.skip_message_accumulate(request).await
         })
         .await
@@ -202,7 +259,10 @@ pub async fn send_topic_message(
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
 ) -> CommandResult<Audited<TopicSendMessageResult>> {
+    let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let topic_manager = topic_manager.inner().clone();
     audit_manager
@@ -210,7 +270,10 @@ pub async fn send_topic_message(
             access,
             AuditAction::SendMessage,
             Some(request.topic.clone()),
-            move |_audit| async move { topic_manager.send_topic_message(request).await },
+            move |audit| async move {
+                let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
+                topic_manager.send_topic_message(request).await
+            },
         )
         .await
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useSyncExternalStore } from 'react';
+import { ConnectionStore } from '../../services/connection.store';
 import {useAppStore} from '../../stores/app.store';
 import {DashboardPage} from '../../pages/dashboard/DashboardPage';
 
@@ -18,6 +19,13 @@ import {AuditPage} from '../../pages/audit/AuditPage';
 import {AccountPage} from '../../pages/account/AccountPage';
 
 export const AppRouter = () => {
+    const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
+    const { activeTab } = useAppStore();
+    const key = ['NameServer', 'Proxy', 'Account', 'Audit'].includes(activeTab) ? activeTab : `${activeTab}:${settings?.revision ?? 0}`;
+    return <RouteContent key={key} />;
+};
+
+const RouteContent = () => {
     const {activeTab} = useAppStore();
 
     switch (activeTab) {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/hooks/useNameServer.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/hooks/useNameServer.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { NameServerService } from '../../../services/nameserver.service';
+import type { ConnectionSettingsView } from '../../../services/connection.store';
 import { dashboardErrorMessage } from '../../../services/invoke';
 import type {
     NameServerConfigSnapshot,
@@ -29,9 +30,15 @@ export const useNameServer = () => {
     const [pendingAction, setPendingAction] = useState<string | null>(null);
     const [newAddress, setNewAddress] = useState('');
 
-    const loadHomePage = async () => {
+    const loadedRevision = useRef<number | null>(null);
+    const loadHomePage = async (poll = false) => {
         try {
             const homePage = await NameServerService.getHomePageInfo();
+            if (poll && loadedRevision.current !== null && loadedRevision.current !== homePage.settings.revision) {
+                setLoadError('Connection settings changed. Refresh and review your pending edits.');
+                return homePage;
+            }
+            loadedRevision.current = homePage.settings.revision;
             setData(homePage);
             setLoadError('');
             return homePage;
@@ -62,7 +69,7 @@ export const useNameServer = () => {
         void loadInitialState();
 
         const intervalId = window.setInterval(() => {
-            void loadHomePage().catch(() => {});
+            void loadHomePage(true).catch(() => {});
         }, NAMESERVER_REFRESH_INTERVAL_MS);
 
         return () => {
@@ -80,7 +87,7 @@ export const useNameServer = () => {
         setPendingAction('add');
 
         try {
-            const result = await NameServerService.addNameServer(nextAddress);
+            const result = await NameServerService.addNameServer(nextAddress, data?.settings.revision ?? -1);
             await loadHomePage();
             setNewAddress('');
             return result.message;
@@ -95,7 +102,7 @@ export const useNameServer = () => {
         setPendingAction(`switch:${address}`);
 
         try {
-            const result = await NameServerService.switchNameServer(address);
+            const result = await NameServerService.switchNameServer(address, data?.settings.revision ?? -1);
             await loadHomePage();
             return result.message;
         } catch (error) {
@@ -109,7 +116,7 @@ export const useNameServer = () => {
         setPendingAction(`delete:${address}`);
 
         try {
-            const result = await NameServerService.deleteNameServer(address);
+            const result = await NameServerService.deleteNameServer(address, data?.settings.revision ?? -1);
             await loadHomePage();
             return result.message;
         } catch (error) {
@@ -123,13 +130,16 @@ export const useNameServer = () => {
         setData((previous) => (previous ? updater(previous) : previous));
     };
 
-    const applySnapshot = (snapshot: NameServerConfigSnapshot) => {
+    const applySnapshot = (settings: ConnectionSettingsView) => {
+        loadedRevision.current = settings.revision;
+        const snapshot = settings.nameserver;
         setData((previous) => ({
             currentNamesrv: snapshot.currentNamesrv,
             namesrvAddrList: snapshot.namesrvAddrList,
             useVIPChannel: snapshot.useVIPChannel,
             useTLS: snapshot.useTLS,
             servers: buildServerStatuses(snapshot, previous?.servers),
+            settings,
         }));
     };
 
@@ -143,8 +153,8 @@ export const useNameServer = () => {
         updateSnapshot((snapshot) => ({ ...snapshot, useVIPChannel: enabled }));
 
         try {
-            const result = await NameServerService.updateVipChannel(enabled);
-            applySnapshot(result.snapshot);
+            const result = await NameServerService.updateVipChannel(enabled, data?.settings.revision ?? -1);
+            applySnapshot(result.settings);
             return result.message;
         } catch (error) {
             setData(previous);
@@ -164,8 +174,8 @@ export const useNameServer = () => {
         updateSnapshot((snapshot) => ({ ...snapshot, useTLS: enabled }));
 
         try {
-            const result = await NameServerService.updateUseTls(enabled);
-            applySnapshot(result.snapshot);
+            const result = await NameServerService.updateUseTls(enabled, data?.settings.revision ?? -1);
+            applySnapshot(result.settings);
             return result.message;
         } catch (error) {
             setData(previous);

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/types/nameserver.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/types/nameserver.types.ts
@@ -1,3 +1,4 @@
+import type { ConnectionSettingsView } from '../../../services/connection.store';
 export interface NameServerConfigSnapshot {
     currentNamesrv: string | null;
     namesrvAddrList: string[];
@@ -13,9 +14,10 @@ export interface NameServerStatusItem {
 
 export interface NameServerHomePageInfo extends NameServerConfigSnapshot {
     servers: NameServerStatusItem[];
+    settings: ConnectionSettingsView;
 }
 
 export interface NameServerMutationResult {
     message: string;
-    snapshot: NameServerConfigSnapshot;
+    settings: ConnectionSettingsView;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/hooks/useProxyCatalog.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/hooks/useProxyCatalog.ts
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ProxyService } from '../../../services/proxy.service';
 import { dashboardErrorMessage } from '../../../services/invoke';
-import type { ProxyConfigSnapshot } from '../types/proxy.types';
+import type { ProxyHomePageInfo } from '../types/proxy.types';
 
 export const useProxyCatalog = () => {
-    const [snapshot, setSnapshot] = useState<ProxyConfigSnapshot | null>(null);
+    const [snapshot, setSnapshot] = useState<ProxyHomePageInfo | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [loadError, setLoadError] = useState('');
     const [pendingAction, setPendingAction] = useState<string | null>(null);
@@ -56,8 +56,8 @@ export const useProxyCatalog = () => {
         setPendingAction('add');
 
         try {
-            const result = await ProxyService.addProxyAddr(address);
-            setSnapshot(result.snapshot);
+            const result = await ProxyService.addProxyAddr(address, snapshot?.settings.revision ?? -1);
+            setSnapshot({ ...result.settings.proxy, settings: result.settings });
             setNewAddress('');
             return result.message;
         } catch (error) {
@@ -71,8 +71,8 @@ export const useProxyCatalog = () => {
         setPendingAction(`switch:${address}`);
 
         try {
-            const result = await ProxyService.switchProxyAddr(address);
-            setSnapshot(result.snapshot);
+            const result = await ProxyService.switchProxyAddr(address, snapshot?.settings.revision ?? -1);
+            setSnapshot({ ...result.settings.proxy, settings: result.settings });
             return result.message;
         } catch (error) {
             throw error;
@@ -85,8 +85,8 @@ export const useProxyCatalog = () => {
         setPendingAction(`delete:${address}`);
 
         try {
-            const result = await ProxyService.deleteProxyAddr(address);
-            setSnapshot(result.snapshot);
+            const result = await ProxyService.deleteProxyAddr(address, snapshot?.settings.revision ?? -1);
+            setSnapshot({ ...result.settings.proxy, settings: result.settings });
             return result.message;
         } catch (error) {
             throw error;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/types/proxy.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/types/proxy.types.ts
@@ -1,3 +1,4 @@
+import type { ConnectionSettingsView } from '../../../services/connection.store';
 export interface ProxyConfigSnapshot {
     currentProxyAddr: string | null;
     proxyAddrList: string[];
@@ -5,5 +6,7 @@ export interface ProxyConfigSnapshot {
 
 export interface ProxyMutationResult {
     message: string;
-    snapshot: ProxyConfigSnapshot;
+    settings: ConnectionSettingsView;
 }
+
+export interface ProxyHomePageInfo extends ProxyConfigSnapshot { settings: ConnectionSettingsView }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
+import { ConnectionStore } from './connection.store';
 import { AuthService } from './auth.service';
 import { invokeAuthenticatedCommand, subscribeAuditWarning } from './invoke';
 import { SessionStorageService } from './session.storage';
@@ -15,6 +16,8 @@ beforeEach(() => {
         removeItem: (key: string) => entries.delete(key),
     } });
     SessionStorageService.setSessionId('current-token');
+    ConnectionStore.reset();
+    ConnectionStore.accept('current-token', { revision: 0, endpoints: [], currentNameserverId: null, currentProxyId: null, environmentId: null, nameserver: { currentNamesrv: null, namesrvAddrList: [], useVIPChannel: false, useTLS: false }, proxy: { currentProxyAddr: null, proxyAddrList: [] } });
 });
 afterEach(() => { vi.resetAllMocks(); vi.unstubAllGlobals(); });
 
@@ -34,6 +37,7 @@ describe('authoritative session lifecycle', () => {
         let reject!: (reason: unknown) => void;
         vi.mocked(invoke).mockImplementation(() => new Promise((_resolve, rejectRequest) => { reject = rejectRequest; }));
         const request = invokeAuthenticatedCommand('get_topic_list');
+        await Promise.resolve();
         SessionStorageService.setSessionId('new-token');
         reject(failure('auth.session.invalid'));
         await expect(request).rejects.toMatchObject({ code: 'auth.session.invalid' });
@@ -99,5 +103,43 @@ describe('audit warnings', () => {
             expect(warning).toHaveBeenCalledOnce();
             expect(invoke).toHaveBeenCalledTimes(1);
         } finally { unsubscribe(); }
+    });
+});
+
+describe('connection revisions', () => {
+    it('rejects a late read response after a configuration switch', async () => {
+        let resolve!: (value: unknown) => void;
+        vi.mocked(invoke).mockImplementation(() => new Promise((complete) => { resolve = complete; }));
+        const request = invokeAuthenticatedCommand('get_topic_list');
+        await Promise.resolve();
+        const previous = ConnectionStore.getSnapshot()!;
+        ConnectionStore.accept('current-token', { ...previous, revision: 1, environmentId: 'new-environment' });
+        resolve({ topics: ['old-environment-topic'] });
+        await expect(request).rejects.toMatchObject({ code: 'dashboard.configuration_conflict' });
+        expect(invoke).toHaveBeenCalledWith('get_topic_list', { sessionId: 'current-token', expectedRevision: 0 });
+    });
+
+    it('preserves a completed mutation receipt after the view changes', async () => {
+        let resolve!: (value: unknown) => void;
+        vi.mocked(invoke).mockImplementation(() => new Promise((complete) => { resolve = complete; }));
+        const request = invokeAuthenticatedCommand('send_topic_message');
+        await Promise.resolve();
+        ConnectionStore.accept('current-token', { ...ConnectionStore.getSnapshot()!, revision: 1 });
+        resolve({ success: true, messageId: 'already-sent' });
+        await expect(request).resolves.toMatchObject({ success: true, messageId: 'already-sent' });
+        expect(invoke).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not automatically retry a conflicting configuration draft', async () => {
+        vi.mocked(invoke).mockRejectedValue({ code: 'dashboard.configuration_conflict', message: 'Review configuration.', category: 'validation', retryable: false });
+        await expect(invokeAuthenticatedCommand('add_name_server', { address: '127.0.0.2:9876', expectedRevision: 0 })).rejects.toMatchObject({ code: 'dashboard.configuration_conflict' });
+        expect(invoke).toHaveBeenCalledTimes(1);
+    });
+
+    it('a stale settings response cannot roll back the shared identity', () => {
+        const previous = ConnectionStore.getSnapshot()!;
+        ConnectionStore.accept('current-token', { ...previous, revision: 2, environmentId: 'current-environment' });
+        ConnectionStore.accept('current-token', { ...previous, revision: 1, environmentId: 'old-environment' });
+        expect(ConnectionStore.getSnapshot()?.environmentId).toBe('current-environment');
     });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/connection.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/connection.service.ts
@@ -1,0 +1,7 @@
+import { invokeAuthenticatedCommand } from './invoke';
+import type { ConnectionSettingsView } from './connection.store';
+export interface ConnectionMutationResult { message: string; settings: ConnectionSettingsView }
+export type NameServerSelection = { kind: 'existing_id' | 'address'; value: string };
+export const getConnectionSettings = () => invokeAuthenticatedCommand<ConnectionSettingsView>('get_connection_settings');
+export const replaceNameServers = (addresses: string[], currentEndpoint: NameServerSelection | null, expectedRevision: number) =>
+    invokeAuthenticatedCommand<ConnectionMutationResult>('replace_name_servers', { request: { addresses, currentEndpoint, expectedRevision } });

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/connection.store.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/connection.store.ts
@@ -1,0 +1,25 @@
+import { SessionStorageService } from './session.storage';
+import type { NameServerConfigSnapshot } from '../features/nameserver/types/nameserver.types';
+import type { ProxyConfigSnapshot } from '../features/proxy/types/proxy.types';
+export interface ConnectionSettingsView {
+    revision: number;
+    endpoints: Array<{ endpointId: string; kind: 'name_server' | 'proxy'; address: string; environmentId: string | null }>;
+    currentNameserverId: string | null; currentProxyId: string | null; environmentId: string | null;
+    nameserver: NameServerConfigSnapshot; proxy: ProxyConfigSnapshot;
+}
+const listeners = new Set<() => void>();
+let owner: string | null = null;
+let settings: ConnectionSettingsView | null = null;
+export const ConnectionStore = {
+    getSnapshot: (): ConnectionSettingsView | null => owner === SessionStorageService.getSessionId() ? settings : null,
+    subscribe: (listener: () => void): (() => void) => { listeners.add(listener); return () => { listeners.delete(listener); }; },
+    accept: (sessionId: string, next: ConnectionSettingsView): void => {
+        if (sessionId !== SessionStorageService.getSessionId()) return;
+        const previous = ConnectionStore.getSnapshot();
+        if (previous && next.revision <= previous.revision) return;
+        owner = sessionId; settings = next;
+        for (const listener of listeners) listener();
+    },
+    reset: (): void => { owner = null; settings = null; for (const listener of listeners) listener(); },
+};
+SessionStorageService.subscribeAuthenticationFailure((reason) => { if (reason === 'invalid') ConnectionStore.reset(); });

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
@@ -1,3 +1,4 @@
+import { ConnectionStore, type ConnectionSettingsView } from './connection.store';
 import { invoke } from '@tauri-apps/api/core';
 import { SessionStorageService } from './session.storage';
 
@@ -107,7 +108,25 @@ export const invokeSessionCommand = <T>(
     throw error;
 });
 
-export const invokeAuthenticatedCommand = <T>(command: string, args?: Record<string, unknown>): Promise<T> => {
+const localCommands = new Set(['change_password', 'get_current_user_profile', 'get_auth_bootstrap_status', 'list_sessions', 'revoke_user_sessions', 'query_audit_events']);
+const connectionWrites = new Set(['add_name_server', 'switch_name_server', 'delete_name_server', 'update_vip_channel', 'update_use_tls', 'add_proxy_addr', 'switch_proxy_addr', 'delete_proxy_addr', 'replace_name_servers']);
+const remoteWrites = new Set(['create_or_update_topic', 'delete_topic', 'delete_topic_by_broker', 'reset_consumer_offset', 'skip_message_accumulate', 'send_topic_message', 'create_or_update_consumer_group', 'delete_consumer_group', 'consume_message_directly', 'resend_dlq_message', 'batch_resend_dlq_message']);
+const pendingSettings = new Map<string, Promise<ConnectionSettingsView>>();
+const ensureSettings = (token: string): Promise<ConnectionSettingsView> => {
+    const current = ConnectionStore.getSnapshot();
+    if (current) return Promise.resolve(current);
+    const pending = pendingSettings.get(token);
+    if (pending) return pending;
+    const loading = invokeSessionCommand<ConnectionSettingsView>('get_connection_settings', token).then((settings) => {
+        ConnectionStore.accept(token, settings);
+        return ConnectionStore.getSnapshot() ?? settings;
+    }).finally(() => pendingSettings.delete(token));
+    pendingSettings.set(token, loading);
+    return loading;
+};
+const configurationChanged = () => new DashboardClientError({ code: 'dashboard.configuration_conflict', category: 'validation', retryable: false, message: 'Connection settings changed. Refresh and review the current configuration.' });
+
+export const invokeAuthenticatedCommand = async <T>(command: string, args?: Record<string, unknown>): Promise<T> => {
     const sessionId = SessionStorageService.getSessionId();
     if (!sessionId) {
         SessionStorageService.reportAuthenticationFailure(null, 'invalid');
@@ -121,5 +140,31 @@ export const invokeAuthenticatedCommand = <T>(command: string, args?: Record<str
         );
     }
 
-    return invokeSessionCommand<T>(command, sessionId, args);
+    if (localCommands.has(command)) return invokeSessionCommand<T>(command, sessionId, args);
+    if (command === 'get_connection_settings') {
+        const result = await invokeSessionCommand<ConnectionSettingsView>(command, sessionId, args);
+        ConnectionStore.accept(sessionId, result);
+        return result as T;
+    }
+    if (connectionWrites.has(command)) {
+        const result = await invokeSessionCommand<T>(command, sessionId, args);
+        if (result && typeof result === 'object' && 'settings' in result) ConnectionStore.accept(sessionId, result.settings as ConnectionSettingsView);
+        return result;
+    }
+    const settings = await ensureSettings(sessionId);
+    if (SessionStorageService.getSessionId() !== sessionId) throw configurationChanged();
+    let result: T;
+    try {
+        result = await invokeSessionCommand<T>(command, sessionId, { ...args, expectedRevision: settings.revision });
+    } catch (error) {
+        if (isDashboardClientError(error) && error.code === 'dashboard.configuration_conflict') {
+            // Refresh the view identity only. Never replay the rejected operation.
+            try { ConnectionStore.accept(sessionId, await invokeSessionCommand<ConnectionSettingsView>('get_connection_settings', sessionId)); } catch {}
+        }
+        throw error;
+    }
+    // Remote writes retain their actual receipt even if the user later changes views.
+    if (!remoteWrites.has(command) && ConnectionStore.getSnapshot()?.revision !== settings.revision) throw configurationChanged();
+    if (result && typeof result === 'object' && 'settings' in result) ConnectionStore.accept(sessionId, result.settings as ConnectionSettingsView);
+    return result;
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/nameserver.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/nameserver.service.ts
@@ -9,23 +9,23 @@ export class NameServerService {
         return invokeAuthenticatedCommand<NameServerHomePageInfo>('get_name_server_home_page');
     }
 
-    static async addNameServer(address: string): Promise<NameServerMutationResult> {
-        return invokeAuthenticatedCommand<NameServerMutationResult>('add_name_server', { address });
+    static async addNameServer(address: string, expectedRevision: number): Promise<NameServerMutationResult> {
+        return invokeAuthenticatedCommand<NameServerMutationResult>('add_name_server', { address, expectedRevision });
     }
 
-    static async switchNameServer(address: string): Promise<NameServerMutationResult> {
-        return invokeAuthenticatedCommand<NameServerMutationResult>('switch_name_server', { address });
+    static async switchNameServer(address: string, expectedRevision: number): Promise<NameServerMutationResult> {
+        return invokeAuthenticatedCommand<NameServerMutationResult>('switch_name_server', { address, expectedRevision });
     }
 
-    static async deleteNameServer(address: string): Promise<NameServerMutationResult> {
-        return invokeAuthenticatedCommand<NameServerMutationResult>('delete_name_server', { address });
+    static async deleteNameServer(address: string, expectedRevision: number): Promise<NameServerMutationResult> {
+        return invokeAuthenticatedCommand<NameServerMutationResult>('delete_name_server', { address, expectedRevision });
     }
 
-    static async updateVipChannel(enabled: boolean): Promise<NameServerMutationResult> {
-        return invokeAuthenticatedCommand<NameServerMutationResult>('update_vip_channel', { enabled });
+    static async updateVipChannel(enabled: boolean, expectedRevision: number): Promise<NameServerMutationResult> {
+        return invokeAuthenticatedCommand<NameServerMutationResult>('update_vip_channel', { enabled, expectedRevision });
     }
 
-    static async updateUseTls(enabled: boolean): Promise<NameServerMutationResult> {
-        return invokeAuthenticatedCommand<NameServerMutationResult>('update_use_tls', { enabled });
+    static async updateUseTls(enabled: boolean, expectedRevision: number): Promise<NameServerMutationResult> {
+        return invokeAuthenticatedCommand<NameServerMutationResult>('update_use_tls', { enabled, expectedRevision });
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/proxy.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/proxy.service.ts
@@ -1,23 +1,23 @@
 import { invokeAuthenticatedCommand } from './invoke';
 import type {
-    ProxyConfigSnapshot,
+    ProxyHomePageInfo,
     ProxyMutationResult,
 } from '../features/proxy/types/proxy.types';
 
 export class ProxyService {
-    static async getHomePageInfo(): Promise<ProxyConfigSnapshot> {
-        return invokeAuthenticatedCommand<ProxyConfigSnapshot>('get_proxy_home_page');
+    static async getHomePageInfo(): Promise<ProxyHomePageInfo> {
+        return invokeAuthenticatedCommand<ProxyHomePageInfo>('get_proxy_home_page');
     }
 
-    static async addProxyAddr(address: string): Promise<ProxyMutationResult> {
-        return invokeAuthenticatedCommand<ProxyMutationResult>('add_proxy_addr', { address });
+    static async addProxyAddr(address: string, expectedRevision: number): Promise<ProxyMutationResult> {
+        return invokeAuthenticatedCommand<ProxyMutationResult>('add_proxy_addr', { address, expectedRevision });
     }
 
-    static async switchProxyAddr(address: string): Promise<ProxyMutationResult> {
-        return invokeAuthenticatedCommand<ProxyMutationResult>('switch_proxy_addr', { address });
+    static async switchProxyAddr(address: string, expectedRevision: number): Promise<ProxyMutationResult> {
+        return invokeAuthenticatedCommand<ProxyMutationResult>('switch_proxy_addr', { address, expectedRevision });
     }
 
-    static async deleteProxyAddr(address: string): Promise<ProxyMutationResult> {
-        return invokeAuthenticatedCommand<ProxyMutationResult>('delete_proxy_addr', { address });
+    static async deleteProxyAddr(address: string, expectedRevision: number): Promise<ProxyMutationResult> {
+        return invokeAuthenticatedCommand<ProxyMutationResult>('delete_proxy_addr', { address, expectedRevision });
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10368

### Brief Description

Unify all exported NameServer/Proxy configuration writes behind expectedRevision checks. Configuration snapshots, stable endpoint/environment UUIDs, success audits, and revision increments commit together, followed by one runtime publication. Empty saved configurations remain empty after restart, and identities survive removal and readdition.

Add ConnectionSettingsView and the registered atomic replace_name_servers command with a typed frontend service. The bulk editing UI is explicitly optional and documented. Remote writes require the displayed revision and hold a lease through RPC dispatch; reads check revision before and after querying. Shared frontend state rejects late responses, preserves completed write receipts, and keeps configuration drafts for review instead of retrying them blindly. Fresh schema version 4 intentionally leaves earlier development formats untouched.

### How Did You Test This Change?

From the standalone Tauri backend:
- `cargo test --lib connection::`: 5 passed, covering concurrent revision conflicts, replacement rollback, identity stability, empty-list reopening, mutation leases, and audit-failure rollback without runtime publication.
- `cargo test --lib nameserver::`: 8 passed.
- `cargo test --lib proxy::`: 6 passed.
- `cargo test --lib audit::`: 5 passed.
- `cargo test --lib error::`: 5 passed, including authorization coverage of existing business commands.
- `cargo fmt -p rocketmq-dashboard-tauri -- --check`: passed.

From the Tauri frontend:
- `npm run build`: passed; existing large-bundle warning remains.
- `npm test -- src/services/auth-session.test.ts src/services/invoke.test.ts`: 15 passed, including revision propagation, late read rejection, stable shared identity, and preserving completed writes without retrying conflicting drafts.
- `git diff --check`: passed.

Native desktop interaction remains part of the final smoke step. CI was not used as a merge gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added centralized connection settings for NameServer and Proxy endpoints, including stable identities and current environment details.
  - Added atomic NameServer replacement with validation and audit records.
  - Added revision tracking to prevent stale reads and conflicting configuration changes.
  - Connection changes now synchronize dashboard views and runtime operations across tabs.
- **Bug Fixes**
  - Prevented outdated responses or drafts from overwriting newer connection settings.
  - Added clear, non-retryable conflict messaging when settings change during an operation.
- **Documentation**
  - Added connection settings guidance and updated authentication and audit documentation for schema version 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->