### PR TITLE
[ISSUE #10382]🚀Preserve Tauri Topic batch results and failed-target review

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/TOPIC_BATCH_RESULTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/TOPIC_BATCH_RESULTS.md
@@ -1,0 +1,31 @@
+# Topic batch results
+
+Create/update calls admin-core `TopicBatchMutationAdmin`; whole-Topic deletion
+calls `TopicBatchDeleteAdmin`. Broker deletion uses the existing single-Broker
+operation and projects the same receipt shape. Local policy and the mutation
+session still guard all checks and writes.
+
+Receipts contain operation, Topic, target count, target identities and kinds,
+success, safe errors, and a separate `orderConfig` result. Only all-target success
+with successful required order configuration produces overall success. Raw
+upstream error text is not exposed. Audit records retain the success/failure
+counts rather than flattening a partial operation into a successful action.
+
+The current admin-core deletion contract returns Cluster-level outcomes. Those
+rows are explicitly labeled `cluster`; the dashboard does not invent individual
+Broker acknowledgments from a failed Cluster operation. Create/update and direct
+Broker deletion use Broker rows. A Cluster failure may have partially changed
+its Brokers and requires state verification before another deletion.
+
+The shared receipt component keeps every result visible, including successful
+targets and independent `ORDER_TOPIC_CONFIG` failures. An editor can load only
+failed Brokers into a review draft. A partially successful create becomes an
+explicit update draft; an entirely failed create retains create intent. Nothing
+is retried automatically. A failed whole-Topic deletion can be reviewed one
+failed Cluster at a time without repeating successful Cluster targets. The
+success receipt stays visible until the user closes it.
+
+Validation: focused backend Topic and audit tests, production frontend build,
+and the receipt rendering tests. The fake batch projection checks one successful
+and one failed target, all-success behavior, order-only failures, and error
+redaction. This is not a cross-Broker transaction or rollback promise.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
@@ -347,3 +347,13 @@ impl AuditContext {
         super::db::insert(connection, &self.event(Some(actor.into()), Summary::count(1, 0)))
     }
 }
