### PR TITLE
[ISSUE #10402]🚀Filter Tauri Topics by exact Broker and Cluster membership

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/TOPIC_FILTERS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/TOPIC_FILTERS.md
@@ -1,0 +1,5 @@
+# Topic filtering
+
+Broker, Cluster, and message type selectors come from the current catalog. Broker and Cluster use exact, case-sensitive array membership; free-text search retains case-insensitive substring matching across the existing name, category, message type, Broker and Cluster fields. All conditions compose with the category toggles.
+
+Changing a filter returns to page one and selects its first matching Topic for an ordinary catalog view. A navigation target keeps its exact identity; if filtered out, its details are hidden and an explicit message offers clearing filters. A removed filter value remains visible as absent from the current catalog instead of silently broadening the query. Navigation history preserves filter state.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
@@ -1,3 +1,4 @@
+import { filterTopics } from '../features/topic/filters';
 import { ConsumerService } from '../services/consumer.service';
 import { OffsetResetForm } from '../features/topic/components/OffsetResetForm';
 import { TopicMutationReceipt, failedBrokerNames } from '../features/topic/components/TopicMutationReceipt';
@@ -2839,6 +2840,9 @@ export const TopicView = () => {
 
     const {data, error, isLoading, isRefreshPending, isRefreshing, refresh} = useTopicCatalog();
     const [searchTerm, setSearchTerm] = useNavigationState('search', '');
+    const [brokerFilter, setBrokerFilter] = useNavigationState('brokerFilter', '');
+    const [clusterFilter, setClusterFilter] = useNavigationState('clusterFilter', '');
+    const [messageTypeFilter, setMessageTypeFilter] = useNavigationState('messageTypeFilter', '');
     const [selectedFilters, setSelectedFilters] = useNavigationState<Record<TopicCategory, boolean>>('filters', () => target ? Object.fromEntries(TOPIC_FILTER_ORDER.map((key) => [key, true])) as Record<TopicCategory, boolean> : buildDefaultTopicFilters());
     const [currentPage, setCurrentPage] = useNavigationState('page', 1);
     const [selectedTopicName, setSelectedTopicName] = useNavigationState<string | null>('selection', target?.name ?? null);
@@ -2864,36 +2868,18 @@ export const TopicView = () => {
 
     const topics = useMemo(() => (data?.items ?? []).map(mapTopicListItem), [data?.items]);
     const normalizedSearch = searchTerm.trim().toLowerCase();
-    const filteredTopics = useMemo(
-        () =>
-            topics.filter((topic) => {
-                const matchesType = selectedFilters[topic.type as TopicCategory] ?? true;
-                if (!matchesType) {
-                    return false;
-                }
-
-                if (!normalizedSearch) {
-                    return true;
-                }
-
-                const searchableText = [
-                    topic.name,
-                    topic.type,
-                    topic.messageType,
-                    ...topic.clusters,
-                    ...topic.brokers,
-                ].join(' ').toLowerCase();
-
-                return searchableText.includes(normalizedSearch);
-            }),
-        [normalizedSearch, selectedFilters, topics],
-    );
+    const filteredTopics = useMemo(() => filterTopics(topics, {
+        search: normalizedSearch, categories: selectedFilters, brokerName: brokerFilter, clusterName: clusterFilter, messageType: messageTypeFilter,
+    }), [normalizedSearch, selectedFilters, brokerFilter, clusterFilter, messageTypeFilter, topics]);
+    const brokerOptions = useMemo(() => [...new Set(topics.flatMap(topic => topic.brokers))].sort(), [topics]);
+    const clusterOptions = useMemo(() => [...new Set(topics.flatMap(topic => topic.clusters))].sort(), [topics]);
+    const messageTypes = useMemo(() => [...new Set(topics.map(topic => topic.messageType))].sort(), [topics]);
     const totalPages = Math.max(1, Math.ceil(filteredTopics.length / TOPIC_PAGE_SIZE));
     const pagedTopics = filteredTopics.slice(
         (currentPage - 1) * TOPIC_PAGE_SIZE,
         currentPage * TOPIC_PAGE_SIZE,
     );
-    const selectedTopic = findEntity(target ? topics : filteredTopics, (topic) => topic.name, selectedTopicName);
+    const selectedTopic = findEntity(filteredTopics, (topic) => topic.name, selectedTopicName);
     const targetMissing = target && data && !isLoading && !error && !topics.some((topic) => topic.name === target.name);
     const topicTypeCounts = useMemo(
         () =>
@@ -2909,11 +2895,16 @@ export const TopicView = () => {
     const targetBrokerCount = data?.targets.reduce((sum, target) => sum + target.brokerNames.length, 0) ?? 0;
     const activeFilterCount = TOPIC_FILTER_ORDER.filter((key) => selectedFilters[key]).length;
 
-    const previousFilter = useRef({ normalizedSearch, selectedFilters });
+    const previousFilter = useRef({ normalizedSearch, selectedFilters, brokerFilter, clusterFilter, messageTypeFilter });
     useEffect(() => {
-        if (previousFilter.current.normalizedSearch !== normalizedSearch || previousFilter.current.selectedFilters !== selectedFilters) setCurrentPage(1);
-        previousFilter.current = { normalizedSearch, selectedFilters };
-    }, [normalizedSearch, selectedFilters]);
+        const previous = previousFilter.current;
+        if (previous.normalizedSearch !== normalizedSearch || previous.selectedFilters !== selectedFilters ||
+            previous.brokerFilter !== brokerFilter || previous.clusterFilter !== clusterFilter || previous.messageTypeFilter !== messageTypeFilter) {
+            setCurrentPage(1);
+            setSelectedTopicName(target?.name ?? filteredTopics[0]?.name ?? null);
+        }
+        previousFilter.current = { normalizedSearch, selectedFilters, brokerFilter, clusterFilter, messageTypeFilter };
+    }, [normalizedSearch, selectedFilters, brokerFilter, clusterFilter, messageTypeFilter]);
 
     useEffect(() => {
         if (data && currentPage > totalPages) {
@@ -3113,6 +3104,7 @@ export const TopicView = () => {
                 />
             </section>
 
+            {target && !targetMissing && data && !filteredTopics.some(topic => topic.name === target.name) && <p role="status" className="p-4">The requested Topic is hidden by current filters. Clear the filters to inspect it.</p>}
             <section className="topic-command-panel" aria-label="Topic filters and actions">
                 <div className="topic-command-main">
                     <label className="topic-search-field">
@@ -3146,6 +3138,20 @@ export const TopicView = () => {
                     </div>
                 </div>
 
+                <div className="flex flex-wrap gap-4 p-4" aria-label="Exact Topic filters">
+                    <label>Broker <select className="rounded border p-2 dark:bg-gray-900" value={brokerFilter} onChange={event => setBrokerFilter(event.target.value)}>
+                        <option value="">All Brokers</option>{brokerFilter && !brokerOptions.includes(brokerFilter) && <option value={brokerFilter}>{brokerFilter} (not in current catalog)</option>}
+                        {brokerOptions.map(value => <option key={value} value={value}>{value}</option>)}
+                    </select></label>
+                    <label>Cluster <select className="rounded border p-2 dark:bg-gray-900" value={clusterFilter} onChange={event => setClusterFilter(event.target.value)}>
+                        <option value="">All clusters</option>{clusterFilter && !clusterOptions.includes(clusterFilter) && <option value={clusterFilter}>{clusterFilter} (not in current catalog)</option>}
+                        {clusterOptions.map(value => <option key={value} value={value}>{value}</option>)}
+                    </select></label>
+                    <label>Message type <select className="rounded border p-2 dark:bg-gray-900" value={messageTypeFilter} onChange={event => setMessageTypeFilter(event.target.value)}>
+                        <option value="">All message types</option>{messageTypeFilter && !messageTypes.includes(messageTypeFilter) && <option value={messageTypeFilter}>{messageTypeFilter} (not in current catalog)</option>}{messageTypes.map(value => <option key={value} value={value}>{value}</option>)}
+                    </select></label>
+                    <button type="button" onClick={() => { setBrokerFilter(''); setClusterFilter(''); setMessageTypeFilter(''); setSearchTerm(''); setSelectedFilters(Object.fromEntries(TOPIC_FILTER_ORDER.map(key => [key, true])) as Record<TopicCategory, boolean>); }}>Clear filters</button>
+                </div>
                 <div className="topic-filter-row">
                     <div className="topic-filter-label">
                         <Filter className="topic-icon" aria-hidden="true"/>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/filters.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/filters.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from 'vitest';
+import { filterTopics, type TopicFilters } from './filters';
+
+const topics = [
+    { name: 'orders', type: 'NORMAL', messageType: 'NORMAL', brokers: ['broker-a'], clusters: ['cluster-a'] },
+    { name: 'orders-archive', type: 'NORMAL', messageType: 'NORMAL', brokers: ['broker-a-extra'], clusters: ['cluster-a-extra'] },
+    { name: 'orders-fifo', type: 'FIFO', messageType: 'FIFO', brokers: ['broker-a'], clusters: ['cluster-a'] },
+    { name: 'other', type: 'NORMAL', messageType: 'NORMAL', brokers: ['broker-a'], clusters: ['cluster-b'] },
+];
+const filters: TopicFilters = { search: '', categories: {}, brokerName: '', clusterName: '', messageType: '' };
+
+it('combines search, category, exact Broker/Cluster membership and message type', () => {
+    const selected = filterTopics(topics, { ...filters, search: ' ORDERS ', brokerName: 'broker-a', clusterName: 'cluster-a', messageType: 'NORMAL' });
+    expect(selected.map(topic => topic.name)).toEqual(['orders']);
+    expect(filterTopics(topics, { ...filters, categories: { NORMAL: false }, brokerName: 'broker-a', clusterName: 'cluster-a' }).map(topic => topic.name)).toEqual(['orders-fifo']);
+    expect(filterTopics(topics, { ...filters, brokerName: 'broker' })).toEqual([]);
+});
+
+it('preserves broad text search while exact route filters never match substrings', () => {
+    expect(filterTopics(topics, { ...filters, search: 'cluster-a' })).toHaveLength(3);
+    expect(filterTopics(topics, { ...filters, clusterName: 'cluster-a' })).toHaveLength(2);
+    expect(filterTopics(topics, { ...filters, brokerName: 'BROKER-A' })).toEqual([]);
+    expect(filterTopics(topics, filters)).toEqual(topics);
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/filters.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/filters.ts
@@ -1,0 +1,26 @@
+export interface FilterableTopic {
+    name: string;
+    type: string;
+    messageType: string;
+    clusters: string[];
+    brokers: string[];
+}
+
+export interface TopicFilters {
+    search: string;
+    categories: Partial<Record<string, boolean>>;
+    brokerName: string;
+    clusterName: string;
+    messageType: string;
+}
+
+export function filterTopics<T extends FilterableTopic>(topics: T[], filters: TopicFilters): T[] {
+    const search = filters.search.trim().toLowerCase();
+    return topics.filter(topic => {
+        if (filters.categories[topic.type] === false) return false;
+        if (filters.brokerName && !topic.brokers.includes(filters.brokerName)) return false;
+        if (filters.clusterName && !topic.clusters.includes(filters.clusterName)) return false;
+        if (filters.messageType && topic.messageType !== filters.messageType) return false;
+        return !search || [topic.name, topic.type, topic.messageType, ...topic.clusters, ...topic.brokers].join(' ').toLowerCase().includes(search);
+    });
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10402

### Brief Description
Combine exact Broker/Cluster membership and message type selectors with existing Topic text/category filters. Preserve navigation filter state, return changed filters to page one, and explicitly hide details for filtered navigation targets instead of showing an unrelated entity.

### How Did You Test This Change?
- Two pure filter tests passed for combined criteria, exact membership, case sensitivity, and existing text search.
- Frontend build and git diff check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Broker, Cluster, and Message Type filters to the topic view.
  * Filters can be combined with category toggles and text search.
  * Changing filters returns to the first page and selects the first matching topic.
  * Added a Clear filters option and a message when the requested topic is hidden by active filters.
  * Navigation preserves filter selections and exact topic targeting.

* **Documentation**
  * Documented topic filtering, navigation, and filter-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->