### PR TITLE
[ISSUE #10394]🚀Summarize Tauri Consumer configuration across Brokers

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_CONFIG_SUMMARY.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_CONFIG_SUMMARY.md
@@ -1,0 +1,9 @@
+# Consumer configuration summary
+
+Configuration reads discover the current group through NameServer and query each Broker separately. This is a Broker configuration operation even when the Consumer list uses a Proxy. The existing single-Broker command remains available.
+
+The overview retains every discovered target, its configuration or a safe error, and any Broker whose group inventory could not be discovered. `complete` is false for empty, failed, or incomplete discovery. `effective` contains only fields common to successful reads; these are not evidence of cluster-wide consistency when coverage is incomplete. `inconsistentFields` compares successful configurations, including subscriptions and attributes, excluding Broker identity. Subscription and attribute ordering does not create false differences.
+
+Select a successful Broker to inspect or edit it. The editor displays its source, requires a successful source read, and initially selects only that Broker with no cluster expansion. Changing the source replaces the draft. Any added target receives the source-derived edited values, and the target names remain visible before submission. Failed source reads cannot submit default values.
+
+Validation covers differing Broker retry values with a failed third Broker, preservation of common values and individual configurations, empty and incomplete discovery, and a complete single-Broker summary.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
@@ -173,6 +173,25 @@ pub async fn query_consumer_config(
 }
 
 #[tauri::command]
+pub async fn query_consumer_config_summary(
+    session_id: String,
+    consumer_group: String,
+    consumer_manager: State<'_, ConsumerManager>,
+    session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
+) -> CommandResult<super::service::config_summary::ConsumerConfigSummary> {
+    authorize_command(&session_id, &session_state).await?;
+    connection_manager.check_revision(expected_revision)?;
+    let result = consumer_manager
+        .query_consumer_config_summary(consumer_group)
+        .await
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
+}
+
+#[tauri::command]
 pub async fn create_or_update_consumer_group(
     session_id: String,
     request: ConsumerCreateOrUpdateRequest,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
@@ -47,6 +47,7 @@ use rocketmq_dashboard_common::NameServerConfigSnapshot;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+pub(crate) mod config_summary;
 mod mapping;
 
 use self::mapping::build_summary;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service/config_summary.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service/config_summary.rs
@@ -1,0 +1,192 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use rocketmq_admin_core::core::consumer_workspace::WorkspaceFailureStage;
+use serde::Serialize;
+use serde_json::Value;
+
+use super::*;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConfigTarget {
+    cluster_name: String,
+    broker_name: String,
+    broker_address: String,
+    config: Option<ConsumerConfigView>,
+    error: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConsumerConfigSummary {
+    consumer_group: String,
+    targets: Vec<ConfigTarget>,
+    discovery_failures: Vec<String>,
+    complete: bool,
+    inconsistent_fields: Vec<String>,
+    // Only values common to successful reads. `complete` qualifies the coverage.
+    effective: BTreeMap<String, Value>,
+}
+
+impl ConsumerManager {
+    pub(crate) async fn query_consumer_config_summary(&self, group: String) -> ConsumerResult<ConsumerConfigSummary> {
+        let group = validate_consumer_group_name(&group)?;
+        let mut session = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session).await?;
+        let admin = &mut session
+            .as_mut()
+            .ok_or_else(|| ConsumerError::Validation("Consumer connection unavailable.".into()))?
+            .admin;
+        // Workspace discovery retains failed inventory targets; the legacy catalog does not.
+        let discovery = admin.consumer_configuration(&group).await.map_err(map_admin_error)?;
+        let discovery_failures = discovery
+            .failures
+            .into_iter()
+            .filter(|failure| failure.stage == WorkspaceFailureStage::Inventory)
+            .map(|failure| failure.target)
+            .collect();
+        let mut targets = Vec::with_capacity(discovery.targets.len());
+        for target in discovery.targets {
+            let identity = target.target;
+            let result = admin
+                .query_dashboard_consumer_config(&DashboardConsumerConfigRequest {
+                    consumer_group: group.clone(),
+                    address: Some(identity.broker_address.clone()),
+                })
+                .await;
+            let (config, error) = match result {
+                Ok(config) => (Some(map_consumer_config_view(config)), None),
+                Err(_) => (None, Some("Configuration unavailable on this Broker.".into())),
+            };
+            targets.push(ConfigTarget {
+                cluster_name: identity.cluster_name,
+                broker_name: identity.broker_name,
+                broker_address: identity.broker_address,
+                config,
+                error,
+            });
+        }
+        summarize(group, targets, discovery_failures)
+    }
+}
+
+fn summarize(
+    group: String,
+    targets: Vec<ConfigTarget>,
+    discovery_failures: Vec<String>,
+) -> ConsumerResult<ConsumerConfigSummary> {
+    let mut values = Vec::new();
+    for config in targets.iter().filter_map(|target| target.config.as_ref()) {
+        let mut config = config.clone();
+        config.subscription_topics.sort();
+        config
+            .attributes
+            .sort_by(|a, b| a.key.cmp(&b.key).then(a.value.cmp(&b.value)));
+        let Value::Object(mut fields) = serde_json::to_value(config)
+            .map_err(|_| ConsumerError::Validation("Cannot represent Consumer configuration.".into()))?
+        else {
+            return Err(ConsumerError::Validation("Invalid Consumer configuration.".into()));
+        };
+        for identity in ["consumerGroup", "brokerName", "brokerAddress"] {
+            fields.remove(identity);
+        }
+        values.push(fields);
+    }
+    let mut effective = BTreeMap::new();
+    let mut inconsistent_fields = Vec::new();
+    if let Some(first) = values.first() {
+        for (field, value) in first {
+            if values.iter().all(|fields| fields.get(field) == Some(value)) {
+                effective.insert(field.clone(), value.clone());
+            } else {
+                inconsistent_fields.push(field.clone());
+            }
+        }
+    }
+    Ok(ConsumerConfigSummary {
+        consumer_group: group,
+        complete: !targets.is_empty() && values.len() == targets.len() && discovery_failures.is_empty(),
+        targets,
+        discovery_failures,
+        inconsistent_fields,
+        effective,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(name: &str, retries: Option<i32>) -> ConfigTarget {
+        let config = retries.map(|retry_max_times| ConsumerConfigView {
+            consumer_group: "group".into(),
+            broker_name: name.into(),
+            broker_address: name.into(),
+            consume_enable: true,
+            consume_from_min_enable: true,
+            consume_broadcast_enable: true,
+            consume_message_orderly: false,
+            retry_queue_nums: 1,
+            retry_max_times,
+            broker_id: 0,
+            which_broker_when_consume_slowly: 1,
+            notify_consumer_ids_changed_enable: true,
+            group_sys_flag: 0,
+            consume_timeout_minute: 15,
+            group_retry_policy_json: "{}".into(),
+            subscription_topic_count: 0,
+            subscription_topics: vec![],
+            attributes: vec![],
+        });
+        ConfigTarget {
+            cluster_name: "cluster".into(),
+            broker_name: name.into(),
+            broker_address: name.into(),
+            error: config.is_none().then(|| "unavailable".into()),
+            config,
+        }
+    }
+
+    #[test]
+    fn summary_preserves_differences_common_fields_and_failures() {
+        let summary = summarize(
+            "group".into(),
+            vec![target("a", Some(2)), target("b", Some(3)), target("c", None)],
+            vec![],
+        )
+        .unwrap();
+        assert!(!summary.complete);
+        assert_eq!(summary.inconsistent_fields, ["retryMaxTimes"]);
+        assert_eq!(summary.effective["consumeEnable"], true);
+        assert!(!summary.effective.contains_key("retryMaxTimes"));
+        assert!(summary.targets[2].error.is_some());
+        assert_eq!(summary.targets[1].config.as_ref().unwrap().retry_max_times, 3);
+    }
+
+    #[test]
+    fn summary_never_claims_complete_for_missing_or_undiscovered_targets() {
+        assert!(!summarize("group".into(), vec![], vec![]).unwrap().complete);
+        let single = summarize("group".into(), vec![target("a", Some(2))], vec![]).unwrap();
+        assert!(single.complete);
+        assert_eq!(single.effective["retryMaxTimes"], 2);
+        assert!(
+            !summarize("group".into(), vec![target("a", Some(2))], vec!["b".into()])
+                .unwrap()
+                .complete
+        );
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -287,6 +287,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
             consumer::commands::query_consumer_connection,
             consumer::commands::query_consumer_topic_detail,
             consumer::commands::query_consumer_config,
+            consumer::commands::query_consumer_config_summary,
             consumer::commands::create_or_update_consumer_group,
             consumer::commands::delete_consumer_group,
             dashboard::commands::get_dashboard_broker_overview,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerConfigModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerConfigModal.tsx
@@ -1,5 +1,5 @@
 import { isReadOnlyConsumer } from '../mutation';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
     Activity,
@@ -17,6 +17,7 @@ import {
 import { ConsumerService } from '../../../services/consumer.service';
 import { dashboardErrorMessage } from '../../../services/invoke';
 import type {
+    ConsumerConfigSummary,
     ConsumerConfigView,
     ConsumerGroupListItem,
 } from '../types/consumer.types';
@@ -72,61 +73,28 @@ export const ConsumerConfigModal = ({
     consumer,
     onEdit,
 }: ConsumerConfigModalProps) => {
-    const brokerAddresses = useMemo(() => consumer?.brokerAddresses ?? [], [consumer]);
     const [selectedBrokerAddress, setSelectedBrokerAddress] = useState('');
     const [activeSection, setActiveSection] = useState<ConfigSectionKey>('overview');
-    const [data, setData] = useState<ConsumerConfigView | null>(null);
+    const [summary, setSummary] = useState<ConsumerConfigSummary | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
+    const [refresh, setRefresh] = useState(0);
+    const brokerAddresses = summary?.targets.map(target => target.brokerAddress) ?? [];
+    const target = summary?.targets.find(target => target.brokerAddress === selectedBrokerAddress);
+    const data = target?.config ?? null;
 
     useEffect(() => {
-        if (!isOpen || !consumer) {
-            return;
-        }
-
-        setActiveSection('overview');
-        setSelectedBrokerAddress((current) => {
-            if (current && brokerAddresses.includes(current)) {
-                return current;
-            }
-            return brokerAddresses[0] ?? '';
-        });
-    }, [brokerAddresses, consumer, isOpen]);
-
-    useEffect(() => {
-        if (!isOpen || !consumer || !selectedBrokerAddress) {
-            return;
-        }
-
+        if (!isOpen || !consumer) return;
         let cancelled = false;
-        setIsLoading(true);
-        setError('');
-        setData(null);
-
-        void ConsumerService.queryConsumerConfig({
-            consumerGroup: consumer.rawGroupName,
-            address: selectedBrokerAddress,
-        })
-            .then((response) => {
-                if (!cancelled) {
-                    setData(response);
-                }
-            })
-            .catch((loadError) => {
-                if (!cancelled) {
-                    setError(dashboardErrorMessage(loadError, 'Failed to load consumer configuration.'));
-                }
-            })
-            .finally(() => {
-                if (!cancelled) {
-                    setIsLoading(false);
-                }
-            });
-
-        return () => {
-            cancelled = true;
-        };
-    }, [consumer, isOpen, selectedBrokerAddress]);
+        setIsLoading(true); setError(''); setSummary(null); setSelectedBrokerAddress('');
+        setActiveSection('overview');
+        void ConsumerService.queryConsumerConfigSummary(consumer.rawGroupName).then(response => {
+            if (!cancelled) setSummary(response);
+        }).catch(error => {
+            if (!cancelled) setError(dashboardErrorMessage(error, 'Failed to load Consumer configuration summary.'));
+        }).finally(() => { if (!cancelled) setIsLoading(false); });
+        return () => { cancelled = true; };
+    }, [consumer, isOpen, refresh]);
 
     if (!isOpen) {
         return null;
@@ -190,6 +158,24 @@ export const ConsumerConfigModal = ({
                     </header>
 
                     <div className="topic-status-body consumer-config-body">
+                        <button type="button" disabled={isLoading} onClick={() => setRefresh(value => value + 1)}>Refresh all Brokers</button>
+                        {summary && <section aria-label="Cross Broker configuration summary" className="space-y-3 p-4">
+                            <strong>{summary.complete ? 'All discovered Brokers read' : 'Incomplete coverage — consistency across all Brokers is unknown'}</strong>
+                            {summary.discoveryFailures.length > 0 && <p role="alert">Inventory unavailable: {summary.discoveryFailures.join(', ')}</p>}
+                            <p>Different fields: {summary.inconsistentFields.join(', ') || 'None among successful reads'}</p>
+                            <details><summary>Common values among successful reads</summary><pre className="overflow-auto">{JSON.stringify(summary.effective, null, 2)}</pre></details>
+                            <table className="w-full text-left"><thead><tr><th>Broker / Cluster</th><th>Address</th><th>Result</th></tr></thead>
+                                <tbody>{summary.targets.map(item => <tr key={item.brokerAddress}>
+                                    <td>{item.brokerName} / {item.clusterName}</td><td>{item.brokerAddress}</td>
+                                    <td><button type="button" onClick={() => setSelectedBrokerAddress(item.brokerAddress)}>View details</button> {item.error || 'Read'}</td>
+                                </tr>)}</tbody>
+                            </table>
+                            {target?.error && <p role="alert">{target.brokerName}: {target.error}</p>}
+                            {data && summary.inconsistentFields.length > 0 && <div className="rounded border border-amber-400 p-3"><strong>Different values on {target?.brokerName}</strong>
+                                {summary.inconsistentFields.map(field => <p key={field}>{field}: {JSON.stringify(data[field as keyof typeof data])}</p>)}
+                            </div>}
+                        </section>}
+
                         <section className="consumer-config-broker-scope" aria-label="Broker address scope">
                             <div>
                                 <span>Broker Address</span>
@@ -203,6 +189,7 @@ export const ConsumerConfigModal = ({
                                     onChange={(event) => setSelectedBrokerAddress(event.target.value)}
                                     disabled={brokerAddresses.length === 0}
                                 >
+                                    <option value="">Select a Broker for details and editing</option>
                                     {brokerAddresses.length > 0 ? (
                                         brokerAddresses.map((address) => (
                                             <option key={address} value={address}>
@@ -220,7 +207,7 @@ export const ConsumerConfigModal = ({
                             <div className="topic-status-state">
                                 <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true" />
                                 <strong>Loading consumer configuration</strong>
-                                <span>Querying group settings from the selected broker address.</span>
+                                <span>Querying the current group configuration on each discovered Broker.</span>
                             </div>
                         ) : error ? (
                             <div className="topic-status-state is-error">
@@ -305,8 +292,8 @@ export const ConsumerConfigModal = ({
                         ) : (
                             <div className="topic-status-state">
                                 <Settings className="topic-icon" aria-hidden="true" />
-                                <strong>No consumer configuration</strong>
-                                <span>No consumer configuration was returned for the selected broker address.</span>
+                                <strong>{selectedBrokerAddress ? "No consumer configuration" : "Select a Broker for details"}</strong>
+                                <span>The summary above retains each Broker result. Select a successful Broker to inspect its fields.</span>
                             </div>
                         )}
                     </div>
@@ -318,7 +305,7 @@ export const ConsumerConfigModal = ({
                                 <button
                                     type="button"
                                     onClick={() => onEdit(consumer, selectedBrokerAddress)}
-                                    disabled={isReadOnlyConsumer(consumer)}
+                                    disabled={!data || isReadOnlyConsumer(consumer)}
                                     title={isReadOnlyConsumer(consumer) ? "System Consumer groups are read-only." : undefined}
                                     className="topic-status-primary-button consumer-config-edit-button"
                                 >

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerEditorModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerEditorModal.tsx
@@ -139,16 +139,6 @@ const buildClusterOptions = (items: ClusterBrokerCardItem[]): ClusterBrokerOptio
         .sort((left, right) => left.clusterName.localeCompare(right.clusterName));
 };
 
-const deriveClusterSelection = (
-    options: ClusterBrokerOptionGroup[],
-    brokerNames: string[],
-): string[] => {
-    const selected = new Set(brokerNames);
-    return options
-        .filter((option) => option.brokers.some((brokerName) => selected.has(brokerName)))
-        .map((option) => option.clusterName);
-};
-
 const mergeConfigIntoForm = (
     config: ConsumerConfigView,
     clusterNameList: string[],
@@ -181,6 +171,9 @@ export const ConsumerEditorModal = ({
     onSaved,
 }: ConsumerEditorModalProps) => {
     const isEditMode = Boolean(consumer);
+    const [configSource, setConfigSource] = useState('');
+    const [sourceLoaded, setSourceLoaded] = useState(false);
+    useEffect(() => { setConfigSource(preferredBrokerAddress ?? ''); }, [consumer, isOpen, preferredBrokerAddress]);
     const [form, setForm] = useState<ConsumerEditorFormState>(createDefaultFormState);
     const [clusterOptions, setClusterOptions] = useState<ClusterBrokerOptionGroup[]>([]);
     const [activeSection, setActiveSection] = useState<EditorSectionKey>('basic');
@@ -194,7 +187,7 @@ export const ConsumerEditorModal = ({
         setReceipt(null);
         setIsSaving(false);
         return () => generation.current.invalidate();
-    }, [isOpen, consumer]);
+    }, [isOpen, consumer, configSource]);
 
 
     useEffect(() => {
@@ -210,6 +203,7 @@ export const ConsumerEditorModal = ({
 
         let cancelled = false;
         setIsLoading(true);
+        setSourceLoaded(false);
         setError('');
 
         const load = async () => {
@@ -226,18 +220,9 @@ export const ConsumerEditorModal = ({
                     return;
                 }
 
-                const brokerNames = [...(consumer.brokerNames ?? [])].sort((left, right) =>
-                    left.localeCompare(right),
-                );
-                const clusterNames = deriveClusterSelection(options, brokerNames);
-                const configAddress = preferredBrokerAddress || consumer.brokerAddresses[0];
+                const configAddress = configSource;
                 if (!configAddress) {
-                    setForm({
-                        ...createDefaultFormState(),
-                        consumerGroup: consumer.rawGroupName,
-                        brokerNameList: brokerNames,
-                        clusterNameList: clusterNames,
-                    });
+                    setForm({ ...createDefaultFormState(), consumerGroup: consumer.rawGroupName });
                     return;
                 }
 
@@ -246,7 +231,11 @@ export const ConsumerEditorModal = ({
                     address: configAddress,
                 });
                 if (!cancelled) {
-                    setForm(mergeConfigIntoForm(config, clusterNames, brokerNames));
+                    if (!config.brokerName || !options.some(option => option.brokers.includes(config.brokerName))) {
+                        throw new Error('The source Broker is no longer in the current cluster. Refresh the group before editing.');
+                    }
+                    setForm(mergeConfigIntoForm(config, [], [config.brokerName]));
+                    setSourceLoaded(true);
                 }
             } catch (loadError) {
                 if (!cancelled) {
@@ -269,7 +258,7 @@ export const ConsumerEditorModal = ({
         return () => {
             cancelled = true;
         };
-    }, [consumer, isOpen, preferredBrokerAddress]);
+    }, [consumer, isOpen, configSource]);
 
     const brokerOptions = useMemo(
         () =>
@@ -330,7 +319,7 @@ export const ConsumerEditorModal = ({
     };
 
     const handleSubmit = async () => {
-        if (isSaving || receipt || isReadOnlyConsumer(consumer)) return;
+        if (isLoading || isSaving || receipt || isReadOnlyConsumer(consumer) || (isEditMode && !sourceLoaded)) return;
         const isCurrent = generation.current.begin();
         setError('');
         const trimmedGroup = form.consumerGroup.trim();
@@ -564,6 +553,18 @@ export const ConsumerEditorModal = ({
                     </header>
 
                     <div className="topic-status-body consumer-editor-body">
+                        {consumer && <label className="block p-4">Configuration source
+                            <select aria-label="Configuration source Broker" value={configSource} disabled={isSaving || Boolean(receipt)} onChange={event => setConfigSource(event.target.value)}>
+                                <option value="">Select a Broker before editing</option>
+                                {consumer.brokerAddresses.map(address => <option key={address} value={address}>{address}</option>)}
+                            </select>
+                            <p>Loading another source replaces this draft. Only that Broker is initially selected; expanding the target selection applies these values to the added Brokers.</p>
+                        </label>}
+                        <p className="p-4" role="status">Write targets: {[...new Set([
+                            ...form.brokerNameList,
+                            ...clusterOptions.filter(option => form.clusterNameList.includes(option.clusterName)).flatMap(option => option.brokers),
+                        ])].join(', ') || 'None selected'}</p>
+
                         {isLoading ? (
                             <div className="topic-status-state">
                                 <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true" />
@@ -710,7 +711,7 @@ export const ConsumerEditorModal = ({
                             <button
                                 type="button"
                                 onClick={() => void handleSubmit()}
-                                disabled={isLoading || isSaving || Boolean(receipt) || isReadOnlyConsumer(consumer)}
+                                disabled={(isEditMode && !sourceLoaded) || isLoading || isSaving || Boolean(receipt) || isReadOnlyConsumer(consumer)}
                                 className="topic-status-primary-button consumer-editor-save-button"
                             >
                                 {isSaving ? (

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
@@ -170,3 +170,12 @@ export interface ConsumerTargetResult {
     errorCode: string | null;
     message: string;
 }
+
+export interface ConsumerConfigSummary {
+    consumerGroup: string;
+    targets: { clusterName: string; brokerName: string; brokerAddress: string; config: ConsumerConfigView | null; error: string | null }[];
+    discoveryFailures: string[];
+    complete: boolean;
+    inconsistentFields: string[];
+    effective: Partial<Omit<ConsumerConfigView, 'consumerGroup' | 'brokerName' | 'brokerAddress'>>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
@@ -2,6 +2,7 @@ import { invokeAuthenticatedCommand } from './invoke';
 import type {
     ConsumerConfigQueryRequest,
     ConsumerConfigView,
+    ConsumerConfigSummary,
     ConsumerCreateOrUpdateRequest,
     ConsumerDeleteRequest,
     ConsumerConnectionQueryRequest,
@@ -16,6 +17,10 @@ import type {
 } from '../features/consumer/types/consumer.types';
 
 export class ConsumerService {
+    static async queryConsumerConfigSummary(consumerGroup: string): Promise<ConsumerConfigSummary> {
+        return invokeAuthenticatedCommand<ConsumerConfigSummary>('query_consumer_config_summary', { consumerGroup });
+    }
+
     static async queryConsumerGroups(request: ConsumerGroupListRequest): Promise<ConsumerGroupListResponse> {
         return invokeAuthenticatedCommand<ConsumerGroupListResponse>('query_consumer_groups', { request });
     }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10394

### Brief Description
Display per-Broker Consumer configuration, failed discovery and reads, common successful values, and differing fields without claiming consistency for incomplete coverage. Preserve single-Broker inspection and require an explicit, successfully loaded editor source, initially selecting only that Broker.

### How Did You Test This Change?
- Tauri `cargo test --lib consumer::`: 12 passed, including differing values, partial failure, incomplete discovery, and single-Broker summaries.
- Frontend `npm run build`: passed.
- Package-scoped formatting and `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-Broker consumer configuration summaries, showing common values, differences, discovery issues, completeness, and per-Broker results.
  * Added a “Refresh all Brokers” option and detailed views for individual Broker configurations.
  * Added configuration-source selection in the consumer editor, requiring a successfully loaded source before editing or saving.
  * Forms now initialize from the selected source Broker and apply its values when adding targets.

* **Documentation**
  * Added documentation covering summary behavior, editing workflows, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->