+
+impl AuditReceipt for crate::topic::batch::TopicBatchResult {
+    fn summary(&self) -> Summary {
+        let success = self.targets.iter().filter(|target| target.success).count()
+            + usize::from(self.order_config.as_ref().is_some_and(|result| result.success));
+        let failure = self.targets.iter().filter(|target| !target.success).count()
+            + usize::from(self.order_config.as_ref().is_some_and(|result| !result.success));
+        Summary::count(success, failure.max(usize::from(!self.success)))
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic.rs
@@ -20,3 +20,5 @@ pub(crate) mod types;
 pub(crate) use service::TopicManager;
 
 pub(crate) mod guard;
+
+pub(crate) mod batch;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/batch.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/batch.rs
@@ -1,0 +1,161 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_admin_core::core::topic::{TopicBatchOrderConfigOutcome, TopicBatchTargetOutcome};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TopicBatchOperation {
+    Create,
+    Update,
+    Delete,
+    DeleteBroker,
+}
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TopicTargetKind {
+    Broker,
+    Cluster,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicTargetReceipt {
+    pub(crate) kind: TopicTargetKind,
+    pub(crate) name: String,
+    pub(crate) success: bool,
+    pub(crate) error_code: Option<String>,
+    pub(crate) message: String,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicOrderReceipt {
+    pub(crate) success: bool,
+    pub(crate) error_code: Option<String>,
+    pub(crate) message: String,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicBatchResult {
+    pub(crate) operation: TopicBatchOperation,
+    pub(crate) topic: String,
+    pub(crate) target_count: usize,
+    pub(crate) targets: Vec<TopicTargetReceipt>,
+    pub(crate) order_config: Option<TopicOrderReceipt>,
+    pub(crate) success: bool,
+    pub(crate) message: String,
+}
+
+pub(crate) fn project_batch(
+    operation: TopicBatchOperation,
+    topic: String,
+    kind: TopicTargetKind,
+    targets: Vec<TopicBatchTargetOutcome>,
+    order_config: Option<TopicBatchOrderConfigOutcome>,
+) -> TopicBatchResult {
+    let order_required = operation != TopicBatchOperation::DeleteBroker;
+    let success = !targets.is_empty()
+        && targets.iter().all(|target| target.success)
+        && (!order_required || order_config.as_ref().is_some_and(|result| result.success));
+    TopicBatchResult {
+        operation,
+        topic,
+        target_count: targets.len(),
+        success,
+        message: if success {
+            "All requested targets completed."
+        } else {
+            "Some targets did not complete. Review each result before retrying."
+        }
+        .into(),
+        targets: targets
+            .into_iter()
+            .map(|target| TopicTargetReceipt {
+                kind,
+                name: target.broker_name,
+                success: target.success,
+                error_code: (!target.success).then(|| "dashboard.topic_target_failed".into()),
+                message: if target.success {
+                    "Target completed."
+                } else {
+                    "Target operation did not complete; verify its current state."
+                }
+                .into(),
+            })
+            .collect(),
+        order_config: order_config.map(|result| TopicOrderReceipt {
+            success: result.success,
+            error_code: (!result.success).then(|| "dashboard.topic_order_config_failed".into()),
+            message: if result.success {
+                "Order configuration completed."
+            } else {
+                "Order configuration did not complete; verify it before retrying."
+            }
+            .into(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn partial_targets_and_order_failure_remain_visible_without_raw_error_details() {
+        let target = |name: &str, success| TopicBatchTargetOutcome {
+            broker_name: name.into(),
+            success,
+            message: "password=secret path=C:/private".into(),
+        };
+        let result = project_batch(
+            TopicBatchOperation::Update,
+            "orders".into(),
+            TopicTargetKind::Broker,
+            vec![target("broker-a", true), target("broker-b", false)],
+            Some(TopicBatchOrderConfigOutcome {
+                success: false,
+                message: "credential=secret".into(),
+            }),
+        );
+        assert!(!result.success);
+        assert_eq!(result.target_count, 2);
+        assert!(result.targets[0].success);
+        assert!(!result.targets[1].success);
+        assert!(!result.order_config.unwrap().success);
+        let result = project_batch(
+            TopicBatchOperation::Update,
+            "orders".into(),
+            TopicTargetKind::Broker,
+            vec![target("broker-a", true)],
+            Some(TopicBatchOrderConfigOutcome {
+                success: true,
+                message: String::new(),
+            }),
+        );
+        assert!(result.success);
+        assert!(!serde_json::to_string(&result).unwrap().contains("secret"));
+        let result = project_batch(
+            TopicBatchOperation::Update,
+            "orders".into(),
+            TopicTargetKind::Broker,
+            vec![target("broker-a", true)],
+            Some(TopicBatchOrderConfigOutcome {
+                success: false,
+                message: "secret".into(),
+            }),
+        );
+        assert!(!result.success, "an order-only failure must not disappear");
+        assert!(!serde_json::to_string(&result).unwrap().contains("secret"));
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
@@ -14,6 +14,7 @@
 
 use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
 use crate::connection::ConnectionManager;
+use crate::topic::batch::TopicBatchResult;
 use crate::topic::service::TopicManager;
 use crate::topic::types::TopicConfigView;
 use crate::topic::types::TopicConsumerGroupListResponse;
@@ -107,7 +108,7 @@ pub async fn create_or_update_topic(
     audit_manager: State<'_, AuditManager>,
     connection_manager: State<'_, ConnectionManager>,
     expected_revision: i64,
-) -> CommandResult<Audited<TopicMutationResult>> {
+) -> CommandResult<Audited<TopicBatchResult>> {
     let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let topic_manager = topic_manager.inner().clone();
@@ -133,7 +134,7 @@ pub async fn delete_topic(
     audit_manager: State<'_, AuditManager>,
     connection_manager: State<'_, ConnectionManager>,
     expected_revision: i64,
-) -> CommandResult<Audited<TopicMutationResult>> {
+) -> CommandResult<Audited<TopicBatchResult>> {
     let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let topic_manager = topic_manager.inner().clone();
@@ -159,7 +160,7 @@ pub async fn delete_topic_by_broker(
     audit_manager: State<'_, AuditManager>,
     connection_manager: State<'_, ConnectionManager>,
     expected_revision: i64,
-) -> CommandResult<Audited<TopicMutationResult>> {
+) -> CommandResult<Audited<TopicBatchResult>> {
     let connection_manager = connection_manager.inner().clone();
     let access = AuditAccess::dashboard(&session_state, session_id);
     let topic_manager = topic_manager.inner().clone();

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::topic::batch::{TopicBatchOperation, TopicBatchResult, TopicTargetKind, project_batch};
 use crate::topic::guard::{TopicIntent, TopicWriteMode, check_topic, validate_targets};
+use rocketmq_admin_core::core::topic::{
+    TopicBatchDeleteAdmin, TopicBatchDeleteRequest, TopicBatchMutationAdmin, TopicBatchTargetOutcome,
+    TopicBatchUpsertRequest,
+};
 use std::sync::Arc;
 
 use rocketmq_admin_core::client_adapter::AdminSession;
@@ -22,12 +27,10 @@ use rocketmq_admin_core::core::topic::GetTopicRouteRequest;
 use rocketmq_admin_core::core::topic::ResetTopicConsumerOffsetRequest;
 use rocketmq_admin_core::core::topic::TopicAdmin;
 use rocketmq_admin_core::core::topic::TopicCatalogRequest;
-use rocketmq_admin_core::core::topic::TopicMutationOutcome;
 use rocketmq_admin_core::core::topic::TopicRoute;
 use rocketmq_admin_core::core::topic::TopicSendRequest as AdminTopicSendRequest;
 use rocketmq_admin_core::core::topic::TopicSendResult as AdminTopicSendResult;
 use rocketmq_admin_core::core::topic::TopicStats;
-use rocketmq_admin_core::core::topic::UpsertTopicRequest;
 use rocketmq_dashboard_common::DeleteTopicByBrokerRequest;
 use rocketmq_dashboard_common::DeleteTopicRequest;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
@@ -246,7 +249,7 @@ impl TopicManager {
         &self,
         request: TopicConfigRequest,
         mode: TopicWriteMode,
-    ) -> TopicResult<TopicMutationResult> {
+    ) -> TopicResult<TopicBatchResult> {
         let mut session_guard = self.mutation_session.lock().await;
         self.ensure_admin_session(&mut session_guard).await?;
         let result = {
@@ -264,7 +267,7 @@ impl TopicManager {
         result
     }
 
-    pub(crate) async fn delete_topic(&self, request: DeleteTopicRequest) -> TopicResult<TopicMutationResult> {
+    pub(crate) async fn delete_topic(&self, request: DeleteTopicRequest) -> TopicResult<TopicBatchResult> {
         let mut session_guard = self.mutation_session.lock().await;
         self.ensure_admin_session(&mut session_guard).await?;
         let result = {
@@ -284,7 +287,7 @@ impl TopicManager {
     pub(crate) async fn delete_topic_by_broker(
         &self,
         request: DeleteTopicByBrokerRequest,
-    ) -> TopicResult<TopicMutationResult> {
+    ) -> TopicResult<TopicBatchResult> {
         let mut session_guard = self.mutation_session.lock().await;
         self.ensure_admin_session(&mut session_guard).await?;
         let result = {
@@ -569,7 +572,7 @@ impl TopicManager {
         admin: &mut AdminSession,
         mut request: TopicConfigRequest,
         mode: TopicWriteMode,
-    ) -> TopicResult<TopicMutationResult> {
+    ) -> TopicResult<TopicBatchResult> {
         if request.topic_name.trim().is_empty() {
             return Err(TopicError::Validation("Topic name is required.".into()));
         }
@@ -588,21 +591,38 @@ impl TopicManager {
         checked
             .execute(|catalog| async move {
                 validate_targets(&catalog, &request.cluster_name_list, &request.broker_name_list)?;
-                let topic_name = request.topic_name.clone();
-                let outcome = admin
-                    .upsert_topic(&UpsertTopicRequest {
-                        cluster_names: request.cluster_name_list,
-                        broker_names: request.broker_name_list,
-                        topic: request.topic_name,
-                        write_queue_nums: request.write_queue_nums.max(1) as u32,
-                        read_queue_nums: request.read_queue_nums.max(1) as u32,
-                        perm: request.perm.max(0) as u32,
-                        order: request.order,
-                        message_type: request.message_type,
-                    })
-                    .await
-                    .map_err(map_admin_error)?;
-                Ok(project_topic_mutation_outcome(outcome, topic_name, "Topic saved."))
+                let broker_names = if request.broker_name_list.is_empty() {
+                    catalog
+                        .targets
+                        .iter()
+                        .filter(|target| request.cluster_name_list.contains(&target.cluster_name))
+                        .flat_map(|target| target.broker_names.clone())
+                        .collect()
+                } else {
+                    request.broker_name_list.clone()
+                };
+                let batch = TopicBatchUpsertRequest::try_new(
+                    request.topic_name.clone(),
+                    broker_names,
+                    request.write_queue_nums as u32,
+                    request.read_queue_nums as u32,
+                    request.perm as u32,
+                    request.order,
+                    request.message_type,
+                )
+                .map_err(map_admin_error)?;
+                let outcome = admin.upsert_topic_batch(&batch).await.map_err(map_admin_error)?;
+                let operation = match mode {
+                    TopicWriteMode::Create => TopicBatchOperation::Create,
+                    TopicWriteMode::Update => TopicBatchOperation::Update,
+                };
+                Ok(project_batch(
+                    operation,
+                    request.topic_name,
+                    TopicTargetKind::Broker,
+                    outcome.targets,
+                    outcome.order_config,
+                ))
             })
             .await
     }
@@ -611,7 +631,7 @@ impl TopicManager {
         &self,
         admin: &mut AdminSession,
         request: DeleteTopicRequest,
-    ) -> TopicResult<TopicMutationResult> {
+    ) -> TopicResult<TopicBatchResult> {
         let topic = request.topic.trim().to_string();
         if topic.is_empty() {
             return Err(TopicError::Validation("Topic name is required.".into()));
@@ -622,15 +642,23 @@ impl TopicManager {
                 if let Some(cluster) = &request.cluster_name {
                     validate_targets(&catalog, std::slice::from_ref(cluster), &[])?;
                 }
-                let outcome = admin
-                    .delete_topic(&DeleteTopicAdminRequest {
-                        topic: topic.clone(),
-                        cluster_name: request.cluster_name,
-                        broker_name: None,
-                    })
-                    .await
-                    .map_err(map_admin_error)?;
-                Ok(project_topic_mutation_outcome(outcome, topic, "Topic deleted."))
+                let cluster_names = request.cluster_name.map(|cluster| vec![cluster]).unwrap_or_else(|| {
+                    catalog
+                        .items
+                        .iter()
+                        .find(|item| item.topic == topic)
+                        .map(|item| item.clusters.clone())
+                        .unwrap_or_default()
+                });
+                let batch = TopicBatchDeleteRequest::try_new(topic.clone(), cluster_names).map_err(map_admin_error)?;
+                let outcome = admin.delete_topic_batch(&batch).await.map_err(map_admin_error)?;
+                Ok(project_batch(
+                    TopicBatchOperation::Delete,
+                    topic,
+                    TopicTargetKind::Cluster,
+                    outcome.targets,
+                    outcome.order_config,
+                ))
             })
             .await
     }
@@ -639,7 +667,7 @@ impl TopicManager {
         &self,
         admin: &mut AdminSession,
         request: DeleteTopicByBrokerRequest,
-    ) -> TopicResult<TopicMutationResult> {
+    ) -> TopicResult<TopicBatchResult> {
         let topic = request.topic.trim().to_string();
         if topic.is_empty() {
             return Err(TopicError::Validation("Topic name is required.".into()));
@@ -664,11 +692,21 @@ impl TopicManager {
                     .delete_topic(&DeleteTopicAdminRequest {
                         topic: topic.clone(),
                         cluster_name: None,
-                        broker_name: Some(broker_name),
+                        broker_name: Some(broker_name.clone()),
                     })
-                    .await
-                    .map_err(map_admin_error)?;
-                Ok(project_topic_mutation_outcome(outcome, topic, "Topic deleted."))
+                    .await;
+                let target = TopicBatchTargetOutcome {
+                    broker_name,
+                    success: outcome.is_ok(),
+                    message: String::new(),
+                };
+                Ok(project_batch(
+                    TopicBatchOperation::DeleteBroker,
+                    topic,
+                    TopicTargetKind::Broker,
+                    vec![target],
+                    None,
+                ))
             })
             .await
     }
@@ -798,41 +836,6 @@ impl TopicManager {
                 Ok(map_send_result(result))
             })
             .await
-    }
-}
-
-fn project_topic_mutation_outcome(
-    _outcome: TopicMutationOutcome,
-    topic_name: String,
-    message: &'static str,
-) -> TopicMutationResult {
-    TopicMutationResult {
-        success: true,
-        message: message.to_string(),
-        topic_name: Some(topic_name),
-        affected_queues: None,
-    }
-}
-
-#[cfg(test)]
-mod boundary_projection_tests {
-    use super::project_topic_mutation_outcome;
-    use rocketmq_admin_core::core::topic::TopicMutationOutcome;
-
-    #[test]
-    fn topic_mutation_projection_discards_upstream_message() {
-        let result = project_topic_mutation_outcome(
-            TopicMutationOutcome {
-                message: "password=secret C:\\private\\broker".to_string(),
-                target_count: 1,
-            },
-            "orders".to_string(),
-            "Topic saved.",
-        );
-
-        assert_eq!(result.message, "Topic saved.");
-        assert!(!result.message.contains("secret"));
-        assert!(!result.message.contains("private"));
     }
 }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
@@ -1,3 +1,5 @@
+import { TopicMutationReceipt, failedBrokerNames } from '../features/topic/components/TopicMutationReceipt';
+import type { TopicBatchResult } from '../features/topic/types/topic.types';
 import { useAppStore, useNavigationState } from '../stores/app.store';
 import { findEntity } from '../stores/navigation';
 import React, {useEffect, useMemo, useState, useRef, ReactNode} from 'react';
@@ -519,6 +521,9 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit, onRefresh}: TopicConf
     const [error, setError] = useState('');
     const [actionError, setActionError] = useState('');
     const [isDeletingBroker, setIsDeletingBroker] = useState(false);
+    const [mutationReceipt, setMutationReceipt] = useState<TopicBatchResult | null>(null);
+    const mutationGeneration = useRef(0);
+    useEffect(() => { setMutationReceipt(null); return () => { mutationGeneration.current += 1; }; }, [isOpen, topic?.name]);
 
     useEffect(() => {
         if (!isOpen || !topic?.name) {
@@ -628,6 +633,7 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit, onRefresh}: TopicConf
             return;
         }
 
+        const generation = ++mutationGeneration.current;
         setIsDeletingBroker(true);
         setActionError('');
 
@@ -636,13 +642,14 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit, onRefresh}: TopicConf
                 brokerName: activeBroker,
                 topic: configData.topicName,
             });
-            toast.success(result.message || `Deleted ${configData.topicName} from ${activeBroker}`);
+            if (generation !== mutationGeneration.current) return;
+            setMutationReceipt(result);
+            if (result.success) toast.success(result.message); else toast.warning(result.message);
             await onRefresh();
-            onClose();
         } catch (deleteError) {
-            setActionError(dashboardErrorMessage(deleteError, 'Failed to delete topic from the selected broker.'));
+            if (generation === mutationGeneration.current) setActionError(dashboardErrorMessage(deleteError, 'Failed to delete topic from the selected broker.'));
         } finally {
-            setIsDeletingBroker(false);
+            if (generation === mutationGeneration.current) setIsDeletingBroker(false);
         }
     };
 
@@ -910,6 +917,7 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit, onRefresh}: TopicConf
                         )}
                     </div>
 
+                    {mutationReceipt && <TopicMutationReceipt result={mutationReceipt} />}
                     <footer className="topic-status-footer topic-config-footer">
                         <span>Config is read-only here. Use Edit Topic to commit queue, permission, or type changes.</span>
                         <div className="topic-config-footer-actions">
@@ -920,7 +928,7 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit, onRefresh}: TopicConf
                                 type="button"
                                 className="topic-status-secondary-button topic-config-danger-button"
                                 onClick={() => void handleDeleteByBroker()}
-                                disabled={topic?.systemTopic || !configData || isLoading || isDeletingBroker || !activeBroker}
+                                disabled={topic?.systemTopic || !configData || isLoading || isDeletingBroker || !activeBroker || !!mutationReceipt?.targets.some((target) => target.name === activeBroker && target.success)}
                                 title={topic?.systemTopic ? 'System topics are read-only' : undefined}
                             >
                                 <Trash2 className="topic-icon" aria-hidden="true"/>
@@ -2313,6 +2321,10 @@ const TopicEditorModal = ({isOpen, onClose, targets, seed, mode, onSaved}: Topic
     const [perm, setPerm] = useState(6);
     const [order, setOrder] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [receipt, setReceipt] = useState<TopicBatchResult | null>(null);
+    const [submitMode, setSubmitMode] = useState(mode);
+    const generation = useRef(0);
+    useEffect(() => () => { generation.current += 1; }, [isOpen, seed, mode]);
     const [error, setError] = useState('');
 
     useEffect(() => {
@@ -2330,6 +2342,8 @@ const TopicEditorModal = ({isOpen, onClose, targets, seed, mode, onSaved}: Topic
         setOrder(seed?.order ?? false);
         setIsBrokerDropdownOpen(false);
         setIsSubmitting(false);
+        setReceipt(null);
+        setSubmitMode(mode);
         setError('');
     }, [isOpen, seed, mode]);
 
@@ -2379,6 +2393,7 @@ const TopicEditorModal = ({isOpen, onClose, targets, seed, mode, onSaved}: Topic
             return;
         }
 
+        const requestGeneration = ++generation.current;
         setIsSubmitting(true);
         setError('');
 
@@ -2392,18 +2407,19 @@ const TopicEditorModal = ({isOpen, onClose, targets, seed, mode, onSaved}: Topic
                 perm,
                 order,
                 messageType,
-            }, mode);
-            toast.success(result.message || `${mode === 'create' ? 'Created' : 'Updated'} topic ${topicName.trim()}`);
+            }, submitMode);
+            if (requestGeneration !== generation.current) return;
+            setReceipt(result);
+            if (result.success) toast.success(result.message); else toast.warning(result.message);
             await onSaved();
-            onClose();
         } catch (submitError) {
-            setError(dashboardErrorMessage(submitError, 'Failed to save topic changes.'));
+            if (requestGeneration === generation.current) setError(dashboardErrorMessage(submitError, 'Failed to save topic changes.'));
         } finally {
-            setIsSubmitting(false);
+            if (requestGeneration === generation.current) setIsSubmitting(false);
         }
     };
 
-    const isCreateMode = mode === 'create';
+    const isCreateMode = submitMode === 'create';
     const targetSummary = selectedClusters.length > 0
         ? `${selectedClusters.length} cluster${selectedClusters.length === 1 ? '' : 's'}`
         : 'No cluster';
@@ -2718,6 +2734,13 @@ const TopicEditorModal = ({isOpen, onClose, targets, seed, mode, onSaved}: Topic
                         </section>
                     </div>
 
+                    {receipt && <TopicMutationReceipt result={receipt} onReviewFailed={() => {
+                        const failed = failedBrokerNames(receipt);
+                        setSelectedClusters(targets.filter((target) => target.brokerNames.some((broker) => failed.includes(broker))).map((target) => target.clusterName));
+                        setSelectedBrokers(failed);
+                        setSubmitMode(receipt.operation === 'create' && !receipt.targets.some((target) => target.success) ? 'create' : 'update');
+                        setReceipt(null);
+                    }} />}
                     <footer className="topic-status-footer topic-editor-footer">
                         <span>Create/Update validates topic name, target cluster, and queue counts before submit.</span>
                         <div>
@@ -2727,7 +2750,7 @@ const TopicEditorModal = ({isOpen, onClose, targets, seed, mode, onSaved}: Topic
                             <button
                                 type="button"
                                 onClick={() => void handleSubmit()}
-                                disabled={isSubmitting}
+                                disabled={isSubmitting || !!receipt}
                                 className="topic-status-primary-button topic-editor-submit-button"
                             >
                                 <Save className="topic-icon" aria-hidden="true"/>
@@ -2747,6 +2770,10 @@ interface TopicDeleteModalProps extends TopicRouterModalProps {
 
 const TopicDeleteModal = ({isOpen, onClose, topic, onDeleted}: TopicDeleteModalProps) => {
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [receipt, setReceipt] = useState<TopicBatchResult | null>(null);
+    const [retryCluster, setRetryCluster] = useState<string | undefined>();
+    const generation = useRef(0);
+    useEffect(() => () => { generation.current += 1; }, [isOpen, topic?.name]);
     const [error, setError] = useState('');
 
     useEffect(() => {
@@ -2754,6 +2781,8 @@ const TopicDeleteModal = ({isOpen, onClose, topic, onDeleted}: TopicDeleteModalP
             return;
         }
         setIsSubmitting(false);
+        setReceipt(null);
+        setRetryCluster(undefined);
         setError('');
     }, [isOpen, topic?.name]);
 
@@ -2762,20 +2791,24 @@ const TopicDeleteModal = ({isOpen, onClose, topic, onDeleted}: TopicDeleteModalP
             return;
         }
 
+        const requestGeneration = ++generation.current;
         setIsSubmitting(true);
         setError('');
 
         try {
             const result = await TopicService.deleteTopic({
                 topic: topic.name,
+                clusterName: retryCluster,
             });
-            toast.success(result.message || `Deleted topic ${topic.name}`);
+            if (requestGeneration !== generation.current) return;
+            setReceipt(result);
+            setRetryCluster(undefined);
+            if (result.success) toast.success(result.message); else toast.warning(result.message);
             await onDeleted();
-            onClose();
         } catch (deleteError) {
-            setError(dashboardErrorMessage(deleteError, 'Failed to delete topic.'));
+            if (requestGeneration === generation.current) setError(dashboardErrorMessage(deleteError, 'Failed to delete topic.'));
         } finally {
-            setIsSubmitting(false);
+            if (requestGeneration === generation.current) setIsSubmitting(false);
         }
     };
 
@@ -2857,6 +2890,8 @@ const TopicDeleteModal = ({isOpen, onClose, topic, onDeleted}: TopicDeleteModalP
                         </div>
                     </div>
 
+                    {receipt && <TopicMutationReceipt result={receipt} onReviewTarget={(target) => { if (target.kind === 'cluster') setRetryCluster(target.name); }} />}
+                    {retryCluster && <p className="px-6 text-sm">Reviewing deletion for Cluster: {retryCluster}</p>}
                     <div className="px-6 py-4 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex justify-end space-x-3 z-10">
                         <button
                             onClick={onClose}
@@ -2866,7 +2901,7 @@ const TopicDeleteModal = ({isOpen, onClose, topic, onDeleted}: TopicDeleteModalP
                         </button>
                         <button
                             onClick={() => void handleDelete()}
-                            disabled={isSubmitting}
+                            disabled={isSubmitting || (!!receipt && !retryCluster)}
                             className="px-6 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-500 transition-all shadow-md hover:shadow-lg flex items-center disabled:cursor-not-allowed disabled:opacity-70 dark:bg-red-600 dark:text-white dark:hover:bg-red-500"
                         >
                             <Trash2 className="w-4 h-4 mr-2"/>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/components/TopicMutationReceipt.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/components/TopicMutationReceipt.test.tsx
@@ -1,0 +1,33 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { failedBrokerNames, TopicMutationReceipt } from './TopicMutationReceipt';
+import type { TopicBatchResult } from '../types/topic.types';
+
+const partial: TopicBatchResult = {
+    operation: 'update', topic: 'orders', targetCount: 2, success: false, message: 'Review results',
+    targets: [
+        { kind: 'broker', name: 'broker-a', success: true, errorCode: null, message: 'Completed' },
+        { kind: 'broker', name: 'broker-b', success: false, errorCode: 'target.failed', message: 'Verify current state' },
+    ],
+    orderConfig: { success: false, errorCode: 'order.failed', message: 'Order configuration failed' },
+};
+
+describe('Topic mutation receipts', () => {
+    it('renders both targets and the independent order failure', () => {
+        const html = renderToStaticMarkup(createElement(TopicMutationReceipt, { result: partial, onReviewFailed: () => {} }));
+        expect(html).toContain('broker-a');
+        expect(html).toContain('broker-b');
+        expect(html).toContain('ORDER_TOPIC_CONFIG');
+        expect(html).toContain('order.failed');
+        expect(html).toContain('Review failed Brokers only');
+        expect(failedBrokerNames(partial)).toEqual(['broker-b']);
+    });
+
+    it('does not offer successful Brokers or Cluster-level results as failed Broker retries', () => {
+        const result = { ...partial, targets: partial.targets.map((target) => ({ ...target, success: true })), success: true, orderConfig: { success: true, errorCode: null, message: 'Completed' } };
+        expect(failedBrokerNames(result)).toEqual([]);
+        expect(renderToStaticMarkup(createElement(TopicMutationReceipt, { result, onReviewFailed: () => {} }))).not.toContain('Review failed Brokers only');
+        expect(failedBrokerNames({ ...partial, targets: [{ ...partial.targets[1], kind: 'cluster' }] })).toEqual([]);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/components/TopicMutationReceipt.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/components/TopicMutationReceipt.tsx
@@ -1,0 +1,25 @@
+import type { TopicBatchResult, TopicTargetReceipt } from '../types/topic.types';
+
+export const failedBrokerNames = (result: TopicBatchResult): string[] =>
+    result.targets.filter((target) => target.kind === 'broker' && !target.success).map((target) => target.name);
+
+export const TopicMutationReceipt = ({ result, onReviewFailed, onReviewTarget }: {
+    result: TopicBatchResult;
+    onReviewFailed?: () => void;
+    onReviewTarget?: (target: TopicTargetReceipt) => void;
+}) => <section aria-label="Topic operation receipt" className="m-4 max-h-60 overflow-auto shrink-0 rounded-lg border border-gray-300 dark:border-gray-700 p-4 space-y-3">
+    <div role="status"><strong>{result.operation}: {result.topic}</strong><p>{result.message}</p></div>
+    <p className="text-sm">{result.targetCount} targets. Completed targets are not automatically retried.</p>
+    <div className="overflow-x-auto"><table className="w-full text-left text-sm">
+        <thead><tr><th>Target</th><th>Result</th><th>Details</th><th /></tr></thead>
+        <tbody>{result.targets.map((target) => <tr key={`${target.kind}:${target.name}`}>
+            <td className="py-2 pr-3">{target.kind}: {target.name}</td>
+            <td className="pr-3">{target.success ? 'Completed' : 'Needs review'}</td>
+            <td>{target.message}{target.errorCode && <code className="block">{target.errorCode}</code>}</td>
+            <td>{!target.success && onReviewTarget && <button type="button" className="underline" onClick={() => onReviewTarget(target)}>Review target</button>}</td>
+        </tr>)}</tbody>
+    </table></div>
+    {result.orderConfig && <p className="text-sm"><strong>ORDER_TOPIC_CONFIG: </strong>{result.orderConfig.message}{result.orderConfig.errorCode && <code className="block">{result.orderConfig.errorCode}</code>}</p>}
+    {!result.orderConfig && result.operation !== 'delete_broker' && <p className="text-sm">Order configuration was not completed.</p>}
+    {onReviewFailed && failedBrokerNames(result).length > 0 && <button type="button" className="underline text-sm" onClick={onReviewFailed}>Review failed Brokers only</button>}
+</section>;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/types/topic.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/types/topic.types.ts
@@ -207,3 +207,12 @@ export const TOPIC_MESSAGE_TYPE_OPTIONS: TopicMessageType[] = [
     'TRANSACTION',
     'UNSPECIFIED',
 ];
+
+export interface TopicTargetReceipt {
+    kind: 'broker' | 'cluster'; name: string; success: boolean; errorCode: string | null; message: string;
+}
+export interface TopicBatchResult {
+    operation: 'create' | 'update' | 'delete' | 'delete_broker'; topic: string;
+    targetCount: number; targets: TopicTargetReceipt[]; success: boolean; message: string;
+    orderConfig: { success: boolean; errorCode: string | null; message: string } | null;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/topic.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/topic.service.ts
@@ -12,6 +12,7 @@ import type {
     TopicListRequest,
     TopicListResponse,
     TopicMutationResult,
+    TopicBatchResult,
     TopicQueryRequest,
     TopicRouteView,
     TopicSendMessageResult,
@@ -35,16 +36,16 @@ export class TopicService {
         return invokeAuthenticatedCommand<TopicConfigView>('get_topic_config', { request });
     }
 
-    static async createOrUpdateTopic(request: TopicConfigRequest, mode: 'create' | 'update'): Promise<TopicMutationResult> {
-        return invokeAuthenticatedCommand<TopicMutationResult>('create_or_update_topic', { request, mode });
+    static async createOrUpdateTopic(request: TopicConfigRequest, mode: 'create' | 'update'): Promise<TopicBatchResult> {
+        return invokeAuthenticatedCommand<TopicBatchResult>('create_or_update_topic', { request, mode });
     }
 
-    static async deleteTopic(request: DeleteTopicRequest): Promise<TopicMutationResult> {
-        return invokeAuthenticatedCommand<TopicMutationResult>('delete_topic', { request });
+    static async deleteTopic(request: DeleteTopicRequest): Promise<TopicBatchResult> {
+        return invokeAuthenticatedCommand<TopicBatchResult>('delete_topic', { request });
     }
 
-    static async deleteTopicByBroker(request: DeleteTopicByBrokerRequest): Promise<TopicMutationResult> {
-        return invokeAuthenticatedCommand<TopicMutationResult>('delete_topic_by_broker', { request });
+    static async deleteTopicByBroker(request: DeleteTopicByBrokerRequest): Promise<TopicBatchResult> {
+        return invokeAuthenticatedCommand<TopicBatchResult>('delete_topic_by_broker', { request });
     }
 
     static async getTopicConsumerGroups(request: TopicQueryRequest): Promise<TopicConsumerGroupListResponse> {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10382

### Brief Description
Use admin-core batch workflows for Topic create/update and whole-Topic deletion. Return complete target receipts and separate order-configuration results, with overall success only when every required result succeeds. Preserve safe audit counts and project single-Broker deletion into the same shape.

Keep receipts visible after completion. Failed Brokers can be loaded into a review draft without resubmitting successful Brokers; failed whole-Topic deletion targets can be reviewed individually. The current admin-core deletion contract reports Clusters, so those rows are explicitly labeled as Clusters rather than inventing Broker acknowledgments. No automatic retries or cross-Broker rollback are implied.

### How Did You Test This Change?
- Tauri backend: 8 Topic tests and 5 audit tests passed; package-scoped format check passed.
- Reused admin-core batch workflow suite: 8 tests passed, including partial targets and order cleanup failures.
- Frontend: 2 receipt rendering/review tests and npm run build passed; existing bundle-size warning remains.
- git diff --check passed. Desktop interaction and live multi-Broker smoke remain in the final integration step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Topic create, update, and delete operations now provide batch results for each affected cluster or broker.
  * Added detailed operation receipts showing target outcomes, order-configuration status, and safe error messages.
  * Failed broker targets can be reviewed and retried directly from topic dialogs.
  * Topic dialogs remain open after operations so results and follow-up actions are visible.

* **Documentation**
  * Added guidance covering batch topic results, partial failures, audit records, and retry behavior.

* **Tests**
  * Added coverage for receipt rendering and partial-failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->