### PR TITLE
[ISSUE #10400]🚀Preserve Tauri DLQ receipts and exact query scope

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/DLQ_RECEIPTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/DLQ_RECEIPTS.md
@@ -1,0 +1,9 @@
+# DLQ query modes and resend receipts
+
+Choose one explicit mode. Message ID performs a detail lookup. Key takes precedence over time paging when a nonblank `key` is supplied to the DLQ page command; it returns at most 64 matches across the DLQ topic, ignores time/page cursor inputs, and returns no task ID. Blank/absent Key retains the existing time-range page contract. A new time search starts with no cursor; only subsequent time pages reuse it. Changing query inputs invalidates older query responses.
+
+Single and batch resend accept optional `clientId`. Missing or blank values preserve automatic client selection. Before direct consumption the backend loads the actual DLQ message, checks that it belongs to the selected group's DLQ, and derives the business Topic and original message ID from its properties. Missing origin metadata or a retry/DLQ original Topic is rejected. Requests cannot nominate an arbitrary original business Topic. A batch is limited to 256 unique group/message identities.
+
+Each receipt retains `requestMessageId` (the selected DLQ identity) separately from the original `msgId`, plus group, Topic, success, consumeResult and safe remark. Refreshing query results does not clear the receipt. Select only failed messages for review selects failed identities currently visible in the same group, excluding successful identities. It sends nothing; Batch resend still requires explicit confirmation including the chosen ClientId. A group change discards that group's display state and invalidates old mutation callbacks.
+
+Single and selected-message batch CSV exports remain available, including Key and ID result modes. Export scope is the selected messages, not an unbounded full DLQ export.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/service/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/service/tests.rs
@@ -66,6 +66,7 @@ impl Drop for Fixture {
 }
 fn result(success: bool) -> MessageResendResult {
     MessageResendResult {
+        request_message_id: None,
         success,
         message: "secret-result-text".into(),
         consumer_group: "test-group".into(),

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message.rs
@@ -19,3 +19,5 @@ pub(crate) mod service;
 pub(crate) mod types;
 
 pub(crate) use service::MessageManager;
+
+pub(crate) mod dlq;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
@@ -14,6 +14,9 @@
 
 use crate::audit::{AuditAccess, AuditAction, AuditManager, Audited};
 use crate::connection::ConnectionManager;
+use crate::message::dlq::DlqBatchResendMessageRequest;
+use crate::message::dlq::DlqMessagePageQueryRequest;
+use crate::message::dlq::DlqResendMessageRequest;
 use crate::message::service::MessageManager;
 use crate::message::types::DlqBatchMessageExportView;
 use crate::message::types::DlqMessageExportView;
@@ -24,9 +27,6 @@ use crate::message::types::MessageResendResult;
 use crate::message::types::MessageSummaryListResponse;
 use crate::message::types::MessageTraceDetailView;
 use rocketmq_dashboard_common::DlqBatchExportMessageRequest;
-use rocketmq_dashboard_common::DlqBatchResendMessageRequest;
-use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
-use rocketmq_dashboard_common::DlqResendMessageRequest;
 use rocketmq_dashboard_common::DlqViewMessageRequest;
 use rocketmq_dashboard_common::MessageDirectConsumeRequest;
 use rocketmq_dashboard_common::MessageIdQueryRequest;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/dlq.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/dlq.rs
@@ -1,0 +1,142 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::types::MessageResult;
+use crate::error::DashboardError;
+use rocketmq_admin_core::core::message::{DirectConsumeRequest, MessageRecord};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DlqMessagePageQueryRequest {
+    pub(crate) consumer_group: String,
+    pub(crate) begin: i64,
+    pub(crate) end: i64,
+    pub(crate) page_num: u32,
+    pub(crate) page_size: u32,
+    pub(crate) task_id: Option<String>,
+    pub(crate) key: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DlqResendMessageRequest {
+    pub(crate) consumer_group: String,
+    pub(crate) message_id: String,
+    pub(crate) client_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DlqBatchResendMessageRequest {
+    pub(crate) messages: Vec<DlqResendMessageRequest>,
+}
+
+pub(super) fn direct_request(
+    group: String,
+    client_id: Option<String>,
+    message: &MessageRecord,
+) -> MessageResult<DirectConsumeRequest> {
+    if message.topic != format!("%DLQ%{group}") {
+        return Err(DashboardError::Validation(
+            "The selected message does not belong to this group's DLQ.".into(),
+        ));
+    }
+    let property = |key: &str| {
+        message
+            .properties
+            .get(key)
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+    };
+    let topic = property("RETRY_TOPIC")
+        .filter(|topic| !topic.starts_with("%DLQ%") && !topic.starts_with("%RETRY%"))
+        .ok_or_else(|| DashboardError::Validation("The DLQ message has no valid original Topic.".into()))?;
+    let id = property("ORIGIN_MESSAGE_ID")
+        .or_else(|| property("DLQ_ORIGIN_MESSAGE_ID"))
+        .ok_or_else(|| DashboardError::Validation("The DLQ message has no original message ID.".into()))?;
+    Ok(DirectConsumeRequest {
+        topic: topic.into(),
+        consumer_group: group,
+        message_id: id.into(),
+        client_id: client_id.and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_string())
+        }),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn message() -> MessageRecord {
+        MessageRecord {
+            topic: "%DLQ%g".into(),
+            message_id: "dlq-id".into(),
+            unique_message_id: None,
+            keys: None,
+            tags: None,
+            born_timestamp: 0,
+            store_timestamp: 0,
+            born_host: String::new(),
+            store_host: String::new(),
+            queue_id: 0,
+            queue_offset: 0,
+            store_size: 0,
+            reconsume_times: 0,
+            body_crc: 0,
+            sys_flag: 0,
+            flag: 0,
+            prepared_transaction_offset: 0,
+            body: vec![],
+            properties: [
+                ("RETRY_TOPIC".into(), "orders".into()),
+                ("ORIGIN_MESSAGE_ID".into(), "original-id".into()),
+            ]
+            .into(),
+        }
+    }
+    #[test]
+    fn dlq_resend_uses_authoritative_origin_and_optional_client() {
+        let message = message();
+        let request = direct_request("g".into(), Some(" client ".into()), &message).unwrap();
+        assert_eq!(request.topic, "orders");
+        assert_eq!(request.message_id, "original-id");
+        assert_eq!(request.client_id.as_deref(), Some("client"));
+        let old: DlqResendMessageRequest =
+            serde_json::from_str(r#"{"consumerGroup":"g","messageId":"dlq-id"}"#).unwrap();
+        assert!(
+            direct_request(old.consumer_group, old.client_id, &message)
+                .unwrap()
+                .client_id
+                .is_none()
+        );
+    }
+    #[test]
+    fn dlq_resend_rejects_wrong_group_missing_origin_and_dlq_as_original_topic() {
+        let mut message = message();
+        assert!(direct_request("other".into(), None, &message).is_err());
+        message.properties.remove("ORIGIN_MESSAGE_ID");
+        assert!(direct_request("g".into(), None, &message).is_err());
+        message
+            .properties
+            .insert("DLQ_ORIGIN_MESSAGE_ID".into(), "fallback-id".into());
+        assert_eq!(
+            direct_request("g".into(), None, &message).unwrap().message_id,
+            "fallback-id"
+        );
+        message.properties.insert("RETRY_TOPIC".into(), "%DLQ%g".into());
+        assert!(direct_request("g".into(), None, &message).is_err());
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
@@ -14,6 +14,9 @@
 
 use crate::error::DashboardError as MessageError;
 use crate::message::admin::ManagedMessageAdmin;
+use crate::message::dlq::DlqBatchResendMessageRequest;
+use crate::message::dlq::DlqMessagePageQueryRequest;
+use crate::message::dlq::DlqResendMessageRequest;
 use crate::message::page_cache::MessagePageCache;
 use crate::message::page_cache::MessagePageCacheEntry;
 use crate::message::page_cache::MessagePageCacheKey;
@@ -56,9 +59,6 @@ use rocketmq_admin_core::core::message::QueryMessagesByKeyRequest;
 use rocketmq_admin_core::core::message::TraceQueryRequest;
 use rocketmq_admin_core::core::message::TraceSeed;
 use rocketmq_dashboard_common::DlqBatchExportMessageRequest;
-use rocketmq_dashboard_common::DlqBatchResendMessageRequest;
-use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
-use rocketmq_dashboard_common::DlqResendMessageRequest;
 use rocketmq_dashboard_common::DlqViewMessageRequest;
 use rocketmq_dashboard_common::MessageDirectConsumeRequest;
 use rocketmq_dashboard_common::MessageIdQueryRequest;
@@ -188,6 +188,25 @@ impl MessageManager {
         &self,
         request: DlqMessagePageQueryRequest,
     ) -> MessageResult<MessagePageResponse> {
+        if let Some(key) = request.key.as_deref().and_then(non_empty) {
+            let mut response = self
+                .query_message_by_topic_key(MessageKeyQueryRequest {
+                    topic: build_dlq_topic(&request.consumer_group)?,
+                    key,
+                })
+                .await?;
+            response.items.truncate(64);
+            response.total = response.items.len();
+            let query = normalize_message_page_query(MessagePageQueryRequest {
+                topic: build_dlq_topic(&request.consumer_group)?,
+                begin: 0,
+                end: i64::MAX,
+                page_num: 1,
+                page_size: response.items.len().max(1) as u32,
+                task_id: None,
+            })?;
+            return Ok(build_message_page_response(response.items, response.total, &query, ""));
+        }
         let query = normalize_message_page_query(dlq_page_query_to_message_page_request(request)?)?;
         let generation = self.runtime.generation();
 
@@ -954,19 +973,21 @@ impl MessageManager {
     ) -> MessageResult<MessageResendResult> {
         let consumer_group = normalize_required_field("consumerGroup", request.consumer_group)?;
         let message_id = normalize_required_field("messageId", request.message_id)?;
-        let result = admin
-            .resend_dlq_message(&DlqMessageLookupRequest {
+        let message = admin
+            .find_dlq_message(&DlqMessageLookupRequest {
                 consumer_group: consumer_group.clone(),
-                message_id,
+                message_id: message_id.clone(),
             })
             .await
             .map_err(MessageError::Admin)?;
-        Ok(build_message_resend_result(
-            consumer_group,
-            result.topic,
-            result.message_id,
-            result.consume,
-        ))
+        let direct = super::dlq::direct_request(consumer_group.clone(), request.client_id, &message)?;
+        let consume = admin
+            .consume_message_directly(&direct)
+            .await
+            .map_err(MessageError::Admin)?;
+        let mut result = build_message_resend_result(consumer_group, direct.topic, direct.message_id, consume);
+        result.request_message_id = Some(message_id);
+        Ok(result)
     }
 
     async fn export_dlq_message_with_admin(
@@ -1140,19 +1161,30 @@ fn normalize_batch_resend_requests(
 ) -> MessageResult<Vec<DlqResendMessageRequest>> {
     if requests.is_empty() {
         return Err(MessageError::Validation(
-            "At least one DLQ message must be selected for batch resend.".to_string(),
+            "At least one DLQ message must be selected for batch resend.".into(),
         ));
     }
-
-    requests
-        .into_iter()
-        .map(|request| {
-            Ok(DlqResendMessageRequest {
-                consumer_group: normalize_required_field("consumerGroup", request.consumer_group)?,
-                message_id: normalize_required_field("messageId", request.message_id)?,
-            })
-        })
-        .collect()
+    if requests.len() > 256 {
+        return Err(MessageError::Validation(
+            "Select at most 256 DLQ messages per batch.".into(),
+        ));
+    }
+    let mut identities = std::collections::HashSet::new();
+    let mut result = Vec::with_capacity(requests.len());
+    for request in requests {
+        let request = DlqResendMessageRequest {
+            consumer_group: normalize_required_field("consumerGroup", request.consumer_group)?,
+            message_id: normalize_required_field("messageId", request.message_id)?,
+            client_id: request.client_id.as_deref().and_then(non_empty),
+        };
+        if !identities.insert((request.consumer_group.clone(), request.message_id.clone())) {
+            return Err(MessageError::Validation(
+                "A DLQ message can appear only once in a resend batch.".into(),
+            ));
+        }
+        result.push(request);
+    }
+    Ok(result)
 }
 
 fn normalize_batch_export_requests(requests: Vec<DlqViewMessageRequest>) -> MessageResult<Vec<DlqViewMessageRequest>> {
@@ -1320,6 +1352,7 @@ fn build_message_resend_result(
         consumer_group,
         topic,
         msg_id,
+        request_message_id: None,
         consume_result: Some(public_consume_result.to_string()),
         remark: public_remark,
     }
@@ -1347,6 +1380,7 @@ fn build_failed_message_resend_result(
         message: format!("Direct consume failed for `{msg_id}` in consumer group `{consumer_group}`."),
         consumer_group,
         topic: String::new(),
+        request_message_id: Some(msg_id.clone()),
         msg_id,
         consume_result: None,
         remark: Some(crate::error::CommandError::from(error).message.to_string()),
@@ -1936,10 +1970,23 @@ mod tests {
     }
 
     #[test]
+    fn normalize_batch_resend_rejects_duplicate_delivery_even_with_different_clients() {
+        let request = DlqResendMessageRequest {
+            consumer_group: "g".into(),
+            message_id: "m".into(),
+            client_id: None,
+        };
+        let mut duplicate = request.clone();
+        duplicate.client_id = Some("another-client".into());
+        assert!(normalize_batch_resend_requests(vec![request, duplicate]).is_err());
+    }
+
+    #[test]
     fn normalize_batch_resend_requests_trims_fields() {
         let requests = normalize_batch_resend_requests(vec![DlqResendMessageRequest {
             consumer_group: " group-a ".to_string(),
             message_id: " msg-1 ".to_string(),
+            client_id: None,
         }])
         .expect("batch resend requests should normalize");
 
@@ -1948,6 +1995,7 @@ mod tests {
             vec![DlqResendMessageRequest {
                 consumer_group: "group-a".to_string(),
                 message_id: "msg-1".to_string(),
+                client_id: None,
             }]
         );
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
@@ -65,6 +65,7 @@ pub(crate) struct MessageResendResult {
     pub(crate) consumer_group: String,
     pub(crate) topic: String,
     pub(crate) msg_id: String,
+    pub(crate) request_message_id: Option<String>,
     pub(crate) consume_result: Option<String>,
     pub(crate) remark: Option<String>,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { ConsumerRequestGeneration } from '../features/consumer/scope';
+import { failedDlqSelection, dlqQueryTaskId } from '../features/dlq/receipts';
+import type { DlqBatchResendMessageResponse } from '../features/dlq/types/dlq.types';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'motion/react';
 import { toast } from 'sonner@2.0.3';
 import {
@@ -23,7 +26,7 @@ import type { DlqMessageSummary } from '../features/dlq/types/dlq.types';
 import { DlqService } from '../services/dlq.service';
 import { dashboardErrorMessage } from '../services/invoke';
 
-type DlqTab = 'Consumer' | 'Message ID';
+type DlqTab = 'Consumer' | 'Key' | 'Message ID';
 
 const DEFAULT_PAGE_SIZE = 20;
 
@@ -68,6 +71,16 @@ export const DLQMessageView = () => {
   const [activeTab, setActiveTab] = useState<DlqTab>('Consumer');
   const [consumerGroup, setConsumerGroup] = useState('');
   const [messageId, setMessageId] = useState('');
+  const [messageKey, setMessageKey] = useState('');
+  const [clientId, setClientId] = useState('');
+  const [receipt, setReceipt] = useState<DlqBatchResendMessageResponse | null>(null);
+  const queryGeneration = useRef(new ConsumerRequestGeneration());
+  const writeGeneration = useRef(new ConsumerRequestGeneration());
+  useEffect(() => {
+    writeGeneration.current.invalidate(); setReceipt(null);
+    setIsBatchResending(false); setResendingMessageId(null);
+    return () => { writeGeneration.current.invalidate(); queryGeneration.current.invalidate(); };
+  }, [consumerGroup]);
   const [beginTime, setBeginTime] = useState(formatDateTimeInput(new Date(Date.now() - 3 * 60 * 60 * 1000)));
   const [endTime, setEndTime] = useState(formatDateTimeInput(new Date()));
   const [messages, setMessages] = useState<DlqMessageSummary[]>([]);
@@ -103,6 +116,7 @@ export const DLQMessageView = () => {
   }, [consumerGroupOptions, consumerGroup]);
 
   useEffect(() => {
+    setIsSearching(false);
     setMessages([]);
     setSelectedMessage(null);
     setSearchError('');
@@ -111,6 +125,8 @@ export const DLQMessageView = () => {
     setTaskId('');
     setPagination(defaultPagination);
   }, [activeTab]);
+
+  useEffect(() => { queryGeneration.current.invalidate(); return () => queryGeneration.current.invalidate(); }, [activeTab, consumerGroup, messageId, messageKey, beginTime, endTime]);
 
   const formatTimestamp = (value: number) => {
     if (!value) {
@@ -131,6 +147,8 @@ export const DLQMessageView = () => {
   };
 
   const resetConsumerPagingState = () => {
+    queryGeneration.current.invalidate();
+    setIsSearching(false);
     setMessages([]);
     setSelectedMessage(null);
     setSearchError('');
@@ -146,8 +164,9 @@ export const DLQMessageView = () => {
       return;
     }
 
-    const begin = parseDateTimeInput(beginTime);
-    const end = parseDateTimeInput(endTime);
+    if (activeTab === 'Key' && !messageKey.trim()) { setSearchError('Message Key is required.'); return; }
+    const begin = activeTab === 'Key' ? 0 : parseDateTimeInput(beginTime);
+    const end = activeTab === 'Key' ? Date.now() : parseDateTimeInput(endTime);
     if (begin === null || end === null) {
       setSearchError('Begin and end must be valid date-time strings.');
       return;
@@ -157,6 +176,7 @@ export const DLQMessageView = () => {
       return;
     }
 
+    const isCurrent = queryGeneration.current.begin();
     setIsSearching(true);
     setSearchError('');
     setHasSearched(true);
@@ -168,9 +188,11 @@ export const DLQMessageView = () => {
         end,
         pageNum,
         pageSize: pagination.pageSize,
-        taskId: taskId || undefined,
+        taskId: dlqQueryTaskId(activeTab, pageNum, taskId),
+        key: activeTab === 'Key' ? messageKey.trim() : undefined,
       });
 
+      if (!isCurrent()) return;
       setMessages(response.page.content);
       setSelectedMessageIds(EMPTY_SELECTED_IDS);
       setTaskId(response.taskId);
@@ -181,10 +203,11 @@ export const DLQMessageView = () => {
         totalElements: response.page.totalElements,
       });
     } catch (error) {
+      if (!isCurrent()) return;
       setMessages([]);
       setSearchError(dashboardErrorMessage(error, 'Failed to query DLQ messages.'));
     } finally {
-      setIsSearching(false);
+      if (isCurrent()) setIsSearching(false);
     }
   };
 
@@ -198,6 +221,7 @@ export const DLQMessageView = () => {
       return;
     }
 
+    const isCurrent = queryGeneration.current.begin();
     setIsSearching(true);
     setSearchError('');
     setHasSearched(true);
@@ -210,17 +234,19 @@ export const DLQMessageView = () => {
         consumerGroup: consumerGroup.trim(),
         messageId: messageId.trim(),
       });
+      if (!isCurrent()) return;
       setMessages([toSummary(detail)]);
     } catch (error) {
+      if (!isCurrent()) return;
       setMessages([]);
       setSearchError(dashboardErrorMessage(error, 'Failed to query DLQ message detail.'));
     } finally {
-      setIsSearching(false);
+      if (isCurrent()) setIsSearching(false);
     }
   };
 
   const handleSearch = async () => {
-    if (activeTab === 'Consumer') {
+    if (activeTab !== 'Message ID') {
       await queryDlqPage(1);
       return;
     }
@@ -229,6 +255,7 @@ export const DLQMessageView = () => {
   };
 
   const handleResend = async (message: DlqMessageSummary) => {
+    if (isBatchResending || resendingMessageId) return;
     const normalizedConsumerGroup = consumerGroup.trim();
     if (!normalizedConsumerGroup) {
       setSearchError('Consumer group is required.');
@@ -236,12 +263,13 @@ export const DLQMessageView = () => {
     }
 
     const confirmed = window.confirm(
-      `Request direct consume for DLQ message ${message.msgId} in consumer group ${normalizedConsumerGroup}?`,
+      `Request direct consume for DLQ message ${message.msgId} in consumer group ${normalizedConsumerGroup}, ClientId ${clientId.trim() || 'automatic'}?`,
     );
     if (!confirmed) {
       return;
     }
 
+    const isCurrent = writeGeneration.current.begin();
     setResendingMessageId(message.queryMsgId);
     setSearchError('');
 
@@ -249,19 +277,23 @@ export const DLQMessageView = () => {
       const result = await DlqService.resendDlqMessage({
         consumerGroup: normalizedConsumerGroup,
         messageId: message.queryMsgId,
+        clientId: clientId.trim() || undefined,
       });
 
+      if (!isCurrent()) return;
+      setReceipt({ items: [result], total: 1, successCount: Number(result.success), failureCount: Number(!result.success) });
       if (result.success) {
         toast.success(result.message);
       } else {
         toast.error(result.message);
       }
     } catch (error) {
+      if (!isCurrent()) return;
       const messageText = dashboardErrorMessage(error, 'Failed to resend DLQ message.');
       toast.error(messageText);
       setSearchError(messageText);
     } finally {
-      setResendingMessageId(null);
+      if (isCurrent()) setResendingMessageId(null);
     }
   };
 
@@ -299,6 +331,7 @@ export const DLQMessageView = () => {
   };
 
   const handleBatchResend = async () => {
+    if (isBatchResending || resendingMessageId) return;
     const normalizedConsumerGroup = consumerGroup.trim();
     if (!normalizedConsumerGroup) {
       setSearchError('Consumer group is required.');
@@ -312,12 +345,13 @@ export const DLQMessageView = () => {
     }
 
     const confirmed = window.confirm(
-      `Request direct consume for ${selectedMessages.length} DLQ message(s) in consumer group ${normalizedConsumerGroup}?`,
+      `Request direct consume for ${selectedMessages.length} DLQ message(s) in consumer group ${normalizedConsumerGroup}, ClientId ${clientId.trim() || 'automatic'}?`,
     );
     if (!confirmed) {
       return;
     }
 
+    const isCurrent = writeGeneration.current.begin();
     setIsBatchResending(true);
     setSearchError('');
 
@@ -326,9 +360,12 @@ export const DLQMessageView = () => {
         messages: selectedMessages.map((message) => ({
           consumerGroup: normalizedConsumerGroup,
           messageId: message.queryMsgId,
+          clientId: clientId.trim() || undefined,
         })),
       });
 
+      if (!isCurrent()) return;
+      setReceipt(response);
       if (response.failureCount === 0) {
         toast.success(`Batch resend completed for ${response.successCount} DLQ message(s).`);
       } else if (response.successCount === 0) {
@@ -347,13 +384,14 @@ export const DLQMessageView = () => {
         }
       }
 
-      await queryDlqPage(pagination.currentPage || 1);
+      setSelectedMessageIds(EMPTY_SELECTED_IDS);
     } catch (error) {
+      if (!isCurrent()) return;
       const messageText = dashboardErrorMessage(error, 'Failed to batch resend DLQ messages.');
       toast.error(messageText);
       setSearchError(messageText);
     } finally {
-      setIsBatchResending(false);
+      if (isCurrent()) setIsBatchResending(false);
     }
   };
 
@@ -435,7 +473,7 @@ export const DLQMessageView = () => {
     if (activeTab === 'Consumer') {
       return 'Enter a consumer group and time range to search DLQ messages.';
     }
-    return 'Enter a consumer group and message id to load the DLQ message detail.';
+    return activeTab === 'Key' ? 'Enter a Consumer group and exact message Key.' : 'Enter a consumer group and message id to load the DLQ message detail.';
   };
 
   return (
@@ -446,9 +484,22 @@ export const DLQMessageView = () => {
         message={selectedMessage}
       />
 
+      {receipt && <section aria-label="DLQ resend receipts" className="rounded border border-blue-300 p-4 mb-4 overflow-auto">
+        <h3>Latest resend receipt: {receipt.successCount} succeeded / {receipt.failureCount} failed</h3>
+        <table className="w-full text-left text-sm"><thead><tr><th>DLQ request ID</th><th>Original ID / Topic</th><th>Group</th><th>Success</th><th>Consume result</th><th>Remark</th></tr></thead><tbody>
+          {receipt.items.map((item, index) => <tr key={`${item.requestMessageId ?? item.msgId}:${index}`}><td>{item.requestMessageId ?? item.msgId}</td><td>{item.msgId} / {item.topic}</td><td>{item.consumerGroup}</td><td>{String(item.success)}</td><td>{item.consumeResult ?? 'Not confirmed'}</td><td>{item.remark || item.message}</td></tr>)}
+        </tbody></table>
+        <button type="button" disabled={isBatchResending || Boolean(resendingMessageId)} onClick={() => {
+          const failed = failedDlqSelection(receipt, consumerGroup.trim(), messages);
+          setSelectedMessageIds(failed);
+          setSearchError(failed.size ? 'Only visible failed messages are selected. Review and confirm Batch resend to retry.' : 'No failed messages from this receipt are visible in the current query. Refresh or query their IDs first.');
+        }}>Select only failed messages for review</button>
+      </section>}
+      <details className="mb-4"><summary>Advanced resend target</summary><label>Optional ClientId <Input value={clientId} onChange={event => setClientId(event.target.value)} placeholder="Automatic client selection when empty" /></label></details>
+      <p className="text-sm mb-3">Select a query mode: Message ID and Key are exact queries with no time-page cursor. Key returns at most 64 matches. CSV exports include only explicitly selected messages.</p>
       <div className="mb-8 flex justify-center">
         <div className="inline-flex rounded-xl bg-gray-100 p-1 shadow-inner dark:bg-gray-800">
-          {(['Consumer', 'Message ID'] as DlqTab[]).map((tab) => (
+          {(['Consumer', 'Key', 'Message ID'] as DlqTab[]).map((tab) => (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
@@ -480,9 +531,8 @@ export const DLQMessageView = () => {
                 value={consumerGroup}
                 onChange={(event) => {
                   setConsumerGroup(event.target.value);
-                  if (activeTab === 'Consumer') {
-                    resetConsumerPagingState();
-                  }
+                  writeGeneration.current.invalidate();
+                  resetConsumerPagingState();
                 }}
                 list="dlq-consumer-group-options"
                 placeholder={isConsumerCatalogLoading ? 'Loading consumer groups...' : 'Enter consumer group...'}
@@ -532,13 +582,13 @@ export const DLQMessageView = () => {
           ) : (
             <div className="flex min-w-[320px] flex-1 items-center space-x-2">
               <span className="whitespace-nowrap text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                Message ID:
+                {activeTab === 'Key' ? 'Message Key:' : 'Message ID:'}
               </span>
               <div className="relative flex-1">
                 <Input
-                  value={messageId}
-                  onChange={(event) => setMessageId(event.target.value)}
-                  placeholder="Enter Message ID..."
+                  value={activeTab === 'Key' ? messageKey : messageId}
+                  onChange={(event) => { if (activeTab === 'Key') setMessageKey(event.target.value); else setMessageId(event.target.value); resetConsumerPagingState(); }}
+                  placeholder={activeTab === 'Key' ? 'Enter Message Key...' : 'Enter Message ID...'}
                   className="border-gray-200 bg-gray-50 pr-10 font-mono text-gray-900 placeholder:text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
                 />
                 <Hash className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
@@ -557,11 +607,11 @@ export const DLQMessageView = () => {
             {isSearching ? 'SEARCHING...' : 'SEARCH'}
           </button>
 
-          {activeTab === 'Consumer' ? (
+
             <>
               <button
                 onClick={() => void handleBatchResend()}
-                disabled={isBatchResending || isBatchExporting || selectedMessageIds.size === 0}
+                disabled={isBatchResending || Boolean(resendingMessageId) || isBatchExporting || selectedMessageIds.size === 0}
                 className="flex items-center rounded-xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
               >
                 <Send className="mr-2 h-4 w-4" />
@@ -576,7 +626,7 @@ export const DLQMessageView = () => {
                 {isBatchExporting ? 'Batch Exporting...' : `Batch Export${selectedMessageIds.size > 0 ? ` (${selectedMessageIds.size})` : ''}`}
               </button>
             </>
-          ) : null}
+
         </div>
       </div>
 
@@ -597,7 +647,7 @@ export const DLQMessageView = () => {
       <div>
         {messages.length > 0 ? (
           <>
-            {activeTab === 'Consumer' ? (
+
               <div className="mb-4 flex items-center justify-between rounded-2xl border border-gray-100 bg-white px-4 py-3 text-sm text-gray-600 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
                 <label className="flex items-center gap-3">
                   <input
@@ -612,7 +662,7 @@ export const DLQMessageView = () => {
                   {selectedMessageIds.size} selected
                 </span>
               </div>
-            ) : null}
+
 
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2 2xl:grid-cols-3">
             {messages.map((message, index) => (
@@ -629,14 +679,14 @@ export const DLQMessageView = () => {
                       Message ID
                     </span>
                     <div className="flex items-center gap-3">
-                      {activeTab === 'Consumer' ? (
+
                         <input
                           type="checkbox"
                           checked={isMessageSelected(message)}
                           onChange={() => toggleMessageSelection(message)}
                           className="h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800"
                         />
-                      ) : null}
+
                       <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-500 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
                         DLQ
                       </span>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/receipts.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/receipts.test.ts
@@ -1,0 +1,16 @@
+import { expect, it } from 'vitest';
+import { dlqQueryTaskId, failedDlqSelection } from './receipts';
+
+it('reviews only visible failed DLQ request identities without successful or other-group messages', () => {
+    const row = (id: string, success: boolean, group = 'g') => ({ requestMessageId: id, msgId: `original-${id}`, consumerGroup: group, success, topic: 'orders', message: '' });
+    const receipt = { items: [row('a', true), row('a', false), row('b', false), row('c', false, 'other'), row('missing', false)], total: 5, successCount: 1, failureCount: 4 };
+    const messages = ['a', 'b', 'c'].map(id => ({ queryMsgId: id, msgId: id, topic: '%DLQ%g', storeTimestamp: 0 }));
+    expect([...failedDlqSelection(receipt, 'g', messages)]).toEqual(['b']);
+});
+
+it('starts fresh searches and never reuses time pagination in exact modes', () => {
+    expect(dlqQueryTaskId('Consumer', 2, 'task')).toBe('task');
+    expect(dlqQueryTaskId('Consumer', 1, 'task')).toBeUndefined();
+    expect(dlqQueryTaskId('Key', 2, 'task')).toBeUndefined();
+    expect(dlqQueryTaskId('Message ID', 2, 'task')).toBeUndefined();
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/receipts.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/receipts.ts
@@ -1,0 +1,10 @@
+import type { DlqBatchResendMessageResponse, DlqMessageSummary } from './types/dlq.types';
+
+export function failedDlqSelection(receipt: DlqBatchResendMessageResponse, group: string, messages: DlqMessageSummary[]): Set<string> {
+    const visible = new Set(messages.map(message => message.queryMsgId));
+    const successful = new Set(receipt.items.filter(item => item.success && item.consumerGroup === group).map(item => item.requestMessageId ?? item.msgId));
+    return new Set(receipt.items.filter(item => !item.success && item.consumerGroup === group)
+        .map(item => item.requestMessageId ?? item.msgId).filter(id => visible.has(id) && !successful.has(id)));
+}
+
+export const dlqQueryTaskId = (mode: string, page: number, taskId: string) => mode === 'Consumer' && page > 1 ? taskId || undefined : undefined;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/types/dlq.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/types/dlq.types.ts
@@ -11,6 +11,7 @@ export interface DlqMessagePageQueryRequest {
     pageNum: number;
     pageSize: number;
     taskId?: string | null;
+    key?: string | null;
 }
 
 export interface DlqMessageDetailRequest {
@@ -24,6 +25,7 @@ export interface DlqMessageExportRequest {
 }
 
 export interface DlqResendMessageRequest {
+    clientId?: string | null;
     consumerGroup: string;
     messageId: string;
 }
@@ -37,6 +39,7 @@ export interface DlqBatchExportMessageRequest {
 }
 
 export interface DlqResendMessageResult {
+    requestMessageId?: string | null;
     success: boolean;
     message: string;
     consumerGroup: string;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10400

### Brief Description
Keep complete single/batch DLQ receipts with requested and original message identities, safe failure-only review, and manual retry confirmation. Add exact Key queries independent of time cursors and optional ClientId for direct consumption. Resolve original metadata from the selected group's actual DLQ message, reject duplicate deliveries in one batch, and preserve selected-message CSV export in all query modes.

### How Did You Test This Change?
- Tauri `cargo test --lib message::`: 30 passed, including authoritative origin validation, absent ClientId compatibility, duplicate rejection and error redaction.
- Two frontend tests passed for failed selection and cursor isolation.
- Frontend build, package format check and git diff check passed.
