### PR TITLE
[ISSUE #10378]🚀Use configured Proxy scopes for Tauri Consumer queries

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_SCOPE.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_SCOPE.md
@@ -1,0 +1,24 @@
+# Consumer query scope
+
+Consumer catalog, refresh, connection, progress, and topic-detail requests carry
+an explicit `scope`: `{ mode: 'name_server' }` or
+`{ mode: 'proxy', endpointId }`. Proxy mode reads the selected endpoint from
+shared connection settings; there is no page-local address default or editable
+query address. The backend verifies the endpoint is the current configured
+Proxy before resolving its address for admin-core. A stale, unknown, or
+NameServer endpoint ID is rejected. Revision checks still surround the query.
+
+The mode preference survives module navigation and connection revision refreshes.
+Each history entry retains its mode. Changing scope remounts the catalog and
+closes old detail dialogs. Request generations reject callbacks from previous
+scopes, superseded refreshes, and disposed pages. A missing Proxy prevents Proxy
+queries and links to connection settings; NameServer mode remains available.
+
+Consumer configuration reads still take a separate direct Broker address. The
+DLQ group picker explicitly uses NameServer discovery. Neither treats a direct
+Broker target as a Proxy scope.
+
+Validation: `cargo test --lib consumer::` from `src-tauri`, and `npm run build`
+plus focused Consumer scope, navigation, and authenticated invocation tests from
+the app root. The development cluster's Proxy is `127.0.0.1:8080`; select it in
+Proxy settings before enabling Proxy mode in Consumers.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ENTITY_NAVIGATION.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ENTITY_NAVIGATION.md
@@ -1,7 +1,7 @@
 # Desktop entity navigation
 
 The app store exposes `openTopic(name, detail)`,
-`openConsumer(group, detail, proxyAddress?)`, `openBroker(address, detail)`, and
+`openConsumer(group, detail, scope?)`, `openBroker(address, detail)`, and
 `goBack()`. Targets are discriminated by entity kind, contain an exact identity
 and detail selection, and belong to the current connection environment. They
 are browsing state, never authorization evidence.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer.rs
@@ -14,6 +14,7 @@
 
 pub(crate) mod admin;
 pub(crate) mod commands;
+mod scope;
 pub(crate) mod service;
 pub(crate) mod types;
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
@@ -14,6 +14,7 @@
 
 use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
 use crate::connection::ConnectionManager;
+use crate::consumer::scope::{ScopedConsumerGroupRequest, ScopedConsumerListRequest};
 use crate::consumer::service::ConsumerManager;
 use crate::consumer::types::ConsumerConfigView;
 use crate::consumer::types::ConsumerConnectionView;
@@ -35,7 +36,7 @@ use tauri::State;
 #[tauri::command]
 pub async fn query_consumer_groups(
     session_id: String,
-    request: ConsumerGroupListRequest,
+    request: ScopedConsumerListRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
     expected_revision: i64,
@@ -43,6 +44,11 @@ pub async fn query_consumer_groups(
 ) -> CommandResult<ConsumerGroupListResponse> {
     authorize_command(&session_id, &session_state).await?;
     connection_manager.check_revision(expected_revision)?;
+    let address = request.scope.address(&connection_manager.snapshot()?)?;
+    let request = ConsumerGroupListRequest {
+        skip_sys_group: request.skip_sys_group,
+        address,
+    };
     let result = consumer_manager
         .query_consumer_groups(request)
         .await
@@ -54,7 +60,7 @@ pub async fn query_consumer_groups(
 #[tauri::command]
 pub async fn refresh_consumer_group(
     session_id: String,
-    request: ConsumerGroupRefreshRequest,
+    request: ScopedConsumerGroupRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
     expected_revision: i64,
@@ -62,6 +68,11 @@ pub async fn refresh_consumer_group(
 ) -> CommandResult<ConsumerGroupListItem> {
     authorize_command(&session_id, &session_state).await?;
     connection_manager.check_revision(expected_revision)?;
+    let address = request.scope.address(&connection_manager.snapshot()?)?;
+    let request = ConsumerGroupRefreshRequest {
+        consumer_group: request.consumer_group,
+        address,
+    };
     let result = consumer_manager
         .refresh_consumer_group(request)
         .await
@@ -73,7 +84,7 @@ pub async fn refresh_consumer_group(
 #[tauri::command]
 pub async fn refresh_all_consumer_groups(
     session_id: String,
-    request: ConsumerGroupListRequest,
+    request: ScopedConsumerListRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
     expected_revision: i64,
@@ -81,6 +92,11 @@ pub async fn refresh_all_consumer_groups(
 ) -> CommandResult<ConsumerGroupListResponse> {
     authorize_command(&session_id, &session_state).await?;
     connection_manager.check_revision(expected_revision)?;
+    let address = request.scope.address(&connection_manager.snapshot()?)?;
+    let request = ConsumerGroupListRequest {
+        skip_sys_group: request.skip_sys_group,
+        address,
+    };
     let result = consumer_manager
         .refresh_all_consumer_groups(request)
         .await
@@ -92,7 +108,7 @@ pub async fn refresh_all_consumer_groups(
 #[tauri::command]
 pub async fn query_consumer_connection(
     session_id: String,
-    request: ConsumerConnectionQueryRequest,
+    request: ScopedConsumerGroupRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
     expected_revision: i64,
@@ -100,6 +116,11 @@ pub async fn query_consumer_connection(
 ) -> CommandResult<ConsumerConnectionView> {
     authorize_command(&session_id, &session_state).await?;
     connection_manager.check_revision(expected_revision)?;
+    let address = request.scope.address(&connection_manager.snapshot()?)?;
+    let request = ConsumerConnectionQueryRequest {
+        consumer_group: request.consumer_group,
+        address,
+    };
     let result = consumer_manager
         .query_consumer_connection(request)
         .await
@@ -111,7 +132,7 @@ pub async fn query_consumer_connection(
 #[tauri::command]
 pub async fn query_consumer_topic_detail(
     session_id: String,
-    request: ConsumerTopicDetailQueryRequest,
+    request: ScopedConsumerGroupRequest,
     consumer_manager: State<'_, ConsumerManager>,
     session_state: State<'_, SessionState>,
     expected_revision: i64,
@@ -119,6 +140,11 @@ pub async fn query_consumer_topic_detail(
 ) -> CommandResult<ConsumerTopicDetailView> {
     authorize_command(&session_id, &session_state).await?;
     connection_manager.check_revision(expected_revision)?;
+    let address = request.scope.address(&connection_manager.snapshot()?)?;
+    let request = ConsumerTopicDetailQueryRequest {
+        consumer_group: request.consumer_group,
+        address,
+    };
     let result = consumer_manager
         .query_consumer_topic_detail(request)
         .await

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/scope.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/scope.rs
@@ -1,0 +1,128 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::connection::{ConnectionSettingsView, EndpointKind};
+use crate::error::{DashboardError, DashboardResult};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum ConsumerQueryScope {
+    NameServer,
+    Proxy {
+        #[serde(rename = "endpointId")]
+        endpoint_id: String,
+    },
+}
+
+impl ConsumerQueryScope {
+    pub(crate) fn address(&self, settings: &ConnectionSettingsView) -> DashboardResult<Option<String>> {
+        match self {
+            Self::NameServer => Ok(None),
+            Self::Proxy { endpoint_id } => {
+                let endpoint = settings
+                    .endpoints
+                    .iter()
+                    .find(|endpoint| {
+                        endpoint.kind == EndpointKind::Proxy
+                            && &endpoint.endpoint_id == endpoint_id
+                            && settings.current_proxy_id.as_ref() == Some(endpoint_id)
+                            && settings.proxy.current_proxy_addr.as_ref() == Some(&endpoint.address)
+                    })
+                    .ok_or_else(|| {
+                        DashboardError::Configuration("select a configured Proxy before querying consumers".into())
+                    })?;
+                Ok(Some(endpoint.address.clone()))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ScopedConsumerListRequest {
+    pub(crate) scope: ConsumerQueryScope,
+    #[serde(default)]
+    pub(crate) skip_sys_group: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ScopedConsumerGroupRequest {
+    pub(crate) scope: ConsumerQueryScope,
+    pub(crate) consumer_group: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::EndpointView;
+    use rocketmq_dashboard_common::{NameServerConfigSnapshot, ProxyConfigSnapshot};
+
+    #[test]
+    fn only_the_current_configured_proxy_is_resolved() {
+        let mut settings = ConnectionSettingsView {
+            revision: 1,
+            credentials_configured: false,
+            current_nameserver_id: None,
+            environment_id: None,
+            current_proxy_id: Some("proxy-a".into()),
+            nameserver: NameServerConfigSnapshot::default(),
+            proxy: ProxyConfigSnapshot {
+                current_proxy_addr: Some("127.0.0.1:8080".into()),
+                proxy_addr_list: vec!["127.0.0.1:8080".into()],
+            },
+            endpoints: vec![EndpointView {
+                endpoint_id: "proxy-a".into(),
+                kind: EndpointKind::Proxy,
+                address: "127.0.0.1:8080".into(),
+                environment_id: None,
+            }],
+        };
+        let scope = ConsumerQueryScope::Proxy {
+            endpoint_id: "proxy-a".into(),
+        };
+        assert_eq!(scope.address(&settings).unwrap().as_deref(), Some("127.0.0.1:8080"));
+        assert_eq!(ConsumerQueryScope::NameServer.address(&settings).unwrap(), None);
+        assert!(
+            ConsumerQueryScope::Proxy {
+                endpoint_id: "unsaved".into()
+            }
+            .address(&settings)
+            .is_err()
+        );
+        settings.current_proxy_id = None;
+        assert!(scope.address(&settings).is_err());
+        settings.current_proxy_id = Some("proxy-a".into());
+        settings.endpoints[0].kind = EndpointKind::NameServer;
+        assert!(scope.address(&settings).is_err());
+    }
+
+    #[test]
+    fn query_contract_rejects_arbitrary_addresses_and_missing_scope() {
+        assert!(serde_json::from_str::<ScopedConsumerListRequest>(r#"{"address":"127.0.0.1:8080"}"#).is_err());
+        assert!(
+            serde_json::from_str::<ScopedConsumerListRequest>(
+                r#"{"scope":{"mode":"name_server"},"address":"127.0.0.1:8080"}"#
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<ScopedConsumerGroupRequest>(
+                r#"{"consumerGroup":"orders","scope":{"mode":"proxy","endpointId":"proxy-a"}}"#
+            )
+            .is_ok()
+        );
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
@@ -1,1443 +1,531 @@
-import { useAppStore, useNavigationState } from '../stores/app.store';
-import { findEntity } from '../stores/navigation';
-import React, { useEffect, useMemo, useState, useRef } from 'react';
-import { motion, AnimatePresence } from 'motion/react';
-import { 
-  Users, 
-  X, 
-  Settings, 
-  RotateCcw, 
-  Trash2, 
-  Search, 
-  Check, 
-  RefreshCw, 
-  Plus, 
-  Clock, 
-  FileText, 
-  Activity, 
-  Network, 
-  ListChecks, 
-  Hash, 
-  Cpu, 
-  Layers, 
-  FileBox,
-  AlertCircle,
-  LoaderCircle,
-} from 'lucide-react';
-import { toast } from 'sonner@2.0.3';
-import { Pagination } from './Pagination';
-import { useConsumerCatalog } from '../features/consumer/hooks/useConsumerCatalog';
-import { ConsumerClientModal } from '../features/consumer/components/ConsumerClientModal';
-import { ConsumerConfigModal } from '../features/consumer/components/ConsumerConfigModal';
-import { ConsumerDeleteModal } from '../features/consumer/components/ConsumerDeleteModal';
-import { ConsumerDetailModal } from '../features/consumer/components/ConsumerDetailModal';
-import { ConsumerEditorModal } from '../features/consumer/components/ConsumerEditorModal';
-import type { ConsumerGroupListItem } from '../features/consumer/types/consumer.types';
-
-const LegacyConsumerDetailModal = ({ isOpen, onClose, consumer }: any) => {
-  if (!isOpen) return null;
-
-  return (
-    <AnimatePresence>
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 0.3 }}
-          exit={{ opacity: 0 }}
-          onClick={onClose}
-          className="absolute inset-0 bg-black"
-        />
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95, y: 10 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          exit={{ opacity: 0, scale: 0.95, y: 10 }}
-          className="relative w-full max-w-5xl max-h-[90vh] bg-white dark:bg-gray-900 rounded-xl shadow-2xl flex flex-col overflow-hidden border border-gray-100 dark:border-gray-800"
-        >
-          {/* Header */}
-          <div className="px-6 py-5 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between bg-white dark:bg-gray-900 z-10 shrink-0">
-            <div>
-              <h3 className="text-xl font-bold text-gray-800 dark:text-white flex items-center">
-                <FileText className="w-5 h-5 mr-2 text-blue-500" />
-                Consumer Details
-              </h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 flex items-center">
-                <span className="font-mono text-gray-700 dark:text-gray-300 font-medium">{consumer?.displayGroupName ?? consumer?.rawGroupName}</span>
-                <span className="mx-2 text-gray-300 dark:text-gray-600">|</span>
-                <span>Address: 172.20.48.1:10911</span>
-              </p>
-            </div>
-            <button 
-              onClick={onClose}
-              className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-            >
-              <X className="w-5 h-5" />
-            </button>
-          </div>
-
-          {/* Content */}
-          <div className="flex-1 overflow-y-auto p-6 bg-gray-50/50 dark:bg-gray-950/50 space-y-6">
-            {/* Topic Section 1: RETRY */}
-            <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden">
-                <div className="px-6 py-4 bg-gray-50/50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-800 flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                        <div className="p-1.5 bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-lg">
-                           <Layers className="w-4 h-4" />
-                        </div>
-                        <span className="font-mono text-sm font-semibold text-gray-700 dark:text-gray-300">%RETRY%{consumer?.displayGroupName ?? consumer?.rawGroupName}</span>
-                    </div>
-                    <div className="flex items-center space-x-6 text-xs font-mono">
-                        <div className="flex items-center text-gray-500 dark:text-gray-400">
-                            <span className="uppercase font-semibold tracking-wider text-gray-400 dark:text-gray-500 mr-2">Total Lag:</span>
-                            <span className="text-gray-900 dark:text-white font-bold bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 px-2 py-0.5 rounded">0</span>
-                        </div>
-                        <div className="flex items-center text-gray-500 dark:text-gray-400">
-                            <span className="uppercase font-semibold tracking-wider text-gray-400 dark:text-gray-500 mr-2">Last Consume:</span>
-                            <span className="text-gray-900 dark:text-white">-</span>
-                        </div>
-                    </div>
-                </div>
-                
-                <div className="overflow-x-auto">
-                    <table className="w-full text-left text-sm">
-                        <thead>
-                            <tr className="bg-gray-50 dark:bg-gray-800/50 text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider font-semibold border-b border-gray-100 dark:border-gray-800">
-                                <th className="px-6 py-3 font-medium">Broker</th>
-                                <th className="px-6 py-3 font-medium">Queue ID</th>
-                                <th className="px-6 py-3 font-medium text-right">Broker Offset</th>
-                                <th className="px-6 py-3 font-medium text-right">Consumer Offset</th>
-                                <th className="px-6 py-3 font-medium text-right">Lag (Diff)</th>
-                                <th className="px-6 py-3 font-medium">Client Info</th>
-                                <th className="px-6 py-3 font-medium text-right">Last Consume Time</th>
-                            </tr>
-                        </thead>
-                        <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-                            <tr className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                                <td className="px-6 py-3 font-mono text-gray-600 dark:text-gray-400">mxsm</td>
-                                <td className="px-6 py-3 font-mono text-gray-600 dark:text-gray-400">0</td>
-                                <td className="px-6 py-3 font-mono text-gray-900 dark:text-gray-300 text-right">0</td>
-                                <td className="px-6 py-3 font-mono text-gray-900 dark:text-gray-300 text-right">0</td>
-                                <td className="px-6 py-3 font-mono text-gray-400 dark:text-gray-600 text-right">-</td>
-                                <td className="px-6 py-3 text-gray-500 dark:text-gray-500 italic"></td>
-                                <td className="px-6 py-3 font-mono text-gray-400 dark:text-gray-600 text-right">-</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-
-             {/* Topic Section 2: TopicTest */}
-             <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden">
-                <div className="px-6 py-4 bg-gray-50/50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-800 flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                        <div className="p-1.5 bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 rounded-lg">
-                           <FileBox className="w-4 h-4" />
-                        </div>
-                        <span className="font-mono text-sm font-semibold text-gray-700 dark:text-gray-300">TopicTest</span>
-                    </div>
-                    <div className="flex items-center space-x-6 text-xs font-mono">
-                        <div className="flex items-center text-gray-500 dark:text-gray-400">
-                            <span className="uppercase font-semibold tracking-wider text-gray-400 dark:text-gray-500 mr-2">Total Lag:</span>
-                            <span className="text-gray-900 dark:text-white font-bold bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-2 py-0.5 rounded">1000</span>
-                        </div>
-                        <div className="flex items-center text-gray-500 dark:text-gray-400">
-                            <span className="uppercase font-semibold tracking-wider text-gray-400 dark:text-gray-500 mr-2">Last Consume:</span>
-                            <span className="text-gray-900 dark:text-white">2026/1/21 12:24:40</span>
-                        </div>
-                    </div>
-                </div>
-                
-                <div className="overflow-x-auto">
-                    <table className="w-full text-left text-sm">
-                        <thead>
-                            <tr className="bg-gray-50 dark:bg-gray-800/50 text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider font-semibold border-b border-gray-100 dark:border-gray-800">
-                                <th className="px-6 py-3 font-medium">Broker</th>
-                                <th className="px-6 py-3 font-medium">Queue ID</th>
-                                <th className="px-6 py-3 font-medium text-right">Broker Offset</th>
-                                <th className="px-6 py-3 font-medium text-right">Consumer Offset</th>
-                                <th className="px-6 py-3 font-medium text-right">Lag (Diff)</th>
-                                <th className="px-6 py-3 font-medium">Client Info</th>
-                                <th className="px-6 py-3 font-medium text-right">Last Consume Time</th>
-                            </tr>
-                        </thead>
-                        <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-                            {[0, 1, 2, 3].map((qid) => (
-                                <tr key={qid} className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                                    <td className="px-6 py-3 font-mono text-gray-600 dark:text-gray-400">mxsm</td>
-                                    <td className="px-6 py-3 font-mono text-gray-600 dark:text-gray-400">{qid}</td>
-                                    <td className="px-6 py-3 font-mono text-gray-900 dark:text-gray-300 text-right">{280 + qid * 2}</td>
-                                    <td className="px-6 py-3 font-mono text-gray-900 dark:text-gray-300 text-right">{30 + qid * 2}</td>
-                                    <td className="px-6 py-3 font-mono text-amber-600 dark:text-amber-400 font-bold text-right">{250}</td>
-                                    <td className="px-6 py-3 text-gray-500 dark:text-gray-500 italic"></td>
-                                    <td className="px-6 py-3 font-mono text-gray-500 dark:text-gray-400 text-right">2026/1/21 12:24:40</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-          </div>
-
-          {/* Footer */}
-          <div className="px-6 py-4 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex justify-end z-10 shrink-0">
-             <button
-               onClick={onClose}
-               className="px-6 py-2 bg-gray-900 text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-all shadow-md hover:shadow-lg dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
-             >
-               Close
-             </button>
-          </div>
-        </motion.div>
-      </div>
-    </AnimatePresence>
-  );
-};
-
-const LegacyConsumerConfigModal = ({ isOpen, onClose, consumer }: any) => {
-  if (!isOpen) return null;
-
-  return (
-    <AnimatePresence>
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 0.3 }}
-          exit={{ opacity: 0 }}
-          onClick={onClose}
-          className="absolute inset-0 bg-black"
-        />
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95, y: 10 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          exit={{ opacity: 0, scale: 0.95, y: 10 }}
-          className="relative w-full max-w-4xl max-h-[90vh] bg-white dark:bg-gray-900 rounded-xl shadow-2xl flex flex-col overflow-hidden border border-gray-100 dark:border-gray-800"
-        >
-          {/* Header */}
-          <div className="px-6 py-5 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between bg-white dark:bg-gray-900 z-10 shrink-0">
-            <div>
-              <h3 className="text-xl font-bold text-gray-800 dark:text-white flex items-center">
-                <Settings className="w-5 h-5 mr-2 text-blue-500" />
-                Configuration
-              </h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 flex items-center">
-                 <span className="font-mono font-medium text-gray-700 dark:text-gray-300">{consumer?.displayGroupName ?? consumer?.rawGroupName}</span>
-              </p>
-            </div>
-            <button 
-              onClick={onClose}
-              className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-            >
-              <X className="w-5 h-5" />
-            </button>
-          </div>
-
-          {/* Content - Card Grid Layout */}
-          <div className="flex-1 overflow-y-auto p-6 bg-gray-50/50 dark:bg-gray-950/50">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                
-                {/* Card 1: Basic Info */}
-                <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-5 space-y-4">
-                     <div className="flex items-center space-x-2 mb-2">
-                        <div className="p-1.5 bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-lg">
-                            <Hash className="w-4 h-4" />
-                        </div>
-                        <h4 className="font-semibold text-gray-900 dark:text-white">Basic Information</h4>
-                     </div>
-                     
-                     <div className="space-y-1">
-                         <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Group Name</label>
-                         <div className="px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg text-sm font-mono text-gray-600 dark:text-gray-300 break-all">
-                             {consumer?.displayGroupName ?? consumer?.rawGroupName}
-                         </div>
-                     </div>
-
-                     <div className="space-y-1">
-                         <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Broker Name</label>
-                         <div className="px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg text-sm font-mono text-gray-600 dark:text-gray-300">
-                             mxsm
-                         </div>
-                     </div>
-
-                     <div className="space-y-1">
-                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Broker ID</label>
-                        <input type="number" defaultValue={0} className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all" />
-                     </div>
-                </div>
-
-                {/* Card 2: Consumption Control */}
-                <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-5 space-y-4">
-                     <div className="flex items-center space-x-2 mb-2">
-                        <div className="p-1.5 bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-lg">
-                            <Activity className="w-4 h-4" />
-                        </div>
-                        <h4 className="font-semibold text-gray-900 dark:text-white">Control Settings</h4>
-                     </div>
-
-                     <div className="space-y-4 pt-1">
-                         <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-100 dark:border-gray-700">
-                             <div>
-                                 <label className="text-sm font-medium text-gray-700 dark:text-gray-200 block">Consume Enable</label>
-                                 <span className="text-xs text-gray-400 dark:text-gray-500">Master switch for consumption</span>
-                             </div>
-                             <button className="w-11 h-6 bg-blue-500 rounded-full p-1 transition-colors relative shrink-0">
-                                 <div className="w-4 h-4 bg-white rounded-full shadow-sm absolute right-1 top-1" />
-                             </button>
-                         </div>
-                         <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-100 dark:border-gray-700">
-                             <div>
-                                 <label className="text-sm font-medium text-gray-700 dark:text-gray-200 block">Orderly Consumption</label>
-                                 <span className="text-xs text-gray-400 dark:text-gray-500">Strict FIFO order</span>
-                             </div>
-                             <button className="w-11 h-6 bg-gray-200 dark:bg-gray-700 rounded-full p-1 transition-colors relative shrink-0">
-                                 <div className="w-4 h-4 bg-white rounded-full shadow-sm absolute left-1 top-1" />
-                             </button>
-                         </div>
-                          <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-100 dark:border-gray-700">
-                             <div>
-                                 <label className="text-sm font-medium text-gray-700 dark:text-gray-200 block">Broadcast Mode</label>
-                                 <span className="text-xs text-gray-400 dark:text-gray-500">All consumers receive messages</span>
-                             </div>
-                             <button className="w-11 h-6 bg-blue-500 rounded-full p-1 transition-colors relative shrink-0">
-                                 <div className="w-4 h-4 bg-white rounded-full shadow-sm absolute right-1 top-1" />
-                             </button>
-                         </div>
-                     </div>
-                </div>
-
-                {/* Card 3: Retry & Throttling */}
-                <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-5 space-y-4">
-                     <div className="flex items-center space-x-2 mb-2">
-                        <div className="p-1.5 bg-orange-50 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400 rounded-lg">
-                            <RotateCcw className="w-4 h-4" />
-                        </div>
-                        <h4 className="font-semibold text-gray-900 dark:text-white">Retry & Throttling</h4>
-                     </div>
-
-                     <div className="grid grid-cols-2 gap-4">
-                         <div className="space-y-1">
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Retry Queues</label>
-                            <input type="number" defaultValue={1} className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all" />
-                         </div>
-                         <div className="space-y-1">
-                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Max Retries</label>
-                            <input type="number" defaultValue={16} className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all" />
-                         </div>
-                     </div>
-
-                     <div className="space-y-1 pt-2">
-                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Slow Consumption Broker</label>
-                        <div className="flex items-center space-x-2">
-                            <input type="number" defaultValue={1} className="flex-1 px-3 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all" />
-                            <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">Threshold ID</span>
-                        </div>
-                     </div>
-
-                     <div className="space-y-1 pt-2">
-                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Consume Timeout</label>
-                        <div className="px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg text-sm text-gray-600 dark:text-gray-300 flex justify-between items-center">
-                            <span>15</span>
-                            <span className="text-xs text-gray-400 dark:text-gray-500">Minutes</span>
-                        </div>
-                     </div>
-                </div>
-
-                {/* Card 4: Advanced JSON */}
-                <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-5 space-y-4">
-                     <div className="flex items-center space-x-2 mb-2">
-                        <div className="p-1.5 bg-purple-50 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 rounded-lg">
-                            <Cpu className="w-4 h-4" />
-                        </div>
-                        <h4 className="font-semibold text-gray-900 dark:text-white">System Config</h4>
-                     </div>
-
-                     <div className="space-y-1">
-                         <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Retry Policy (JSON)</label>
-                         <div className="bg-gray-900 dark:bg-gray-950 rounded-lg p-3 overflow-hidden border border-gray-800">
-                             <pre className="font-mono text-[10px] text-gray-300 overflow-x-auto custom-scrollbar">
-{`{
-  "type": "CUSTOMIZED",
-  "exponentialRetryPolicy": null,
-  "customizedRetryPolicy": null,
-  "retryPolicy": {
-    "maxRetries": 16
-  }
-}`}
-                             </pre>
-                         </div>
-                     </div>
-
-                     <div className="grid grid-cols-2 gap-4 pt-2">
-                        <div className="space-y-1">
-                             <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Cluster Name</label>
-                             <div className="px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg text-xs font-mono text-gray-400 dark:text-gray-500">
-                                 DefaultCluster
-                             </div>
-                        </div>
-                        <div className="space-y-1">
-                             <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">System Flag</label>
-                             <div className="px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg text-xs font-mono text-gray-400 dark:text-gray-500">
-                                 0
-                             </div>
-                        </div>
-                     </div>
-                </div>
-
-            </div>
-          </div>
-
-          {/* Footer */}
-          <div className="px-6 py-4 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex justify-end items-center gap-3 z-10 shrink-0">
-             <button
-               onClick={onClose}
-               className="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-gray-700 transition-all shadow-sm"
-             >
-               Cancel
-             </button>
-             <button
-               onClick={() => {
-                   toast.success("Configuration updated successfully");
-                   onClose();
-               }}
-               className="px-6 py-2 bg-gray-900 text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-all shadow-md hover:shadow-lg dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
-             >
-               Save Changes
-             </button>
-          </div>
-        </motion.div>
-      </div>
-    </AnimatePresence>
-  );
-};
-
-const LegacyConsumerClientModal = ({ isOpen, onClose, consumer }: any) => {
-  if (!isOpen) return null;
-
-  return (
-    <AnimatePresence>
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 0.3 }}
-          exit={{ opacity: 0 }}
-          onClick={onClose}
-          className="absolute inset-0 bg-black"
-        />
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95, y: 10 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          exit={{ opacity: 0, scale: 0.95, y: 10 }}
-          className="relative w-full max-w-6xl max-h-[90vh] bg-white dark:bg-gray-900 rounded-xl shadow-2xl flex flex-col overflow-hidden border border-gray-100 dark:border-gray-800"
-        >
-          {/* Header */}
-          <div className="px-6 py-5 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between bg-white dark:bg-gray-900 z-10 shrink-0">
-            <div>
-              <h3 className="text-xl font-bold text-gray-800 dark:text-white flex items-center">
-                <Users className="w-5 h-5 mr-2 text-blue-500" />
-                Client Information
-              </h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 flex items-center">
-                 <span className="font-mono font-medium text-gray-700 dark:text-gray-300">{consumer?.displayGroupName ?? consumer?.rawGroupName}</span>
-              </p>
-            </div>
-            <button 
-              onClick={onClose}
-              className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-            >
-              <X className="w-5 h-5" />
-            </button>
-          </div>
-
-          {/* Content */}
-          <div className="flex-1 overflow-y-auto p-6 bg-gray-50/50 dark:bg-gray-950/50 space-y-6">
-            
-            {/* 1. Connection Overview */}
-            <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-6">
-                <h4 className="font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
-                    <Activity className="w-4 h-4 mr-2 text-gray-500 dark:text-gray-400" />
-                    Connection Overview
-                </h4>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                     <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-100 dark:border-gray-700">
-                         <span className="text-sm font-medium text-gray-600 dark:text-gray-300">Consume Type</span>
-                         <span className="px-2 py-1 text-xs font-bold bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400 border border-green-100 dark:border-green-800 rounded uppercase tracking-wide">
-                             CONSUME_PASSIVELY
-                         </span>
-                     </div>
-                     <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-100 dark:border-gray-700">
-                         <span className="text-sm font-medium text-gray-600 dark:text-gray-300">Message Model</span>
-                         <span className="px-2 py-1 text-xs font-bold bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 border border-blue-100 dark:border-blue-800 rounded uppercase tracking-wide">
-                             CLUSTERING
-                         </span>
-                     </div>
-                     <div className="col-span-1 md:col-span-2 flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-100 dark:border-gray-700">
-                         <span className="text-sm font-medium text-gray-600 dark:text-gray-300">Consume From Where</span>
-                         <span className="px-2 py-1 text-xs font-bold bg-purple-50 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 border border-purple-100 dark:border-purple-800 rounded uppercase tracking-wide">
-                             CONSUME_FROM_FIRST_OFFSET
-                         </span>
-                     </div>
-                </div>
-            </div>
-
-            {/* 2. Client Connections */}
-            <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden">
-                <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center">
-                    <Network className="w-4 h-4 mr-2 text-gray-500 dark:text-gray-400" />
-                    <h4 className="font-semibold text-gray-900 dark:text-white">Client Connections</h4>
-                </div>
-                <div className="overflow-x-auto">
-                    <table className="w-full text-left text-sm">
-                        <thead>
-                            <tr className="bg-gray-50 dark:bg-gray-800/50 text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider font-semibold border-b border-gray-100 dark:border-gray-800">
-                                <th className="px-6 py-3 font-medium">Client ID</th>
-                                <th className="px-6 py-3 font-medium">Client Address</th>
-                                <th className="px-6 py-3 font-medium">Language</th>
-                                <th className="px-6 py-3 font-medium text-right">Version</th>
-                            </tr>
-                        </thead>
-                        <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-                            <tr className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                                <td className="px-6 py-3 font-mono text-gray-600 dark:text-gray-400">172.20.48.1@29136#17844441802200</td>
-                                <td className="px-6 py-3 font-mono text-gray-900 dark:text-gray-300">172.20.48.1:59326</td>
-                                <td className="px-6 py-3">
-                                    <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-orange-50 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 border border-orange-100 dark:border-orange-800">JAVA</span>
-                                </td>
-                                <td className="px-6 py-3 font-mono text-gray-500 dark:text-gray-400 text-right">V5_4_0</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-
-            {/* 3. Client Subscriptions */}
-            <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden">
-                 <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-800 flex items-center">
-                    <ListChecks className="w-4 h-4 mr-2 text-gray-500 dark:text-gray-400" />
-                    <h4 className="font-semibold text-gray-900 dark:text-white">Client Subscriptions</h4>
-                </div>
-                <div className="overflow-x-auto">
-                    <table className="w-full text-left text-sm">
-                        <thead>
-                            <tr className="bg-gray-50 dark:bg-gray-800/50 text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider font-semibold border-b border-gray-100 dark:border-gray-800">
-                                <th className="px-6 py-3 font-medium">Topic</th>
-                                <th className="px-6 py-3 font-medium">Subscription Expression</th>
-                                <th className="px-6 py-3 font-medium">Expression Type</th>
-                                <th className="px-6 py-3 font-medium">Tags Set</th>
-                                <th className="px-6 py-3 font-medium">Code Set</th>
-                                <th className="px-6 py-3 font-medium text-right">Sub Version</th>
-                            </tr>
-                        </thead>
-                        <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-                            <tr className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                                <td className="px-6 py-3 font-mono text-gray-900 dark:text-white">%RETRY%please_rename_unique_group_name_4</td>
-                                <td className="px-6 py-3 font-mono text-gray-600 dark:text-gray-400">*</td>
-                                <td className="px-6 py-3">
-                                     <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 border border-blue-100 dark:border-blue-800">TAG</span>
-                                </td>
-                                <td className="px-6 py-3 text-gray-400 dark:text-gray-500">N/A</td>
-                                <td className="px-6 py-3 text-gray-400 dark:text-gray-500">N/A</td>
-                                <td className="px-6 py-3 font-mono text-gray-500 dark:text-gray-400 text-right">1769520097252</td>
-                            </tr>
-                            <tr className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                                <td className="px-6 py-3 font-mono text-gray-900 dark:text-white">TopicTest</td>
-                                <td className="px-6 py-3 font-mono text-gray-600 dark:text-gray-400">*</td>
-                                <td className="px-6 py-3">
-                                     <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 border border-blue-100 dark:border-blue-800">TAG</span>
-                                </td>
-                                <td className="px-6 py-3 text-gray-400 dark:text-gray-500">N/A</td>
-                                <td className="px-6 py-3 text-gray-400 dark:text-gray-500">N/A</td>
-                                <td className="px-6 py-3 font-mono text-gray-500 dark:text-gray-400 text-right">1769520097262</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-          </div>
-
-          {/* Footer */}
-          <div className="px-6 py-4 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex justify-end z-10 shrink-0">
-             <button
-               onClick={onClose}
-               className="px-6 py-2 bg-gray-900 text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-all shadow-md hover:shadow-lg dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
-             >
-               Close
-             </button>
-          </div>
-        </motion.div>
-      </div>
-    </AnimatePresence>
-  );
-};
-
-const LegacyConsumerCardView = () => {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [filters, setFilters] = useState<any>({
-    NORMAL: true,
-    FIFO: false,
-    SYSTEM: true
-  });
-  const [proxy, setProxy] = useState('127.0.0.1:8080');
-  const [enableProxy, setEnableProxy] = useState(false);
-  const [detailModal, setDetailModal] = useState<{isOpen: boolean, consumer: ConsumerGroupListItem | null}>({ isOpen: false, consumer: null });
-  const [configModal, setConfigModal] = useState<{isOpen: boolean, consumer: ConsumerGroupListItem | null}>({ isOpen: false, consumer: null });
-  const [clientModal, setClientModal] = useState<{isOpen: boolean, consumer: ConsumerGroupListItem | null}>({ isOpen: false, consumer: null });
-  const [editorModal, setEditorModal] = useState<{isOpen: boolean, consumer: ConsumerGroupListItem | null, preferredBrokerAddress?: string}>({ isOpen: false, consumer: null });
-  const [deleteModal, setDeleteModal] = useState<{isOpen: boolean, consumer: ConsumerGroupListItem | null}>({ isOpen: false, consumer: null });
-  const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 6;
-  const sourceAddress = enableProxy ? proxy : undefined;
-  const {
-    items,
-    summary,
-    response,
-    isInitialLoading,
-    isRefreshPending,
-    isRefreshing,
-    refreshingGroup,
-    error,
-    refresh,
-    refreshGroup,
-  } = useConsumerCatalog(sourceAddress);
-
-  const toggleFilter = (key: string) => {
-    setCurrentPage(1);
-    setFilters((prev: any) => ({ ...prev, [key]: !prev[key] }));
-  };
-
-  const filteredConsumers = useMemo(() => {
-    const normalizedTerm = searchTerm.trim().toLowerCase();
-    const activeCategories = Object.entries(filters)
-      .filter(([, value]) => Boolean(value))
-      .map(([key]) => key);
-
-    return items.filter((consumer) => {
-      const matchesSearch =
-        normalizedTerm.length === 0 ||
-        consumer.displayGroupName.toLowerCase().includes(normalizedTerm) ||
-        consumer.rawGroupName.toLowerCase().includes(normalizedTerm);
-      const matchesCategory =
-        activeCategories.length === 0 || activeCategories.includes(consumer.category);
-      return matchesSearch && matchesCategory;
-    });
-  }, [filters, items, searchTerm]);
-
-  const totalPages = Math.max(1, Math.ceil(filteredConsumers.length / itemsPerPage));
-  const currentConsumers = filteredConsumers.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage
-  );
-
-  const goToPage = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page);
-    }
-  };
-
-  const handleEditorSaved = async () => {
-    setEditorModal({ isOpen: false, consumer: null });
-    await refresh();
-  };
-
-  const handleDeleteSaved = async () => {
-    setDeleteModal({ isOpen: false, consumer: null });
-    await refresh();
-  };
-
-  const handleEditFromConfig = (consumer: ConsumerGroupListItem, preferredBrokerAddress?: string) => {
-    setConfigModal({ isOpen: false, consumer: null });
-    setEditorModal({ isOpen: true, consumer, preferredBrokerAddress });
-  };
-
-  return (
-    <div className="max-w-[1600px] mx-auto space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500 pb-12">
-        <ConsumerDetailModal 
-           isOpen={detailModal.isOpen} 
-           onClose={() => setDetailModal({ isOpen: false, consumer: null })} 
-           consumer={detailModal.consumer} 
-           address={sourceAddress}
-        />
-        <ConsumerConfigModal
-           isOpen={configModal.isOpen}
-           onClose={() => setConfigModal({ isOpen: false, consumer: null })}
-           consumer={configModal.consumer}
-           onEdit={handleEditFromConfig}
-        />
-        <ConsumerClientModal
-           isOpen={clientModal.isOpen}
-           onClose={() => setClientModal({ isOpen: false, consumer: null })}
-           consumer={clientModal.consumer}
-           address={sourceAddress}
-        />
-        <ConsumerEditorModal
-           isOpen={editorModal.isOpen}
-           onClose={() => setEditorModal({ isOpen: false, consumer: null })}
-           consumer={editorModal.consumer}
-           preferredBrokerAddress={editorModal.preferredBrokerAddress}
-           onSaved={() => void handleEditorSaved()}
-        />
-        <ConsumerDeleteModal
-           isOpen={deleteModal.isOpen}
-           onClose={() => setDeleteModal({ isOpen: false, consumer: null })}
-           consumer={deleteModal.consumer}
-           onDeleted={() => void handleDeleteSaved()}
-        />
-        {/* Toolbar */}
-        <div className="flex flex-col xl:flex-row xl:items-center justify-between gap-4 bg-white dark:bg-gray-900 p-4 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm sticky top-0 z-20 backdrop-blur-xl bg-white/90 dark:bg-gray-900/90 transition-colors">
-             {/* Left: Search & Filters */}
-             <div className="flex flex-wrap items-center gap-4">
-                <div className="relative group">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500 group-focus-within:text-blue-500 transition-colors" />
-                    <input 
-                      type="text" 
-                      placeholder="SubscriptionGroup..." 
-                      className="pl-10 pr-4 py-2 w-64 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all dark:text-white dark:placeholder:text-gray-500"
-                      value={searchTerm}
-                      onChange={(e) => {
-                        setSearchTerm(e.target.value);
-                        setCurrentPage(1);
-                      }}
-                    />
-                </div>
-
-                <div className="h-8 w-px bg-gray-200 dark:bg-gray-700 mx-2 hidden md:block"></div>
-
-                <div className="flex items-center space-x-2">
-                    {Object.entries(filters).map(([key, value]) => (
-                        <button
-                            key={key}
-                            onClick={() => toggleFilter(key)}
-                            className={`flex items-center px-3 py-1.5 rounded-lg text-xs font-medium border transition-all ${
-                                value 
-                                ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 shadow-sm' 
-                                : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700'
-                            }`}
-                        >
-                            {value && <Check className="w-3 h-3 mr-1.5" />}
-                            {key}
-                        </button>
-                    ))}
-                </div>
-             </div>
-
-             {/* Right: Actions */}
-             <div className="flex flex-wrap items-center gap-3">
-                 <div className="flex items-center space-x-2 bg-gray-50 dark:bg-gray-800 p-1 rounded-lg border border-gray-200 dark:border-gray-700">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 px-2">Proxy:</span>
-                    <select 
-                      onChange={(e) => setProxy(e.target.value)}
-                      className="bg-transparent text-xs font-medium text-gray-700 dark:text-gray-300 outline-none pr-2 cursor-pointer dark:bg-gray-800"
-                    >
-                        <option>127.0.0.1:8080</option>
-                    </select>
-                 </div>
-                 
-                 <div className="flex items-center space-x-2 px-2">
-                    <span className="text-xs font-medium text-gray-600 dark:text-gray-400">Enable Proxy</span>
-                    <button 
-                        onClick={() => setEnableProxy(!enableProxy)}
-                        className={`w-9 h-5 rounded-full p-0.5 transition-colors duration-200 ease-in-out ${enableProxy ? 'bg-blue-500' : 'bg-gray-200 dark:bg-gray-700'}`}
-                    >
-                        <div className={`w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform duration-200 ${enableProxy ? 'translate-x-4' : 'translate-x-0'}`} />
-                    </button>
-                 </div>
-
-                 <div className="h-8 w-px bg-gray-200 dark:bg-gray-700 mx-2"></div>
-
-                 <button
-                    onClick={() => setEditorModal({ isOpen: true, consumer: null })}
-                    className="flex items-center px-4 py-2 bg-gray-900 text-white rounded-xl text-sm font-medium hover:bg-gray-800 transition-all shadow-md hover:shadow-lg active:scale-95 dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
-                 >
-                    <Plus className="w-4 h-4 mr-2" />
-                    Add/Update
-                 </button>
-
-                 <button
-                    onClick={() => void refresh()}
-                    disabled={isRefreshPending || isInitialLoading}
-                    className="p-2 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-white rounded-lg transition-colors border border-transparent hover:border-gray-200 dark:hover:border-gray-700 disabled:opacity-60 disabled:cursor-not-allowed"
-                    title={isRefreshing ? 'Refreshing...' : 'Refresh consumer groups'}
-                 >
-                    {isRefreshing ? (
-                      <LoaderCircle className="w-4 h-4 animate-spin" />
-                    ) : (
-                      <RefreshCw className={`w-4 h-4 transition-transform duration-300 ${isRefreshPending ? 'rotate-12 scale-110' : ''}`} />
-                    )}
-                 </button>
-             </div>
-        </div>
-
-        {error && (
-          <div className="flex items-start gap-3 rounded-2xl border border-red-200/70 bg-red-50/80 px-4 py-3 text-sm text-red-700 shadow-sm dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-            <span>{error}</span>
-          </div>
-        )}
-
-        {response && (
-          <div className="flex flex-wrap items-center gap-3 rounded-2xl border border-gray-100 bg-white/80 px-4 py-3 text-sm text-gray-600 shadow-sm dark:border-gray-800 dark:bg-gray-900/80 dark:text-gray-300">
-            <span className="font-semibold text-gray-900 dark:text-white">NameServer:</span>
-            <span className="font-mono">{response.currentNamesrv}</span>
-            <span className="text-gray-300 dark:text-gray-600">/</span>
-            <span>Total:</span>
-            <span className="font-semibold text-gray-900 dark:text-white">{summary?.totalGroups ?? 0}</span>
-            <span className="text-gray-300 dark:text-gray-600">/</span>
-            <span>NORMAL:</span>
-            <span className="font-semibold text-gray-900 dark:text-white">{summary?.normalGroups ?? 0}</span>
-            <span className="text-gray-300 dark:text-gray-600">/</span>
-            <span>FIFO:</span>
-            <span className="font-semibold text-gray-900 dark:text-white">{summary?.fifoGroups ?? 0}</span>
-            <span className="text-gray-300 dark:text-gray-600">/</span>
-            <span>SYSTEM:</span>
-            <span className="font-semibold text-gray-900 dark:text-white">{summary?.systemGroups ?? 0}</span>
-            <span className="ml-auto rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
-              {response.useVipChannel ? 'VIP ON' : 'VIP OFF'} / {response.useTls ? 'TLS ON' : 'TLS OFF'}
-            </span>
-          </div>
-        )}
-
-        {isInitialLoading ? (
-          <div className="rounded-2xl border border-gray-100 bg-white/80 px-6 py-20 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900/80">
-            <div className="mx-auto flex w-fit items-center gap-3 rounded-full bg-gray-50 px-4 py-2 text-sm text-gray-600 dark:bg-gray-800 dark:text-gray-300">
-              <LoaderCircle className="h-4 w-4 animate-spin" />
-              Loading consumer groups...
-            </div>
-          </div>
-        ) : filteredConsumers.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-gray-200 bg-white/70 px-6 py-16 text-center text-sm text-gray-500 shadow-sm dark:border-gray-800 dark:bg-gray-900/70 dark:text-gray-400">
-            No consumer groups matched the current search and category filters.
-          </div>
-        ) : (
-        <>
-        {/* Card Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-6">
-            {currentConsumers.map((consumer, index) => (
-                <motion.div
-                    key={consumer.rawGroupName}
-                    initial={{ opacity: 0, y: 20, scale: 0.95 }}
-                    animate={{ opacity: 1, y: 0, scale: 1 }}
-                    whileHover={{ 
-                      y: -5, 
-                      scale: 1.01,
-                      boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.01)" 
-                    }}
-                    transition={{ 
-                      duration: 0.3, 
-                      delay: index * 0.05,
-                      ease: [0.22, 1, 0.36, 1]
-                    }}
-                    className="group bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm transition-all duration-200 overflow-hidden flex flex-col cursor-default"
-                >
-                    {/* Card Header */}
-                    <div className="p-5 border-b border-gray-50 dark:border-gray-800 bg-gradient-to-br from-gray-50/50 to-white dark:from-gray-800/50 dark:to-gray-900">
-                        <div className="flex justify-between items-start mb-3">
-                            <div>
-                                <h3 className="font-bold text-gray-900 dark:text-white text-lg break-all leading-tight">{consumer.displayGroupName}</h3>
-                                <div className="flex items-center mt-2 space-x-2">
-                                     <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 border border-blue-100 dark:border-blue-800 uppercase tracking-wide">
-                                        {consumer.messageModel}
-                                     </span>
-                                     <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 border border-purple-100 dark:border-purple-800 uppercase tracking-wide">
-                                        {consumer.consumeType}
-                                     </span>
-                                     <span className={`inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold border uppercase tracking-wide ${
-                                        consumer.category === 'SYSTEM'
-                                          ? 'bg-orange-50 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 border-orange-100 dark:border-orange-800'
-                                          : consumer.category === 'FIFO'
-                                            ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 border-emerald-100 dark:border-emerald-800'
-                                            : 'bg-slate-50 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border-slate-100 dark:border-slate-700'
-                                      }`}>
-                                        {consumer.category}
-                                     </span>
-                                </div>
-                            </div>
-                            <div className="text-[10px] font-mono text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-800 px-2 py-1 rounded border border-gray-100 dark:border-gray-700">
-                                {consumer.versionDesc}
-                            </div>
-                        </div>
-                    </div>
-
-                    {/* Metrics */}
-                    <div className="p-5 grid grid-cols-3 gap-4 bg-white dark:bg-gray-900">
-                        <div className="flex flex-col items-center p-3 rounded-xl bg-gray-50/50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-800 group-hover:border-blue-100 dark:group-hover:border-blue-900/50 transition-colors">
-                            <span className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500 font-semibold mb-1">TPS</span>
-                            <span className="text-lg font-mono font-bold text-gray-900 dark:text-white">{consumer.consumeTps}</span>
-                        </div>
-                        <div className="flex flex-col items-center p-3 rounded-xl bg-gray-50/50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-800 group-hover:border-orange-100 dark:group-hover:border-orange-900/50 transition-colors">
-                            <span className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500 font-semibold mb-1">Lag</span>
-                            <span className={`text-lg font-mono font-bold ${consumer.diffTotal > 0 ? 'text-orange-500' : 'text-gray-900 dark:text-white'}`}>{consumer.diffTotal}</span>
-                        </div>
-                        <div className="flex flex-col items-center p-3 rounded-xl bg-gray-50/50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-800 group-hover:border-green-100 dark:group-hover:border-green-900/50 transition-colors">
-                            <span className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500 font-semibold mb-1">Clients</span>
-                            <span className="text-lg font-mono font-bold text-gray-900 dark:text-white">{consumer.connectionCount}</span>
-                        </div>
-                    </div>
-
-                    {/* Footer / Actions */}
-                    <div className="mt-auto border-t border-gray-100 dark:border-gray-800 bg-gray-50/30 dark:bg-gray-800/30 p-3">
-                        <div className="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mb-3 px-2">
-                            <div className="flex items-center">
-                                <Clock className="w-3 h-3 mr-1" />
-                                Updated: {new Date(consumer.updateTimestamp).toLocaleTimeString()}
-                            </div>
-                        </div>
-                        <div className="grid grid-cols-5 gap-2">
-                             <button 
-                                onClick={() => setClientModal({ isOpen: true, consumer })}
-                                className="col-span-1 flex flex-col items-center justify-center p-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-600 dark:hover:text-blue-400 hover:border-blue-200 dark:hover:border-blue-800 transition-all shadow-sm group/btn"
-                                title="Client"
-                             >
-                                <Users className="w-4 h-4 mb-1" />
-                                <span className="text-[9px] font-medium">Client</span>
-                             </button>
-                             <button 
-                                onClick={() => setDetailModal({ isOpen: true, consumer })}
-                                className="col-span-1 flex flex-col items-center justify-center p-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-600 dark:hover:text-blue-400 hover:border-blue-200 dark:hover:border-blue-800 transition-all shadow-sm group/btn"
-                                title="Detail"
-                             >
-                                <FileText className="w-4 h-4 mb-1" />
-                                <span className="text-[9px] font-medium">Detail</span>
-                             </button>
-                             <button 
-                                onClick={() => setConfigModal({ isOpen: true, consumer })}
-                                className="col-span-1 flex flex-col items-center justify-center p-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-600 dark:hover:text-blue-400 hover:border-blue-200 dark:hover:border-blue-800 transition-all shadow-sm group/btn"
-                                title="Config"
-                             >
-                                <Settings className="w-4 h-4 mb-1" />
-                                <span className="text-[9px] font-medium">Config</span>
-                             </button>
-                             <button 
-                                onClick={() => void refreshGroup(consumer.rawGroupName)}
-                                disabled={refreshingGroup === consumer.rawGroupName}
-                                className="col-span-1 flex flex-col items-center justify-center p-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-600 dark:hover:text-blue-400 hover:border-blue-200 dark:hover:border-blue-800 transition-all shadow-sm group/btn disabled:opacity-60 disabled:cursor-not-allowed"
-                                title="Refresh"
-                             >
-                                {refreshingGroup === consumer.rawGroupName ? (
-                                  <LoaderCircle className="w-4 h-4 mb-1 animate-spin" />
-                                ) : (
-                                  <RefreshCw className="w-4 h-4 mb-1" />
-                                )}
-                                <span className="text-[9px] font-medium">Sync</span>
-                             </button>
-                             <button 
-                                onClick={() => setDeleteModal({ isOpen: true, consumer })}
-                                className="col-span-1 flex flex-col items-center justify-center p-2 rounded-lg bg-white dark:bg-gray-800 border border-red-100 dark:border-red-900/30 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 hover:border-red-200 dark:hover:border-red-800 transition-all shadow-sm group/btn"
-                                title="Delete"
-                             >
-                                <Trash2 className="w-4 h-4 mb-1" />
-                                <span className="text-[9px] font-medium">Delete</span>
-                             </button>
-                        </div>
-                    </div>
-                </motion.div>
-            ))}
-        </div>
-        </>
-        )}
-
-        {/* Pagination */}
-        <div className="flex items-center justify-center pt-6">
-            <Pagination 
-                currentPage={currentPage}
-                totalPages={totalPages}
-                onPageChange={goToPage}
-            />
-        </div>
-    </div>
-  );
-};
-
-export const ConsumerView = () => {
-  const { navigation, openConsumer, goBack } = useAppStore();
-  const target = navigation.target?.kind === 'consumer' ? navigation.target : null;
-  const openedTarget = useRef(false);
-
-  const [searchTerm, setSearchTerm] = useNavigationState('search', '');
-  const [filters, setFilters] = useNavigationState<Record<string, boolean>>('filters', {
-    NORMAL: true,
-    FIFO: !!target,
-    SYSTEM: true,
-  });
-  const [proxy, setProxy] = useNavigationState('proxy', target?.proxyAddress ?? '127.0.0.1:8080');
-  const [enableProxy, setEnableProxy] = useNavigationState('enableProxy', !!target?.proxyAddress);
-  const [detailModal, setDetailModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
-  const [configModal, setConfigModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
-  const [clientModal, setClientModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
-  const [editorModal, setEditorModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null, preferredBrokerAddress?: string }>({isOpen: false, consumer: null});
-  const [deleteModal, setDeleteModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
-  const [selectedGroup, setSelectedGroup] = useNavigationState('selection', target?.name ?? '');
-  const [currentPage, setCurrentPage] = useNavigationState('page', 1);
-  const itemsPerPage = 6;
-  const sourceAddress = enableProxy ? proxy : undefined;
-  const {
-    items,
-    summary,
-    response,
-    isInitialLoading,
-    isRefreshPending,
-    isRefreshing,
-    refreshingGroup,
-    error,
-    refresh,
-    refreshGroup,
-  } = useConsumerCatalog(sourceAddress);
-
-  const activeCategories = useMemo(
-    () => Object.entries(filters).filter(([, value]) => value).map(([key]) => key),
-    [filters],
-  );
-
-  const filteredConsumers = useMemo(() => {
-    const normalizedTerm = searchTerm.trim().toLowerCase();
-    return items.filter((consumer) => {
-      const matchesSearch =
-        normalizedTerm.length === 0 ||
-        consumer.displayGroupName.toLowerCase().includes(normalizedTerm) ||
-        consumer.rawGroupName.toLowerCase().includes(normalizedTerm);
-      const matchesCategory =
-        activeCategories.length === 0 || activeCategories.includes(consumer.category);
-      return matchesSearch && matchesCategory;
-    });
-  }, [activeCategories, items, searchTerm]);
-
-  const totalPages = Math.max(1, Math.ceil(filteredConsumers.length / itemsPerPage));
-  const currentConsumers = filteredConsumers.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage,
-  );
-  const selectedConsumer = findEntity(target ? items : filteredConsumers, (consumer) => consumer.rawGroupName, selectedGroup || null);
-  const targetMissing = target && response && !isInitialLoading && !error && !items.some((item) => item.rawGroupName === target.name);
-  const activeClientCount = items.reduce((total, consumer) => total + consumer.connectionCount, 0);
-  const totalLag = items.reduce((total, consumer) => total + consumer.diffTotal, 0);
-  const lagHealthClass = selectedConsumer && selectedConsumer.diffTotal > 0 ? 'is-warning' : 'is-healthy';
-
-  useEffect(() => {
-    if (response && currentPage > totalPages) {
-      setCurrentPage(totalPages);
-    }
-  }, [currentPage, totalPages]);
-
-  useEffect(() => {
-    if (target || !response) return;
-    if (filteredConsumers.length === 0) {
-      setSelectedGroup('');
-      return;
-    }
-    if (!filteredConsumers.some((consumer) => consumer.rawGroupName === selectedGroup)) {
-      setSelectedGroup(filteredConsumers[0].rawGroupName);
-    }
-  }, [filteredConsumers, selectedGroup]);
-
-  useEffect(() => {
-    if (!target || openedTarget.current || !response || isInitialLoading) return;
-    const consumer = items.find((item) => item.rawGroupName === target.name);
-    if (!consumer) return;
-    openedTarget.current = true;
-    const setters = { progress: setDetailModal, config: setConfigModal, clients: setClientModal };
-    if (target.detail !== 'overview') setters[target.detail]({ isOpen: true, consumer });
-  }, [target, response, isInitialLoading, items]);
-
-  const toggleFilter = (key: string) => {
-    setCurrentPage(1);
-    setFilters((current) => ({...current, [key]: !current[key]}));
-  };
-
-  const goToPage = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page);
-    }
-  };
-
-  const handleEditorSaved = async () => {
-    setEditorModal({isOpen: false, consumer: null});
-    await refresh();
-  };
-
-  const handleDeleteSaved = async () => {
-    setDeleteModal({isOpen: false, consumer: null});
-    await refresh();
-  };
-
-  const handleEditFromConfig = (consumer: ConsumerGroupListItem, preferredBrokerAddress?: string) => {
-    setConfigModal({isOpen: false, consumer: null});
-    setEditorModal({isOpen: true, consumer, preferredBrokerAddress});
-  };
-
-  const formatUpdatedTime = (timestamp: number) => {
-    if (!Number.isFinite(timestamp) || timestamp <= 0) {
-      return '-';
-    }
-    return new Date(timestamp).toLocaleTimeString();
-  };
-
-  const getCategoryClass = (category: string) => {
-    if (category === 'SYSTEM') {
-      return 'is-system';
-    }
-    if (category === 'FIFO') {
-      return 'is-fifo';
-    }
-    return 'is-normal';
-  };
-
-  return (
-    <div className="consumer-page">
-      {targetMissing && <p role="alert" className="p-4 text-red-600">Consumer group not found: {target.name}</p>}
-      <ConsumerDetailModal
-        isOpen={detailModal.isOpen}
-        onClose={() => { setDetailModal({isOpen: false, consumer: null}); if (target) goBack(); }}
-        consumer={detailModal.consumer}
-        address={sourceAddress}
-      />
-      <ConsumerConfigModal
-        isOpen={configModal.isOpen}
-        onClose={() => { setConfigModal({isOpen: false, consumer: null}); if (target) goBack(); }}
-        consumer={configModal.consumer}
-        onEdit={handleEditFromConfig}
-      />
-      <ConsumerClientModal
-        isOpen={clientModal.isOpen}
-        onClose={() => { setClientModal({isOpen: false, consumer: null}); if (target) goBack(); }}
-        consumer={clientModal.consumer}
-        address={sourceAddress}
-      />
-      <ConsumerEditorModal
-        isOpen={editorModal.isOpen}
-        onClose={() => setEditorModal({isOpen: false, consumer: null})}
-        consumer={editorModal.consumer}
-        preferredBrokerAddress={editorModal.preferredBrokerAddress}
-        onSaved={() => void handleEditorSaved()}
-      />
-      <ConsumerDeleteModal
-        isOpen={deleteModal.isOpen}
-        onClose={() => setDeleteModal({isOpen: false, consumer: null})}
-        consumer={deleteModal.consumer}
-        onDeleted={() => void handleDeleteSaved()}
-      />
-
-      <section className="consumer-summary-grid" aria-label="Consumer summary">
-        <div className="topic-summary-card">
-          <div>
-            <span>Consumer Groups</span>
-            <strong>{summary?.totalGroups ?? items.length}</strong>
-            <small>{summary?.normalGroups ?? 0} normal / {summary?.systemGroups ?? 0} system</small>
-          </div>
-          <span className="topic-summary-icon">
-            <Users className="topic-icon" aria-hidden="true"/>
-          </span>
-        </div>
-        <div className="topic-summary-card is-success">
-          <div>
-            <span>Active Clients</span>
-            <strong>{activeClientCount}</strong>
-            <small>connected consumers</small>
-          </div>
-          <span className="topic-summary-icon">
-            <Network className="topic-icon" aria-hidden="true"/>
-          </span>
-        </div>
-        <div className={`topic-summary-card ${totalLag > 0 ? 'is-warning' : 'is-blue'}`}>
-          <div>
-            <span>Total Lag</span>
-            <strong>{totalLag}</strong>
-            <small>{totalLag > 0 ? 'queue pressure detected' : 'no queue pressure'}</small>
-          </div>
-          <span className="topic-summary-icon">
-            <Activity className="topic-icon" aria-hidden="true"/>
-          </span>
-        </div>
-        <div className="topic-summary-card is-blue">
-          <div>
-            <span>Transport</span>
-            <strong>{response?.useVipChannel ? 'VIP' : 'Direct'}</strong>
-            <small>{response?.useVipChannel ? 'VIP on' : 'VIP off'} / {response?.useTls ? 'TLS on' : 'TLS off'}</small>
-          </div>
-          <span className="topic-summary-icon">
-            <Cpu className="topic-icon" aria-hidden="true"/>
-          </span>
-        </div>
-      </section>
-
-      <section className="consumer-command-panel" aria-label="Consumer filters and actions">
-        <div className="consumer-command-copy is-compact">
-          <span>Scope</span>
-          <div className="consumer-scope-pills" aria-label="Consumer catalog filter scope">
-            <b>Local filters</b>
-            <b>Proxy source</b>
-          </div>
-        </div>
-
-        <div className="consumer-query-controls">
-          <label className="consumer-search-field">
-            <Search className="topic-icon" aria-hidden="true"/>
-            <input
-              type="text"
-              placeholder="SubscriptionGroup..."
-              value={searchTerm}
-              onChange={(event) => {
-                setSearchTerm(event.target.value);
-                setCurrentPage(1);
-              }}
-            />
-          </label>
-
-          <div className="consumer-filter-row" aria-label="Consumer group category filters">
-            {Object.entries(filters).map(([key, value]) => (
-              <button
-                type="button"
-                key={key}
-                onClick={() => toggleFilter(key)}
-                className={`consumer-filter-chip ${value ? 'is-active' : ''} ${getCategoryClass(key)}`}
-              >
-                {value && <Check className="topic-icon" aria-hidden="true"/>}
-                <span>{key}</span>
-              </button>
-            ))}
-          </div>
-
-          <div className="consumer-proxy-control">
-            <span>Proxy</span>
-            <select value={proxy} onChange={(event) => setProxy(event.target.value)}>
-              <option>127.0.0.1:8080</option>
-            </select>
-          </div>
-
-          <button
-            type="button"
-            className={`consumer-proxy-toggle ${enableProxy ? 'is-on' : ''}`}
-            onClick={() => setEnableProxy((current) => !current)}
-          >
-            <span>Enable Proxy</span>
-            <i aria-hidden="true"/>
-          </button>
-
-          <button
-            type="button"
-            className="topic-action-button is-status consumer-add-button"
-            onClick={() => setEditorModal({isOpen: true, consumer: null})}
-          >
-            <Plus className="topic-icon" aria-hidden="true"/>
-            <span>Add / Update</span>
-          </button>
-
-          <button
-            type="button"
-            className="topic-action-button consumer-refresh-button"
-            onClick={() => void refresh()}
-            disabled={isRefreshPending || isInitialLoading}
-            title={isRefreshing ? 'Refreshing...' : 'Refresh consumer groups'}
-          >
-            {isRefreshing ? (
-              <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
-            ) : (
-              <RefreshCw className={`topic-icon ${isRefreshPending ? 'consumer-tilt' : ''}`} aria-hidden="true"/>
-            )}
-            <span className="sr-only">Refresh</span>
-          </button>
-        </div>
-      </section>
-
-      {error && (
-        <div className="consumer-alert" role="alert">
-          <AlertCircle className="topic-icon" aria-hidden="true"/>
-          <span>{error}</span>
-        </div>
-      )}
-
-      {response && (
-        <section className="consumer-scope-strip" aria-label="Consumer source details">
-          <div>
-            <span>NameServer:</span>
-            <strong>{response.currentNamesrv}</strong>
-            <i aria-hidden="true">/</i>
-            <span>Total</span>
-            <strong>{summary?.totalGroups ?? 0}</strong>
-            <i aria-hidden="true">/</i>
-            <span>NORMAL</span>
-            <strong>{summary?.normalGroups ?? 0}</strong>
-            <i aria-hidden="true">/</i>
-            <span>FIFO</span>
-            <strong>{summary?.fifoGroups ?? 0}</strong>
-            <i aria-hidden="true">/</i>
-            <span>SYSTEM</span>
-            <strong>{summary?.systemGroups ?? 0}</strong>
-          </div>
-          <b>{response.useVipChannel ? 'VIP ON' : 'VIP OFF'} / {response.useTls ? 'TLS ON' : 'TLS OFF'}</b>
-        </section>
-      )}
-
-      {isInitialLoading ? (
-        <div className="consumer-loading-state">
-          <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
-          <span>Loading consumer groups...</span>
-        </div>
-      ) : filteredConsumers.length === 0 ? (
-        <div className="consumer-empty-state">
-          <Search className="topic-icon" aria-hidden="true"/>
-          <strong>No consumer groups matched</strong>
-          <span>Adjust the search term or category filters to inspect another subscription group.</span>
-        </div>
-      ) : (
-        <section className="consumer-workspace">
-          <div className="consumer-panel consumer-list-panel">
-            <div className="topic-panel-header">
-              <div>
-                <h2>Consumer Catalog</h2>
-                <p>Subscription groups ranked by lag, clients, and lifecycle category.</p>
-              </div>
-              <div className="topic-panel-meta">
-                <span>{filteredConsumers.length} visible</span>
-              </div>
-            </div>
-
-            <div className="consumer-list">
-              {currentConsumers.map((consumer, index) => {
-                const selected = selectedConsumer?.rawGroupName === consumer.rawGroupName;
-                return (
-                  <motion.button
-                    type="button"
-                    key={consumer.rawGroupName}
-                    initial={{opacity: 0, y: 14}}
-                    animate={{opacity: 1, y: 0}}
-                    transition={{duration: 0.24, delay: index * 0.03}}
-                    className={`consumer-row ${selected ? 'is-selected' : ''} ${getCategoryClass(consumer.category)}`}
-                    onClick={() => setSelectedGroup(consumer.rawGroupName)}
-                  >
-                    <span className="consumer-row-main">
-                      <span className="consumer-row-icon">
-                        <Users className="topic-icon" aria-hidden="true"/>
-                      </span>
-                      <span className="consumer-row-copy">
-                        <strong title={consumer.displayGroupName}>{consumer.displayGroupName}</strong>
-                        <span>{consumer.rawGroupName}</span>
-                      </span>
-                    </span>
-                    <span className="consumer-badge-stack">
-                      <b className="is-model">{consumer.messageModel}</b>
-                      <b className="is-type">{consumer.consumeType}</b>
-                      <b className={getCategoryClass(consumer.category)}>{consumer.category}</b>
-                    </span>
-                    <span className="consumer-row-metric">
-                      <span>TPS</span>
-                      <strong>{consumer.consumeTps}</strong>
-                    </span>
-                    <span className={`consumer-row-metric ${consumer.diffTotal > 0 ? 'is-warning' : ''}`}>
-                      <span>Lag</span>
-                      <strong>{consumer.diffTotal}</strong>
-                    </span>
-                    <span className="consumer-row-metric">
-                      <span>Clients</span>
-                      <strong>{consumer.connectionCount}</strong>
-                    </span>
-                    <span className="consumer-row-updated">
-                      <Clock className="topic-icon" aria-hidden="true"/>
-                      {formatUpdatedTime(consumer.updateTimestamp)}
-                    </span>
-                  </motion.button>
-                );
-              })}
-            </div>
-          </div>
-
-          <aside className="consumer-panel consumer-inspector-panel" aria-label="Selected consumer group">
-            {selectedConsumer ? (
-              <>
-                <div className="consumer-inspector-header">
-                  <span>Selected Consumer</span>
-                  <strong>{selectedConsumer.displayGroupName}</strong>
-                  <small>{selectedConsumer.rawGroupName}</small>
-                  <div className="consumer-badge-stack">
-                    <b className="is-model">{selectedConsumer.messageModel}</b>
-                    <b className="is-type">{selectedConsumer.consumeType}</b>
-                    <b className={getCategoryClass(selectedConsumer.category)}>{selectedConsumer.category}</b>
-                  </div>
-                </div>
-
-                <div className={`consumer-health-card ${lagHealthClass}`}>
-                  <span>Lag health</span>
-                  <strong>{selectedConsumer.diffTotal > 0 ? 'Lagging' : 'Healthy'}</strong>
-                  <small>
-                    {selectedConsumer.diffTotal > 0
-                      ? 'This group has queue backlog and needs inspection.'
-                      : 'No queue pressure reported by this group.'}
-                  </small>
-                </div>
-
-                <div className="consumer-detail-grid">
-                  <div>
-                    <span>TPS</span>
-                    <strong>{selectedConsumer.consumeTps}</strong>
-                  </div>
-                  <div>
-                    <span>Lag</span>
-                    <strong>{selectedConsumer.diffTotal}</strong>
-                  </div>
-                  <div>
-                    <span>Clients</span>
-                    <strong>{selectedConsumer.connectionCount}</strong>
-                  </div>
-                  <div>
-                    <span>Version</span>
-                    <strong>{selectedConsumer.versionDesc}</strong>
-                  </div>
-                  <div>
-                    <span>Brokers</span>
-                    <strong>{selectedConsumer.brokerNames.length || '-'}</strong>
-                  </div>
-                  <div>
-                    <span>Updated</span>
-                    <strong>{formatUpdatedTime(selectedConsumer.updateTimestamp)}</strong>
-                  </div>
-                </div>
-
-                <div className="consumer-action-grid">
-                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'clients', sourceAddress)}>
-                    <Users className="topic-icon" aria-hidden="true"/>
-                    <span>Client</span>
-                  </button>
-                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'progress', sourceAddress)}>
-                    <FileText className="topic-icon" aria-hidden="true"/>
-                    <span>Detail</span>
-                  </button>
-                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'config', sourceAddress)}>
-                    <Settings className="topic-icon" aria-hidden="true"/>
-                    <span>Config</span>
-                  </button>
-                  <button
-                    type="button"
-                    className="topic-action-button"
-                    onClick={() => void refreshGroup(selectedConsumer.rawGroupName)}
-                    disabled={refreshingGroup === selectedConsumer.rawGroupName}
-                  >
-                    {refreshingGroup === selectedConsumer.rawGroupName ? (
-                      <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
-                    ) : (
-                      <RefreshCw className="topic-icon" aria-hidden="true"/>
-                    )}
-                    <span>Sync</span>
-                  </button>
-                  <button type="button" className="topic-action-button is-danger" onClick={() => setDeleteModal({isOpen: true, consumer: selectedConsumer})}>
-                    <Trash2 className="topic-icon" aria-hidden="true"/>
-                    <span>Delete</span>
-                  </button>
-                </div>
-              </>
-            ) : (
-              <div className="consumer-empty-state is-compact">
-                <Users className="topic-icon" aria-hidden="true"/>
-                <strong>No consumer selected</strong>
-                <span>Select a consumer group from the catalog to inspect actions.</span>
-              </div>
-            )}
-          </aside>
-        </section>
-      )}
-
-      <footer className="consumer-footer">
-        <span>Consumer group data is read-only until Add/Update, Config, or Delete opens a scoped mutation flow.</span>
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={goToPage}
-        />
-      </footer>
-    </div>
-  );
-};
+import { motion } from 'motion/react';
+import { ConnectionStore } from '../services/connection.store';
+import { getConnectionSettings } from '../services/connection.service';
+import { resolveConsumerScope, consumerScopeKey } from '../features/consumer/scope';
+import type { ConsumerQueryScope } from '../features/consumer/types/consumer.types';
+import { useAppStore, useNavigationState } from '../stores/app.store';
+import { findEntity } from '../stores/navigation';
+import React, { useEffect, useMemo, useState, useRef, useSyncExternalStore } from 'react';
+import { Users, Settings, Trash2, Search, Check, RefreshCw, Plus, Clock, FileText, Activity, Network, Cpu, AlertCircle, LoaderCircle } from 'lucide-react';
+import { toast } from 'sonner@2.0.3';
+import { Pagination } from './Pagination';
+import { useConsumerCatalog } from '../features/consumer/hooks/useConsumerCatalog';
+import { ConsumerClientModal } from '../features/consumer/components/ConsumerClientModal';
+import { ConsumerConfigModal } from '../features/consumer/components/ConsumerConfigModal';
+import { ConsumerDeleteModal } from '../features/consumer/components/ConsumerDeleteModal';
+import { ConsumerDetailModal } from '../features/consumer/components/ConsumerDetailModal';
+import { ConsumerEditorModal } from '../features/consumer/components/ConsumerEditorModal';
+import type { ConsumerGroupListItem } from '../features/consumer/types/consumer.types';
+
+export const ConsumerView = () => {
+  const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
+  const { consumerQueryMode, setConsumerQueryMode, setActiveTab, navigation } = useAppStore();
+  const [queryMode, setQueryMode] = useNavigationState<ConsumerQueryScope['mode']>('queryMode', navigation.target?.kind === 'consumer' ? navigation.target.scope.mode : consumerQueryMode);
+  const changeMode = (mode: ConsumerQueryScope['mode']) => { setQueryMode(mode); setConsumerQueryMode(mode); };
+  const [settingsError, setSettingsError] = useState('');
+  useEffect(() => {
+    let active = true;
+    if (!settings) void getConnectionSettings().catch(() => { if (active) setSettingsError('Unable to load connection settings.'); });
+    return () => { active = false; };
+  }, [settings]);
+  const scope = useMemo(() => resolveConsumerScope(settings, queryMode), [settings, queryMode]);
+  if (!settings) return <p role="status" className="p-6">{settingsError || 'Loading connection settings...'}</p>;
+  if (!scope) return <div className="p-6 space-y-3"><p role="alert">Select a Proxy in connection settings before using Proxy mode.</p><button type="button" className="underline mr-4" onClick={() => setActiveTab('Proxy')}>Configure Proxy</button><button type="button" className="underline" onClick={() => changeMode('name_server')}>Use NameServer</button></div>;
+  return <ConsumerCatalog key={consumerScopeKey(scope)} scope={scope} proxyAddress={settings.proxy.currentProxyAddr} changeMode={changeMode} />;
+};
+
+const ConsumerCatalog = ({ scope, proxyAddress, changeMode }: { scope: ConsumerQueryScope; proxyAddress: string | null; changeMode: (mode: ConsumerQueryScope['mode']) => void }) => {
+  const { navigation, openConsumer, goBack, setActiveTab } = useAppStore();
+  const target = navigation.target?.kind === 'consumer' && consumerScopeKey(navigation.target.scope) === consumerScopeKey(scope) ? navigation.target : null;
+  const openedTarget = useRef(false);
+
+  const [searchTerm, setSearchTerm] = useNavigationState(`search:${consumerScopeKey(scope)}`, '');
+  const [filters, setFilters] = useNavigationState<Record<string, boolean>>(`filters:${consumerScopeKey(scope)}`, {
+    NORMAL: true,
+    FIFO: !!target,
+    SYSTEM: true,
+  });
+  const enableProxy = scope.mode === 'proxy';
+  const [detailModal, setDetailModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
+  const [configModal, setConfigModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
+  const [clientModal, setClientModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
+  const [editorModal, setEditorModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null, preferredBrokerAddress?: string }>({isOpen: false, consumer: null});
+  const [deleteModal, setDeleteModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
+  const [selectedGroup, setSelectedGroup] = useNavigationState(`selection:${consumerScopeKey(scope)}`, target?.name ?? '');
+  const [currentPage, setCurrentPage] = useNavigationState(`page:${consumerScopeKey(scope)}`, 1);
+  const itemsPerPage = 6;
+  const {
+    items,
+    summary,
+    response,
+    isInitialLoading,
+    isRefreshPending,
+    isRefreshing,
+    refreshingGroup,
+    error,
+    refresh,
+    refreshGroup,
+  } = useConsumerCatalog(scope);
+
+  const activeCategories = useMemo(
+    () => Object.entries(filters).filter(([, value]) => value).map(([key]) => key),
+    [filters],
+  );
+
+  const filteredConsumers = useMemo(() => {
+    const normalizedTerm = searchTerm.trim().toLowerCase();
+    return items.filter((consumer) => {
+      const matchesSearch =
+        normalizedTerm.length === 0 ||
+        consumer.displayGroupName.toLowerCase().includes(normalizedTerm) ||
+        consumer.rawGroupName.toLowerCase().includes(normalizedTerm);
+      const matchesCategory =
+        activeCategories.length === 0 || activeCategories.includes(consumer.category);
+      return matchesSearch && matchesCategory;
+    });
+  }, [activeCategories, items, searchTerm]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredConsumers.length / itemsPerPage));
+  const currentConsumers = filteredConsumers.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage,
+  );
+  const selectedConsumer = findEntity(target ? items : filteredConsumers, (consumer) => consumer.rawGroupName, selectedGroup || null);
+  const targetMissing = target && response && !isInitialLoading && !error && !items.some((item) => item.rawGroupName === target.name);
+  const activeClientCount = items.reduce((total, consumer) => total + consumer.connectionCount, 0);
+  const totalLag = items.reduce((total, consumer) => total + consumer.diffTotal, 0);
+  const lagHealthClass = selectedConsumer && selectedConsumer.diffTotal > 0 ? 'is-warning' : 'is-healthy';
+
+  useEffect(() => {
+    if (response && currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  useEffect(() => {
+    if (target || !response) return;
+    if (filteredConsumers.length === 0) {
+      setSelectedGroup('');
+      return;
+    }
+    if (!filteredConsumers.some((consumer) => consumer.rawGroupName === selectedGroup)) {
+      setSelectedGroup(filteredConsumers[0].rawGroupName);
+    }
+  }, [filteredConsumers, selectedGroup]);
+
+  useEffect(() => {
+    if (!target || openedTarget.current || !response || isInitialLoading) return;
+    const consumer = items.find((item) => item.rawGroupName === target.name);
+    if (!consumer) return;
+    openedTarget.current = true;
+    const setters = { progress: setDetailModal, config: setConfigModal, clients: setClientModal };
+    if (target.detail !== 'overview') setters[target.detail]({ isOpen: true, consumer });
+  }, [target, response, isInitialLoading, items]);
+
+  const toggleFilter = (key: string) => {
+    setCurrentPage(1);
+    setFilters((current) => ({...current, [key]: !current[key]}));
+  };
+
+  const goToPage = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
+
+  const handleEditorSaved = async () => {
+    setEditorModal({isOpen: false, consumer: null});
+    await refresh();
+  };
+
+  const handleDeleteSaved = async () => {
+    setDeleteModal({isOpen: false, consumer: null});
+    await refresh();
+  };
+
+  const handleEditFromConfig = (consumer: ConsumerGroupListItem, preferredBrokerAddress?: string) => {
+    setConfigModal({isOpen: false, consumer: null});
+    setEditorModal({isOpen: true, consumer, preferredBrokerAddress});
+  };
+
+  const formatUpdatedTime = (timestamp: number) => {
+    if (!Number.isFinite(timestamp) || timestamp <= 0) {
+      return '-';
+    }
+    return new Date(timestamp).toLocaleTimeString();
+  };
+
+  const getCategoryClass = (category: string) => {
+    if (category === 'SYSTEM') {
+      return 'is-system';
+    }
+    if (category === 'FIFO') {
+      return 'is-fifo';
+    }
+    return 'is-normal';
+  };
+
+  return (
+    <div className="consumer-page">
+      {targetMissing && <p role="alert" className="p-4 text-red-600">Consumer group not found: {target.name}</p>}
+      <ConsumerDetailModal
+        isOpen={detailModal.isOpen}
+        onClose={() => { setDetailModal({isOpen: false, consumer: null}); if (target) goBack(); }}
+        consumer={detailModal.consumer}
+        scope={scope}
+      />
+      <ConsumerConfigModal
+        isOpen={configModal.isOpen}
+        onClose={() => { setConfigModal({isOpen: false, consumer: null}); if (target) goBack(); }}
+        consumer={configModal.consumer}
+        onEdit={handleEditFromConfig}
+      />
+      <ConsumerClientModal
+        isOpen={clientModal.isOpen}
+        onClose={() => { setClientModal({isOpen: false, consumer: null}); if (target) goBack(); }}
+        consumer={clientModal.consumer}
+        scope={scope}
+      />
+      <ConsumerEditorModal
+        isOpen={editorModal.isOpen}
+        onClose={() => setEditorModal({isOpen: false, consumer: null})}
+        consumer={editorModal.consumer}
+        preferredBrokerAddress={editorModal.preferredBrokerAddress}
+        onSaved={() => void handleEditorSaved()}
+      />
+      <ConsumerDeleteModal
+        isOpen={deleteModal.isOpen}
+        onClose={() => setDeleteModal({isOpen: false, consumer: null})}
+        consumer={deleteModal.consumer}
+        onDeleted={() => void handleDeleteSaved()}
+      />
+
+      <section className="consumer-summary-grid" aria-label="Consumer summary">
+        <div className="topic-summary-card">
+          <div>
+            <span>Consumer Groups</span>
+            <strong>{summary?.totalGroups ?? items.length}</strong>
+            <small>{summary?.normalGroups ?? 0} normal / {summary?.systemGroups ?? 0} system</small>
+          </div>
+          <span className="topic-summary-icon">
+            <Users className="topic-icon" aria-hidden="true"/>
+          </span>
+        </div>
+        <div className="topic-summary-card is-success">
+          <div>
+            <span>Active Clients</span>
+            <strong>{activeClientCount}</strong>
+            <small>connected consumers</small>
+          </div>
+          <span className="topic-summary-icon">
+            <Network className="topic-icon" aria-hidden="true"/>
+          </span>
+        </div>
+        <div className={`topic-summary-card ${totalLag > 0 ? 'is-warning' : 'is-blue'}`}>
+          <div>
+            <span>Total Lag</span>
+            <strong>{totalLag}</strong>
+            <small>{totalLag > 0 ? 'queue pressure detected' : 'no queue pressure'}</small>
+          </div>
+          <span className="topic-summary-icon">
+            <Activity className="topic-icon" aria-hidden="true"/>
+          </span>
+        </div>
+        <div className="topic-summary-card is-blue">
+          <div>
+            <span>Transport</span>
+            <strong>{response?.useVipChannel ? 'VIP' : 'Direct'}</strong>
+            <small>{response?.useVipChannel ? 'VIP on' : 'VIP off'} / {response?.useTls ? 'TLS on' : 'TLS off'}</small>
+          </div>
+          <span className="topic-summary-icon">
+            <Cpu className="topic-icon" aria-hidden="true"/>
+          </span>
+        </div>
+      </section>
+
+      <section className="consumer-command-panel" aria-label="Consumer filters and actions">
+        <div className="consumer-command-copy is-compact">
+          <span>Scope</span>
+          <div className="consumer-scope-pills" aria-label="Consumer catalog filter scope">
+            <b>Local filters</b>
+            <b>Proxy source</b>
+          </div>
+        </div>
+
+        <div className="consumer-query-controls">
+          <label className="consumer-search-field">
+            <Search className="topic-icon" aria-hidden="true"/>
+            <input
+              type="text"
+              placeholder="SubscriptionGroup..."
+              value={searchTerm}
+              onChange={(event) => {
+                setSearchTerm(event.target.value);
+                setCurrentPage(1);
+              }}
+            />
+          </label>
+
+          <div className="consumer-filter-row" aria-label="Consumer group category filters">
+            {Object.entries(filters).map(([key, value]) => (
+              <button
+                type="button"
+                key={key}
+                onClick={() => toggleFilter(key)}
+                className={`consumer-filter-chip ${value ? 'is-active' : ''} ${getCategoryClass(key)}`}
+              >
+                {value && <Check className="topic-icon" aria-hidden="true"/>}
+                <span>{key}</span>
+              </button>
+            ))}
+          </div>
+
+          <div className="consumer-proxy-control">
+            <span>Proxy</span>
+            <span>{proxyAddress ?? 'Not configured'}</span>
+            <button type="button" className="underline" onClick={() => setActiveTab('Proxy')}>Configure</button>
+          </div>
+
+          <button
+            type="button"
+            className={`consumer-proxy-toggle ${enableProxy ? 'is-on' : ''}`}
+            disabled={!proxyAddress && !enableProxy}
+            onClick={() => changeMode(enableProxy ? 'name_server' : 'proxy')}
+          >
+            <span>Enable Proxy</span>
+            <i aria-hidden="true"/>
+          </button>
+
+          <button
+            type="button"
+            className="topic-action-button is-status consumer-add-button"
+            onClick={() => setEditorModal({isOpen: true, consumer: null})}
+          >
+            <Plus className="topic-icon" aria-hidden="true"/>
+            <span>Add / Update</span>
+          </button>
+
+          <button
+            type="button"
+            className="topic-action-button consumer-refresh-button"
+            onClick={() => void refresh()}
+            disabled={isRefreshPending || isInitialLoading}
+            title={isRefreshing ? 'Refreshing...' : 'Refresh consumer groups'}
+          >
+            {isRefreshing ? (
+              <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
+            ) : (
+              <RefreshCw className={`topic-icon ${isRefreshPending ? 'consumer-tilt' : ''}`} aria-hidden="true"/>
+            )}
+            <span className="sr-only">Refresh</span>
+          </button>
+        </div>
+      </section>
+
+      {error && (
+        <div className="consumer-alert" role="alert">
+          <AlertCircle className="topic-icon" aria-hidden="true"/>
+          <span>{error}</span>
+        </div>
+      )}
+
+      {response && (
+        <section className="consumer-scope-strip" aria-label="Consumer source details">
+          <div>
+            <span>NameServer:</span>
+            <strong>{response.currentNamesrv}</strong>
+            <i aria-hidden="true">/</i>
+            <span>Total</span>
+            <strong>{summary?.totalGroups ?? 0}</strong>
+            <i aria-hidden="true">/</i>
+            <span>NORMAL</span>
+            <strong>{summary?.normalGroups ?? 0}</strong>
+            <i aria-hidden="true">/</i>
+            <span>FIFO</span>
+            <strong>{summary?.fifoGroups ?? 0}</strong>
+            <i aria-hidden="true">/</i>
+            <span>SYSTEM</span>
+            <strong>{summary?.systemGroups ?? 0}</strong>
+          </div>
+          <b>{response.useVipChannel ? 'VIP ON' : 'VIP OFF'} / {response.useTls ? 'TLS ON' : 'TLS OFF'}</b>
+        </section>
+      )}
+
+      {isInitialLoading ? (
+        <div className="consumer-loading-state">
+          <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
+          <span>Loading consumer groups...</span>
+        </div>
+      ) : filteredConsumers.length === 0 ? (
+        <div className="consumer-empty-state">
+          <Search className="topic-icon" aria-hidden="true"/>
+          <strong>No consumer groups matched</strong>
+          <span>Adjust the search term or category filters to inspect another subscription group.</span>
+        </div>
+      ) : (
+        <section className="consumer-workspace">
+          <div className="consumer-panel consumer-list-panel">
+            <div className="topic-panel-header">
+              <div>
+                <h2>Consumer Catalog</h2>
+                <p>Subscription groups ranked by lag, clients, and lifecycle category.</p>
+              </div>
+              <div className="topic-panel-meta">
+                <span>{filteredConsumers.length} visible</span>
+              </div>
+            </div>
+
+            <div className="consumer-list">
+              {currentConsumers.map((consumer, index) => {
+                const selected = selectedConsumer?.rawGroupName === consumer.rawGroupName;
+                return (
+                  <motion.button
+                    type="button"
+                    key={consumer.rawGroupName}
+                    initial={{opacity: 0, y: 14}}
+                    animate={{opacity: 1, y: 0}}
+                    transition={{duration: 0.24, delay: index * 0.03}}
+                    className={`consumer-row ${selected ? 'is-selected' : ''} ${getCategoryClass(consumer.category)}`}
+                    onClick={() => setSelectedGroup(consumer.rawGroupName)}
+                  >
+                    <span className="consumer-row-main">
+                      <span className="consumer-row-icon">
+                        <Users className="topic-icon" aria-hidden="true"/>
+                      </span>
+                      <span className="consumer-row-copy">
+                        <strong title={consumer.displayGroupName}>{consumer.displayGroupName}</strong>
+                        <span>{consumer.rawGroupName}</span>
+                      </span>
+                    </span>
+                    <span className="consumer-badge-stack">
+                      <b className="is-model">{consumer.messageModel}</b>
+                      <b className="is-type">{consumer.consumeType}</b>
+                      <b className={getCategoryClass(consumer.category)}>{consumer.category}</b>
+                    </span>
+                    <span className="consumer-row-metric">
+                      <span>TPS</span>
+                      <strong>{consumer.consumeTps}</strong>
+                    </span>
+                    <span className={`consumer-row-metric ${consumer.diffTotal > 0 ? 'is-warning' : ''}`}>
+                      <span>Lag</span>
+                      <strong>{consumer.diffTotal}</strong>
+                    </span>
+                    <span className="consumer-row-metric">
+                      <span>Clients</span>
+                      <strong>{consumer.connectionCount}</strong>
+                    </span>
+                    <span className="consumer-row-updated">
+                      <Clock className="topic-icon" aria-hidden="true"/>
+                      {formatUpdatedTime(consumer.updateTimestamp)}
+                    </span>
+                  </motion.button>
+                );
+              })}
+            </div>
+          </div>
+
+          <aside className="consumer-panel consumer-inspector-panel" aria-label="Selected consumer group">
+            {selectedConsumer ? (
+              <>
+                <div className="consumer-inspector-header">
+                  <span>Selected Consumer</span>
+                  <strong>{selectedConsumer.displayGroupName}</strong>
+                  <small>{selectedConsumer.rawGroupName}</small>
+                  <div className="consumer-badge-stack">
+                    <b className="is-model">{selectedConsumer.messageModel}</b>
+                    <b className="is-type">{selectedConsumer.consumeType}</b>
+                    <b className={getCategoryClass(selectedConsumer.category)}>{selectedConsumer.category}</b>
+                  </div>
+                </div>
+
+                <div className={`consumer-health-card ${lagHealthClass}`}>
+                  <span>Lag health</span>
+                  <strong>{selectedConsumer.diffTotal > 0 ? 'Lagging' : 'Healthy'}</strong>
+                  <small>
+                    {selectedConsumer.diffTotal > 0
+                      ? 'This group has queue backlog and needs inspection.'
+                      : 'No queue pressure reported by this group.'}
+                  </small>
+                </div>
+
+                <div className="consumer-detail-grid">
+                  <div>
+                    <span>TPS</span>
+                    <strong>{selectedConsumer.consumeTps}</strong>
+                  </div>
+                  <div>
+                    <span>Lag</span>
+                    <strong>{selectedConsumer.diffTotal}</strong>
+                  </div>
+                  <div>
+                    <span>Clients</span>
+                    <strong>{selectedConsumer.connectionCount}</strong>
+                  </div>
+                  <div>
+                    <span>Version</span>
+                    <strong>{selectedConsumer.versionDesc}</strong>
+                  </div>
+                  <div>
+                    <span>Brokers</span>
+                    <strong>{selectedConsumer.brokerNames.length || '-'}</strong>
+                  </div>
+                  <div>
+                    <span>Updated</span>
+                    <strong>{formatUpdatedTime(selectedConsumer.updateTimestamp)}</strong>
+                  </div>
+                </div>
+
+                <div className="consumer-action-grid">
+                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'clients', scope)}>
+                    <Users className="topic-icon" aria-hidden="true"/>
+                    <span>Client</span>
+                  </button>
+                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'progress', scope)}>
+                    <FileText className="topic-icon" aria-hidden="true"/>
+                    <span>Detail</span>
+                  </button>
+                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'config', scope)}>
+                    <Settings className="topic-icon" aria-hidden="true"/>
+                    <span>Config</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="topic-action-button"
+                    onClick={() => void refreshGroup(selectedConsumer.rawGroupName)}
+                    disabled={refreshingGroup === selectedConsumer.rawGroupName}
+                  >
+                    {refreshingGroup === selectedConsumer.rawGroupName ? (
+                      <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
+                    ) : (
+                      <RefreshCw className="topic-icon" aria-hidden="true"/>
+                    )}
+                    <span>Sync</span>
+                  </button>
+                  <button type="button" className="topic-action-button is-danger" onClick={() => setDeleteModal({isOpen: true, consumer: selectedConsumer})}>
+                    <Trash2 className="topic-icon" aria-hidden="true"/>
+                    <span>Delete</span>
+                  </button>
+                </div>
+              </>
+            ) : (
+              <div className="consumer-empty-state is-compact">
+                <Users className="topic-icon" aria-hidden="true"/>
+                <strong>No consumer selected</strong>
+                <span>Select a consumer group from the catalog to inspect actions.</span>
+              </div>
+            )}
+          </aside>
+        </section>
+      )}
+
+      <footer className="consumer-footer">
+        <span>Consumer group data is read-only until Add/Update, Config, or Delete opens a scoped mutation flow.</span>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+        />
+      </footer>
+    </div>
+  );
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
@@ -1,531 +1,531 @@
 import { motion } from 'motion/react';
-import { ConnectionStore } from '../services/connection.store';
-import { getConnectionSettings } from '../services/connection.service';
-import { resolveConsumerScope, consumerScopeKey } from '../features/consumer/scope';
-import type { ConsumerQueryScope } from '../features/consumer/types/consumer.types';
-import { useAppStore, useNavigationState } from '../stores/app.store';
-import { findEntity } from '../stores/navigation';
-import React, { useEffect, useMemo, useState, useRef, useSyncExternalStore } from 'react';
-import { Users, Settings, Trash2, Search, Check, RefreshCw, Plus, Clock, FileText, Activity, Network, Cpu, AlertCircle, LoaderCircle } from 'lucide-react';
-import { toast } from 'sonner@2.0.3';
-import { Pagination } from './Pagination';
-import { useConsumerCatalog } from '../features/consumer/hooks/useConsumerCatalog';
-import { ConsumerClientModal } from '../features/consumer/components/ConsumerClientModal';
-import { ConsumerConfigModal } from '../features/consumer/components/ConsumerConfigModal';
-import { ConsumerDeleteModal } from '../features/consumer/components/ConsumerDeleteModal';
-import { ConsumerDetailModal } from '../features/consumer/components/ConsumerDetailModal';
-import { ConsumerEditorModal } from '../features/consumer/components/ConsumerEditorModal';
-import type { ConsumerGroupListItem } from '../features/consumer/types/consumer.types';
-
-export const ConsumerView = () => {
-  const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
-  const { consumerQueryMode, setConsumerQueryMode, setActiveTab, navigation } = useAppStore();
-  const [queryMode, setQueryMode] = useNavigationState<ConsumerQueryScope['mode']>('queryMode', navigation.target?.kind === 'consumer' ? navigation.target.scope.mode : consumerQueryMode);
-  const changeMode = (mode: ConsumerQueryScope['mode']) => { setQueryMode(mode); setConsumerQueryMode(mode); };
-  const [settingsError, setSettingsError] = useState('');
-  useEffect(() => {
-    let active = true;
-    if (!settings) void getConnectionSettings().catch(() => { if (active) setSettingsError('Unable to load connection settings.'); });
-    return () => { active = false; };
-  }, [settings]);
-  const scope = useMemo(() => resolveConsumerScope(settings, queryMode), [settings, queryMode]);
-  if (!settings) return <p role="status" className="p-6">{settingsError || 'Loading connection settings...'}</p>;
-  if (!scope) return <div className="p-6 space-y-3"><p role="alert">Select a Proxy in connection settings before using Proxy mode.</p><button type="button" className="underline mr-4" onClick={() => setActiveTab('Proxy')}>Configure Proxy</button><button type="button" className="underline" onClick={() => changeMode('name_server')}>Use NameServer</button></div>;
-  return <ConsumerCatalog key={consumerScopeKey(scope)} scope={scope} proxyAddress={settings.proxy.currentProxyAddr} changeMode={changeMode} />;
-};
-
-const ConsumerCatalog = ({ scope, proxyAddress, changeMode }: { scope: ConsumerQueryScope; proxyAddress: string | null; changeMode: (mode: ConsumerQueryScope['mode']) => void }) => {
-  const { navigation, openConsumer, goBack, setActiveTab } = useAppStore();
-  const target = navigation.target?.kind === 'consumer' && consumerScopeKey(navigation.target.scope) === consumerScopeKey(scope) ? navigation.target : null;
-  const openedTarget = useRef(false);
-
-  const [searchTerm, setSearchTerm] = useNavigationState(`search:${consumerScopeKey(scope)}`, '');
-  const [filters, setFilters] = useNavigationState<Record<string, boolean>>(`filters:${consumerScopeKey(scope)}`, {
-    NORMAL: true,
-    FIFO: !!target,
-    SYSTEM: true,
-  });
-  const enableProxy = scope.mode === 'proxy';
-  const [detailModal, setDetailModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
-  const [configModal, setConfigModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
-  const [clientModal, setClientModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
-  const [editorModal, setEditorModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null, preferredBrokerAddress?: string }>({isOpen: false, consumer: null});
-  const [deleteModal, setDeleteModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
-  const [selectedGroup, setSelectedGroup] = useNavigationState(`selection:${consumerScopeKey(scope)}`, target?.name ?? '');
-  const [currentPage, setCurrentPage] = useNavigationState(`page:${consumerScopeKey(scope)}`, 1);
-  const itemsPerPage = 6;
-  const {
-    items,
-    summary,
-    response,
-    isInitialLoading,
-    isRefreshPending,
-    isRefreshing,
-    refreshingGroup,
-    error,
-    refresh,
-    refreshGroup,
-  } = useConsumerCatalog(scope);
-
-  const activeCategories = useMemo(
-    () => Object.entries(filters).filter(([, value]) => value).map(([key]) => key),
-    [filters],
-  );
-
-  const filteredConsumers = useMemo(() => {
-    const normalizedTerm = searchTerm.trim().toLowerCase();
-    return items.filter((consumer) => {
-      const matchesSearch =
-        normalizedTerm.length === 0 ||
-        consumer.displayGroupName.toLowerCase().includes(normalizedTerm) ||
-        consumer.rawGroupName.toLowerCase().includes(normalizedTerm);
-      const matchesCategory =
-        activeCategories.length === 0 || activeCategories.includes(consumer.category);
-      return matchesSearch && matchesCategory;
-    });
-  }, [activeCategories, items, searchTerm]);
-
-  const totalPages = Math.max(1, Math.ceil(filteredConsumers.length / itemsPerPage));
-  const currentConsumers = filteredConsumers.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage,
-  );
-  const selectedConsumer = findEntity(target ? items : filteredConsumers, (consumer) => consumer.rawGroupName, selectedGroup || null);
-  const targetMissing = target && response && !isInitialLoading && !error && !items.some((item) => item.rawGroupName === target.name);
-  const activeClientCount = items.reduce((total, consumer) => total + consumer.connectionCount, 0);
-  const totalLag = items.reduce((total, consumer) => total + consumer.diffTotal, 0);
-  const lagHealthClass = selectedConsumer && selectedConsumer.diffTotal > 0 ? 'is-warning' : 'is-healthy';
-
-  useEffect(() => {
-    if (response && currentPage > totalPages) {
-      setCurrentPage(totalPages);
-    }
-  }, [currentPage, totalPages]);
-
-  useEffect(() => {
-    if (target || !response) return;
-    if (filteredConsumers.length === 0) {
-      setSelectedGroup('');
-      return;
-    }
-    if (!filteredConsumers.some((consumer) => consumer.rawGroupName === selectedGroup)) {
-      setSelectedGroup(filteredConsumers[0].rawGroupName);
-    }
-  }, [filteredConsumers, selectedGroup]);
-
-  useEffect(() => {
-    if (!target || openedTarget.current || !response || isInitialLoading) return;
-    const consumer = items.find((item) => item.rawGroupName === target.name);
-    if (!consumer) return;
-    openedTarget.current = true;
-    const setters = { progress: setDetailModal, config: setConfigModal, clients: setClientModal };
-    if (target.detail !== 'overview') setters[target.detail]({ isOpen: true, consumer });
-  }, [target, response, isInitialLoading, items]);
-
-  const toggleFilter = (key: string) => {
-    setCurrentPage(1);
-    setFilters((current) => ({...current, [key]: !current[key]}));
-  };
-
-  const goToPage = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page);
-    }
-  };
-
-  const handleEditorSaved = async () => {
-    setEditorModal({isOpen: false, consumer: null});
-    await refresh();
-  };
-
-  const handleDeleteSaved = async () => {
-    setDeleteModal({isOpen: false, consumer: null});
-    await refresh();
-  };
-
-  const handleEditFromConfig = (consumer: ConsumerGroupListItem, preferredBrokerAddress?: string) => {
-    setConfigModal({isOpen: false, consumer: null});
-    setEditorModal({isOpen: true, consumer, preferredBrokerAddress});
-  };
-
-  const formatUpdatedTime = (timestamp: number) => {
-    if (!Number.isFinite(timestamp) || timestamp <= 0) {
-      return '-';
-    }
-    return new Date(timestamp).toLocaleTimeString();
-  };
-
-  const getCategoryClass = (category: string) => {
-    if (category === 'SYSTEM') {
-      return 'is-system';
-    }
-    if (category === 'FIFO') {
-      return 'is-fifo';
-    }
-    return 'is-normal';
-  };
-
-  return (
-    <div className="consumer-page">
-      {targetMissing && <p role="alert" className="p-4 text-red-600">Consumer group not found: {target.name}</p>}
-      <ConsumerDetailModal
-        isOpen={detailModal.isOpen}
-        onClose={() => { setDetailModal({isOpen: false, consumer: null}); if (target) goBack(); }}
-        consumer={detailModal.consumer}
-        scope={scope}
-      />
-      <ConsumerConfigModal
-        isOpen={configModal.isOpen}
-        onClose={() => { setConfigModal({isOpen: false, consumer: null}); if (target) goBack(); }}
-        consumer={configModal.consumer}
-        onEdit={handleEditFromConfig}
-      />
-      <ConsumerClientModal
-        isOpen={clientModal.isOpen}
-        onClose={() => { setClientModal({isOpen: false, consumer: null}); if (target) goBack(); }}
-        consumer={clientModal.consumer}
-        scope={scope}
-      />
-      <ConsumerEditorModal
-        isOpen={editorModal.isOpen}
-        onClose={() => setEditorModal({isOpen: false, consumer: null})}
-        consumer={editorModal.consumer}
-        preferredBrokerAddress={editorModal.preferredBrokerAddress}
-        onSaved={() => void handleEditorSaved()}
-      />
-      <ConsumerDeleteModal
-        isOpen={deleteModal.isOpen}
-        onClose={() => setDeleteModal({isOpen: false, consumer: null})}
-        consumer={deleteModal.consumer}
-        onDeleted={() => void handleDeleteSaved()}
-      />
-
-      <section className="consumer-summary-grid" aria-label="Consumer summary">
-        <div className="topic-summary-card">
-          <div>
-            <span>Consumer Groups</span>
-            <strong>{summary?.totalGroups ?? items.length}</strong>
-            <small>{summary?.normalGroups ?? 0} normal / {summary?.systemGroups ?? 0} system</small>
-          </div>
-          <span className="topic-summary-icon">
-            <Users className="topic-icon" aria-hidden="true"/>
-          </span>
-        </div>
-        <div className="topic-summary-card is-success">
-          <div>
-            <span>Active Clients</span>
-            <strong>{activeClientCount}</strong>
-            <small>connected consumers</small>
-          </div>
-          <span className="topic-summary-icon">
-            <Network className="topic-icon" aria-hidden="true"/>
-          </span>
-        </div>
-        <div className={`topic-summary-card ${totalLag > 0 ? 'is-warning' : 'is-blue'}`}>
-          <div>
-            <span>Total Lag</span>
-            <strong>{totalLag}</strong>
-            <small>{totalLag > 0 ? 'queue pressure detected' : 'no queue pressure'}</small>
-          </div>
-          <span className="topic-summary-icon">
-            <Activity className="topic-icon" aria-hidden="true"/>
-          </span>
-        </div>
-        <div className="topic-summary-card is-blue">
-          <div>
-            <span>Transport</span>
-            <strong>{response?.useVipChannel ? 'VIP' : 'Direct'}</strong>
-            <small>{response?.useVipChannel ? 'VIP on' : 'VIP off'} / {response?.useTls ? 'TLS on' : 'TLS off'}</small>
-          </div>
-          <span className="topic-summary-icon">
-            <Cpu className="topic-icon" aria-hidden="true"/>
-          </span>
-        </div>
-      </section>
-
-      <section className="consumer-command-panel" aria-label="Consumer filters and actions">
-        <div className="consumer-command-copy is-compact">
-          <span>Scope</span>
-          <div className="consumer-scope-pills" aria-label="Consumer catalog filter scope">
-            <b>Local filters</b>
-            <b>Proxy source</b>
-          </div>
-        </div>
-
-        <div className="consumer-query-controls">
-          <label className="consumer-search-field">
-            <Search className="topic-icon" aria-hidden="true"/>
-            <input
-              type="text"
-              placeholder="SubscriptionGroup..."
-              value={searchTerm}
-              onChange={(event) => {
-                setSearchTerm(event.target.value);
-                setCurrentPage(1);
-              }}
-            />
-          </label>
-
-          <div className="consumer-filter-row" aria-label="Consumer group category filters">
-            {Object.entries(filters).map(([key, value]) => (
-              <button
-                type="button"
-                key={key}
-                onClick={() => toggleFilter(key)}
-                className={`consumer-filter-chip ${value ? 'is-active' : ''} ${getCategoryClass(key)}`}
-              >
-                {value && <Check className="topic-icon" aria-hidden="true"/>}
-                <span>{key}</span>
-              </button>
-            ))}
-          </div>
-
-          <div className="consumer-proxy-control">
-            <span>Proxy</span>
-            <span>{proxyAddress ?? 'Not configured'}</span>
-            <button type="button" className="underline" onClick={() => setActiveTab('Proxy')}>Configure</button>
-          </div>
-
-          <button
-            type="button"
-            className={`consumer-proxy-toggle ${enableProxy ? 'is-on' : ''}`}
-            disabled={!proxyAddress && !enableProxy}
-            onClick={() => changeMode(enableProxy ? 'name_server' : 'proxy')}
-          >
-            <span>Enable Proxy</span>
-            <i aria-hidden="true"/>
-          </button>
-
-          <button
-            type="button"
-            className="topic-action-button is-status consumer-add-button"
-            onClick={() => setEditorModal({isOpen: true, consumer: null})}
-          >
-            <Plus className="topic-icon" aria-hidden="true"/>
-            <span>Add / Update</span>
-          </button>
-
-          <button
-            type="button"
-            className="topic-action-button consumer-refresh-button"
-            onClick={() => void refresh()}
-            disabled={isRefreshPending || isInitialLoading}
-            title={isRefreshing ? 'Refreshing...' : 'Refresh consumer groups'}
-          >
-            {isRefreshing ? (
-              <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
-            ) : (
-              <RefreshCw className={`topic-icon ${isRefreshPending ? 'consumer-tilt' : ''}`} aria-hidden="true"/>
-            )}
-            <span className="sr-only">Refresh</span>
-          </button>
-        </div>
-      </section>
-
-      {error && (
-        <div className="consumer-alert" role="alert">
-          <AlertCircle className="topic-icon" aria-hidden="true"/>
-          <span>{error}</span>
-        </div>
-      )}
-
-      {response && (
-        <section className="consumer-scope-strip" aria-label="Consumer source details">
-          <div>
-            <span>NameServer:</span>
-            <strong>{response.currentNamesrv}</strong>
-            <i aria-hidden="true">/</i>
-            <span>Total</span>
-            <strong>{summary?.totalGroups ?? 0}</strong>
-            <i aria-hidden="true">/</i>
-            <span>NORMAL</span>
-            <strong>{summary?.normalGroups ?? 0}</strong>
-            <i aria-hidden="true">/</i>
-            <span>FIFO</span>
-            <strong>{summary?.fifoGroups ?? 0}</strong>
-            <i aria-hidden="true">/</i>
-            <span>SYSTEM</span>
-            <strong>{summary?.systemGroups ?? 0}</strong>
-          </div>
-          <b>{response.useVipChannel ? 'VIP ON' : 'VIP OFF'} / {response.useTls ? 'TLS ON' : 'TLS OFF'}</b>
-        </section>
-      )}
-
-      {isInitialLoading ? (
-        <div className="consumer-loading-state">
-          <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
-          <span>Loading consumer groups...</span>
-        </div>
-      ) : filteredConsumers.length === 0 ? (
-        <div className="consumer-empty-state">
-          <Search className="topic-icon" aria-hidden="true"/>
-          <strong>No consumer groups matched</strong>
-          <span>Adjust the search term or category filters to inspect another subscription group.</span>
-        </div>
-      ) : (
-        <section className="consumer-workspace">
-          <div className="consumer-panel consumer-list-panel">
-            <div className="topic-panel-header">
-              <div>
-                <h2>Consumer Catalog</h2>
-                <p>Subscription groups ranked by lag, clients, and lifecycle category.</p>
-              </div>
-              <div className="topic-panel-meta">
-                <span>{filteredConsumers.length} visible</span>
-              </div>
-            </div>
-
-            <div className="consumer-list">
-              {currentConsumers.map((consumer, index) => {
-                const selected = selectedConsumer?.rawGroupName === consumer.rawGroupName;
-                return (
-                  <motion.button
-                    type="button"
-                    key={consumer.rawGroupName}
-                    initial={{opacity: 0, y: 14}}
-                    animate={{opacity: 1, y: 0}}
-                    transition={{duration: 0.24, delay: index * 0.03}}
-                    className={`consumer-row ${selected ? 'is-selected' : ''} ${getCategoryClass(consumer.category)}`}
-                    onClick={() => setSelectedGroup(consumer.rawGroupName)}
-                  >
-                    <span className="consumer-row-main">
-                      <span className="consumer-row-icon">
-                        <Users className="topic-icon" aria-hidden="true"/>
-                      </span>
-                      <span className="consumer-row-copy">
-                        <strong title={consumer.displayGroupName}>{consumer.displayGroupName}</strong>
-                        <span>{consumer.rawGroupName}</span>
-                      </span>
-                    </span>
-                    <span className="consumer-badge-stack">
-                      <b className="is-model">{consumer.messageModel}</b>
-                      <b className="is-type">{consumer.consumeType}</b>
-                      <b className={getCategoryClass(consumer.category)}>{consumer.category}</b>
-                    </span>
-                    <span className="consumer-row-metric">
-                      <span>TPS</span>
-                      <strong>{consumer.consumeTps}</strong>
-                    </span>
-                    <span className={`consumer-row-metric ${consumer.diffTotal > 0 ? 'is-warning' : ''}`}>
-                      <span>Lag</span>
-                      <strong>{consumer.diffTotal}</strong>
-                    </span>
-                    <span className="consumer-row-metric">
-                      <span>Clients</span>
-                      <strong>{consumer.connectionCount}</strong>
-                    </span>
-                    <span className="consumer-row-updated">
-                      <Clock className="topic-icon" aria-hidden="true"/>
-                      {formatUpdatedTime(consumer.updateTimestamp)}
-                    </span>
-                  </motion.button>
-                );
-              })}
-            </div>
-          </div>
-
-          <aside className="consumer-panel consumer-inspector-panel" aria-label="Selected consumer group">
-            {selectedConsumer ? (
-              <>
-                <div className="consumer-inspector-header">
-                  <span>Selected Consumer</span>
-                  <strong>{selectedConsumer.displayGroupName}</strong>
-                  <small>{selectedConsumer.rawGroupName}</small>
-                  <div className="consumer-badge-stack">
-                    <b className="is-model">{selectedConsumer.messageModel}</b>
-                    <b className="is-type">{selectedConsumer.consumeType}</b>
-                    <b className={getCategoryClass(selectedConsumer.category)}>{selectedConsumer.category}</b>
-                  </div>
-                </div>
-
-                <div className={`consumer-health-card ${lagHealthClass}`}>
-                  <span>Lag health</span>
-                  <strong>{selectedConsumer.diffTotal > 0 ? 'Lagging' : 'Healthy'}</strong>
-                  <small>
-                    {selectedConsumer.diffTotal > 0
-                      ? 'This group has queue backlog and needs inspection.'
-                      : 'No queue pressure reported by this group.'}
-                  </small>
-                </div>
-
-                <div className="consumer-detail-grid">
-                  <div>
-                    <span>TPS</span>
-                    <strong>{selectedConsumer.consumeTps}</strong>
-                  </div>
-                  <div>
-                    <span>Lag</span>
-                    <strong>{selectedConsumer.diffTotal}</strong>
-                  </div>
-                  <div>
-                    <span>Clients</span>
-                    <strong>{selectedConsumer.connectionCount}</strong>
-                  </div>
-                  <div>
-                    <span>Version</span>
-                    <strong>{selectedConsumer.versionDesc}</strong>
-                  </div>
-                  <div>
-                    <span>Brokers</span>
-                    <strong>{selectedConsumer.brokerNames.length || '-'}</strong>
-                  </div>
-                  <div>
-                    <span>Updated</span>
-                    <strong>{formatUpdatedTime(selectedConsumer.updateTimestamp)}</strong>
-                  </div>
-                </div>
-
-                <div className="consumer-action-grid">
-                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'clients', scope)}>
-                    <Users className="topic-icon" aria-hidden="true"/>
-                    <span>Client</span>
-                  </button>
-                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'progress', scope)}>
-                    <FileText className="topic-icon" aria-hidden="true"/>
-                    <span>Detail</span>
-                  </button>
-                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'config', scope)}>
-                    <Settings className="topic-icon" aria-hidden="true"/>
-                    <span>Config</span>
-                  </button>
-                  <button
-                    type="button"
-                    className="topic-action-button"
-                    onClick={() => void refreshGroup(selectedConsumer.rawGroupName)}
-                    disabled={refreshingGroup === selectedConsumer.rawGroupName}
-                  >
-                    {refreshingGroup === selectedConsumer.rawGroupName ? (
-                      <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
-                    ) : (
-                      <RefreshCw className="topic-icon" aria-hidden="true"/>
-                    )}
-                    <span>Sync</span>
-                  </button>
-                  <button type="button" className="topic-action-button is-danger" onClick={() => setDeleteModal({isOpen: true, consumer: selectedConsumer})}>
-                    <Trash2 className="topic-icon" aria-hidden="true"/>
-                    <span>Delete</span>
-                  </button>
-                </div>
-              </>
-            ) : (
-              <div className="consumer-empty-state is-compact">
-                <Users className="topic-icon" aria-hidden="true"/>
-                <strong>No consumer selected</strong>
-                <span>Select a consumer group from the catalog to inspect actions.</span>
-              </div>
-            )}
-          </aside>
-        </section>
-      )}
-
-      <footer className="consumer-footer">
-        <span>Consumer group data is read-only until Add/Update, Config, or Delete opens a scoped mutation flow.</span>
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={goToPage}
-        />
-      </footer>
-    </div>
-  );
-};
+import { ConnectionStore } from '../services/connection.store';
+import { getConnectionSettings } from '../services/connection.service';
+import { resolveConsumerScope, consumerScopeKey } from '../features/consumer/scope';
+import type { ConsumerQueryScope } from '../features/consumer/types/consumer.types';
+import { useAppStore, useNavigationState } from '../stores/app.store';
+import { findEntity } from '../stores/navigation';
+import React, { useEffect, useMemo, useState, useRef, useSyncExternalStore } from 'react';
+import { Users, Settings, Trash2, Search, Check, RefreshCw, Plus, Clock, FileText, Activity, Network, Cpu, AlertCircle, LoaderCircle } from 'lucide-react';
+import { toast } from 'sonner@2.0.3';
+import { Pagination } from './Pagination';
+import { useConsumerCatalog } from '../features/consumer/hooks/useConsumerCatalog';
+import { ConsumerClientModal } from '../features/consumer/components/ConsumerClientModal';
+import { ConsumerConfigModal } from '../features/consumer/components/ConsumerConfigModal';
+import { ConsumerDeleteModal } from '../features/consumer/components/ConsumerDeleteModal';
+import { ConsumerDetailModal } from '../features/consumer/components/ConsumerDetailModal';
+import { ConsumerEditorModal } from '../features/consumer/components/ConsumerEditorModal';
+import type { ConsumerGroupListItem } from '../features/consumer/types/consumer.types';
+
+export const ConsumerView = () => {
+  const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
+  const { consumerQueryMode, setConsumerQueryMode, setActiveTab, navigation } = useAppStore();
+  const [queryMode, setQueryMode] = useNavigationState<ConsumerQueryScope['mode']>('queryMode', navigation.target?.kind === 'consumer' ? navigation.target.scope.mode : consumerQueryMode);
+  const changeMode = (mode: ConsumerQueryScope['mode']) => { setQueryMode(mode); setConsumerQueryMode(mode); };
+  const [settingsError, setSettingsError] = useState('');
+  useEffect(() => {
+    let active = true;
+    if (!settings) void getConnectionSettings().catch(() => { if (active) setSettingsError('Unable to load connection settings.'); });
+    return () => { active = false; };
+  }, [settings]);
+  const scope = useMemo(() => resolveConsumerScope(settings, queryMode), [settings, queryMode]);
+  if (!settings) return <p role="status" className="p-6">{settingsError || 'Loading connection settings...'}</p>;
+  if (!scope) return <div className="p-6 space-y-3"><p role="alert">Select a Proxy in connection settings before using Proxy mode.</p><button type="button" className="underline mr-4" onClick={() => setActiveTab('Proxy')}>Configure Proxy</button><button type="button" className="underline" onClick={() => changeMode('name_server')}>Use NameServer</button></div>;
+  return <ConsumerCatalog key={consumerScopeKey(scope)} scope={scope} proxyAddress={settings.proxy.currentProxyAddr} changeMode={changeMode} />;
+};
+
+const ConsumerCatalog = ({ scope, proxyAddress, changeMode }: { scope: ConsumerQueryScope; proxyAddress: string | null; changeMode: (mode: ConsumerQueryScope['mode']) => void }) => {
+  const { navigation, openConsumer, goBack, setActiveTab } = useAppStore();
+  const target = navigation.target?.kind === 'consumer' && consumerScopeKey(navigation.target.scope) === consumerScopeKey(scope) ? navigation.target : null;
+  const openedTarget = useRef(false);
+
+  const [searchTerm, setSearchTerm] = useNavigationState(`search:${consumerScopeKey(scope)}`, '');
+  const [filters, setFilters] = useNavigationState<Record<string, boolean>>(`filters:${consumerScopeKey(scope)}`, {
+    NORMAL: true,
+    FIFO: !!target,
+    SYSTEM: true,
+  });
+  const enableProxy = scope.mode === 'proxy';
+  const [detailModal, setDetailModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
+  const [configModal, setConfigModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
+  const [clientModal, setClientModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
+  const [editorModal, setEditorModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null, preferredBrokerAddress?: string }>({isOpen: false, consumer: null});
+  const [deleteModal, setDeleteModal] = useState<{ isOpen: boolean, consumer: ConsumerGroupListItem | null }>({isOpen: false, consumer: null});
+  const [selectedGroup, setSelectedGroup] = useNavigationState(`selection:${consumerScopeKey(scope)}`, target?.name ?? '');
+  const [currentPage, setCurrentPage] = useNavigationState(`page:${consumerScopeKey(scope)}`, 1);
+  const itemsPerPage = 6;
+  const {
+    items,
+    summary,
+    response,
+    isInitialLoading,
+    isRefreshPending,
+    isRefreshing,
+    refreshingGroup,
+    error,
+    refresh,
+    refreshGroup,
+  } = useConsumerCatalog(scope);
+
+  const activeCategories = useMemo(
+    () => Object.entries(filters).filter(([, value]) => value).map(([key]) => key),
+    [filters],
+  );
+
+  const filteredConsumers = useMemo(() => {
+    const normalizedTerm = searchTerm.trim().toLowerCase();
+    return items.filter((consumer) => {
+      const matchesSearch =
+        normalizedTerm.length === 0 ||
+        consumer.displayGroupName.toLowerCase().includes(normalizedTerm) ||
+        consumer.rawGroupName.toLowerCase().includes(normalizedTerm);
+      const matchesCategory =
+        activeCategories.length === 0 || activeCategories.includes(consumer.category);
+      return matchesSearch && matchesCategory;
+    });
+  }, [activeCategories, items, searchTerm]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredConsumers.length / itemsPerPage));
+  const currentConsumers = filteredConsumers.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage,
+  );
+  const selectedConsumer = findEntity(target ? items : filteredConsumers, (consumer) => consumer.rawGroupName, selectedGroup || null);
+  const targetMissing = target && response && !isInitialLoading && !error && !items.some((item) => item.rawGroupName === target.name);
+  const activeClientCount = items.reduce((total, consumer) => total + consumer.connectionCount, 0);
+  const totalLag = items.reduce((total, consumer) => total + consumer.diffTotal, 0);
+  const lagHealthClass = selectedConsumer && selectedConsumer.diffTotal > 0 ? 'is-warning' : 'is-healthy';
+
+  useEffect(() => {
+    if (response && currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  useEffect(() => {
+    if (target || !response) return;
+    if (filteredConsumers.length === 0) {
+      setSelectedGroup('');
+      return;
+    }
+    if (!filteredConsumers.some((consumer) => consumer.rawGroupName === selectedGroup)) {
+      setSelectedGroup(filteredConsumers[0].rawGroupName);
+    }
+  }, [filteredConsumers, selectedGroup]);
+
+  useEffect(() => {
+    if (!target || openedTarget.current || !response || isInitialLoading) return;
+    const consumer = items.find((item) => item.rawGroupName === target.name);
+    if (!consumer) return;
+    openedTarget.current = true;
+    const setters = { progress: setDetailModal, config: setConfigModal, clients: setClientModal };
+    if (target.detail !== 'overview') setters[target.detail]({ isOpen: true, consumer });
+  }, [target, response, isInitialLoading, items]);
+
+  const toggleFilter = (key: string) => {
+    setCurrentPage(1);
+    setFilters((current) => ({...current, [key]: !current[key]}));
+  };
+
+  const goToPage = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
+
+  const handleEditorSaved = async () => {
+    setEditorModal({isOpen: false, consumer: null});
+    await refresh();
+  };
+
+  const handleDeleteSaved = async () => {
+    setDeleteModal({isOpen: false, consumer: null});
+    await refresh();
+  };
+
+  const handleEditFromConfig = (consumer: ConsumerGroupListItem, preferredBrokerAddress?: string) => {
+    setConfigModal({isOpen: false, consumer: null});
+    setEditorModal({isOpen: true, consumer, preferredBrokerAddress});
+  };
+
+  const formatUpdatedTime = (timestamp: number) => {
+    if (!Number.isFinite(timestamp) || timestamp <= 0) {
+      return '-';
+    }
+    return new Date(timestamp).toLocaleTimeString();
+  };
+
+  const getCategoryClass = (category: string) => {
+    if (category === 'SYSTEM') {
+      return 'is-system';
+    }
+    if (category === 'FIFO') {
+      return 'is-fifo';
+    }
+    return 'is-normal';
+  };
+
+  return (
+    <div className="consumer-page">
+      {targetMissing && <p role="alert" className="p-4 text-red-600">Consumer group not found: {target.name}</p>}
+      <ConsumerDetailModal
+        isOpen={detailModal.isOpen}
+        onClose={() => { setDetailModal({isOpen: false, consumer: null}); if (target) goBack(); }}
+        consumer={detailModal.consumer}
+        scope={scope}
+      />
+      <ConsumerConfigModal
+        isOpen={configModal.isOpen}
+        onClose={() => { setConfigModal({isOpen: false, consumer: null}); if (target) goBack(); }}
+        consumer={configModal.consumer}
+        onEdit={handleEditFromConfig}
+      />
+      <ConsumerClientModal
+        isOpen={clientModal.isOpen}
+        onClose={() => { setClientModal({isOpen: false, consumer: null}); if (target) goBack(); }}
+        consumer={clientModal.consumer}
+        scope={scope}
+      />
+      <ConsumerEditorModal
+        isOpen={editorModal.isOpen}
+        onClose={() => setEditorModal({isOpen: false, consumer: null})}
+        consumer={editorModal.consumer}
+        preferredBrokerAddress={editorModal.preferredBrokerAddress}
+        onSaved={() => void handleEditorSaved()}
+      />
+      <ConsumerDeleteModal
+        isOpen={deleteModal.isOpen}
+        onClose={() => setDeleteModal({isOpen: false, consumer: null})}
+        consumer={deleteModal.consumer}
+        onDeleted={() => void handleDeleteSaved()}
+      />
+
+      <section className="consumer-summary-grid" aria-label="Consumer summary">
+        <div className="topic-summary-card">
+          <div>
+            <span>Consumer Groups</span>
+            <strong>{summary?.totalGroups ?? items.length}</strong>
+            <small>{summary?.normalGroups ?? 0} normal / {summary?.systemGroups ?? 0} system</small>
+          </div>
+          <span className="topic-summary-icon">
+            <Users className="topic-icon" aria-hidden="true"/>
+          </span>
+        </div>
+        <div className="topic-summary-card is-success">
+          <div>
+            <span>Active Clients</span>
+            <strong>{activeClientCount}</strong>
+            <small>connected consumers</small>
+          </div>
+          <span className="topic-summary-icon">
+            <Network className="topic-icon" aria-hidden="true"/>
+          </span>
+        </div>
+        <div className={`topic-summary-card ${totalLag > 0 ? 'is-warning' : 'is-blue'}`}>
+          <div>
+            <span>Total Lag</span>
+            <strong>{totalLag}</strong>
+            <small>{totalLag > 0 ? 'queue pressure detected' : 'no queue pressure'}</small>
+          </div>
+          <span className="topic-summary-icon">
+            <Activity className="topic-icon" aria-hidden="true"/>
+          </span>
+        </div>
+        <div className="topic-summary-card is-blue">
+          <div>
+            <span>Transport</span>
+            <strong>{response?.useVipChannel ? 'VIP' : 'Direct'}</strong>
+            <small>{response?.useVipChannel ? 'VIP on' : 'VIP off'} / {response?.useTls ? 'TLS on' : 'TLS off'}</small>
+          </div>
+          <span className="topic-summary-icon">
+            <Cpu className="topic-icon" aria-hidden="true"/>
+          </span>
+        </div>
+      </section>
+
+      <section className="consumer-command-panel" aria-label="Consumer filters and actions">
+        <div className="consumer-command-copy is-compact">
+          <span>Scope</span>
+          <div className="consumer-scope-pills" aria-label="Consumer catalog filter scope">
+            <b>Local filters</b>
+            <b>Proxy source</b>
+          </div>
+        </div>
+
+        <div className="consumer-query-controls">
+          <label className="consumer-search-field">
+            <Search className="topic-icon" aria-hidden="true"/>
+            <input
+              type="text"
+              placeholder="SubscriptionGroup..."
+              value={searchTerm}
+              onChange={(event) => {
+                setSearchTerm(event.target.value);
+                setCurrentPage(1);
+              }}
+            />
+          </label>
+
+          <div className="consumer-filter-row" aria-label="Consumer group category filters">
+            {Object.entries(filters).map(([key, value]) => (
+              <button
+                type="button"
+                key={key}
+                onClick={() => toggleFilter(key)}
+                className={`consumer-filter-chip ${value ? 'is-active' : ''} ${getCategoryClass(key)}`}
+              >
+                {value && <Check className="topic-icon" aria-hidden="true"/>}
+                <span>{key}</span>
+              </button>
+            ))}
+          </div>
+
+          <div className="consumer-proxy-control">
+            <span>Proxy</span>
+            <span>{proxyAddress ?? 'Not configured'}</span>
+            <button type="button" className="underline" onClick={() => setActiveTab('Proxy')}>Configure</button>
+          </div>
+
+          <button
+            type="button"
+            className={`consumer-proxy-toggle ${enableProxy ? 'is-on' : ''}`}
+            disabled={!proxyAddress && !enableProxy}
+            onClick={() => changeMode(enableProxy ? 'name_server' : 'proxy')}
+          >
+            <span>Enable Proxy</span>
+            <i aria-hidden="true"/>
+          </button>
+
+          <button
+            type="button"
+            className="topic-action-button is-status consumer-add-button"
+            onClick={() => setEditorModal({isOpen: true, consumer: null})}
+          >
+            <Plus className="topic-icon" aria-hidden="true"/>
+            <span>Add / Update</span>
+          </button>
+
+          <button
+            type="button"
+            className="topic-action-button consumer-refresh-button"
+            onClick={() => void refresh()}
+            disabled={isRefreshPending || isInitialLoading}
+            title={isRefreshing ? 'Refreshing...' : 'Refresh consumer groups'}
+          >
+            {isRefreshing ? (
+              <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
+            ) : (
+              <RefreshCw className={`topic-icon ${isRefreshPending ? 'consumer-tilt' : ''}`} aria-hidden="true"/>
+            )}
+            <span className="sr-only">Refresh</span>
+          </button>
+        </div>
+      </section>
+
+      {error && (
+        <div className="consumer-alert" role="alert">
+          <AlertCircle className="topic-icon" aria-hidden="true"/>
+          <span>{error}</span>
+        </div>
+      )}
+
+      {response && (
+        <section className="consumer-scope-strip" aria-label="Consumer source details">
+          <div>
+            <span>NameServer:</span>
+            <strong>{response.currentNamesrv}</strong>
+            <i aria-hidden="true">/</i>
+            <span>Total</span>
+            <strong>{summary?.totalGroups ?? 0}</strong>
+            <i aria-hidden="true">/</i>
+            <span>NORMAL</span>
+            <strong>{summary?.normalGroups ?? 0}</strong>
+            <i aria-hidden="true">/</i>
+            <span>FIFO</span>
+            <strong>{summary?.fifoGroups ?? 0}</strong>
+            <i aria-hidden="true">/</i>
+            <span>SYSTEM</span>
+            <strong>{summary?.systemGroups ?? 0}</strong>
+          </div>
+          <b>{response.useVipChannel ? 'VIP ON' : 'VIP OFF'} / {response.useTls ? 'TLS ON' : 'TLS OFF'}</b>
+        </section>
+      )}
+
+      {isInitialLoading ? (
+        <div className="consumer-loading-state">
+          <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
+          <span>Loading consumer groups...</span>
+        </div>
+      ) : filteredConsumers.length === 0 ? (
+        <div className="consumer-empty-state">
+          <Search className="topic-icon" aria-hidden="true"/>
+          <strong>No consumer groups matched</strong>
+          <span>Adjust the search term or category filters to inspect another subscription group.</span>
+        </div>
+      ) : (
+        <section className="consumer-workspace">
+          <div className="consumer-panel consumer-list-panel">
+            <div className="topic-panel-header">
+              <div>
+                <h2>Consumer Catalog</h2>
+                <p>Subscription groups ranked by lag, clients, and lifecycle category.</p>
+              </div>
+              <div className="topic-panel-meta">
+                <span>{filteredConsumers.length} visible</span>
+              </div>
+            </div>
+
+            <div className="consumer-list">
+              {currentConsumers.map((consumer, index) => {
+                const selected = selectedConsumer?.rawGroupName === consumer.rawGroupName;
+                return (
+                  <motion.button
+                    type="button"
+                    key={consumer.rawGroupName}
+                    initial={{opacity: 0, y: 14}}
+                    animate={{opacity: 1, y: 0}}
+                    transition={{duration: 0.24, delay: index * 0.03}}
+                    className={`consumer-row ${selected ? 'is-selected' : ''} ${getCategoryClass(consumer.category)}`}
+                    onClick={() => setSelectedGroup(consumer.rawGroupName)}
+                  >
+                    <span className="consumer-row-main">
+                      <span className="consumer-row-icon">
+                        <Users className="topic-icon" aria-hidden="true"/>
+                      </span>
+                      <span className="consumer-row-copy">
+                        <strong title={consumer.displayGroupName}>{consumer.displayGroupName}</strong>
+                        <span>{consumer.rawGroupName}</span>
+                      </span>
+                    </span>
+                    <span className="consumer-badge-stack">
+                      <b className="is-model">{consumer.messageModel}</b>
+                      <b className="is-type">{consumer.consumeType}</b>
+                      <b className={getCategoryClass(consumer.category)}>{consumer.category}</b>
+                    </span>
+                    <span className="consumer-row-metric">
+                      <span>TPS</span>
+                      <strong>{consumer.consumeTps}</strong>
+                    </span>
+                    <span className={`consumer-row-metric ${consumer.diffTotal > 0 ? 'is-warning' : ''}`}>
+                      <span>Lag</span>
+                      <strong>{consumer.diffTotal}</strong>
+                    </span>
+                    <span className="consumer-row-metric">
+                      <span>Clients</span>
+                      <strong>{consumer.connectionCount}</strong>
+                    </span>
+                    <span className="consumer-row-updated">
+                      <Clock className="topic-icon" aria-hidden="true"/>
+                      {formatUpdatedTime(consumer.updateTimestamp)}
+                    </span>
+                  </motion.button>
+                );
+              })}
+            </div>
+          </div>
+
+          <aside className="consumer-panel consumer-inspector-panel" aria-label="Selected consumer group">
+            {selectedConsumer ? (
+              <>
+                <div className="consumer-inspector-header">
+                  <span>Selected Consumer</span>
+                  <strong>{selectedConsumer.displayGroupName}</strong>
+                  <small>{selectedConsumer.rawGroupName}</small>
+                  <div className="consumer-badge-stack">
+                    <b className="is-model">{selectedConsumer.messageModel}</b>
+                    <b className="is-type">{selectedConsumer.consumeType}</b>
+                    <b className={getCategoryClass(selectedConsumer.category)}>{selectedConsumer.category}</b>
+                  </div>
+                </div>
+
+                <div className={`consumer-health-card ${lagHealthClass}`}>
+                  <span>Lag health</span>
+                  <strong>{selectedConsumer.diffTotal > 0 ? 'Lagging' : 'Healthy'}</strong>
+                  <small>
+                    {selectedConsumer.diffTotal > 0
+                      ? 'This group has queue backlog and needs inspection.'
+                      : 'No queue pressure reported by this group.'}
+                  </small>
+                </div>
+
+                <div className="consumer-detail-grid">
+                  <div>
+                    <span>TPS</span>
+                    <strong>{selectedConsumer.consumeTps}</strong>
+                  </div>
+                  <div>
+                    <span>Lag</span>
+                    <strong>{selectedConsumer.diffTotal}</strong>
+                  </div>
+                  <div>
+                    <span>Clients</span>
+                    <strong>{selectedConsumer.connectionCount}</strong>
+                  </div>
+                  <div>
+                    <span>Version</span>
+                    <strong>{selectedConsumer.versionDesc}</strong>
+                  </div>
+                  <div>
+                    <span>Brokers</span>
+                    <strong>{selectedConsumer.brokerNames.length || '-'}</strong>
+                  </div>
+                  <div>
+                    <span>Updated</span>
+                    <strong>{formatUpdatedTime(selectedConsumer.updateTimestamp)}</strong>
+                  </div>
+                </div>
+
+                <div className="consumer-action-grid">
+                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'clients', scope)}>
+                    <Users className="topic-icon" aria-hidden="true"/>
+                    <span>Client</span>
+                  </button>
+                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'progress', scope)}>
+                    <FileText className="topic-icon" aria-hidden="true"/>
+                    <span>Detail</span>
+                  </button>
+                  <button type="button" className="topic-action-button" onClick={() => openConsumer(selectedConsumer.rawGroupName, 'config', scope)}>
+                    <Settings className="topic-icon" aria-hidden="true"/>
+                    <span>Config</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="topic-action-button"
+                    onClick={() => void refreshGroup(selectedConsumer.rawGroupName)}
+                    disabled={refreshingGroup === selectedConsumer.rawGroupName}
+                  >
+                    {refreshingGroup === selectedConsumer.rawGroupName ? (
+                      <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true"/>
+                    ) : (
+                      <RefreshCw className="topic-icon" aria-hidden="true"/>
+                    )}
+                    <span>Sync</span>
+                  </button>
+                  <button type="button" className="topic-action-button is-danger" onClick={() => setDeleteModal({isOpen: true, consumer: selectedConsumer})}>
+                    <Trash2 className="topic-icon" aria-hidden="true"/>
+                    <span>Delete</span>
+                  </button>
+                </div>
+              </>
+            ) : (
+              <div className="consumer-empty-state is-compact">
+                <Users className="topic-icon" aria-hidden="true"/>
+                <strong>No consumer selected</strong>
+                <span>Select a consumer group from the catalog to inspect actions.</span>
+              </div>
+            )}
+          </aside>
+        </section>
+      )}
+
+      <footer className="consumer-footer">
+        <span>Consumer group data is read-only until Add/Update, Config, or Delete opens a scoped mutation flow.</span>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+        />
+      </footer>
+    </div>
+  );
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
@@ -86,7 +86,7 @@ export const DLQMessageView = () => {
     items: consumerItems,
     isInitialLoading: isConsumerCatalogLoading,
     error: consumerCatalogError,
-  } = useConsumerCatalog();
+  } = useConsumerCatalog({ mode: 'name_server' });
 
   const consumerGroupOptions = useMemo(
     () =>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerClientModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerClientModal.tsx
@@ -1,3 +1,5 @@
+import type { ConsumerQueryScope } from '../types/consumer.types';
+import { consumerScopeLabel } from '../scope';
 import { useEffect, useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
@@ -24,22 +26,19 @@ interface ConsumerClientModalProps {
     isOpen: boolean;
     onClose: () => void;
     consumer: ConsumerGroupListItem | null;
-    address?: string;
+    scope: ConsumerQueryScope;
 }
 
 const getConsumerLabel = (consumer: ConsumerGroupListItem | null) =>
     consumer?.displayGroupName ?? consumer?.rawGroupName ?? '-';
 
-const getBrokerScope = (address?: string) => {
-    const trimmed = address?.trim();
-    return trimmed && trimmed.length > 0 ? trimmed : 'All brokers';
-};
+
 
 export const ConsumerClientModal = ({
     isOpen,
     onClose,
     consumer,
-    address,
+    scope,
 }: ConsumerClientModalProps) => {
     const [data, setData] = useState<ConsumerConnectionView | null>(null);
     const [isLoading, setIsLoading] = useState(false);
@@ -57,7 +56,7 @@ export const ConsumerClientModal = ({
 
         void ConsumerService.queryConsumerConnection({
             consumerGroup: consumer.rawGroupName,
-            address,
+            scope,
         })
             .then((response) => {
                 if (!cancelled) {
@@ -78,10 +77,10 @@ export const ConsumerClientModal = ({
         return () => {
             cancelled = true;
         };
-    }, [address, consumer, isOpen]);
+    }, [scope, consumer, isOpen]);
 
     const consumerLabel = getConsumerLabel(consumer);
-    const brokerScope = getBrokerScope(address);
+    const brokerScope = consumerScopeLabel(scope);
 
     const latestSubscriptionVersion = useMemo(() => {
         if (!data || data.subscriptions.length === 0) {
@@ -343,7 +342,7 @@ export const ConsumerClientModal = ({
                     </div>
 
                     <footer className="topic-status-footer consumer-client-footer">
-                        <span>Client data is scoped by consumer group and broker address.</span>
+                        <span>Client data uses the selected consumer query scope.</span>
                         <div>
                             <button type="button" onClick={onClose} className="topic-status-secondary-button">
                                 Close

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDetailModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDetailModal.tsx
@@ -1,3 +1,5 @@
+import type { ConsumerQueryScope } from '../types/consumer.types';
+import { consumerScopeLabel } from '../scope';
 import { useAppStore } from '../../../stores/app.store';
 import { useEffect, useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
@@ -25,16 +27,13 @@ interface ConsumerDetailModalProps {
     isOpen: boolean;
     onClose: () => void;
     consumer: ConsumerGroupListItem | null;
-    address?: string;
+    scope: ConsumerQueryScope;
 }
 
 const getConsumerLabel = (consumer: ConsumerGroupListItem | null) =>
     consumer?.displayGroupName ?? consumer?.rawGroupName ?? '-';
 
-const getBrokerScope = (address?: string) => {
-    const trimmed = address?.trim();
-    return trimmed && trimmed.length > 0 ? trimmed : 'All brokers';
-};
+
 
 const formatTimestamp = (timestamp: number) => {
     if (!timestamp || timestamp <= 0) {
@@ -49,7 +48,7 @@ export const ConsumerDetailModal = ({
     isOpen,
     onClose,
     consumer,
-    address,
+    scope,
 }: ConsumerDetailModalProps) => {
     const { openTopic } = useAppStore();
     const [data, setData] = useState<ConsumerTopicDetailView | null>(null);
@@ -70,7 +69,7 @@ export const ConsumerDetailModal = ({
 
         void ConsumerService.queryConsumerTopicDetail({
             consumerGroup: consumer.rawGroupName,
-            address,
+            scope,
         })
             .then((response) => {
                 if (!cancelled) {
@@ -92,10 +91,10 @@ export const ConsumerDetailModal = ({
         return () => {
             cancelled = true;
         };
-    }, [address, consumer, isOpen]);
+    }, [scope, consumer, isOpen]);
 
     const consumerLabel = getConsumerLabel(consumer);
-    const brokerScope = getBrokerScope(address);
+    const brokerScope = consumerScopeLabel(scope);
     const topics = data?.topics ?? [];
     const queueCount = useMemo(
         () => topics.reduce((total, topic) => total + topic.queueStatInfoList.length, 0),

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/hooks/useConsumerCatalog.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/hooks/useConsumerCatalog.ts
@@ -1,4 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import type { ConsumerQueryScope } from '../types/consumer.types';
+import { ConsumerRequestGeneration, consumerScopeKey } from '../scope';
+import { useEffect, useRef, useState } from 'react';
 import { ConsumerService } from '../../../services/consumer.service';
 import { dashboardErrorMessage } from '../../../services/invoke';
 import type {
@@ -8,7 +10,7 @@ import type {
 
 const REFRESH_LABEL_DELAY_MS = 180;
 
-export const useConsumerCatalog = (address?: string) => {
+export const useConsumerCatalog = (scope: ConsumerQueryScope) => {
     const [response, setResponse] = useState<ConsumerGroupListResponse | null>(null);
     const [isInitialLoading, setIsInitialLoading] = useState(true);
     const [isRefreshPending, setIsRefreshPending] = useState(false);
@@ -16,12 +18,11 @@ export const useConsumerCatalog = (address?: string) => {
     const [refreshingGroup, setRefreshingGroup] = useState('');
     const [error, setError] = useState('');
 
-    const normalizedAddress = useMemo(() => {
-        const value = address?.trim() ?? '';
-        return value.length > 0 ? value : undefined;
-    }, [address]);
+    const generation = useRef(new ConsumerRequestGeneration());
+    const scopeKey = consumerScopeKey(scope);
 
     const load = async (mode: 'initial' | 'refresh' = 'initial') => {
+        const current = generation.current.begin();
         let refreshIndicatorTimer: number | null = null;
 
         if (mode === 'initial') {
@@ -29,7 +30,7 @@ export const useConsumerCatalog = (address?: string) => {
         } else {
             setIsRefreshPending(true);
             refreshIndicatorTimer = window.setTimeout(() => {
-                setIsRefreshing(true);
+                if (current()) setIsRefreshing(true);
             }, REFRESH_LABEL_DELAY_MS);
         }
 
@@ -37,46 +38,54 @@ export const useConsumerCatalog = (address?: string) => {
         try {
             const request = {
                 skipSysGroup: false,
-                address: normalizedAddress,
+                scope,
             };
             const next = mode === 'initial'
                 ? await ConsumerService.queryConsumerGroups(request)
                 : await ConsumerService.refreshAllConsumerGroups(request);
+            if (!current()) return null;
             setResponse(next);
             return next;
         } catch (loadError) {
-            setError(dashboardErrorMessage(loadError, 'Failed to load consumer groups'));
+            if (current()) setError(dashboardErrorMessage(loadError, 'Failed to load consumer groups'));
             return null;
         } finally {
             if (refreshIndicatorTimer !== null) {
                 window.clearTimeout(refreshIndicatorTimer);
             }
-            setIsInitialLoading(false);
-            setIsRefreshPending(false);
-            setIsRefreshing(false);
+            if (current()) {
+                setIsInitialLoading(false);
+                setIsRefreshPending(false);
+                setIsRefreshing(false);
+                setRefreshingGroup('');
+            }
         }
     };
 
     useEffect(() => {
+        setResponse(null);
         void load('initial');
-    }, [normalizedAddress]);
+        return () => generation.current.invalidate();
+    }, [scopeKey]);
 
     const refresh = async () => load('refresh');
 
     const refreshGroup = async (consumerGroup: string) => {
         const group = consumerGroup.trim();
-        if (!group) {
+        if (!group || !response) {
             return false;
         }
 
+        const current = generation.current.begin();
         setRefreshingGroup(group);
         setError('');
         try {
             const item = await ConsumerService.refreshConsumerGroup({
                 consumerGroup: group,
-                address: normalizedAddress,
+                scope,
             });
 
+            if (!current()) return false;
             setResponse((current) => {
                 if (!current) {
                     return current;
@@ -88,10 +97,10 @@ export const useConsumerCatalog = (address?: string) => {
             });
             return true;
         } catch (refreshError) {
-            setError(dashboardErrorMessage(refreshError, 'Failed to refresh consumer group'));
+            if (current()) setError(dashboardErrorMessage(refreshError, 'Failed to refresh consumer group'));
             return false;
         } finally {
-            setRefreshingGroup('');
+            if (current()) { setRefreshingGroup(''); setIsRefreshPending(false); setIsRefreshing(false); }
         }
     };
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/scope.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/scope.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { ConnectionSettingsView } from '../../services/connection.store';
+import { ConsumerRequestGeneration, resolveConsumerScope } from './scope';
+
+const settings: ConnectionSettingsView = {
+    revision: 1, credentialsConfigured: false, currentNameserverId: null, environmentId: 'env-a',
+    nameserver: { currentNamesrv: null, namesrvAddrList: [], useTLS: false, useVIPChannel: false },
+    currentProxyId: 'proxy-a',
+    proxy: { currentProxyAddr: '127.0.0.1:8080', proxyAddrList: ['127.0.0.1:8080'] },
+    endpoints: [{ endpointId: 'proxy-a', kind: 'proxy', address: '127.0.0.1:8080', environmentId: null }],
+};
+
+describe('consumer query scope', () => {
+    it('uses only the selected configured Proxy and preserves NameServer mode without one', () => {
+        expect(resolveConsumerScope(settings, 'proxy')).toEqual({ mode: 'proxy', endpointId: 'proxy-a' });
+        const empty = { ...settings, currentProxyId: null };
+        expect(resolveConsumerScope(empty, 'proxy')).toBeNull();
+        expect(resolveConsumerScope(empty, 'name_server')).toEqual({ mode: 'name_server' });
+        expect(resolveConsumerScope({ ...settings, endpoints: [] }, 'proxy')).toBeNull();
+        expect(resolveConsumerScope(null, 'name_server')).toBeNull();
+    });
+
+    it('uses the new endpoint after a configuration change', () => {
+        const changed = { ...settings, currentProxyId: 'proxy-b', proxy: { currentProxyAddr: '127.0.0.1:8082', proxyAddrList: ['127.0.0.1:8082'] }, endpoints: [{ endpointId: 'proxy-b', kind: 'proxy' as const, address: '127.0.0.1:8082', environmentId: null }] };
+        expect(resolveConsumerScope(changed, 'proxy')).toEqual({ mode: 'proxy', endpointId: 'proxy-b' });
+    });
+
+    it('discards an older response resolving after the new scope or after disposal', async () => {
+        const generation = new ConsumerRequestGeneration();
+        let release!: (value: string) => void;
+        const delayed = new Promise<string>((resolve) => { release = resolve; });
+        const oldRequest = generation.begin();
+        const applied: string[] = [];
+        const older = delayed.then((value) => { if (oldRequest()) applied.push(value); });
+        const current = generation.begin();
+        if (current()) applied.push('new-scope');
+        release('old-scope');
+        await older;
+        expect(applied).toEqual(['new-scope']);
+        generation.invalidate();
+        expect(current()).toBe(false);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/scope.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/scope.ts
@@ -1,0 +1,22 @@
+import type { ConnectionSettingsView } from '../../services/connection.store';
+import type { ConsumerQueryScope } from './types/consumer.types';
+
+export function resolveConsumerScope(settings: ConnectionSettingsView | null, mode: ConsumerQueryScope['mode']): ConsumerQueryScope | null {
+    if (!settings) return null;
+    if (mode === 'name_server') return { mode: 'name_server' };
+    const endpoint = settings.endpoints.find((item) => item.kind === 'proxy' && item.endpointId === settings.currentProxyId && item.address === settings.proxy.currentProxyAddr);
+    return endpoint ? { mode: 'proxy', endpointId: endpoint.endpointId } : null;
+}
+
+export const consumerScopeKey = (scope: ConsumerQueryScope) => scope.mode === 'name_server' ? 'name_server' : `proxy:${scope.endpointId}`;
+export const consumerScopeLabel = (scope: ConsumerQueryScope) => scope.mode === 'name_server' ? 'NameServer discovery' : 'Configured Proxy';
+
+// A later request or page disposal invalidates every callback from the older request.
+export class ConsumerRequestGeneration {
+    private revision = 0;
+    begin(): () => boolean {
+        const revision = ++this.revision;
+        return () => revision === this.revision;
+    }
+    invalidate(): void { this.revision++; }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
@@ -1,21 +1,23 @@
+export type ConsumerQueryScope = { mode: 'name_server' } | { mode: 'proxy'; endpointId: string };
+
 export interface ConsumerGroupListRequest {
     skipSysGroup?: boolean;
-    address?: string;
+    scope: ConsumerQueryScope;
 }
 
 export interface ConsumerGroupRefreshRequest {
     consumerGroup: string;
-    address?: string;
+    scope: ConsumerQueryScope;
 }
 
 export interface ConsumerConnectionQueryRequest {
     consumerGroup: string;
-    address?: string;
+    scope: ConsumerQueryScope;
 }
 
 export interface ConsumerTopicDetailQueryRequest {
     consumerGroup: string;
-    address?: string;
+    scope: ConsumerQueryScope;
 }
 
 export interface ConsumerConfigQueryRequest {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
@@ -16,7 +16,7 @@ import type {
 } from '../features/consumer/types/consumer.types';
 
 export class ConsumerService {
-    static async queryConsumerGroups(request: ConsumerGroupListRequest = {}): Promise<ConsumerGroupListResponse> {
+    static async queryConsumerGroups(request: ConsumerGroupListRequest): Promise<ConsumerGroupListResponse> {
         return invokeAuthenticatedCommand<ConsumerGroupListResponse>('query_consumer_groups', { request });
     }
 
@@ -25,7 +25,7 @@ export class ConsumerService {
     }
 
     static async refreshAllConsumerGroups(
-        request: ConsumerGroupListRequest = {},
+        request: ConsumerGroupListRequest,
     ): Promise<ConsumerGroupListResponse> {
         return invokeAuthenticatedCommand<ConsumerGroupListResponse>('refresh_all_consumer_groups', { request });
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -1,3 +1,4 @@
+import type { ConsumerQueryScope } from '../features/consumer/types/consumer.types';
 import React, { createContext, useContext, useEffect, useState, useReducer, useRef, useSyncExternalStore, ReactNode } from 'react';
 import { subscribeAuditWarning } from '../services/invoke';
 import { SessionStorageService } from '../services/session.storage';
@@ -15,9 +16,11 @@ interface AppState {
   activeTab: Tab;
   navigation: NavigationLocation;
   canGoBack: boolean;
+  consumerQueryMode: ConsumerQueryScope['mode'];
+  setConsumerQueryMode: (mode: ConsumerQueryScope['mode']) => void;
   goBack: () => void;
   openTopic: (name: string, detail?: Extract<EntityTarget, { kind: 'topic' }>['detail']) => void;
-  openConsumer: (name: string, detail?: Extract<EntityTarget, { kind: 'consumer' }>['detail'], proxyAddress?: string) => void;
+  openConsumer: (name: string, detail?: Extract<EntityTarget, { kind: 'consumer' }>['detail'], scope?: ConsumerQueryScope) => void;
   openBroker: (address: string, detail?: Extract<EntityTarget, { kind: 'broker' }>['detail']) => void;
   pageStates: React.MutableRefObject<Map<number, Record<string, unknown>>>;
   setActiveTab: (tab: Tab) => void;
@@ -39,18 +42,20 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   const [auditWarning, setAuditWarning] = useState<string | null>(null);
   useEffect(() => subscribeAuditWarning(setAuditWarning), []);
   const [navigationState, navigate] = useReducer(navigationReducer, initialNavigation);
+  const [consumerQueryMode, setConsumerQueryMode] = useState<ConsumerQueryScope['mode']>('name_server');
   const pageStates = useRef(new Map<number, Record<string, unknown>>());
   const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
   const environmentId = settings?.environmentId ?? null;
-  const previousEnvironment = useRef(environmentId);
+  const connectionScope = `${environmentId}:${settings?.currentProxyId ?? ''}`;
+  const previousEnvironment = useRef(connectionScope);
   const activeTab = navigationState.current.tab;
   useEffect(() => {
-    if (previousEnvironment.current !== environmentId) {
-      previousEnvironment.current = environmentId;
+    if (previousEnvironment.current !== connectionScope) {
+      previousEnvironment.current = connectionScope;
       pageStates.current.clear();
       navigate({ type: 'reset', environmentId });
     }
-  }, [environmentId]);
+  }, [connectionScope, environmentId]);
   useEffect(() => {
     const retained = new Set([navigationState.current.id, ...navigationState.history.map((entry) => entry.id)]);
     for (const id of pageStates.current.keys()) if (!retained.has(id)) pageStates.current.delete(id);
@@ -130,9 +135,12 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         canGoBack: navigationState.current.environmentId === environmentId && navigationState.history.length > 0,
         goBack: () => navigate({ type: 'back' }),
         openTopic: (name, detail = 'overview') => navigate({ type: 'open', tab: 'Topic', target: { kind: 'topic', name, detail }, environmentId }),
-        openConsumer: (name, detail = 'overview', proxyAddress) => navigate({ type: 'open', tab: 'Consumer', target: { kind: 'consumer', name, detail, proxyAddress }, environmentId }),
+        openConsumer: (name, detail = 'overview', scope = { mode: 'name_server' }) => {
+          setConsumerQueryMode(scope.mode);
+          navigate({ type: 'open', tab: 'Consumer', target: { kind: 'consumer', name, detail, scope }, environmentId });
+        },
         openBroker: (address, detail = 'overview') => navigate({ type: 'open', tab: 'Cluster', target: { kind: 'broker', address, detail }, environmentId }),
-        pageStates,
+        pageStates, consumerQueryMode, setConsumerQueryMode,
         setActiveTab,
         setAuthSession,
         clearAuthSession,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.test.ts
@@ -5,7 +5,7 @@ describe('entity navigation', () => {
     it('returns to the exact source entry and reopens an entity as a new visit', () => {
         const list = navigationReducer(initialNavigation, { type: 'open', tab: 'Topic', environmentId: 'env-a' });
         const topic = navigationReducer(list, { type: 'open', tab: 'Topic', environmentId: 'env-a', target: { kind: 'topic', name: 'Orders', detail: 'consumers' } });
-        const consumer = navigationReducer(topic, { type: 'open', tab: 'Consumer', environmentId: 'env-a', target: { kind: 'consumer', name: 'OrderReaders', detail: 'progress', proxyAddress: '127.0.0.1:8080' } });
+        const consumer = navigationReducer(topic, { type: 'open', tab: 'Consumer', environmentId: 'env-a', target: { kind: 'consumer', name: 'OrderReaders', detail: 'progress', scope: { mode: 'proxy', endpointId: 'proxy-a' } } });
         const returned = navigationReducer(consumer, { type: 'back' });
         expect(returned.current).toEqual(topic.current);
         expect(navigationReducer(returned, { type: 'back' }).current).toEqual(list.current);
@@ -35,5 +35,12 @@ describe('entity navigation', () => {
         for (let index = 0; index < 40; index++) state = navigationReducer(state, { type: 'open', tab: 'Topic', environmentId: 'env-a' });
         expect(state.history).toHaveLength(20);
         expect(navigationReducer(state, { type: 'back' }).current.id).toBe(39);
+    });
+
+    it('keeps configuration pages mounted so a connection refresh cannot discard a draft', () => {
+        const source = navigationReducer(initialNavigation, { type: 'open', tab: 'NameServer', environmentId: 'env-a' });
+        const next = navigationReducer(source, { type: 'reset', environmentId: 'env-b' });
+        expect(next.current.id).toBe(source.current.id);
+        expect(next.history).toEqual([]);
     });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.ts
@@ -1,10 +1,11 @@
+import type { ConsumerQueryScope } from '../features/consumer/types/consumer.types';
 export type Tab = 'NameServer' | 'Proxy' | 'Dashboard' | 'Cluster' | 'Topic' |
     'Consumer' | 'Producer' | 'Message' | 'MessageTrace' | 'DLQ' | 'ACL' |
     'Account' | 'Sessions' | 'Audit' | 'Monitors' | 'Storage';
 
 export type EntityTarget =
     | { kind: 'topic'; name: string; detail: 'overview' | 'status' | 'route' | 'consumers' | 'config' }
-    | { kind: 'consumer'; name: string; detail: 'overview' | 'progress' | 'clients' | 'config'; proxyAddress?: string }
+    | { kind: 'consumer'; name: string; detail: 'overview' | 'progress' | 'clients' | 'config'; scope: ConsumerQueryScope }
     | { kind: 'broker'; address: string; detail: 'overview' | 'status' | 'config' };
 
 export interface NavigationLocation {
@@ -37,7 +38,8 @@ export function navigationReducer(state: NavigationState, action: NavigationActi
     }
     const id = state.sequence + 1;
     if (action.type === 'reset') {
-        return { current: { id, tab: state.current.tab, target: null, environmentId: action.environmentId }, history: [], sequence: id };
+        const keepMounted = ['NameServer', 'Proxy', 'Account', 'Sessions', 'Audit'].includes(state.current.tab);
+        return { current: { id: keepMounted ? state.current.id : id, tab: state.current.tab, target: null, environmentId: action.environmentId }, history: [], sequence: id };
     }
     return {
         current: { id, tab: action.tab, target: action.target ?? null, environmentId: action.environmentId },


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10378

### Brief Description
Consumer list, refresh, connections, and progress requests now use explicit NameServer or configured Proxy scopes. The backend validates the active Proxy endpoint ID and resolves its address; direct Broker configuration reads remain separate. The UI reads shared settings, retains mode preferences, and prevents old scope responses or dialogs from resurfacing.

Remove unreachable legacy Consumer views that retained the obsolete address contract. Keep connection pages mounted during navigation invalidation so draft settings survive refreshes.

### How Did You Test This Change?
- Backend: cargo test --lib consumer:: (8 passed); package-scoped cargo fmt check passed.
- Frontend: npm run build passed with the existing bundle-size warning.
- Focused Consumer scope, navigation, and authenticated invocation tests: 20 passed, including configured endpoint validation and delayed-response rejection.
- git diff --check passed. Live Consumer/Proxy interaction remains part of final integration smoke against the running local Rust cluster.
