### PR TITLE
[ISSUE #10424]🐛Route direct consumption through the message-owning Broker

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl/admin_api.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl/admin_api.rs
@@ -1043,13 +1043,18 @@ impl ConsumerAdmin for DefaultMQAdminExtImpl {
         topic: CheetahString,
         msg_id: CheetahString,
     ) -> crate::ClientResult<ConsumeMessageDirectlyResult> {
-        let consumer_connection = self
-            .examine_consumer_connection_info(consumer_group.clone(), None)
-            .await?;
-        let (resolved_client_id, client_addr) =
-            select_consumer_direct_connection(&consumer_group, &consumer_connection, Some(&client_id))?;
         let message =
             ConsumerAdmin::query_message(self, CheetahString::default(), topic.clone(), msg_id.clone()).await?;
+        // The owning Broker resolves this physical offset and forwards the
+        // request over its existing consumer connection. A client's outbound
+        // socket is not an RPC listener; retrying another Broker could consume
+        // a different message at the same offset.
+        let broker_addr = CheetahString::from(message.store_host().to_string());
+        let consumer_connection = self
+            .examine_consumer_connection_info(consumer_group.clone(), Some(broker_addr.clone()))
+            .await?;
+        let (resolved_client_id, _) =
+            select_consumer_direct_connection(&consumer_group, &consumer_connection, Some(&client_id))?;
         let request_header = ConsumeMessageDirectlyResultRequestHeader {
             consumer_group,
             client_id: Some(resolved_client_id),
@@ -1065,7 +1070,7 @@ impl ConsumerAdmin for DefaultMQAdminExtImpl {
             .as_ref()
             .ok_or(crate::ClientError::not_started())?
             .get_mq_client_api_impl()?
-            .consume_message_directly(&client_addr, request_header, &message, self.remoting_timeout_millis()?)
+            .consume_message_directly(&broker_addr, request_header, &message, self.remoting_timeout_millis()?)
             .await
     }
 

--- a/rocketmq-client/tests/admin/default_mq_admin_ext_impl/unit.rs
+++ b/rocketmq-client/tests/admin/default_mq_admin_ext_impl/unit.rs
@@ -634,7 +634,7 @@ fn select_consumer_direct_connection_errors_when_group_is_offline() {
     let error = select_consumer_direct_connection(&consumer_group, &consumer_connection, None)
         .expect_err("offline group should not resolve a client");
 
-    assert!(error.to_string().contains("NO CONSUMER"));
+    assert!(error.is(&rocketmq_error::CORE_ARGUMENT_INVALID));
 }
 
 #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/message.rs
@@ -460,13 +460,19 @@ async fn consume_directly(
     request: &DirectConsumeRequest,
 ) -> Result<DirectConsumeResult, AdminError> {
     session.ensure_open()?;
+    let consumer_group = require_non_empty("consumerGroup", &request.consumer_group)?;
+    let topic = require_non_empty("topic", &request.topic)?;
+    let message_id = require_non_empty("messageId", &request.message_id)?;
+    // Dashboard lookups accept producer unique IDs as well as physical IDs.
+    // Direct consumption requires the resolved Broker address and store offset.
+    let message = find_raw_message(session, topic, message_id).await?;
     let result = session
         .inner
         .consume_message_directly(
-            require_non_empty("consumerGroup", &request.consumer_group)?.into(),
+            consumer_group.into(),
             request.client_id.as_deref().unwrap_or_default().into(),
-            require_non_empty("topic", &request.topic)?.into(),
-            require_non_empty("messageId", &request.message_id)?.into(),
+            topic.into(),
+            message.msg_id().clone(),
         )
         .await
         .map_err(|error| backend_error("consume_message_directly", error))?;
@@ -523,6 +529,49 @@ fn backend_error(operation: &'static str, error: impl crate::IntoCanonicalError)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[ignore = "requires an accepting debug consumer and explicit DASHBOARD_DEBUG_NAMESRV, TOPIC, GROUP, MESSAGE_ID"]
+    fn live_direct_consumption_resolves_unique_id_and_uses_owning_broker() {
+        use crate::client_adapter::{AdminBuilder, ClientRuntime, ClientRuntimeConfig, TelemetryHandle};
+        use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
+
+        let namesrv = std::env::var("DASHBOARD_DEBUG_NAMESRV").expect("explicit development NameServer");
+        let request = DirectConsumeRequest {
+            topic: std::env::var("DASHBOARD_DEBUG_TOPIC").expect("explicit development Topic"),
+            consumer_group: std::env::var("DASHBOARD_DEBUG_GROUP").expect("explicit debug consumer group"),
+            message_id: std::env::var("DASHBOARD_DEBUG_MESSAGE_ID").expect("producer unique message ID"),
+            client_id: None,
+        };
+        let owner = RuntimeOwner::plan(RuntimeConfig::server_default("live-direct-consumption"))
+            .unwrap()
+            .build()
+            .unwrap();
+        let runtime = ClientRuntime::try_new(
+            owner.root_context().component("client"),
+            ClientRuntimeConfig::default(),
+            TelemetryHandle::noop(),
+        )
+        .unwrap();
+        let result = owner.block_on(async {
+            let mut session = AdminBuilder::new(runtime.clone())
+                .namesrv_addr(namesrv)
+                .vip_channel_enabled(false)
+                .build_and_start()
+                .await?;
+            let result = consume_directly(&session, &request).await;
+            session.shutdown().await;
+            result
+        });
+        assert!(owner.block_on(runtime.shutdown()).is_healthy());
+        assert!(owner.block_on(owner.shutdown_tasks()).is_healthy());
+        assert!(owner.shutdown_background().is_healthy());
+        assert!(
+            result
+                .expect("Broker must forward the physical message to the online consumer")
+                .success
+        );
+    }
 
     #[test]
     #[ignore = "requires DASHBOARD_DEBUG_NAMESRV, DASHBOARD_DEBUG_TRACE_TOPIC, and DASHBOARD_DEBUG_MESSAGE_ID"]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10424

### Brief Description

Resolve producer unique IDs to physical message IDs before direct consumption. The SDK queries consumer connections on the message-owning Broker and forwards through that Broker instead of opening a connection to the consumer outbound socket. Mutations are never retried across Brokers with unrelated physical offsets.

Add an explicitly opted-in live regression and update the offline consumer test to assert its canonical error descriptor instead of discarded free-form text.

### How Did You Test This Change?

- Client selection tests: 3 passed.
- `cargo test -p rocketmq-admin-core --features client-adapter --lib client_adapter::message::tests`: 2 passed, 2 live tests ignored by default.
- `live_direct_consumption_resolves_unique_id_and_uses_owning_broker` explicitly run against the local Rust cluster: passed; debug consumer logged ACCEPTED.
- Package format checks and `git diff --check`: passed.
- Desktop UI verification follows rebuilding the desktop with these SDK changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direct message consumption by routing requests to the broker that stores the message.
  * Added support for resolving messages through unique or physical message identifiers.
  * Improved validation and handling of message-consumption requests, including clearer errors when a consumer group is offline.
  * Increased reliability when consuming messages directly from their owning broker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->