### PR TITLE
[ISSUE #10416]🐛Fix live Consumer diagnostics and Rust DLQ origin lookup

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -269,6 +269,10 @@ name = "consumer"
 path = "examples/quickstart/consumer.rs"
 
 [[example]]
+name = "dashboard-debug-client"
+path = "examples/quickstart/dashboard_debug_client.rs"
+
+[[example]]
 name = "broadcast-consumer"
 path = "examples/broadcast/push_consumer.rs"
 

--- a/rocketmq-client/examples/quickstart/dashboard_debug_client.rs
+++ b/rocketmq-client/examples/quickstart/dashboard_debug_client.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![recursion_limit = "512"]
+
+#[path = "../support/mod.rs"]
+mod support;
+
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use rocketmq_client_rust::ClientConfig;
+use rocketmq_client_rust::ClientResult;
+use rocketmq_client_rust::ConsumeConcurrentlyContext;
+use rocketmq_client_rust::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::DefaultMQProducer;
+use rocketmq_client_rust::DefaultMQPushConsumer;
+use rocketmq_client_rust::MQPushConsumer;
+use rocketmq_client_rust::MessageListenerConcurrently;
+use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_model::common::message::message_ext::MessageExt;
+use rocketmq_model::common::message::message_single::Message;
+
+struct RejectFirstDelivery(AtomicBool);
+
+impl MessageListenerConcurrently for RejectFirstDelivery {
+    fn consume_message(
+        &self,
+        messages: &[&MessageExt],
+        _context: &ConsumeConcurrentlyContext,
+    ) -> ClientResult<ConsumeConcurrentlyStatus> {
+        // One message per callback: the first rejection creates a DLQ fixture;
+        // subsequent direct-consume requests can exercise successful redelivery.
+        if self.0.swap(false, Ordering::AcqRel) {
+            println!("REJECTED deliveries={}", messages.len());
+            Ok(ConsumeConcurrentlyStatus::ReconsumeLater)
+        } else {
+            println!("ACCEPTED deliveries={}", messages.len());
+            Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.len() != 4 {
+        return Err("usage: dashboard-debug-client <namesrv> <fresh-topic> <fresh-group> <seconds:1..3600>".into());
+    }
+    let seconds: u64 = args[3].parse()?;
+    if !(1..=3600).contains(&seconds) || args[..3].iter().any(|value| value.trim().is_empty()) {
+        return Err("provide nonempty addresses/names and a lifetime between 1 and 3600 seconds".into());
+    }
+    let runtime = support::ExampleClientRuntime::try_new("dashboard-debug")?;
+    let config = ClientConfig {
+        namesrv_addr: Some(args[0].clone().into()),
+        vip_channel_enabled: false,
+        enable_trace: true,
+        trace_topic: Some(format!("{}_trace", args[1]).into()),
+        ..Default::default()
+    };
+    let mut consumer = DefaultMQPushConsumer::builder(runtime.client_runtime())
+        .client_config(config.clone())
+        .consumer_group(args[2].clone())
+        .consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset)
+        .consume_message_batch_max_size(1)
+        .max_reconsume_times(0)
+        .build();
+    let mut producer = DefaultMQProducer::builder(runtime.client_runtime())
+        .client_config(config)
+        .producer_group(format!("{}_producer", args[2]))
+        .build();
+    let outcome: ClientResult<()> = async {
+        consumer.subscribe(args[1].as_str(), "*").await?;
+        consumer.register_message_listener_concurrently(RejectFirstDelivery(AtomicBool::new(true)));
+        consumer.start().await?;
+        producer.start().await?;
+        let message = Message::builder()
+            .topic(args[1].clone())
+            .keys(vec!["dashboard-debug-key".into()])
+            .tags("dashboard-debug")
+            .body_slice(b"dashboard local acceptance fixture")
+            .build_unchecked();
+        let receipt = producer.send_with_timeout(message, 10_000).await?;
+        println!("SENT {receipt:?}");
+        println!("READY group={} topic={} lifetime_seconds={seconds}", args[2], args[1]);
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = tokio::time::sleep(Duration::from_secs(seconds)) => {}
+        }
+        Ok(())
+    }
+    .await;
+    Box::pin(consumer.shutdown()).await;
+    Box::pin(producer.shutdown()).await;
+    Box::pin(runtime.shutdown()).await;
+    outcome?;
+    println!("SHUTDOWN complete");
+    Ok(())
+}

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl/admin_api.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl/admin_api.rs
@@ -1010,32 +1010,30 @@ impl ConsumerAdmin for DefaultMQAdminExtImpl {
         jstack: bool,
         _metrics: Option<bool>,
     ) -> crate::ClientResult<ConsumerRunningInfo> {
-        let broker_addr = self
-            .examine_consumer_connection_info(consumer_group.clone(), None)
+        let retry_topic = CheetahString::from_string(mix_all::get_retry_topic(&consumer_group));
+        let route = self
+            .examine_topic_route_info(retry_topic.clone())
             .await?
-            .get_connection_set()
-            .iter()
-            .find(|connection| connection.get_client_id() == client_id)
-            .map(|connection| connection.get_client_addr().clone())
-            .ok_or_else(|| {
-                crate::ClientError::illegal_argument(format!(
-                    "Client `{}` was not found in consumer group `{}`",
-                    client_id, consumer_group
-                ))
-            })?;
-
-        self.client_instance
-            .as_ref()
-            .ok_or(crate::ClientError::not_started())?
-            .get_mq_client_api_impl()?
-            .get_consumer_running_info(
-                &broker_addr,
-                consumer_group,
-                client_id,
-                jstack,
-                self.remoting_timeout_millis()?,
-            )
-            .await
+            .ok_or_else(|| admin_route_not_found(&retry_topic))?;
+        let api = self.mq_client_api()?;
+        let timeout = self.remoting_timeout_millis()?;
+        let mut last_error = None;
+        // A client's advertised connection is an outbound ephemeral socket, not
+        // an RPC listener. The Broker forwards diagnostics over that connection.
+        // Try each route because the client may only be connected to one Broker.
+        for broker in &route.broker_datas {
+            let Some(address) = broker.select_broker_addr() else {
+                continue;
+            };
+            match api
+                .get_consumer_running_info(&address, consumer_group.clone(), client_id.clone(), jstack, timeout)
+                .await
+            {
+                Ok(info) => return Ok(info),
+                Err(error) => last_error = Some(error),
+            }
+        }
+        Err(last_error.unwrap_or_else(|| admin_route_not_found(&retry_topic)))
     }
 
     async fn consume_message_directly(

--- a/rocketmq-client/tests/admin/default_mq_admin_ext_impl/unit.rs
+++ b/rocketmq-client/tests/admin/default_mq_admin_ext_impl/unit.rs
@@ -112,6 +112,37 @@ fn new_unstarted_admin() -> DefaultMQAdminExtImpl {
     )
 }
 
+#[tokio::test]
+#[ignore = "requires DASHBOARD_DEBUG_NAMESRV and DASHBOARD_DEBUG_GROUP with an online Rust consumer"]
+async fn live_consumer_diagnostics_are_forwarded_by_the_broker() {
+    let namesrv = std::env::var("DASHBOARD_DEBUG_NAMESRV").expect("explicit development NameServer");
+    let group: CheetahString = std::env::var("DASHBOARD_DEBUG_GROUP")
+        .expect("explicit development Consumer group")
+        .into();
+    let runtime = crate::runtime::test_client_runtime("live-consumer-diagnostics");
+    let mut admin = crate::DefaultMQAdminExt::new(runtime.clone());
+    admin.set_namesrv_addr(namesrv);
+    let outcome: crate::ClientResult<_> = async {
+        admin.start().await?;
+        let connections = admin.examine_consumer_connection_info(group.clone(), None).await?;
+        let client = connections.get_connection_set().iter().next().expect("online consumer");
+        let running = admin
+            .get_consumer_running_info(group.clone(), client.get_client_id(), false, None)
+            .await?;
+        let stack = admin
+            .get_consumer_running_info(group, client.get_client_id(), true, None)
+            .await?;
+        Ok((running, stack))
+    }
+    .await;
+    admin.shutdown().await;
+    let shutdown = runtime.shutdown().await;
+    assert!(shutdown.is_healthy(), "{}", shutdown.to_json());
+    let (running, stack) = outcome.expect("Broker must forward to the outbound client connection");
+    assert!(!running.subscription_set.is_empty());
+    assert!(stack.jstack.as_ref().is_some_and(|stack| !stack.is_empty()));
+}
+
 #[test]
 fn retain_java_user_topic_config_filters_java_internal_topics() {
     let mut topic_table = HashMap::from([

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/README.md
@@ -72,8 +72,54 @@ the send. To read the message, run `message queryMsgByOffset` with the Broker
 name (`-b`), queue ID (`-i`), and queue offset (`-o`) from that send receipt,
 along with `-t TauriDebugSmoke`. Sending appends to existing data; do not assume
 queue zero or offset zero identifies the newly sent message.
-This checks remoting administration and basic message storage, not gRPC clients,
-ACL, consumer processing, scheduled messages, or failover.
+This checks remoting administration and basic message storage. Use the bounded
+client below to exercise consumer processing and Trace. gRPC clients, ACL,
+scheduled messages, and failover require their own fixtures.
+
+## Online client, DLQ, and Trace fixture
+
+Use fresh Topic and group names for each run. The example sends one keyed message,
+rejects its first delivery with zero retries, then accepts later deliveries. It
+keeps a Producer and Consumer online until Ctrl-C or the specified lifetime
+(1–3600 seconds), and awaits both clients and their runtime during shutdown.
+It prints delivery counts and send receipts without printing message bodies.
+
+Prepare the normal Topic and a dedicated Trace Topic using `Invoke-DebugAdmin`
+above. Both must exist because this fixture disables automatic Topic creation:
+
+```powershell
+$debugTopic = 'DesktopAcceptanceFresh'
+$debugGroup = 'DesktopAcceptanceFreshGroup'
+Invoke-DebugAdmin topic updateTopic -n 127.0.0.1:9876 -c TauriDebugCluster -t $debugTopic -r 1 -w 1 -y
+Invoke-DebugAdmin topic updateTopic -n 127.0.0.1:9876 -c TauriDebugCluster -t "${debugTopic}_trace" -r 1 -w 1 -y
+
+# Run from the repository root; leave this process running during desktop checks.
+cargo run -p rocketmq-client-rust --example dashboard-debug-client -- 127.0.0.1:9876 $debugTopic $debugGroup 600
+```
+
+In the desktop, discover the group in Consumers and open its connection details,
+RunningInfo, and JStack. Discover `${debugGroup}_producer` in Producers and open
+its connection details. Query the group's DLQ by Key `dashboard-debug-key`, inspect
+its unique ID, export CSV, and resend to the displayed online client. Mixed valid
+and invalid selections should retain individual success/failure receipts.
+
+For Trace, use `${debugTopic}_trace` and the producer message ID in the send receipt.
+Wait for the asynchronous trace flush before querying. A dedicated normal Topic
+avoids changing the cluster's system Trace Topic policy.
+
+The ignored SDK regression can also verify live Broker forwarding while the
+example remains online (run from the repository root in another terminal):
+
+```powershell
+$env:DASHBOARD_DEBUG_NAMESRV = '127.0.0.1:9876'
+$env:DASHBOARD_DEBUG_GROUP = $debugGroup
+cargo test -p rocketmq-client-rust --lib live_consumer_diagnostics_are_forwarded_by_the_broker -- --ignored
+```
+
+After the client exits, delete only these test resources through the desktop:
+the Consumer group (including retry/DLQ cleanup), the normal Topic, and its Trace
+Topic. Existing physical message IDs generated with an unspecified Broker host
+remain a separate Broker limitation; do not count those lookups as passing.
 
 ## Stop and inspect
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/IMPLEMENTATION_ACCEPTANCE.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/IMPLEMENTATION_ACCEPTANCE.md
@@ -84,12 +84,13 @@ WebView and authenticated IPC were used; no mock backend supplied these results.
 | Visible Monitor / Storage pages | Rule create and confirmed delete; available SQLite, actual page capacity, unknown filesystem free space, collector status; consecutive diagnostics refreshes did not change the write timestamp |
 | Connection IPC | Address add/switch/delete, stale revision rejection, invalid atomic replacement rollback, environment-isolated rules, configured Proxy Consumer query |
 | Topic and message IPC | Two-Broker create/update, route, SEND_OK receipt, ID/Key lookup, message detail, single-Broker delete and whole-Topic delete |
-| Consumer / Broker IPC | Two-Broker group writes, complete configuration summary, detected differing configuration, reset of four queues, skip to latest, per-target group deletion; Broker configuration write/readback and restoration of the original value |
+| Consumer / Broker IPC | Two-Broker group writes, complete configuration summary, detected differing configuration, reset of four queues, skip to latest, per-target group deletion; Broker configuration write/readback and restoration of the original value; online Rust Consumer RunningInfo available (5 properties, 4 queue entries), JStack available (27,337 characters) after correcting SDK Broker forwarding |
 | Directory and history IPC | Producer directory query without a supplied group, audit filtering/cursor, Broker/Topic stored samples and pagination; history remained readable after restart |
 | Storage CLI / restored desktop | Live backup, verify, restore; restored cached session rejected, new login successful, rules/history retained, restore audit present |
 | New local Rust images | NameServer, Broker, Proxy, and admin CLI rebuilt from local source; ordinary and ACL Compose projects healthy (six containers); two-Broker listing and desktop SEND_OK after replacement |
 | Isolated ACL integration | Valid/invalid/anonymous credential query behavior, normal/transactional sends, user CRUD, typed policy deletion preserving other entries: all three live tests passed |
 | Exit | The initial real exit exposed a Windows main-thread stack overflow. Heap-pinning the joined SDK shutdown futures fixed it. A 1 MiB-stack lifecycle regression passed; two subsequent real desktop exits returned code 0 |
+| Online Producer and populated DLQ | Producer directory discovered the live group and connection detail returned one Rust client. A rejected message was found by DLQ Key and unique ID; CSV export returned one successful row. Batch resend retained both failures while the separate physical store-host defect remains open |
 
 Temporary Topic, Consumer group, and Monitor smoke resources were deleted. Both
 Docker clusters remain running for development. The desktop and its temporary
@@ -99,13 +100,16 @@ Vite process were closed after checking graceful shutdown.
 
 - TLS certificate/handshake integration was not exercised; the local fixtures use
   plaintext remoting. Configuration and credential boundaries have automated tests.
-- No live consumer implementing RunningInfo/JStack was attached. The no-client
-  query returned a safe unavailable result; Proxy diagnostics reported unsupported.
-  Offline, unsupported, bounded and truncated response branches have unit coverage.
-- No populated DLQ with an online recipient or recorded Trace fixture was present.
-  The empty DLQ route reported topic-not-found. Actual DLQ resend/CSV and Trace
-  round trips remain unverified; receipt identity, failure retention, Key/client
-  parameter handling, and export behavior are covered by focused tests.
+- Online Rust RunningInfo/JStack were exercised after fixing the diagnostic target
+  in [issue #10416](https://github.com/mxsm/rocketmq-rust/issues/10416). The ignored
+  live SDK regression also passed. Proxy diagnostics remain explicitly unsupported;
+  offline, bounded and truncated branches have focused coverage.
+- Populated DLQ Key/unique-ID lookup and CSV export passed. Rust origin-ID fallback
+  has three focused regression tests. Successful DLQ resend and physical-ID detail
+  remain blocked by [issue #10417](https://github.com/mxsm/rocketmq-rust/issues/10417):
+  Broker metadata encodes the wildcard listener instead of its advertised IP.
+  Mixed failed results were retained correctly. Trace round trips still require
+  the dedicated Trace Topic fixture described in the development README.
 - Topic/Consumer modal interactions were not exhaustively clicked. Their real
   service/IPC mutations were exercised above, with focused receipt and navigation
   tests covering result branches. This is not a complete visual or cross-platform

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/dlq.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/dlq.rs
@@ -65,6 +65,9 @@ pub(super) fn direct_request(
         .ok_or_else(|| DashboardError::Validation("The DLQ message has no valid original Topic.".into()))?;
     let id = property("ORIGIN_MESSAGE_ID")
         .or_else(|| property("DLQ_ORIGIN_MESSAGE_ID"))
+        // Rust send-back preserves the original producer's unique ID even when
+        // no physical origin ID is attached. Resolve it within the original Topic.
+        .or_else(|| property("UNIQ_KEY"))
         .ok_or_else(|| DashboardError::Validation("The DLQ message has no original message ID.".into()))?;
     Ok(DirectConsumeRequest {
         topic: topic.into(),
@@ -123,6 +126,28 @@ mod tests {
                 .is_none()
         );
     }
+    #[test]
+    fn dlq_resend_resolves_preserved_rust_unique_id_in_original_topic() {
+        let mut message = message();
+        message.properties.remove("ORIGIN_MESSAGE_ID");
+        message
+            .properties
+            .insert("UNIQ_KEY".into(), "producer-unique-id".into());
+        let request = direct_request("g".into(), None, &message).unwrap();
+        assert_eq!(request.topic, "orders");
+        assert_eq!(request.message_id, "producer-unique-id");
+        message
+            .properties
+            .insert("ORIGIN_MESSAGE_ID".into(), "physical-origin".into());
+        assert_eq!(
+            direct_request("g".into(), None, &message).unwrap().message_id,
+            "physical-origin"
+        );
+        message.properties.remove("ORIGIN_MESSAGE_ID");
+        message.properties.insert("UNIQ_KEY".into(), "  ".into());
+        assert!(direct_request("g".into(), None, &message).is_err());
+    }
+
     #[test]
     fn dlq_resend_rejects_wrong_group_missing_origin_and_dlq_as_original_topic() {
         let mut message = message();


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10416

### Brief Description

Forward Consumer RunningInfo/JStack through Brokers discovered from the retry Topic instead of opening a connection to the client's outbound ephemeral port. Try the available Broker routes so clients attached to a subset remain discoverable.

Allow DLQ redelivery to resolve the original Topic using the producer UNIQ_KEY preserved by Rust send-back, while retaining explicit origin-ID precedence and group/topic validation. Add a bounded Rust debug client and documented DLQ/Trace setup for repeatable desktop acceptance.

The separate wildcard physical store-host defect remains tracked in #10417; successful DLQ redelivery is not claimed yet.

### How Did You Test This Change?

- Live SDK regression against an online Rust consumer: RunningInfo and JStack passed.
- Actual Windows desktop authenticated IPC: RunningInfo available with 5 properties and 4 queue entries; JStack available with 27,337 characters.
- Three focused Tauri DLQ origin tests passed; the desktop binary built successfully.
- Client admin-read feature-absence compilation and affected package format checks passed.
- Live Producer directory/connection, populated DLQ Key/unique-ID lookup, CSV export and retained batch failures verified.
- Debug example build and bounded shutdown verified as recorded in the acceptance document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard debugging client example for sending messages, testing redelivery, tracing, and controlled shutdown.
  * Consumer running information and JStack diagnostics can now be retrieved through broker forwarding.
  * DLQ requests can use a message’s unique ID when the original message ID is unavailable.

* **Documentation**
  * Expanded deployment and acceptance guidance for consumer diagnostics, DLQ workflows, tracing, and live validation.

* **Tests**
  * Added coverage for broker-forwarded diagnostics and DLQ identifier handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->