### PR TITLE
[ISSUE #10398]🚀Inspect Tauri Consumer runtime diagnostics on demand

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_DIAGNOSTICS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_DIAGNOSTICS.md
@@ -1,0 +1,9 @@
+# Consumer diagnostics
+
+The client connection view exposes a manual diagnostic panel with separate Running information and Request thread stack actions. Opening the panel never requests JStack. Switching client, group, scope, or closing the dialog discards old results and invalidates late callbacks. Results remain in component memory only.
+
+Both authenticated commands validate the current connection revision and the configured Consumer scope. NameServer mode checks the client in current connections before calling `ConsumerDiagnosticAdmin`. Proxy mode reports unsupported: that trait cannot express a forwarding address, so the application does not silently use NameServer routing for a Proxy selection.
+
+Responses distinguish available, offline, unsupported, and unavailable. Broker response codes and canonical unsupported conditions are classified without exposing backend error detail. Absence from the fresh connection list is reported as offline. A returned running-info response without a requested thread stack retains the other sections and explains that JStack may be unsupported.
+
+Properties retain the admin-core allowlist. Each of properties, subscriptions, process queues, and thread stack has a 60 KiB serialized budget, leaving envelope room within 256 KiB. Thread-stack truncation respects Unicode character boundaries and JSON escaping. The `truncated` marker is visible and also preserves upstream truncation or missing-section evidence. The IPC limit does not replace the transport decoder's own frame limit.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
@@ -243,3 +243,43 @@ pub async fn delete_consumer_group(
         .await
 }
 use crate::auth::SessionState;
+
+#[tauri::command]
+pub async fn query_consumer_running_info(
+    session_id: String,
+    request: super::service::diagnostics::DiagnosticRequest,
+    consumer_manager: State<'_, ConsumerManager>,
+    session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
+) -> CommandResult<super::service::diagnostics::DiagnosticResult> {
+    authorize_command(&session_id, &session_state).await?;
+    connection_manager.check_revision(expected_revision)?;
+    request.scope.address(&connection_manager.snapshot()?)?;
+    let result = consumer_manager
+        .query_diagnostic(request, false)
+        .await
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
+}
+
+#[tauri::command]
+pub async fn query_consumer_jstack(
+    session_id: String,
+    request: super::service::diagnostics::DiagnosticRequest,
+    consumer_manager: State<'_, ConsumerManager>,
+    session_state: State<'_, SessionState>,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
+) -> CommandResult<super::service::diagnostics::DiagnosticResult> {
+    authorize_command(&session_id, &session_state).await?;
+    connection_manager.check_revision(expected_revision)?;
+    request.scope.address(&connection_manager.snapshot()?)?;
+    let result = consumer_manager
+        .query_diagnostic(request, true)
+        .await
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
@@ -48,6 +48,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub(crate) mod config_summary;
+pub(crate) mod diagnostics;
 mod mapping;
 
 use self::mapping::build_summary;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service/diagnostics.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service/diagnostics.rs
@@ -1,0 +1,298 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_admin_core::core::AdminError;
+use rocketmq_admin_core::core::consumer::{
+    ConsumerDiagnosticAdmin, DashboardConsumerRunningInfo, DashboardConsumerRunningInfoRequest,
+};
+use rocketmq_error::CanonicalCondition;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::*;
+use crate::consumer::scope::ConsumerQueryScope;
+
+// Four independently bounded sections leave space for identities and the envelope under 256 KiB.
+const SECTION_BYTES: usize = 60 * 1024;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DiagnosticRequest {
+    pub(crate) consumer_group: String,
+    pub(crate) client_id: String,
+    pub(crate) scope: ConsumerQueryScope,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DiagnosticStatus {
+    Available,
+    Offline,
+    Unsupported,
+    Unavailable,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DiagnosticResult {
+    consumer_group: String,
+    client_id: String,
+    status: DiagnosticStatus,
+    reason: Option<&'static str>,
+    properties: Vec<Value>,
+    subscriptions: Vec<Value>,
+    process_queues: Vec<Value>,
+    jstack: Option<String>,
+    truncated: bool,
+}
+
+impl DiagnosticResult {
+    fn empty(group: String, client: String, status: DiagnosticStatus, reason: &'static str) -> Self {
+        Self {
+            consumer_group: group,
+            client_id: client,
+            status,
+            reason: Some(reason),
+            properties: vec![],
+            subscriptions: vec![],
+            process_queues: vec![],
+            jstack: None,
+            truncated: false,
+        }
+    }
+}
+
+impl ConsumerManager {
+    pub(crate) async fn query_diagnostic(
+        &self,
+        request: DiagnosticRequest,
+        include_jstack: bool,
+    ) -> ConsumerResult<DiagnosticResult> {
+        let group = validate_consumer_group_name(&request.consumer_group)?;
+        let client = request.client_id.trim().to_string();
+        if client.is_empty() || client.len() > 512 || group.len() > 512 {
+            return Err(ConsumerError::Validation(
+                "A bounded Consumer group and client ID are required.".into(),
+            ));
+        }
+        if matches!(request.scope, ConsumerQueryScope::Proxy { .. }) {
+            return Ok(DiagnosticResult::empty(
+                group,
+                client,
+                DiagnosticStatus::Unsupported,
+                "The diagnostic admin capability cannot forward through a Proxy. Select NameServer discovery to inspect remoting clients.",
+            ));
+        }
+        let mut session = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session).await?;
+        let admin = &mut session
+            .as_mut()
+            .ok_or_else(|| ConsumerError::Validation("Consumer connection unavailable.".into()))?
+            .admin;
+        let connections = match admin
+            .query_dashboard_consumer_connection(&DashboardConsumerConnectionRequest {
+                consumer_group: group.clone(),
+                address: None,
+            })
+            .await
+        {
+            Ok(connections) => connections,
+            Err(error) => return Ok(failed(group, client, &error)),
+        };
+        if !connections
+            .connections
+            .iter()
+            .any(|connection| connection.client_id == client)
+        {
+            return Ok(DiagnosticResult::empty(
+                group,
+                client,
+                DiagnosticStatus::Offline,
+                "This client is absent from the current Consumer connections. Refresh the connection list.",
+            ));
+        }
+        let core_request = DashboardConsumerRunningInfoRequest::try_new(&group, &client, include_jstack, SECTION_BYTES)
+            .map_err(map_admin_error)?;
+        match admin.query_dashboard_consumer_running_info(&core_request).await {
+            Ok(info) => project(info, include_jstack),
+            Err(error) => Ok(failed(group, client, &error)),
+        }
+    }
+}
+
+fn failed(group: String, client: String, error: &AdminError) -> DiagnosticResult {
+    let broker_code = error.diagnostic_view().ok().and_then(|view| {
+        view.fields().find_map(|field| match (field.name(), field.value()) {
+            ("broker_code", rocketmq_error::ViewValueRef::I64(code)) => Some(code),
+            _ => None,
+        })
+    });
+    let (status, reason) = if error.condition() == CanonicalCondition::Unimplemented || broker_code == Some(3) {
+        (
+            DiagnosticStatus::Unsupported,
+            "The Broker or client does not support this diagnostic request.",
+        )
+    } else if broker_code == Some(206) || error.remoting_response_code().as_i32() == 206 {
+        (DiagnosticStatus::Offline, "The Consumer client is offline.")
+    } else {
+        (
+            DiagnosticStatus::Unavailable,
+            "Diagnostic data is unavailable. Check the connection and Broker permissions.",
+        )
+    };
+    DiagnosticResult::empty(group, client, status, reason)
+}
+
+fn bounded_entries<T: Serialize>(entries: Vec<T>, truncated: &mut bool) -> ConsumerResult<Vec<Value>> {
+    let mut remaining = SECTION_BYTES - 2;
+    let mut output = Vec::new();
+    for entry in entries {
+        let value = serde_json::to_value(entry)
+            .map_err(|_| ConsumerError::Validation("Cannot represent diagnostic data.".into()))?;
+        let bytes = serde_json::to_vec(&value)
+            .map_err(|_| ConsumerError::Validation("Cannot encode diagnostic data.".into()))?
+            .len()
+            + 1;
+        if bytes > remaining {
+            *truncated = true;
+            break;
+        }
+        remaining -= bytes;
+        output.push(value);
+    }
+    Ok(output)
+}
+
+fn bounded_jstack(text: String, truncated: &mut bool) -> ConsumerResult<String> {
+    // Count JSON escaping as well as UTF-8 bytes so IPC output remains bounded.
+    let mut remaining = SECTION_BYTES - 2;
+    let mut end = 0;
+    for (index, character) in text.char_indices() {
+        let bytes = serde_json::to_string(&character)
+            .map_err(|_| ConsumerError::Validation("Cannot encode thread stack.".into()))?
+            .len()
+            - 2;
+        if bytes > remaining {
+            *truncated = true;
+            break;
+        }
+        remaining -= bytes;
+        end = index + character.len_utf8();
+    }
+    Ok(text[..end].to_string())
+}
+
+fn project(info: DashboardConsumerRunningInfo, include_jstack: bool) -> ConsumerResult<DiagnosticResult> {
+    let parts = info.into_parts();
+    let mut truncated = parts.truncated;
+    let properties = bounded_entries(parts.properties, &mut truncated)?;
+    let subscriptions = bounded_entries(parts.subscriptions, &mut truncated)?;
+    let process_queues = bounded_entries(parts.process_queues, &mut truncated)?;
+    let jstack = parts
+        .jstack
+        .filter(|_| include_jstack)
+        .map(|text| bounded_jstack(text, &mut truncated))
+        .transpose()?;
+    let reason = (include_jstack && jstack.as_ref().is_none_or(String::is_empty))
+        .then_some("The client returned no thread stack; it may not support JStack.");
+    Ok(DiagnosticResult {
+        consumer_group: parts.consumer_group,
+        client_id: parts.client_id,
+        status: DiagnosticStatus::Available,
+        reason,
+        properties,
+        subscriptions,
+        process_queues,
+        jstack,
+        truncated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocketmq_admin_core::core::consumer::DashboardConsumerConfigAttribute;
+
+    #[test]
+    fn diagnostic_projection_bounds_escaped_unicode_and_preserves_manual_stack_selection() {
+        let info = DashboardConsumerRunningInfo::new(
+            "group".into(),
+            "client".into(),
+            vec![DashboardConsumerConfigAttribute {
+                key: "threads".into(),
+                value: "8".into(),
+            }],
+            vec![],
+            vec![],
+            Some("\n线程".repeat(30_000)),
+            false,
+        );
+        let result = project(info, true).unwrap();
+        assert!(result.truncated);
+        assert_eq!(result.status, DiagnosticStatus::Available);
+        assert_eq!(result.properties[0]["value"], "8");
+        assert!(serde_json::to_vec(&result).unwrap().len() < 256 * 1024);
+        let info = DashboardConsumerRunningInfo::new(
+            "group".into(),
+            "client".into(),
+            vec![],
+            vec![],
+            vec![],
+            Some("stack".into()),
+            false,
+        );
+        assert!(project(info, false).unwrap().jstack.is_none());
+    }
+
+    #[test]
+    fn diagnostic_collection_budget_omits_large_entries_and_reports_truncation() {
+        let mut truncated = false;
+        let result = bounded_entries(vec!["small".to_string(), "x".repeat(SECTION_BYTES)], &mut truncated).unwrap();
+        assert_eq!(result, [Value::String("small".into())]);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn diagnostic_broker_responses_distinguish_offline_and_unsupported() {
+        for (code, status) in [
+            (206, DiagnosticStatus::Offline),
+            (3, DiagnosticStatus::Unsupported),
+            (1, DiagnosticStatus::Unavailable),
+        ] {
+            let error = AdminError::from_error(
+                "diagnostic",
+                rocketmq_error::Error::new(&rocketmq_error::BROKER_OPERATION_FAILED).with_context(
+                    rocketmq_error::ErrorContext::new().with_i64(rocketmq_error::fields::BROKER_CODE, code),
+                ),
+            );
+            assert_eq!(failed("group".into(), "client".into(), &error).status, status);
+        }
+    }
+
+    #[test]
+    fn diagnostic_failures_are_explicit_and_do_not_leak_backend_details() {
+        let error = AdminError::from_error(
+            "diagnostic",
+            rocketmq_error::Error::new(&rocketmq_error::PROTOCOL_REQUEST_UNSUPPORTED),
+        );
+        assert_eq!(
+            failed("g".into(), "c".into(), &error).status,
+            DiagnosticStatus::Unsupported
+        );
+        let error = AdminError::backend("diagnostic", "secret-debug-detail");
+        let result = failed("g".into(), "c".into(), &error);
+        assert_eq!(result.status, DiagnosticStatus::Unavailable);
+        assert!(!serde_json::to_string(&result).unwrap().contains("secret-debug-detail"));
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -288,6 +288,8 @@ fn build_application() -> Result<DashboardApplication, i32> {
             consumer::commands::query_consumer_topic_detail,
             consumer::commands::query_consumer_config,
             consumer::commands::query_consumer_config_summary,
+            consumer::commands::query_consumer_running_info,
+            consumer::commands::query_consumer_jstack,
             consumer::commands::create_or_update_consumer_group,
             consumer::commands::delete_consumer_group,
             dashboard::commands::get_dashboard_broker_overview,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerClientModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerClientModal.tsx
@@ -1,3 +1,5 @@
+import { ConsumerDiagnostics } from './ConsumerDiagnostics';
+import { consumerScopeKey } from '../scope';
 import type { ConsumerQueryScope } from '../types/consumer.types';
 import { consumerScopeLabel } from '../scope';
 import { useEffect, useMemo, useState } from 'react';
@@ -41,6 +43,7 @@ export const ConsumerClientModal = ({
     scope,
 }: ConsumerClientModalProps) => {
     const [data, setData] = useState<ConsumerConnectionView | null>(null);
+    const [selectedClient, setSelectedClient] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
 
@@ -53,6 +56,7 @@ export const ConsumerClientModal = ({
         setIsLoading(true);
         setError('');
         setData(null);
+        setSelectedClient('');
 
         void ConsumerService.queryConsumerConnection({
             consumerGroup: consumer.rawGroupName,
@@ -273,13 +277,19 @@ export const ConsumerClientModal = ({
                                                             </span>
                                                             <span data-label="Client Addr" className="consumer-client-cell is-mono">{item.clientAddr}</span>
                                                             <span data-label="Language" className="consumer-client-cell">{item.language}</span>
-                                                            <span data-label="Version" className="consumer-client-cell">{item.versionDesc}</span>
+                                                            <span data-label="Version" className="consumer-client-cell">{item.versionDesc}
+                                                                <small className="block">{scope.mode === 'proxy' ? 'Diagnostics unsupported in Proxy scope' : 'Diagnostics available to request; support not yet verified'}</small>
+                                                                <button type="button" disabled={scope.mode === 'proxy'} onClick={() => setSelectedClient(item.clientId)}>Inspect diagnostics</button>
+                                                            </span>
                                                         </div>
                                                     ))}
                                                 </div>
                                             )}
                                         </section>
 
+                                        {selectedClient && consumer && data.connections.some(item => item.clientId === selectedClient) &&
+                                            <ConsumerDiagnostics key={`${consumer.rawGroupName}:${consumerScopeKey(scope)}:${selectedClient}`} request={{ consumerGroup: consumer.rawGroupName, clientId: selectedClient, scope }} />}
+                                        {scope.mode === 'proxy' && <p>Diagnostic requests cannot be forwarded through the selected Proxy by the current admin capability. Use NameServer discovery for remoting client diagnostics.</p>}
                                         <section className="consumer-client-panel" aria-label="Client subscriptions">
                                             <div className="consumer-client-panel-header">
                                                 <div className="consumer-client-panel-title">

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDiagnostics.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerDiagnostics.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from 'react';
+import { ConsumerService } from '../../../services/consumer.service';
+import { dashboardErrorMessage } from '../../../services/invoke';
+import { ConsumerRequestGeneration } from '../scope';
+import type { ConsumerDiagnosticRequest, ConsumerDiagnosticResult } from '../types/consumer.types';
+
+export function ConsumerDiagnostics({ request }: { request: ConsumerDiagnosticRequest }) {
+    const [result, setResult] = useState<ConsumerDiagnosticResult | null>(null);
+    const [pending, setPending] = useState(false);
+    const [error, setError] = useState('');
+    const generation = useRef(new ConsumerRequestGeneration());
+    useEffect(() => () => generation.current.invalidate(), []);
+    const query = async (kind: 'running' | 'jstack') => {
+        if (pending) return;
+        const current = generation.current.begin();
+        setPending(true); setResult(null); setError('');
+        try {
+            const value = await (kind === 'jstack' ? ConsumerService.queryJstack(request) : ConsumerService.queryRunningInfo(request));
+            if (current()) setResult(value);
+        } catch (error) { if (current()) setError(dashboardErrorMessage(error, 'Unable to query client diagnostics.')); }
+        finally { if (current()) setPending(false); }
+    };
+    return <section aria-label="Consumer diagnostics" className="space-y-3 rounded border p-4">
+        <h4>Diagnostics: {request.consumerGroup} / {request.clientId}</h4>
+        <p>Manually request current runtime data. Support is determined by the Broker and client response; opening this panel does not request a thread stack.</p>
+        <div className="flex gap-4">
+            <button type="button" disabled={pending} onClick={() => void query('running')}>Running information</button>
+            <button type="button" disabled={pending} onClick={() => void query('jstack')}>Request thread stack</button>
+        </div>
+        {pending && <p role="status">Requesting diagnostics…</p>}
+        {error && <p role="alert" className="text-red-600">{error}</p>}
+        {result && <>
+            <p role="status">Status: {result.status}{result.reason ? ` — ${result.reason}` : ''}</p>
+            {result.truncated && <p role="alert" className="text-amber-600">Output is truncated or a requested section was unavailable. This is not the complete diagnostic output.</p>}
+            {result.status === 'available' && <>
+                {([['Properties', result.properties], ['Subscriptions', result.subscriptions], ['Process queues', result.processQueues]] as const).map(([label, values]) =>
+                    <details key={label}><summary>{label} ({values.length})</summary><pre className="max-h-64 overflow-auto whitespace-pre-wrap">{JSON.stringify(values, null, 2)}</pre></details>)}
+                {result.jstack !== null && <details open><summary>Thread stack</summary><pre className="max-h-96 overflow-auto whitespace-pre-wrap">{result.jstack}</pre></details>}
+            </>}
+        </>}
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
@@ -179,3 +179,20 @@ export interface ConsumerConfigSummary {
     inconsistentFields: string[];
     effective: Partial<Omit<ConsumerConfigView, 'consumerGroup' | 'brokerName' | 'brokerAddress'>>;
 }
+
+export interface ConsumerDiagnosticRequest {
+    consumerGroup: string;
+    clientId: string;
+    scope: ConsumerQueryScope;
+}
+export interface ConsumerDiagnosticResult {
+    consumerGroup: string;
+    clientId: string;
+    status: 'available' | 'offline' | 'unsupported' | 'unavailable';
+    reason: string | null;
+    properties: unknown[];
+    subscriptions: unknown[];
+    processQueues: unknown[];
+    jstack: string | null;
+    truncated: boolean;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
@@ -3,6 +3,8 @@ import type {
     ConsumerConfigQueryRequest,
     ConsumerConfigView,
     ConsumerConfigSummary,
+    ConsumerDiagnosticRequest,
+    ConsumerDiagnosticResult,
     ConsumerCreateOrUpdateRequest,
     ConsumerDeleteRequest,
     ConsumerConnectionQueryRequest,
@@ -17,6 +19,13 @@ import type {
 } from '../features/consumer/types/consumer.types';
 
 export class ConsumerService {
+    static queryRunningInfo(request: ConsumerDiagnosticRequest): Promise<ConsumerDiagnosticResult> {
+        return invokeAuthenticatedCommand('query_consumer_running_info', { request });
+    }
+    static queryJstack(request: ConsumerDiagnosticRequest): Promise<ConsumerDiagnosticResult> {
+        return invokeAuthenticatedCommand('query_consumer_jstack', { request });
+    }
+
     static async queryConsumerConfigSummary(consumerGroup: string): Promise<ConsumerConfigSummary> {
         return invokeAuthenticatedCommand<ConsumerConfigSummary>('query_consumer_config_summary', { consumerGroup });
     }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10398

### Brief Description
Add manual Consumer runtime and thread-stack queries with authenticated scope/revision checks, fresh connection preflight, explicit availability states, and bounded serialized output. Show properties, subscriptions, process queues, truncation, and diagnostic capability reasons in the client view. Proxy forwarding is explicitly unsupported by the current diagnostic trait instead of silently changing scope.

### How Did You Test This Change?
- Four Tauri diagnostic tests passed: unsupported/offline Broker responses, safe errors, bounded collections, and escaped Unicode thread stacks.
- Frontend build passed.
- Package-scoped Rust formatting and git diff checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consumer diagnostics from the client connection view.
  - Inspect running information or request a thread stack for an individual consumer client.
  - Results include properties, subscriptions, process queues, thread stacks, availability status, and explanatory messages.
  - Long diagnostic responses are safely truncated with a visible warning.
  - Proxy-scope diagnostics are clearly identified as unsupported.

- **Documentation**
  - Added guidance describing diagnostic actions, supported scopes, result states, and response limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->