### PR TITLE
[ISSUE #10388]🚀Discover Tauri Producer groups and invalidate stale lookups

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/PRODUCER_DISCOVERY.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/PRODUCER_DISCOVERY.md
@@ -1,0 +1,11 @@
+# Producer discovery
+
+`list_producer_groups` is an authenticated, connection-revision-checked query backed by `DashboardAdmin::dashboard_list_producers`. Each item contains a group name and a reported connection count. The command does not manufacture Topic associations or client rows.
+
+The directory loads on page entry and supports search, pagination, refresh, and group selection. Selecting a group fills the existing Topic + Group connection lookup; manual group entry starts empty and remains available. Changing either query field invalidates the prior result and any outstanding callbacks or delayed loading indicator. Closing the page also invalidates requests.
+
+The directory and connection lookup have independent loading, empty, and error states. An item with a reported connection count of zero remains visible. Connection statistics stay unset until a scoped lookup returns.
+
+## Coverage limitation
+
+The current core discovery API aggregates Broker-reported connection counts and does not return coverage evidence. It can omit Brokers whose producer-table queries fail, and counts can overlap across Brokers. The UI therefore says "reported connections" and "no groups were reported" and explicitly states that coverage is unavailable. It does not claim a complete cluster client count or fabricate a partial-coverage percentage. Client details come only from the separate scoped lookup.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -296,6 +296,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
             message::commands::query_message_trace_by_id,
             message::commands::view_message_trace_detail,
             producer::commands::get_producer_topic_options,
+            producer::commands::list_producer_groups,
             producer::commands::query_producer_connections,
             proxy::commands::get_proxy_home_page,
             proxy::commands::add_proxy_addr,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/commands.rs
@@ -60,3 +60,18 @@ pub async fn query_producer_connections(
 use crate::auth::SessionState;
 use crate::error::CommandResult;
 use crate::error::authorize_command;
+
+#[tauri::command]
+pub async fn list_producer_groups(
+    session_id: String,
+    producer_manager: State<'_, ProducerManager>,
+    session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
+) -> CommandResult<Vec<super::types::ProducerGroupItem>> {
+    authorize_command(&session_id, &session_state).await?;
+    connection_manager.check_revision(expected_revision)?;
+    let result = producer_manager.list_producer_groups().await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/service.rs
@@ -17,6 +17,7 @@ use crate::nameserver::NameServerRuntimeState;
 use crate::producer::admin::ManagedProducerAdmin;
 use crate::producer::types::ProducerConnectionItem;
 use crate::producer::types::ProducerConnectionView;
+use crate::producer::types::ProducerGroupItem;
 use crate::producer::types::ProducerResult;
 use crate::producer::types::ProducerTopicOptionsView;
 use rocketmq_admin_core::client_adapter::AdminSession;
@@ -126,6 +127,25 @@ impl ProducerManager {
         }
     }
 
+    pub(crate) async fn list_producer_groups(&self) -> ProducerResult<Vec<ProducerGroupItem>> {
+        let mut session_guard = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session_guard).await?;
+        let session = session_guard
+            .as_ref()
+            .ok_or(ProducerError::Internal("Producer session was not initialized"))?;
+        let result = session
+            .admin
+            .dashboard_list_producers()
+            .await
+            .map(|items| items.into_iter().map(map_producer_group).collect())
+            .map_err(ProducerError::Admin);
+        if Self::should_reset_session(&result) {
+            self.reset_admin_session(&mut session_guard, "list_producer_groups failed")
+                .await;
+        }
+        result
+    }
+
     fn validate_query_request(&self, request: &ProducerConnectionQueryRequest) -> ProducerResult<()> {
         if request.topic.trim().is_empty() {
             return Err(ProducerError::Validation("Topic is required.".into()));
@@ -233,8 +253,27 @@ fn build_connection_view(
     }
 }
 
+fn map_producer_group(item: rocketmq_admin_core::core::dashboard::DashboardProducerInfo) -> ProducerGroupItem {
+    ProducerGroupItem {
+        producer_group: item.producer_group,
+        reported_connection_count: item.connection_count,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn discovered_zero_connection_group_is_preserved_without_inventing_clients() {
+        let item = super::map_producer_group(rocketmq_admin_core::core::dashboard::DashboardProducerInfo {
+            topic: String::new(),
+            producer_group: "idle-group".into(),
+            connection_count: 0,
+        });
+        assert_eq!(item.producer_group, "idle-group");
+        assert_eq!(item.reported_connection_count, 0);
+        assert!(!serde_json::to_string(&item).unwrap().contains("clients"));
+    }
+
     use super::ProducerTopicOptionsView;
     use super::build_connection_view;
     use rocketmq_admin_core::core::dashboard::DashboardProducerConnection;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/types.rs
@@ -44,3 +44,10 @@ pub(crate) struct ProducerConnectionView {
     pub(crate) connection_count: usize,
     pub(crate) connections: Vec<ProducerConnectionItem>,
 }
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProducerGroupItem {
+    pub(crate) producer_group: String,
+    pub(crate) reported_connection_count: usize,
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ProducerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ProducerView.tsx
@@ -1,3 +1,4 @@
+import { ProducerGroupDirectory } from '../features/producer/components/ProducerGroupDirectory';
 import React, {useEffect, useMemo, useState} from 'react';
 import {motion} from 'motion/react';
 import {
@@ -46,7 +47,7 @@ export const ProducerView = () => {
     const versionCount = new Set(clients.map((client) => client.versionDesc).filter(Boolean)).size;
     const runtimeLabel = selectedClient?.language ?? 'Pending';
     const versionLabel = selectedClient?.versionDesc ?? 'No client';
-    const connectionCount = result?.connectionCount ?? clients.length;
+    const connectionCount = result?.connectionCount ?? '—';
     const canSearch = Boolean(selectedTopic.trim()) && Boolean(producerGroup.trim()) && !isTopicLoading && !isSearchPending;
 
     useEffect(() => {
@@ -83,7 +84,7 @@ export const ProducerView = () => {
                     <div>
                         <span>Connections</span>
                         <strong>{connectionCount}</strong>
-                        <small>{hasSearched ? 'active producer clients' : 'run a scoped lookup'}</small>
+                        <small>{result ? 'clients from the scoped lookup' : error ? 'lookup unavailable' : 'run a scoped lookup'}</small>
                     </div>
                     <span className="topic-summary-icon">
                         <RadioTower className="topic-icon" aria-hidden="true"/>
@@ -111,6 +112,7 @@ export const ProducerView = () => {
                 </div>
             </section>
 
+            <ProducerGroupDirectory selectedGroup={producerGroup} onSelect={setProducerGroup} />
             <form
                 className="producer-command-panel"
                 aria-label="Producer connection search"
@@ -196,7 +198,7 @@ export const ProducerView = () => {
                         </div>
                     </div>
 
-                    {hasSearched && !isSearching && clients.length === 0 ? (
+                    {hasSearched && !error && result && !isSearching && clients.length === 0 ? (
                         <div className="producer-empty-state">
                             <Users className="topic-icon" aria-hidden="true"/>
                             <strong>No producer connections</strong>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/components/ProducerGroupDirectory.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/components/ProducerGroupDirectory.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ProducerService } from '../../../services/producer.service';
+import { dashboardErrorMessage } from '../../../services/invoke';
+import { Pagination } from '../../../components/Pagination';
+import { ProducerRequestGuard } from '../requestGuard';
+import type { ProducerGroupItem } from '../types/producer.types';
+
+export function ProducerGroupDirectory({ selectedGroup, onSelect }: { selectedGroup: string; onSelect: (group: string) => void }) {
+    const [items, setItems] = useState<ProducerGroupItem[] | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+    const [query, setQuery] = useState('');
+    const [page, setPage] = useState(1);
+    const guard = useRef(new ProducerRequestGuard());
+    const load = async () => {
+        const isCurrent = guard.current.begin();
+        setLoading(true);
+        setError('');
+        setItems(null);
+        try {
+            const groups = await ProducerService.listProducerGroups();
+            if (!isCurrent()) return;
+            setItems(groups);
+            setPage(1);
+        } catch (error) {
+            if (isCurrent()) setError(dashboardErrorMessage(error, 'Unable to read the Producer directory.'));
+        } finally { if (isCurrent()) setLoading(false); }
+    };
+    useEffect(() => { void load(); return () => guard.current.invalidate(); }, []);
+    const filtered = useMemo(() => (items ?? []).filter(item => item.producerGroup.toLowerCase().includes(query.trim().toLowerCase())), [items, query]);
+    const totalPages = Math.max(1, Math.ceil(filtered.length / 8));
+    return <section aria-label="Discovered Producer groups" className="rounded-xl border bg-white p-5 dark:border-gray-800 dark:bg-gray-900">
+        <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <h2 className="font-semibold">Discovered Producer groups</h2>
+            <input aria-label="Search Producer groups" placeholder="Search group name" value={query} onChange={event => { setQuery(event.target.value); setPage(1); }} className="rounded border bg-transparent px-3 py-2 text-sm" />
+            <button type="button" disabled={loading} onClick={() => void load()} className="rounded border px-3 py-2 text-sm">{loading ? 'Loading…' : 'Refresh directory'}</button>
+        </header>
+        <p className="mb-3 text-sm text-gray-500">Discovery reports group names and Broker connection counts, not a complete client list. Coverage is not reported; counts can overlap across Brokers. Select a group, then query its Topic connections below. Manual group input remains available.</p>
+        {error && <p role="alert" className="text-red-600">{error}</p>}
+        {!loading && !error && items === null && <p>Directory has not been queried.</p>}
+        {!loading && items?.length === 0 && <p>No Producer groups were reported. Discovery coverage is unavailable.</p>}
+        {!loading && Boolean(items?.length) && filtered.length === 0 && <p>No group matches this search.</p>}
+        <div className="grid gap-2 sm:grid-cols-2">{filtered.slice((page - 1) * 8, page * 8).map(item => <button key={item.producerGroup} type="button"
+            aria-pressed={selectedGroup === item.producerGroup} onClick={() => onSelect(item.producerGroup)}
+            className={`flex items-center justify-between gap-3 rounded border p-3 text-left text-sm ${selectedGroup === item.producerGroup ? 'border-blue-500 bg-blue-50 dark:bg-blue-950' : ''}`}>
+            <span className="break-all font-mono">{item.producerGroup}</span><span>{item.reportedConnectionCount} reported connections</span>
+        </button>)}</div>
+        {totalPages > 1 && <Pagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />}
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/hooks/useProducerConnections.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/hooks/useProducerConnections.ts
@@ -1,44 +1,66 @@
-import { useEffect, useState } from 'react';
+import { ProducerRequestGuard } from '../requestGuard';
+import { useEffect, useState, useRef } from 'react';
 import { ProducerService } from '../../../services/producer.service';
 import { dashboardErrorMessage } from '../../../services/invoke';
 import type { ProducerConnectionView } from '../types/producer.types';
 const SEARCH_INDICATOR_DELAY_MS = 180;
 
-const defaultProducerGroup = 'please_rename_unique_group_name';
 
 export const useProducerConnections = () => {
     const [topicOptions, setTopicOptions] = useState<string[]>([]);
-    const [selectedTopic, setSelectedTopic] = useState('');
-    const [producerGroup, setProducerGroup] = useState(defaultProducerGroup);
+    const [selectedTopic, storeSelectedTopic] = useState('');
+    const [producerGroup, storeProducerGroup] = useState('');
     const [result, setResult] = useState<ProducerConnectionView | null>(null);
     const [isTopicLoading, setIsTopicLoading] = useState(true);
     const [isSearchPending, setIsSearchPending] = useState(false);
     const [isSearching, setIsSearching] = useState(false);
     const [hasSearched, setHasSearched] = useState(false);
     const [error, setError] = useState('');
+    const guard = useRef(new ProducerRequestGuard());
+    const indicator = useRef<number | null>(null);
+    const invalidate = () => {
+        guard.current.invalidate();
+        if (indicator.current !== null) window.clearTimeout(indicator.current);
+        setIsSearchPending(false);
+        setIsSearching(false);
+        setResult(null);
+        setHasSearched(false);
+        setError('');
+    };
+    const setSelectedTopic = (topic: string) => { invalidate(); storeSelectedTopic(topic); };
+    const setProducerGroup = (group: string) => { invalidate(); storeProducerGroup(group); };
+
 
     useEffect(() => {
+        let cancelled = false;
         const loadTopics = async () => {
             setIsTopicLoading(true);
             setError('');
 
             try {
                 const response = await ProducerService.getProducerTopicOptions();
+                if (cancelled) return;
                 setTopicOptions(response.topics);
-                setSelectedTopic((current) => {
+                storeSelectedTopic((current) => {
                     if (current && response.topics.includes(current)) {
                         return current;
                     }
                     return response.topics[0] ?? '';
                 });
             } catch (loadError) {
+                if (cancelled) return;
                 setError(dashboardErrorMessage(loadError, 'Failed to load producer topics'));
             } finally {
-                setIsTopicLoading(false);
+                if (!cancelled) setIsTopicLoading(false);
             }
         };
 
         void loadTopics();
+        return () => {
+            cancelled = true;
+            guard.current.invalidate();
+            if (indicator.current !== null) window.clearTimeout(indicator.current);
+        };
     }, []);
 
     const search = async () => {
@@ -54,11 +76,14 @@ export const useProducerConnections = () => {
             return false;
         }
 
+        const isCurrent = guard.current.begin();
+        if (indicator.current !== null) window.clearTimeout(indicator.current);
         let searchIndicatorTimer: number | null = null;
         setIsSearchPending(true);
         searchIndicatorTimer = window.setTimeout(() => {
-            setIsSearching(true);
+            if (isCurrent()) setIsSearching(true);
         }, SEARCH_INDICATOR_DELAY_MS);
+        indicator.current = searchIndicatorTimer;
         setError('');
 
         try {
@@ -66,10 +91,12 @@ export const useProducerConnections = () => {
                 topic,
                 producerGroup: group,
             });
+            if (!isCurrent()) return false;
             setResult(response);
             setHasSearched(true);
             return true;
         } catch (searchError) {
+            if (!isCurrent()) return false;
             setResult(null);
             setHasSearched(true);
             setError(dashboardErrorMessage(searchError, 'Failed to query producer connections'));
@@ -78,8 +105,10 @@ export const useProducerConnections = () => {
             if (searchIndicatorTimer !== null) {
                 window.clearTimeout(searchIndicatorTimer);
             }
-            setIsSearchPending(false);
-            setIsSearching(false);
+            if (isCurrent()) {
+                setIsSearchPending(false);
+                setIsSearching(false);
+            }
         }
     };
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/requestGuard.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/requestGuard.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ProducerRequestGuard } from './requestGuard';
+
+describe('Producer request ownership', () => {
+    it('discards a delayed response after changing the Group or starting a newer lookup', async () => {
+        const guard = new ProducerRequestGuard();
+        const applied: string[] = [];
+        let completeOld!: (value: string) => void;
+        const old = new Promise<string>(resolve => { completeOld = resolve; });
+        const oldCurrent = guard.begin();
+        const pending = old.then(value => { if (oldCurrent()) applied.push(value); });
+        guard.invalidate();
+        const newCurrent = guard.begin();
+        if (newCurrent()) applied.push('new-group');
+        completeOld('old-group');
+        await pending;
+        expect(applied).toEqual(['new-group']);
+        guard.invalidate();
+        expect(newCurrent()).toBe(false);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/requestGuard.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/requestGuard.ts
@@ -1,0 +1,8 @@
+export class ProducerRequestGuard {
+    private revision = 0;
+    begin(): () => boolean {
+        const revision = ++this.revision;
+        return () => revision === this.revision;
+    }
+    invalidate(): void { this.revision++; }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/types/producer.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/types/producer.types.ts
@@ -26,3 +26,8 @@ export interface ProducerConnectionQueryRequest {
     topic: string;
     producerGroup: string;
 }
+
+export interface ProducerGroupItem {
+    producerGroup: string;
+    reportedConnectionCount: number;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/producer.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/producer.service.ts
@@ -1,12 +1,17 @@
 import { invokeAuthenticatedCommand } from './invoke';
 import type {
     ProducerConnectionQueryRequest,
+    ProducerGroupItem,
     ProducerConnectionView,
     ProducerTopicOptionsRequest,
     ProducerTopicOptionsView,
 } from '../features/producer/types/producer.types';
 
 export class ProducerService {
+    static async listProducerGroups(): Promise<ProducerGroupItem[]> {
+        return invokeAuthenticatedCommand<ProducerGroupItem[]>('list_producer_groups');
+    }
+
     static async getProducerTopicOptions(
         request: ProducerTopicOptionsRequest = {},
     ): Promise<ProducerTopicOptionsView> {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10388

### Brief Description

The Producer page now loads a searchable, paginated group directory through an authenticated DashboardAdmin query. Selecting a discovered group fills the existing Topic + Group lookup; manual input starts empty. Counts are labeled as Broker-reported observations with unavailable coverage, never as a complete client inventory.

Changing Group or Topic clears old connection results and invalidates outstanding callbacks and loading indicators. Directory errors, empty reports, zero-connection groups, and unqueried client details remain distinct.

### How Did You Test This Change?

- `cargo test --lib producer::`: 3 passed; package-scoped Rust format check passed.
- Delayed Producer response regression test passed.
- `npm run build` and `git diff --check` passed; existing bundle-size warning remains.
- The underlying discovery API does not report Broker coverage. This limitation is documented and displayed in the directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Producer Group directory with search, pagination, refresh, and group selection.
  - Displays reported Broker connection counts, including groups with zero connections.
  - Added clear loading, empty, and error states for group discovery and connection lookups.
  - Clarified that counts represent reported connections, not a complete client inventory.

- **Bug Fixes**
  - Prevented outdated or cancelled searches and lookups from overwriting current results.
  - Improved connection summary messaging before results are available or when lookups fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->