### PR TITLE
[ISSUE #10419]🐛Restore Trace Key lookup and producer-consumer correlation

### DIFF
--- a/rocketmq-client/src/trace/hook/consume_message_trace_hook_impl.rs
+++ b/rocketmq-client/src/trace/hook/consume_message_trace_hook_impl.rs
@@ -73,8 +73,15 @@ impl ConsumeMessageTraceHookImpl {
             // Build trace bean for this message
             let trace_bean = TraceBean {
                 topic: Self::without_namespace(msg.topic()),
-                msg_id: msg.msg_id().clone(),
-                offset_msg_id: CheetahString::new(),
+                // Producer traces use UNIQ_KEY. Keep the same identity after
+                // delivery, where MessageExt::msg_id contains the physical ID.
+                msg_id: msg
+                    .get_property(&CheetahString::from_static_str(
+                        MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+                    ))
+                    .filter(|id| !id.is_empty())
+                    .unwrap_or_else(|| msg.msg_id().clone()),
+                offset_msg_id: msg.msg_id().clone(),
                 tags: msg.get_tags().unwrap_or_default(),
                 keys: msg
                     .keys()
@@ -335,6 +342,23 @@ mod tests {
             );
         }
         Arc::new(msg)
+    }
+
+    #[test]
+    fn consume_trace_correlates_producer_unique_id_and_retains_physical_id() {
+        let hook = ConsumeMessageTraceHookImpl::new(Arc::new(CapturingTraceDispatcher::new()));
+        let mut delivery = message("TopicA", "physical-offset-id", "RegionA", None);
+        Arc::make_mut(&mut delivery).put_property(
+            MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX.into(),
+            "producer-unique-id".into(),
+        );
+        let (beans, _) = hook.build_trace_beans(&[delivery]).unwrap();
+        assert_eq!(beans[0].msg_id, "producer-unique-id");
+        assert_eq!(beans[0].offset_msg_id, "physical-offset-id");
+        let (legacy, _) = hook
+            .build_trace_beans(&[message("TopicA", "legacy-physical-id", "RegionA", None)])
+            .unwrap();
+        assert_eq!(legacy[0].msg_id, "legacy-physical-id");
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/message.rs
@@ -324,26 +324,22 @@ impl MessageAdmin for AdminSession {
                 .as_deref()
                 .and_then(non_empty)
                 .unwrap_or_else(|| DEFAULT_TRACE_TOPIC.to_string());
-            let result = self
-                .inner
-                .query_message_by_key(
-                    None,
-                    trace_topic.as_str().into(),
-                    message_id.into(),
-                    64,
-                    0,
-                    i64::MAX,
-                    CheetahString::from_static_str(""),
-                    None,
-                )
-                .await
-                .map_err(|error| backend_error("query_message_by_key", error))?;
+            // Trace records index the original message ID as a normal Key.
+            // Reuse the normal query contract, including its valid index type.
+            let result = MessageAdmin::query_messages_by_key(
+                self,
+                &QueryMessagesByKeyRequest {
+                    topic: trace_topic.clone(),
+                    key: message_id.to_string(),
+                    max_messages: 64,
+                    begin: 0,
+                    end: i64::MAX,
+                },
+            )
+            .await?;
             let mut seeds = Vec::new();
-            for trace_message in result.message_list() {
-                let Some(body) = trace_message.body() else {
-                    continue;
-                };
-                let body_text = String::from_utf8_lossy(body.as_ref());
+            for trace_message in &result.messages {
+                let body_text = String::from_utf8_lossy(&trace_message.body);
                 if body_text.trim().is_empty() {
                     continue;
                 }
@@ -362,12 +358,12 @@ impl MessageAdmin for AdminSession {
                             trace_type: trace_type.clone(),
                             group_name: group_name.clone(),
                             client_host: if bean.client_host.is_empty() {
-                                trace_message.born_host().to_string()
+                                trace_message.born_host.clone()
                             } else {
                                 bean.client_host.to_string()
                             },
                             store_host: if bean.store_host.is_empty() {
-                                trace_message.store_host().to_string()
+                                trace_message.store_host.clone()
                             } else {
                                 bean.store_host.to_string()
                             },
@@ -527,6 +523,45 @@ fn backend_error(operation: &'static str, error: impl crate::IntoCanonicalError)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[ignore = "requires DASHBOARD_DEBUG_NAMESRV, DASHBOARD_DEBUG_TRACE_TOPIC, and DASHBOARD_DEBUG_MESSAGE_ID"]
+    fn live_trace_query_reads_the_normal_key_index() {
+        use crate::client_adapter::{AdminBuilder, ClientRuntime, ClientRuntimeConfig, TelemetryHandle};
+        use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
+
+        let namesrv = std::env::var("DASHBOARD_DEBUG_NAMESRV").expect("explicit development NameServer");
+        let request = TraceQueryRequest {
+            trace_topic: Some(std::env::var("DASHBOARD_DEBUG_TRACE_TOPIC").expect("explicit Trace Topic")),
+            message_id: std::env::var("DASHBOARD_DEBUG_MESSAGE_ID").expect("original producer message ID"),
+        };
+        let owner = RuntimeOwner::plan(RuntimeConfig::server_default("live-trace-query"))
+            .unwrap()
+            .build()
+            .unwrap();
+        let runtime = ClientRuntime::try_new(
+            owner.root_context().component("client"),
+            ClientRuntimeConfig::default(),
+            TelemetryHandle::noop(),
+        )
+        .unwrap();
+        let result = owner.block_on(async {
+            let mut session = AdminBuilder::new(runtime.clone())
+                .namesrv_addr(namesrv)
+                .vip_channel_enabled(false)
+                .build_and_start()
+                .await?;
+            let result = MessageAdmin::query_trace_data(&mut session, &request).await;
+            session.shutdown().await;
+            result
+        });
+        assert!(owner.block_on(runtime.shutdown()).is_healthy());
+        assert!(owner.block_on(owner.shutdown_tasks()).is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
+        let trace = result.expect("stored producer Trace must be found through the Key index");
+        assert_eq!(trace.message_id, request.message_id);
+        assert!(trace.seeds.iter().any(|seed| seed.trace_type == "Pub"));
+    }
 
     #[test]
     fn dlq_topic_accepts_plain_and_prefixed_consumer_groups() {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10419

### Brief Description

Use the normal message Key query contract for Trace lookup. The previous empty indexType was rejected by the Broker, so stored Trace records were invisible to the dashboard.

Correlate Consumer Trace events with the producer UNIQ_KEY while retaining the physical offset ID separately. Messages without a unique ID preserve the legacy fallback. Add a live admin-core regression with explicit fixture identifiers and a focused consumer-hook regression.

### How Did You Test This Change?

- Three Consumer Trace hook tests passed, including producer-ID correlation, legacy fallback, trace-switch/region handling, and bounded timing behavior.
- Live Trace query regression passed against recorded messages in the local Rust Docker fixture.
- Affected package format checks passed.
- Windows desktop build passed. Actual desktop IPC returned Pub, SubBefore and SubAfter events correlated to the same producer message ID and Consumer group. A separate indexed-query buffer defect causes duplicate/adjacent results and is being corrected independently.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message tracing so producer-generated unique IDs are preserved for correlation, while physical message IDs remain available for offset tracking.
  * Trace-data lookups now use the standard message-key search flow, improving retrieval and decoding of trace records.
  * Added fallback handling for messages without a unique client ID, ensuring tracing continues to use the physical message ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->