### PR TITLE
[ISSUE #10443]🐛Make the smoke Broker reachable across containers

### DIFF
--- a/docker/container-policy.json
+++ b/docker/container-policy.json
@@ -7,6 +7,7 @@
   "smoke_network": {
     "network_prefix": "rocketmq-service-smoke",
     "namesrv_alias": "rocketmq-namesrv",
+    "broker_alias": "rocketmq-broker",
     "namesrv_port": 9876,
     "dependency_chain": ["namesrv", "broker"],
     "dependent_services": ["proxy", "mcp"]

--- a/docker/smoke-config/broker.toml
+++ b/docker/smoke-config/broker.toml
@@ -3,7 +3,7 @@
 
 [broker]
 listenPort = 10911
-brokerIp1 = "127.0.0.1"
+brokerIp1 = "rocketmq-broker"
 storePathRootDir = "/var/lib/rocketmq/broker"
 namesrvAddr = "rocketmq-namesrv:9876"
 autoCreateTopicEnable = false
@@ -14,7 +14,7 @@ brokerClusterName = "ContainerSmoke"
 brokerId = 0
 
 [broker.brokerServerConfig]
-bindAddress = "127.0.0.1"
+bindAddress = "0.0.0.0"
 
 [store]
 storePathRootDir = "/var/lib/rocketmq/broker"

--- a/scripts/container_image_guard.py
+++ b/scripts/container_image_guard.py
@@ -125,6 +125,7 @@ def audit_foundation(
     expected_smoke_network = {
         "network_prefix": "rocketmq-service-smoke",
         "namesrv_alias": "rocketmq-namesrv",
+        "broker_alias": "rocketmq-broker",
         "namesrv_port": 9876,
         "dependency_chain": ["namesrv", "broker"],
         "dependent_services": ["proxy", "mcp"],
@@ -145,7 +146,13 @@ def audit_foundation(
         elif address(parsed_smoke_configs[name]) != expected_namesrv_address:
             findings.append(f"{name} must use the isolated smoke NameServer alias")
 
-    broker_identity = parsed_smoke_configs.get("broker.toml", {}).get("broker", {}).get("brokerIdentity", {})
+    broker_config = parsed_smoke_configs.get("broker.toml", {}).get("broker", {})
+    if broker_config.get("brokerIp1") != expected_smoke_network["broker_alias"]:
+        findings.append("broker.toml must advertise the isolated smoke Broker alias")
+    if broker_config.get("brokerServerConfig", {}).get("bindAddress") != "0.0.0.0":
+        findings.append("broker.toml must listen on the container network interface")
+
+    broker_identity = broker_config.get("brokerIdentity", {})
     proxy_config = parsed_smoke_configs.get("proxy.toml", {})
     smoke_cluster_names = {
         "broker.toml broker.brokerIdentity.brokerClusterName": broker_identity.get("brokerClusterName"),
@@ -480,6 +487,9 @@ def audit_foundation(
         "-NetworkAlias $networkAlias",
         "--volumes",
         "$policy.smoke_network.namesrv_alias",
+        "broker = $policy.smoke_network.broker_alias",
+        "$networkAlias = $dependencyAliases[$dependencyServiceName]",
+        "Initialize-HelperSmokeConfig -SourcePath $smokeConfigPath -DestinationPath $helperSmokeConfigPath",
         "$policy.smoke_network.dependency_chain",
         "$service.data_path",
         "--entrypoint /usr/bin/find",

--- a/scripts/service-image-contract.ps1
+++ b/scripts/service-image-contract.ps1
@@ -72,6 +72,34 @@ function Assert-ServiceImageBinaries {
     }
 }
 
+function Initialize-HelperSmokeConfig {
+    param(
+        [string]$SourcePath,
+        [string]$DestinationPath,
+        [object]$SmokeNetwork
+    )
+
+    New-Item -ItemType Directory -Force -Path $DestinationPath | Out-Null
+    Copy-Item -Path (Join-Path $SourcePath "*") -Destination $DestinationPath -Force
+    $networkNameServerAddress = "$($SmokeNetwork.namesrv_alias):$($SmokeNetwork.namesrv_port)"
+    $loopbackNameServerAddress = "127.0.0.1:$($SmokeNetwork.namesrv_port)"
+    foreach ($configName in @("broker.toml", "proxy.toml", "mcp.toml")) {
+        $configPath = Join-Path $DestinationPath $configName
+        $configText = (Get-Content -Raw -LiteralPath $configPath).Replace(
+            $networkNameServerAddress,
+            $loopbackNameServerAddress
+        )
+        if ($configName -eq "broker.toml") {
+            # Helpers share a network namespace and use the loopback-only profile.
+            $configText = $configText.Replace(
+                'brokerIp1 = "' + $SmokeNetwork.broker_alias + '"',
+                'brokerIp1 = "127.0.0.1"'
+            ).Replace('bindAddress = "0.0.0.0"', 'bindAddress = "127.0.0.1"')
+        }
+        [System.IO.File]::WriteAllText($configPath, $configText, [System.Text.UTF8Encoding]::new($false))
+    }
+}
+
 function Start-ServiceSmokeContainer {
     param(
         [Parameter(Mandatory = $true)]
@@ -210,18 +238,8 @@ try {
     $env:COSIGN_PASSWORD = [Convert]::ToBase64String($randomBytes)
     Invoke-Checked cosign generate-key-pair --output-key-prefix $keyPrefix
 
-    New-Item -ItemType Directory -Force -Path $helperSmokeConfigPath | Out-Null
-    Copy-Item -Path (Join-Path $smokeConfigPath "*") -Destination $helperSmokeConfigPath -Force
-    $networkNameServerAddress = "$($policy.smoke_network.namesrv_alias):$($policy.smoke_network.namesrv_port)"
-    $loopbackNameServerAddress = "127.0.0.1:$($policy.smoke_network.namesrv_port)"
-    foreach ($configName in @("broker.toml", "proxy.toml", "mcp.toml")) {
-        $configPath = Join-Path $helperSmokeConfigPath $configName
-        $configText = (Get-Content -Raw -LiteralPath $configPath).Replace(
-            $networkNameServerAddress,
-            $loopbackNameServerAddress
-        )
-        [System.IO.File]::WriteAllText($configPath, $configText, [System.Text.UTF8Encoding]::new($false))
-    }
+    Initialize-HelperSmokeConfig -SourcePath $smokeConfigPath -DestinationPath $helperSmokeConfigPath `
+        -SmokeNetwork $policy.smoke_network
 
     $nameServerImageRef = "rocketmq-rust/namesrv:verification"
     Invoke-Checked docker buildx build --load --file $dockerfilePath --target namesrv --tag $nameServerImageRef --build-arg "SOURCE_REVISION=$sourceCommit" --build-arg "SOURCE_VERSION=$sourceVersion" $root
@@ -480,14 +498,12 @@ try {
     Invoke-Checked docker network create $smokeNetwork
     $smokeNetworkCreated = $true
 
-    $namesrvAlias = $policy.smoke_network.namesrv_alias
+    $dependencyAliases = @{
+        namesrv = $policy.smoke_network.namesrv_alias
+        broker = $policy.smoke_network.broker_alias
+    }
     foreach ($dependencyServiceName in @($policy.smoke_network.dependency_chain)) {
-        $networkAlias = if ($dependencyServiceName -eq "namesrv") {
-            $namesrvAlias
-        }
-        else {
-            ""
-        }
+        $networkAlias = $dependencyAliases[$dependencyServiceName]
         $containerId = Start-ServiceSmokeContainer `
             -ImageRef "rocketmq-rust/$($dependencyServiceName):verification" `
             -NetworkName $smokeNetwork `

--- a/scripts/tests/test_m11_container_foundation.py
+++ b/scripts/tests/test_m11_container_foundation.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -586,6 +587,91 @@ class ContainerFoundationTests(unittest.TestCase):
         policy = copy.deepcopy(self.policy)
         policy["smoke_network"]["dependency_chain"].remove("broker")
         self.assertTrue(any("smoke network contract" in finding for finding in self.audit(policy=policy)))
+
+    def test_broker_smoke_network_addresses_must_be_reachable(self) -> None:
+        cases = (
+            ('brokerIp1 = "rocketmq-broker"', 'brokerIp1 = "127.0.0.1"', "advertise the isolated smoke Broker alias"),
+            ('bindAddress = "0.0.0.0"', 'bindAddress = "127.0.0.1"', "listen on the container network interface"),
+        )
+        for original, replacement, expected in cases:
+            with self.subTest(field=original):
+                invalid = dict(self.smoke_configs)
+                self.assertIn(original, invalid["broker.toml"])
+                invalid["broker.toml"] = invalid["broker.toml"].replace(original, replacement, 1)
+                self.assertTrue(any(expected in finding for finding in self.audit(smoke_configs=invalid)))
+
+        missing_alias = self.service_script.replace("broker = $policy.smoke_network.broker_alias", 'broker = ""', 1)
+        self.assertTrue(any("broker_alias" in finding for finding in self.audit(service_script=missing_alias)))
+        policy = copy.deepcopy(self.policy)
+        policy["smoke_network"].pop("broker_alias")
+        self.assertTrue(any("smoke network contract" in finding for finding in self.audit(policy=policy)))
+
+    def test_helper_smoke_config_uses_loopback_and_preserves_bridge_fixtures(self) -> None:
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        self.assertIsNotNone(powershell, "PowerShell is required to validate container scripts")
+        harness = r"""
+param([string]$ScriptPath, [string]$PolicyPath, [string]$SourcePath, [string]$DestinationPath)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $ScriptPath, [ref]$tokens, [ref]$parseErrors
+)
+if ($parseErrors.Count -ne 0) {
+    throw "failed to parse service image script: $($parseErrors[0].Message)"
+}
+$definition = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq "Initialize-HelperSmokeConfig"
+}, $true)
+if ($null -eq $definition) {
+    throw "missing helper configuration generator"
+}
+Invoke-Expression $definition.Extent.Text
+$policy = Get-Content -Raw -LiteralPath $PolicyPath | ConvertFrom-Json
+Initialize-HelperSmokeConfig -SourcePath $SourcePath -DestinationPath $DestinationPath -SmokeNetwork $policy.smoke_network
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            source_path = temporary / "bridge"
+            source_path.mkdir()
+            destination_path = temporary / "helper"
+            for name, source in self.smoke_configs.items():
+                (source_path / name).write_text(source, encoding="utf-8")
+            harness_path = temporary / "helper-config-harness.ps1"
+            harness_path.write_text(harness, encoding="utf-8")
+            result = subprocess.run(
+                [
+                    powershell, "-NoProfile", "-File", str(harness_path),
+                    str(ROOT / "scripts" / "service-image-contract.ps1"),
+                    str(ROOT / "docker" / "container-policy.json"),
+                    str(source_path), str(destination_path),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(set(self.smoke_configs), {path.name for path in destination_path.iterdir()})
+            for name, source in self.smoke_configs.items():
+                with self.subTest(config=name):
+                    self.assertEqual(source, (source_path / name).read_text(encoding="utf-8"))
+                    expected = tomllib.loads(source)
+                    address = f"127.0.0.1:{self.policy['smoke_network']['namesrv_port']}"
+                    if name == "broker.toml":
+                        expected["broker"]["namesrvAddr"] = address
+                        expected["broker"]["brokerIp1"] = "127.0.0.1"
+                        expected["broker"]["brokerServerConfig"]["bindAddress"] = "127.0.0.1"
+                    elif name == "proxy.toml":
+                        expected["cluster"]["namesrvAddr"] = address
+                    elif name == "mcp.toml":
+                        expected["clusters"][0]["namesrv_addr"] = address
+                    actual = tomllib.loads((destination_path / name).read_text(encoding="utf-8"))
+                    self.assertEqual(expected, actual)
 
     def test_proxy_smoke_cluster_names_must_match_broker_identity(self) -> None:
         fields = (


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10443

### Brief Description

The Docker bridge smoke failed after Proxy discovered a Broker advertising `127.0.0.1`: that address referred to Proxy's own container, and the Broker listener was also bound to loopback.

Assign the Broker the policy-defined `rocketmq-broker` network alias, advertise it in the smoke fixture, and bind the Broker remoting listener to `0.0.0.0`. Extract the existing helper configuration generation and convert the Broker advertisement and listener back to loopback for smoke containers that share the NameServer network namespace.

Extend the static guard to check the Broker endpoint and alias wiring. Add regression tests for unreachable bridge settings and execute the actual PowerShell helper generator, verifying generated TOML settings and preservation of source fixtures.

### How Did You Test This Change?

- `python scripts/container_image_guard.py` - passed on Windows and Linux.
- `python -m unittest scripts.tests.test_m11_container_foundation` - all 33 tests passed on Windows and Linux.
- Regression cases reject loopback Broker advertisement/listening and missing alias wiring; the helper test validates all generated configurations against the source settings.
- Linux validation used Ubuntu 26.04 under WSL and portable PowerShell 7.6.6 with `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` because the local distribution lacks a compatible ICU runtime.
- `git diff --check` - passed.
- Full Docker image builds and service smoke tests were not rerun locally because the Docker engine is unavailable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved container-based smoke testing by ensuring broker services are reachable through their configured network alias.
  - Updated broker binding and advertised addresses for reliable communication across isolated container networks.
  - Preserved loopback-based settings for local helper test configurations.

- **Tests**
  - Expanded validation to confirm broker network settings, aliases, and generated helper configurations remain consistent and usable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->