### PR TITLE
[ISSUE #10384]🚀Protect Tauri Consumer groups and preserve batch outcomes

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_MUTATIONS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_MUTATIONS.md
@@ -1,0 +1,15 @@
+# Consumer mutation results
+
+Consumer writes reject protected raw and normalized names before opening an admin session. The backend uses the admin-core classifier; list and configuration views keep system groups read-only.
+
+Create/update uses the validated Consumer batch API without changing configuration or retry defaults. Cluster selections expand to their Brokers and explicit Broker selections are added to that set. Deletion discovers current group membership through the Consumer workspace inventory. Inventory failures block deletion; missing client or progress data does not imply missing subscription metadata. Only selected Brokers are passed to the batch deletion API. Internal retry/DLQ Topic cleanup runs only after every authoritative Broker is selected and successfully deleted.
+
+The IPC result contains `operation`, `consumerGroup`, `targets`, `targetCount`, and `success`. Targets preserve Broker and internal-Topic-cleanup outcomes independently. Raw backend errors are replaced with a stable safe code and message. Audit counts reflect partial results.
+
+Editor and Delete dialogs close normally only after full success. Partial or failed outcomes remain visible. Reviewing failed Brokers first refreshes current target state, then selects only those failed Brokers; another explicit submission is required. Cluster selections are cleared for an editor retry so a failed subset cannot silently expand. Cleanup-only failures do not offer a Broker retry. Closing the dialog, changing the entity, or switching connection settings invalidates old callbacks.
+
+## Validation
+
+- Backend Consumer tests cover protected-name validation, incomplete inventory rejection, result mapping, and error redaction.
+- Admin-core Consumer batch regressions cover unknown targets, subset deletion, partial failures, and cleanup results.
+- Frontend receipt tests cover mixed results, cleanup isolation, and read-only groups; the production frontend build type-checks the integration.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
@@ -220,8 +220,7 @@ successful_receipt!(
     crate::auth::types::CommonResponse,
     crate::auth::types::RevokeSessionsResponse,
     rocketmq_dashboard_common::NameServerMutationResult,
-    rocketmq_dashboard_common::ProxyMutationResult,
-    crate::consumer::types::ConsumerMutationResult
+    rocketmq_dashboard_common::ProxyMutationResult
 );
 impl AuditReceipt for AuthSessionResponse {
     fn summary(&self) -> Summary {
@@ -355,5 +354,15 @@ impl AuditReceipt for crate::topic::batch::TopicBatchResult {
         let failure = self.targets.iter().filter(|target| !target.success).count()
             + usize::from(self.order_config.as_ref().is_some_and(|result| !result.success));
         Summary::count(success, failure.max(usize::from(!self.success)))
+    }
+}
+
+impl AuditReceipt for crate::consumer::types::ConsumerMutationResult {
+    fn summary(&self) -> Summary {
+        let successes = self.targets.iter().filter(|target| target.success).count();
+        Summary::count(
+            successes,
+            (self.targets.len() - successes).max(usize::from(!self.success)),
+        )
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
@@ -18,6 +18,7 @@ use crate::consumer::types::ConsumerConnectionView;
 use crate::consumer::types::ConsumerGroupListItem;
 use crate::consumer::types::ConsumerGroupListResponse;
 use crate::consumer::types::ConsumerMutationResult;
+use crate::consumer::types::ConsumerOperation;
 use crate::consumer::types::ConsumerResult;
 use crate::consumer::types::ConsumerTopicDetailView;
 use crate::error::DashboardError as ConsumerError;
@@ -26,10 +27,15 @@ use rocketmq_admin_core::client_adapter::AdminSession;
 use rocketmq_admin_core::core::consumer::ConsumerAdmin;
 use rocketmq_admin_core::core::consumer::DashboardConsumerConfigRequest;
 use rocketmq_admin_core::core::consumer::DashboardConsumerConnectionRequest;
-use rocketmq_admin_core::core::consumer::DashboardConsumerDeleteRequest;
 use rocketmq_admin_core::core::consumer::DashboardConsumerGroupListRequest;
 use rocketmq_admin_core::core::consumer::DashboardConsumerProgressRequest;
 use rocketmq_admin_core::core::consumer::DashboardConsumerUpsertRequest;
+use rocketmq_admin_core::core::consumer::{
+    ConsumerBatchDeleteRequest, ConsumerBatchMutationAdmin, ConsumerBatchUpsertRequest, is_protected_consumer_group,
+};
+use rocketmq_admin_core::core::consumer_workspace::{
+    ConsumerInventoryRequest, ConsumerInventoryResult, ConsumerWorkspaceAdmin, WorkspaceFailureStage,
+};
 use rocketmq_dashboard_common::ConsumerConfigQueryRequest;
 use rocketmq_dashboard_common::ConsumerConnectionQueryRequest;
 use rocketmq_dashboard_common::ConsumerCreateOrUpdateRequest;
@@ -273,7 +279,7 @@ impl ConsumerManager {
         &self,
         request: ConsumerCreateOrUpdateRequest,
     ) -> ConsumerResult<ConsumerMutationResult> {
-        let group_name = validate_consumer_group_name(&request.consumer_group)?;
+        let group_name = validate_mutable_consumer_group(&request.consumer_group)?;
         validate_consumer_targets(&request.cluster_name_list, &request.broker_name_list)?;
         validate_consumer_limits(&request)?;
 
@@ -302,7 +308,7 @@ impl ConsumerManager {
         &self,
         request: ConsumerDeleteRequest,
     ) -> ConsumerResult<ConsumerMutationResult> {
-        let group_name = validate_consumer_group_name(&request.consumer_group)?;
+        let group_name = validate_mutable_consumer_group(&request.consumer_group)?;
         if request.broker_name_list.is_empty() {
             return Err(ConsumerError::Validation(
                 "Select at least one broker before deleting the consumer group.".into(),
@@ -479,24 +485,27 @@ impl ConsumerManager {
         request: ConsumerCreateOrUpdateRequest,
     ) -> ConsumerResult<ConsumerMutationResult> {
         admin
-            .upsert_dashboard_consumer_group(&DashboardConsumerUpsertRequest {
-                cluster_name_list: request.cluster_name_list,
-                broker_name_list: request.broker_name_list,
-                consumer_group: raw_group_name.to_string(),
-                consume_enable: request.consume_enable,
-                consume_from_min_enable: request.consume_from_min_enable,
-                consume_broadcast_enable: request.consume_broadcast_enable,
-                consume_message_orderly: request.consume_message_orderly,
-                retry_queue_nums: request.retry_queue_nums,
-                retry_max_times: request.retry_max_times,
-                broker_id: request.broker_id,
-                which_broker_when_consume_slowly: request.which_broker_when_consume_slowly,
-                notify_consumer_ids_changed_enable: request.notify_consumer_ids_changed_enable,
-                group_sys_flag: request.group_sys_flag,
-                consume_timeout_minute: request.consume_timeout_minute,
-            })
+            .upsert_consumer_group_batch(
+                &ConsumerBatchUpsertRequest::try_new(DashboardConsumerUpsertRequest {
+                    cluster_name_list: request.cluster_name_list,
+                    broker_name_list: request.broker_name_list,
+                    consumer_group: raw_group_name.to_string(),
+                    consume_enable: request.consume_enable,
+                    consume_from_min_enable: request.consume_from_min_enable,
+                    consume_broadcast_enable: request.consume_broadcast_enable,
+                    consume_message_orderly: request.consume_message_orderly,
+                    retry_queue_nums: request.retry_queue_nums,
+                    retry_max_times: request.retry_max_times,
+                    broker_id: request.broker_id,
+                    which_broker_when_consume_slowly: request.which_broker_when_consume_slowly,
+                    notify_consumer_ids_changed_enable: request.notify_consumer_ids_changed_enable,
+                    group_sys_flag: request.group_sys_flag,
+                    consume_timeout_minute: request.consume_timeout_minute,
+                })
+                .map_err(map_admin_error)?,
+            )
             .await
-            .map(map_consumer_mutation_result)
+            .map(|result| map_consumer_mutation_result(result, ConsumerOperation::Upsert))
             .map_err(map_admin_error)
     }
 
@@ -506,13 +515,17 @@ impl ConsumerManager {
         raw_group_name: &str,
         request: ConsumerDeleteRequest,
     ) -> ConsumerResult<ConsumerMutationResult> {
-        admin
-            .delete_dashboard_consumer_group(&DashboardConsumerDeleteRequest {
-                consumer_group: raw_group_name.to_string(),
-                broker_name_list: request.broker_name_list,
-            })
+        let catalog = admin
+            .consumer_inventory(&ConsumerInventoryRequest::default())
             .await
-            .map(map_consumer_mutation_result)
+            .map_err(map_admin_error)?;
+        let all_brokers = authoritative_group_brokers(catalog, raw_group_name)?;
+        let batch = ConsumerBatchDeleteRequest::try_new(raw_group_name, request.broker_name_list, all_brokers)
+            .map_err(map_admin_error)?;
+        admin
+            .delete_consumer_group_batch(&batch)
+            .await
+            .map(|result| map_consumer_mutation_result(result, ConsumerOperation::Delete))
             .map_err(map_admin_error)
     }
 }
@@ -532,6 +545,45 @@ fn validate_consumer_group_name(group_name: &str) -> ConsumerResult<String> {
     } else {
         Ok(normalized)
     }
+}
+
+fn authoritative_group_brokers(catalog: ConsumerInventoryResult, group_name: &str) -> ConsumerResult<Vec<String>> {
+    // Read-only lists tolerate failed brokers. Deletion must not mistake that partial list
+    // for full group coverage and trigger retry/DLQ cleanup on unselected brokers.
+    if catalog.targets.is_empty()
+        || catalog
+            .failures
+            .iter()
+            .any(|failure| failure.stage == WorkspaceFailureStage::Inventory)
+    {
+        return Err(ConsumerError::Validation(
+            "Complete Broker subscription metadata is required before deletion. Refresh the cluster and try again."
+                .into(),
+        ));
+    }
+    let group = catalog
+        .items
+        .into_iter()
+        .find(|group| group.group == group_name)
+        .ok_or_else(|| ConsumerError::Validation("Consumer group was not found in the current cluster.".into()))?;
+    validate_mutable_consumer_group(&group.group)?;
+    if group.category == "SYSTEM" {
+        return Err(ConsumerError::Validation(
+            "System consumer groups are read-only.".into(),
+        ));
+    }
+    Ok(group.targets.into_iter().map(|target| target.broker_name).collect())
+}
+
+fn validate_mutable_consumer_group(group_name: &str) -> ConsumerResult<String> {
+    let raw = group_name.trim();
+    let normalized = validate_consumer_group_name(raw)?;
+    if is_protected_consumer_group(raw) || is_protected_consumer_group(&normalized) {
+        return Err(ConsumerError::Validation(
+            "System consumer groups are read-only.".into(),
+        ));
+    }
+    Ok(normalized)
 }
 
 fn validate_consumer_targets(cluster_name_list: &[String], broker_name_list: &[String]) -> ConsumerResult<()> {
@@ -564,7 +616,46 @@ fn validate_consumer_limits(request: &ConsumerCreateOrUpdateRequest) -> Consumer
 
 #[cfg(test)]
 mod tests {
-    use super::strip_system_prefix;
+    use super::{authoritative_group_brokers, strip_system_prefix, validate_mutable_consumer_group};
+    use rocketmq_admin_core::core::consumer_workspace::*;
+
+    #[test]
+    fn incomplete_inventory_cannot_authorize_deletion() {
+        let catalog = ConsumerInventoryResult {
+            items: vec![],
+            targets: vec![ConsumerWorkspaceTarget {
+                cluster_name: "cluster".into(),
+                broker_name: "broker".into(),
+                broker_address: "localhost:10911".into(),
+            }],
+            observation: WorkspaceObservationState::Partial,
+            failures: vec![WorkspaceTargetFailure {
+                target: "broker".into(),
+                stage: WorkspaceFailureStage::Inventory,
+                code: WorkspaceFailureCode::Unavailable,
+                retryable: true,
+            }],
+        };
+        let error = authoritative_group_brokers(catalog, "group").unwrap_err();
+        assert!(error.to_string().contains("Complete Broker subscription metadata"));
+    }
+
+    #[test]
+    fn protected_names_are_rejected_before_opening_a_session() {
+        for group in [
+            "%SYS%ordinary",
+            " %SYS%TOOLS_CONSUMER ",
+            "TOOLS_CONSUMER",
+            "CID_RMQ_SYS_TEST",
+            " ",
+        ] {
+            assert!(validate_mutable_consumer_group(group).is_err(), "{group}");
+        }
+        assert_eq!(
+            validate_mutable_consumer_group(" normal-group ").unwrap(),
+            "normal-group"
+        );
+    }
 
     #[test]
     fn strip_system_prefix_handles_prefixed_group_names() {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service/mapping.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service/mapping.rs
@@ -18,17 +18,17 @@ use crate::consumer::types::ConsumerConnectionItem;
 use crate::consumer::types::ConsumerConnectionView;
 use crate::consumer::types::ConsumerGroupListItem;
 use crate::consumer::types::ConsumerGroupListSummary;
-use crate::consumer::types::ConsumerMutationResult;
 use crate::consumer::types::ConsumerSubscriptionItem;
 use crate::consumer::types::ConsumerTopicDetailItem;
 use crate::consumer::types::ConsumerTopicDetailQueueItem;
 use crate::consumer::types::ConsumerTopicDetailView;
+use crate::consumer::types::{ConsumerMutationResult, ConsumerOperation, ConsumerTargetResult};
 use crate::error::DashboardError as ConsumerError;
 use rocketmq_admin_core::core::AdminError;
+use rocketmq_admin_core::core::consumer::DashboardConsumerBatchResult as AdminConsumerMutationResult;
 use rocketmq_admin_core::core::consumer::DashboardConsumerConfig;
 use rocketmq_admin_core::core::consumer::DashboardConsumerConnection;
 use rocketmq_admin_core::core::consumer::DashboardConsumerGroupItem;
-use rocketmq_admin_core::core::consumer::DashboardConsumerMutationResult as AdminConsumerMutationResult;
 use rocketmq_admin_core::core::consumer::DashboardConsumerProgress;
 
 pub(super) fn map_consumer_group_item(item: DashboardConsumerGroupItem) -> ConsumerGroupListItem {
@@ -161,11 +161,32 @@ pub(super) fn map_consumer_topic_detail_view(progress: DashboardConsumerProgress
     }
 }
 
-pub(super) fn map_consumer_mutation_result(result: AdminConsumerMutationResult) -> ConsumerMutationResult {
+pub(super) fn map_consumer_mutation_result(
+    result: AdminConsumerMutationResult,
+    operation: ConsumerOperation,
+) -> ConsumerMutationResult {
+    let success = result.success && !result.targets.is_empty() && result.targets.iter().all(|target| target.success);
     ConsumerMutationResult {
         consumer_group: result.consumer_group,
-        broker_names: result.broker_names,
-        updated: result.updated,
+        operation,
+        target_count: result.targets.len(),
+        success,
+        targets: result
+            .targets
+            .into_iter()
+            .map(|target| ConsumerTargetResult {
+                target: target.target,
+                kind: target.kind,
+                success: target.success,
+                error_code: (!target.success).then(|| "dashboard.consumer_target_failed".into()),
+                message: if target.success {
+                    "Target operation completed."
+                } else {
+                    "Target operation was not confirmed. Refresh its state before another attempt."
+                }
+                .into(),
+            })
+            .collect(),
     }
 }
 
@@ -182,6 +203,7 @@ mod tests {
     use super::map_consumer_group_item;
     use super::map_consumer_mutation_result;
     use super::map_consumer_topic_detail_view;
+    use crate::consumer::types::ConsumerOperation;
     use crate::error::DashboardError as ConsumerError;
     use rocketmq_admin_core::core::AdminError;
     use rocketmq_admin_core::core::consumer::DashboardConsumerConfig;
@@ -189,11 +211,11 @@ mod tests {
     use rocketmq_admin_core::core::consumer::DashboardConsumerConnection;
     use rocketmq_admin_core::core::consumer::DashboardConsumerConnectionItem;
     use rocketmq_admin_core::core::consumer::DashboardConsumerGroupItem;
-    use rocketmq_admin_core::core::consumer::DashboardConsumerMutationResult;
     use rocketmq_admin_core::core::consumer::DashboardConsumerProgress;
     use rocketmq_admin_core::core::consumer::DashboardConsumerSubscriptionItem;
     use rocketmq_admin_core::core::consumer::DashboardConsumerTopicDetail;
     use rocketmq_admin_core::core::consumer::DashboardConsumerTopicQueue;
+    use rocketmq_admin_core::core::consumer::{DashboardConsumerBatchResult, DashboardConsumerTargetOutcome};
 
     #[test]
     fn group_mapping_and_summary_preserve_dashboard_fields() {
@@ -298,14 +320,37 @@ mod tests {
 
     #[test]
     fn mutation_and_error_mapping_preserve_ui_contract() {
-        let result = map_consumer_mutation_result(DashboardConsumerMutationResult {
-            consumer_group: "group-a".into(),
-            broker_names: vec!["broker-a".into()],
-            updated: true,
-        });
+        let result = map_consumer_mutation_result(
+            DashboardConsumerBatchResult {
+                consumer_group: "group-a".into(),
+                success: false,
+                targets: vec![
+                    DashboardConsumerTargetOutcome {
+                        target: "broker-a".into(),
+                        kind: "BROKER".into(),
+                        success: true,
+                        message: "ok".into(),
+                    },
+                    DashboardConsumerTargetOutcome {
+                        target: "broker-b".into(),
+                        kind: "BROKER".into(),
+                        success: false,
+                        message: "secret backend details".into(),
+                    },
+                ],
+            },
+            ConsumerOperation::Upsert,
+        );
+        assert!(!result.success);
+        assert_eq!(result.target_count, 2);
+        assert!(result.targets[0].success);
+        assert_eq!(
+            result.targets[1].error_code.as_deref(),
+            Some("dashboard.consumer_target_failed")
+        );
+        assert!(!serde_json::to_string(&result).unwrap().contains("secret backend"));
         let error = map_admin_error(AdminError::invalid_argument("consumer_group", "required"));
 
-        assert!(result.updated);
         let ConsumerError::Admin(error) = error else {
             panic!("invalid admin input must retain the canonical admin facade");
         };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/types.rs
@@ -151,6 +151,25 @@ pub(crate) struct ConsumerConfigView {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConsumerMutationResult {
     pub(crate) consumer_group: String,
-    pub(crate) broker_names: Vec<String>,
-    pub(crate) updated: bool,
+    pub(crate) operation: ConsumerOperation,
+    pub(crate) targets: Vec<ConsumerTargetResult>,
+    pub(crate) target_count: usize,
+    pub(crate) success: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ConsumerOperation {
+    Upsert,
+    Delete,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConsumerTargetResult {
+    pub(crate) target: String,
+    pub(crate) kind: String,
+    pub(crate) success: bool,
+    pub(crate) error_code: Option<String>,
+    pub(crate) message: String,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
@@ -1,3 +1,4 @@
+import { isReadOnlyConsumer } from '../features/consumer/mutation';
 import { motion } from 'motion/react';
 import { ConnectionStore } from '../services/connection.store';
 import { getConnectionSettings } from '../services/connection.service';
@@ -15,7 +16,7 @@ import { ConsumerConfigModal } from '../features/consumer/components/ConsumerCon
 import { ConsumerDeleteModal } from '../features/consumer/components/ConsumerDeleteModal';
 import { ConsumerDetailModal } from '../features/consumer/components/ConsumerDetailModal';
 import { ConsumerEditorModal } from '../features/consumer/components/ConsumerEditorModal';
-import type { ConsumerGroupListItem } from '../features/consumer/types/consumer.types';
+import type { ConsumerGroupListItem, ConsumerMutationResult } from '../features/consumer/types/consumer.types';
 
 export const ConsumerView = () => {
   const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
@@ -133,17 +134,18 @@ const ConsumerCatalog = ({ scope, proxyAddress, changeMode }: { scope: ConsumerQ
     }
   };
 
-  const handleEditorSaved = async () => {
-    setEditorModal({isOpen: false, consumer: null});
+  const handleEditorSaved = async (result: ConsumerMutationResult) => {
+    if (result.success) setEditorModal({isOpen: false, consumer: null});
     await refresh();
   };
 
-  const handleDeleteSaved = async () => {
-    setDeleteModal({isOpen: false, consumer: null});
+  const handleDeleteSaved = async (result: ConsumerMutationResult) => {
+    if (result.success) setDeleteModal({isOpen: false, consumer: null});
     await refresh();
   };
 
   const handleEditFromConfig = (consumer: ConsumerGroupListItem, preferredBrokerAddress?: string) => {
+    if (isReadOnlyConsumer(consumer)) return;
     setConfigModal({isOpen: false, consumer: null});
     setEditorModal({isOpen: true, consumer, preferredBrokerAddress});
   };
@@ -191,13 +193,13 @@ const ConsumerCatalog = ({ scope, proxyAddress, changeMode }: { scope: ConsumerQ
         onClose={() => setEditorModal({isOpen: false, consumer: null})}
         consumer={editorModal.consumer}
         preferredBrokerAddress={editorModal.preferredBrokerAddress}
-        onSaved={() => void handleEditorSaved()}
+        onSaved={(result) => void handleEditorSaved(result)}
       />
       <ConsumerDeleteModal
         isOpen={deleteModal.isOpen}
         onClose={() => setDeleteModal({isOpen: false, consumer: null})}
         consumer={deleteModal.consumer}
-        onDeleted={() => void handleDeleteSaved()}
+        onDeleted={(result) => void handleDeleteSaved(result)}
       />
 
       <section className="consumer-summary-grid" aria-label="Consumer summary">
@@ -501,7 +503,7 @@ const ConsumerCatalog = ({ scope, proxyAddress, changeMode }: { scope: ConsumerQ
                     )}
                     <span>Sync</span>
                   </button>
-                  <button type="button" className="topic-action-button is-danger" onClick={() => setDeleteModal({isOpen: true, consumer: selectedConsumer})}>
+                  <button type="button" className="topic-action-button is-danger" disabled={isReadOnlyConsumer(selectedConsumer)} title={isReadOnlyConsumer(selectedConsumer) ? "System Consumer groups are read-only." : undefined} onClick={() => setDeleteModal({isOpen: true, consumer: selectedConsumer})}>
                     <Trash2 className="topic-icon" aria-hidden="true"/>
                     <span>Delete</span>
                   </button>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerConfigModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerConfigModal.tsx
@@ -1,3 +1,4 @@
+import { isReadOnlyConsumer } from '../mutation';
 import { useEffect, useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
@@ -317,6 +318,8 @@ export const ConsumerConfigModal = ({
                                 <button
                                     type="button"
                                     onClick={() => onEdit(consumer, selectedBrokerAddress)}
+                                    disabled={isReadOnlyConsumer(consumer)}
+                                    title={isReadOnlyConsumer(consumer) ? "System Consumer groups are read-only." : undefined}
                                     className="topic-status-primary-button consumer-config-edit-button"
                                 >
                                     Edit Group

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDeleteModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDeleteModal.tsx
@@ -1,4 +1,7 @@
-import { useEffect, useState } from 'react';
+import { ConsumerRequestGeneration } from '../scope';
+import { isReadOnlyConsumer, failedConsumerBrokers } from '../mutation';
+import { ConsumerMutationReceipt } from './ConsumerMutationReceipt';
+import { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { AlertCircle, LoaderCircle, Trash2, X } from 'lucide-react';
 import { toast } from 'sonner@2.0.3';
@@ -25,6 +28,15 @@ export const ConsumerDeleteModal = ({
     const [selectedBrokerNames, setSelectedBrokerNames] = useState<string[]>([]);
     const [isDeleting, setIsDeleting] = useState(false);
     const [error, setError] = useState('');
+    const [receipt, setReceipt] = useState<ConsumerMutationResult | null>(null);
+    const generation = useRef(new ConsumerRequestGeneration());
+    useEffect(() => {
+        generation.current.invalidate();
+        setReceipt(null);
+        setIsDeleting(false);
+        return () => generation.current.invalidate();
+    }, [isOpen, consumer]);
+
 
     useEffect(() => {
         if (!isOpen) {
@@ -46,7 +58,26 @@ export const ConsumerDeleteModal = ({
         );
     };
 
+    const reviewFailed = async () => {
+        if (!receipt || isDeleting) return;
+        const isCurrent = generation.current.begin();
+        setIsDeleting(true);
+        try {
+            const current = await ConsumerService.refreshConsumerGroup({ consumerGroup: receipt.consumerGroup, scope: { mode: 'name_server' } });
+            if (!isCurrent()) return;
+            const failed = failedConsumerBrokers(receipt);
+            if (failed.some(name => !current.brokerNames.includes(name))) throw new Error('A failed Broker no longer hosts this group. Reopen deletion to review current state.');
+            setSelectedBrokerNames(failed);
+            setReceipt(null);
+            setError('');
+        } catch (error) {
+            if (isCurrent()) setError(dashboardErrorMessage(error, 'Unable to refresh group state.'));
+        } finally { if (isCurrent()) setIsDeleting(false); }
+    };
+
     const handleDelete = async () => {
+        if (isDeleting || receipt || isReadOnlyConsumer(consumer)) return;
+        const isCurrent = generation.current.begin();
         if (!consumer) {
             return;
         }
@@ -62,12 +93,16 @@ export const ConsumerDeleteModal = ({
                 consumerGroup: consumer.rawGroupName,
                 brokerNameList: selectedBrokerNames,
             });
-            toast.success('Consumer group deleted from the selected brokers.');
+            if (!isCurrent()) return;
+            setReceipt(result);
+            if (result.success) toast.success('Consumer group deleted from the selected brokers.');
+            else toast.warning('Some Consumer operations were not confirmed. Review each result.');
             onDeleted(result);
         } catch (deleteError) {
+            if (!isCurrent()) return;
             setError(dashboardErrorMessage(deleteError, 'Failed to delete the consumer group.'));
         } finally {
-            setIsDeleting(false);
+            if (isCurrent()) setIsDeleting(false);
         }
     };
 
@@ -113,6 +148,8 @@ export const ConsumerDeleteModal = ({
                             associated retry / DLQ topics where the full broker coverage is selected.
                         </div>
 
+                        {receipt && <ConsumerMutationReceipt result={receipt} onReviewFailed={() => void reviewFailed()} disabled={isDeleting} />}
+                        {isReadOnlyConsumer(consumer) && <p role="note">System Consumer groups are read-only.</p>}
                         {error && (
                             <div className="flex items-start gap-3 rounded-2xl border border-red-200/70 bg-red-50/80 px-4 py-3 text-sm text-red-700 shadow-sm dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
                                 <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
@@ -155,7 +192,7 @@ export const ConsumerDeleteModal = ({
                         </button>
                         <button
                             onClick={() => void handleDelete()}
-                            disabled={isDeleting}
+                            disabled={isDeleting || Boolean(receipt) || isReadOnlyConsumer(consumer)}
                             className="flex items-center rounded-xl bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
                         >
                             {isDeleting ? (

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerEditorModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerEditorModal.tsx
@@ -1,4 +1,7 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { ConsumerRequestGeneration } from '../scope';
+import { isReadOnlyConsumer, failedConsumerBrokers } from '../mutation';
+import { ConsumerMutationReceipt } from './ConsumerMutationReceipt';
+import { useEffect, useRef, useMemo, useState, type ReactNode } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
     Activity,
@@ -184,6 +187,15 @@ export const ConsumerEditorModal = ({
     const [isLoading, setIsLoading] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [error, setError] = useState('');
+    const [receipt, setReceipt] = useState<ConsumerMutationResult | null>(null);
+    const generation = useRef(new ConsumerRequestGeneration());
+    useEffect(() => {
+        generation.current.invalidate();
+        setReceipt(null);
+        setIsSaving(false);
+        return () => generation.current.invalidate();
+    }, [isOpen, consumer]);
+
 
     useEffect(() => {
         if (isOpen) {
@@ -295,7 +307,31 @@ export const ConsumerEditorModal = ({
         }));
     };
 
+    const reviewFailed = async () => {
+        if (!receipt || isSaving) return;
+        const isCurrent = generation.current.begin();
+        setIsSaving(true);
+        try {
+            const cluster = await ClusterService.getClusterHomePage({ forceRefresh: true });
+            if (!isCurrent()) return;
+            const options = buildClusterOptions(cluster.items);
+            const available = new Set(options.flatMap(option => option.brokers));
+            const failed = failedConsumerBrokers(receipt);
+            if (failed.some(name => !available.has(name))) throw new Error('A failed Broker is no longer in the current cluster. Reopen the editor to review targets.');
+            setClusterOptions(options);
+            // Empty cluster selection prevents expanding the failed Broker subset.
+            setForm(current => ({ ...current, clusterNameList: [], brokerNameList: failed }));
+            setActiveSection('targets');
+            setReceipt(null);
+            setError('');
+        } catch (error) {
+            if (isCurrent()) setError(dashboardErrorMessage(error, 'Unable to refresh target state.'));
+        } finally { if (isCurrent()) setIsSaving(false); }
+    };
+
     const handleSubmit = async () => {
+        if (isSaving || receipt || isReadOnlyConsumer(consumer)) return;
+        const isCurrent = generation.current.begin();
         setError('');
         const trimmedGroup = form.consumerGroup.trim();
         if (!trimmedGroup) {
@@ -317,16 +353,16 @@ export const ConsumerEditorModal = ({
         try {
             setIsSaving(true);
             const result = await ConsumerService.createOrUpdateConsumerGroup(request);
-            toast.success(
-                isEditMode
-                    ? 'Consumer group configuration updated.'
-                    : 'Consumer group created successfully.',
-            );
+            if (!isCurrent()) return;
+            setReceipt(result);
+            if (result.success) toast.success('Consumer group saved on all selected targets.');
+            else toast.warning('Some Consumer operations were not confirmed. Review each result.');
             onSaved(result);
         } catch (saveError) {
+            if (!isCurrent()) return;
             setError(dashboardErrorMessage(saveError, 'Failed to save consumer group changes.'));
         } finally {
-            setIsSaving(false);
+            if (isCurrent()) setIsSaving(false);
         }
     };
 
@@ -659,6 +695,8 @@ export const ConsumerEditorModal = ({
                         )}
                     </div>
 
+                    {receipt && <ConsumerMutationReceipt result={receipt} onReviewFailed={() => void reviewFailed()} disabled={isSaving} />}
+                    {isReadOnlyConsumer(consumer) && <p role="note">System Consumer groups are read-only.</p>}
                     <footer className="topic-status-footer consumer-editor-footer">
                         <span>
                             {isEditMode
@@ -672,7 +710,7 @@ export const ConsumerEditorModal = ({
                             <button
                                 type="button"
                                 onClick={() => void handleSubmit()}
-                                disabled={isLoading || isSaving}
+                                disabled={isLoading || isSaving || Boolean(receipt) || isReadOnlyConsumer(consumer)}
                                 className="topic-status-primary-button consumer-editor-save-button"
                             >
                                 {isSaving ? (

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerMutationReceipt.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerMutationReceipt.test.tsx
@@ -1,0 +1,35 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ConsumerMutationReceipt } from './ConsumerMutationReceipt';
+import { failedConsumerBrokers, isReadOnlyConsumer } from '../mutation';
+import type { ConsumerMutationResult, ConsumerGroupListItem } from '../types/consumer.types';
+
+const partial: ConsumerMutationResult = {
+    operation: 'delete', consumerGroup: 'orders', success: false, targetCount: 3,
+    targets: [
+        { kind: 'BROKER', target: 'broker-a', success: true, errorCode: null, message: 'Completed' },
+        { kind: 'BROKER', target: 'broker-b', success: false, errorCode: 'target.failed', message: 'Refresh current state' },
+        { kind: 'INTERNAL_TOPIC_CLEANUP', target: '%DLQ%orders', success: false, errorCode: 'target.failed', message: 'Cleanup failed' },
+    ],
+};
+
+describe('Consumer mutation results', () => {
+    it('shows successful, failed, and cleanup results independently', () => {
+        const html = renderToStaticMarkup(createElement(ConsumerMutationReceipt, { result: partial, onReviewFailed: () => {}, disabled: false }));
+        for (const text of ['broker-a', 'broker-b', '%DLQ%orders', 'INTERNAL_TOPIC_CLEANUP', 'Completed', 'Not confirmed']) expect(html).toContain(text);
+        expect(failedConsumerBrokers(partial)).toEqual(['broker-b']);
+    });
+    it('never offers cleanup failures as a Broker retry', () => {
+        const result = { ...partial, targets: [partial.targets[0], partial.targets[2]] };
+        expect(failedConsumerBrokers(result)).toEqual([]);
+        expect(renderToStaticMarkup(createElement(ConsumerMutationReceipt, { result, onReviewFailed: () => {}, disabled: false }))).not.toContain('Refresh and review failed Brokers only');
+    });
+    it('keeps system groups read-only through either display or raw names', () => {
+        const group = { category: 'NORMAL', rawGroupName: 'orders', displayGroupName: 'orders' } as ConsumerGroupListItem;
+        expect(isReadOnlyConsumer(group)).toBe(false);
+        expect(isReadOnlyConsumer({ ...group, category: 'SYSTEM' })).toBe(true);
+        expect(isReadOnlyConsumer({ ...group, rawGroupName: ' %SYS%orders ' })).toBe(true);
+        expect(isReadOnlyConsumer({ ...group, displayGroupName: '%SYS%orders' })).toBe(true);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerMutationReceipt.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerMutationReceipt.tsx
@@ -1,0 +1,19 @@
+import type { ConsumerMutationResult } from '../types/consumer.types';
+import { failedConsumerBrokers } from '../mutation';
+
+export const ConsumerMutationReceipt = ({ result, onReviewFailed, disabled }: {
+    result: ConsumerMutationResult; onReviewFailed: () => void; disabled: boolean;
+}) => <section aria-label="Consumer operation results" className="space-y-3 rounded-xl border p-4">
+    <p className="text-sm font-semibold">{result.consumerGroup}: {result.success ? 'Completed' : 'Review incomplete results'}</p>
+    <div className="max-h-60 overflow-auto"><table className="w-full text-left text-sm">
+        <thead><tr><th>Target</th><th>Operation</th><th>Result</th></tr></thead>
+        <tbody>{result.targets.map((target, index) => <tr key={`${target.kind}:${target.target}:${index}`}>
+            <td className="p-2 font-mono">{target.target}</td><td>{target.kind}</td>
+            <td className="p-2"><strong>{target.success ? 'Completed' : 'Not confirmed'}</strong>
+                <p>{target.message}</p>{target.errorCode && <code>{target.errorCode}</code>}</td>
+        </tr>)}</tbody>
+    </table></div>
+    <p className="text-sm">Completed changes remain applied. Refresh and review current state before submitting another operation.</p>
+    {failedConsumerBrokers(result).length > 0 && <button type="button" disabled={disabled}
+        className="rounded border px-3 py-2 text-sm" onClick={onReviewFailed}>Refresh and review failed Brokers only</button>}
+</section>;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/mutation.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/mutation.ts
@@ -1,0 +1,8 @@
+import type { ConsumerGroupListItem, ConsumerMutationResult } from './types/consumer.types';
+
+// The backend classifier is authoritative, including for manually entered names.
+export const isReadOnlyConsumer = (consumer: ConsumerGroupListItem | null) => Boolean(consumer && (
+    consumer.category === 'SYSTEM' || consumer.rawGroupName.trim().startsWith('%SYS%') || consumer.displayGroupName.trim().startsWith('%SYS%')
+));
+export const failedConsumerBrokers = (result: ConsumerMutationResult) =>
+    result.targets.filter(target => target.kind === 'BROKER' && !target.success).map(target => target.target);

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
@@ -157,6 +157,16 @@ export interface ConsumerConfigView {
 
 export interface ConsumerMutationResult {
     consumerGroup: string;
-    brokerNames: string[];
-    updated: boolean;
+    operation: 'upsert' | 'delete';
+    targets: ConsumerTargetResult[];
+    targetCount: number;
+    success: boolean;
+}
+
+export interface ConsumerTargetResult {
+    target: string;
+    kind: string;
+    success: boolean;
+    errorCode: string | null;
+    message: string;
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10384

### Brief Description

Consumer mutations now reject protected raw and normalized names and use validated batch APIs. Deletion requires current subscription inventory without Broker inventory failures, validates the selected subset, and preserves independent Broker and internal Topic cleanup outcomes with safe error messages and truthful audit counts.

Editor and Delete dialogs retain partial results and close normally only on full success. Reviewing failed Brokers refreshes current targets and requires another explicit submission; the editor clears cluster selections so the failed subset cannot expand. System groups remain read-only and stale dialog callbacks are discarded.

### How Did You Test This Change?

- Tauri backend: `cargo test --lib consumer::` (10 passed) and package-scoped format check.
- Admin core: `cargo test -p rocketmq-admin-core --features client-adapter --lib batch_consumer` (10 passed).
- Frontend: focused Consumer receipt tests (3 passed), `npm run build`, and `git diff --check`.
- Full desktop integration remains part of the final implementation validation. Existing frontend bundle-size warning remains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-broker results for consumer group creation, updates, and deletions.
  * Added mutation receipts showing successful and failed targets, with options to review failed brokers.
  * Added safeguards preventing edits or deletions of protected system consumer groups.
  * Added clearer handling for partial operations and safe error messages.

* **Bug Fixes**
  * Prevented incomplete broker inventory from triggering unsafe deletions.
  * Improved modal behavior by ignoring stale requests and keeping dialogs open after partial failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->