### PR TITLE
[ISSUE #10396]🚀Reset Tauri Consumer offsets with reviewed scope and readback

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/OFFSET_RESET.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/OFFSET_RESET.md
@@ -1,0 +1,9 @@
+# Reviewed Consumer offset reset
+
+Topic operations and the Consumer detail Reset offset tab use the same form. The detail flow fixes the exact Consumer group and gets Topic choices from its progress. System groups are read-only. The existing audited reset command retains current connection revision and protected Topic checks, and now also rejects protected/blank groups and negative reset timestamps before opening an admin session.
+
+Enter a local date and minute and review the Topic, group, displayed timezone, millisecond timestamp, and force flag. Invalid dates (including nonexistent local times) cannot be submitted. Changing inputs clears confirmation; changing the entity/scope or closing the form disposes pending callbacks. Accepted remote work can finish, but cannot refresh another group's page.
+
+After the reset returns, keep its receipt and query progress for the submitted group and Topic. A failed readback preserves the write receipt and explicitly reports the unavailable progress. The form does not automatically repeat a reset.
+
+Skip accumulated messages uses the admin client's dedicated skip capability. It does not pass the old `-1` through an unsigned timestamp, which the checked client conversion rejects. Timestamp-based resets keep their nonnegative millisecond contract.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -15,8 +15,8 @@
 use crate::topic::batch::{TopicBatchOperation, TopicBatchResult, TopicTargetKind, project_batch};
 use crate::topic::guard::{TopicIntent, TopicWriteMode, check_topic, validate_targets};
 use rocketmq_admin_core::core::topic::{
-    TopicBatchDeleteAdmin, TopicBatchDeleteRequest, TopicBatchMutationAdmin, TopicBatchTargetOutcome,
-    TopicBatchUpsertRequest,
+    SkipTopicAccumulatedRequest, TopicBatchDeleteAdmin, TopicBatchDeleteRequest, TopicBatchMutationAdmin,
+    TopicBatchTargetOutcome, TopicBatchUpsertRequest, TopicSkipMutationAdmin,
 };
 use std::sync::Arc;
 
@@ -755,9 +755,7 @@ impl TopicManager {
         request: ResetOffsetRequest,
         skip_accumulate: bool,
     ) -> TopicResult<TopicMutationResult> {
-        if request.consumer_group_list.is_empty() {
-            return Err(TopicError::Validation("Select at least one consumer group.".into()));
-        }
+        let reset_timestamp = validate_offset_reset(&request, skip_accumulate)?;
         let operation_name = if skip_accumulate {
             "skip_message_accumulate"
         } else {
@@ -774,16 +772,34 @@ impl TopicManager {
                 .execute(|_| async {
                     let mut affected_queues = 0usize;
                     for consumer_group in &request.consumer_group_list {
-                        let outcome = session
-                            .admin
-                            .reset_topic_consumer_offset(&ResetTopicConsumerOffsetRequest {
-                                consumer_group: consumer_group.clone(),
-                                topic: request.topic.clone(),
-                                reset_timestamp: request.reset_time as u64,
-                                force: request.force,
-                            })
-                            .await
-                            .map_err(map_admin_error)?;
+                        let outcome = match reset_timestamp {
+                            OffsetResetPosition::Latest => {
+                                session
+                                    .admin
+                                    .skip_accumulated(
+                                        &SkipTopicAccumulatedRequest::try_new(
+                                            request.topic.clone(),
+                                            consumer_group.clone(),
+                                            None,
+                                            request.force,
+                                        )
+                                        .map_err(map_admin_error)?,
+                                    )
+                                    .await
+                            }
+                            OffsetResetPosition::Timestamp(timestamp) => {
+                                session
+                                    .admin
+                                    .reset_topic_consumer_offset(&ResetTopicConsumerOffsetRequest {
+                                        consumer_group: consumer_group.clone(),
+                                        topic: request.topic.clone(),
+                                        reset_timestamp: timestamp,
+                                        force: request.force,
+                                    })
+                                    .await
+                            }
+                        }
+                        .map_err(map_admin_error)?;
                         affected_queues += outcome.target_count;
                     }
                     Ok(TopicMutationResult {
@@ -842,6 +858,32 @@ impl TopicManager {
 mod mapping;
 
 use mapping::*;
+
+#[derive(Debug, PartialEq, Eq)]
+enum OffsetResetPosition {
+    Latest,
+    Timestamp(u64),
+}
+
+fn validate_offset_reset(request: &ResetOffsetRequest, skip_accumulate: bool) -> TopicResult<OffsetResetPosition> {
+    use rocketmq_admin_core::core::consumer::is_protected_consumer_group;
+    if request.consumer_group_list.is_empty()
+        || request
+            .consumer_group_list
+            .iter()
+            .any(|group| group.trim().is_empty() || group.trim() != group || is_protected_consumer_group(group))
+    {
+        return Err(TopicError::Validation(
+            "Select non-system Consumer groups before resetting offsets.".into(),
+        ));
+    }
+    if skip_accumulate {
+        return Ok(OffsetResetPosition::Latest);
+    }
+    u64::try_from(request.reset_time)
+        .map(OffsetResetPosition::Timestamp)
+        .map_err(|_| TopicError::Validation("Reset time must be a nonnegative millisecond timestamp.".into()))
+}
 
 #[cfg(test)]
 mod tests;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service/tests.rs
@@ -100,3 +100,28 @@ fn non_send_ok_receipts_preserve_identifiers_without_claiming_success() {
         assert_ne!(result.send_status, "SEND_OK");
     }
 }
+
+#[test]
+fn offset_reset_validation_rejects_protected_groups_and_negative_time() {
+    use rocketmq_dashboard_common::ResetOffsetRequest;
+    let mut request = ResetOffsetRequest {
+        consumer_group_list: vec!["orders-reader".into()],
+        topic: "orders".into(),
+        reset_time: 1_700_000_000_000,
+        force: false,
+    };
+    assert_eq!(
+        super::validate_offset_reset(&request, false).unwrap(),
+        super::OffsetResetPosition::Timestamp(1_700_000_000_000)
+    );
+    request.reset_time = -1;
+    assert!(super::validate_offset_reset(&request, false).is_err());
+    assert_eq!(
+        super::validate_offset_reset(&request, true).unwrap(),
+        super::OffsetResetPosition::Latest
+    );
+    for group in ["", " reader ", "%SYS%reader", "TOOLS_CONSUMER"] {
+        request.consumer_group_list = vec![group.into()];
+        assert!(super::validate_offset_reset(&request, true).is_err(), "{group}");
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
@@ -1,3 +1,5 @@
+import { ConsumerService } from '../services/consumer.service';
+import { OffsetResetForm } from '../features/topic/components/OffsetResetForm';
 import { TopicMutationReceipt, failedBrokerNames } from '../features/topic/components/TopicMutationReceipt';
 import type { TopicBatchResult } from '../features/topic/types/topic.types';
 import { useAppStore, useNavigationState } from '../stores/app.store';
@@ -127,11 +129,6 @@ const mapTopicListItem = (item: TopicListItem): Topic => ({
     messageType: item.messageType,
     operations: buildTopicOperations(item),
 });
-
-const toDateTimeLocalValue = (date: Date): string => {
-    const adjusted = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
-    return adjusted.toISOString().slice(0, 16);
-};
 
 const buildTopicEditorSeedFromConfig = (config: TopicConfigView): TopicEditorSeed => ({
     topicName: config.topicName,
@@ -1899,218 +1896,36 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
 };
 
 const TopicResetOffsetModal = ({isOpen, onClose, topic}: TopicRouterModalProps) => {
-    const [consumerGroups, setConsumerGroups] = useState<string[]>([]);
-    const [selectedConsumerGroup, setSelectedConsumerGroup] = useState('');
-    const [selectedTime, setSelectedTime] = useState('');
-    const [isLoadingGroups, setIsLoadingGroups] = useState(false);
-    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [groups, setGroups] = useState<string[]>([]);
+    const [group, setGroup] = useState('');
     const [error, setError] = useState('');
-
     useEffect(() => {
-        if (!isOpen || !topic?.name) {
-            return;
-        }
-
+        if (!isOpen || !topic) return;
         let cancelled = false;
-
-        setConsumerGroups([]);
-        setSelectedConsumerGroup('');
-        setSelectedTime(toDateTimeLocalValue(new Date()));
-        setIsLoadingGroups(true);
-        setIsSubmitting(false);
-        setError('');
-
-        const loadConsumerGroups = async () => {
-            try {
-                const response = await TopicService.getTopicConsumerGroups({topic: topic.name});
-                if (cancelled) {
-                    return;
-                }
-
-                const groups = response.consumerGroups ?? [];
-                setConsumerGroups(groups);
-                setSelectedConsumerGroup(groups[0] ?? '');
-            } catch (loadError) {
-                if (!cancelled) {
-                    setError(dashboardErrorMessage(loadError, 'Failed to load consumer groups.'));
-                }
-            } finally {
-                if (!cancelled) {
-                    setIsLoadingGroups(false);
-                }
-            }
-        };
-
-        void loadConsumerGroups();
-
-        return () => {
-            cancelled = true;
-        };
-    }, [isOpen, topic?.name]);
-
-    const handleReset = async () => {
-        if (!topic?.name) {
-            return;
-        }
-
-        if (!selectedConsumerGroup) {
-            setError('Select a consumer group before resetting offsets.');
-            return;
-        }
-
-        if (!selectedTime) {
-            setError('Select a reset time before submitting.');
-            return;
-        }
-
-        const resetTime = new Date(selectedTime).getTime();
-        if (Number.isNaN(resetTime)) {
-            setError('The selected reset time is invalid.');
-            return;
-        }
-
-        setIsSubmitting(true);
-        setError('');
-
-        try {
-            const result = await TopicService.resetConsumerOffset({
-                consumerGroupList: [selectedConsumerGroup],
-                topic: topic.name,
-                resetTime,
-                force: true,
-            });
-            toast.success(result.message || `Offset reset requested for ${topic.name}`);
-            onClose();
-        } catch (resetError) {
-            setError(dashboardErrorMessage(resetError, 'Failed to reset consumer offset.'));
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
-
-    if (!isOpen) return null;
-
-    return (
-        <AnimatePresence>
-            <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-                <motion.div
-                    initial={{opacity: 0}}
-                    animate={{opacity: 0.3}}
-                    exit={{opacity: 0}}
-                    onClick={onClose}
-                    className="absolute inset-0 bg-black"
-                />
-                <motion.div
-                    initial={{opacity: 0, scale: 0.95, y: 10}}
-                    animate={{opacity: 1, scale: 1, y: 0}}
-                    exit={{opacity: 0, scale: 0.95, y: 10}}
-                    className="relative w-full max-w-lg bg-white dark:bg-gray-900 rounded-xl shadow-2xl overflow-hidden flex flex-col border border-gray-100 dark:border-gray-800"
-                >
-                    {/* Header */}
-                    <div className="px-6 py-5 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between bg-white dark:bg-gray-900 z-10">
-                        <div>
-                            <h3 className="text-xl font-bold text-gray-800 dark:text-white flex items-center">
-                                <RotateCcw className="w-5 h-5 mr-2 text-blue-500"/>
-                                Reset Consumer Offset
-                            </h3>
-                            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                                <span className="font-mono text-gray-700 dark:text-gray-300 font-medium">{topic?.name}</span> resetOffset
-                            </p>
-                        </div>
-                        <button
-                            onClick={onClose}
-                            className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-                        >
-                            <X className="w-5 h-5"/>
-                        </button>
-                    </div>
-
-                    {/* Content */}
-                    <div className="p-6 space-y-5 bg-gray-50/50 dark:bg-gray-950/50">
-                        <div className="bg-white dark:bg-gray-900 p-6 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm space-y-5">
-                            {isLoadingGroups && (
-                                <div className="rounded-xl border border-gray-200 bg-gray-50/80 px-4 py-3 text-sm text-gray-500 dark:border-gray-800 dark:bg-gray-800/60 dark:text-gray-400">
-                                    Loading consumer groups for this topic...
-                                </div>
-                            )}
-
-                            {!isLoadingGroups && error && (
-                                <div className="rounded-xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-600 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-                                    {error}
-                                </div>
-                            )}
-
-                            {/* SubscriptionGroup */}
-                            <div className="space-y-1.5">
-                                <label className="flex items-center text-sm font-medium text-gray-700 dark:text-gray-300">
-                                    <span className="text-red-500 mr-1">*</span>SubscriptionGroup
-                                </label>
-                                <div className="relative">
-                                    <select
-                                        value={selectedConsumerGroup}
-                                        onChange={(event) => setSelectedConsumerGroup(event.target.value)}
-                                        disabled={isLoadingGroups || consumerGroups.length === 0 || isSubmitting}
-                                        className="w-full px-3 py-2.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all appearance-none cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-750">
-                                        <option value="" disabled>
-                                            {isLoadingGroups ? 'Loading groups...' : 'Select a group...'}
-                                        </option>
-                                        {consumerGroups.map((group) => (
-                                            <option key={group} value={group}>
-                                                {group}
-                                            </option>
-                                        ))}
-                                    </select>
-                                    <ChevronDown className="absolute right-3 top-3 w-4 h-4 text-gray-400 dark:text-gray-500 pointer-events-none"/>
-                                </div>
-                                {!isLoadingGroups && consumerGroups.length === 0 && !error && (
-                                    <p className="text-xs text-amber-600 dark:text-amber-400">
-                                        No consumer groups are currently associated with this topic.
-                                    </p>
-                                )}
-                            </div>
-
-                            {/* Time */}
-                            <div className="space-y-1.5">
-                                <label className="flex items-center text-sm font-medium text-gray-700 dark:text-gray-300">
-                                    <span className="text-red-500 mr-1">*</span>Time
-                                </label>
-                                <div className="relative">
-                                    <input
-                                        type="datetime-local"
-                                        value={selectedTime}
-                                        onChange={(event) => setSelectedTime(event.target.value)}
-                                        disabled={isSubmitting}
-                                        className="w-full px-3 py-2.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all placeholder:text-gray-400 dark:placeholder:text-gray-600 dark:[color-scheme:dark]"
-                                    />
-                                </div>
-                                <p className="text-xs text-gray-500 dark:text-gray-400">
-                                    The selected consumer group will rewind to the nearest offset at this timestamp.
-                                </p>
-                            </div>
-
-                        </div>
-                    </div>
-
-                    {/* Footer */}
-                    <div className="px-6 py-4 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex justify-end space-x-3 z-10">
-                        <button
-                            onClick={onClose}
-                            className="px-6 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm"
-                        >
-                            Close
-                        </button>
-                        <button
-                            onClick={() => void handleReset()}
-                            disabled={isLoadingGroups || consumerGroups.length === 0 || isSubmitting}
-                            className="px-6 py-2 bg-gray-900 text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-all shadow-md hover:shadow-lg flex items-center dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
-                        >
-                            {isSubmitting ? 'Resetting...' : 'RESET'}
-                        </button>
-                    </div>
-                </motion.div>
+        setGroups([]); setGroup(''); setError('');
+        void TopicService.getTopicConsumerGroups({ topic: topic.name }).then(result => {
+            if (!cancelled) setGroups(result.consumerGroups);
+        }).catch(error => { if (!cancelled) setError(dashboardErrorMessage(error, 'Unable to load Consumer groups.')); });
+        return () => { cancelled = true; };
+    }, [isOpen, topic]);
+    if (!isOpen || !topic) return null;
+    return <div className="topic-status-modal-root">
+        <div className="topic-status-backdrop" onClick={onClose} />
+        <div className="topic-status-dialog max-w-xl">
+            <header className="topic-status-header"><h3>Reset Consumer Offset</h3><button type="button" onClick={onClose} aria-label="Close offset reset">Close</button></header>
+            <div className="topic-status-body p-4">
+                {error && <p role="alert">{error}</p>}
+                <label>Consumer group <select className="rounded border p-2 dark:bg-gray-900" value={group} onChange={event => setGroup(event.target.value)}>
+                    <option value="">Select a group</option>{groups.map(value => <option key={value} value={value}>{value}</option>)}
+                </select></label>
+                <OffsetResetForm key={`${topic.name}:${group}`} topic={topic.name} group={group} disabled={topic.systemTopic}
+                    readProgress={async request => {
+                        const result = await ConsumerService.queryConsumerTopicDetail({ consumerGroup: request.consumerGroupList[0], scope: { mode: 'name_server' } });
+                        return { consumerGroup: result.consumerGroup, topics: result.topics.filter(item => item.topic === request.topic) };
+                    }} />
             </div>
-        </AnimatePresence>
-    );
+        </div>
+    </div>;
 };
 
 const TopicSkipMessageAccumulateModal = ({isOpen, onClose, topic}: TopicRouterModalProps) => {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDetailModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDetailModal.tsx
@@ -1,3 +1,6 @@
+import { OffsetResetForm } from '../../topic/components/OffsetResetForm';
+import { isReadOnlyConsumer } from '../mutation';
+import { consumerScopeKey } from '../scope';
 import type { ConsumerQueryScope } from '../types/consumer.types';
 import { consumerScopeLabel } from '../scope';
 import { useAppStore } from '../../../stores/app.store';
@@ -51,6 +54,8 @@ export const ConsumerDetailModal = ({
     scope,
 }: ConsumerDetailModalProps) => {
     const { openTopic } = useAppStore();
+    const [activeTab, setActiveTab] = useState<'progress' | 'reset'>('progress');
+    useEffect(() => { setActiveTab('progress'); }, [scope, consumer, isOpen]);
     const [data, setData] = useState<ConsumerTopicDetailView | null>(null);
     const [selectedTopicName, setSelectedTopicName] = useState('');
     const [isLoading, setIsLoading] = useState(false);
@@ -145,7 +150,7 @@ export const ConsumerDetailModal = ({
                         <div className="topic-status-header-actions consumer-topic-detail-header-actions">
                             <span className={`consumer-topic-detail-chip ${lagStateClass}`}>
                                 <i aria-hidden="true" />
-                                {data && data.totalDiff > 0 ? 'Lagging' : 'No lag'}
+                                {!data ? 'Unknown' : data.totalDiff > 0 ? 'Lagging' : 'No lag'}
                             </span>
                             {data && (
                                 <span className="consumer-topic-detail-chip is-info">
@@ -163,8 +168,22 @@ export const ConsumerDetailModal = ({
                         </div>
                     </header>
 
+                    <nav className="flex gap-4 p-4" aria-label="Consumer detail sections">
+                        <button type="button" aria-pressed={activeTab === 'progress'} onClick={() => setActiveTab('progress')}>Progress</button>
+                        <button type="button" aria-pressed={activeTab === 'reset'} disabled={isReadOnlyConsumer(consumer)} onClick={() => setActiveTab('reset')}>Reset offset</button>
+                    </nav>
                     <div className="topic-status-body consumer-topic-detail-body">
-                        {isLoading ? (
+                        {activeTab === 'reset' && consumer ? <>
+                            <label>Topic from Consumer progress <select className="rounded border p-2 dark:bg-gray-900" value={selectedTopicName} onChange={event => setSelectedTopicName(event.target.value)}>
+                                <option value="">Select a Topic</option>{topics.map(item => <option key={item.topic} value={item.topic}>{item.topic}</option>)}
+                            </select></label>
+                            {topics.length === 0 && <p>No Topics available from Consumer progress. Refresh the detail view first.</p>}
+                            <OffsetResetForm key={`${consumer.rawGroupName}:${consumerScopeKey(scope)}:${selectedTopicName}`} topic={selectedTopicName} group={consumer.rawGroupName}
+                                disabled={isLoading || isReadOnlyConsumer(consumer)} readProgress={async request => {
+                                    const result = await ConsumerService.queryConsumerTopicDetail({ consumerGroup: request.consumerGroupList[0], scope });
+                                    return { consumerGroup: result.consumerGroup, topics: result.topics.filter(item => item.topic === request.topic) };
+                                }} />
+                        </> : isLoading ? (
                             <div className="topic-status-state">
                                 <LoaderCircle className="topic-icon consumer-spin" aria-hidden="true" />
                                 <strong>Loading consumer details</strong>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/components/OffsetResetForm.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/components/OffsetResetForm.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from 'react';
+import { TopicService } from '../../../services/topic.service';
+import { dashboardErrorMessage } from '../../../services/invoke';
+import { ConsumerRequestGeneration } from '../../consumer/scope';
+import { currentLocalMinute, offsetResetRequest } from '../offsetReset';
+import type { ResetOffsetRequest, TopicMutationResult } from '../types/topic.types';
+
+interface Props {
+    topic: string;
+    group: string;
+    disabled?: boolean;
+    readProgress: (request: ResetOffsetRequest) => Promise<unknown>;
+}
+
+// Parent keys this form by entity/scope. Accepted writes survive unmount, but their callbacks do not.
+export function OffsetResetForm({ topic, group, disabled = false, readProgress }: Props) {
+    const [time, setTime] = useState(currentLocalMinute);
+    const [force, setForce] = useState(false);
+    const [confirmation, setConfirmation] = useState<ResetOffsetRequest | null>(null);
+    const [receipt, setReceipt] = useState<TopicMutationResult | null>(null);
+    const [progress, setProgress] = useState<unknown>(null);
+    const [error, setError] = useState('');
+    const [pending, setPending] = useState(false);
+    const generation = useRef(new ConsumerRequestGeneration());
+    const busy = useRef(false);
+    useEffect(() => {
+        generation.current.invalidate(); setConfirmation(null); setReceipt(null); setProgress(null); setError(''); setPending(false); busy.current = false;
+        return () => generation.current.invalidate();
+    }, [topic, group]);
+
+    const review = () => {
+        try { setConfirmation(offsetResetRequest(topic, group, time, force)); setError(''); }
+        catch (error) { setError((error as Error).message); }
+    };
+    const submit = async () => {
+        if (!confirmation || disabled || busy.current || confirmation.topic !== topic || confirmation.consumerGroupList[0] !== group) return;
+        const request = confirmation;
+        const current = generation.current.begin();
+        busy.current = true; setPending(true); setError(''); setConfirmation(null);
+        try {
+            const result = await TopicService.resetConsumerOffset(request);
+            if (!current()) return;
+            setReceipt(result);
+            try {
+                const result = await readProgress(request);
+                if (current()) setProgress(result);
+            } catch {
+                if (current()) setError('The reset receipt is retained, but progress could not be read. Refresh progress before another operation.');
+            }
+        } catch (error) {
+            if (current()) setError(dashboardErrorMessage(error, 'Offset reset was not confirmed. Inspect progress before manually retrying.'));
+        } finally { if (current()) { busy.current = false; setPending(false); } }
+    };
+    return <section className="space-y-4 p-4" aria-label="Reset offset">
+        <p>Topic: <strong>{topic || 'Select a Topic'}</strong> · Group: <strong>{group || 'Select a group'}</strong></p>
+        <label className="block">Local date and time ({Intl.DateTimeFormat().resolvedOptions().timeZone})
+            <input className="block rounded border p-2 dark:bg-gray-900" type="datetime-local" value={time} disabled={pending || Boolean(receipt)} onChange={event => { setTime(event.target.value); setConfirmation(null); }} />
+        </label>
+        <label className="block"><input type="checkbox" checked={force} disabled={pending || Boolean(receipt)} onChange={event => { setForce(event.target.checked); setConfirmation(null); }} /> Force reset (allows moving offsets backwards)</label>
+        {error && <p role="alert" className="text-red-600">{error}</p>}
+        {receipt && <div role="status"><strong>{receipt.success ? 'Reset acknowledged' : 'Reset not confirmed'}</strong><p>{receipt.message}</p></div>}
+        {progress !== null && <details open><summary>Progress read after reset</summary><pre className="max-h-52 overflow-auto">{JSON.stringify(progress, null, 2)}</pre></details>}
+        {confirmation && <div className="rounded border border-amber-400 p-3" role="alert">
+            <p>Confirm Topic: {confirmation.topic} · Group: {confirmation.consumerGroupList[0]}</p>
+            <p>Time: {new Date(confirmation.resetTime).toLocaleString()} · Timestamp: {confirmation.resetTime} ms · Force: {String(confirmation.force)}</p>
+            <button type="button" onClick={() => void submit()} disabled={pending || disabled}>Confirm offset reset</button>
+            <button type="button" className="ml-4" onClick={() => setConfirmation(null)}>Cancel confirmation</button>
+        </div>}
+        {!confirmation && !receipt && <button type="button" disabled={pending || disabled || !topic || !group} onClick={review}>{pending ? 'Resetting and reading progress…' : 'Review offset reset'}</button>}
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/offsetReset.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/offsetReset.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { offsetResetRequest } from './offsetReset';
+import { ConsumerRequestGeneration } from '../consumer/scope';
+
+describe('offset reset confirmation', () => {
+    it('keeps the exact entity and converts local time to milliseconds', () => {
+        expect(offsetResetRequest('orders', 'orders-reader', '2026-09-10T12:34', false)).toEqual({
+            topic: 'orders', consumerGroupList: ['orders-reader'], resetTime: new Date(2026, 8, 10, 12, 34).getTime(), force: false,
+        });
+    });
+    it('rejects empty identities, invalid dates and pre-epoch input', () => {
+        for (const value of ['', 'invalid', '2026-02-30T12:00', '2026-09-10T25:00', '1900-01-01T12:00']) {
+            expect(() => offsetResetRequest('orders', 'reader', value, true)).toThrow();
+        }
+        expect(() => offsetResetRequest('orders', '', '2026-09-10T12:00', false)).toThrow();
+    });
+    it('prevents an old reset from refreshing a new group after disposal', async () => {
+        const generation = new ConsumerRequestGeneration();
+        const current = generation.begin();
+        generation.invalidate();
+        const readGroups: string[] = [];
+        await Promise.resolve();
+        if (current()) readGroups.push('previous-group');
+        expect(readGroups).toEqual([]);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/offsetReset.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/offsetReset.ts
@@ -1,0 +1,20 @@
+import type { ResetOffsetRequest } from './types/topic.types';
+
+export function offsetResetRequest(topic: string, group: string, localTime: string, force: boolean): ResetOffsetRequest {
+    if (!topic.trim() || !group.trim()) throw new Error('Select a Topic and Consumer group.');
+    const parts = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(localTime);
+    if (!parts) throw new Error('Select a valid local date and time.');
+    const [year, month, day, hour, minute] = parts.slice(1).map(Number);
+    const date = new Date(localTime);
+    const resetTime = date.getTime();
+    if (!Number.isSafeInteger(resetTime) || resetTime < 0 || date.getFullYear() !== year || date.getMonth() + 1 !== month ||
+        date.getDate() !== day || date.getHours() !== hour || date.getMinutes() !== minute) {
+        throw new Error('The selected local time is invalid or does not exist in this time zone.');
+    }
+    return { topic, consumerGroupList: [group], resetTime, force };
+}
+
+export const currentLocalMinute = () => {
+    const date = new Date();
+    return new Date(date.getTime() - date.getTimezoneOffset() * 60_000).toISOString().slice(0, 16);
+};

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic.rs
@@ -753,3 +753,27 @@ mod tests {
         assert_eq!(normalize_message_type(Some("transaction")), "TRANSACTION");
     }
 }
+
+impl crate::core::topic::TopicSkipMutationAdmin for AdminSession {
+    fn skip_accumulated<'a>(
+        &'a mut self,
+        request: &'a crate::core::topic::SkipTopicAccumulatedRequest,
+    ) -> AdminFuture<'a, TopicMutationOutcome> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let affected_queues = rocketmq_client_rust::MQAdminMutationExt::skip_accumulated_message(
+                &self.inner,
+                request.cluster_name().map(CheetahString::from),
+                CheetahString::from(request.topic()),
+                CheetahString::from(request.consumer_group()),
+                request.force(),
+            )
+            .await
+            .map_err(|error| backend_error("skip_accumulated_message", error))?;
+            Ok(TopicMutationOutcome {
+                message: "Accumulated messages were skipped to the latest offsets.".into(),
+                target_count: affected_queues,
+            })
+        })
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10396

### Brief Description
Share a reviewed offset reset form between Topic operations and Consumer details. Keep exact group/Topic identity, validate local time, preview milliseconds and force, invalidate stale callbacks, and retain reset receipts with progress readback. Reject protected groups and negative reset times before RPC. Use the existing dedicated skip capability through the full admin session instead of converting -1 to an invalid unsigned timestamp.

### How Did You Test This Change?
- Frontend build and three offset confirmation tests passed.
- Tauri `cargo test --lib topic::`: nine passed.
- Package-scoped Rust format checks and `git diff --check` passed.
- Admin-core client-adapter skip test passed; both the shared adapter and Tauri consumer compiled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared consumer offset reset form for topic views and consumer details.
  * Added a **Reset offset** tab to consumer details, with topics based on consumer progress.
  * Added support for skipping accumulated messages.
  * Added confirmation and progress refresh after successful resets.

* **Bug Fixes**
  * Improved validation for consumer groups, topics, dates, and reset timestamps.
  * Prevented resets for protected or read-only consumer groups and system topics.
  * Improved handling of reset errors and stale requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->