### PR TITLE
[ISSUE #10404]🚀Show Tauri dashboard metrics with observation quality

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/DASHBOARD_OVERVIEW.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/DASHBOARD_OVERVIEW.md
@@ -1,0 +1,7 @@
+# Global dashboard overview
+
+The authenticated overview command reuses the Cluster, Topic, Consumer and Producer managers and checks connection revision before and after the combined read. No additional admin session or detached worker is created.
+
+Statuses distinguish UNCONFIGURED, DOWN (all metrics unavailable), PARTIAL, and READY (queries returned). Each nullable metric also carries complete, reported, partial, or unknown quality. Topic catalog counts are reported because the existing catalog does not expose source coverage. Consumer and Producer counts use workspace inventory failure evidence; total lag sums only observed nonnegative values and is explicitly partial if any group is missing. No unavailable metric is substituted with zero.
+
+Existing Broker TPS/Top and Topic queue/type charts remain. New cards show Topic, Consumer-group, Producer-group and observed lag counts. Actions use the shared navigation store to open NameServer configuration, Broker availability, Consumer backlog, or a specific lagging group's progress. Refresh timestamps describe observations, not persisted history.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
@@ -66,6 +66,19 @@ pub(crate) struct ConsumerManager {
 }
 
 impl ConsumerManager {
+    pub(crate) async fn workspace_inventory(&self) -> ConsumerResult<ConsumerInventoryResult> {
+        let mut session = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session).await?;
+        let admin = &session
+            .as_ref()
+            .ok_or_else(|| ConsumerError::Validation("Consumer connection unavailable.".into()))?
+            .admin;
+        admin
+            .consumer_inventory(&ConsumerInventoryRequest::default())
+            .await
+            .map_err(map_admin_error)
+    }
+
     pub(crate) fn new(runtime: Arc<NameServerRuntimeState>) -> Self {
         Self {
             runtime,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/commands.rs
@@ -58,3 +58,29 @@ pub async fn query_dashboard_topic_current(
     result
 }
 use crate::auth::SessionState;
+
+#[tauri::command]
+pub async fn get_dashboard_overview(
+    session_id: String,
+    expected_revision: i64,
+    connection_manager: State<'_, ConnectionManager>,
+    session_state: State<'_, SessionState>,
+    cluster_manager: State<'_, ClusterManager>,
+    topic_manager: State<'_, TopicManager>,
+    consumer_manager: State<'_, crate::consumer::ConsumerManager>,
+    producer_manager: State<'_, crate::producer::service::ProducerManager>,
+) -> CommandResult<super::overview::Overview> {
+    authorize_command(&session_id, &session_state).await?;
+    connection_manager.check_revision(expected_revision)?;
+    let configured = connection_manager.snapshot()?.nameserver.current_namesrv.is_some();
+    let result = super::overview::query(
+        configured,
+        &cluster_manager,
+        &topic_manager,
+        &consumer_manager,
+        &producer_manager,
+    )
+    .await;
+    connection_manager.check_revision(expected_revision)?;
+    Ok(result)
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/mod.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/mod.rs
@@ -15,3 +15,5 @@
 pub(crate) mod commands;
 mod service;
 mod types;
+
+mod overview;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/overview.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/overview.rs
@@ -1,0 +1,277 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    cluster::service::ClusterManager, consumer::ConsumerManager, producer::service::ProducerManager,
+    topic::service::TopicManager,
+};
+use rocketmq_admin_core::core::consumer_workspace::{
+    ConsumerInventoryResult, WorkspaceFailureStage, WorkspaceObservationState,
+};
+use rocketmq_dashboard_common::{ClusterHomePageRequest, TopicListRequest};
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Quality {
+    Complete,
+    Reported,
+    Partial,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct Metric {
+    value: Option<i64>,
+    quality: Quality,
+}
+impl Metric {
+    fn unknown() -> Self {
+        Self {
+            value: None,
+            quality: Quality::Unknown,
+        }
+    }
+    fn count(value: usize, quality: Quality) -> Self {
+        Self {
+            value: i64::try_from(value).ok(),
+            quality,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum OverviewStatus {
+    Unconfigured,
+    Down,
+    Partial,
+    Ready,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Overview {
+    status: OverviewStatus,
+    observed_at_ms: i64,
+    brokers: Metric,
+    topics: Metric,
+    consumer_groups: Metric,
+    producer_groups: Metric,
+    total_lag: Metric,
+    lagging_groups: Vec<String>,
+}
+
+fn assemble(configured: bool, metrics: [Metric; 5], lagging_groups: Vec<String>) -> Overview {
+    let status = if !configured {
+        OverviewStatus::Unconfigured
+    } else if metrics.iter().all(|metric| metric.value.is_none()) {
+        OverviewStatus::Down
+    } else if metrics
+        .iter()
+        .any(|metric| matches!(metric.quality, Quality::Partial | Quality::Unknown))
+    {
+        OverviewStatus::Partial
+    } else {
+        OverviewStatus::Ready
+    };
+    let [brokers, topics, consumer_groups, producer_groups, total_lag] = metrics;
+    Overview {
+        status,
+        observed_at_ms: chrono::Utc::now().timestamp_millis(),
+        brokers,
+        topics,
+        consumer_groups,
+        producer_groups,
+        total_lag,
+        lagging_groups,
+    }
+}
+
+pub(super) async fn query(
+    configured: bool,
+    cluster: &ClusterManager,
+    topic: &TopicManager,
+    consumer: &ConsumerManager,
+    producer: &ProducerManager,
+) -> Overview {
+    if !configured {
+        return assemble(false, std::array::from_fn(|_| Metric::unknown()), vec![]);
+    }
+    let (brokers, topics, consumers, producers) = tokio::join!(
+        cluster.get_cluster_home_page(ClusterHomePageRequest { force_refresh: false }),
+        topic.get_topic_list(TopicListRequest {
+            skip_sys_process: false,
+            skip_retry_and_dlq: false
+        }),
+        consumer.workspace_inventory(),
+        producer.workspace_inventory(),
+    );
+    let brokers = brokers
+        .map(|value| {
+            Metric::count(
+                value.summary.total_brokers,
+                if value.summary.brokers_with_status_errors > 0 {
+                    Quality::Partial
+                } else {
+                    Quality::Complete
+                },
+            )
+        })
+        .unwrap_or_else(|_| Metric::unknown());
+    // The existing Topic catalog does not expose per-source coverage; keep that qualification visible.
+    let topics = topics
+        .map(|value| Metric::count(value.total, Quality::Reported))
+        .unwrap_or_else(|_| Metric::unknown());
+    let (consumer_groups, total_lag, lagging_groups) = consumers
+        .map(consumer_metrics)
+        .unwrap_or_else(|_| (Metric::unknown(), Metric::unknown(), vec![]));
+    let producer_groups = producers
+        .map(|value| match value.observation {
+            WorkspaceObservationState::Complete => Metric::count(value.items.len(), Quality::Complete),
+            WorkspaceObservationState::Partial => Metric::count(value.items.len(), Quality::Partial),
+            WorkspaceObservationState::Unknown => Metric::unknown(),
+        })
+        .unwrap_or_else(|_| Metric::unknown());
+    assemble(
+        true,
+        [brokers, topics, consumer_groups, producer_groups, total_lag],
+        lagging_groups,
+    )
+}
+
+fn consumer_metrics(inventory: ConsumerInventoryResult) -> (Metric, Metric, Vec<String>) {
+    let discovery_complete = !inventory.targets.is_empty()
+        && !inventory
+            .failures
+            .iter()
+            .any(|failure| failure.stage == WorkspaceFailureStage::Inventory);
+    let groups = if discovery_complete {
+        Metric::count(inventory.items.len(), Quality::Complete)
+    } else if !inventory.items.is_empty() {
+        Metric::count(inventory.items.len(), Quality::Partial)
+    } else {
+        Metric::unknown()
+    };
+    let mut lag = 0i64;
+    let mut observed = 0;
+    let mut complete = discovery_complete;
+    let mut lagging = Vec::new();
+    for group in &inventory.items {
+        match group.diff_total.value().copied() {
+            Some(value) if value >= 0 => {
+                let Some(sum) = lag.checked_add(value) else {
+                    return (groups, Metric::unknown(), lagging);
+                };
+                lag = sum;
+                observed += 1;
+                complete &= group.diff_total.state() == WorkspaceObservationState::Complete;
+                if value > 0 && lagging.len() < 10 {
+                    lagging.push(group.group.clone());
+                }
+            }
+            _ => complete = false,
+        }
+    }
+    let lag = if complete {
+        Metric {
+            value: Some(lag),
+            quality: Quality::Complete,
+        }
+    } else if observed > 0 {
+        Metric {
+            value: Some(lag),
+            quality: Quality::Partial,
+        }
+    } else {
+        Metric::unknown()
+    };
+    (groups, lag, lagging)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn overview_distinguishes_unconfigured_down_ready_and_partial_without_zero_fallback() {
+        let unknown = || std::array::from_fn(|_| Metric::unknown());
+        assert_eq!(assemble(false, unknown(), vec![]).status, OverviewStatus::Unconfigured);
+        let down = assemble(true, unknown(), vec![]);
+        assert_eq!(down.status, OverviewStatus::Down);
+        assert!(down.brokers.value.is_none());
+        let metrics = std::array::from_fn(|_| Metric::count(2, Quality::Complete));
+        assert_eq!(assemble(true, metrics.clone(), vec![]).status, OverviewStatus::Ready);
+        let mut partial = metrics;
+        partial[4] = Metric::unknown();
+        assert_eq!(assemble(true, partial, vec![]).status, OverviewStatus::Partial);
+    }
+    #[test]
+    fn partial_consumer_lag_preserves_observed_values_without_claiming_complete() {
+        use rocketmq_admin_core::core::consumer_workspace::{
+            ConsumerInventoryItem, ConsumerWorkspaceTarget, WorkspaceObservation, WorkspaceUnknownReason,
+        };
+        let group = |name: &str, lag| ConsumerInventoryItem {
+            group: name.into(),
+            category: "NORMAL".into(),
+            client_count: WorkspaceObservation::Unknown {
+                reason: WorkspaceUnknownReason::Unavailable,
+            },
+            diff_total: lag,
+            consume_type: WorkspaceObservation::Unknown {
+                reason: WorkspaceUnknownReason::Unavailable,
+            },
+            message_model: WorkspaceObservation::Unknown {
+                reason: WorkspaceUnknownReason::Unavailable,
+            },
+            targets: vec![],
+        };
+        let inventory = ConsumerInventoryResult {
+            items: vec![
+                group("a", WorkspaceObservation::Complete { value: 10 }),
+                group(
+                    "b",
+                    WorkspaceObservation::Unknown {
+                        reason: WorkspaceUnknownReason::Unavailable,
+                    },
+                ),
+            ],
+            targets: vec![ConsumerWorkspaceTarget {
+                cluster_name: "c".into(),
+                broker_name: "b".into(),
+                broker_address: "addr".into(),
+            }],
+            observation: WorkspaceObservationState::Partial,
+            failures: vec![],
+        };
+        let (groups, lag, lagging) = consumer_metrics(inventory);
+        assert_eq!(groups.value, Some(2));
+        assert_eq!(groups.quality, Quality::Complete);
+        assert_eq!(lag.value, Some(10));
+        assert_eq!(lag.quality, Quality::Partial);
+        assert_eq!(lagging, ["a"]);
+    }
+
+    #[test]
+    fn missing_consumer_inventory_cannot_claim_zero_lag() {
+        let inventory = ConsumerInventoryResult {
+            items: vec![],
+            targets: vec![],
+            observation: WorkspaceObservationState::Unknown,
+            failures: vec![],
+        };
+        let (groups, lag, _) = consumer_metrics(inventory);
+        assert!(groups.value.is_none());
+        assert!(lag.value.is_none());
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -293,6 +293,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
             consumer::commands::create_or_update_consumer_group,
             consumer::commands::delete_consumer_group,
             dashboard::commands::get_dashboard_broker_overview,
+            dashboard::commands::get_dashboard_overview,
             dashboard::commands::query_dashboard_topic_current,
             message::commands::query_message_by_topic_key,
             message::commands::query_message_by_id,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/producer/service.rs
@@ -36,6 +36,19 @@ pub(crate) struct ProducerManager {
 }
 
 impl ProducerManager {
+    pub(crate) async fn workspace_inventory(
+        &self,
+    ) -> ProducerResult<rocketmq_admin_core::core::consumer_workspace::ProducerInventoryResult> {
+        use rocketmq_admin_core::core::consumer_workspace::ConsumerWorkspaceAdmin;
+        let mut session = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session).await?;
+        let admin = &session
+            .as_ref()
+            .ok_or_else(|| ProducerError::Validation("Producer connection unavailable.".into()))?
+            .admin;
+        admin.producer_inventory().await.map_err(Into::into)
+    }
+
     pub(crate) fn new(runtime: Arc<NameServerRuntimeState>) -> Self {
         Self {
             runtime,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/components/GlobalOverview.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/components/GlobalOverview.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { DashboardService } from '../../../services/dashboard.service';
+import { dashboardErrorMessage } from '../../../services/invoke';
+import { useAppStore } from '../../../stores/app.store';
+import type { DashboardOverview } from '../types/dashboard.types';
+
+export function GlobalOverview() {
+    const { setActiveTab, openConsumer } = useAppStore();
+    const [data, setData] = useState<DashboardOverview | null>(null);
+    const [error, setError] = useState('');
+    const [pending, setPending] = useState(false);
+    const [refresh, setRefresh] = useState(0);
+    useEffect(() => {
+        let current = true;
+        setPending(true); setError('');
+        void DashboardService.getOverview().then(value => { if (current) setData(value); })
+            .catch(error => { if (current) { setData(null); setError(dashboardErrorMessage(error, 'Overview unavailable.')); } })
+            .finally(() => { if (current) setPending(false); });
+        return () => { current = false; };
+    }, [refresh]);
+    return <section aria-label="Global overview" className="space-y-4">
+        <div className="flex justify-between"><h2 className="text-lg font-semibold">Cluster overview</h2><button type="button" disabled={pending} onClick={() => setRefresh(value => value + 1)}>{pending ? 'Refreshing…' : 'Refresh overview'}</button></div>
+        {error && <p role="alert" className="text-red-600">{error}</p>}
+        {data && <>
+            <p role="status">{data.status === 'READY' ? 'Queries returned' : data.status} · Observed {new Date(data.observedAtMs).toLocaleString()}{pending ? ' · Showing the previous observation while refreshing' : ''}</p>
+            <div className="grid grid-cols-2 xl:grid-cols-4 gap-4">
+                {([['Topics', data.topics], ['Consumer groups', data.consumerGroups], ['Producer groups', data.producerGroups], ['Observed lag', data.totalLag]] as const).map(([label, metric]) =>
+                    <article key={label} className="dashboard-metric-card is-info"><div className="dashboard-metric-copy"><span>{label}</span><strong>{metric.value === null ? 'Unknown' : metric.value.toLocaleString()}</strong><small>{metric.quality === 'reported' ? 'Reported count; source coverage not exposed' : metric.quality === 'partial' ? 'Partial observation; other targets may be missing' : metric.quality}</small></div></article>)}
+            </div>
+            <div className="flex flex-wrap gap-4">
+                {(data.status === 'UNCONFIGURED' || data.status === 'DOWN') && <button type="button" onClick={() => setActiveTab('NameServer')}>Configure or inspect NameServer connection</button>}
+                {(data.brokers.value === 0 || data.brokers.quality !== 'complete') && <button type="button" onClick={() => setActiveTab('Cluster')}>Inspect Broker availability</button>}
+                {(data.totalLag.value ?? 0) > 0 && <button type="button" onClick={() => setActiveTab('Consumer')}>Inspect Consumer backlog</button>}
+                {data.laggingGroups.map(group => <button key={group} type="button" onClick={() => openConsumer(group, 'progress', { mode: 'name_server' })}>{group} progress</button>)}
+            </div>
+        </>}
+        {!data && !error && <p role="status">Waiting for cluster observations…</p>}
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/types/dashboard.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/types/dashboard.types.ts
@@ -71,3 +71,15 @@ export interface DashboardTopicCurrentResponse {
     topicQueueTop: DashboardTopicQueueItem[];
     topicCategoryDistribution: DashboardTopicCategoryItem[];
 }
+
+export interface OverviewMetric { value: number | null; quality: 'complete' | 'reported' | 'partial' | 'unknown' }
+export interface DashboardOverview {
+    status: 'UNCONFIGURED' | 'DOWN' | 'PARTIAL' | 'READY';
+    observedAtMs: number;
+    brokers: OverviewMetric;
+    topics: OverviewMetric;
+    consumerGroups: OverviewMetric;
+    producerGroups: OverviewMetric;
+    totalLag: OverviewMetric;
+    laggingGroups: string[];
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/dashboard/DashboardPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/dashboard/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { GlobalOverview } from '../../features/dashboard/components/GlobalOverview';
 import React from 'react';
 import { BrokerOverview } from '../../features/dashboard/components/BrokerOverview';
 import { DashboardCharts } from '../../features/dashboard/components/Charts';
@@ -5,6 +6,7 @@ import { DashboardCharts } from '../../features/dashboard/components/Charts';
 export const DashboardPage = () => {
   return (
     <div className="dashboard-page">
+      <GlobalOverview />
       <BrokerOverview />
       <DashboardCharts />
     </div>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dashboard.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dashboard.service.ts
@@ -1,11 +1,16 @@
 import { invokeAuthenticatedCommand } from './invoke';
 import type {
     DashboardBrokerOverviewRequest,
+    DashboardOverview,
     DashboardBrokerOverviewResponse,
     DashboardTopicCurrentResponse,
 } from '../features/dashboard/types/dashboard.types';
 
 export class DashboardService {
+    static getOverview(): Promise<DashboardOverview> {
+        return invokeAuthenticatedCommand('get_dashboard_overview');
+    }
+
     static async getBrokerOverview(
         request: DashboardBrokerOverviewRequest = { forceRefresh: false }
     ): Promise<DashboardBrokerOverviewResponse> {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10404

### Brief Description
Add an authenticated global overview reusing existing managers and failure-aware Consumer/Producer inventories. Distinguish unconfigured, down, partial and returned-query states with nullable per-metric quality. Add missing count/backlog cards and shared navigation actions while preserving existing Broker and Topic charts.

### How Did You Test This Change?
- Existing Dashboard tests passed; overview regressions cover the four connection states, missing inventory without zero fallback, and partial observed lag.
- Frontend build passed.
- Package-scoped formatting and git diff checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global dashboard overview with status indicators for configuration and connectivity.
  * Added summary cards for brokers, topics, consumer groups, producer groups, and observed lag.
  * Added metric quality labels to distinguish complete, partial, reported, and unavailable data.
  * Added manual refresh, observation timestamps, and navigation to related dashboard views.
  * Highlighted lagging consumer groups with quick access to their progress details.
  * Preserved existing broker metrics and dashboard charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->