### PR TITLE
[ISSUE #10408]🚀Manage Tauri Consumer Monitor rules with audited revisions

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/MONITOR_RULES.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/MONITOR_RULES.md
@@ -1,0 +1,14 @@
+# Consumer Monitor rules (S22)
+
+The Monitors page manages nonnegative Consumer group thresholds in the selected
+NameServer environment. Rules do not evaluate alerts, send notifications, or
+perform automatic recovery. No Broker mutation is involved.
+
+Creation expects rule revision zero. Updates and deletes must match the stored
+revision. On conflict the page reloads the current list and retains the draft;
+choose Edit on the current row to review that version before saving. Connection
+revision leases prevent accepted changes from moving to another environment.
+Each successful mutation and its audit event commit in the same transaction.
+
+The fresh database schema includes the rules table. Older formats require a new
+data directory; no migration or compatibility layer is provided.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
@@ -49,11 +49,15 @@ pub(crate) enum AuditAction {
     ConsumeDirectly,
     ResendDlq,
     BatchResendDlq,
+    SaveMonitor,
+    DeleteMonitor,
 }
 
 impl AuditAction {
     pub(crate) fn name(self) -> &'static str {
         match self {
+            Self::SaveMonitor => "monitor.save",
+            Self::DeleteMonitor => "monitor.delete",
             Self::Login => "auth.login",
             Self::Logout => "auth.logout",
             Self::ChangePassword => "auth.change_password",
@@ -89,6 +93,7 @@ impl AuditAction {
     }
     pub(crate) fn resource_type(self) -> &'static str {
         match self {
+            Self::SaveMonitor | Self::DeleteMonitor => "consumer_monitor",
             Self::Login | Self::Logout | Self::ChangePassword | Self::RevokeSessions => "account",
             Self::AddNameServer
             | Self::SwitchNameServer

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/error.rs
@@ -47,6 +47,8 @@ pub(crate) enum DashboardError {
     PasswordChangeRequired,
     #[error("connection settings changed; review the current configuration")]
     ConfigurationConflict,
+    #[error("monitor rule changed; review the current rule")]
+    MonitorConflict,
     #[error("I/O operation failed")]
     Io(#[from] std::io::Error),
     #[error("database operation failed")]
@@ -77,6 +79,13 @@ impl DashboardError {
             Self::Validation(_) => (
                 "dashboard.invalid_argument",
                 "The request is invalid.",
+                CommandErrorCategory::Validation,
+                false,
+                None,
+            ),
+            Self::MonitorConflict => (
+                "dashboard.monitor_conflict",
+                "This rule changed. Review its current version before saving again.",
                 CommandErrorCategory::Validation,
                 false,
                 None,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ mod dashboard;
 mod error;
 mod history;
 mod message;
+mod monitor;
 mod nameserver;
 mod persistence;
 mod producer;
@@ -252,6 +253,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
 
             let sessions = auth::SessionState::new(storage.clone(), auth_service)?;
             sessions.start_cleanup()?;
+            app.manage(monitor::MonitorManager::new(storage.clone(), connections.clone()));
             app.manage(history);
             app.manage(storage);
             app.manage(sessions);
@@ -306,6 +308,9 @@ fn build_application() -> Result<DashboardApplication, i32> {
             history::query_broker_history,
             history::query_topic_history,
             history::get_history_status,
+            monitor::list_consumer_monitor_rules,
+            monitor::save_consumer_monitor_rule,
+            monitor::delete_consumer_monitor_rule,
             dashboard::commands::query_dashboard_topic_current,
             message::commands::query_message_by_topic_key,
             message::commands::query_message_by_id,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/monitor.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/monitor.rs
@@ -1,0 +1,159 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod repository;
+use crate::{
+    audit::{AuditAccess, AuditAction, AuditContext, AuditManager, Audited},
+    auth::SessionState,
+    connection::ConnectionManager,
+    error::{CommandResult, DashboardError, DashboardResult, authorize_command},
+    persistence::StorageManager,
+};
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MonitorRule {
+    consumer_group: String,
+    min_count: i64,
+    max_diff_total: i64,
+    revision: i64,
+    created_at_ms: i64,
+    updated_at_ms: i64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SaveRule {
+    consumer_group: String,
+    min_count: i64,
+    max_diff_total: i64,
+    expected_revision: i64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DeleteRule {
+    consumer_group: String,
+    expected_revision: i64,
+}
+
+#[derive(Serialize)]
+pub(crate) struct MutationReceipt {
+    message: &'static str,
+}
+impl crate::audit::types::AuditReceipt for MutationReceipt {
+    fn summary(&self) -> crate::audit::types::Summary {
+        crate::audit::types::Summary::count(1, 0)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct MonitorManager {
+    storage: StorageManager,
+    connections: ConnectionManager,
+}
+impl MonitorManager {
+    pub(crate) fn new(storage: StorageManager, connections: ConnectionManager) -> Self {
+        Self { storage, connections }
+    }
+    fn environment(&self) -> DashboardResult<String> {
+        self.connections
+            .snapshot()?
+            .environment_id
+            .ok_or_else(|| DashboardError::Configuration("Select a NameServer environment.".into()))
+    }
+    async fn list(&self) -> DashboardResult<Vec<MonitorRule>> {
+        let environment = self.environment()?;
+        self.storage
+            .run("monitor-list", move |connection| {
+                repository::list(connection, &environment)
+            })
+            .await
+    }
+    async fn change(&self, revision: i64, change: Change, audit: AuditContext) -> DashboardResult<MutationReceipt> {
+        let _lease = self.connections.mutation_lease(revision, &audit).await?;
+        let environment = self.environment()?;
+        self.storage
+            .run("monitor-change", move |connection| {
+                repository::change(connection, &environment, change, &audit)?;
+                Ok(MutationReceipt {
+                    message: "Monitor rule saved.",
+                })
+            })
+            .await
+    }
+}
+enum Change {
+    Save(SaveRule),
+    Delete(DeleteRule),
+}
+
+#[tauri::command]
+pub async fn list_consumer_monitor_rules(
+    session_id: String,
+    expected_revision: i64,
+    session_state: State<'_, SessionState>,
+    connection_manager: State<'_, ConnectionManager>,
+    monitor: State<'_, MonitorManager>,
+) -> CommandResult<Vec<MonitorRule>> {
+    authorize_command(&session_id, &session_state).await?;
+    connection_manager.check_revision(expected_revision)?;
+    let result = monitor.list().await.map_err(Into::into);
+    connection_manager.check_revision(expected_revision)?;
+    result
+}
+
+#[tauri::command]
+pub async fn save_consumer_monitor_rule(
+    session_id: String,
+    expected_revision: i64,
+    request: SaveRule,
+    session_state: State<'_, SessionState>,
+    monitor: State<'_, MonitorManager>,
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<MutationReceipt>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let manager = monitor.inner().clone();
+    audit_manager
+        .execute(
+            access,
+            AuditAction::SaveMonitor,
+            Some(request.consumer_group.clone()),
+            move |audit| async move { manager.change(expected_revision, Change::Save(request), audit).await },
+        )
+        .await
+}
+
+#[tauri::command]
+pub async fn delete_consumer_monitor_rule(
+    session_id: String,
+    expected_revision: i64,
+    request: DeleteRule,
+    session_state: State<'_, SessionState>,
+    monitor: State<'_, MonitorManager>,
+    audit_manager: State<'_, AuditManager>,
+) -> CommandResult<Audited<MutationReceipt>> {
+    let access = AuditAccess::dashboard(&session_state, session_id);
+    let manager = monitor.inner().clone();
+    audit_manager
+        .execute(
+            access,
+            AuditAction::DeleteMonitor,
+            Some(request.consumer_group.clone()),
+            move |audit| async move { manager.change(expected_revision, Change::Delete(request), audit).await },
+        )
+        .await
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/monitor/repository.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/monitor/repository.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use rusqlite::{Connection, TransactionBehavior, params};
+const MAX_INTEGER: i64 = 9_007_199_254_740_991;
+
+pub(super) fn list(connection: &Connection, environment: &str) -> DashboardResult<Vec<MonitorRule>> {
+    let mut statement = connection.prepare("SELECT consumer_group, min_count, max_diff_total, revision, created_at_ms, updated_at_ms FROM consumer_monitor_rules WHERE environment_id = ?1 ORDER BY consumer_group")?;
+    let rows = statement.query_map([environment], |row| {
+        Ok(MonitorRule {
+            consumer_group: row.get(0)?,
+            min_count: row.get(1)?,
+            max_diff_total: row.get(2)?,
+            revision: row.get(3)?,
+            created_at_ms: row.get(4)?,
+            updated_at_ms: row.get(5)?,
+        })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+pub(super) fn change(
+    connection: &mut Connection,
+    environment: &str,
+    change: Change,
+    audit: &AuditContext,
+) -> DashboardResult<()> {
+    let (group, revision) = match &change {
+        Change::Save(request) => {
+            if !(0..=MAX_INTEGER).contains(&request.min_count) || !(0..=MAX_INTEGER).contains(&request.max_diff_total) {
+                return Err(DashboardError::Validation(
+                    "Thresholds must be nonnegative safe integers.".into(),
+                ));
+            }
+            (&request.consumer_group, request.expected_revision)
+        }
+        Change::Delete(request) => (&request.consumer_group, request.expected_revision),
+    };
+    if environment.is_empty()
+        || group.is_empty()
+        || group.len() > 255
+        || group.trim() != group
+        || group.chars().any(|c| c.is_control() || c.is_whitespace())
+        || !(0..MAX_INTEGER).contains(&revision)
+    {
+        return Err(DashboardError::Validation(
+            "Invalid monitor identity or revision.".into(),
+        ));
+    }
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let now = chrono::Utc::now().timestamp_millis();
+    let changed = match &change {
+        Change::Save(request) if revision == 0 => transaction.execute("INSERT INTO consumer_monitor_rules(environment_id,consumer_group,min_count,max_diff_total,revision,created_at_ms,updated_at_ms) VALUES(?1,?2,?3,?4,1,?5,?5) ON CONFLICT(environment_id,consumer_group) DO NOTHING", params![environment, group, request.min_count, request.max_diff_total, now])?,
+        Change::Save(request) => transaction.execute("UPDATE consumer_monitor_rules SET min_count=?3,max_diff_total=?4,revision=revision+1,updated_at_ms=?5 WHERE environment_id=?1 AND consumer_group=?2 AND revision=?6", params![environment,group,request.min_count,request.max_diff_total,now,revision])?,
+        Change::Delete(_) => transaction.execute("DELETE FROM consumer_monitor_rules WHERE environment_id=?1 AND consumer_group=?2 AND revision=?3", params![environment,group,revision])?,
+    };
+    if changed != 1 {
+        return Err(DashboardError::MonitorConflict);
+    }
+    // Failure to persist the audit must roll back the rule too.
+    audit.record_local_success(&transaction)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn audit() -> AuditContext {
+        AuditContext {
+            actor: Some("tester".into()),
+            environment: std::sync::Arc::new(std::sync::Mutex::new(Some("env-a".into()))),
+            event_id: uuid::Uuid::new_v4().to_string(),
+            request_id: uuid::Uuid::new_v4().to_string(),
+            action: AuditAction::SaveMonitor,
+            resource_name: Some("group".into()),
+        }
+    }
+    fn save(revision: i64, threshold: i64) -> Change {
+        Change::Save(SaveRule {
+            consumer_group: "group".into(),
+            min_count: threshold,
+            max_diff_total: 100,
+            expected_revision: revision,
+        })
+    }
+    #[test]
+    fn monitor_rules_reopen_isolate_compare_and_swap_and_audit_atomically() {
+        let path = std::env::temp_dir().join(format!("monitor-{}.db", uuid::Uuid::new_v4()));
+        let mut db = Connection::open(&path).unwrap();
+        crate::persistence::schema::initialize(&mut db).unwrap();
+        change(&mut db, "env-a", save(0, 2), &audit()).unwrap();
+        change(&mut db, "env-b", save(0, 7), &audit()).unwrap();
+        assert!(change(&mut db, "env-a", save(0, 9), &audit()).is_err());
+        assert!(change(&mut db, "env-a", save(1, -1), &audit()).is_err());
+        change(&mut db, "env-a", save(1, 3), &audit()).unwrap();
+        assert!(matches!(
+            change(&mut db, "env-a", save(1, 9), &audit()),
+            Err(DashboardError::MonitorConflict)
+        ));
+        let mut invalid_audit = audit();
+        invalid_audit.actor = None;
+        assert!(change(&mut db, "env-a", save(2, 9), &invalid_audit).is_err());
+        drop(db);
+        let mut db = Connection::open(&path).unwrap();
+        let rules = list(&db, "env-a").unwrap();
+        assert_eq!((rules[0].revision, rules[0].min_count), (2, 3));
+        assert_eq!(list(&db, "env-b").unwrap()[0].min_count, 7);
+        assert_eq!(
+            db.query_row("SELECT count(*) FROM audit_events", [], |r| r.get::<_, i64>(0))
+                .unwrap(),
+            3
+        );
+        assert!(
+            change(
+                &mut db,
+                "env-a",
+                Change::Delete(DeleteRule {
+                    consumer_group: "group".into(),
+                    expected_revision: 1
+                }),
+                &audit()
+            )
+            .is_err()
+        );
+        change(
+            &mut db,
+            "env-a",
+            Change::Delete(DeleteRule {
+                consumer_group: "group".into(),
+                expected_revision: 2,
+            }),
+            &audit(),
+        )
+        .unwrap();
+        assert!(list(&db, "env-a").unwrap().is_empty());
+        drop(db);
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
@@ -17,7 +17,7 @@ use crate::error::DashboardResult;
 use rusqlite::Connection;
 use rusqlite::TransactionBehavior;
 
-pub(crate) const SCHEMA_VERSION: i64 = 5;
+pub(crate) const SCHEMA_VERSION: i64 = 6;
 
 pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
     // IMMEDIATE serializes competing initializers before reading the version.
@@ -70,6 +70,16 @@ pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
                 endpoint_id TEXT NOT NULL UNIQUE,
                 environment_id TEXT UNIQUE,
                 PRIMARY KEY(kind, address)
+            );
+            CREATE TABLE consumer_monitor_rules (
+                environment_id TEXT NOT NULL,
+                consumer_group TEXT NOT NULL,
+                min_count INTEGER NOT NULL CHECK(min_count >= 0),
+                max_diff_total INTEGER NOT NULL CHECK(max_diff_total >= 0),
+                revision INTEGER NOT NULL CHECK(revision > 0 AND revision <= 9007199254740991),
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL,
+                PRIMARY KEY(environment_id,consumer_group)
             );
             CREATE TABLE history_samples (
                 environment_id TEXT NOT NULL,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
@@ -64,6 +64,7 @@ const NAV_SECTIONS = [
         title: 'Governance',
         items: [
             {tab: 'ACL', label: 'ACL', icon: Shield},
+            {tab: 'Monitors', label: 'Monitors', icon: MonitorDot},
             {tab: 'Audit', label: 'Audit', icon: Shield},
             {tab: 'Sessions', label: 'Sessions', icon: UserRound}
         ]
@@ -82,6 +83,7 @@ const PAGE_SUMMARIES: Record<string, string> = {
     MessageTrace: 'End-to-end trace timeline for produced and consumed messages.',
     DLQ: 'Dead-letter queue search, retry context, and payload inspection.',
     ACL: 'Access-control resources, credentials, and permission posture.',
+    Monitors: 'Environment-scoped Consumer group thresholds.',
     Audit: 'Operation history, outcomes, and audit receipts.',
     Sessions: 'Active, expired, and revoked sessions for your account.',
     Account: 'Local administrator profile, active session, and account security.'

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -15,6 +15,7 @@ import {MessageView} from '../../components/MessageView';
 import {MessageTraceView} from '../../components/MessageTraceView';
 import {DLQMessageView} from '../../components/DLQMessageView';
 import {Activity} from 'lucide-react';
+import {MonitorPage} from '../../pages/monitor/MonitorPage';
 import {AuditPage} from '../../pages/audit/AuditPage';
 import {SessionsPanel} from '../../pages/account/SessionsPanel';
 import {AccountPage} from '../../pages/account/AccountPage';
@@ -55,6 +56,8 @@ const RouteContent = () => {
             return <DLQMessageView/>;
         case 'ACL':
             return <ACLView/>;
+        case 'Monitors':
+            return <MonitorPage/>;
         case 'Audit':
             return <AuditPage/>;
         case 'Sessions':

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorPage.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { MonitorService, type MonitorRule, type SaveMonitorRule } from '../../services/monitor.service';
+import { dashboardErrorMessage, isDashboardClientError } from '../../services/invoke';
+
+const emptyDraft = (): SaveMonitorRule => ({ consumerGroup: '', minCount: 0, maxDiffTotal: 0, expectedRevision: 0 });
+
+export const MonitorPage = () => {
+    const [rules, setRules] = useState<MonitorRule[]>([]);
+    const [filter, setFilter] = useState('');
+    const [draft, setDraft] = useState<SaveMonitorRule | null>(null);
+    const [deleting, setDeleting] = useState<MonitorRule | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState('');
+    const [notice, setNotice] = useState('');
+    const alive = useRef(true);
+    const generation = useRef(0);
+    const refresh = async () => {
+        const request = ++generation.current;
+        setBusy(true);
+        setError('');
+        try {
+            const current = await MonitorService.list();
+            if (alive.current && request === generation.current) setRules(current);
+        } catch (failure) {
+            if (alive.current && request === generation.current) setError(dashboardErrorMessage(failure, 'Rules could not be loaded.'));
+        } finally {
+            if (alive.current && request === generation.current) setBusy(false);
+        }
+    };
+    useEffect(() => { alive.current = true; void refresh(); return () => { alive.current = false; generation.current++; }; }, []);
+
+    const mutate = async (operation: () => Promise<unknown>) => {
+        setBusy(true);
+        setError('');
+        setNotice('');
+        try {
+            await operation();
+            if (!alive.current) return;
+            setDraft(null);
+            setDeleting(null);
+            setNotice('Rule change saved.');
+            await refresh();
+        } catch (failure) {
+            if (!alive.current) return;
+            if (isDashboardClientError(failure) && failure.code === 'dashboard.monitor_conflict') {
+                // Refresh the table, retaining the draft and its old revision until explicit review.
+                await refresh();
+                if (!alive.current) return;
+                setDeleting(null);
+                setNotice('The rule changed. Your draft is retained. Choose Edit on the current row to load its version, or New rule if it was deleted.');
+            }
+            setError(dashboardErrorMessage(failure, 'The rule change failed.'));
+        } finally {
+            if (alive.current) setBusy(false);
+        }
+    };
+    const valid = draft && draft.consumerGroup.length > 0 && draft.consumerGroup.length <= 255 && !/\s/.test(draft.consumerGroup) &&
+        Number.isSafeInteger(draft.minCount) && draft.minCount >= 0 && Number.isSafeInteger(draft.maxDiffTotal) && draft.maxDiffTotal >= 0;
+    const inputClass = 'rounded border bg-transparent px-3 py-2';
+    return <section className="p-6 space-y-4">
+        <h2 className="text-xl font-semibold">Consumer Monitor rules</h2>
+        <p className="text-sm text-gray-500">Rules belong to the selected NameServer environment. This page manages thresholds; it does not evaluate alerts or send notifications.</p>
+        <div className="flex gap-3 items-center">
+            <input className={inputClass} aria-label="Filter Consumer group" placeholder="Filter Consumer group" value={filter} onChange={event => setFilter(event.target.value)} />
+            <button disabled={busy} onClick={() => void refresh()}>Refresh</button>
+            <button disabled={busy} onClick={() => { setDraft(emptyDraft()); setDeleting(null); setNotice(''); }}>New rule</button>
+        </div>
+        {busy && <p role="status">Loading…</p>}
+        {error && <p role="alert" className="text-red-600">{error}</p>}
+        {notice && <p role="status" className="text-amber-600">{notice}</p>}
+        <table className="w-full text-left text-sm"><thead><tr><th>Consumer group</th><th>Min count</th><th>Max total lag</th><th>Revision</th><th>Updated</th><th>Actions</th></tr></thead>
+            <tbody>{rules.filter(rule => rule.consumerGroup.toLowerCase().includes(filter.toLowerCase())).map(rule => <tr key={rule.consumerGroup} className="border-t">
+                <td className="py-3">{rule.consumerGroup}</td><td>{rule.minCount}</td><td>{rule.maxDiffTotal}</td><td>{rule.revision}</td><td>{new Date(rule.updatedAtMs).toLocaleString()}</td>
+                <td className="space-x-3"><button disabled={busy} onClick={() => { setDraft({ consumerGroup: rule.consumerGroup, minCount: rule.minCount, maxDiffTotal: rule.maxDiffTotal, expectedRevision: rule.revision }); setDeleting(null); setNotice('Current version loaded for review.'); }}>Edit</button><button disabled={busy} onClick={() => { setDeleting(rule); setDraft(null); }}>Delete</button></td>
+            </tr>)}</tbody>
+        </table>
+        {!busy && !error && rules.length === 0 && <p>No rules in this environment.</p>}
+        {draft && <form className="rounded border p-4 space-y-3" onSubmit={event => { event.preventDefault(); if (valid && !busy) void mutate(() => MonitorService.save(draft)); }}>
+            <h3 className="font-semibold">{draft.expectedRevision === 0 ? 'New rule' : `Edit revision ${draft.expectedRevision}`}</h3>
+            <label className="flex gap-3 items-center">Consumer group<input required maxLength={255} disabled={busy || draft.expectedRevision !== 0} className={inputClass} value={draft.consumerGroup} onChange={event => setDraft({ ...draft, consumerGroup: event.target.value })} /></label>
+            <label className="flex gap-3 items-center">Min count<input required disabled={busy} className={inputClass} type="number" min="0" step="1" value={Number.isNaN(draft.minCount) ? '' : draft.minCount} onChange={event => setDraft({ ...draft, minCount: event.target.valueAsNumber })} /></label>
+            <label className="flex gap-3 items-center">Max total lag<input required disabled={busy} className={inputClass} type="number" min="0" step="1" value={Number.isNaN(draft.maxDiffTotal) ? '' : draft.maxDiffTotal} onChange={event => setDraft({ ...draft, maxDiffTotal: event.target.valueAsNumber })} /></label>
+            <div className="flex gap-3"><button type="submit" disabled={busy || !valid}>Save rule</button><button type="button" disabled={busy} onClick={() => setDraft(null)}>Cancel</button></div>
+        </form>}
+        {deleting && <div role="alertdialog" aria-label="Confirm rule deletion" className="rounded border p-4 space-y-3"><p>Delete {deleting.consumerGroup}, revision {deleting.revision}, from this environment?</p><div className="flex gap-3"><button disabled={busy} onClick={() => void mutate(() => MonitorService.delete(deleting))}>Confirm delete</button><button disabled={busy} onClick={() => setDeleting(null)}>Cancel</button></div></div>}
+    </section>;
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/monitor.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/monitor.service.ts
@@ -1,0 +1,21 @@
+import { invokeAuthenticatedCommand } from './invoke';
+
+export interface MonitorRule {
+    consumerGroup: string;
+    minCount: number;
+    maxDiffTotal: number;
+    revision: number;
+    createdAtMs: number;
+    updatedAtMs: number;
+}
+export interface SaveMonitorRule {
+    consumerGroup: string;
+    minCount: number;
+    maxDiffTotal: number;
+    expectedRevision: number;
+}
+export const MonitorService = {
+    list: (): Promise<MonitorRule[]> => invokeAuthenticatedCommand('list_consumer_monitor_rules'),
+    save: (request: SaveMonitorRule): Promise<{ message: string }> => invokeAuthenticatedCommand('save_consumer_monitor_rule', { request }),
+    delete: (rule: MonitorRule): Promise<{ message: string }> => invokeAuthenticatedCommand('delete_consumer_monitor_rule', { request: { consumerGroup: rule.consumerGroup, expectedRevision: rule.revision } }),
+};


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10408

### Brief Description
Add environment-scoped Consumer Monitor rules with nonnegative thresholds, optimistic revision checks, and atomic mutation/audit commits. Expose authenticated commands and a Monitors page with filtering, create/edit, confirmed delete, and current-version review after conflicts. This step manages rules without introducing alert evaluation.

### How Did You Test This Change?
- Monitor repository regression covers restart reads, environment isolation, invalid thresholds, stale update/delete rejection, and audit rollback.
- Frontend production build passed.
- Package formatting and git diff --check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Monitors section for managing consumer monitor rules.
  - Create, edit, delete, filter, and review consumer monitor rules from the dashboard.
  - Added validation for consumer groups and threshold values.
  - Added conflict detection when rules are changed concurrently.
  - Monitor changes now produce auditable operation records.

- **Documentation**
  - Added documentation describing consumer monitor rules, validation, conflicts, auditing, and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->