### PR TITLE
[ISSUE #10439]🐛Prevent host glob expansion in service image binary checks

### DIFF
--- a/scripts/service-image-contract.ps1
+++ b/scripts/service-image-contract.ps1
@@ -52,6 +52,26 @@ function Invoke-Captured {
     return $output
 }
 
+function Assert-ServiceImageBinaries {
+    param(
+        [string]$ServiceName,
+        [string]$ImageRef,
+        [string]$ExpectedBinary
+    )
+
+    # Splatting native arguments on Unix loses quoting and expands wildcards
+    # against the host checkout. Filter the container's filenames in PowerShell.
+    $ownedBinaries = @(
+        (Invoke-Captured docker run --rm --network none --entrypoint /usr/bin/find $ImageRef `
+            /usr/local/bin -maxdepth 1 -type f -printf '%f\n'
+        ).Split("`n", [System.StringSplitOptions]::RemoveEmptyEntries) |
+            Where-Object { $_ -clike "rocketmq-*" }
+    )
+    if ($ownedBinaries.Count -ne 1 -or $ownedBinaries[0] -ne $ExpectedBinary) {
+        throw "$ServiceName runtime image contains binaries outside its owner boundary: $($ownedBinaries -join ',')"
+    }
+}
+
 function Start-ServiceSmokeContainer {
     param(
         [Parameter(Mandatory = $true)]
@@ -274,13 +294,7 @@ try {
             }
         }
 
-        $ownedBinaries = (
-            Invoke-Captured docker run --rm --network none --entrypoint /usr/bin/find $imageRef `
-                /usr/local/bin -maxdepth 1 -type f -name "rocketmq-*" -printf '%f\n'
-        ).Split("`n", [System.StringSplitOptions]::RemoveEmptyEntries)
-        if ($ownedBinaries.Count -ne 1 -or $ownedBinaries[0] -ne $service.binary) {
-            throw "$serviceName runtime image contains binaries outside its owner boundary: $($ownedBinaries -join ',')"
-        }
+        Assert-ServiceImageBinaries -ServiceName $serviceName -ImageRef $imageRef -ExpectedBinary $service.binary
 
         $missingConfigExitCode = 0
         $previousErrorActionPreference = $ErrorActionPreference

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -799,6 +799,91 @@ else {
                     )
                     self.assertEqual(expected, actual)
 
+    def test_service_binary_ownership_ignores_host_globs_and_fails_closed(self) -> None:
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        self.assertIsNotNone(powershell, "PowerShell is required to validate container scripts")
+        harness = r"""
+param([string]$SourcePath, [string]$PythonPath)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $SourcePath, [ref]$tokens, [ref]$parseErrors
+)
+if ($parseErrors.Count -ne 0) {
+    throw "failed to parse service image script: $($parseErrors[0].Message)"
+}
+foreach ($functionName in @("Invoke-Captured", "Assert-ServiceImageBinaries")) {
+    $definition = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $functionName
+    }, $true)
+    if ($null -eq $definition) {
+        throw "missing helper: $functionName"
+    }
+    Invoke-Expression $definition.Extent.Text
+}
+# Python executes the fixture named 'run', preserving the real native argument
+# binding path (a PowerShell mock function would hide Unix wildcard expansion).
+Set-Alias -Name docker -Value $PythonPath
+Assert-ServiceImageBinaries -ServiceName broker -ImageRef test-image -ExpectedBinary rocketmq-broker-rust
+"""
+        probe = r"""
+import json
+import sys
+from pathlib import Path
+
+expected = [
+    "--rm", "--network", "none", "--entrypoint", "/usr/bin/find", "test-image",
+    "/usr/local/bin", "-maxdepth", "1", "-type", "f", "-printf", "%f\\n",
+]
+if sys.argv[1:] != expected:
+    sys.exit("unexpected container find arguments: " + repr(sys.argv[1:]))
+fixture = json.loads(Path("fixture.json").read_text(encoding="utf-8"))
+print("\n".join(fixture["binaries"]))
+sys.exit(fixture["exit_code"])
+"""
+        cases = (
+            ("owner", ["rocketmq-broker-rust"], 0, None),
+            ("unrelated", ["helper", "RocketMQ-helper", "rocketmq-broker-rust"], 0, None),
+            ("extra", ["rocketmq-broker-rust", "rocketmq-namesrv-rust"], 0, "owner boundary"),
+            ("wrong", ["rocketmq-namesrv-rust"], 0, "owner boundary"),
+            ("missing", ["helper"], 0, "owner boundary"),
+            ("empty", [], 0, "owner boundary"),
+            ("command-failure", ["rocketmq-broker-rust"], 3, "failed with exit code 3"),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            # These host paths must never become arguments to the container's find.
+            for name in ("rocketmq-ai", "rocketmq-auth"):
+                (temporary / name).mkdir()
+            harness_path = temporary / "binary-ownership-harness.ps1"
+            harness_path.write_text(harness, encoding="utf-8")
+            (temporary / "run").write_text(probe, encoding="utf-8")
+            for name, binaries, exit_code, error in cases:
+                with self.subTest(case=name):
+                    (temporary / "fixture.json").write_text(
+                        json.dumps({"binaries": binaries, "exit_code": exit_code}), encoding="utf-8"
+                    )
+                    result = subprocess.run(
+                        [
+                            powershell, "-NoProfile", "-File", str(harness_path),
+                            str(ROOT / "scripts" / "service-image-contract.ps1"), sys.executable,
+                        ],
+                        cwd=temporary,
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        check=False,
+                    )
+                    if error is None:
+                        self.assertEqual(0, result.returncode, result.stderr)
+                    else:
+                        self.assertNotEqual(0, result.returncode)
+                        self.assertIn(error, result.stderr)
+
     def test_native_runner_parameter_collision_is_rejected(self) -> None:
         supply_script = self.supply_script.replace("[string]$Executable", "[string]$Command", 1)
         findings = self.audit(supply_script=supply_script)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10439

### Brief Description

The service image binary probe failed on Linux because forwarding `-name "rocketmq-*"` through PowerShell's native argument splatting expanded the pattern into host repository directory names. The resulting `find` error stopped Container Foundation after the broker image build.

Extract the ownership check into `Assert-ServiceImageBinaries`, enumerate regular container files without a native wildcard, and filter their names with PowerShell's case-sensitive `-clike`. Preserve the requirement for exactly the expected service binary and propagate native command failures.

Add a regression test that loads the real script helpers and uses a native Python fixture in place of Docker. Matching host directories exercise the Unix argument-binding path; seven cases cover the expected binary, unrelated files, extra/wrong/missing binaries, empty output, and command failure.

### How Did You Test This Change?

- Reproduced the original GNU find argument-parsing failure with the real `Invoke-Captured` helper on Linux.
- `python scripts/container_image_guard.py` - passed on Windows and Linux.
- `python -m unittest scripts.tests.test_m11_container_foundation` - all 29 tests passed on Windows and Linux.
- Linux validation used Ubuntu 26.04 under WSL and portable PowerShell 7.6.6 with `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`, because the local distribution lacks a compatible ICU runtime.
- `git diff --check` - passed.
- Full Docker image builds and service smoke tests were not rerun locally because the Docker engine is unavailable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service image validation now checks that each image contains exactly the expected service binary.
  * Validation ignores unrelated files and prevents host path patterns from affecting container checks.
  * Errors are reported when binaries are missing, unexpected, duplicated, or when file discovery fails.

* **Tests**
  * Added coverage for valid, invalid, empty, and failed binary-discovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->