### PR TITLE
[ISSUE #10373]🚀Share RocketMQ credentials across Tauri admin connections

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/README.md
@@ -33,6 +33,8 @@ Readiness checks use each service's `/readyz` endpoint. Logs are rotated and
 service data uses separate named volumes. All published ports bind to host
 loopback; this is an unauthenticated local debugging fixture. ACL and TLS require
 a separately configured secured fixture before claiming authentication coverage.
+The [ACL fixture](acl/README.md) provides isolated credential verification with
+the same local Rust images.
 
 | Desktop setting | Address |
 | --- | --- |

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/acl/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/acl/README.md
@@ -1,0 +1,38 @@
+# Isolated RocketMQ Rust ACL fixture
+
+This fixture uses the local source-built images from the [main debugging
+fixture](../README.md). Start from this directory:
+
+```powershell
+docker compose config --quiet
+docker compose up -d --wait --wait-timeout 120
+```
+
+Docker Desktop shows a separate `rocketmq-tauri-acl-debug` group. Its NameServer
+is `127.0.0.1:29876`, Broker is `127.0.0.1:22911`, and health endpoints are
+`28088` and `28090`. Disable VIP and TLS. It uses separate data volumes and only
+publishes loopback ports. The public `tauri-dev-admin` / `tauri-dev-secret` seed is
+solely for local testing. The Broker enables authentication and authorization;
+the NameServer is a discovery service without ACL enforcement in this fixture.
+
+From the app root, start the Windows app with the fixture credentials:
+
+```powershell
+$env:DASHBOARD_TAURI_ROCKETMQ_ACCESS_KEY = 'tauri-dev-admin'
+$env:DASHBOARD_TAURI_ROCKETMQ_SECRET_KEY = 'tauri-dev-secret'
+npm run tauri dev
+```
+
+Select the ACL NameServer address in connection settings. Restart the app to
+change credentials. From `src-tauri`, run the opt-in real Broker query:
+
+```powershell
+cargo test --lib local_acl_query_accepts_configured_credentials_and_rejects_invalid_credentials -- --ignored
+```
+
+The test uses the desktop's common AdminBuilder and checks the seeded user can be
+queried with correct credentials, while anonymous and incorrectly signed queries
+are rejected. It shuts down each session and the owned client runtime.
+
+Stop with `docker compose down`; volumes are retained. This fixture tests ACL,
+not TLS or token-provider behavior.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/acl/broker.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/acl/broker.toml
@@ -1,0 +1,29 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+[broker]
+listenPort = 22911
+brokerIp1 = "127.0.0.1"
+storePathRootDir = "/var/lib/rocketmq/broker"
+namesrvAddr = "127.0.0.1:9876"
+autoCreateTopicEnable = false
+authenticationEnabled = true
+authorizationEnabled = true
+signatureAlgorithm = "HmacSHA256"
+authConfigPath = "/var/lib/rocketmq/auth"
+# Public development fixture credentials; never use for a deployed Broker.
+initAuthenticationUser = "tauri-dev-admin:tauri-dev-secret"
+
+[broker.brokerIdentity]
+brokerName = "tauri-acl-broker"
+brokerClusterName = "TauriAclDebugCluster"
+brokerId = 0
+
+[store]
+storePathRootDir = "/var/lib/rocketmq/broker"
+haListenPort = 22912
+mappedFileSizeCommitLog = 67108864
+mappedFileSizeConsumeQueue = 6000
+mappedFileSizeConsumeQueueExt = 65536
+maxHashSlotNum = 1000
+maxIndexNum = 4000
+timerWheelEnable = false

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/acl/compose.yaml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/acl/compose.yaml
@@ -1,0 +1,53 @@
+name: rocketmq-tauri-acl-debug
+
+x-common: &common
+  stop_grace_period: 60s
+  logging:
+    driver: json-file
+    options:
+      max-size: "10m"
+      max-file: "3"
+  healthcheck:
+    test:
+      - CMD
+      - bash
+      - -c
+      - 'exec 3<>/dev/tcp/127.0.0.1/$${ROCKETMQ_HEALTH_BIND_ADDR##*:}; printf "GET /readyz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3; read -r status <&3; [[ "$$status" == *" 200 "* ]]'
+    interval: 5s
+    timeout: 3s
+    retries: 20
+    start_period: 10s
+
+services:
+  namesrv:
+    <<: *common
+    image: rocketmq-rust/namesrv:local
+    command: [--configFile, /etc/rocketmq/namesrv.toml]
+    environment:
+      RUST_LOG: warn
+      ROCKETMQ_HEALTH_BIND_ADDR: 0.0.0.0:28088
+    volumes:
+      - ../namesrv.toml:/etc/rocketmq/namesrv.toml:ro
+      - namesrv-data:/var/lib/rocketmq
+    ports:
+      - "127.0.0.1:29876:9876"
+      - "127.0.0.1:22911:22911"
+      - "127.0.0.1:28088:28088"
+      - "127.0.0.1:28090:28090"
+  broker:
+    <<: *common
+    image: rocketmq-rust/broker:local
+    network_mode: service:namesrv
+    depends_on:
+      namesrv:
+        condition: service_healthy
+    command: [--configFile, /etc/rocketmq/broker.toml]
+    environment:
+      RUST_LOG: warn
+      ROCKETMQ_HEALTH_BIND_ADDR: 0.0.0.0:28090
+    volumes:
+      - ./broker.toml:/etc/rocketmq/broker.toml:ro
+      - broker-data:/var/lib/rocketmq
+volumes:
+  namesrv-data:
+  broker-data:

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONNECTION_SETTINGS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONNECTION_SETTINGS.md
@@ -58,3 +58,23 @@ NameServer, Proxy, audit, and error tests. Tests cover competing revisions, inva
 replacement rollback, stable IDs, empty-list reopening, write leases, and atomic
 audit failure. From the frontend: `npm run build` and the focused auth/session
 service tests, including stale reads and preservation of completed writes.
+
+## RocketMQ administration credentials
+
+Set `DASHBOARD_TAURI_ROCKETMQ_ACCESS_KEY` and
+`DASHBOARD_TAURI_ROCKETMQ_SECRET_KEY` in the process environment before starting
+the desktop app. `DASHBOARD_TAURI_ROCKETMQ_SECURITY_TOKEN` is optional. Missing
+half of a credential pair, empty keys, or a token without keys fails startup with
+a safe configuration error. With none configured, the client remains anonymous.
+
+Credentials stay in backend memory and are shared by all administration sessions
+and NameServer probes. They are not saved in SQLite or returned to the frontend.
+Connection settings expose only `credentialsConfigured`; the NameServer page
+shows that status. Environment changes require restarting the app. Desktop login
+credentials and RocketMQ administration credentials serve separate purposes.
+The current admin-core client signs using HMAC-SHA256. Configure the target Rust
+Broker with `signatureAlgorithm = "HmacSHA256"`; its default HMAC-SHA1 setting
+does not match this client.
+
+See the [isolated ACL fixture](../deploy/dev/acl/README.md) for a reproducible local
+authentication query with the same builder used by the desktop app.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/admin.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 use crate::cluster::types::ClusterResult;
+use crate::connection::AdminPurpose;
 use crate::error::DashboardError as ClusterError;
 use crate::nameserver::NameServerRuntimeState;
-use rocketmq_admin_core::client_adapter::AdminBuilder;
 use rocketmq_admin_core::client_adapter::AdminSession;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
 use std::sync::Arc;
-use uuid::Uuid;
 
 pub(crate) struct ManagedClusterAdmin {
     pub(crate) admin: AdminSession,
@@ -30,16 +29,8 @@ pub(crate) struct ManagedClusterAdmin {
 impl ManagedClusterAdmin {
     pub(crate) async fn connect(runtime: &Arc<NameServerRuntimeState>) -> ClusterResult<Self> {
         let (snapshot, generation) = runtime.snapshot_and_generation();
-        let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
-            ClusterError::Configuration("No active NameServer is configured. Add and select a NameServer first.".into())
-        })?;
-
-        let admin = AdminBuilder::new(runtime.client_runtime())
-            .admin_group(format!("dashboard-cluster-admin-{}", Uuid::new_v4()))
-            .namesrv_addr(current_namesrv)
-            .timeout_millis(5_000)
-            .vip_channel_enabled(snapshot.use_vip_channel)
-            .use_tls(snapshot.use_tls)
+        let admin = runtime
+            .admin_builder(&snapshot, AdminPurpose::Cluster)?
             .build_and_start()
             .await
             .map_err(ClusterError::from)?;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod admin;
 pub(crate) mod commands;
 mod db;
 mod service;
 mod types;
 pub(crate) use service::ConnectionManager;
 pub(crate) use types::*;
+
+pub(crate) use admin::{AdminConnectionConfig, AdminPurpose};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/admin.rs
@@ -1,0 +1,239 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) use crate::error::{DashboardError, DashboardResult};
+use rocketmq_admin_core::client_adapter::{AdminBuilder, ClientRuntime};
+use rocketmq_admin_core::core::security::AdminCredentials;
+use rocketmq_dashboard_common::NameServerConfigSnapshot;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct AdminConnectionConfig {
+    credentials: Option<AdminCredentials>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum AdminPurpose {
+    Cluster,
+    Consumer,
+    Message,
+    Producer,
+    Topic,
+    Probe,
+}
+impl AdminPurpose {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Cluster => "cluster",
+            Self::Consumer => "consumer",
+            Self::Message => "message",
+            Self::Producer => "producer",
+            Self::Topic => "topic",
+            Self::Probe => "probe",
+        }
+    }
+    fn timeout_millis(self) -> u64 {
+        match self {
+            Self::Probe => 1500,
+            Self::Cluster | Self::Consumer | Self::Message | Self::Producer | Self::Topic => 5000,
+        }
+    }
+}
+
+impl AdminConnectionConfig {
+    pub(crate) fn from_environment() -> DashboardResult<Self> {
+        let read = |key| match std::env::var(key) {
+            Ok(value) => Ok(Some(value)),
+            Err(std::env::VarError::NotPresent) => Ok(None),
+            Err(_) => Err(DashboardError::Configuration(
+                "invalid RocketMQ credential encoding".into(),
+            )),
+        };
+        Self::from_values(
+            read("DASHBOARD_TAURI_ROCKETMQ_ACCESS_KEY")?,
+            read("DASHBOARD_TAURI_ROCKETMQ_SECRET_KEY")?,
+            read("DASHBOARD_TAURI_ROCKETMQ_SECURITY_TOKEN")?,
+        )
+    }
+
+    fn from_values(
+        access_key: Option<String>,
+        secret_key: Option<String>,
+        security_token: Option<String>,
+    ) -> DashboardResult<Self> {
+        let credentials = match (access_key, secret_key, security_token) {
+            (None, None, None) => None,
+            (Some(access), Some(secret), token) => {
+                Some(AdminCredentials::try_new(access, secret, token).map_err(|_| {
+                    DashboardError::Configuration("RocketMQ access and secret keys must both be nonempty".into())
+                })?)
+            }
+            _ => {
+                return Err(DashboardError::Configuration(
+                    "RocketMQ access and secret keys must be configured together".into(),
+                ));
+            }
+        };
+        Ok(Self { credentials })
+    }
+
+    pub(crate) fn credentials_configured(&self) -> bool {
+        self.credentials.is_some()
+    }
+
+    pub(crate) fn builder(
+        &self,
+        runtime: Arc<ClientRuntime>,
+        snapshot: &NameServerConfigSnapshot,
+        address: &str,
+        purpose: AdminPurpose,
+    ) -> AdminBuilder {
+        let mut builder = AdminBuilder::new(runtime)
+            .admin_group(format!("dashboard-{}-{}", purpose.name(), Uuid::new_v4()))
+            .namesrv_addr(address)
+            .vip_channel_enabled(snapshot.use_vip_channel)
+            .use_tls(snapshot.use_tls)
+            .timeout_millis(purpose.timeout_millis());
+        if let Some(credentials) = &self.credentials {
+            builder = builder.credentials(credentials.clone());
+        }
+        builder
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn configuration_requires_complete_nonempty_credentials_and_redacts_values() {
+        assert!(
+            !AdminConnectionConfig::from_values(None, None, None)
+                .unwrap()
+                .credentials_configured()
+        );
+        for (access, secret, token) in [
+            (Some("access-sentinel"), None, None),
+            (None, Some("secret-sentinel"), None),
+            (None, None, Some("token-sentinel")),
+            (Some(""), Some("secret-sentinel"), None),
+        ] {
+            let error = AdminConnectionConfig::from_values(
+                access.map(str::to_owned),
+                secret.map(str::to_owned),
+                token.map(str::to_owned),
+            )
+            .unwrap_err();
+            let public = serde_json::to_string(&crate::error::CommandError::from(error)).unwrap();
+            assert!(!public.contains("sentinel"));
+        }
+        let config = AdminConnectionConfig::from_values(
+            Some("access-sentinel".into()),
+            Some("secret-sentinel".into()),
+            Some("token-sentinel".into()),
+        )
+        .unwrap();
+        assert!(config.credentials_configured());
+        assert!(!format!("{config:?}").contains("sentinel"));
+    }
+
+    #[test]
+    fn common_builder_keeps_transport_settings_for_signed_and_unsigned_paths() {
+        let snapshot = NameServerConfigSnapshot {
+            use_vip_channel: true,
+            use_tls: true,
+            ..Default::default()
+        };
+        let signed =
+            AdminConnectionConfig::from_values(Some("access-sentinel".into()), Some("secret-sentinel".into()), None)
+                .unwrap();
+        for config in [AdminConnectionConfig::default(), signed] {
+            let builder = config.builder(
+                crate::nameserver::runtime::test_client_runtime(),
+                &snapshot,
+                "127.0.0.1:9876",
+                AdminPurpose::Probe,
+            );
+            let debug = format!("{builder:?}");
+            assert!(!debug.contains("sentinel"));
+            assert!(debug.contains("1500"));
+            assert!(!debug.contains("127.0.0.1:9876"));
+            assert!(debug.contains("use_tls: true"));
+            assert!(debug.contains("vip_channel_enabled: true"));
+        }
+    }
+
+    #[test]
+    #[ignore = "requires the isolated deploy/dev/acl Docker fixture"]
+    fn local_acl_query_accepts_configured_credentials_and_rejects_invalid_credentials() {
+        use rocketmq_admin_core::client_adapter::{ClientRuntimeConfig, TelemetryHandle};
+        use rocketmq_admin_core::core::security::{ListUsersRequest, SecurityAdmin};
+        use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
+
+        let owner = RuntimeOwner::plan(RuntimeConfig::server_default("tauri-acl-smoke"))
+            .unwrap()
+            .build()
+            .unwrap();
+        let runtime = ClientRuntime::try_new(
+            owner.root_context().component("client"),
+            ClientRuntimeConfig::default(),
+            TelemetryHandle::noop(),
+        )
+        .unwrap();
+        let snapshot = NameServerConfigSnapshot {
+            current_namesrv: Some("127.0.0.1:29876".into()),
+            namesrv_addr_list: vec!["127.0.0.1:29876".into()],
+            use_vip_channel: false,
+            use_tls: false,
+        };
+        let outcomes = owner.block_on(async {
+            let mut outcomes = Vec::new();
+            for secret in [Some("tauri-dev-secret"), None, Some("incorrect-dev-secret")] {
+                let config = AdminConnectionConfig::from_values(
+                    secret.map(|_| "tauri-dev-admin".into()),
+                    secret.map(str::to_owned),
+                    None,
+                )
+                .unwrap();
+                let result = match config
+                    .builder(runtime.clone(), &snapshot, "127.0.0.1:29876", AdminPurpose::Cluster)
+                    .build_and_start()
+                    .await
+                {
+                    Ok(mut session) => {
+                        let request = ListUsersRequest::try_new("127.0.0.1:22911", "").unwrap();
+                        let result = session.list_users(&request).await;
+                        session.shutdown().await;
+                        result
+                    }
+                    Err(error) => Err(error),
+                };
+                outcomes.push(result);
+            }
+            runtime.shutdown().await;
+            outcomes
+        });
+        owner.shutdown_runtime_blocking().unwrap();
+        assert!(
+            outcomes[0]
+                .as_ref()
+                .unwrap()
+                .users
+                .iter()
+                .any(|user| { user.username.as_deref() == Some("tauri-dev-admin") })
+        );
+        assert!(outcomes[1].is_err(), "anonymous requests must be rejected");
+        assert!(outcomes[2].is_err(), "incorrect signatures must be rejected");
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/db.rs
@@ -71,6 +71,7 @@ pub(super) fn load(connection: &Connection) -> DashboardResult<ConnectionSetting
         })
         .map(|endpoint| endpoint.endpoint_id.clone());
     Ok(ConnectionSettingsView {
+        credentials_configured: false,
         revision,
         endpoints,
         current_nameserver_id,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/service.rs
@@ -35,7 +35,7 @@ impl ConnectionManager {
         storage: StorageManager,
         runtime: Arc<NameServerRuntimeState>,
     ) -> DashboardResult<Self> {
-        let view = storage
+        let mut view = storage
             .run("connection-initialize", |connection| {
                 let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
                 db::ensure_identities(&transaction)?;
@@ -44,6 +44,7 @@ impl ConnectionManager {
                 Ok(view)
             })
             .await?;
+        view.credentials_configured = runtime.credentials_configured();
         Ok(Self {
             storage,
             runtime,
@@ -105,7 +106,8 @@ impl ConnectionManager {
                     "UPDATE connection_metadata SET revision = revision + 1 WHERE id = 1",
                     [],
                 )?;
-                let view = db::load(&transaction)?;
+                let mut view = db::load(&transaction)?;
+                view.credentials_configured = runtime.credentials_configured();
                 audit.set_environment(view.environment_id.clone())?;
                 audit.record_local_success(&transaction)?;
                 // Lock publication before committing; a poisoned state must not commit an invisible configuration.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/types.rs
@@ -43,6 +43,7 @@ pub(crate) struct EndpointView {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConnectionSettingsView {
     pub(crate) revision: i64,
+    pub(crate) credentials_configured: bool,
     pub(crate) endpoints: Vec<EndpointView>,
     pub(crate) current_nameserver_id: Option<String>,
     pub(crate) current_proxy_id: Option<String>,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/admin.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::connection::AdminPurpose;
 use crate::consumer::types::ConsumerResult;
 use crate::error::DashboardError as ConsumerError;
 use crate::nameserver::NameServerRuntimeState;
-use rocketmq_admin_core::client_adapter::AdminBuilder;
 use rocketmq_admin_core::client_adapter::AdminSession;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
 use std::sync::Arc;
-use uuid::Uuid;
 
 pub(crate) struct ManagedConsumerAdmin {
     pub(crate) admin: AdminSession,
@@ -30,18 +29,8 @@ pub(crate) struct ManagedConsumerAdmin {
 impl ManagedConsumerAdmin {
     pub(crate) async fn connect(runtime: &Arc<NameServerRuntimeState>) -> ConsumerResult<Self> {
         let (snapshot, generation) = runtime.snapshot_and_generation();
-        let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
-            ConsumerError::Configuration(
-                "No active NameServer is configured. Add and select a NameServer first.".into(),
-            )
-        })?;
-
-        let admin = AdminBuilder::new(runtime.client_runtime())
-            .admin_group(format!("dashboard-consumer-admin-{}", Uuid::new_v4()))
-            .namesrv_addr(current_namesrv)
-            .timeout_millis(5_000)
-            .vip_channel_enabled(snapshot.use_vip_channel)
-            .use_tls(snapshot.use_tls)
+        let admin = runtime
+            .admin_builder(&snapshot, AdminPurpose::Consumer)?
             .build_and_start()
             .await
             .map_err(ConsumerError::from)?;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -121,9 +121,10 @@ fn initialize_services(
     log::info!("Local NameServer SQLite tables initialized");
 
     let nameserver_store = nameserver::SqliteNameServerStore::new(nameserver_db.clone());
-    let nameserver_runtime = Arc::new(nameserver::NameServerRuntimeState::new(
+    let nameserver_runtime = Arc::new(nameserver::NameServerRuntimeState::with_admin_config(
         nameserver_store.load_snapshot()?,
         client_runtime,
+        connection::AdminConnectionConfig::from_environment()?,
     ));
     let nameserver_manager = nameserver::NameServerManager::new(nameserver_db, nameserver_runtime.clone())?;
     let cluster_manager = cluster::ClusterManager::new(nameserver_runtime.clone());

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/admin.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::connection::AdminPurpose;
 use crate::error::DashboardError as MessageError;
 use crate::message::types::MessageResult;
 use crate::nameserver::NameServerRuntimeState;
-use rocketmq_admin_core::client_adapter::AdminBuilder;
 use rocketmq_admin_core::client_adapter::AdminSession;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
 use std::sync::Arc;
-use uuid::Uuid;
 
 pub(crate) struct ManagedMessageAdmin {
     pub(crate) admin: AdminSession,
@@ -30,16 +29,8 @@ pub(crate) struct ManagedMessageAdmin {
 impl ManagedMessageAdmin {
     pub(crate) async fn connect(runtime: &Arc<NameServerRuntimeState>) -> MessageResult<Self> {
         let (snapshot, generation) = runtime.snapshot_and_generation();
-        let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
-            MessageError::Configuration("No active NameServer is configured. Add and select a NameServer first.".into())
-        })?;
-
-        let admin = AdminBuilder::new(runtime.client_runtime())
-            .admin_group(format!("dashboard-message-admin-{}", Uuid::new_v4()))
-            .namesrv_addr(current_namesrv)
-            .timeout_millis(5_000)
-            .vip_channel_enabled(snapshot.use_vip_channel)
-            .use_tls(snapshot.use_tls)
+        let admin = runtime
+            .admin_builder(&snapshot, AdminPurpose::Message)?
             .build_and_start()
             .await
             .map_err(MessageError::from)?;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/runtime.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/runtime.rs
@@ -38,6 +38,7 @@ struct RuntimeState {
 
 pub(crate) struct NameServerRuntimeState {
     state: Mutex<RuntimeState>,
+    admin_config: crate::connection::AdminConnectionConfig,
     client_runtime: Arc<ClientRuntime>,
     reset_hook: Arc<dyn ClientResetHook>,
 }
@@ -53,6 +54,7 @@ impl NameServerRuntimeState {
         reset_hook: Arc<dyn ClientResetHook>,
     ) -> Self {
         Self {
+            admin_config: crate::connection::AdminConnectionConfig::default(),
             state: Mutex::new(RuntimeState {
                 snapshot,
                 generation: 0,
@@ -60,6 +62,42 @@ impl NameServerRuntimeState {
             client_runtime,
             reset_hook,
         }
+    }
+
+    pub(crate) fn with_admin_config(
+        snapshot: NameServerConfigSnapshot,
+        client_runtime: Arc<ClientRuntime>,
+        config: crate::connection::AdminConnectionConfig,
+    ) -> Self {
+        let mut runtime = Self::new(snapshot, client_runtime);
+        runtime.admin_config = config;
+        runtime
+    }
+
+    pub(crate) fn credentials_configured(&self) -> bool {
+        self.admin_config.credentials_configured()
+    }
+
+    pub(crate) fn admin_builder(
+        &self,
+        snapshot: &NameServerConfigSnapshot,
+        purpose: crate::connection::AdminPurpose,
+    ) -> crate::error::DashboardResult<rocketmq_admin_core::client_adapter::AdminBuilder> {
+        let address = snapshot
+            .current_namesrv
+            .as_deref()
+            .ok_or_else(|| crate::error::DashboardError::Configuration("select an active NameServer".into()))?;
+        Ok(self.admin_builder_for(snapshot, address, purpose))
+    }
+
+    pub(crate) fn admin_builder_for(
+        &self,
+        snapshot: &NameServerConfigSnapshot,
+        address: &str,
+        purpose: crate::connection::AdminPurpose,
+    ) -> rocketmq_admin_core::client_adapter::AdminBuilder {
+        self.admin_config
+            .builder(self.client_runtime(), snapshot, address, purpose)
     }
 
     pub(crate) fn client_runtime(&self) -> Arc<ClientRuntime> {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::connection::AdminPurpose;
 use crate::error::DashboardResult as Result;
 use crate::nameserver::db::NameServerDb;
 #[cfg(test)]
@@ -19,7 +20,6 @@ use crate::nameserver::db::SqliteNameServerStore;
 use crate::nameserver::runtime::NameServerRuntimeState;
 use crate::nameserver::types::NameServerHomePageView;
 use crate::nameserver::types::NameServerStatusItem;
-use rocketmq_admin_core::client_adapter::AdminBuilder;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
 #[cfg(test)]
 use rocketmq_dashboard_common::NameServerMutationResult;
@@ -28,9 +28,6 @@ use rocketmq_dashboard_common::NameServerService;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use uuid::Uuid;
-
-const NAMESERVER_PROBE_TIMEOUT_MILLIS: u64 = 1_500;
 
 pub(crate) trait NameServerProbe: Send + Sync {
     fn probe<'a>(
@@ -41,7 +38,7 @@ pub(crate) trait NameServerProbe: Send + Sync {
 }
 
 struct DefaultNameServerProbe {
-    client_runtime: Arc<rocketmq_admin_core::client_adapter::ClientRuntime>,
+    runtime: Arc<NameServerRuntimeState>,
 }
 
 impl NameServerProbe for DefaultNameServerProbe {
@@ -51,12 +48,9 @@ impl NameServerProbe for DefaultNameServerProbe {
         address: &'a str,
     ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
         Box::pin(async move {
-            let mut admin = match AdminBuilder::new(Arc::clone(&self.client_runtime))
-                .admin_group(format!("dashboard-nameserver-probe-{}", Uuid::new_v4()))
-                .namesrv_addr(address)
-                .timeout_millis(NAMESERVER_PROBE_TIMEOUT_MILLIS)
-                .vip_channel_enabled(snapshot.use_vip_channel)
-                .use_tls(snapshot.use_tls)
+            let mut admin = match self
+                .runtime
+                .admin_builder_for(snapshot, address, AdminPurpose::Probe)
                 .build_and_start()
                 .await
             {
@@ -94,7 +88,7 @@ pub(crate) struct NameServerManager {
 impl NameServerManager {
     pub(crate) fn new(db: NameServerDb, runtime: Arc<NameServerRuntimeState>) -> Result<Self> {
         let probe = Arc::new(DefaultNameServerProbe {
-            client_runtime: runtime.client_runtime(),
+            runtime: runtime.clone(),
         });
         Self::with_probe(db, runtime, probe)
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/admin.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::connection::AdminPurpose;
 use crate::error::DashboardError as ProducerError;
 use crate::nameserver::NameServerRuntimeState;
 use crate::producer::types::ProducerResult;
-use rocketmq_admin_core::client_adapter::AdminBuilder;
 use rocketmq_admin_core::client_adapter::AdminSession;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
 use std::sync::Arc;
-use uuid::Uuid;
 
 pub(crate) struct ManagedProducerAdmin {
     pub(crate) admin: AdminSession,
@@ -30,18 +29,8 @@ pub(crate) struct ManagedProducerAdmin {
 impl ManagedProducerAdmin {
     pub(crate) async fn connect(runtime: &Arc<NameServerRuntimeState>) -> ProducerResult<Self> {
         let (snapshot, generation) = runtime.snapshot_and_generation();
-        let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
-            ProducerError::Configuration(
-                "No active NameServer is configured. Add and select a NameServer first.".into(),
-            )
-        })?;
-
-        let admin = AdminBuilder::new(runtime.client_runtime())
-            .admin_group(format!("dashboard-producer-admin-{}", Uuid::new_v4()))
-            .namesrv_addr(current_namesrv)
-            .timeout_millis(5_000)
-            .vip_channel_enabled(snapshot.use_vip_channel)
-            .use_tls(snapshot.use_tls)
+        let admin = runtime
+            .admin_builder(&snapshot, AdminPurpose::Producer)?
             .build_and_start()
             .await
             .map_err(ProducerError::from)?;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/admin.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::connection::AdminPurpose;
 use crate::error::DashboardError as TopicError;
 use crate::nameserver::NameServerRuntimeState;
 use crate::topic::types::TopicResult;
-use rocketmq_admin_core::client_adapter::AdminBuilder;
 use rocketmq_admin_core::client_adapter::AdminSession;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
 use std::sync::Arc;
-use uuid::Uuid;
 
 pub(crate) struct ManagedTopicAdmin {
     pub(crate) admin: AdminSession,
@@ -30,16 +29,8 @@ pub(crate) struct ManagedTopicAdmin {
 impl ManagedTopicAdmin {
     pub(crate) async fn connect(runtime: &Arc<NameServerRuntimeState>) -> TopicResult<Self> {
         let (snapshot, generation) = runtime.snapshot_and_generation();
-        let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
-            TopicError::Configuration("No active NameServer is configured. Add and select a NameServer first.".into())
-        })?;
-
-        let admin = AdminBuilder::new(runtime.client_runtime())
-            .admin_group(format!("dashboard-topic-admin-{}", Uuid::new_v4()))
-            .namesrv_addr(current_namesrv)
-            .timeout_millis(5_000)
-            .vip_channel_enabled(snapshot.use_vip_channel)
-            .use_tls(snapshot.use_tls)
+        let admin = runtime
+            .admin_builder(&snapshot, AdminPurpose::Topic)?
             .build_and_start()
             .await
             .map_err(TopicError::from)?;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/NameServerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/NameServerView.tsx
@@ -392,6 +392,10 @@ export const NameServerView = () => {
                         </div>
 
                         <div className="nameserver-security-list">
+                            <div className="px-4 py-3 text-sm">
+                                <strong>RocketMQ credentials: {data?.settings.credentialsConfigured ? 'Configured' : 'Not configured'}</strong>
+                                <p>Management credentials are set when the app starts. Restart after changing them.</p>
+                            </div>
                             <SecurityRow
                                 icon={Wifi}
                                 label="VIP Channel"

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
     } });
     SessionStorageService.setSessionId('current-token');
     ConnectionStore.reset();
-    ConnectionStore.accept('current-token', { revision: 0, endpoints: [], currentNameserverId: null, currentProxyId: null, environmentId: null, nameserver: { currentNamesrv: null, namesrvAddrList: [], useVIPChannel: false, useTLS: false }, proxy: { currentProxyAddr: null, proxyAddrList: [] } });
+    ConnectionStore.accept('current-token', { revision: 0, credentialsConfigured: false, endpoints: [], currentNameserverId: null, currentProxyId: null, environmentId: null, nameserver: { currentNamesrv: null, namesrvAddrList: [], useVIPChannel: false, useTLS: false }, proxy: { currentProxyAddr: null, proxyAddrList: [] } });
 });
 afterEach(() => { vi.resetAllMocks(); vi.unstubAllGlobals(); });
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/connection.store.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/connection.store.ts
@@ -3,6 +3,7 @@ import type { NameServerConfigSnapshot } from '../features/nameserver/types/name
 import type { ProxyConfigSnapshot } from '../features/proxy/types/proxy.types';
 export interface ConnectionSettingsView {
     revision: number;
+    credentialsConfigured: boolean;
     endpoints: Array<{ endpointId: string; kind: 'name_server' | 'proxy'; address: string; environmentId: string | null }>;
     currentNameserverId: string | null; currentProxyId: string | null; environmentId: string | null;
     nameserver: NameServerConfigSnapshot; proxy: ProxyConfigSnapshot;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10373

### Brief Description
Read paired RocketMQ credentials at desktop startup and apply them through a shared internal AdminBuilder across every administration module and NameServer probe. Keep credentials in backend memory; connection settings expose only credentialsConfigured. Existing session ownership and transport settings remain intact.

Add a separate local-source Rust ACL Compose fixture and document restart-based configuration and the admin-core HMAC-SHA256 requirement. The opt-in smoke checks successful signed queries and rejects anonymous and incorrect signatures.

### How Did You Test This Change?
- Backend: cargo test --lib connection:: (7 passed; live test skipped by default), cargo test --lib nameserver:: (8 passed).
- Real ACL Broker: cargo test --lib local_acl_query -- --ignored (passed against the local Rust fixture).
- Package format check passed; package-scoped formatting avoids the Windows command-length failure of the all-workspace path-dependency invocation.
- Frontend: npm run build and npx vitest run src/services/auth-session.test.ts (12 passed; existing bundle-size warning).
- Docker Compose validation and both ACL fixture readiness checks passed; git diff --check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring RocketMQ administration credentials through environment variables.
  * Added credential status to connection settings and displayed it in the NameServer security panel.
  * Added an isolated development fixture for testing ACL authentication.

* **Documentation**
  * Documented credential configuration, validation, restart requirements, and ACL fixture usage.

* **Bug Fixes**
  * Standardized administration connections across cluster, consumer, message, producer, topic, and probe operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->