### PR TITLE
[ISSUE #10437]🐛Align the container guard with the MCP stdio lifecycle API

### DIFF
--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -342,7 +342,7 @@ def audit_foundation(
     for name, source in (signal_sources or {}).items():
         lifecycle_markers = ["wait_for_shutdown_signal", "wait_for_signal_result"]
         if name == "mcp_stdio":
-            lifecycle_markers.append("transport::stdio::serve_typed_with_lifecycle")
+            lifecycle_markers.append("transport::stdio::serve_with_lifecycle")
         if not any(marker in source for marker in lifecycle_markers):
             findings.append(f"{name} entrypoint must use the shared lifecycle SIGINT/SIGTERM waiter")
         if "tokio::signal::ctrl_c" in source:

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -677,6 +677,20 @@ class ContainerFoundationTests(unittest.TestCase):
         findings = self.audit(dockerfile=secret_command)
         self.assertTrue(any("secret arguments" in finding for finding in findings))
 
+    def test_mcp_stdio_without_lifecycle_is_rejected(self) -> None:
+        lifecycle_call = "transport::stdio::serve_with_lifecycle(app, lifecycle).await"
+        signal_sources = dict(self.signal_sources)
+        self.assertIn(lifecycle_call, signal_sources["mcp_stdio"])
+        signal_sources["mcp_stdio"] = signal_sources["mcp_stdio"].replace(
+            lifecycle_call,
+            "transport::stdio::serve(app).await",
+            1,
+        )
+        self.assertEqual(
+            ["mcp_stdio entrypoint must use the shared lifecycle SIGINT/SIGTERM waiter"],
+            self.audit(signal_sources=signal_sources),
+        )
+
     def test_ctrl_c_only_signal_or_weakened_service_smoke_is_rejected(self) -> None:
         signal_sources = dict(self.signal_sources)
         signal_sources["proxy"] = signal_sources["proxy"].replace(
@@ -686,15 +700,6 @@ class ContainerFoundationTests(unittest.TestCase):
         )
         findings = self.audit(signal_sources=signal_sources)
         self.assertTrue(any("Ctrl-C-only" in finding for finding in findings))
-
-        signal_sources = dict(self.signal_sources)
-        signal_sources["mcp_stdio"] = signal_sources["mcp_stdio"].replace(
-            "serve_typed_with_lifecycle",
-            "serve_typed",
-            1,
-        )
-        findings = self.audit(signal_sources=signal_sources)
-        self.assertTrue(any("mcp_stdio entrypoint" in finding for finding in findings))
 
         stop_contract = "docker stop --signal SIGTERM --timeout $GracePeriodSeconds"
         weakened = self.service_script.replace(stop_contract, "docker kill", 1)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10437

### Brief Description

The Container Foundation guard incorrectly rejects MCP stdio because it still looks for `serve_typed_with_lifecycle`. Recognize the current `transport::stdio::serve_with_lifecycle` delegation, whose implementation retains the shared SIGINT/SIGTERM waiter.

Replace the stale negative test with a focused regression test that first verifies the current call exists, replaces it with the plain stdio server, and asserts the exact lifecycle finding. This prevents a no-op replacement from making the negative test pass accidentally.

### How Did You Test This Change?

Reproduced the reported guard failure and failing foundation test before the fix. After applying the fix on the latest main:

- `python scripts/container_image_guard.py` - passed.
- `python -m unittest scripts.tests.test_m11_container_foundation` - all 28 tests passed.
- `git -c core.safecrlf=false diff --check` - passed.

Full Docker image builds and supply-chain verification were not rerun locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation for MCP stdio services to recognize the supported lifecycle handling.
  * Improved detection and reporting when MCP stdio services do not use the shared SIGINT/SIGTERM lifecycle waiter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->