### PR TITLE
[ISSUE #10406]🚀Persist environment-scoped Tauri metric history

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/HISTORY.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/HISTORY.md
@@ -1,0 +1,11 @@
+# Persisted desktop history
+
+The fresh SQLite schema includes environment/metric/dimension/time samples with a unique primary key and a retention index. Older schema versions remain explicitly unsupported; no migration or deletion of an old database is attempted. Select a fresh data directory for this schema when necessary.
+
+The application-owned collector records broker-count, topic-count, and per-Topic topic-total-messages. It uses existing managers, runs one collection at a time, and skips missed timer ticks. Counts are discovered values, not proof that all Brokers are healthy. Failed metrics produce no zero samples. Partial collection stores successful metrics and reports a safe warning. Topic totals are actual current queue-offset totals; TPS charts are never repurposed as history.
+
+Defaults are 60 seconds and 30 days. `DASHBOARD_TAURI_HISTORY_INTERVAL_SECONDS` accepts 15 through 3600; `DASHBOARD_TAURI_HISTORY_RETENTION_DAYS` accepts 1 through 365. Invalid settings reject startup. Configuration is read on startup.
+
+Each collection captures environment and connection revision. The sample transaction acquires an IMMEDIATE write lock and checks the persisted revision before inserting, so a configuration change discards the obsolete result. Cleanup deletes expired rows in batches of 1000 with an await boundary between batches. Storage owns the timer task, cancels and awaits background work, and drains accepted writes before admin managers close.
+
+The Dashboard history section queries the selected local calendar day using UTC millisecond boundaries, displays its timezone, and supports Broker/Topic count or selected-Topic message history. Samples are returned newest-first with a bounded timestamp cursor; the chart renders them chronologically. Missing data shows a waiting/empty state and read failures show an error. Collector status reports its last successful sample/write and recent safe error. These process-local collector timestamps restart with the application; persisted samples remain readable.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/history.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/history.rs
@@ -1,0 +1,271 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod repository;
+use crate::{
+    auth::SessionState,
+    cluster::ClusterManager,
+    connection::ConnectionManager,
+    error::{CommandResult, DashboardError, DashboardResult, authorize_command},
+    persistence::StorageManager,
+    topic::TopicManager,
+};
+use repository::{HistoryMetric, HistoryPage, HistoryQuery, Sample};
+use rocketmq_dashboard_common::{ClusterHomePageRequest, TopicListRequest};
+use serde::Serialize;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tauri::State;
+
+#[derive(Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CollectorStatus {
+    pub(crate) interval_seconds: u64,
+    pub(crate) retention_days: u64,
+    pub(crate) last_sample_ms: Option<i64>,
+    pub(crate) last_write_ms: Option<i64>,
+    pub(crate) last_error: Option<&'static str>,
+}
+
+#[derive(Clone)]
+pub(crate) struct HistoryManager {
+    storage: StorageManager,
+    connections: ConnectionManager,
+    cluster: ClusterManager,
+    topic: TopicManager,
+    status: Arc<Mutex<CollectorStatus>>,
+    interval_seconds: u64,
+    retention_days: u64,
+}
+
+impl HistoryManager {
+    pub(crate) fn new(
+        storage: StorageManager,
+        connections: ConnectionManager,
+        cluster: ClusterManager,
+        topic: TopicManager,
+    ) -> DashboardResult<Self> {
+        let interval_seconds = setting("DASHBOARD_TAURI_HISTORY_INTERVAL_SECONDS", 60, 15, 3600)?;
+        let retention_days = setting("DASHBOARD_TAURI_HISTORY_RETENTION_DAYS", 30, 1, 365)?;
+        Ok(Self {
+            storage,
+            connections,
+            cluster,
+            topic,
+            interval_seconds,
+            retention_days,
+            status: Arc::new(Mutex::new(CollectorStatus {
+                interval_seconds,
+                retention_days,
+                ..CollectorStatus::default()
+            })),
+        })
+    }
+
+    pub(crate) fn status(&self) -> DashboardResult<CollectorStatus> {
+        self.status
+            .lock()
+            .map(|status| status.clone())
+            .map_err(|_| DashboardError::Internal("history state unavailable"))
+    }
+
+    pub(crate) fn start(&self) -> DashboardResult<()> {
+        let manager = self.clone();
+        // Storage shutdown cancels and awaits this loop before closing the admin managers.
+        self.storage.start_background("history-collector", async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(manager.interval_seconds));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                if manager.collect().await.is_err() {
+                    manager.record_error("History sampling or storage is unavailable.");
+                }
+                let cutoff = chrono::Utc::now().timestamp_millis() - manager.retention_days as i64 * 86_400_000;
+                loop {
+                    match manager
+                        .storage
+                        .run("history-retention", move |connection| {
+                            repository::cleanup(connection, cutoff)
+                        })
+                        .await
+                    {
+                        Ok(1000) => continue,
+                        Ok(_) => break,
+                        Err(_) => {
+                            manager.record_error("History retention cleanup is unavailable.");
+                            break;
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    fn record_error(&self, error: &'static str) {
+        if let Ok(mut status) = self.status.lock() {
+            status.last_error = Some(error);
+        }
+    }
+
+    async fn collect(&self) -> DashboardResult<()> {
+        let snapshot = self.connections.snapshot()?;
+        let Some(environment) = snapshot.environment_id else {
+            return Ok(());
+        };
+        let revision = snapshot.revision;
+        let timestamp_ms = chrono::Utc::now().timestamp_millis();
+        let (brokers, topics, statistics) = tokio::join!(
+            self.cluster
+                .get_cluster_home_page(ClusterHomePageRequest { force_refresh: false }),
+            self.topic.get_topic_list(TopicListRequest {
+                skip_sys_process: false,
+                skip_retry_and_dlq: false
+            }),
+            self.topic.get_topic_current_stats(),
+        );
+        let partial =
+            brokers.is_err() || topics.is_err() || statistics.as_ref().map_or(true, |stats| !stats.failures.is_empty());
+        let mut samples = Vec::new();
+        if let Ok(brokers) = brokers {
+            samples.push(Sample {
+                metric: HistoryMetric::BrokerCount,
+                dimension: String::new(),
+                timestamp_ms,
+                value: brokers.summary.total_brokers as f64,
+            });
+        }
+        if let Ok(topics) = topics {
+            samples.push(Sample {
+                metric: HistoryMetric::TopicCount,
+                dimension: String::new(),
+                timestamp_ms,
+                value: topics.total as f64,
+            });
+        }
+        if let Ok(statistics) = statistics {
+            samples.extend(statistics.items.into_iter().map(|topic| Sample {
+                metric: HistoryMetric::TopicTotalMessages,
+                dimension: topic.topic,
+                timestamp_ms,
+                value: topic.total_msg as f64,
+            }));
+        }
+        if samples.is_empty() {
+            self.record_error("No history metrics could be sampled.");
+            return Ok(());
+        }
+        // IMMEDIATE checks the persisted revision in the same transaction as the sample writes.
+        // A settings commit cannot race that check and attach old results to a new environment.
+        let committed = self
+            .storage
+            .run("history-sample", move |connection| {
+                repository::insert(connection, &environment, revision, &samples)
+            })
+            .await?;
+        if committed {
+            let mut status = self
+                .status
+                .lock()
+                .map_err(|_| DashboardError::Internal("history state unavailable"))?;
+            status.last_sample_ms = Some(timestamp_ms);
+            status.last_write_ms = Some(chrono::Utc::now().timestamp_millis());
+            status.last_error =
+                partial.then_some("Some metrics were unavailable; only successful samples were stored.");
+        } else {
+            self.record_error("An obsolete sample was discarded after connection settings changed.");
+        }
+        Ok(())
+    }
+
+    async fn query(&self, metric: HistoryMetric, request: HistoryQuery) -> DashboardResult<HistoryPage> {
+        let environment = self.connections.snapshot()?.environment_id.ok_or_else(|| {
+            DashboardError::Configuration("Select a NameServer environment before reading history.".into())
+        })?;
+        self.storage
+            .run("history-query", move |connection| {
+                repository::query(connection, &environment, metric, request)
+            })
+            .await
+    }
+}
+
+fn setting(name: &'static str, default: u64, minimum: u64, maximum: u64) -> DashboardResult<u64> {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse::<u64>()
+            .ok()
+            .filter(|value| (minimum..=maximum).contains(value))
+            .ok_or_else(|| DashboardError::Configuration(format!("Invalid {name}."))),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(_) => Err(DashboardError::Configuration(format!("Invalid {name}."))),
+    }
+}
+
+#[tauri::command]
+pub async fn query_broker_history(
+    session_id: String,
+    expected_revision: i64,
+    request: HistoryQuery,
+    session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
+    history: State<'_, HistoryManager>,
+) -> CommandResult<HistoryPage> {
+    authorize_command(&session_id, &session_state).await?;
+    connection_manager.check_revision(expected_revision)?;
+    let result = history
+        .query(
+            HistoryMetric::BrokerCount,
+            HistoryQuery {
+                topic_name: None,
+                ..request
+            },
+        )
+        .await
+        .map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
+}
+
+#[tauri::command]
+pub async fn query_topic_history(
+    session_id: String,
+    expected_revision: i64,
+    request: HistoryQuery,
+    session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
+    history: State<'_, HistoryManager>,
+) -> CommandResult<HistoryPage> {
+    authorize_command(&session_id, &session_state).await?;
+    connection_manager.check_revision(expected_revision)?;
+    let metric = if request.topic_name.as_ref().is_some_and(|name| !name.is_empty()) {
+        HistoryMetric::TopicTotalMessages
+    } else {
+        HistoryMetric::TopicCount
+    };
+    let result = history.query(metric, request).await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
+}
+
+#[tauri::command]
+pub async fn get_history_status(
+    session_id: String,
+    session_state: State<'_, SessionState>,
+    history: State<'_, HistoryManager>,
+) -> CommandResult<CollectorStatus> {
+    authorize_command(&session_id, &session_state).await?;
+    history.status().map_err(Into::into)
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/history/repository.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/history/repository.rs
@@ -1,0 +1,220 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::{DashboardError, DashboardResult};
+use rusqlite::{Connection, TransactionBehavior, params};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum HistoryMetric {
+    BrokerCount,
+    TopicCount,
+    TopicTotalMessages,
+}
+impl HistoryMetric {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::BrokerCount => "broker-count",
+            Self::TopicCount => "topic-count",
+            Self::TopicTotalMessages => "topic-total-messages",
+        }
+    }
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Sample {
+    pub(crate) metric: HistoryMetric,
+    pub(crate) dimension: String,
+    pub(crate) timestamp_ms: i64,
+    pub(crate) value: f64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct HistoryQuery {
+    pub(crate) begin_ms: i64,
+    pub(crate) end_ms: i64,
+    pub(crate) topic_name: Option<String>,
+    pub(crate) limit: Option<usize>,
+    pub(crate) before_ms: Option<i64>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct HistoryPage {
+    pub(crate) samples: Vec<Sample>,
+    pub(crate) next_before_ms: Option<i64>,
+}
+
+pub(super) fn insert(
+    connection: &mut Connection,
+    environment: &str,
+    revision: i64,
+    samples: &[Sample],
+) -> DashboardResult<bool> {
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let current: i64 = transaction.query_row("SELECT revision FROM connection_metadata WHERE id=1", [], |row| {
+        row.get(0)
+    })?;
+    if current != revision {
+        return Ok(false);
+    }
+    for sample in samples {
+        if !sample.value.is_finite() || sample.value < 0.0 || sample.timestamp_ms < 0 {
+            return Err(DashboardError::Validation("Invalid history sample.".into()));
+        }
+        transaction.execute("INSERT INTO history_samples(environment_id,metric,dimension,timestamp_ms,value) VALUES (?1,?2,?3,?4,?5) ON CONFLICT DO NOTHING",
+            params![environment, sample.metric.as_str(), sample.dimension, sample.timestamp_ms, sample.value])?;
+    }
+    transaction.commit()?;
+    Ok(true)
+}
+
+pub(super) fn query(
+    connection: &Connection,
+    environment: &str,
+    metric: HistoryMetric,
+    request: HistoryQuery,
+) -> DashboardResult<HistoryPage> {
+    let limit = request.limit.unwrap_or(1000);
+    if request.begin_ms < 0
+        || request.end_ms <= request.begin_ms
+        || request.end_ms - request.begin_ms > 366 * 86_400_000
+        || !(1..=2000).contains(&limit)
+    {
+        return Err(DashboardError::Validation(
+            "Select a valid UTC range of at most 366 days and a limit from 1 to 2000.".into(),
+        ));
+    }
+    let dimension = request.topic_name.unwrap_or_default();
+    let mut statement = connection.prepare("SELECT timestamp_ms,value FROM history_samples WHERE environment_id=?1 AND metric=?2 AND dimension=?3 AND timestamp_ms>=?4 AND timestamp_ms<?5 AND timestamp_ms<?6 ORDER BY timestamp_ms DESC LIMIT ?7")?;
+    let samples = statement
+        .query_map(
+            params![
+                environment,
+                metric.as_str(),
+                dimension,
+                request.begin_ms,
+                request.end_ms,
+                request.before_ms.unwrap_or(request.end_ms),
+                limit + 1
+            ],
+            |row| {
+                Ok(Sample {
+                    metric,
+                    dimension: dimension.clone(),
+                    timestamp_ms: row.get(0)?,
+                    value: row.get(1)?,
+                })
+            },
+        )?
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut page = HistoryPage {
+        samples,
+        next_before_ms: None,
+    };
+    if page.samples.len() > limit {
+        page.samples.truncate(limit);
+        page.next_before_ms = page.samples.last().map(|sample| sample.timestamp_ms);
+    }
+    Ok(page)
+}
+
+pub(super) fn cleanup(connection: &Connection, cutoff: i64) -> DashboardResult<usize> {
+    Ok(connection.execute("DELETE FROM history_samples WHERE rowid IN (SELECT rowid FROM history_samples WHERE timestamp_ms < ?1 ORDER BY timestamp_ms LIMIT 1000)", [cutoff])?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn history_is_persistent_scoped_unique_paginated_and_retained() {
+        let path = std::env::temp_dir().join(format!("tauri-history-{}.db", uuid::Uuid::new_v4()));
+        let mut connection = Connection::open(&path).unwrap();
+        crate::persistence::schema::initialize(&mut connection).unwrap();
+        let samples = [100, 200, 300].map(|timestamp_ms| Sample {
+            metric: HistoryMetric::TopicTotalMessages,
+            dimension: "orders".into(),
+            timestamp_ms,
+            value: 7.0,
+        });
+        assert!(insert(&mut connection, "env-a", 0, &samples).unwrap());
+        assert!(insert(&mut connection, "env-a", 0, &samples).unwrap());
+        assert!(insert(&mut connection, "env-b", 0, &samples).unwrap());
+        connection
+            .execute("UPDATE connection_metadata SET revision=1", [])
+            .unwrap();
+        assert!(!insert(&mut connection, "stale-env", 0, &samples).unwrap());
+        drop(connection);
+        let connection = Connection::open(&path).unwrap();
+        let request = |before_ms| HistoryQuery {
+            begin_ms: 0,
+            end_ms: 400,
+            topic_name: Some("orders".into()),
+            limit: Some(2),
+            before_ms,
+        };
+        let first = query(&connection, "env-a", HistoryMetric::TopicTotalMessages, request(None)).unwrap();
+        assert_eq!(
+            first
+                .samples
+                .iter()
+                .map(|sample| sample.timestamp_ms)
+                .collect::<Vec<_>>(),
+            [300, 200]
+        );
+        assert_eq!(first.next_before_ms, Some(200));
+        assert_eq!(
+            query(
+                &connection,
+                "env-a",
+                HistoryMetric::TopicTotalMessages,
+                request(first.next_before_ms)
+            )
+            .unwrap()
+            .samples
+            .len(),
+            1
+        );
+        assert!(
+            query(
+                &connection,
+                "stale-env",
+                HistoryMetric::TopicTotalMessages,
+                request(None)
+            )
+            .unwrap()
+            .samples
+            .is_empty()
+        );
+        assert_eq!(cleanup(&connection, 200).unwrap(), 2);
+        assert_eq!(
+            query(&connection, "env-a", HistoryMetric::TopicTotalMessages, request(None))
+                .unwrap()
+                .samples
+                .len(),
+            2
+        );
+        assert!(
+            query(&connection, "env-a", HistoryMetric::BrokerCount, request(None))
+                .unwrap()
+                .samples
+                .is_empty()
+        );
+        drop(connection);
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod connection;
 mod consumer;
 mod dashboard;
 mod error;
+mod history;
 mod message;
 mod nameserver;
 mod persistence;
@@ -227,6 +228,13 @@ fn build_application() -> Result<DashboardApplication, i32> {
                 storage.clone(),
                 nameserver_runtime.clone(),
             ))?;
+            let history = history::HistoryManager::new(
+                storage.clone(),
+                connections.clone(),
+                cluster_manager.clone(),
+                topic_manager.clone(),
+            )?;
+            history.start()?;
             let audit = audit::AuditManager::new(storage.clone(), audit_context);
             audit.start_cleanup()?;
             setup_lifecycle
@@ -244,6 +252,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
 
             let sessions = auth::SessionState::new(storage.clone(), auth_service)?;
             sessions.start_cleanup()?;
+            app.manage(history);
             app.manage(storage);
             app.manage(sessions);
             app.manage(audit);
@@ -294,6 +303,9 @@ fn build_application() -> Result<DashboardApplication, i32> {
             consumer::commands::delete_consumer_group,
             dashboard::commands::get_dashboard_broker_overview,
             dashboard::commands::get_dashboard_overview,
+            history::query_broker_history,
+            history::query_topic_history,
+            history::get_history_status,
             dashboard::commands::query_dashboard_topic_current,
             message::commands::query_message_by_topic_key,
             message::commands::query_message_by_id,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
@@ -17,7 +17,7 @@ use crate::error::DashboardResult;
 use rusqlite::Connection;
 use rusqlite::TransactionBehavior;
 
-pub(crate) const SCHEMA_VERSION: i64 = 4;
+pub(crate) const SCHEMA_VERSION: i64 = 5;
 
 pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
     // IMMEDIATE serializes competing initializers before reading the version.
@@ -71,6 +71,15 @@ pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
                 environment_id TEXT UNIQUE,
                 PRIMARY KEY(kind, address)
             );
+            CREATE TABLE history_samples (
+                environment_id TEXT NOT NULL,
+                metric TEXT NOT NULL CHECK(metric IN ('broker-count', 'topic-count', 'topic-total-messages')),
+                dimension TEXT NOT NULL DEFAULT '',
+                timestamp_ms INTEGER NOT NULL CHECK(timestamp_ms >= 0),
+                value REAL NOT NULL CHECK(value >= 0),
+                PRIMARY KEY(environment_id, metric, dimension, timestamp_ms)
+            );
+            CREATE INDEX history_retention ON history_samples(timestamp_ms);
             CREATE TABLE audit_events (
                 event_id TEXT PRIMARY KEY,
                 request_id TEXT NOT NULL UNIQUE,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/components/HistoryChart.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/components/HistoryChart.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { HistoryService, type CollectorStatus, type HistorySample } from '../../../services/history.service';
+import { dashboardErrorMessage } from '../../../services/invoke';
+import { ConsumerRequestGeneration } from '../../consumer/scope';
+import { useTopicCatalog } from '../../topic/hooks/useTopicCatalog';
+import { localHistoryDay, todayLocal } from '../history';
+
+export function HistoryChart() {
+    const [date, setDate] = useState(todayLocal);
+    const [metric, setMetric] = useState<'broker-count' | 'topic-count' | 'topic-total-messages'>('broker-count');
+    const [topic, setTopic] = useState('');
+    const [samples, setSamples] = useState<HistorySample[]>([]);
+    const [next, setNext] = useState<number | null>(null);
+    const [status, setStatus] = useState<CollectorStatus | null>(null);
+    const [pending, setPending] = useState(false);
+    const [error, setError] = useState('');
+    const [refresh, setRefresh] = useState(0);
+    const generation = useRef(new ConsumerRequestGeneration());
+    const { data: topics } = useTopicCatalog();
+    const load = async (beforeMs?: number) => {
+        const current = generation.current.begin();
+        setPending(true); setError('');
+        if (beforeMs === undefined) { setSamples([]); setNext(null); }
+        try {
+            if (metric === 'topic-total-messages' && !topic.trim()) throw new Error('Select a Topic to read its stored message history.');
+            const [page, collector] = await Promise.all([
+                HistoryService.query(metric === 'broker-count' ? 'broker' : 'topic', { ...localHistoryDay(date), topicName: metric === 'topic-total-messages' ? topic.trim() : undefined, beforeMs, limit: 1000 }),
+                HistoryService.status(),
+            ]);
+            if (!current()) return;
+            setSamples(previous => beforeMs === undefined ? page.samples : [...previous, ...page.samples]); setNext(page.nextBeforeMs); setStatus(collector);
+        } catch (error) { if (current()) setError(dashboardErrorMessage(error, 'History could not be read.')); }
+        finally { if (current()) setPending(false); }
+    };
+    useEffect(() => { void load(); return () => generation.current.invalidate(); }, [date, metric, topic, refresh]);
+    const points = useMemo(() => [...samples].sort((a, b) => a.timestampMs - b.timestampMs), [samples]);
+    return <section className="space-y-4 rounded border p-4" aria-label="Persisted history">
+        <h2 className="text-lg font-semibold">Stored metric history</h2>
+        <div className="flex flex-wrap gap-4">
+            <label>Date <input type="date" value={date} onChange={event => setDate(event.target.value)} className="rounded border p-2 dark:bg-gray-900" /></label>
+            <label>Metric <select value={metric} onChange={event => setMetric(event.target.value as typeof metric)} className="rounded border p-2 dark:bg-gray-900"><option value="broker-count">Broker count</option><option value="topic-count">Topic count</option><option value="topic-total-messages">Topic total messages</option></select></label>
+            {metric === 'topic-total-messages' && <label>Topic <input list="history-topics" value={topic} onChange={event => setTopic(event.target.value)} className="rounded border p-2 dark:bg-gray-900" /><datalist id="history-topics">{topics?.items.map(item => <option key={item.topic} value={item.topic} />)}</datalist></label>}
+            <button type="button" disabled={pending} onClick={() => setRefresh(value => value + 1)}>Refresh history</button>
+        </div>
+        <p>Local calendar day in {Intl.DateTimeFormat().resolvedOptions().timeZone}. Only stored samples are shown; failed observations are omitted.</p>
+        {status && <p>Sample interval: {status.intervalSeconds}s · Retention: {status.retentionDays} days · Last write: {status.lastWriteMs ? new Date(status.lastWriteMs).toLocaleString() : 'Waiting for a successful sample'}{status.lastError ? ` · ${status.lastError}` : ''}</p>}
+        {error && <p role="alert" className="text-red-600">{error}</p>}
+        {pending && <p role="status">Reading stored samples…</p>}
+        {!pending && !error && points.length === 0 && <p>No samples for this selection. Wait for collection or choose another date or Topic.</p>}
+        {points.length > 0 && <div className="h-72"><ResponsiveContainer width="100%" height="100%"><LineChart data={points}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="timestampMs" type="number" domain={['dataMin', 'dataMax']} tickFormatter={value => new Date(value).toLocaleTimeString()} /><YAxis /><Tooltip labelFormatter={value => new Date(Number(value)).toLocaleString()} /><Line type="stepAfter" dataKey="value" stroke="#3b82f6" dot={points.length < 60} isAnimationActive={false} /></LineChart></ResponsiveContainer></div>}
+        {next !== null && <button type="button" disabled={pending} onClick={() => void load(next)}>Load older samples in this day</button>}
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/history.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/history.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from 'vitest';
+import { localHistoryDay } from './history';
+
+it('uses local calendar boundaries instead of assuming every day has 24 hours', () => {
+    expect(localHistoryDay('2026-03-08')).toEqual({ beginMs: new Date(2026, 2, 8).getTime(), endMs: new Date(2026, 2, 9).getTime() });
+    expect(() => localHistoryDay('2026-02-30')).toThrow();
+    expect(() => localHistoryDay('invalid')).toThrow();
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/history.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/history.ts
@@ -1,0 +1,13 @@
+export function localHistoryDay(date: string): { beginMs: number; endMs: number } {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+    if (!match) throw new Error('Select a valid local calendar date.');
+    const [year, month, day] = match.slice(1).map(Number);
+    const begin = new Date(year, month - 1, day);
+    if (begin.getFullYear() !== year || begin.getMonth() !== month - 1 || begin.getDate() !== day || begin.getTime() < 0) throw new Error('Invalid history date.');
+    return { beginMs: begin.getTime(), endMs: new Date(year, month - 1, day + 1).getTime() };
+}
+
+export const todayLocal = () => {
+    const date = new Date();
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/dashboard/DashboardPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/dashboard/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { HistoryChart } from '../../features/dashboard/components/HistoryChart';
 import { GlobalOverview } from '../../features/dashboard/components/GlobalOverview';
 import React from 'react';
 import { BrokerOverview } from '../../features/dashboard/components/BrokerOverview';
@@ -9,6 +10,7 @@ export const DashboardPage = () => {
       <GlobalOverview />
       <BrokerOverview />
       <DashboardCharts />
+      <HistoryChart />
     </div>
   );
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/history.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/history.service.ts
@@ -1,0 +1,11 @@
+import { invokeAuthenticatedCommand } from './invoke';
+
+export interface HistorySample { metric: 'broker-count' | 'topic-count' | 'topic-total-messages'; dimension: string; timestampMs: number; value: number }
+export interface HistoryQuery { beginMs: number; endMs: number; topicName?: string; limit?: number; beforeMs?: number }
+export interface HistoryPage { samples: HistorySample[]; nextBeforeMs: number | null }
+export interface CollectorStatus { intervalSeconds: number; retentionDays: number; lastSampleMs: number | null; lastWriteMs: number | null; lastError: string | null }
+
+export const HistoryService = {
+    query(kind: 'broker' | 'topic', request: HistoryQuery): Promise<HistoryPage> { return invokeAuthenticatedCommand(kind === 'broker' ? 'query_broker_history' : 'query_topic_history', { request }); },
+    status(): Promise<CollectorStatus> { return invokeAuthenticatedCommand('get_history_status'); },
+};


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10406

### Brief Description
Persist environment-scoped Broker counts, Topic counts, and Topic message totals in the fresh dashboard schema. Collect through an owned, non-overlapping task, discard results when connection settings change, retain successful samples without substituting failed queries with zero, and clean expired samples in bounded transactions. Add local-day history charts with bounded cursor pagination and visible collector status.

### How Did You Test This Change?
- Backend persistence tests: 7 passed.
- History repository regression: passed, covering reopen, environment isolation, stale revision rejection, duplicate samples, pagination, and retention.
- Frontend local-day boundary test and production build passed.
- Package format check and git diff --check passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Dashboard history section with charts for broker count, topic count, and per-topic message totals.
  * Added date selection, topic filtering, pagination, and loading, empty, and error states.
  * Added collector status visibility, including sampling interval, retention period, and recent errors.
  * History is collected automatically and retained for up to 30 days by default.

* **Bug Fixes**
  * Added validation for history date ranges and collection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->