### PR TITLE
[ISSUE #10375]🚀Add exact Tauri entity navigation and return history

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ENTITY_NAVIGATION.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ENTITY_NAVIGATION.md
@@ -1,0 +1,22 @@
+# Desktop entity navigation
+
+The app store exposes `openTopic(name, detail)`,
+`openConsumer(group, detail, proxyAddress?)`, `openBroker(address, detail)`, and
+`goBack()`. Targets are discriminated by entity kind, contain an exact identity
+and detail selection, and belong to the current connection environment. They
+are browsing state, never authorization evidence.
+
+Topic route and consumer panels link to their corresponding entities; Consumer
+topic details link back to Topic. Read-only detail actions create history entries.
+The Back control restores the source entry, including list selection, filters,
+search, and pagination. History is bounded to twenty entries and discarded on
+environment change or logout. Stale Broker responses cannot reopen closed sheets.
+Each target is resolved against the loaded catalog; an explicit missing target
+shows a not-found message rather than selecting the first row.
+
+Sessions and Audit are available from Governance. Monitors and Storage are
+reserved navigation types; their entries stay hidden until their pages are
+implemented.
+
+Validate from the app root with `npm run build` and
+`npx vitest run src/stores/navigation.test.ts src/services/auth-session.test.ts`.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
@@ -64,7 +64,8 @@ const NAV_SECTIONS = [
         title: 'Governance',
         items: [
             {tab: 'ACL', label: 'ACL', icon: Shield},
-            {tab: 'Audit', label: 'Audit', icon: Shield}
+            {tab: 'Audit', label: 'Audit', icon: Shield},
+            {tab: 'Sessions', label: 'Sessions', icon: UserRound}
         ]
     }
 ] as const;
@@ -82,6 +83,7 @@ const PAGE_SUMMARIES: Record<string, string> = {
     DLQ: 'Dead-letter queue search, retry context, and payload inspection.',
     ACL: 'Access-control resources, credentials, and permission posture.',
     Audit: 'Operation history, outcomes, and audit receipts.',
+    Sessions: 'Active, expired, and revoked sessions for your account.',
     Account: 'Local administrator profile, active session, and account security.'
 };
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -16,17 +16,21 @@ import {MessageTraceView} from '../../components/MessageTraceView';
 import {DLQMessageView} from '../../components/DLQMessageView';
 import {Activity} from 'lucide-react';
 import {AuditPage} from '../../pages/audit/AuditPage';
