### PR TITLE
[ISSUE #10370]📝Add AGENTS routing for the first-message tutorial

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Node projects require their own commands. Consult the matching local guide when 
 | `rocketmq-dashboard/rocketmq-dashboard-web/backend/` | [Web backend](rocketmq-dashboard/rocketmq-dashboard-web/backend/AGENTS.md) |
 | `rocketmq-dashboard/rocketmq-dashboard-web/frontend/` | [Web frontend](rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md) |
 | `rocketmq-website/` | [Docusaurus site](rocketmq-website/AGENTS.md) |
+| `rocketmq-website/examples/first-message/` | [Standalone first-message tutorial](rocketmq-website/examples/first-message/AGENTS.md) |
 
 ## Working agreement
 

--- a/rocketmq-website/AGENTS.md
+++ b/rocketmq-website/AGENTS.md
@@ -5,7 +5,9 @@ This file applies to `rocketmq-website/`.
 
 ## Project role
 - This directory is the standalone Docusaurus website for RocketMQ Rust.
-- It is a Node project, not a Cargo project and not part of the root Rust workspace.
+- The website is a Node project outside the root Rust workspace.
+- `examples/first-message/` is a standalone Cargo tutorial; follow its
+  [local guide](examples/first-message/AGENTS.md) for Rust validation.
 - Root Cargo validation does not validate this website.
 
 ## Repository boundaries

--- a/rocketmq-website/examples/first-message/AGENTS.md
+++ b/rocketmq-website/examples/first-message/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Scope and role
+
+- This file applies to `rocketmq-website/examples/first-message/`.
+- `rocketmq-doc-first-message` is a standalone Cargo binary with its own `[workspace]` and
+  checkout-relative dependencies. Root workspace checks and the Docusaurus build do not compile it.
+- It provides the paired `produce` and `consume` modes for the website's first-message tutorial.
+
+## Development validation
+
+Run from this directory for Rust source or manifest changes:
+
+```bash
+cargo fmt --all -- --check
+cargo check --bin rocketmq-doc-first-message
+```
+
+For changed testable behavior, add or reuse focused tests and run
+`cargo test --bin rocketmq-doc-first-message <test_name>`.
+Instruction-only changes need the repository routing check and `git diff --check`.
+
+## Tutorial consistency
+
+- Keep the client modes, Topic and group names, NameServer address, and the supplied TOML files aligned
+  with the English and Chinese getting-started pages.
+- Preserve explicit producer/consumer, client runtime, process runtime, and telemetry shutdown on
+  success and failure paths, including bounded consumption and Ctrl+C handling.
+- When a change needs live validation, follow [local setup](../../docs/getting-started/local-source.md)
+  and [the first-message walkthrough](../../docs/getting-started/quick-start.md) from the repository root.
+  The sample requires local services and explicitly provisioned Topic/group metadata; its configuration
+  resolves data paths beneath `.rocketmq-doc-demo/` relative to the process working directory.
+- Keep generated build output and local service data out of commits. Rendered website changes use
+  the [website validation guide](../../AGENTS.md).


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10370

### Brief Description

The routing check fails because the standalone first-message Cargo project has no local AGENTS guide or entry in the root project map. Add both and link the example's guide from the website instructions.

The new guide documents scoped Rust validation, runtime cleanup, and consistency with the tutorial and service configurations. It distinguishes the example's Cargo checks from the website's Docusaurus build.

### How Did You Test This Change?

- `bash ./scripts/check-agents-routing.sh` (Git Bash on Windows) - passed.
- `./scripts/check-agents-routing.ps1` (PowerShell) - passed.
- Both reported `AGENTS_ROUTING_CHECK_OK standalone_cargo=10 node_projects=5 routes=15`.
- `git -c core.safecrlf=false diff --check` - passed.
- Verified the local guide and tutorial links resolve.

No Cargo or website build was needed for these instruction-only changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added repository guidance for the standalone first-message tutorial example.
  - Clarified that the tutorial is maintained separately from the website’s Node project and root Rust workspace.
  - Documented validation commands, focused testing expectations, and repository hygiene checks.
  - Added instructions to keep the tutorial implementation aligned with the English and Chinese getting-started guides, including client modes, connection settings, shutdown behavior, and live walkthrough steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->