### PR TITLE
[ISSUE #10441]🐛Align Proxy container smoke cluster settings with the Broker

### DIFF
--- a/docker/smoke-config/proxy.toml
+++ b/docker/smoke-config/proxy.toml
@@ -15,3 +15,8 @@ listenAddr = "127.0.0.1:8080"
 
 [cluster]
 namesrvAddr = "rocketmq-namesrv:9876"
+brokerClusterName = "ContainerSmoke"
+
+[auth]
+# Proxy bootstrap uses this value to select the cluster for Broker readiness checks.
+clusterName = "ContainerSmoke"

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -145,6 +145,21 @@ def audit_foundation(
         elif address(parsed_smoke_configs[name]) != expected_namesrv_address:
             findings.append(f"{name} must use the isolated smoke NameServer alias")
 
+    broker_identity = parsed_smoke_configs.get("broker.toml", {}).get("broker", {}).get("brokerIdentity", {})
+    proxy_config = parsed_smoke_configs.get("proxy.toml", {})
+    smoke_cluster_names = {
+        "broker.toml broker.brokerIdentity.brokerClusterName": broker_identity.get("brokerClusterName"),
+        "proxy.toml cluster.brokerClusterName": proxy_config.get("cluster", {}).get("brokerClusterName"),
+        # Proxy bootstrap overrides the cluster adapter with auth.clusterName.
+        "proxy.toml auth.clusterName": proxy_config.get("auth", {}).get("clusterName"),
+    }
+    for field, cluster_name in smoke_cluster_names.items():
+        if not isinstance(cluster_name, str) or not cluster_name.strip():
+            findings.append(f"service smoke config must declare a non-blank cluster name: {field}")
+    if all(isinstance(name, str) and name.strip() for name in smoke_cluster_names.values()):
+        if len(set(smoke_cluster_names.values())) != 1:
+            findings.append("Proxy smoke cluster and auth cluster names must match the Broker identity")
+
     builder_ref = policy["base_images"]["builder"]["reference"]
     runtime_ref = policy["base_images"]["runtime"]["reference"]
     for name, reference in (("builder", builder_ref), ("runtime", runtime_ref)):

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -587,6 +587,50 @@ class ContainerFoundationTests(unittest.TestCase):
         policy["smoke_network"]["dependency_chain"].remove("broker")
         self.assertTrue(any("smoke network contract" in finding for finding in self.audit(policy=policy)))
 
+    def test_proxy_smoke_cluster_names_must_match_broker_identity(self) -> None:
+        fields = (
+            ("broker.toml", "brokerClusterName"),
+            ("proxy.toml", "brokerClusterName"),
+            ("proxy.toml", "clusterName"),
+        )
+        for config_name, field in fields:
+            with self.subTest(config=config_name, field=field):
+                mismatched = dict(self.smoke_configs)
+                original = f'{field} = "ContainerSmoke"'
+                self.assertIn(original, mismatched[config_name])
+                mismatched[config_name] = mismatched[config_name].replace(
+                    original, f'{field} = "DefaultCluster"', 1
+                )
+                self.assertIn(
+                    "Proxy smoke cluster and auth cluster names must match the Broker identity",
+                    self.audit(smoke_configs=mismatched),
+                )
+
+        renamed = {
+            name: source.replace('"ContainerSmoke"', '"RenamedSmokeCluster"')
+            for name, source in self.smoke_configs.items()
+        }
+        self.assertEqual([], self.audit(smoke_configs=renamed))
+
+    def test_smoke_cluster_names_must_be_explicit_non_blank_strings(self) -> None:
+        fields = (
+            ("broker.toml", "brokerClusterName", "broker.brokerIdentity.brokerClusterName"),
+            ("proxy.toml", "brokerClusterName", "cluster.brokerClusterName"),
+            ("proxy.toml", "clusterName", "auth.clusterName"),
+        )
+        for config_name, field, field_path in fields:
+            for value in (None, '""', '"   "', "123"):
+                with self.subTest(config=config_name, field=field, value=value):
+                    invalid = dict(self.smoke_configs)
+                    original = f'{field} = "ContainerSmoke"'
+                    self.assertIn(original, invalid[config_name])
+                    replacement = "" if value is None else f"{field} = {value}"
+                    invalid[config_name] = invalid[config_name].replace(original, replacement, 1)
+                    self.assertIn(
+                        f"service smoke config must declare a non-blank cluster name: {config_name} {field_path}",
+                        self.audit(smoke_configs=invalid),
+                    )
+
     def test_missing_read_only_or_signature_verification_is_rejected(self) -> None:
         no_read_only = self.supply_script.replace("--read-only", "--read-write", 1)
         self.assertTrue(any("--read-only" in finding for finding in self.audit(supply_script=no_read_only)))


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10441

### Brief Description

Proxy's container smoke configuration selected the default `DefaultCluster`, while the Broker fixture registered in `ContainerSmoke`. The Proxy readiness check therefore exited with `broker.lookup.not_found` after connecting to NameServer.

Set both `cluster.brokerClusterName` and `auth.clusterName` to `ContainerSmoke`, accounting for Proxy bootstrap's authentication cluster override. Extend the container guard to require explicit nonblank string cluster names and equality with the Broker identity before any image builds.

Add regression coverage for independent mismatches, missing/blank/invalid values, and a coordinated cluster rename.

### How Did You Test This Change?

- Confirmed the new guard rejects the original smoke configuration because both Proxy cluster fields are missing.
- `python scripts/container_image_guard.py` - passed.
- `python -m unittest scripts.tests.test_m11_container_foundation` - all 31 tests passed on Windows and Linux.
- Linux validation used Ubuntu 26.04 under WSL and portable PowerShell 7.6.6 with `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` because the local distribution lacks a compatible ICU runtime.
- `git diff --check` - passed.
- Full Docker image builds and service smoke tests were not rerun locally because the Docker engine is unavailable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved container smoke-test validation to require explicit, non-blank cluster names.
  - Detects inconsistent cluster names across Broker and proxy smoke-test configurations, helping prevent readiness checks from targeting the wrong cluster.

- **Configuration**
  - Updated proxy smoke-test settings with matching cluster identifiers for Broker readiness checks.

- **Tests**
  - Added coverage for missing, blank, invalid, and mismatched cluster-name values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->