### PR TITLE
docs: expand architecture diagram to full width

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ performance while maintaining full compatibility with the RocketMQ protocol.
 ## 🏗️ Architecture
 
 <p align="center">
-  <img src="resources/architecture-current-v4.png" alt="RocketMQ-Rust Architecture" width="80%"/>
+  <img src="resources/architecture-current-v4.png" alt="RocketMQ-Rust Architecture" width="100%"/>
 </p>
 
 RocketMQ-Rust implements a distributed architecture with the following core components:


### PR DESCRIPTION
Fixes #10371

Updates the architecture diagram to use the full available README content width while preserving its source, alt text, centering, and aspect ratio.

## Testing

- `git diff --check`
- Reviewed the focused README diff

## Worked on by

- nightcityblade


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README architecture diagram to span the full available container width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->