### PR TITLE
[ISSUE #10432]🐛Retain completed Tauri mutation receipts across connection changes

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/IMPLEMENTATION_ACCEPTANCE.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/IMPLEMENTATION_ACCEPTANCE.md
@@ -78,7 +78,7 @@ target parameter. Unknown or partial observations are not reported as healthy.
 
 ## Automated validation
 
-- Frontend production build passed; all 41 tests across 13 Vitest files passed.
+- Frontend production build passed; all 50 tests across 13 Vitest files passed.
 - Backend full library suite passed: 141 tests, with three live ACL tests selected
   separately and also passing against the rebuilt local images. The registration coverage test includes every non-auth command and
   checks its dashboard authorization boundary instead of a historical fixed count.
@@ -96,6 +96,15 @@ target parameter. Unknown or partial observations are not reported as healthy.
   also compiled without TLS; the desktop compiled with TLS enabled.
 
 ## Desktop and cluster verification
+
+The subsequent plan-conformance review found that the IPC response guard treated
+Broker configuration, ACL user/policy, and Monitor mutations as reads. A connection
+switch could therefore replace a completed write receipt with a conflict error.
+[Issue #10432](https://github.com/mxsm/rocketmq-rust/issues/10432) corrects all nine
+commands. Deferred-response regressions failed before the fix and passed afterward;
+obsolete reads still fail, accepted writes are not replayed, and backend revision
+checks remain authoritative. This race was verified with deterministic frontend
+tests, not a claim of reproducing every response ordering in the live desktop.
 
 The Windows Tauri executable was started with an isolated data directory. Its real
 WebView and authenticated IPC were used; no mock backend supplied these results.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
@@ -119,15 +119,22 @@ describe('connection revisions', () => {
         expect(invoke).toHaveBeenCalledWith('get_topic_list', { sessionId: 'current-token', expectedRevision: 0 });
     });
 
-    it('preserves a completed mutation receipt after the view changes', async () => {
+    it.each([
+        'send_topic_message',
+        'update_cluster_broker_config',
+        'create_acl_user', 'update_acl_user', 'delete_acl_user',
+        'create_acl_policy', 'update_acl_policy', 'delete_acl_policy',
+        'save_consumer_monitor_rule', 'delete_consumer_monitor_rule',
+    ])('preserves a completed %s receipt after the view changes', async (command) => {
         let resolve!: (value: unknown) => void;
         vi.mocked(invoke).mockImplementation(() => new Promise((complete) => { resolve = complete; }));
-        const request = invokeAuthenticatedCommand('send_topic_message');
+        const request = invokeAuthenticatedCommand(command);
         await Promise.resolve();
         ConnectionStore.accept('current-token', { ...ConnectionStore.getSnapshot()!, revision: 1 });
         resolve({ success: true, messageId: 'already-sent' });
         await expect(request).resolves.toMatchObject({ success: true, messageId: 'already-sent' });
         expect(invoke).toHaveBeenCalledTimes(1);
+        expect(invoke).toHaveBeenCalledWith(command, { sessionId: 'current-token', expectedRevision: 0 });
     });
 
     it('does not automatically retry a conflicting configuration draft', async () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/invoke.ts
@@ -110,7 +110,16 @@ export const invokeSessionCommand = <T>(
 
 const localCommands = new Set(['get_storage_status', 'get_history_status', 'change_password', 'get_current_user_profile', 'get_auth_bootstrap_status', 'list_sessions', 'revoke_user_sessions', 'query_audit_events']);
 const connectionWrites = new Set(['add_name_server', 'switch_name_server', 'delete_name_server', 'update_vip_channel', 'update_use_tls', 'add_proxy_addr', 'switch_proxy_addr', 'delete_proxy_addr', 'replace_name_servers']);
-const remoteWrites = new Set(['create_or_update_topic', 'delete_topic', 'delete_topic_by_broker', 'reset_consumer_offset', 'skip_message_accumulate', 'send_topic_message', 'create_or_update_consumer_group', 'delete_consumer_group', 'consume_message_directly', 'resend_dlq_message', 'batch_resend_dlq_message']);
+const mutationCommands = new Set([
+    'create_or_update_topic', 'delete_topic', 'delete_topic_by_broker',
+    'reset_consumer_offset', 'skip_message_accumulate', 'send_topic_message',
+    'create_or_update_consumer_group', 'delete_consumer_group',
+    'consume_message_directly', 'resend_dlq_message', 'batch_resend_dlq_message',
+    'update_cluster_broker_config',
+    'create_acl_user', 'update_acl_user', 'delete_acl_user',
+    'create_acl_policy', 'update_acl_policy', 'delete_acl_policy',
+    'save_consumer_monitor_rule', 'delete_consumer_monitor_rule',
+]);
 const pendingSettings = new Map<string, Promise<ConnectionSettingsView>>();
 const ensureSettings = (token: string): Promise<ConnectionSettingsView> => {
     const current = ConnectionStore.getSnapshot();
@@ -163,8 +172,9 @@ export const invokeAuthenticatedCommand = async <T>(command: string, args?: Reco
         }
         throw error;
     }
-    // Remote writes retain their actual receipt even if the user later changes views.
-    if (!remoteWrites.has(command) && ConnectionStore.getSnapshot()?.revision !== settings.revision) throw configurationChanged();
+    // Accepted writes retain their receipt after a switch, including committed local rules.
+    // The backend rejects stale writes before execution; page generations guard old views.
+    if (!mutationCommands.has(command) && ConnectionStore.getSnapshot()?.revision !== settings.revision) throw configurationChanged();
     if (result && typeof result === 'object' && 'settings' in result) ConnectionStore.accept(sessionId, result.settings as ConnectionSettingsView);
     return result;
 };


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10432

### Brief Description

Preserve completed Broker configuration, ACL user/policy, and local Monitor mutation receipts when connection settings change before IPC response delivery. These nine commands were incorrectly handled as reads, producing a false configuration-conflict error after a committed write.

Keep obsolete read rejection, backend revision validation, and the no-replay behavior. Extend deferred-response coverage and record the finding in the implementation acceptance document.

### How Did You Test This Change?

From rocketmq-dashboard/rocketmq-dashboard-tauri:
- Before the fix, npx vitest run src/services/auth-session.test.ts reproduced all nine new failures.
- After the fix, npx vitest run passed all 50 tests across 13 files.
- npm run build passed; the existing Vite large-chunk advisory remains.
- git diff --check passed.

No Rust code or Docker build inputs changed; existing backend and live-cluster acceptance results remain applicable. The race is covered with deterministic deferred IPC responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where completed mutation results could be replaced by conflict errors after switching connections or views.
  * Broker configuration updates, ACL user and policy changes, consumer monitor rule changes, and topic message operations now preserve their completion receipts reliably.
  * Stale non-mutating operations continue to be rejected appropriately.

* **Tests**
  * Expanded automated coverage to validate receipt handling across all supported mutation commands.

* **Documentation**
  * Updated validation documentation to reflect the expanded test coverage and corrected command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->