+import {SessionsPanel} from '../../pages/account/SessionsPanel';
 import {AccountPage} from '../../pages/account/AccountPage';
 
 export const AppRouter = () => {
     const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
-    const { activeTab } = useAppStore();
-    const key = ['NameServer', 'Proxy', 'Account', 'Audit'].includes(activeTab) ? activeTab : `${activeTab}:${settings?.revision ?? 0}`;
-    return <RouteContent key={key} />;
+    const { activeTab, navigation, canGoBack, goBack } = useAppStore();
+    const key = ['NameServer', 'Proxy', 'Account', 'Sessions', 'Audit'].includes(activeTab) ? activeTab : `${activeTab}:${settings?.revision ?? 0}`;
+    return <><div className="flex items-center gap-3 px-6 py-2">
+        {canGoBack && <button type="button" className="text-sm underline" onClick={goBack}>Back</button>}
+        {navigation.target && <span className="text-sm text-gray-500">{navigation.target.kind}: {'name' in navigation.target ? navigation.target.name : navigation.target.address}</span>}
+    </div><RouteContent key={`${key}:${navigation.id}`} /></>;
 };
 
 const RouteContent = () => {
-    const {activeTab} = useAppStore();
+    const {activeTab, currentUser} = useAppStore();
 
     switch (activeTab) {
         case 'NameServer':
@@ -53,6 +57,8 @@ const RouteContent = () => {
             return <ACLView/>;
         case 'Audit':
             return <AuditPage/>;
+        case 'Sessions':
+            return currentUser ? <SessionsPanel username={currentUser.username}/> : null;
         case 'Account':
             return <AccountPage/>;
         default:

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ClusterView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ClusterView.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useAppStore, useNavigationState } from '../stores/app.store';
+import React, { useEffect, useMemo, useState, useRef, type ReactNode } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
   Activity,
@@ -81,6 +82,11 @@ const BrokerTpsTile = ({
 );
 
 export const ClusterView = () => {
+  const { navigation, openBroker, goBack } = useAppStore();
+  const target = navigation.target?.kind === 'broker' ? navigation.target : null;
+  const openedTarget = useRef(false);
+  const sheetGeneration = useRef(0);
+  useEffect(() => () => { sheetGeneration.current += 1; }, []);
   const {
     data,
     isLoading,
@@ -92,7 +98,7 @@ export const ClusterView = () => {
     getBrokerConfig,
     getBrokerStatus,
   } = useClusterCatalog();
-  const [selectedCluster, setSelectedCluster] = useState('');
+  const [selectedCluster, setSelectedCluster] = useNavigationState('cluster', '');
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [detailSheet, setDetailSheet] = useState<{
     isOpen: boolean;
@@ -107,6 +113,10 @@ export const ClusterView = () => {
   });
 
   useEffect(() => {
+    if (target) {
+      setSelectedCluster(data?.items.find((item) => item.address === target.address)?.clusterName ?? '');
+      return;
+    }
     if (!data?.clusters.length) {
       setSelectedCluster('');
       return;
@@ -117,7 +127,8 @@ export const ClusterView = () => {
     );
   }, [data?.clusters]);
 
-  const visibleCluster = selectedCluster || data?.clusters[0] || '';
+  const visibleCluster = selectedCluster || (target ? '' : data?.clusters[0]) || '';
+  const targetMissing = target && data && !isLoading && !loadError && !data.items.some((item) => item.address === target.address);
 
   const clusterData = useMemo(
     () => (data?.items ?? []).filter((broker) => broker.clusterName === visibleCluster),
@@ -205,6 +216,7 @@ export const ClusterView = () => {
         : 'No brokers available';
 
   const openStatusSheet = async (brokerData: ClusterBrokerCardItem) => {
+    const generation = ++sheetGeneration.current;
     setDetailSheet({
       isOpen: true,
       type: 'Status',
@@ -217,6 +229,7 @@ export const ClusterView = () => {
 
     try {
       const status = await getBrokerStatus(brokerData.address);
+      if (generation !== sheetGeneration.current) return;
       setDetailSheet({
         isOpen: true,
         type: 'Status',
@@ -227,6 +240,7 @@ export const ClusterView = () => {
         },
       });
     } catch (error) {
+      if (generation !== sheetGeneration.current) return;
       const message = dashboardErrorMessage(error, 'Failed to load broker status');
       setDetailSheet({
         isOpen: true,
@@ -242,6 +256,7 @@ export const ClusterView = () => {
   };
 
   const openConfigSheet = async (brokerData: ClusterBrokerCardItem) => {
+    const generation = ++sheetGeneration.current;
     setDetailSheet({
       isOpen: true,
       type: 'Config',
@@ -254,6 +269,7 @@ export const ClusterView = () => {
 
     try {
       const config = await getBrokerConfig(brokerData.address);
+      if (generation !== sheetGeneration.current) return;
       setDetailSheet({
         isOpen: true,
         type: 'Config',
@@ -264,6 +280,7 @@ export const ClusterView = () => {
         },
       });
     } catch (error) {
+      if (generation !== sheetGeneration.current) return;
       const message = dashboardErrorMessage(error, 'Failed to load broker config');
       setDetailSheet({
         isOpen: true,
@@ -278,6 +295,15 @@ export const ClusterView = () => {
     }
   };
 
+  useEffect(() => {
+    if (!target || openedTarget.current || !data || isLoading) return;
+    const broker = data.items.find((item) => item.address === target.address);
+    if (!broker) return;
+    openedTarget.current = true;
+    if (target.detail === 'status') void openStatusSheet(broker);
+    if (target.detail === 'config') void openConfigSheet(broker);
+  }, [target, data, isLoading]);
+
   const handleRefresh = async () => {
     try {
       await refresh();
@@ -290,9 +316,10 @@ export const ClusterView = () => {
 
   return (
     <div className="cluster-page">
+      {targetMissing && <p role="alert" className="p-4 text-red-600">Broker not found: {target.address}</p>}
       <SideSheet
         isOpen={detailSheet.isOpen}
-        onClose={() => setDetailSheet({ ...detailSheet, isOpen: false })}
+        onClose={() => { sheetGeneration.current += 1; setDetailSheet({ ...detailSheet, isOpen: false }); if (target) goBack(); }}
         title={detailSheet.title}
         data={detailSheet.data}
         type={detailSheet.type}
@@ -602,7 +629,7 @@ export const ClusterView = () => {
                 <div className="cluster-broker-actions">
                   <Button
                     variant="secondary"
-                    onClick={() => void openStatusSheet(broker)}
+                    onClick={() => openBroker(broker.address, 'status')}
                     className="cluster-action-button"
                     disabled={pendingStatusAddr === broker.address}
                   >
@@ -610,7 +637,7 @@ export const ClusterView = () => {
                   </Button>
                   <Button
                     variant="primary"
-                    onClick={() => void openConfigSheet(broker)}
+                    onClick={() => openBroker(broker.address, 'config')}
                     className="cluster-action-button"
                     disabled={pendingConfigAddr === broker.address}
                   >

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useAppStore, useNavigationState } from '../stores/app.store';
+import { findEntity } from '../stores/navigation';
+import React, { useEffect, useMemo, useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { 
   Users, 
@@ -943,21 +945,25 @@ const LegacyConsumerCardView = () => {
 };
 
 export const ConsumerView = () => {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [filters, setFilters] = useState<Record<string, boolean>>({
+  const { navigation, openConsumer, goBack } = useAppStore();
+  const target = navigation.target?.kind === 'consumer' ? navigation.target : null;
+  const openedTarget = useRef(false);
+
+  const [searchTerm, setSearchTerm] = useNavigationState('search', '');
+  const [filters, setFilters] = useNavigationState<Record<string, boolean>>('filters', {
     NORMAL: true,
-    FIFO: false,
+    FIFO: !!target,
     SYSTEM: true,
   });
-  const [proxy, setProxy] = useState('127.0.0.1:8080');
-  const [enableProxy, setEnableProxy] = useState(false);
+  const [proxy, setProxy] = useNavigationState('proxy', target?.proxyAddress ?? '127.0.0.1:8080');
+  const [enableProxy, setEnableProxy] = useNavigationState('enableProxy', !!target?.proxyAddress);
   const [detailModal, setDetailModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
   const [configModal, setConfigModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
   const [clientModal, setClientModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
   const [editorModal, setEditorModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null, preferredBrokerAddress?: string }>({isOpen: false, consumer: null});
   const [deleteModal, setDeleteModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
-  const [selectedGroup, setSelectedGroup] = useState('');
-  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedGroup, setSelectedGroup] = useNavigationState('selection', target?.name ?? '');
+  const [currentPage, setCurrentPage] = useNavigationState('page', 1);
   const itemsPerPage = 6;
   const sourceAddress = enableProxy ? proxy : undefined;
   const {
@@ -996,22 +1002,20 @@ export const ConsumerView = () => {
     (currentPage - 1) * itemsPerPage,
     currentPage * itemsPerPage,
   );
-  const selectedConsumer =
-    filteredConsumers.find((consumer) => consumer.rawGroupName === selectedGroup) ??
-    currentConsumers[0] ??
-    filteredConsumers[0] ??
-    null;
+  const selectedConsumer = findEntity(target ? items : filteredConsumers, (consumer) => consumer.rawGroupName, selectedGroup || null);
+  const targetMissing = target && response && !isInitialLoading && !error && !items.some((item) => item.rawGroupName === target.name);
   const activeClientCount = items.reduce((total, consumer) => total + consumer.connectionCount, 0);
   const totalLag = items.reduce((total, consumer) => total + consumer.diffTotal, 0);
   const lagHealthClass = selectedConsumer && selectedConsumer.diffTotal > 0 ? 'is-warning' : 'is-healthy';
 
   useEffect(() => {
-    if (currentPage > totalPages) {
+    if (response && currentPage > totalPages) {
       setCurrentPage(totalPages);
     }
   }, [currentPage, totalPages]);
 
   useEffect(() => {
+    if (target || !response) return;
     if (filteredConsumers.length === 0) {
       setSelectedGroup('');
       return;
@@ -1020,6 +1024,15 @@ export const ConsumerView = () => {
       setSelectedGroup(filteredConsumers[0].rawGroupName);
     }
   }, [filteredConsumers, selectedGroup]);
+
+  useEffect(() => {
+    if (!target || openedTarget.current || !response || isInitialLoading) return;
+    const consumer = items.find((item) => item.rawGroupName === target.name);
+    if (!consumer) return;
+    openedTarget.current = true;
+    const setters = { progress: setDetailModal, config: setConfigModal, clients: setClientModal };
+    if (target.detail !== 'overview') setters[target.detail]({ isOpen: true, consumer });
+  }, [target, response, isInitialLoading, items]);
 
   const toggleFilter = (key: string) => {
     setCurrentPage(1);
@@ -1066,21 +1079,22 @@ export const ConsumerView = () => {
 
   return (
     <div className="consumer-page">
+      {targetMissing && <p role="alert" className="p-4 text-red-600">Consumer group not found: {target.name}</p>}
       <ConsumerDetailModal
         isOpen={detailModal.isOpen}
-        onClose={() => setDetailModal({isOpen: false, consumer: null})}
+        onClose={() => { setDetailModal({isOpen: false, consumer: null}); if (target) goBack(); }}
         consumer={detailModal.consumer}
         address={sourceAddress}
       />
       <ConsumerConfigModal
         isOpen={configModal.isOpen}
-        onClose={() => setConfigModal({isOpen: false, consumer: null})}
+        onClose={() => { setConfigModal({isOpen: false, consumer: null}); if (target) goBack(); }}
         consumer={configModal.consumer}
         onEdit={handleEditFromConfig}
       />
       <ConsumerClientModal
         isOpen={clientModal.isOpen}
-        onClose={() => setClientModal({isOpen: false, consumer: null})}
+        onClose={() => { setClientModal({isOpen: false, consumer: null}); if (target) goBack(); }}
         consumer={clientModal.consumer}
         address={sourceAddress}
       />
@@ -1374,15 +1388,15 @@ export const ConsumerView = () => {
                 </div>
 
                 <div className="consumer-action-grid">
-                  <button type="button" className="topic-action-button" onClick={() => setClientModal({isOpen: true, consumer: selectedConsumer})}>
+                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'clients', sourceAddress)}>
                     <Users className="topic-icon" aria-hidden="true"/>
                     <span>Client</span>
                   </button>
-                  <button type="button" className="topic-action-button" onClick={() => setDetailModal({isOpen: true, consumer: selectedConsumer})}>
+                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'progress', sourceAddress)}>
                     <FileText className="topic-icon" aria-hidden="true"/>
                     <span>Detail</span>
                   </button>
-                  <button type="button" className="topic-action-button" onClick={() => setConfigModal({isOpen: true, consumer: selectedConsumer})}>
+                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'config', sourceAddress)}>
                     <Settings className="topic-icon" aria-hidden="true"/>
                     <span>Config</span>
                   </button>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
@@ -1,4 +1,6 @@
-import React, {useEffect, useMemo, useState, ReactNode} from 'react';
+import { useAppStore, useNavigationState } from '../stores/app.store';
+import { findEntity } from '../stores/navigation';
+import React, {useEffect, useMemo, useState, useRef, ReactNode} from 'react';
 import {motion, AnimatePresence} from 'motion/react';
 import {
     Activity,
@@ -147,6 +149,7 @@ interface TopicRouterModalProps {
 }
 
 const TopicRouterModal = ({isOpen, onClose, topic}: TopicRouterModalProps) => {
+    const { openBroker } = useAppStore();
     const [routeData, setRouteData] = useState<TopicRouteView | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
@@ -407,7 +410,7 @@ const TopicRouterModal = ({isOpen, onClose, topic}: TopicRouterModalProps) => {
                                             <div className="topic-router-map-card is-broker">
                                                 <span>Broker</span>
                                                 <strong>{selectedBroker.brokerName}</strong>
-                                                <small>{selectedBroker.addresses[0]?.address ?? 'No address'}</small>
+                                                <small>{selectedBroker.addresses[0] ? <button type="button" className="underline" onClick={() => openBroker(selectedBroker.addresses[0].address, 'status')}>{selectedBroker.addresses[0].address}</button> : 'No address'}</small>
                                             </div>
                                         </div>
                                     ) : (
@@ -1272,6 +1275,7 @@ const TopicStatusModal = ({isOpen, onClose, topic}: TopicRouterModalProps) => {
 };
 
 const TopicConsumerManageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) => {
+    const { openConsumer } = useAppStore();
     const [consumerItems, setConsumerItems] = useState<TopicConsumerInfoView[]>([]);
     const [selectedConsumerGroup, setSelectedConsumerGroup] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
@@ -1490,7 +1494,7 @@ const TopicConsumerManageModal = ({isOpen, onClose, topic}: TopicRouterModalProp
                                             <>
                                                 <div className="topic-consumer-selected-name">
                                                     <span>{selectedConsumer.totalDiff > 0 ? 'Lagging' : 'Caught up'}</span>
-                                                    <strong>{selectedConsumer.consumerGroup}</strong>
+                                                    <button type="button" className="underline" onClick={() => openConsumer(selectedConsumer.consumerGroup, 'progress')}>{selectedConsumer.consumerGroup}</button>
                                                 </div>
 
                                                 <div className={`topic-consumer-pressure-card ${selectedConsumer.totalDiff > 0 ? 'is-warning' : 'is-healthy'}`}>
@@ -2972,11 +2976,15 @@ const TopicActionButton = ({
 };
 
 export const TopicView = () => {
+    const { navigation, openTopic, goBack } = useAppStore();
+    const target = navigation.target?.kind === 'topic' ? navigation.target : null;
+    const openedTarget = useRef(false);
+
     const {data, error, isLoading, isRefreshPending, isRefreshing, refresh} = useTopicCatalog();
-    const [searchTerm, setSearchTerm] = useState('');
-    const [selectedFilters, setSelectedFilters] = useState<Record<TopicCategory, boolean>>(buildDefaultTopicFilters);
-    const [currentPage, setCurrentPage] = useState(1);
-    const [selectedTopicName, setSelectedTopicName] = useState<string | null>(null);
+    const [searchTerm, setSearchTerm] = useNavigationState('search', '');
+    const [selectedFilters, setSelectedFilters] = useNavigationState<Record<TopicCategory, boolean>>('filters', () => target ? Object.fromEntries(TOPIC_FILTER_ORDER.map((key) => [key, true])) as Record<TopicCategory, boolean> : buildDefaultTopicFilters());
+    const [currentPage, setCurrentPage] = useNavigationState('page', 1);
+    const [selectedTopicName, setSelectedTopicName] = useNavigationState<string | null>('selection', target?.name ?? null);
     const [editorModal, setEditorModal] = useState<{ isOpen: boolean, mode: 'create' | 'update', seed: TopicEditorSeed | null }>({
         isOpen: false,
         mode: 'create',
@@ -3028,7 +3036,8 @@ export const TopicView = () => {
         (currentPage - 1) * TOPIC_PAGE_SIZE,
         currentPage * TOPIC_PAGE_SIZE,
     );
-    const selectedTopic = filteredTopics.find((topic) => topic.name === selectedTopicName) ?? filteredTopics[0] ?? null;
+    const selectedTopic = findEntity(target ? topics : filteredTopics, (topic) => topic.name, selectedTopicName);
+    const targetMissing = target && data && !isLoading && !error && !topics.some((topic) => topic.name === target.name);
     const topicTypeCounts = useMemo(
         () =>
             TOPIC_FILTER_ORDER.reduce((acc, key) => {
@@ -3043,17 +3052,20 @@ export const TopicView = () => {
     const targetBrokerCount = data?.targets.reduce((sum, target) => sum + target.brokerNames.length, 0) ?? 0;
     const activeFilterCount = TOPIC_FILTER_ORDER.filter((key) => selectedFilters[key]).length;
 
+    const previousFilter = useRef({ normalizedSearch, selectedFilters });
     useEffect(() => {
-        setCurrentPage(1);
+        if (previousFilter.current.normalizedSearch !== normalizedSearch || previousFilter.current.selectedFilters !== selectedFilters) setCurrentPage(1);
+        previousFilter.current = { normalizedSearch, selectedFilters };
     }, [normalizedSearch, selectedFilters]);
 
     useEffect(() => {
-        if (currentPage > totalPages) {
+        if (data && currentPage > totalPages) {
             setCurrentPage(totalPages);
         }
     }, [currentPage, totalPages]);
 
     useEffect(() => {
+        if (target || !data) return;
         if (filteredTopics.length === 0) {
             if (selectedTopicName !== null) {
                 setSelectedTopicName(null);
@@ -3071,6 +3083,8 @@ export const TopicView = () => {
     };
 
     const handleOperation = (op: string, topic: Topic) => {
+        const detail = ({ Status: 'status', Router: 'route', 'Topic Config': 'config', 'Consumer Manage': 'consumers' } as const)[op as 'Status'];
+        if (detail) { openTopic(topic.name, detail); return; }
         if (op === 'Status') {
             setStatusModal({isOpen: true, topic});
         } else if (op === 'Router') {
@@ -3091,6 +3105,15 @@ export const TopicView = () => {
             toast(`${op} clicked for ${topic.name}`);
         }
     };
+
+    useEffect(() => {
+        if (!target || openedTarget.current || !data || isLoading) return;
+        const topic = topics.find((item) => item.name === target.name);
+        if (!topic) return;
+        openedTarget.current = true;
+        const setters = { status: setStatusModal, route: setRouterModal, config: setConfigModal, consumers: setConsumerModal };
+        if (target.detail !== 'overview') setters[target.detail]({ isOpen: true, topic });
+    }, [data, isLoading, target, topics]);
 
     const getActionIcon = (action: string) => {
         switch (action) {
@@ -3147,17 +3170,18 @@ export const TopicView = () => {
         <div className="topic-page animate-in fade-in slide-in-from-bottom-4 duration-500">
             <TopicStatusModal
                 isOpen={statusModal.isOpen}
-                onClose={() => setStatusModal({isOpen: false, topic: null})}
+                onClose={() => { setStatusModal({isOpen: false, topic: null}); if (target) goBack(); }}
                 topic={statusModal.topic}
             />
+            {targetMissing && <p role="alert" className="p-4 text-red-600">Topic not found: {target.name}</p>}
             <TopicRouterModal
                 isOpen={routerModal.isOpen}
-                onClose={() => setRouterModal({isOpen: false, topic: null})}
+                onClose={() => { setRouterModal({isOpen: false, topic: null}); if (target) goBack(); }}
                 topic={routerModal.topic}
             />
             <TopicConfigModal
                 isOpen={configModal.isOpen}
-                onClose={() => setConfigModal({isOpen: false, topic: null})}
+                onClose={() => { setConfigModal({isOpen: false, topic: null}); if (target) goBack(); }}
                 topic={configModal.topic}
                 onRefresh={refresh}
                 onEdit={(seed) => {
@@ -3175,7 +3199,7 @@ export const TopicView = () => {
             />
             <TopicConsumerManageModal
                 isOpen={consumerModal.isOpen}
-                onClose={() => setConsumerModal({isOpen: false, topic: null})}
+                onClose={() => { setConsumerModal({isOpen: false, topic: null}); if (target) goBack(); }}
                 topic={consumerModal.topic}
             />
             <TopicSendMessageModal

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDetailModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDetailModal.tsx
@@ -1,3 +1,4 @@
+import { useAppStore } from '../../../stores/app.store';
 import { useEffect, useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
@@ -50,6 +51,7 @@ export const ConsumerDetailModal = ({
     consumer,
     address,
 }: ConsumerDetailModalProps) => {
+    const { openTopic } = useAppStore();
     const [data, setData] = useState<ConsumerTopicDetailView | null>(null);
     const [selectedTopicName, setSelectedTopicName] = useState('');
     const [isLoading, setIsLoading] = useState(false);
@@ -258,7 +260,7 @@ export const ConsumerDetailModal = ({
                                             <>
                                                 <div className="consumer-topic-detail-panel-header">
                                                     <div>
-                                                        <h4 title={selectedTopic.topic}>{selectedTopic.topic}</h4>
+                                                        <h4 title={selectedTopic.topic}><button type="button" className="underline" onClick={() => openTopic(selectedTopic.topic, 'status')}>{selectedTopic.topic}</button></h4>
                                                         <p>Last consume {formatTimestamp(selectedTopic.lastTimestamp)}</p>
                                                     </div>
                                                     <span className={`consumer-topic-detail-lag-pill ${selectedTopic.diffTotal > 0 ? 'is-warning' : 'is-healthy'}`}>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -1,22 +1,10 @@
-import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useEffect, useState, useReducer, useRef, useSyncExternalStore, ReactNode } from 'react';
 import { subscribeAuditWarning } from '../services/invoke';
 import { SessionStorageService } from '../services/session.storage';
 import type { SessionUser } from '../features/auth/types/auth.types';
 
-type Tab =
-  | 'NameServer'
-  | 'Proxy'
-  | 'Dashboard'
-  | 'Cluster'
-  | 'Topic'
-  | 'Consumer'
-  | 'Producer'
-  | 'Message'
-  | 'MessageTrace'
-  | 'DLQ'
-  | 'ACL'
-  | 'Account'
-  | 'Audit';
+import { ConnectionStore } from '../services/connection.store';
+import { initialNavigation, navigationReducer, type Tab, type EntityTarget, type NavigationLocation } from './navigation';
 
 interface AppState {
   isLoggedIn: boolean;
@@ -25,6 +13,13 @@ interface AppState {
   currentUser: SessionUser | null;
   mustChangePassword: boolean;
   activeTab: Tab;
+  navigation: NavigationLocation;
+  canGoBack: boolean;
+  goBack: () => void;
+  openTopic: (name: string, detail?: Extract<EntityTarget, { kind: 'topic' }>['detail']) => void;
+  openConsumer: (name: string, detail?: Extract<EntityTarget, { kind: 'consumer' }>['detail'], proxyAddress?: string) => void;
+  openBroker: (address: string, detail?: Extract<EntityTarget, { kind: 'broker' }>['detail']) => void;
+  pageStates: React.MutableRefObject<Map<number, Record<string, unknown>>>;
   setActiveTab: (tab: Tab) => void;
   setAuthSession: (sessionId: string, currentUser: SessionUser) => void;
   clearAuthSession: () => void;
@@ -43,7 +38,24 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   const [mustChangePassword, setMustChangePassword] = useState(false);
   const [auditWarning, setAuditWarning] = useState<string | null>(null);
   useEffect(() => subscribeAuditWarning(setAuditWarning), []);
-  const [activeTab, setActiveTab] = useState<Tab>('Dashboard');
+  const [navigationState, navigate] = useReducer(navigationReducer, initialNavigation);
+  const pageStates = useRef(new Map<number, Record<string, unknown>>());
+  const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
+  const environmentId = settings?.environmentId ?? null;
+  const previousEnvironment = useRef(environmentId);
+  const activeTab = navigationState.current.tab;
+  useEffect(() => {
+    if (previousEnvironment.current !== environmentId) {
+      previousEnvironment.current = environmentId;
+      pageStates.current.clear();
+      navigate({ type: 'reset', environmentId });
+    }
+  }, [environmentId]);
+  useEffect(() => {
+    const retained = new Set([navigationState.current.id, ...navigationState.history.map((entry) => entry.id)]);
+    for (const id of pageStates.current.keys()) if (!retained.has(id)) pageStates.current.delete(id);
+  }, [navigationState]);
+  const setActiveTab = (tab: Tab) => navigate({ type: 'open', tab, environmentId });
 
   const getPageTitle = (tab: Tab) => {
     switch (tab) {
@@ -71,6 +83,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         return 'ACL Management';
       case 'Audit':
         return 'Audit Events';
+      case 'Sessions':
+        return 'Account Sessions';
       case 'Account':
         return 'Account Overview';
       default:
@@ -86,6 +100,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const clearAuthSession = () => {
+    pageStates.current.clear();
+    navigate({ type: 'reset', environmentId: null });
     setSessionId(null);
     setCurrentUser(null);
     setMustChangePassword(false);
@@ -110,6 +126,13 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         currentUser,
         mustChangePassword,
         activeTab,
+        navigation: navigationState.current.environmentId === environmentId ? navigationState.current : { ...navigationState.current, target: null },
+        canGoBack: navigationState.current.environmentId === environmentId && navigationState.history.length > 0,
+        goBack: () => navigate({ type: 'back' }),
+        openTopic: (name, detail = 'overview') => navigate({ type: 'open', tab: 'Topic', target: { kind: 'topic', name, detail }, environmentId }),
+        openConsumer: (name, detail = 'overview', proxyAddress) => navigate({ type: 'open', tab: 'Consumer', target: { kind: 'consumer', name, detail, proxyAddress }, environmentId }),
+        openBroker: (address, detail = 'overview') => navigate({ type: 'open', tab: 'Cluster', target: { kind: 'broker', address, detail }, environmentId }),
+        pageStates,
         setActiveTab,
         setAuthSession,
         clearAuthSession,
@@ -133,3 +156,20 @@ export const useAppStore = () => {
   }
   return context;
 };
+
+// Each history entry keeps its own list position and selection; secrets never belong here.
+export function useNavigationState<T>(key: string, initial: T | (() => T)) {
+  const { navigation, pageStates } = useAppStore();
+  const id = navigation.id;
+  const [value, setValue] = useState<T>(() => {
+    const saved = pageStates.current.get(id);
+    return saved && key in saved ? saved[key] as T : typeof initial === 'function' ? (initial as () => T)() : initial;
+  });
+  const update: React.Dispatch<React.SetStateAction<T>> = (next) => setValue((previous) => {
+    const resolved = typeof next === 'function' ? (next as (value: T) => T)(previous) : next;
+    const saved = pageStates.current.get(id) ?? {};
+    pageStates.current.set(id, { ...saved, [key]: resolved });
+    return resolved;
+  });
+  return [value, update] as const;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { findEntity, initialNavigation, navigationReducer } from './navigation';
+
+describe('entity navigation', () => {
+    it('returns to the exact source entry and reopens an entity as a new visit', () => {
+        const list = navigationReducer(initialNavigation, { type: 'open', tab: 'Topic', environmentId: 'env-a' });
+        const topic = navigationReducer(list, { type: 'open', tab: 'Topic', environmentId: 'env-a', target: { kind: 'topic', name: 'Orders', detail: 'consumers' } });
+        const consumer = navigationReducer(topic, { type: 'open', tab: 'Consumer', environmentId: 'env-a', target: { kind: 'consumer', name: 'OrderReaders', detail: 'progress', proxyAddress: '127.0.0.1:8080' } });
+        const returned = navigationReducer(consumer, { type: 'back' });
+        expect(returned.current).toEqual(topic.current);
+        expect(navigationReducer(returned, { type: 'back' }).current).toEqual(list.current);
+        const reopened = navigationReducer(returned, { type: 'open', tab: 'Consumer', environmentId: 'env-a', target: consumer.current.target! });
+        expect(reopened.current.target).toEqual(consumer.current.target);
+        expect(reopened.current.id).not.toBe(consumer.current.id);
+    });
+
+    it('clears old targets and return history when the environment changes', () => {
+        const source = navigationReducer(initialNavigation, { type: 'open', tab: 'Cluster', environmentId: 'env-a', target: { kind: 'broker', address: '127.0.0.1:10911', detail: 'config' } });
+        const next = navigationReducer(source, { type: 'reset', environmentId: 'env-b' });
+        expect(next.current).toMatchObject({ tab: 'Cluster', target: null, environmentId: 'env-b' });
+        expect(next.history).toEqual([]);
+        expect(navigationReducer(next, { type: 'back' })).toBe(next);
+    });
+
+    it('never selects the first entity for an explicit missing or case-mismatched target', () => {
+        const items = [{ name: 'Orders' }, { name: 'Payments' }];
+        expect(findEntity(items, (item) => item.name, 'Payments')).toBe(items[1]);
+        expect(findEntity(items, (item) => item.name, 'Missing')).toBeNull();
+        expect(findEntity(items, (item) => item.name, 'orders')).toBeNull();
+        expect(findEntity(items, (item) => item.name, null)).toBe(items[0]);
+    });
+
+    it('bounds navigation history while preserving the most recent source', () => {
+        let state = initialNavigation;
+        for (let index = 0; index < 40; index++) state = navigationReducer(state, { type: 'open', tab: 'Topic', environmentId: 'env-a' });
+        expect(state.history).toHaveLength(20);
+        expect(navigationReducer(state, { type: 'back' }).current.id).toBe(39);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.ts
@@ -1,0 +1,50 @@
+export type Tab = 'NameServer' | 'Proxy' | 'Dashboard' | 'Cluster' | 'Topic' |
+    'Consumer' | 'Producer' | 'Message' | 'MessageTrace' | 'DLQ' | 'ACL' |
+    'Account' | 'Sessions' | 'Audit' | 'Monitors' | 'Storage';
+
+export type EntityTarget =
+    | { kind: 'topic'; name: string; detail: 'overview' | 'status' | 'route' | 'consumers' | 'config' }
+    | { kind: 'consumer'; name: string; detail: 'overview' | 'progress' | 'clients' | 'config'; proxyAddress?: string }
+    | { kind: 'broker'; address: string; detail: 'overview' | 'status' | 'config' };
+
+export interface NavigationLocation {
+    id: number;
+    tab: Tab;
+    target: EntityTarget | null;
+    environmentId: string | null;
+}
+
+export interface NavigationState {
+    current: NavigationLocation;
+    history: NavigationLocation[];
+    sequence: number;
+}
+
+export type NavigationAction =
+    | { type: 'open'; tab: Tab; target?: EntityTarget; environmentId: string | null }
+    | { type: 'back' }
+    | { type: 'reset'; environmentId: string | null };
+
+export const initialNavigation: NavigationState = {
+    current: { id: 0, tab: 'Dashboard', target: null, environmentId: null },
+    history: [], sequence: 0,
+};
+
+export function navigationReducer(state: NavigationState, action: NavigationAction): NavigationState {
+    if (action.type === 'back') {
+        const current = state.history[state.history.length - 1];
+        return current ? { ...state, current, history: state.history.slice(0, -1) } : state;
+    }
+    const id = state.sequence + 1;
+    if (action.type === 'reset') {
+        return { current: { id, tab: state.current.tab, target: null, environmentId: action.environmentId }, history: [], sequence: id };
+    }
+    return {
+        current: { id, tab: action.tab, target: action.target ?? null, environmentId: action.environmentId },
+        history: [...state.history, state.current].slice(-20), sequence: id,
+    };
+}
+
+export function findEntity<T>(items: readonly T[], identity: (item: T) => string, requested: string | null): T | null {
+    return requested === null ? items[0] ?? null : items.find((item) => identity(item) === requested) ?? null;
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10375

### Brief Description
Add typed Topic, Consumer Group, and Broker navigation with exact identities, detail selections, environment scope, and a bounded return history. Preserve per-visit list state and link related detail views. Explicit missing targets show a not-found message, and late Broker responses cannot reopen closed sheets.

Expose Sessions alongside Audit. Reserve Monitors and Storage navigation types without showing incomplete pages.

### How Did You Test This Change?
- npm run build passed with the existing bundle-size warning.
- npx vitest run src/stores/navigation.test.ts src/services/auth-session.test.ts: 16 tests passed, covering return/reopen, exact missing targets, environment reset, history bounds, and existing session/revision behavior.
- git diff --check passed.
- Desktop interaction smoke remains part of the final integration step; these checks exercise the navigation model and production frontend compilation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Sessions section and panel for viewing active, expired, and revoked sessions.
  * Added navigation between topics, consumers, brokers, and related detail views.
  * Added Back navigation with history support across entity views.
  * Added clickable links between related topics, consumers, and brokers.
  * Added clear alerts when a requested topic, consumer, or broker cannot be found.

* **Documentation**
  * Added documentation covering entity navigation behavior and available navigation types.

* **Tests**
  * Added coverage for navigation history, entity matching, environment changes, and back navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->