### PR TITLE
[ISSUE #10412]🚀Back up and restore Tauri storage with session revocation

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/STORAGE_OPERATIONS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/STORAGE_OPERATIONS.md
@@ -1,0 +1,40 @@
+# Local storage backup and restore (S24)
+
+Run from `src-tauri`. The tool is synchronous and does not start the desktop or
+an HTTP server. Cargo's default binary remains the desktop app.
+
+```powershell
+# Point explicitly to the directory containing the desktop's dashboard.db.
+$env:DASHBOARD_TAURI_DATA_DIR = 'D:\DashboardData\development'
+cargo run --bin rocketmq-dashboard-storage -- status
+cargo run --bin rocketmq-dashboard-storage -- backup --output 'D:\DashboardBackups\snapshot-01'
+cargo run --bin rocketmq-dashboard-storage -- verify --input 'D:\DashboardBackups\snapshot-01'
+cargo run --bin rocketmq-dashboard-storage -- restore --input 'D:\DashboardBackups\snapshot-01' --target 'D:\DashboardData\restored-01' --confirm-empty-target
+
+# Start an isolated instance using the restored data; sign in again.
+$env:DASHBOARD_TAURI_DATA_DIR = 'D:\DashboardData\restored-01'
+cargo run --bin rocketmq-dashboard-tauri
+```
+
+`status` and `backup` require `DASHBOARD_TAURI_DATA_DIR`; they never guess which
+desktop data directory to operate on. Parent directories must exist. Backup
+requires a new output directory. Restore accepts a new or empty target directory
+and the explicit confirmation flag. Existing files are never overwritten.
+
+Snapshots use SQLite's backup API, including committed WAL content. The output
+contains `dashboard.db` and `metadata.json` with format/schema versions, creation
+time, and content scope. Verify uses read-only access, supported metadata/schema
+checks, and `PRAGMA quick_check`. Busy sources fail explicitly; retry into another
+new directory. Do not substitute a raw copy of an active database file.
+
+The snapshot contains accounts and password hashes, connection settings, monitor
+rules, audit, history, and sessions. Treat it as private account data. Credentials
+supplied through environment variables are excluded. Restore revokes all snapshot
+sessions and commits a local restore audit before publishing `dashboard.db`.
+Publication uses an atomic hard link within the target filesystem and requires
+hard-link support. It never replaces a running desktop's database.
+
+Interrupted operations may leave an incomplete output directory. Verify rejects
+an incomplete backup; failed restores do not publish a startable database with
+active snapshot sessions. Inspect that directory and use another empty target to
+retry. This tool does not migrate older schemas or restore over existing data.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@
 
 [package]
 name         = "rocketmq-dashboard-tauri"
+default-run  = "rocketmq-dashboard-tauri"
 version      = "0.1.0"
 description  = "RocketMQ-Rust Dashboard Desktop App (Tauri)"
 authors      = ["mxsm <mxsm@apache.org>"]
@@ -45,7 +46,7 @@ serde            = { version = "1.0", features = ["derive"] }
 log              = "0.4"
 tauri            = { version = "2.11.5", features = [] }
 tauri-plugin-log = "2.9"
-rusqlite         = { version = "0.32", features = ["bundled"] }
+rusqlite         = { version = "0.32", features = ["bundled", "backup"] }
 argon2           = "0.5"
 password-hash    = "0.5"
 sha2             = "0.11"

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/audit/types.rs
@@ -49,6 +49,7 @@ pub(crate) enum AuditAction {
     ConsumeDirectly,
     ResendDlq,
     BatchResendDlq,
+    RestoreStorage,
     SaveMonitor,
     DeleteMonitor,
 }
@@ -56,6 +57,7 @@ pub(crate) enum AuditAction {
 impl AuditAction {
     pub(crate) fn name(self) -> &'static str {
         match self {
+            Self::RestoreStorage => "storage.restore",
             Self::SaveMonitor => "monitor.save",
             Self::DeleteMonitor => "monitor.delete",
             Self::Login => "auth.login",
@@ -93,6 +95,7 @@ impl AuditAction {
     }
     pub(crate) fn resource_type(self) -> &'static str {
         match self {
+            Self::RestoreStorage => "storage",
             Self::SaveMonitor | Self::DeleteMonitor => "consumer_monitor",
             Self::Login | Self::Logout | Self::ChangePassword | Self::RevokeSessions => "account",
             Self::AddNameServer

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/bin/rocketmq-dashboard-storage.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/bin/rocketmq-dashboard-storage.rs
@@ -1,0 +1,17 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {
+    std::process::exit(app_lib::run_storage_cli(std::env::args_os().skip(1).collect()));
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -30,7 +30,14 @@ mod ops;
 mod persistence;
 mod producer;
 mod proxy;
+mod storage_operations;
 mod topic;
+
+/// Runs the local storage CLI without starting the desktop or a background runtime.
+/// Returns zero on success and a nonzero exit code for invalid arguments or failed operations.
+pub fn run_storage_cli(args: Vec<std::ffi::OsString>) -> i32 {
+    storage_operations::run(args)
+}
 
 use rocketmq_admin_core::client_adapter::ClientRuntime;
 use rocketmq_admin_core::client_adapter::ClientRuntimeConfig;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/storage_operations.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/storage_operations.rs
@@ -1,0 +1,261 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod tests;
+use crate::{
+    audit::{AuditAction, AuditContext},
+    error::{DashboardError, DashboardResult},
+    persistence::{open_read_only, schema::SCHEMA_VERSION},
+};
+use rusqlite::{
+    Connection, OpenFlags,
+    backup::{Backup, StepResult},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    ffi::OsString,
+    fs::{self, OpenOptions},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+const DATABASE: &str = "dashboard.db";
+const METADATA: &str = "metadata.json";
+const CONTENT_SCOPE: &str = "accounts, connections, monitor rules, audit, history, sessions (revoked on restore); excludes environment credentials";
+const USAGE: &str = "Usage: rocketmq-dashboard-storage status | backup --output <new-dir> | verify --input <dir> | restore --input <dir> --target <empty-dir> --confirm-empty-target\nSet DASHBOARD_TAURI_DATA_DIR for status and backup.";
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Metadata {
+    format_version: u32,
+    schema_version: i64,
+    created_at_ms: i64,
+    content_scope: String,
+}
+
+enum Operation {
+    Status,
+    Backup(PathBuf),
+    Verify(PathBuf),
+    Restore { input: PathBuf, target: PathBuf },
+}
+
+fn parse(args: &[OsString]) -> DashboardResult<Operation> {
+    match args {
+        [command] if command == "status" => Ok(Operation::Status),
+        [command, flag, path] if command == "backup" && flag == "--output" => Ok(Operation::Backup(path.into())),
+        [command, flag, path] if command == "verify" && flag == "--input" => Ok(Operation::Verify(path.into())),
+        [command, input_flag, input, target_flag, target, confirm]
+            if command == "restore"
+                && input_flag == "--input"
+                && target_flag == "--target"
+                && confirm == "--confirm-empty-target" =>
+        {
+            Ok(Operation::Restore {
+                input: input.into(),
+                target: target.into(),
+            })
+        }
+        _ => Err(DashboardError::Validation(USAGE.into())),
+    }
+}
+
+fn configured_database() -> DashboardResult<PathBuf> {
+    let directory = std::env::var_os("DASHBOARD_TAURI_DATA_DIR")
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            DashboardError::Configuration("Set DASHBOARD_TAURI_DATA_DIR to the desktop data directory.".into())
+        })?;
+    Ok(PathBuf::from(directory).join(DATABASE))
+}
+
+// This synchronous CLI entry owns all blocking filesystem and SQLite work. No app runtime is started.
+pub(crate) fn run(args: Vec<OsString>) -> i32 {
+    if args.as_slice() == [OsString::from("--help")] {
+        println!("{USAGE}");
+        return 0;
+    }
+    match execute(args) {
+        Ok(output) => {
+            println!("{output}");
+            0
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            1
+        }
+    }
+}
+
+fn execute(args: Vec<OsString>) -> DashboardResult<String> {
+    match parse(&args)? {
+        Operation::Status => {
+            let mut connection = open_read_only(&configured_database()?)?;
+            Ok(serde_json::to_string_pretty(&crate::ops::read_status(
+                &mut connection,
+                chrono::Utc::now().timestamp_millis(),
+            )?)?)
+        }
+        Operation::Backup(output) => {
+            backup(&configured_database()?, &output)?;
+            Ok("Backup complete. Keep the snapshot private; it contains account data.".into())
+        }
+        Operation::Verify(input) => {
+            verify(&input)?;
+            Ok("Backup metadata, schema, and SQLite integrity verified.".into())
+        }
+        Operation::Restore { input, target } => {
+            restore(&input, &target)?;
+            Ok("Restore complete. All restored sessions are revoked. Set DASHBOARD_TAURI_DATA_DIR to the target and sign in again.".into())
+        }
+    }
+}
+
+fn verify_database(connection: &Connection) -> DashboardResult<()> {
+    let version: i64 = connection.query_row("SELECT version FROM dashboard_schema WHERE id=1", [], |row| row.get(0))?;
+    if version != SCHEMA_VERSION {
+        return Err(DashboardError::UnsupportedStorageVersion);
+    }
+    let mut check = connection.prepare("PRAGMA quick_check")?;
+    let results = check
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    if results != ["ok"] {
+        return Err(DashboardError::Validation(
+            "SQLite integrity verification failed.".into(),
+        ));
+    }
+    // Schema version alone is insufficient when a snapshot was truncated or manually edited.
+    for table in [
+        "users",
+        "sessions",
+        "nameserver_addresses",
+        "nameserver_settings",
+        "proxy_addresses",
+        "connection_metadata",
+        "endpoint_identity",
+        "consumer_monitor_rules",
+        "history_samples",
+        "audit_events",
+        "storage_activity",
+    ] {
+        connection.prepare(&format!("SELECT * FROM {table} LIMIT 0"))?;
+    }
+    Ok(())
+}
+
+fn snapshot(source: &Connection, path: &Path) -> DashboardResult<Connection> {
+    // Reserve the exact destination atomically; never open an existing database for replacement.
+    OpenOptions::new().write(true).create_new(true).open(path)?;
+    let mut destination = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
+    {
+        let backup = Backup::new(source, &mut destination)?;
+        // SQLite copies the committed snapshot, including WAL content. Busy/locked results fail
+        // explicitly instead of leaving an unbounded retry loop in an operational command.
+        if !matches!(backup.step(-1)?, StepResult::Done) {
+            return Err(DashboardError::Configuration(
+                "The source is busy; retry backup into another new directory.".into(),
+            ));
+        }
+    }
+    destination.pragma_update(None, "journal_mode", "DELETE")?;
+    destination.pragma_update(None, "foreign_keys", "ON")?;
+    verify_database(&destination)?;
+    Ok(destination)
+}
+
+fn backup(source_path: &Path, output: &Path) -> DashboardResult<()> {
+    let source = open_read_only(source_path)?;
+    source.execute_batch("BEGIN")?;
+    verify_database(&source)?;
+    fs::create_dir(output)?;
+    let destination = snapshot(&source, &output.join(DATABASE))?;
+    drop(destination);
+    let metadata = Metadata {
+        format_version: 1,
+        schema_version: SCHEMA_VERSION,
+        created_at_ms: chrono::Utc::now().timestamp_millis(),
+        content_scope: CONTENT_SCOPE.into(),
+    };
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(output.join(METADATA))?;
+    file.write_all(serde_json::to_string_pretty(&metadata)?.as_bytes())?;
+    file.sync_all()?;
+    Ok(())
+}
+
+/// Hold the validated source read transaction through restore, so writes cannot change its snapshot.
+fn verify(input: &Path) -> DashboardResult<Connection> {
+    let file = fs::File::open(input.join(METADATA))?;
+    let mut bytes = Vec::new();
+    file.take(65_537).read_to_end(&mut bytes)?;
+    if bytes.len() > 65_536 {
+        return Err(DashboardError::Validation("Backup metadata is too large.".into()));
+    }
+    let metadata: Metadata = serde_json::from_slice(&bytes)?;
+    if metadata.format_version != 1
+        || metadata.schema_version != SCHEMA_VERSION
+        || metadata.created_at_ms < 0
+        || metadata.content_scope != CONTENT_SCOPE
+    {
+        return Err(DashboardError::UnsupportedStorageVersion);
+    }
+    let source = open_read_only(&input.join(DATABASE))?;
+    source.execute_batch("BEGIN")?;
+    verify_database(&source)?;
+    Ok(source)
+}
+
+fn restore(input: &Path, target: &Path) -> DashboardResult<()> {
+    let source = verify(input)?;
+    match fs::create_dir(target) {
+        Ok(()) => (),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if fs::read_dir(target)?.next().transpose()?.is_some() {
+                return Err(DashboardError::Validation(
+                    "Restore requires an empty target directory.".into(),
+                ));
+            }
+        }
+        Err(error) => return Err(error.into()),
+    }
+    // Publish only after session revocation and audit commit. An interrupted restore must
+    // never leave a startable dashboard.db containing active snapshot sessions.
+    let pending = target.join(format!(".restore-pending-{}.db", uuid::Uuid::new_v4()));
+    let mut destination = snapshot(&source, &pending)?;
+    let transaction = destination.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    transaction.execute(
+        "UPDATE sessions SET revoked_at_ms=COALESCE(revoked_at_ms,?1)",
+        [chrono::Utc::now().timestamp_millis()],
+    )?;
+    let audit = AuditContext {
+        actor: Some("local-storage-tool".into()),
+        environment: Arc::new(Mutex::new(None)),
+        event_id: uuid::Uuid::new_v4().to_string(),
+        request_id: uuid::Uuid::new_v4().to_string(),
+        action: AuditAction::RestoreStorage,
+        resource_name: None,
+    };
+    audit.record_local_success(&transaction)?;
+    transaction.commit()?;
+    drop(destination);
+    // hard_link creates the final name atomically and refuses any existing destination.
+    fs::hard_link(&pending, target.join(DATABASE))?;
+    fs::remove_file(pending)?;
+    Ok(())
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/storage_operations/tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/storage_operations/tests.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+struct Fixture(PathBuf);
+impl Fixture {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!("storage-operations-{}", uuid::Uuid::new_v4()));
+        fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+fn source(path: &Path) -> Connection {
+    let mut db = Connection::open(path).unwrap();
+    crate::persistence::schema::initialize(&mut db).unwrap();
+    db.pragma_update(None, "journal_mode", "WAL").unwrap();
+    db.pragma_update(None, "wal_autocheckpoint", 0).unwrap();
+    db.execute_batch("INSERT INTO users(id,username,password_hash,must_change_password,created_at,updated_at) VALUES(1,'saved-user','saved-hash',0,'created','updated');
+        INSERT INTO sessions(id,token_digest,user_id,created_at_ms,expires_at_ms,last_seen_at_ms) VALUES('session',X'1234',1,1,9999999999999,1);
+        INSERT INTO nameserver_addresses(address,created_at,updated_at) VALUES('127.0.0.1:9876','created','updated');
+        INSERT INTO consumer_monitor_rules VALUES('env','group',1,100,1,1,1);
+        INSERT INTO history_samples VALUES('env','broker-count','',1,2);
+        UPDATE storage_activity SET last_write_ms=123;").unwrap();
+    db
+}
+
+#[test]
+fn storage_backup_captures_wal_and_restore_revokes_sessions_without_changing_source() {
+    let fixture = Fixture::new();
+    let source_path = fixture.0.join(DATABASE);
+    let source = source(&source_path);
+    assert!(fixture.0.join("dashboard.db-wal").exists());
+    let backup_path = fixture.0.join("snapshot");
+    backup(&source_path, &backup_path).unwrap();
+    let verified = verify(&backup_path).unwrap();
+    assert_eq!(
+        verified
+            .query_row("SELECT username FROM users", [], |row| row.get::<_, String>(0))
+            .unwrap(),
+        "saved-user"
+    );
+    drop(verified);
+    let restored_path = fixture.0.join("restored");
+    restore(&backup_path, &restored_path).unwrap();
+    let restored = open_read_only(&restored_path.join(DATABASE)).unwrap();
+    assert_eq!(
+        restored
+            .query_row("SELECT count(*) FROM sessions WHERE revoked_at_ms IS NULL", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        0
+    );
+    for table in [
+        "users",
+        "nameserver_addresses",
+        "consumer_monitor_rules",
+        "history_samples",
+    ] {
+        assert_eq!(
+            restored
+                .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+    }
+    assert_eq!(
+        restored
+            .query_row(
+                "SELECT count(*) FROM audit_events WHERE action='storage.restore' AND outcome='success'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        source
+            .query_row("SELECT count(*) FROM sessions WHERE revoked_at_ms IS NULL", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        source
+            .query_row("SELECT last_write_ms FROM storage_activity", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        123
+    );
+    assert!(backup(&source_path, &backup_path).is_err());
+    assert!(restore(&backup_path, &restored_path).is_err());
+}
+
+#[test]
+fn storage_verify_rejects_corruption_versions_and_restore_requires_confirmation() {
+    let fixture = Fixture::new();
+    let source_path = fixture.0.join(DATABASE);
+    let _source = source(&source_path);
+    let backup_path = fixture.0.join("snapshot");
+    backup(&source_path, &backup_path).unwrap();
+    let metadata_path = backup_path.join(METADATA);
+    let metadata = fs::read(&metadata_path).unwrap();
+    let mut unsupported: Metadata = serde_json::from_slice(&metadata).unwrap();
+    unsupported.format_version = 99;
+    fs::write(&metadata_path, serde_json::to_vec(&unsupported).unwrap()).unwrap();
+    assert!(verify(&backup_path).is_err());
+    fs::write(metadata_path, metadata).unwrap();
+    fs::write(backup_path.join(DATABASE), b"not a SQLite database").unwrap();
+    assert!(verify(&backup_path).is_err());
+    let target = fixture.0.join("not-created");
+    assert!(restore(&backup_path, &target).is_err());
+    assert!(!target.exists());
+    let args = ["restore", "--input", "input", "--target", "target"].map(OsString::from);
+    assert!(parse(&args).is_err());
+}
+
+#[test]
+fn failed_restore_never_publishes_a_database_with_active_snapshot_sessions() {
+    let fixture = Fixture::new();
+    let source_path = fixture.0.join(DATABASE);
+    let source = source(&source_path);
+    // Force the audit transaction to fail after session revocation.
+    source.execute_batch("CREATE TRIGGER reject_restore BEFORE INSERT ON audit_events BEGIN SELECT RAISE(ABORT,'test audit failure'); END;").unwrap();
+    let backup_path = fixture.0.join("snapshot");
+    backup(&source_path, &backup_path).unwrap();
+    let target = fixture.0.join("restored");
+    assert!(restore(&backup_path, &target).is_err());
+    assert!(!target.join(DATABASE).exists());
+    assert!(
+        source
+            .query_row("SELECT revoked_at_ms FROM sessions", [], |row| row
+                .get::<_, Option<i64>>(0))
+            .unwrap()
+            .is_none()
+    );
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #10412

### Brief Description
Add a local storage CLI with status, SQLite-consistent backup, read-only verification, and confirmed restore into a new or empty directory. Include simple versioned metadata and preserve WAL-backed data. Restore revokes sessions and records a local audit before atomically publishing the database, so failed operations cannot expose active snapshot sessions. Keep the desktop as Cargo's default binary and document isolated recovery.

### How Did You Test This Change?
- Three storage operation regressions passed: WAL-backed round trip/source preservation, corrupt and unsupported backup rejection, and failed restore publication.
- cargo check --bin rocketmq-dashboard-storage passed.
- Package formatting and git diff --check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to check dashboard storage status, create backups, verify snapshots, and restore data.
  * Added safeguards requiring confirmation and an empty destination before restoration.
  * Restores revoke existing sessions and record the operation in the audit history.
  * Backup and restore operations validate storage integrity and handle interrupted operations safely.

* **Documentation**
  * Added guidance covering storage commands, configuration, snapshot contents, safety guarantees, and recovery behavior.

* **Tests**
  * Added coverage for backup, verification, restoration, corrupted data, WAL content, and failed-operation safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->