### PR TITLE
[ISSUE #10417]🐛Use advertised Broker IPs in physical message IDs

### DIFF
--- a/rocketmq-broker/src/broker_runtime/composition.rs
+++ b/rocketmq-broker/src/broker_runtime/composition.rs
@@ -1160,7 +1160,13 @@ impl BrokerRuntime {
         .expect("validated Broker Lite event limits must fit the root resource budget");
         let broker_address = broker_config.get_broker_addr();
         let network = validated_config.sections().network();
-        let store_host = SocketAddr::new(network.bind_address(), network.listen_port());
+        // Persist the advertised IP in physical message IDs. A wildcard listener
+        // is not a destination that remote clients can use for offset lookups.
+        // Hostname advertisements retain the configured bind-address fallback;
+        // runtime composition must not perform blocking DNS resolution.
+        let store_host = broker_address
+            .parse::<SocketAddr>()
+            .unwrap_or_else(|_| SocketAddr::new(network.bind_address(), network.listen_port()));
         let scheduled_task_manager = BrokerScheduledTasks::new_with_task_group(service_context.task_group().clone());
         let metadata_io = Some(
             MetadataIoConfig::default()

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -575,6 +575,38 @@ fn build_auth_config_maps_signature_algorithm() {
 }
 
 #[test]
+fn advertised_store_host_is_used_with_wildcard_listeners() {
+    for (advertised, expected) in [
+        ("127.0.0.1", "127.0.0.1:11911"),
+        ("192.0.2.10", "192.0.2.10:11911"),
+        ("2001:db8::10", "[2001:db8::10]:11911"),
+    ] {
+        let mut broker = BrokerConfig {
+            broker_ip1: advertised.into(),
+            listen_port: 11911,
+            ..BrokerConfig::default()
+        };
+        broker.broker_server_config.bind_address = "0.0.0.0".into();
+        let runtime = BrokerRuntime::new(Arc::new(broker), Arc::new(MessageStoreConfig::default()));
+        assert_eq!(runtime.composition.state.store_host(), expected.parse().unwrap());
+    }
+}
+
+#[test]
+fn advertised_store_host_preserves_hostname_bind_fallback_without_dns() {
+    let mut broker = BrokerConfig {
+        broker_ip1: "broker.example.invalid".into(),
+        ..BrokerConfig::default()
+    };
+    broker.broker_server_config.bind_address = "192.0.2.20".into();
+    let runtime = BrokerRuntime::new(Arc::new(broker), Arc::new(MessageStoreConfig::default()));
+    assert_eq!(
+        runtime.composition.state.store_host(),
+        "192.0.2.20:10911".parse().unwrap()
+    );
+}
+
+#[test]
 fn transaction_capability_handles_share_runtime_generations() {
     let runtime = BrokerRuntime::new(
         Arc::new(BrokerConfig::default()),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10417

### Brief Description

Initialize persisted message store-host metadata from the advertised Broker IP and port. A wildcard listener such as 0.0.0.0 previously appeared in physical message IDs, so remote Windows clients could discover the Broker but could not perform offset-ID lookups or direct consumption.

Preserve the existing bind-address fallback for hostname advertisements without introducing blocking DNS in runtime composition. Existing stored messages are not rewritten.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --lib advertised_store_host`: both tests passed, covering loopback/public IPv4, IPv6 with a wildcard listener, the configured port, and hostname fallback.
- Package-scoped format check passed.
- The local Rust service-image rebuild is running; fresh-message physical lookup and DLQ redelivery are the next integration checks. Existing wildcard-host messages remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the host information recorded in physical message IDs when brokers use wildcard network bindings.
  * Preserved reliable fallback behavior for hostname-based broker configurations that cannot be resolved.
  * Improved handling of advertised IPv4 and IPv6 addresses, including proper IPv6 formatting.

* **Tests**
  * Added coverage for wildcard listeners, advertised hosts, IPv6 addresses, and hostname fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->