### PR TITLE
[ISSUE #10410]🚀Report Tauri storage status from committed observations

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/STORAGE_DIAGNOSTICS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/STORAGE_DIAGNOSTICS.md
@@ -1,0 +1,17 @@
+# Storage diagnostics (S23)
+
+The Storage page reports SQLite availability, schema version, observation start,
+check time, and the latest committed write. Database page and freelist bytes are
+read from SQLite; filesystem free space is unknown, not zero. These sizes exclude
+WAL and filesystem overhead. No connection pool metrics or HTTP listener exist.
+
+Business table triggers update a singleton activity row inside the same
+transaction. Rollbacks also roll back that timestamp. The time identifies a write
+in the latest committed transaction, not the precise disk flush instant. Status
+and collector diagnostics use read-only authentication and connections, so refresh
+does not advance session activity or manufacture a successful write.
+
+Ordinary health responses contain no database path or credentials. Missing files
+are not created by status checks. A failed read reports unavailable. Snapshots
+older than a minute or retained after failed refresh are visibly marked stale.
+Local database availability does not establish Broker reachability.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session.rs
@@ -160,6 +160,19 @@ impl SessionState {
         Ok(session)
     }
 
+    /// Diagnostics authenticate without advancing session activity or storage write timestamps.
+    pub(crate) async fn authorize_read_only(&self, token: &str) -> DashboardResult<SessionUser> {
+        let hash = digest(token);
+        let clock = self.clock.clone();
+        self.storage
+            .read("session-authorize-read-only", move |connection| {
+                let session = lookup(connection, &hash, clock())?;
+                require_password_changed(&session)?;
+                Ok(session)
+            })
+            .await
+    }
+
     pub(crate) async fn restore(&self, token: String) -> DashboardResult<AuthSessionResponse> {
         let current_user = self.require_session(&token).await?;
         Ok(AuthSessionResponse {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/auth/session/tests.rs
@@ -333,3 +333,38 @@ fn ttl_configuration_is_validated_without_changing_process_environment() {
         assert!(ttl_millis(Some(value)).is_err());
     }
 }
+
+#[test]
+fn diagnostic_authorization_does_not_write_and_still_enforces_expiry() {
+    let fixture = Fixture::new();
+    fixture.owner.as_ref().unwrap().block_on(async {
+        let login = fixture.ready_login().await;
+        fixture
+            .storage
+            .run("test-sentinel", |db| {
+                db.execute("UPDATE storage_activity SET last_write_ms=123", [])?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        fixture.clock.fetch_add(500, Ordering::SeqCst);
+        fixture.service.authorize_read_only(&login.session_id).await.unwrap();
+        fixture
+            .storage
+            .read("test-status", |db| {
+                assert_eq!(
+                    db.query_row("SELECT last_write_ms FROM storage_activity", [], |row| row
+                        .get::<_, i64>(0))?,
+                    123
+                );
+                Ok(())
+            })
+            .await
+            .unwrap();
+        fixture.clock.fetch_add(500, Ordering::SeqCst);
+        assert!(matches!(
+            fixture.service.authorize_read_only(&login.session_id).await,
+            Err(DashboardError::Unauthenticated)
+        ));
+    });
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/history.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/history.rs
@@ -266,6 +266,6 @@ pub async fn get_history_status(
     session_state: State<'_, SessionState>,
     history: State<'_, HistoryManager>,
 ) -> CommandResult<CollectorStatus> {
-    authorize_command(&session_id, &session_state).await?;
+    session_state.authorize_read_only(&session_id).await?;
     history.status().map_err(Into::into)
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ mod history;
 mod message;
 mod monitor;
 mod nameserver;
+mod ops;
 mod persistence;
 mod producer;
 mod proxy;
@@ -255,6 +256,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
             sessions.start_cleanup()?;
             app.manage(monitor::MonitorManager::new(storage.clone(), connections.clone()));
             app.manage(history);
+            app.manage(ops::OpsManager::new(storage.clone()));
             app.manage(storage);
             app.manage(sessions);
             app.manage(audit);
@@ -308,6 +310,7 @@ fn build_application() -> Result<DashboardApplication, i32> {
             history::query_broker_history,
             history::query_topic_history,
             history::get_history_status,
+            ops::get_storage_status,
             monitor::list_consumer_monitor_rules,
             monitor::save_consumer_monitor_rule,
             monitor::delete_consumer_monitor_rule,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/ops.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/ops.rs
@@ -1,0 +1,166 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    auth::SessionState,
+    error::{CommandResult, DashboardError, DashboardResult},
+    persistence::{StorageManager, schema::SCHEMA_VERSION},
+};
+use rusqlite::Connection;
+use serde::Serialize;
+use tauri::State;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StorageStatus {
+    backend: &'static str,
+    mode: &'static str,
+    available: bool,
+    schema_version: Option<i64>,
+    observed_since_ms: i64,
+    checked_at_ms: i64,
+    last_write_ms: Option<i64>,
+    database_bytes: Option<i64>,
+    reusable_bytes: Option<i64>,
+    disk_free_bytes: Option<i64>,
+    error: Option<&'static str>,
+}
+impl StorageStatus {
+    fn unavailable(observed_since_ms: i64) -> Self {
+        Self {
+            backend: "sqlite",
+            mode: "singleNode",
+            available: false,
+            schema_version: None,
+            observed_since_ms,
+            checked_at_ms: chrono::Utc::now().timestamp_millis(),
+            last_write_ms: None,
+            database_bytes: None,
+            reusable_bytes: None,
+            disk_free_bytes: None,
+            error: Some("Dashboard storage is unavailable. Retry the check."),
+        }
+    }
+}
+pub(crate) struct OpsManager {
+    storage: StorageManager,
+    observed_since_ms: i64,
+}
+impl OpsManager {
+    pub(crate) fn new(storage: StorageManager) -> Self {
+        Self {
+            storage,
+            observed_since_ms: chrono::Utc::now().timestamp_millis(),
+        }
+    }
+    async fn status(&self) -> StorageStatus {
+        let observed = self.observed_since_ms;
+        self.storage
+            .read("storage-status", move |connection| read_status(connection, observed))
+            .await
+            .unwrap_or_else(|_| StorageStatus::unavailable(observed))
+    }
+}
+
+/// Read a coherent SQLite snapshot. No paths, credentials, or fabricated pool/disk metrics are returned.
+pub(crate) fn read_status(connection: &mut Connection, observed_since_ms: i64) -> DashboardResult<StorageStatus> {
+    let transaction = connection.transaction()?;
+    let version: i64 =
+        transaction.query_row("SELECT version FROM dashboard_schema WHERE id=1", [], |row| row.get(0))?;
+    if version != SCHEMA_VERSION {
+        return Err(DashboardError::UnsupportedStorageVersion);
+    }
+    let last_write_ms = transaction.query_row("SELECT last_write_ms FROM storage_activity WHERE id=1", [], |row| {
+        row.get(0)
+    })?;
+    let page_size = transaction
+        .query_row("PRAGMA page_size", [], |row| row.get::<_, i64>(0))
+        .ok();
+    let bytes = |pragma: &str| {
+        transaction
+            .query_row(pragma, [], |row| row.get::<_, i64>(0))
+            .ok()
+            .and_then(|pages| page_size.and_then(|size| pages.checked_mul(size)))
+            .filter(|value| *value >= 0)
+    };
+    Ok(StorageStatus {
+        backend: "sqlite",
+        mode: "singleNode",
+        available: true,
+        schema_version: Some(version),
+        observed_since_ms,
+        checked_at_ms: chrono::Utc::now().timestamp_millis(),
+        last_write_ms,
+        database_bytes: bytes("PRAGMA page_count"),
+        reusable_bytes: bytes("PRAGMA freelist_count"),
+        disk_free_bytes: None,
+        error: None,
+    })
+}
+
+#[tauri::command]
+pub async fn get_storage_status(
+    session_id: String,
+    session_state: State<'_, SessionState>,
+    ops: State<'_, OpsManager>,
+) -> CommandResult<StorageStatus> {
+    match session_state.authorize_read_only(&session_id).await {
+        Ok(_) => Ok(ops.status().await),
+        Err(
+            DashboardError::Io(_)
+            | DashboardError::Database(_)
+            | DashboardError::StorageClosed
+            | DashboardError::Persistence(_),
+        ) => Ok(StorageStatus::unavailable(ops.observed_since_ms)),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn committed_writes_advance_status_but_reads_and_rollbacks_do_not() {
+        let mut db = Connection::open_in_memory().unwrap();
+        crate::persistence::schema::initialize(&mut db).unwrap();
+        assert_eq!(read_status(&mut db, 1).unwrap().last_write_ms, None);
+        db.execute("INSERT INTO history_samples VALUES('env','broker-count','',1,2)", [])
+            .unwrap();
+        let written = read_status(&mut db, 1).unwrap().last_write_ms;
+        assert!(written.is_some());
+        // A sentinel lets the test detect accidental updates without timing or sleeps.
+        db.execute("UPDATE storage_activity SET last_write_ms=123", []).unwrap();
+        {
+            let tx = db.transaction().unwrap();
+            tx.execute("DELETE FROM history_samples", []).unwrap();
+        }
+        let status = read_status(&mut db, 1).unwrap();
+        assert_eq!(status.last_write_ms, Some(123));
+        assert_eq!(read_status(&mut db, 1).unwrap().last_write_ms, Some(123));
+        assert!(status.database_bytes.unwrap() > 0);
+        assert_eq!(status.disk_free_bytes, None);
+        assert!(!serde_json::to_string(&status).unwrap().contains("path"));
+    }
+    #[test]
+    fn missing_database_is_not_created_and_unavailable_capacity_is_unknown() {
+        let path = std::env::temp_dir().join(format!("private-storage-{}.db", uuid::Uuid::new_v4()));
+        assert!(crate::persistence::open_read_only(&path).is_err());
+        assert!(!path.exists());
+        let status = StorageStatus::unavailable(12);
+        assert!(!status.available);
+        assert_eq!(status.database_bytes, None);
+        assert_eq!(status.disk_free_bytes, None);
+        assert!(!serde_json::to_string(&status).unwrap().contains("private-storage"));
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence.rs
@@ -18,4 +18,5 @@ mod types;
 
 pub(crate) use db::StorageManager;
 pub(crate) use db::open_connection;
+pub(crate) use db::open_read_only;
 pub(crate) use db::resolve_data_path;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/db.rs
@@ -61,6 +61,17 @@ pub(crate) fn open_connection(path: &Path) -> DashboardResult<Connection> {
     Ok(connection)
 }
 
+pub(crate) fn open_read_only(path: &Path) -> DashboardResult<Connection> {
+    let connection = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    connection.busy_timeout(Duration::from_secs(5))?;
+    Ok(connection)
+}
+
+enum StorageAccess {
+    ReadOnly,
+    ReadWrite,
+}
+
 #[derive(Clone)]
 pub(crate) struct StorageManager {
     path: Arc<PathBuf>,
@@ -123,6 +134,22 @@ impl StorageManager {
         T: Send + 'static,
         F: FnOnce(&mut Connection) -> DashboardResult<T> + Send + 'static,
     {
+        self.run_with_access(name, StorageAccess::ReadWrite, operation).await
+    }
+
+    pub(crate) async fn read<T, F>(&self, name: &'static str, operation: F) -> DashboardResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Connection) -> DashboardResult<T> + Send + 'static,
+    {
+        self.run_with_access(name, StorageAccess::ReadOnly, operation).await
+    }
+
+    async fn run_with_access<T, F>(&self, name: &'static str, access: StorageAccess, operation: F) -> DashboardResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Connection) -> DashboardResult<T> + Send + 'static,
+    {
         let (sender, receiver) = oneshot::channel();
         {
             let accepting = self.accepting.lock().map_err(|_| DashboardError::StorageClosed)?;
@@ -139,7 +166,11 @@ impl StorageManager {
                     let result = executor
                         .spawn_io(name, move || {
                             let _guard = guard;
-                            let result = open_connection(&path).and_then(|mut connection| operation(&mut connection));
+                            let opened = match access {
+                                StorageAccess::ReadWrite => open_connection(&path),
+                                StorageAccess::ReadOnly => open_read_only(&path),
+                            };
+                            let result = opened.and_then(|mut connection| operation(&mut connection));
                             if result.is_ok() {
                                 stats.completed.fetch_add(1, Ordering::Relaxed);
                             } else {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/persistence/schema.rs
@@ -17,7 +17,7 @@ use crate::error::DashboardResult;
 use rusqlite::Connection;
 use rusqlite::TransactionBehavior;
 
-pub(crate) const SCHEMA_VERSION: i64 = 6;
+pub(crate) const SCHEMA_VERSION: i64 = 7;
 
 pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
     // IMMEDIATE serializes competing initializers before reading the version.
@@ -141,6 +141,30 @@ pub(crate) fn initialize(connection: &mut Connection) -> DashboardResult<()> {
                 updated_at TEXT NOT NULL
             );",
         )?;
+        transaction.execute_batch(
+            "CREATE TABLE storage_activity (
+            id INTEGER PRIMARY KEY CHECK(id = 1), last_write_ms INTEGER
+        ); INSERT INTO storage_activity(id,last_write_ms) VALUES(1,NULL);",
+        )?;
+        // Trigger effects commit or roll back with the business transaction. Reads never touch this row.
+        // The timestamp identifies a write in the latest committed transaction, not an I/O completion.
+        for table in [
+            "users",
+            "sessions",
+            "connection_metadata",
+            "endpoint_identity",
+            "nameserver_addresses",
+            "nameserver_settings",
+            "proxy_addresses",
+            "audit_events",
+            "history_samples",
+            "consumer_monitor_rules",
+        ] {
+            for action in ["INSERT", "UPDATE", "DELETE"] {
+                transaction.execute_batch(&format!("CREATE TRIGGER activity_{table}_{action} AFTER {action} ON {table}
+                    BEGIN UPDATE storage_activity SET last_write_ms = CAST(unixepoch('subsec') * 1000 AS INTEGER) WHERE id = 1; END;"))?;
+            }
+        }
         transaction.execute(
             "UPDATE dashboard_schema SET version = ?1 WHERE id = 1",
             [SCHEMA_VERSION],

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
@@ -64,6 +64,7 @@ const NAV_SECTIONS = [
         title: 'Governance',
         items: [
             {tab: 'ACL', label: 'ACL', icon: Shield},
+            {tab: 'Storage', label: 'Storage', icon: Database},
             {tab: 'Monitors', label: 'Monitors', icon: MonitorDot},
             {tab: 'Audit', label: 'Audit', icon: Shield},
             {tab: 'Sessions', label: 'Sessions', icon: UserRound}
@@ -83,6 +84,7 @@ const PAGE_SUMMARIES: Record<string, string> = {
     MessageTrace: 'End-to-end trace timeline for produced and consumed messages.',
     DLQ: 'Dead-letter queue search, retry context, and payload inspection.',
     ACL: 'Access-control resources, credentials, and permission posture.',
+    Storage: 'Local database and collector diagnostics.',
     Monitors: 'Environment-scoped Consumer group thresholds.',
     Audit: 'Operation history, outcomes, and audit receipts.',
     Sessions: 'Active, expired, and revoked sessions for your account.',

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -15,6 +15,7 @@ import {MessageView} from '../../components/MessageView';
 import {MessageTraceView} from '../../components/MessageTraceView';
 import {DLQMessageView} from '../../components/DLQMessageView';
 import {Activity} from 'lucide-react';
+import {StoragePage} from '../../pages/storage/StoragePage';
 import {MonitorPage} from '../../pages/monitor/MonitorPage';
 import {AuditPage} from '../../pages/audit/AuditPage';
 import {SessionsPanel} from '../../pages/account/SessionsPanel';
@@ -56,6 +57,8 @@ const RouteContent = () => {
             return <DLQMessageView/>;
         case 'ACL':
             return <ACLView/>;
+        case 'Storage':
+            return <StoragePage/>;
         case 'Monitors':
             return <MonitorPage/>;
         case 'Audit':

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/StoragePage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/StoragePage.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { StorageService, type StorageStatus } from '../../services/storage.service';
+import { HistoryService, type CollectorStatus } from '../../services/history.service';
+import { ConnectionStore } from '../../services/connection.store';
+import { dashboardErrorMessage } from '../../services/invoke';
+import { useAppStore } from '../../stores/app.store';
+
+const time = (value: number | null) => value === null ? 'Not observed' : new Date(value).toLocaleString();
+const bytes = (value: number | null) => value === null ? 'Unknown / unavailable' : `${value.toLocaleString()} bytes`;
+
+export const StoragePage = () => {
+    const [status, setStatus] = useState<StorageStatus | null>(null);
+    const [collector, setCollector] = useState<CollectorStatus | null>(null);
+    const [error, setError] = useState('');
+    const [collectorError, setCollectorError] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [now, setNow] = useState(Date.now());
+    const generation = useRef(0);
+    const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
+    const { setActiveTab } = useAppStore();
+    const refresh = async () => {
+        const current = ++generation.current;
+        setBusy(true); setError(''); setCollectorError('');
+        const [storage, history] = await Promise.allSettled([StorageService.status(), HistoryService.status()]);
+        if (current !== generation.current) return;
+        if (storage.status === 'fulfilled') setStatus(storage.value);
+        else setError(dashboardErrorMessage(storage.reason, 'Storage status could not be read.'));
+        if (history.status === 'fulfilled') setCollector(history.value);
+        else setCollectorError(dashboardErrorMessage(history.reason, 'Collector status could not be read.'));
+        setNow(Date.now()); setBusy(false);
+    };
+    useEffect(() => {
+        void refresh();
+        const timer = window.setInterval(() => setNow(Date.now()), 15_000);
+        return () => { generation.current++; window.clearInterval(timer); };
+    }, []);
+    const stale = status && (Boolean(error) || now - status.checkedAtMs >= 60_000);
+    return <section className="p-6 space-y-5">
+        <div className="flex justify-between"><h2 className="text-xl font-semibold">Storage and diagnostics</h2><button disabled={busy} onClick={() => void refresh()}>{busy ? 'Checking…' : 'Refresh / retry'}</button></div>
+        {error && <p role="alert" className="text-red-600">{error}</p>}
+        {stale && <p role="status" className="text-amber-600">This is an older snapshot. Refresh before relying on these values.</p>}
+        {status && <div className="rounded border p-4 space-y-2">
+            <h3 className="font-semibold">Local database: {status.available ? 'Available' : 'Unavailable'}</h3>
+            {status.error && <p role="alert" className="text-red-600">{status.error}</p>}
+            <dl className="grid grid-cols-2 gap-2 text-sm">
+                <dt>Backend / mode</dt><dd>{status.backend} / {status.mode}</dd>
+                <dt>Schema version</dt><dd>{status.schemaVersion ?? 'Unknown'}</dd>
+                <dt>Observation started</dt><dd>{time(status.observedSinceMs)}</dd>
+                <dt>Last check</dt><dd>{time(status.checkedAtMs)}</dd>
+                <dt>Latest committed write</dt><dd>{time(status.lastWriteMs)}</dd>
+                <dt>Allocated database pages</dt><dd>{bytes(status.databaseBytes)}</dd>
+                <dt>Reusable database pages</dt><dd>{bytes(status.reusableBytes)}</dd>
+                <dt>Filesystem free space</dt><dd>{bytes(status.diskFreeBytes)}</dd>
+            </dl>
+            <p className="text-sm text-gray-500">Page sizes describe the SQLite database, excluding WAL and filesystem overhead. Free disk space is not measured. Refreshing diagnostics does not create a write.</p>
+        </div>}
+        <div className="rounded border p-4 space-y-2">
+            <h3 className="font-semibold">History collector</h3>
+            {collectorError && <p role="alert" className="text-red-600">{collectorError}{collector ? ' Previously loaded values are shown below.' : ''}</p>}
+            {collector && <><p>Interval {collector.intervalSeconds}s · Retention {collector.retentionDays} days</p><p>Last sample: {time(collector.lastSampleMs)} · Last write: {time(collector.lastWriteMs)}</p>{collector.lastError && <p className="text-amber-600">{collector.lastError}</p>}</>}
+        </div>
+        <div className="rounded border p-4 space-y-2">
+            <h3 className="font-semibold">Connection configuration</h3>
+            <p>{settings?.environmentId ? `Environment selected · configuration revision ${settings.revision}` : 'No NameServer environment selected'}</p>
+            <p className="text-sm text-gray-500">Database availability and saved connection settings do not establish Broker reachability. Use Dashboard or Cluster to query the cluster.</p>
+            <div className="flex gap-4"><button onClick={() => setActiveTab('NameServer')}>NameServer settings</button><button onClick={() => setActiveTab('Cluster')}>Query Cluster</button></div>
+        </div>
+    </section>;
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
@@ -108,7 +108,7 @@ export const invokeSessionCommand = <T>(
     throw error;
 });
 
-const localCommands = new Set(['change_password', 'get_current_user_profile', 'get_auth_bootstrap_status', 'list_sessions', 'revoke_user_sessions', 'query_audit_events']);
+const localCommands = new Set(['get_storage_status', 'get_history_status', 'change_password', 'get_current_user_profile', 'get_auth_bootstrap_status', 'list_sessions', 'revoke_user_sessions', 'query_audit_events']);
 const connectionWrites = new Set(['add_name_server', 'switch_name_server', 'delete_name_server', 'update_vip_channel', 'update_use_tls', 'add_proxy_addr', 'switch_proxy_addr', 'delete_proxy_addr', 'replace_name_servers']);
 const remoteWrites = new Set(['create_or_update_topic', 'delete_topic', 'delete_topic_by_broker', 'reset_consumer_offset', 'skip_message_accumulate', 'send_topic_message', 'create_or_update_consumer_group', 'delete_consumer_group', 'consume_message_directly', 'resend_dlq_message', 'batch_resend_dlq_message']);
 const pendingSettings = new Map<string, Promise<ConnectionSettingsView>>();

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/storage.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/storage.service.ts
@@ -1,0 +1,18 @@
+import { invokeAuthenticatedCommand } from './invoke';
+
+export interface StorageStatus {
+    backend: 'sqlite';
+    mode: 'singleNode';
+    available: boolean;
+    schemaVersion: number | null;
+    observedSinceMs: number;
+    checkedAtMs: number;
+    lastWriteMs: number | null;
+    databaseBytes: number | null;
+    reusableBytes: number | null;
+    diskFreeBytes: number | null;
+    error: string | null;
+}
+export const StorageService = {
+    status: (): Promise<StorageStatus> => invokeAuthenticatedCommand('get_storage_status'),
+};


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10410

### Brief Description
Add a Storage page backed by read-only SQLite diagnostics. Track committed business writes transactionally, preserve unknown capacity values, and show stale snapshots, collector state, and connection configuration without private paths. Diagnostic authentication checks expiry and account state without advancing session activity or write timestamps.

### How Did You Test This Change?
- Storage status regressions cover committed writes, rollback/read stability, missing database behavior, null capacity, and safe response fields.
- Read-only authorization regression checks no writes and enforced expiry; persistence lifecycle regressions passed.
- Frontend production build and 3 invoke tests passed.
- Package formatting and git diff --check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Storage page with local database availability, schema, activity, capacity, and disk-space diagnostics.
  * Added history collector status visibility, refresh and retry controls, and stale-data warnings.
  * Added read-only diagnostic access to avoid modifying activity timestamps during status checks.
  * Added privacy safeguards that prevent database paths from appearing in diagnostic results.

* **Documentation**
  * Added documentation describing storage diagnostics, privacy behavior, and local database versus Broker availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->