### PR TITLE
[ISSUE #10380]🚀Protect Tauri Topic writes and preserve send receipts

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/README.md
@@ -64,15 +64,14 @@ function Invoke-DebugAdmin {
 Invoke-DebugAdmin cluster clusterList
 Invoke-DebugAdmin topic updateTopic -n 127.0.0.1:9876 -c TauriDebugCluster -t TauriDebugSmoke -r 4 -w 4 -y
 Invoke-DebugAdmin topic topicRoute -n 127.0.0.1:8080 -t TauriDebugSmoke
-Invoke-DebugAdmin message sendMessage -t TauriDebugSmoke -p rocketmq-rust-tauri-smoke -b tauri-broker-a -i 0
-Invoke-DebugAdmin message sendMessage -t TauriDebugSmoke -p rocketmq-rust-tauri-smoke-b -b tauri-broker-b -i 0
-Invoke-DebugAdmin message queryMsgByOffset -t TauriDebugSmoke -b tauri-broker-a -i 0 -o 0
-Invoke-DebugAdmin message queryMsgByOffset -t TauriDebugSmoke -b tauri-broker-b -i 0 -o 0
+Invoke-DebugAdmin message sendMessage -t TauriDebugSmoke -p rocketmq-rust-tauri-smoke
 ```
 
-Expect both Brokers in the cluster and Proxy route response, `SEND_OK` from
-each send, and the sent bodies in the read responses. On subsequent runs, offset
-zero reads the first retained message; sending appends additional messages.
+Expect both Brokers in the cluster and Proxy route response, and `SEND_OK` from
+the send. To read the message, run `message queryMsgByOffset` with the Broker
+name (`-b`), queue ID (`-i`), and queue offset (`-o`) from that send receipt,
+along with `-t TauriDebugSmoke`. Sending appends to existing data; do not assume
+queue zero or offset zero identifies the newly sent message.
 This checks remoting administration and basic message storage, not gRPC clients,
 ACL, consumer processing, scheduled messages, or failover.
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/acl/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/acl/README.md
@@ -32,7 +32,9 @@ cargo test --lib local_acl_query_accepts_configured_credentials_and_rejects_inva
 
 The test uses the desktop's common AdminBuilder and checks the seeded user can be
 queried with correct credentials, while anonymous and incorrectly signed queries
-are rejected. It shuts down each session and the owned client runtime.
+are rejected. It also creates temporary normal and transaction Topics, sends
+signed messages, and deletes those Topics. It shuts down each session and the
+owned client runtime.
 
 Stop with `docker compose down`; volumes are retained. This fixture tests ACL,
 not TLS or token-provider behavior.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/TOPIC_MUTATIONS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/TOPIC_MUTATIONS.md
@@ -1,0 +1,31 @@
+# Topic mutations and send receipts
+
+The desktop `create_or_update_topic` command requires an explicit `mode` of
+`create` or `update`. No implicit upsert path remains. A fresh, unfiltered
+authoritative catalog rejects duplicate creates, missing updates, and all system
+Topic changes. Reserved system names are also protected before creation. Edit,
+send, offset reset/skip, whole-Topic deletion, and Broker-specific deletion share
+this policy. Current targets are revalidated before dispatch.
+
+A dedicated mutation session serializes the check and execution sequence within
+this app while the existing read session remains independent. The connection
+revision lease prevents changing environments during an accepted mutation.
+External administration can still race with a catalog query; this is not a
+distributed transaction or a cross-Broker rollback guarantee.
+
+Send receipts include `success` and a normalized `sendStatus`. Only `SEND_OK`
+counts as success. Timeout, unavailable-replica, and unknown statuses preserve
+message ID, Broker, queue, offset, and transaction metadata for review. The UI
+keeps the receipt visible and does not automatically send again. Closing the
+dialog or changing its Topic invalidates its pending UI callbacks.
+
+Admin-core's normal and transaction test Producers inherit the administration
+session's signing hook. Both disable automatic send retries and switching Brokers
+after a non-store-success response. Their session owner still awaits Producer
+shutdown. Credentials stay in backend memory.
+
+Validation includes fake-catalog mutation rejection, stale target checks,
+normalized send-result tests, and the isolated ACL fixture's signed normal and
+transaction sends. Run `cargo test --lib topic::` and the opt-in
+`cargo test --lib local_acl_query -- --ignored` from `src-tauri`, plus the frontend
+build. The ACL test creates unique temporary Topics and deletes them after sending.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -3835,6 +3835,7 @@ dependencies = [
  "rocketmq-admin-core",
  "rocketmq-dashboard-common",
  "rocketmq-error",
+ "rocketmq-model",
  "rocketmq-runtime",
  "rusqlite",
  "serde",

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
@@ -58,3 +58,5 @@ thiserror        = "2"
 rocketmq-admin-core = { version = "1.0.0", path = "../../../rocketmq-tools/rocketmq-admin/rocketmq-admin-core", default-features = false, features = ["client-adapter"] }
 rocketmq-runtime    = { version = "1.0.0", path = "../../../rocketmq-runtime" }
 rocketmq-error      = { version = "1.0.0", path = "../../../rocketmq-error" }
+
+rocketmq-model = { version = "1.0.0", path = "../../../rocketmq-model" }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
@@ -238,7 +238,7 @@ impl AuditReceipt for crate::topic::types::TopicMutationResult {
 }
 impl AuditReceipt for crate::topic::types::TopicSendMessageResult {
     fn summary(&self) -> Summary {
-        let ok = self.send_status == "SEND_OK";
+        let ok = self.success;
         Summary::count(usize::from(ok), usize::from(!ok))
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/admin.rs
@@ -213,7 +213,57 @@ mod tests {
                 {
                     Ok(mut session) => {
                         let request = ListUsersRequest::try_new("127.0.0.1:22911", "").unwrap();
-                        let result = session.list_users(&request).await;
+                        let result = async {
+                            use rocketmq_admin_core::core::topic::{
+                                DeleteTopicAdminRequest, TopicAdmin, TopicSendRequest, UpsertTopicRequest,
+                            };
+                            let users = session.list_users(&request).await?;
+                            if secret == Some("tauri-dev-secret") {
+                                for message_type in [None, Some("TRANSACTION".to_string())] {
+                                    let topic = format!("TauriAclSend{}", Uuid::new_v4().simple());
+                                    session
+                                        .upsert_topic(&UpsertTopicRequest {
+                                            cluster_names: vec!["TauriAclDebugCluster".into()],
+                                            broker_names: vec![],
+                                            topic: topic.clone(),
+                                            write_queue_nums: 1,
+                                            read_queue_nums: 1,
+                                            perm: 6,
+                                            order: false,
+                                            message_type,
+                                        })
+                                        .await?;
+                                    let sent = session
+                                        .send_topic_test_message(&TopicSendRequest {
+                                            topic: topic.clone(),
+                                            key: String::new(),
+                                            tag: String::new(),
+                                            message_body: "signed-desktop-smoke".into(),
+                                            trace_enabled: false,
+                                        })
+                                        .await;
+                                    let deleted = session
+                                        .delete_topic(&DeleteTopicAdminRequest {
+                                            topic,
+                                            cluster_name: Some("TauriAclDebugCluster".into()),
+                                            broker_name: None,
+                                        })
+                                        .await;
+                                    let sent = sent?;
+                                    deleted?;
+                                    if sent.send_status.split(" (").next() != Some("SendOk")
+                                        || sent.message_id.is_none()
+                                    {
+                                        return Err(rocketmq_admin_core::core::AdminError::backend(
+                                            "acl_send_smoke",
+                                            "expected a successful signed send receipt",
+                                        ));
+                                    }
+                                }
+                            }
+                            Ok(users)
+                        }
+                        .await;
                         session.shutdown().await;
                         result
                     }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic.rs
@@ -18,3 +18,5 @@ pub(crate) mod service;
 pub(crate) mod types;
 
 pub(crate) use service::TopicManager;
+
+pub(crate) mod guard;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
@@ -101,6 +101,7 @@ pub async fn get_topic_config(
 pub async fn create_or_update_topic(
     session_id: String,
     request: TopicConfigRequest,
+    mode: crate::topic::guard::TopicWriteMode,
     topic_manager: State<'_, TopicManager>,
     session_state: State<'_, SessionState>,
     audit_manager: State<'_, AuditManager>,
@@ -117,7 +118,7 @@ pub async fn create_or_update_topic(
             Some(request.topic_name.clone()),
             move |audit| async move {
                 let _lease = connection_manager.mutation_lease(expected_revision, &audit).await?;
-                topic_manager.create_or_update_topic(request).await
+                topic_manager.create_or_update_topic(request, mode).await
             },
         )
         .await

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/guard.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/guard.rs
@@ -1,0 +1,178 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::{DashboardError, DashboardResult};
+use rocketmq_admin_core::client_adapter::AdminSession;
+use rocketmq_admin_core::core::topic::{TopicAdmin, TopicCatalog, TopicCatalogRequest};
+use serde::Deserialize;
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TopicWriteMode {
+    Create,
+    Update,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum TopicIntent {
+    Create,
+    Existing,
+}
+
+impl From<TopicWriteMode> for TopicIntent {
+    fn from(mode: TopicWriteMode) -> Self {
+        match mode {
+            TopicWriteMode::Create => Self::Create,
+            TopicWriteMode::Update => Self::Existing,
+        }
+    }
+}
+
+pub(crate) trait TopicCatalogSource {
+    async fn current_catalog(&mut self) -> DashboardResult<TopicCatalog>;
+}
+impl TopicCatalogSource for AdminSession {
+    async fn current_catalog(&mut self) -> DashboardResult<TopicCatalog> {
+        self.get_topic_catalog(&TopicCatalogRequest::default())
+            .await
+            .map_err(DashboardError::Admin)
+    }
+}
+
+// The private constructor ensures mutation closures run only after authoritative validation.
+pub(crate) struct CheckedTopic(TopicCatalog);
+impl CheckedTopic {
+    pub(crate) fn execute<T>(self, write: impl FnOnce(TopicCatalog) -> T) -> T {
+        write(self.0)
+    }
+}
+
+pub(crate) async fn check_topic(
+    source: &mut impl TopicCatalogSource,
+    topic: &str,
+    intent: TopicIntent,
+) -> DashboardResult<CheckedTopic> {
+    let topic = topic.trim();
+    if topic.is_empty() {
+        return Err(DashboardError::Validation("Topic name is required.".into()));
+    }
+    let catalog = source.current_catalog().await?;
+    let existing = catalog.items.iter().find(|item| item.topic == topic);
+    if topic == "TBW102"
+        || rocketmq_model::topic::is_system_topic(topic)
+        || existing.is_some_and(|item| item.system_topic)
+    {
+        return Err(DashboardError::Validation(
+            "System topics are read-only in the dashboard.".into(),
+        ));
+    }
+    match (intent, existing.is_some()) {
+        (TopicIntent::Create, true) => {
+            return Err(DashboardError::Validation("Topic already exists; use Update.".into()));
+        }
+        (TopicIntent::Existing, false) => {
+            return Err(DashboardError::Validation(
+                "Topic does not exist; refresh the catalog.".into(),
+            ));
+        }
+        _ => {}
+    }
+    Ok(CheckedTopic(catalog))
+}
+
+pub(crate) fn validate_targets(catalog: &TopicCatalog, clusters: &[String], brokers: &[String]) -> DashboardResult<()> {
+    if clusters.is_empty() && brokers.is_empty() {
+        return Err(DashboardError::Validation(
+            "Select at least one current cluster or Broker.".into(),
+        ));
+    }
+    if clusters
+        .iter()
+        .any(|cluster| !catalog.targets.iter().any(|target| &target.cluster_name == cluster))
+        || brokers.iter().any(|broker| {
+            !catalog.targets.iter().any(|target| {
+                target.broker_names.contains(broker) && (clusters.is_empty() || clusters.contains(&target.cluster_name))
+            })
+        })
+    {
+        return Err(DashboardError::Validation(
+            "A selected target no longer belongs to the current catalog.".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocketmq_admin_core::core::topic::{TopicCatalogItem, TopicTargetOption};
+    struct FakeAdmin {
+        catalog: TopicCatalog,
+        writes: usize,
+    }
+    impl TopicCatalogSource for FakeAdmin {
+        async fn current_catalog(&mut self) -> DashboardResult<TopicCatalog> {
+            Ok(self.catalog.clone())
+        }
+    }
+    fn admin(system: bool) -> FakeAdmin {
+        FakeAdmin {
+            writes: 0,
+            catalog: TopicCatalog {
+                items: vec![TopicCatalogItem {
+                    topic: "orders".into(),
+                    category: "NORMAL".into(),
+                    message_type: "NORMAL".into(),
+                    clusters: vec!["cluster".into()],
+                    brokers: vec!["broker".into()],
+                    read_queue_count: 4,
+                    write_queue_count: 4,
+                    perm: 6,
+                    order: false,
+                    system_topic: system,
+                }],
+                targets: vec![TopicTargetOption {
+                    cluster_name: "cluster".into(),
+                    broker_names: vec!["broker".into()],
+                }],
+            },
+        }
+    }
+    #[tokio::test]
+    async fn prohibited_mutations_never_reach_the_executor() {
+        for (system, name, intent) in [
+            (true, "orders", TopicIntent::Existing),
+            (false, "orders", TopicIntent::Create),
+            (false, "missing", TopicIntent::Existing),
+            (false, "TBW102", TopicIntent::Create),
+        ] {
+            let mut admin = admin(system);
+            let result = check_topic(&mut admin, name, intent).await;
+            assert!(result.is_err());
+            if let Ok(checked) = result {
+                checked.execute(|_| admin.writes += 1);
+            }
+            assert_eq!(admin.writes, 0);
+        }
+        let mut admin = admin(false);
+        check_topic(&mut admin, "orders", TopicIntent::Existing)
+            .await
+            .unwrap()
+            .execute(|_| admin.writes += 1);
+        assert_eq!(admin.writes, 1);
+        assert!(validate_targets(&admin.catalog, &["stale-cluster".into()], &[]).is_err());
+        assert!(validate_targets(&admin.catalog, &[], &["stale-broker".into()]).is_err());
+        assert!(validate_targets(&admin.catalog, &["cluster".into()], &["broker".into()]).is_ok());
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::topic::guard::{TopicIntent, TopicWriteMode, check_topic, validate_targets};
 use std::sync::Arc;
 
 use rocketmq_admin_core::client_adapter::AdminSession;
@@ -65,6 +66,7 @@ use crate::topic::types::TopicTargetOption;
 pub(crate) struct TopicManager {
     runtime: Arc<NameServerRuntimeState>,
     admin_session: Arc<Mutex<Option<ManagedTopicAdmin>>>,
+    mutation_session: Arc<Mutex<Option<ManagedTopicAdmin>>>,
 }
 
 impl TopicManager {
@@ -72,13 +74,16 @@ impl TopicManager {
         Self {
             runtime,
             admin_session: Arc::new(Mutex::new(None)),
+            mutation_session: Arc::new(Mutex::new(None)),
         }
     }
 
     pub(crate) async fn shutdown(&self) {
-        let mut session = self.admin_session.lock().await;
-        if let Some(mut admin) = session.take() {
-            admin.shutdown().await;
+        for slot in [&self.admin_session, &self.mutation_session] {
+            let mut session = slot.lock().await;
+            if let Some(mut admin) = session.take() {
+                admin.shutdown().await;
+            }
         }
     }
 
@@ -237,14 +242,18 @@ impl TopicManager {
         }
     }
 
-    pub(crate) async fn create_or_update_topic(&self, request: TopicConfigRequest) -> TopicResult<TopicMutationResult> {
-        let mut session_guard = self.admin_session.lock().await;
+    pub(crate) async fn create_or_update_topic(
+        &self,
+        request: TopicConfigRequest,
+        mode: TopicWriteMode,
+    ) -> TopicResult<TopicMutationResult> {
+        let mut session_guard = self.mutation_session.lock().await;
         self.ensure_admin_session(&mut session_guard).await?;
         let result = {
             let session = session_guard
                 .as_mut()
                 .expect("topic admin session should be initialized before use");
-            self.create_or_update_topic_with_admin(&mut session.admin, request)
+            self.create_or_update_topic_with_admin(&mut session.admin, request, mode)
                 .await
         };
         if Self::should_reset_session(&result) {
@@ -256,7 +265,7 @@ impl TopicManager {
     }
 
     pub(crate) async fn delete_topic(&self, request: DeleteTopicRequest) -> TopicResult<TopicMutationResult> {
-        let mut session_guard = self.admin_session.lock().await;
+        let mut session_guard = self.mutation_session.lock().await;
         self.ensure_admin_session(&mut session_guard).await?;
         let result = {
             let session = session_guard
@@ -276,7 +285,7 @@ impl TopicManager {
         &self,
         request: DeleteTopicByBrokerRequest,
     ) -> TopicResult<TopicMutationResult> {
-        let mut session_guard = self.admin_session.lock().await;
+        let mut session_guard = self.mutation_session.lock().await;
         self.ensure_admin_session(&mut session_guard).await?;
         let result = {
             let session = session_guard
@@ -372,7 +381,7 @@ impl TopicManager {
         &self,
         request: SendTopicMessageRequest,
     ) -> TopicResult<TopicSendMessageResult> {
-        let mut session_guard = self.admin_session.lock().await;
+        let mut session_guard = self.mutation_session.lock().await;
         self.ensure_admin_session(&mut session_guard).await?;
         let result = {
             let session = session_guard
@@ -558,7 +567,8 @@ impl TopicManager {
     async fn create_or_update_topic_with_admin(
         &self,
         admin: &mut AdminSession,
-        request: TopicConfigRequest,
+        mut request: TopicConfigRequest,
+        mode: TopicWriteMode,
     ) -> TopicResult<TopicMutationResult> {
         if request.topic_name.trim().is_empty() {
             return Err(TopicError::Validation("Topic name is required.".into()));
@@ -568,21 +578,33 @@ impl TopicManager {
                 "Select at least one cluster or broker before saving the topic.".into(),
             ));
         }
-        let topic_name = request.topic_name.clone();
-        let outcome = admin
-            .upsert_topic(&UpsertTopicRequest {
-                cluster_names: request.cluster_name_list,
-                broker_names: request.broker_name_list,
-                topic: request.topic_name,
-                write_queue_nums: request.write_queue_nums.max(1) as u32,
-                read_queue_nums: request.read_queue_nums.max(1) as u32,
-                perm: request.perm.max(0) as u32,
-                order: request.order,
-                message_type: request.message_type,
+        request.topic_name = request.topic_name.trim().to_string();
+        if request.write_queue_nums <= 0 || request.read_queue_nums <= 0 || ![2, 4, 6].contains(&request.perm) {
+            return Err(TopicError::Validation(
+                "Positive queue counts and read/write permissions are required.".into(),
+            ));
+        }
+        let checked = check_topic(admin, &request.topic_name, mode.into()).await?;
+        checked
+            .execute(|catalog| async move {
+                validate_targets(&catalog, &request.cluster_name_list, &request.broker_name_list)?;
+                let topic_name = request.topic_name.clone();
+                let outcome = admin
+                    .upsert_topic(&UpsertTopicRequest {
+                        cluster_names: request.cluster_name_list,
+                        broker_names: request.broker_name_list,
+                        topic: request.topic_name,
+                        write_queue_nums: request.write_queue_nums.max(1) as u32,
+                        read_queue_nums: request.read_queue_nums.max(1) as u32,
+                        perm: request.perm.max(0) as u32,
+                        order: request.order,
+                        message_type: request.message_type,
+                    })
+                    .await
+                    .map_err(map_admin_error)?;
+                Ok(project_topic_mutation_outcome(outcome, topic_name, "Topic saved."))
             })
             .await
-            .map_err(map_admin_error)?;
-        Ok(project_topic_mutation_outcome(outcome, topic_name, "Topic saved."))
     }
 
     async fn delete_topic_with_admin(
@@ -594,15 +616,23 @@ impl TopicManager {
         if topic.is_empty() {
             return Err(TopicError::Validation("Topic name is required.".into()));
         }
-        let outcome = admin
-            .delete_topic(&DeleteTopicAdminRequest {
-                topic: topic.clone(),
-                cluster_name: request.cluster_name,
-                broker_name: None,
+        let checked = check_topic(admin, &topic, TopicIntent::Existing).await?;
+        checked
+            .execute(|catalog| async move {
+                if let Some(cluster) = &request.cluster_name {
+                    validate_targets(&catalog, std::slice::from_ref(cluster), &[])?;
+                }
+                let outcome = admin
+                    .delete_topic(&DeleteTopicAdminRequest {
+                        topic: topic.clone(),
+                        cluster_name: request.cluster_name,
+                        broker_name: None,
+                    })
+                    .await
+                    .map_err(map_admin_error)?;
+                Ok(project_topic_mutation_outcome(outcome, topic, "Topic deleted."))
             })
             .await
-            .map_err(map_admin_error)?;
-        Ok(project_topic_mutation_outcome(outcome, topic, "Topic deleted."))
     }
 
     async fn delete_topic_by_broker_with_admin(
@@ -618,15 +648,29 @@ impl TopicManager {
         if broker_name.is_empty() {
             return Err(TopicError::Validation("Broker name is required.".into()));
         }
-        let outcome = admin
-            .delete_topic(&DeleteTopicAdminRequest {
-                topic: topic.clone(),
-                cluster_name: None,
-                broker_name: Some(broker_name),
+        let checked = check_topic(admin, &topic, TopicIntent::Existing).await?;
+        checked
+            .execute(|catalog| async move {
+                if !catalog
+                    .items
+                    .iter()
+                    .any(|item| item.topic == topic && item.brokers.contains(&broker_name))
+                {
+                    return Err(TopicError::Validation(
+                        "Broker does not host the selected topic.".into(),
+                    ));
+                }
+                let outcome = admin
+                    .delete_topic(&DeleteTopicAdminRequest {
+                        topic: topic.clone(),
+                        cluster_name: None,
+                        broker_name: Some(broker_name),
+                    })
+                    .await
+                    .map_err(map_admin_error)?;
+                Ok(project_topic_mutation_outcome(outcome, topic, "Topic deleted."))
             })
             .await
-            .map_err(map_admin_error)?;
-        Ok(project_topic_mutation_outcome(outcome, topic, "Topic deleted."))
     }
 
     async fn get_topic_consumer_groups_with_admin(
@@ -681,43 +725,49 @@ impl TopicManager {
         } else {
             "reset_consumer_offset"
         };
-        let mut session_guard = self.admin_session.lock().await;
+        let mut session_guard = self.mutation_session.lock().await;
         self.ensure_admin_session(&mut session_guard).await?;
-        let result = {
+        let result = async {
             let session = session_guard
                 .as_mut()
                 .expect("topic admin session should be initialized before use");
-            let mut affected_queues = 0usize;
-            for consumer_group in &request.consumer_group_list {
-                let outcome = session
-                    .admin
-                    .reset_topic_consumer_offset(&ResetTopicConsumerOffsetRequest {
-                        consumer_group: consumer_group.clone(),
-                        topic: request.topic.clone(),
-                        reset_timestamp: request.reset_time as u64,
-                        force: request.force,
+            let checked = check_topic(&mut session.admin, &request.topic, TopicIntent::Existing).await?;
+            checked
+                .execute(|_| async {
+                    let mut affected_queues = 0usize;
+                    for consumer_group in &request.consumer_group_list {
+                        let outcome = session
+                            .admin
+                            .reset_topic_consumer_offset(&ResetTopicConsumerOffsetRequest {
+                                consumer_group: consumer_group.clone(),
+                                topic: request.topic.clone(),
+                                reset_timestamp: request.reset_time as u64,
+                                force: request.force,
+                            })
+                            .await
+                            .map_err(map_admin_error)?;
+                        affected_queues += outcome.target_count;
+                    }
+                    Ok(TopicMutationResult {
+                        success: true,
+                        message: if skip_accumulate {
+                            format!(
+                                "Skipped accumulated messages for {} consumer group(s).",
+                                request.consumer_group_list.len()
+                            )
+                        } else {
+                            format!(
+                                "Reset offsets for {} consumer group(s).",
+                                request.consumer_group_list.len()
+                            )
+                        },
+                        topic_name: Some(request.topic.clone()),
+                        affected_queues: Some(affected_queues),
                     })
-                    .await
-                    .map_err(map_admin_error)?;
-                affected_queues += outcome.target_count;
-            }
-            Ok(TopicMutationResult {
-                success: true,
-                message: if skip_accumulate {
-                    format!(
-                        "Skipped accumulated messages for {} consumer group(s).",
-                        request.consumer_group_list.len()
-                    )
-                } else {
-                    format!(
-                        "Reset offsets for {} consumer group(s).",
-                        request.consumer_group_list.len()
-                    )
-                },
-                topic_name: Some(request.topic.clone()),
-                affected_queues: Some(affected_queues),
-            })
-        };
+                })
+                .await
+        }
+        .await;
         if Self::should_reset_session(&result) {
             self.reset_admin_session(&mut session_guard, &format!("{operation_name} failed"))
                 .await;
@@ -732,17 +782,22 @@ impl TopicManager {
         request: SendTopicMessageRequest,
     ) -> TopicResult<TopicSendMessageResult> {
         let message_body = normalize_topic_message_body(&request.message_body)?;
-        let result = admin
-            .send_topic_test_message(&AdminTopicSendRequest {
-                topic: request.topic,
-                key: request.key,
-                tag: request.tag,
-                message_body,
-                trace_enabled: request.trace_enabled,
+        let checked = check_topic(admin, &request.topic, TopicIntent::Existing).await?;
+        checked
+            .execute(|_| async move {
+                let result = admin
+                    .send_topic_test_message(&AdminTopicSendRequest {
+                        topic: request.topic,
+                        key: request.key,
+                        tag: request.tag,
+                        message_body,
+                        trace_enabled: request.trace_enabled,
+                    })
+                    .await
+                    .map_err(map_admin_error)?;
+                Ok(map_send_result(result))
             })
             .await
-            .map_err(map_admin_error)?;
-        Ok(map_send_result(result))
     }
 }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service/mapping.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service/mapping.rs
@@ -71,9 +71,18 @@ pub(super) fn map_status_view(stats: TopicStats) -> TopicStatusView {
 }
 
 pub(super) fn map_send_result(result: AdminTopicSendResult) -> TopicSendMessageResult {
+    let status = result.send_status.split(" (").next().unwrap_or_default().trim();
+    let send_status = match status {
+        "SendOk" | "SEND_OK" => "SEND_OK",
+        "FlushDiskTimeout" | "FLUSH_DISK_TIMEOUT" => "FLUSH_DISK_TIMEOUT",
+        "FlushSlaveTimeout" | "FLUSH_SLAVE_TIMEOUT" => "FLUSH_SLAVE_TIMEOUT",
+        "SlaveNotAvailable" | "SLAVE_NOT_AVAILABLE" => "SLAVE_NOT_AVAILABLE",
+        _ => "UNKNOWN",
+    };
     TopicSendMessageResult {
+        success: send_status == "SEND_OK",
         topic: result.topic,
-        send_status: result.send_status,
+        send_status: send_status.to_string(),
         message_id: result.message_id,
         broker_name: result.broker_name,
         queue_id: result.queue_id,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service/tests.rs
@@ -64,7 +64,8 @@ fn owned_send_result_preserves_queue_and_transaction_metadata() {
         local_transaction_state: Some("COMMIT_MESSAGE".to_string()),
     });
     assert_eq!(result.topic, "TopicTest");
-    assert_eq!(result.send_status, "SendOk (COMMIT_MESSAGE)");
+    assert_eq!(result.send_status, "SEND_OK");
+    assert!(result.success);
     assert_eq!(result.message_id.as_deref(), Some("msg-1"));
     assert_eq!(result.broker_name.as_deref(), Some("broker-a"));
     assert_eq!(result.queue_id, Some(3));
@@ -72,4 +73,30 @@ fn owned_send_result_preserves_queue_and_transaction_metadata() {
     assert_eq!(result.transaction_id.as_deref(), Some("tx-1"));
     assert_eq!(result.region_id.as_deref(), Some("region-a"));
     assert_eq!(result.local_transaction_state.as_deref(), Some("COMMIT_MESSAGE"));
+}
+
+#[test]
+fn non_send_ok_receipts_preserve_identifiers_without_claiming_success() {
+    for status in [
+        "FlushDiskTimeout",
+        "FLUSH_SLAVE_TIMEOUT",
+        "SlaveNotAvailable",
+        "future-status",
+    ] {
+        let result = map_send_result(TopicSendResult {
+            topic: "orders".into(),
+            send_status: status.into(),
+            message_id: Some("receipt-id".into()),
+            broker_name: Some("broker".into()),
+            queue_id: Some(2),
+            queue_offset: 42,
+            transaction_id: None,
+            region_id: None,
+            local_transaction_state: None,
+        });
+        assert!(!result.success);
+        assert_eq!(result.message_id.as_deref(), Some("receipt-id"));
+        assert_eq!(result.queue_offset, 42);
+        assert_ne!(result.send_status, "SEND_OK");
+    }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
@@ -183,6 +183,7 @@ pub(crate) struct TopicConsumerInfoResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TopicSendMessageResult {
+    pub(crate) success: bool,
     pub(crate) topic: String,
     pub(crate) send_status: String,
     pub(crate) message_id: Option<String>,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
@@ -920,7 +920,8 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit, onRefresh}: TopicConf
                                 type="button"
                                 className="topic-status-secondary-button topic-config-danger-button"
                                 onClick={() => void handleDeleteByBroker()}
-                                disabled={!configData || isLoading || isDeletingBroker || !activeBroker}
+                                disabled={topic?.systemTopic || !configData || isLoading || isDeletingBroker || !activeBroker}
+                                title={topic?.systemTopic ? 'System topics are read-only' : undefined}
                             >
                                 <Trash2 className="topic-icon" aria-hidden="true"/>
                                 {isDeletingBroker ? 'Deleting...' : 'Delete Broker'}
@@ -930,10 +931,11 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit, onRefresh}: TopicConf
                                 className="topic-status-primary-button topic-config-edit-button"
                                 onClick={() => {
                                     if (configData) {
-                                        onEdit(buildTopicEditorSeedFromConfig(configData));
+                                        if (!topic?.systemTopic) onEdit(buildTopicEditorSeedFromConfig(configData));
                                     }
                                 }}
-                                disabled={!configData || isLoading}
+                                disabled={topic?.systemTopic || !configData || isLoading}
+                                title={topic?.systemTopic ? 'System topics are read-only' : undefined}
                             >
                                 <Save className="topic-icon" aria-hidden="true"/>
                                 Edit Topic
@@ -1559,6 +1561,8 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
     const [messageBody, setMessageBody] = useState('');
     const [traceEnabled, setTraceEnabled] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const sendGeneration = useRef(0);
+    useEffect(() => { setIsSubmitting(false); return () => { sendGeneration.current += 1; }; }, [isOpen, topic?.name]);
     const [isLoadingConfig, setIsLoadingConfig] = useState(false);
     const [error, setError] = useState('');
     const [sendResult, setSendResult] = useState<TopicSendMessageResult | null>(null);
@@ -1618,6 +1622,7 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
             return;
         }
 
+        const generation = ++sendGeneration.current;
         setIsSubmitting(true);
         setError('');
         setSendResult(null);
@@ -1630,19 +1635,21 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
                 messageBody,
                 traceEnabled,
             });
+            if (generation !== sendGeneration.current) return;
             setSendResult(result);
-            toast.success(`Message sent to ${topic.name}`);
+            if (result.success) toast.success(`Message sent to ${topic.name}`);
+            else toast.warning(`Send returned ${result.sendStatus}. Review the receipt before sending again.`);
         } catch (submitError) {
-            setError(dashboardErrorMessage(submitError, 'Failed to send topic message.'));
+            if (generation === sendGeneration.current) setError(dashboardErrorMessage(submitError, 'Failed to send topic message.'));
         } finally {
-            setIsSubmitting(false);
+            if (generation === sendGeneration.current) setIsSubmitting(false);
         }
     };
 
     const producerPathText = topicMessageType === 'TRANSACTION'
         ? 'Transaction producer path. Local transaction is committed immediately for test send.'
         : `Standard producer path for ${topicMessageType}.`;
-    const canSubmit = Boolean(messageBody.trim()) && !isSubmitting && !isLoadingConfig;
+    const canSubmit = !topic?.systemTopic && Boolean(messageBody.trim()) && !isSubmitting && !isLoadingConfig;
 
     if (!isOpen) return null;
 
@@ -2385,7 +2392,7 @@ const TopicEditorModal = ({isOpen, onClose, targets, seed, mode, onSaved}: Topic
                 perm,
                 order,
                 messageType,
-            });
+            }, mode);
             toast.success(result.message || `${mode === 'create' ? 'Created' : 'Updated'} topic ${topicName.trim()}`);
             await onSaved();
             onClose();
@@ -3083,6 +3090,7 @@ export const TopicView = () => {
     };
 
     const handleOperation = (op: string, topic: Topic) => {
+        if (topic.systemTopic && !['Status', 'Router', 'Topic Config', 'Consumer Manage'].includes(op)) { toast.error('System topics are read-only.'); return; }
         const detail = ({ Status: 'status', Router: 'route', 'Topic Config': 'config', 'Consumer Manage': 'consumers' } as const)[op as 'Status'];
         if (detail) { openTopic(topic.name, detail); return; }
         if (op === 'Status') {
@@ -3428,6 +3436,7 @@ export const TopicView = () => {
                             <div className="topic-inspector-header">
                                 <span>Selected Topic</span>
                                 <h2>{selectedTopic.name}</h2>
+                                {selectedTopic.systemTopic && <p>System topic: changes, sends, and offset operations are disabled.</p>}
                                 <div className="topic-inspector-tags">
                                     <TopicTypeBadge type={selectedTopic.type}/>
                                     <span>{selectedTopic.messageType}</span>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/types/topic.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/types/topic.types.ts
@@ -116,6 +116,7 @@ export interface TopicConsumerInfoResponse {
 }
 
 export interface TopicSendMessageResult {
+    success: boolean;
     topic: string;
     sendStatus: string;
     messageId?: string | null;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/topic.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/topic.service.ts
@@ -35,8 +35,8 @@ export class TopicService {
         return invokeAuthenticatedCommand<TopicConfigView>('get_topic_config', { request });
     }
 
-    static async createOrUpdateTopic(request: TopicConfigRequest): Promise<TopicMutationResult> {
-        return invokeAuthenticatedCommand<TopicMutationResult>('create_or_update_topic', { request });
+    static async createOrUpdateTopic(request: TopicConfigRequest, mode: 'create' | 'update'): Promise<TopicMutationResult> {
+        return invokeAuthenticatedCommand<TopicMutationResult>('create_or_update_topic', { request, mode });
     }
 
     static async deleteTopic(request: DeleteTopicRequest): Promise<TopicMutationResult> {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/lifecycle.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/lifecycle.rs
@@ -113,6 +113,7 @@ impl AdminBuilder {
 
 #[must_use = "a started admin session must be explicitly shut down"]
 pub struct AdminSession {
+    pub(crate) request_signing_hook: Option<Arc<dyn rocketmq_transport::api::RPCHook>>,
     pub(crate) inner: DefaultMQAdminExt,
     client_runtime: Arc<ClientRuntime>,
     pub(crate) clock: Arc<dyn Clock>,
@@ -124,6 +125,7 @@ impl AdminSession {
     pub(crate) fn from_started(inner: DefaultMQAdminExt, clock: Arc<dyn Clock>) -> Self {
         let client_runtime = inner.client_runtime();
         Self {
+            request_signing_hook: None,
             inner,
             client_runtime,
             clock,
@@ -252,11 +254,14 @@ impl AdminBuilder {
             .map(str::to_owned)
             .unwrap_or_else(|| format!("tools-admin-{now_millis}"));
         let timeout = Duration::from_millis(config.configured_timeout_millis());
-        let mut admin = match credentials {
-            Some(credentials) => DefaultMQAdminExt::with_admin_ext_group_rpc_hook_and_timeout(
+        let request_signing_hook = credentials
+            .as_ref()
+            .map(|credentials| Arc::new(admin_acl_rpc_hook(credentials)) as Arc<dyn rocketmq_transport::api::RPCHook>);
+        let mut admin = match request_signing_hook.clone() {
+            Some(hook) => DefaultMQAdminExt::with_admin_ext_group_rpc_hook_and_timeout(
                 client_runtime.clone(),
                 admin_group,
-                Arc::new(admin_acl_rpc_hook(&credentials)),
+                hook,
                 timeout,
             ),
             None => DefaultMQAdminExt::with_admin_ext_group_and_timeout(client_runtime.clone(), admin_group, timeout),
@@ -282,6 +287,7 @@ impl AdminBuilder {
             .map_err(|error| backend_error("start_admin_session", error))?;
 
         Ok(AdminSession {
+            request_signing_hook,
             inner: admin,
             client_runtime,
             clock,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/mutation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/mutation.rs
@@ -529,9 +529,23 @@ impl TopicMutationAdmin for MutationAdminSession {
             let producer_group = unique_producer_group(self.inner.clock.now_millis(), transactional);
             let client_config = self.inner.inner.client_config().clone_client_config();
             if transactional {
-                send_transaction_message(self.client_runtime(), client_config, producer_group, request).await
+                send_transaction_message(
+                    self.client_runtime(),
+                    client_config,
+                    producer_group,
+                    request,
+                    self.inner.request_signing_hook.clone(),
+                )
+                .await
             } else {
-                send_normal_message(self.client_runtime(), client_config, producer_group, request).await
+                send_normal_message(
+                    self.client_runtime(),
+                    client_config,
+                    producer_group,
+                    request,
+                    self.inner.request_signing_hook.clone(),
+                )
+                .await
             }
         })
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/admin.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/admin.rs
@@ -87,6 +87,7 @@ impl AdminBuilder {
             )
         })?;
         let timeout = self.timeout_millis.map(Duration::from_millis);
+        let request_signing_hook = self.rpc_hook.clone();
         let mut admin = match (self.rpc_hook, timeout) {
             (Some(hook), Some(timeout)) => DefaultMQAdminExt::with_rpc_hook_and_timeout(client_runtime, hook, timeout),
             (Some(hook), None) => DefaultMQAdminExt::with_rpc_hook(client_runtime, hook),
@@ -106,9 +107,9 @@ impl AdminBuilder {
             .start()
             .await
             .map_err(crate::IntoCanonicalError::into_canonical_error)?;
-        Ok(ServiceAdminSession {
-            session: AdminSession::from_started(admin, Arc::new(SystemClock)),
-        })
+        let mut session = AdminSession::from_started(admin, Arc::new(SystemClock));
+        session.request_signing_hook = request_signing_hook;
+        Ok(ServiceAdminSession { session })
     }
 }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic.rs
@@ -577,9 +577,23 @@ impl TopicAdmin for AdminSession {
             let producer_group = unique_producer_group(self.clock.now_millis(), message_type == "TRANSACTION");
 
             if message_type == "TRANSACTION" {
-                send_transaction_message(self.client_runtime(), client_config, producer_group, request).await
+                send_transaction_message(
+                    self.client_runtime(),
+                    client_config,
+                    producer_group,
+                    request,
+                    self.request_signing_hook.clone(),
+                )
+                .await
             } else {
-                send_normal_message(self.client_runtime(), client_config, producer_group, request).await
+                send_normal_message(
+                    self.client_runtime(),
+                    client_config,
+                    producer_group,
+                    request,
+                    self.request_signing_hook.clone(),
+                )
+                .await
             }
         })
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic/producer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic/producer.rs
@@ -84,12 +84,19 @@ pub(crate) async fn send_normal_message(
     mut client_config: rocketmq_client_rust::ClientConfig,
     producer_group: String,
     request: &TopicSendRequest,
+    signing_hook: Option<Arc<dyn rocketmq_transport::api::RPCHook>>,
 ) -> Result<TopicSendResult, AdminError> {
     client_config.set_instance_name(producer_group.clone().into());
-    let mut producer = DefaultMQProducer::builder(client_runtime)
+    let mut builder = DefaultMQProducer::builder(client_runtime)
         .producer_group(producer_group)
         .client_config(client_config)
-        .build();
+        .retry_times_when_send_failed(0)
+        .retry_times_when_send_async_failed(0)
+        .retry_another_broker_when_not_store_ok(false);
+    if let Some(hook) = signing_hook {
+        builder = builder.rpc_hook(hook);
+    }
+    let mut producer = builder.build();
     producer
         .start()
         .await
@@ -114,13 +121,20 @@ pub(crate) async fn send_transaction_message(
     mut client_config: rocketmq_client_rust::ClientConfig,
     producer_group: String,
     request: &TopicSendRequest,
+    signing_hook: Option<Arc<dyn rocketmq_transport::api::RPCHook>>,
 ) -> Result<TopicSendResult, AdminError> {
     client_config.set_instance_name(producer_group.clone().into());
-    let mut producer = TransactionMQProducer::builder(client_runtime)
+    let mut builder = TransactionMQProducer::builder(client_runtime)
         .producer_group(producer_group)
         .client_config(client_config)
         .transaction_listener(CommitTransactionListener)
-        .build();
+        .retry_times_when_send_failed(0)
+        .retry_times_when_send_async_failed(0)
+        .retry_another_broker_when_not_store_ok(false);
+    if let Some(hook) = signing_hook {
+        builder = builder.rpc_hook(hook);
+    }
+    let mut producer = builder.build();
     producer
         .start()
         .await


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10380

### Brief Description
Require explicit create/update intent and validate system status, existence, and current targets from an authoritative Topic catalog before writes. Use a separate owned mutation session to cover validation and execution without adding contention to reads. Guard edit, send, reset/skip, and both deletion paths.

Normalize send receipts and report success only for SEND_OK while retaining identifiers and transaction metadata. Discard stale send-dialog callbacks. Fix admin-core normal and transaction test Producers to inherit the session signing hook and disable automatic send retries; preserve existing shutdown ownership.

### How Did You Test This Change?
- Tauri: cargo test --lib topic:: (8 passed), including fake-executor rejection and non-success receipt preservation.
- Isolated local Rust ACL Broker: cargo test --lib local_acl_query -- --ignored passed for correct/anonymous/incorrect credentials and signed normal/transaction sends with temporary Topic cleanup.
- Admin-core: 3 focused Topic tests passed with client-adapter; mutation-client-adapter standalone compilation checked separately.
- Frontend production build passed; 20 focused session, navigation, and Consumer-scope tests passed. Existing bundle-size warning remains.
- Both affected Rust packages passed format checks; git diff --check passed. Desktop UI smoke remains in the final integration step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards for topic creation, updates, deletion, and message sending.
  - System topics are now read-only, with editing, deletion, and sending disabled.
  - Topic operations validate names, targets, and whether the requested topic already exists.
  - Topic message results now clearly indicate success and normalize delivery statuses.
  - Failed sends display warning notifications while preserving available message details.
  - Authenticated administration and test-message operations now support signed requests.

- **Documentation**
  - Added guidance covering topic mutation policies, message receipts, retries, credentials, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->