### PR TITLE
[ISSUE #10428]🐛Return each indexed physical message only once

### DIFF
--- a/rocketmq-store/src/message_store/local_file_message_store/read_path.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/read_path.rs
@@ -438,6 +438,8 @@ impl LocalFileMessageStore {
             }
 
             query_offset_result.get_phy_offsets_mut().sort();
+            // Repeated Keys can index the same record more than once.
+            query_offset_result.get_phy_offsets_mut().dedup();
 
             query_message_result.index_last_update_timestamp = query_offset_result.get_index_last_update_timestamp();
             query_message_result.index_last_update_phyoffset = query_offset_result.get_index_last_update_phyoffset();

--- a/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
+++ b/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
@@ -4394,6 +4394,29 @@ async fn get_ha_runtime_info_reports_current_commitlog_max_offset() {
 }
 
 #[tokio::test]
+async fn query_message_returns_each_physical_record_once_for_repeated_keys() {
+    let temp_dir = tempdir().unwrap();
+    let mut store = new_async_flush_test_store(&temp_dir);
+    let topic = CheetahString::from_static_str("repeated-query-key-topic");
+    let key = CheetahString::from_static_str("repeated-key");
+    let mut message = MessageExtBrokerInner::default();
+    message.set_topic(topic.clone());
+    message.message_ext_inner.set_queue_id(0);
+    message.set_body(Bytes::from_static(b"single indexed record"));
+    message.set_keys("repeated-key repeated-key".into());
+    assert_eq!(
+        store.put_message(message).await.put_message_status(),
+        PutMessageStatus::PutOk
+    );
+    store.reput_once().await;
+    let result = store.query_message(&topic, &key, 10, 0, i64::MAX).await.unwrap();
+    let mut data = result.get_message_data().expect("indexed message bytes");
+    let messages = rocketmq_protocol::common::message::message_decoder::decodes_batch(&mut data, true, true);
+    assert_eq!(messages.len(), 1, "repeated Keys must not repeat the physical record");
+    assert_eq!(messages[0].body().unwrap().as_ref(), b"single indexed record");
+}
+
+#[tokio::test]
 async fn query_message_returns_only_indexed_records_not_adjacent_commitlog_data() {
     let temp_dir = tempdir().unwrap();
     let mut store = new_async_flush_test_store(&temp_dir);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10428

### Brief Description

Repeated Keys can create multiple index entries for one physical message. Deduplicate the already sorted offset vector before reading records, so DLQ and Trace queries receive each physical record once. Distinct records remain separate even when their producer identifiers match.

### How Did You Test This Change?

- Added a real store/index regression with a repeated Key: failed before the fix with 2 records instead of 1, then passed.
- `cargo test -p rocketmq-store --lib query_message_returns_`: all 3 tests passed, including distinct matching records and adjacent unrelated messages.
- Package format check and `git diff --check`: passed.
- Live duplicate DLQ and Trace results were reproduced; post-fix Docker verification follows rebuilding the local services.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed message queries returning duplicate entries when the same key references a physical record multiple times.
  - Queries now return each matching physical message record only once.

- **Tests**
  - Added coverage for repeated message keys to verify deduplicated query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->