### PR TITLE
[ISSUE #10386]🚀Edit Tauri Broker configuration with explicit write receipts

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/BROKER_CONFIG_EDITS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/BROKER_CONFIG_EDITS.md
@@ -1,0 +1,9 @@
+# Broker configuration edits
+
+The Cluster configuration inspector opens an editor that loads current string-valued properties. Review computes a patch containing only changed keys. Empty keys, non-string JSON values, unsupported key removal, and property-line injection are rejected. Confirmation shows the Broker identity and every submitted key/value change.
+
+The authenticated command `update_cluster_broker_config` holds the current connection revision lease and verifies cluster name, Broker name, Broker ID, and address against current discovery before writing through `DashboardAdmin`. It submits the patch once, then reads configuration once. The result separates an acknowledged write from read-back states `confirmed`, `different`, and `unavailable`. A read-back failure never turns the acknowledged write into a failed write or triggers a retry. Audit records the write outcome and Broker address without configuration values.
+
+The editor retains the result, requires a refresh after an unconfirmed outcome, and ignores callbacks after closure or Broker/environment changes. A successful read-back updates the inspector's displayed properties. Editing another change always requires a fresh confirmation.
+
+Validation covers identity mismatch and invalid input without writes, changed-key projection, successful writes with failed read-back, and audit classification. Configuration is not a compare-and-swap API: another administrator may change the same key concurrently, and the editor reports differing read-back values when observed.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
@@ -37,6 +37,7 @@ pub(crate) enum AuditAction {
     ResetOffset,
     SkipMessages,
     SendMessage,
+    UpdateBrokerConfig,
     UpsertConsumer,
     DeleteConsumer,
     ConsumeDirectly,
@@ -66,6 +67,7 @@ impl AuditAction {
             Self::ResetOffset => "consumer.reset_offset",
             Self::SkipMessages => "consumer.skip_messages",
             Self::SendMessage => "message.send",
+            Self::UpdateBrokerConfig => "broker.update_config",
             Self::UpsertConsumer => "consumer.upsert",
             Self::DeleteConsumer => "consumer.delete",
             Self::ConsumeDirectly => "message.consume_directly",
@@ -86,6 +88,7 @@ impl AuditAction {
             | Self::SwitchProxy
             | Self::DeleteProxy => "connection",
             Self::UpsertTopic | Self::DeleteTopic | Self::DeleteTopicByBroker | Self::SendMessage => "topic",
+            Self::UpdateBrokerConfig => "broker",
             Self::ResetOffset
             | Self::SkipMessages
             | Self::UpsertConsumer
@@ -104,6 +107,7 @@ impl AuditAction {
                 | Self::ResetOffset
                 | Self::SkipMessages
                 | Self::SendMessage
+                | Self::UpdateBrokerConfig
                 | Self::UpsertConsumer
                 | Self::DeleteConsumer
                 | Self::ConsumeDirectly

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster.rs
@@ -14,6 +14,7 @@
 
 pub(crate) mod admin;
 pub(crate) mod commands;
+pub(crate) mod config;
 pub(crate) mod service;
 pub(crate) mod types;
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/commands.rs
@@ -78,3 +78,29 @@ pub async fn get_cluster_broker_status(
     connection_manager.check_revision(expected_revision)?;
     result
 }
+
+#[tauri::command]
+pub async fn update_cluster_broker_config(
+    session_id: String,
+    request: super::config::BrokerConfigUpdateRequest,
+    cluster_manager: State<'_, ClusterManager>,
+    session_state: State<'_, SessionState>,
+    audit_manager: State<'_, crate::audit::AuditManager>,
+    connection_manager: State<'_, ConnectionManager>,
+    expected_revision: i64,
+) -> CommandResult<crate::audit::Audited<super::config::BrokerConfigUpdateResult>> {
+    let access = crate::audit::AuditAccess::dashboard(&session_state, session_id);
+    let manager = cluster_manager.inner().clone();
+    let connection = connection_manager.inner().clone();
+    audit_manager
+        .execute(
+            access,
+            crate::audit::AuditAction::UpdateBrokerConfig,
+            Some(request.broker_addr.clone()),
+            move |audit| async move {
+                let _lease = connection.mutation_lease(expected_revision, &audit).await?;
+                manager.update_broker_config(request).await
+            },
+        )
+        .await
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/config.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/config.rs
@@ -1,0 +1,252 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::audit::types::{AuditReceipt, Summary};
+use crate::error::{DashboardError, DashboardResult};
+use rocketmq_admin_core::client_adapter::AdminSession;
+use rocketmq_admin_core::core::dashboard::{
+    DashboardAdmin, DashboardBrokerConfigUpdateRequest, DashboardBrokerInfo, DashboardBrokerTarget,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct BrokerConfigUpdateRequest {
+    pub(crate) cluster_name: String,
+    pub(crate) broker_name: String,
+    pub(crate) broker_id: u64,
+    pub(crate) broker_addr: String,
+    pub(crate) entries: BTreeMap<String, String>,
+}
+
+impl BrokerConfigUpdateRequest {
+    pub(crate) fn validate(&self) -> DashboardResult<()> {
+        if self.cluster_name.trim().is_empty()
+            || self.broker_name.trim().is_empty()
+            || self.broker_addr.trim().is_empty()
+        {
+            return Err(DashboardError::Validation(
+                "An explicit Broker identity is required.".into(),
+            ));
+        }
+        if self.entries.is_empty()
+            || self.entries.iter().any(|(key, value)| {
+                key.is_empty()
+                    || key
+                        .chars()
+                        .any(|ch| ch.is_whitespace() || "=:# !\\".contains(ch) || ch.is_control())
+                    || value.chars().any(|ch| matches!(ch, '\r' | '\n' | '\0'))
+            })
+        {
+            return Err(DashboardError::Validation(
+                "Provide changed configuration keys with single-line string values.".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ConfigReadBack {
+    Confirmed,
+    Different,
+    Unavailable,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BrokerConfigUpdateResult {
+    pub(crate) broker_addr: String,
+    pub(crate) written: bool,
+    pub(crate) changed_keys: Vec<String>,
+    pub(crate) read_back: ConfigReadBack,
+    pub(crate) entries: Option<BTreeMap<String, String>>,
+}
+impl AuditReceipt for BrokerConfigUpdateResult {
+    fn summary(&self) -> Summary {
+        Summary::count(usize::from(self.written), usize::from(!self.written))
+    }
+}
+
+pub(super) trait BrokerConfigAccess {
+    async fn brokers(&self) -> DashboardResult<Vec<DashboardBrokerInfo>>;
+    async fn write(&self, request: &DashboardBrokerConfigUpdateRequest) -> DashboardResult<()>;
+    async fn read(&self, target: &DashboardBrokerTarget) -> DashboardResult<BTreeMap<String, String>>;
+}
+impl BrokerConfigAccess for AdminSession {
+    async fn brokers(&self) -> DashboardResult<Vec<DashboardBrokerInfo>> {
+        Ok(self.dashboard_list_brokers().await?.items)
+    }
+    async fn write(&self, request: &DashboardBrokerConfigUpdateRequest) -> DashboardResult<()> {
+        self.dashboard_update_broker_config(request).await?;
+        Ok(())
+    }
+    async fn read(&self, target: &DashboardBrokerTarget) -> DashboardResult<BTreeMap<String, String>> {
+        Ok(self.dashboard_broker_config(target).await?.entries)
+    }
+}
+
+pub(super) async fn update_config(
+    admin: &impl BrokerConfigAccess,
+    request: BrokerConfigUpdateRequest,
+) -> DashboardResult<BrokerConfigUpdateResult> {
+    request.validate()?;
+    let brokers = admin.brokers().await?;
+    if !brokers.iter().any(|broker| {
+        broker.cluster_name == request.cluster_name
+            && broker.broker_name == request.broker_name
+            && broker.broker_id == request.broker_id
+            && broker.address == request.broker_addr
+    }) {
+        return Err(DashboardError::Validation(
+            "The selected Broker identity is no longer in the current cluster.".into(),
+        ));
+    }
+    let target = DashboardBrokerTarget {
+        broker_name: request.broker_name.clone(),
+        broker_addr: Some(request.broker_addr.clone()),
+    };
+    let changed_keys = request.entries.keys().cloned().collect();
+    admin
+        .write(&DashboardBrokerConfigUpdateRequest {
+            broker_name: request.broker_name,
+            broker_addr: Some(request.broker_addr.clone()),
+            entries: request.entries.clone(),
+        })
+        .await?;
+    // A failed read cannot reverse an acknowledged write, and must never replay it.
+    let (read_back, entries) = match admin.read(&target).await {
+        Ok(entries) => {
+            let status = if request
+                .entries
+                .iter()
+                .all(|(key, value)| entries.get(key) == Some(value))
+            {
+                ConfigReadBack::Confirmed
+            } else {
+                ConfigReadBack::Different
+            };
+            (status, Some(entries))
+        }
+        Err(_) => (ConfigReadBack::Unavailable, None),
+    };
+    Ok(BrokerConfigUpdateResult {
+        broker_addr: request.broker_addr,
+        written: true,
+        changed_keys,
+        read_back,
+        entries,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    struct Fake {
+        calls: RefCell<Vec<&'static str>>,
+        read_fails: bool,
+    }
+    impl BrokerConfigAccess for Fake {
+        async fn brokers(&self) -> DashboardResult<Vec<DashboardBrokerInfo>> {
+            self.calls.borrow_mut().push("brokers");
+            Ok(vec![DashboardBrokerInfo {
+                cluster_name: "cluster".into(),
+                broker_name: "broker-a".into(),
+                broker_id: 0,
+                address: "127.0.0.1:10911".into(),
+                role: "MASTER".into(),
+                version: "".into(),
+                produce_tps: 0.0,
+                consume_tps: 0.0,
+                runtime_entries: BTreeMap::new(),
+                runtime_error: None,
+            }])
+        }
+        async fn write(&self, request: &DashboardBrokerConfigUpdateRequest) -> DashboardResult<()> {
+            self.calls.borrow_mut().push("write");
+            assert_eq!(request.broker_addr.as_deref(), Some("127.0.0.1:10911"));
+            assert_eq!(
+                request.entries,
+                BTreeMap::from([("brokerPermission".into(), "6".into())])
+            );
+            Ok(())
+        }
+        async fn read(&self, _: &DashboardBrokerTarget) -> DashboardResult<BTreeMap<String, String>> {
+            self.calls.borrow_mut().push("read");
+            if self.read_fails {
+                Err(DashboardError::Internal("read unavailable"))
+            } else {
+                Ok(BTreeMap::from([("brokerPermission".into(), "6".into())]))
+            }
+        }
+    }
+    fn request() -> BrokerConfigUpdateRequest {
+        BrokerConfigUpdateRequest {
+            cluster_name: "cluster".into(),
+            broker_name: "broker-a".into(),
+            broker_id: 0,
+            broker_addr: "127.0.0.1:10911".into(),
+            entries: BTreeMap::from([("brokerPermission".into(), "6".into())]),
+        }
+    }
+    #[tokio::test]
+    async fn write_success_and_read_failure_are_independent() {
+        for read_fails in [false, true] {
+            let admin = Fake {
+                calls: RefCell::new(vec![]),
+                read_fails,
+            };
+            let result = update_config(&admin, request()).await.unwrap();
+            assert!(result.written);
+            assert_eq!(
+                result.read_back,
+                if read_fails {
+                    ConfigReadBack::Unavailable
+                } else {
+                    ConfigReadBack::Confirmed
+                }
+            );
+            assert_eq!(*admin.calls.borrow(), ["brokers", "write", "read"]);
+            assert_eq!(result.summary().outcome, crate::audit::types::Outcome::Success);
+        }
+    }
+    #[tokio::test]
+    async fn invalid_patch_and_changed_identity_never_write() {
+        let admin = Fake {
+            calls: RefCell::new(vec![]),
+            read_fails: false,
+        };
+        let mut invalid = request();
+        invalid.entries.insert(" ".into(), "x".into());
+        assert!(update_config(&admin, invalid).await.is_err());
+        assert!(admin.calls.borrow().is_empty());
+        let mut stale = request();
+        stale.broker_id = 1;
+        assert!(update_config(&admin, stale).await.is_err());
+        assert_eq!(*admin.calls.borrow(), ["brokers"]);
+        let mut json = serde_json::json!({"clusterName":"cluster", "brokerName":"broker-a", "brokerId":0,
+            "brokerAddr":"127.0.0.1:10911", "entries":{"brokerPermission":6}});
+        assert!(serde_json::from_value::<BrokerConfigUpdateRequest>(json.clone()).is_err());
+        json["entries"] = serde_json::json!({"brokerPermission":"6\ninjected=true"});
+        assert!(
+            serde_json::from_value::<BrokerConfigUpdateRequest>(json)
+                .unwrap()
+                .validate()
+                .is_err()
+        );
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/cluster/service.rs
@@ -168,6 +168,24 @@ impl ClusterManager {
         }
     }
 
+    pub(crate) async fn update_broker_config(
+        &self,
+        request: super::config::BrokerConfigUpdateRequest,
+    ) -> ClusterResult<super::config::BrokerConfigUpdateResult> {
+        request.validate()?;
+        let mut session_guard = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session_guard).await?;
+        let session = session_guard
+            .as_ref()
+            .ok_or(ClusterError::Internal("Cluster session was not initialized"))?;
+        let result = super::config::update_config(&session.admin, request).await;
+        if Self::should_reset_session(&result) {
+            self.reset_admin_session(&mut session_guard, "update_broker_config failed")
+                .await;
+        }
+        result
+    }
+
     async fn ensure_admin_session(&self, session_slot: &mut Option<ManagedClusterAdmin>) -> ClusterResult<()> {
         let generation = self.runtime.generation();
         let needs_reconnect = session_slot

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -270,6 +270,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
             nameserver::commands::update_use_tls,
             cluster::commands::get_cluster_home_page,
             cluster::commands::get_cluster_broker_config,
+            cluster::commands::update_cluster_broker_config,
             cluster::commands::get_cluster_broker_status,
             consumer::commands::query_consumer_groups,
             consumer::commands::refresh_consumer_group,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ClusterView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ClusterView.tsx
@@ -1,3 +1,4 @@
+import { BrokerConfigEditor } from '../features/cluster/components/BrokerConfigEditor';
 import { useAppStore, useNavigationState } from '../stores/app.store';
 import React, { useEffect, useMemo, useState, useRef, type ReactNode } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
@@ -86,6 +87,8 @@ export const ClusterView = () => {
   const target = navigation.target?.kind === 'broker' ? navigation.target : null;
   const openedTarget = useRef(false);
   const sheetGeneration = useRef(0);
+  const [configBroker, setConfigBroker] = useState<ClusterBrokerCardItem | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
   useEffect(() => () => { sheetGeneration.current += 1; }, []);
   const {
     data,
@@ -217,6 +220,8 @@ export const ClusterView = () => {
 
   const openStatusSheet = async (brokerData: ClusterBrokerCardItem) => {
     const generation = ++sheetGeneration.current;
+    setEditorOpen(false);
+    setConfigBroker(null);
     setDetailSheet({
       isOpen: true,
       type: 'Status',
@@ -257,6 +262,8 @@ export const ClusterView = () => {
 
   const openConfigSheet = async (brokerData: ClusterBrokerCardItem) => {
     const generation = ++sheetGeneration.current;
+    setEditorOpen(false);
+    setConfigBroker(brokerData);
     setDetailSheet({
       isOpen: true,
       type: 'Config',
@@ -319,12 +326,15 @@ export const ClusterView = () => {
       {targetMissing && <p role="alert" className="p-4 text-red-600">Broker not found: {target.address}</p>}
       <SideSheet
         isOpen={detailSheet.isOpen}
-        onClose={() => { sheetGeneration.current += 1; setDetailSheet({ ...detailSheet, isOpen: false }); if (target) goBack(); }}
+        onClose={() => { setEditorOpen(false); sheetGeneration.current += 1; setDetailSheet({ ...detailSheet, isOpen: false }); if (target) goBack(); }}
         title={detailSheet.title}
         data={detailSheet.data}
         type={detailSheet.type}
+        actions={detailSheet.type === 'Config' && configBroker ? <button className="ops-detail-tool-button" onClick={() => setEditorOpen(true)}>Edit configuration</button> : undefined}
       />
 
+      {editorOpen && configBroker && detailSheet.isOpen && <BrokerConfigEditor key={configBroker.address} broker={configBroker}
+        onClose={() => setEditorOpen(false)} onReadBack={(entries) => setDetailSheet(current => ({ ...current, data: { brokerAddr: configBroker.address, ...entries } }))} />}
       <section className="cluster-command-panel" aria-label="Cluster controls">
         <div className="cluster-select-shell">
           <button

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/SideSheet.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/SideSheet.tsx
@@ -10,6 +10,7 @@ interface SideSheetProps {
   title: string;
   data: Record<string, unknown>;
   type?: SheetType;
+  actions?: React.ReactNode;
 }
 
 interface DetailEntry {
@@ -103,7 +104,7 @@ const extractBrokerLabel = (title: string) => {
   return match ? `${match[1]}-${match[2]}` : title;
 };
 
-export const SideSheet = ({ isOpen, onClose, title, data, type }: SideSheetProps) => {
+export const SideSheet = ({ isOpen, onClose, title, data, type, actions }: SideSheetProps) => {
   const [query, setQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState('All');
   const [copiedKey, setCopiedKey] = useState('');
@@ -214,6 +215,7 @@ export const SideSheet = ({ isOpen, onClose, title, data, type }: SideSheetProps
             </header>
 
             <section className="ops-detail-toolbar" aria-label="Detail filters">
+              {actions}
               <label className="ops-detail-search">
                 <Search className="ops-detail-search-icon" />
                 <span className="sr-only">Search detail entries</span>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/cluster/components/BrokerConfigEditor.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/cluster/components/BrokerConfigEditor.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import { ClusterService } from '../../../services/cluster.service';
+import { dashboardErrorMessage } from '../../../services/invoke';
+import type { BrokerConfigUpdateResult, ClusterBrokerCardItem } from '../types/cluster.types';
+import { changedBrokerConfig } from '../config';
+
+export function BrokerConfigEditor({ broker, onClose, onReadBack }: {
+    broker: ClusterBrokerCardItem; onClose: () => void; onReadBack: (entries: Record<string, string>) => void;
+}) {
+    const [original, setOriginal] = useState<Record<string, string> | null>(null);
+    const [text, setText] = useState('');
+    const [error, setError] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [pending, setPending] = useState<Record<string, string> | null>(null);
+    const [result, setResult] = useState<BrokerConfigUpdateResult | null>(null);
+    const [writeUnknown, setWriteUnknown] = useState(false);
+    const generation = useRef(0);
+
+    const refresh = async () => {
+        const current = ++generation.current;
+        setBusy(true);
+        setError('');
+        setPending(null);
+        try {
+            const config = await ClusterService.getClusterBrokerConfig({ brokerAddr: broker.address });
+            if (current !== generation.current) return;
+            setOriginal(config.entries);
+            setText(JSON.stringify(config.entries, null, 2));
+            setWriteUnknown(false);
+            onReadBack(config.entries);
+        } catch (error) {
+            if (current === generation.current) setError(dashboardErrorMessage(error, 'Unable to read current Broker configuration.'));
+        } finally { if (current === generation.current) setBusy(false); }
+    };
+    useEffect(() => {
+        void refresh();
+        return () => { generation.current++; };
+    }, [broker.address]);
+
+    const review = () => {
+        if (!original || busy || writeUnknown) return;
+        try {
+            const patch = changedBrokerConfig(text, original);
+            if (!Object.keys(patch).length) throw new Error('No configuration values have changed.');
+            setPending(patch);
+            setError('');
+        } catch (error) { setError(error instanceof Error ? error.message : 'Invalid configuration JSON.'); }
+    };
+    const submit = async () => {
+        if (!pending || busy) return;
+        const current = ++generation.current;
+        setBusy(true);
+        setError('');
+        setResult(null);
+        try {
+            const receipt = await ClusterService.updateBrokerConfig({ clusterName: broker.clusterName,
+                brokerName: broker.brokerName, brokerId: broker.brokerId, brokerAddr: broker.address, entries: pending });
+            if (current !== generation.current) return;
+            setResult(receipt);
+            setPending(null);
+            if (receipt.entries) {
+                setOriginal(receipt.entries);
+                setText(JSON.stringify(receipt.entries, null, 2));
+                onReadBack(receipt.entries);
+            } else setWriteUnknown(true);
+        } catch (error) {
+            if (current !== generation.current) return;
+            setPending(null);
+            setWriteUnknown(true);
+            setError(dashboardErrorMessage(error, 'Write result was not confirmed. Refresh the Broker before another change.'));
+        } finally { if (current === generation.current) setBusy(false); }
+    };
+    return <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 p-5">
+        <section role="dialog" aria-modal="true" aria-labelledby="broker-config-editor-title"
+            className="flex max-h-[90vh] w-full max-w-4xl flex-col gap-4 overflow-auto rounded-xl bg-white p-6 shadow-xl dark:bg-gray-900 dark:text-gray-100">
+            <header className="flex items-start justify-between gap-4"><div>
+                <h2 id="broker-config-editor-title" className="text-xl font-semibold">Edit Broker configuration</h2>
+                <p className="font-mono text-sm">{broker.clusterName} / {broker.brokerName} / {broker.brokerId} · {broker.address}</p>
+            </div><button aria-label="Close editor" onClick={onClose}><X /></button></header>
+            {error && <p role="alert" className="text-red-600 dark:text-red-400">{error}</p>}
+            {result && <div role="status" className="rounded border p-3 text-sm">
+                <strong>{result.written ? 'Broker acknowledged the write.' : 'Write was not confirmed.'}</strong>
+                <p>{result.readBack === 'confirmed' ? 'Read-back matches every submitted value.' : result.readBack === 'different'
+                    ? 'Read-back differs from the submitted values. Review the current configuration below.'
+                    : 'Read-back failed. The acknowledged write remains applied. Refresh before another change.'}</p>
+                <p>Submitted keys: {result.changedKeys.join(', ')}</p>
+            </div>}
+            <label className="flex min-h-0 flex-1 flex-col gap-2 text-sm">Configuration JSON · string values
+                <textarea aria-label="Broker configuration JSON" value={text} disabled={busy || !original || Boolean(pending) || writeUnknown}
+                    onChange={event => { setText(event.target.value); setResult(null); }} spellCheck={false}
+                    className="min-h-64 w-full rounded border bg-transparent p-3 font-mono text-sm" />
+            </label>
+            {pending && <section aria-label="Confirm Broker changes" className="rounded border border-amber-400 p-4 text-sm">
+                <h3 className="font-semibold">Confirm changes on {broker.brokerName} [{broker.brokerId}] at {broker.address}</h3>
+                <ul className="my-3 max-h-40 overflow-auto">{Object.keys(pending).map(key => <li key={key} className="font-mono">{key}: {original?.[key] ?? '(not set)'} → {pending[key]}</li>)}</ul>
+                <p>Only these keys will be submitted.</p>
+                <div className="mt-3 flex gap-3"><button disabled={busy} onClick={() => setPending(null)}>Back to editing</button>
+                    <button disabled={busy} onClick={() => void submit()} className="rounded bg-blue-600 px-4 py-2 text-white">{busy ? 'Applying…' : 'Confirm and apply'}</button></div>
+            </section>}
+            <footer className="flex justify-end gap-3 text-sm">
+                <button disabled={busy} onClick={() => void refresh()} className="rounded border px-4 py-2">Refresh current configuration</button>
+                <button disabled={busy || !original || Boolean(pending) || writeUnknown} onClick={review} className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50">Review changes</button>
+            </footer>
+        </section>
+    </div>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/cluster/config.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/cluster/config.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { changedBrokerConfig } from './config';
+
+describe('Broker configuration patches', () => {
+    const original = { brokerPermission: '6', listenPort: '10911' };
+    it('submits only explicitly changed string values', () => {
+        expect(changedBrokerConfig(JSON.stringify({ ...original, brokerPermission: '4' }), original)).toEqual({ brokerPermission: '4' });
+        expect(changedBrokerConfig(JSON.stringify(original), original)).toEqual({});
+        expect(changedBrokerConfig('{"newProperty":""}', {})).toEqual({ newProperty: '' });
+    });
+    it('rejects invalid JSON, non-string values, missing keys and property injection', () => {
+        for (const text of ['{', 'null', '[]', '{"brokerPermission":6}', '{"brokerPermission":true}', '{"": "x"}', '{"a=b":"x"}', '{"a":"b\\nc=d"}']) {
+            expect(() => changedBrokerConfig(text, {})).toThrow();
+        }
+        expect(() => changedBrokerConfig('{"brokerPermission":"4"}', original)).toThrow('Removing configuration keys');
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/cluster/config.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/cluster/config.ts
@@ -1,0 +1,12 @@
+export function changedBrokerConfig(text: string, original: Record<string, string>): Record<string, string> {
+    const parsed: unknown = JSON.parse(text);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('Configuration must be a JSON object of string values.');
+    const entries = Object.entries(parsed);
+    for (const [key, value] of entries) {
+        if (!key || /[\s=:# !\\\x00-\x1f\x7f]/.test(key) || typeof value !== 'string' || /[\r\n\0]/.test(value)) {
+            throw new Error('Use non-empty property names and single-line string values.');
+        }
+    }
+    if (Object.keys(original).some(key => !Object.prototype.hasOwnProperty.call(parsed, key))) throw new Error('Removing configuration keys is not supported. Restore the missing keys.');
+    return Object.fromEntries(entries.filter(([key, value]) => original[key] !== value)) as Record<string, string>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/cluster/types/cluster.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/cluster/types/cluster.types.ts
@@ -57,3 +57,18 @@ export interface ClusterBrokerStatusView {
     brokerAddr: string;
     entries: Record<string, string>;
 }
+
+export interface BrokerConfigUpdateRequest {
+    clusterName: string;
+    brokerName: string;
+    brokerId: number;
+    brokerAddr: string;
+    entries: Record<string, string>;
+}
+export interface BrokerConfigUpdateResult {
+    brokerAddr: string;
+    written: boolean;
+    changedKeys: string[];
+    readBack: 'confirmed' | 'different' | 'unavailable';
+    entries: Record<string, string> | null;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/cluster.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/cluster.service.ts
@@ -1,6 +1,8 @@
 import { invokeAuthenticatedCommand } from './invoke';
 import type {
     ClusterBrokerConfigRequest,
+    BrokerConfigUpdateRequest,
+    BrokerConfigUpdateResult,
     ClusterBrokerConfigView,
     ClusterHomePageRequest,
     ClusterHomePageResponse,
@@ -9,6 +11,10 @@ import type {
 } from '../features/cluster/types/cluster.types';
 
 export class ClusterService {
+    static async updateBrokerConfig(request: BrokerConfigUpdateRequest): Promise<BrokerConfigUpdateResult> {
+        return invokeAuthenticatedCommand<BrokerConfigUpdateResult>('update_cluster_broker_config', { request });
+    }
+
     static async getClusterHomePage(
         request: ClusterHomePageRequest = { forceRefresh: false }
     ): Promise<ClusterHomePageResponse> {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10386

### Brief Description

The Cluster configuration inspector now opens an editor with a confirmation preview and submits only changed string-valued keys. The authenticated backend verifies cluster, Broker name, ID, and address against current discovery while holding the connection revision lease.

The result preserves an acknowledged write even when read-back fails or differs. Audit records the write outcome without configuration values, unconfirmed outcomes require refresh before another edit, and stale callbacks cannot update a closed or changed inspector. Property-line injection, non-string JSON, and unsupported key removal are rejected.

### How Did You Test This Change?

- `cargo test --lib cluster::`: 8 passed, including invalid/stale targets without writes and acknowledged writes with failed read-back.
- Package-scoped Rust format check passed.
- Focused frontend configuration tests: 2 passed. `npm run build` and `git diff --check` passed.
- Existing bundle-size warning remains. Live desktop validation is reserved for the final integration step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broker configuration editing from the cluster broker details view.
  * Supports JSON-based edits with validation, change review, and confirmation before saving.
  * Displays write results and read-back verification status, with refresh and review options.
  * Added audit tracking for broker configuration updates.

* **Bug Fixes**
  * Prevents invalid keys, unsupported value types, accidental key removal, and stale broker updates.

* **Documentation**
  * Added documentation describing the broker configuration editing workflow and outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->