### PR TITLE
[ISSUE #10445]🐛Align Kubernetes validation with telemetry file configuration

### DIFF
--- a/scripts/kubernetes_assets_guard.py
+++ b/scripts/kubernetes_assets_guard.py
@@ -26,7 +26,16 @@ from pathlib import Path
 from typing import Any
 
 
-EXPECTED_RESOURCE_COUNT = 45
+# The canonical profile disables the five Prometheus Services and scrape policy.
+EXPECTED_RESOURCE_COUNT = 39
+TELEMETRY_OVERRIDE_ENVIRONMENT = (
+    "ROCKETMQ_METRICS_ENABLED",
+    "ROCKETMQ_METRICS_EXPORTER",
+    "ROCKETMQ_METRICS_BIND_ADDR",
+    "ROCKETMQ_METRICS_PATH",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+)
 LOCAL_IMAGE_TAG = "local"
 CONTROLLER_SERVICE_IPS = ("10.96.0.201", "10.96.0.202", "10.96.0.203")
 EXPECTED_CONTAINER_AUXILIARY_PORTS = {
@@ -199,15 +208,41 @@ def extract_literal_block(document: Document, key: str) -> str | None:
     return "\n".join(body).rstrip() + "\n"
 
 
-def require_valid_toml(guard: Guard, label: str, document: Document, key: str) -> None:
+def require_valid_toml(guard: Guard, label: str, document: Document, key: str) -> dict[str, Any] | None:
     source = extract_literal_block(document, key)
     guard.require(source is not None, f"{label}: missing config literal {document.name}/{key}")
     if source is None:
         return
     try:
-        tomllib.loads(source)
+        return tomllib.loads(source)
     except tomllib.TOMLDecodeError as error:
         guard.errors.append(f"{label}: invalid TOML in {document.name}/{key}: {error}")
+        return None
+
+
+def require_service_config(guard: Guard, label: str, document: Document, key: str) -> None:
+    config = require_valid_toml(guard, label, document, key)
+    if config is None:
+        return
+    observability = config.get("observability")
+    if not isinstance(observability, dict):
+        guard.errors.append(f"{label}: {document.name}/{key} missing observability file configuration")
+        return
+    expected = {
+        "metrics": {"exporter": "disable"},
+        "traces": {"exporter": "disable"},
+        "logs": {"exporter": "disable"},
+        "otlp": {
+            "endpoint": "http://otel-collector.observability.svc.cluster.local:4317",
+            "protocol": "grpc",
+        },
+        "prometheus": {"host": "0.0.0.0", "port": 5557, "path": "/metrics"},
+    }
+    for section, settings in expected.items():
+        guard.require(
+            observability.get(section) == settings,
+            f"{label}: {document.name}/{key} observability.{section} file settings drifted",
+        )
 
 
 def require_security_bootstrap_environment(guard: Guard, label: str, text: str) -> None:
@@ -597,9 +632,13 @@ def validate_workload(guard: Guard, label: str, document: Document, service: str
         "type: RuntimeDefault",
         "- ALL",
         "mountPath: /var/run/secrets/rocketmq",
-        "OTEL_EXPORTER_OTLP_ENDPOINT",
     ):
         guard.require(snippet in text, f"{label}: {service} missing security/topology contract {snippet}")
+    for name in TELEMETRY_OVERRIDE_ENVIRONMENT:
+        guard.require(
+            re.search(rf"\bname:\s*[\"']?{name}[\"']?(?=[\s,}}])", text) is None,
+            f"{label}: {service} must not override observability file settings with {name}",
+        )
     if expected["replicas"] > 1:
         guard.require(
             "topologyKey: kubernetes.io/hostname" in text,
@@ -778,24 +817,24 @@ def validate_render(guard: Guard, label: str, text: str) -> dict[str, Any]:
             if peer_service is not None:
                 guard.require(f"clusterIP: {address}" in peer_service.text, f"{label}: Controller Service IP {ordinal} drifted")
                 guard.require("statefulset.kubernetes.io/pod-name:" in peer_service.text, f"{label}: Controller Service selector drifted")
-            require_valid_toml(guard, label, controller_config, f"rocketmq-controller-{ordinal}.toml")
+            require_service_config(guard, label, controller_config, f"rocketmq-controller-{ordinal}.toml")
 
     broker_config = find_document(documents, "ConfigMap", "rocketmq-broker-config")
     guard.require(broker_config is not None, f"{label}: broker config map missing")
     if broker_config is not None:
         for ordinal in range(EXPECTED_SERVICES["broker"]["replicas"]):
-            require_valid_toml(guard, label, broker_config, f"rocketmq-broker-{ordinal}.toml")
+            require_service_config(guard, label, broker_config, f"rocketmq-broker-{ordinal}.toml")
 
     for service in ("namesrv", "proxy"):
         config = find_document(documents, "ConfigMap", f"rocketmq-{service}-config")
         guard.require(config is not None, f"{label}: {service} config map missing")
         if config is not None:
-            require_valid_toml(guard, label, config, f"{service}.toml")
+            require_service_config(guard, label, config, f"{service}.toml")
 
     mcp_config = find_document(documents, "ConfigMap", "rocketmq-mcp-config")
     guard.require(mcp_config is not None, f"{label}: MCP secure config missing")
     if mcp_config is not None:
-        require_valid_toml(guard, label, mcp_config, "mcp.toml")
+        require_service_config(guard, label, mcp_config, "mcp.toml")
         require_valid_toml(guard, label, mcp_config, "permissions.toml")
         for snippet in (
             'transport = "streamable-http"',
@@ -832,7 +871,6 @@ def validate_render(guard: Guard, label: str, text: str) -> dict[str, Any]:
         "rocketmq-namesrv",
         "rocketmq-proxy",
         "rocketmq-mcp",
-        "rocketmq-metrics-scrape",
     }
     guard.require(network_policy_names == expected_network_policies, f"{label}: NetworkPolicy set drifted")
     return summary

--- a/scripts/tests/test_m11_kubernetes_assets.py
+++ b/scripts/tests/test_m11_kubernetes_assets.py
@@ -90,6 +90,70 @@ class KubernetesAssetsGuardTests(unittest.TestCase):
     def test_repository_contract_passes(self) -> None:
         self.run_guard(expect_success=True)
 
+    def test_every_service_config_requires_its_file_otlp_endpoint(self) -> None:
+        path = self.root / "distribution/kubernetes/base/manifest.yaml"
+        source = path.read_text(encoding="utf-8")
+        keys = (
+            *(f"rocketmq-broker-{ordinal}.toml" for ordinal in range(3)),
+            *(f"rocketmq-controller-{ordinal}.toml" for ordinal in range(3)),
+            "namesrv.toml", "proxy.toml", "mcp.toml",
+        )
+        endpoint = '    endpoint = "http://otel-collector.observability.svc.cluster.local:4317"\n'
+        for key in keys:
+            with self.subTest(config=key):
+                start = source.index(f"  {key}: |-\n")
+                endpoint_start = source.index(endpoint, start)
+                path.write_text(source[:endpoint_start] + source[endpoint_start + len(endpoint):], encoding="utf-8")
+                result = self.run_guard(expect_success=False)
+                self.assertIn(f"/{key} observability.otlp file settings drifted", result.stderr)
+
+    def test_observability_file_settings_drift_is_rejected(self) -> None:
+        path = self.root / "distribution/kubernetes/base/manifest.yaml"
+        source = path.read_text(encoding="utf-8")
+        cases = (
+            ("metrics", '[observability.metrics]\n    exporter = "disable"', '[observability.metrics]\n    exporter = "otlp"'),
+            ("traces", '[observability.traces]\n    exporter = "disable"', '[observability.traces]\n    exporter = "otlp"'),
+            ("logs", '[observability.logs]\n    exporter = "disable"', '[observability.logs]\n    exporter = "otlp"'),
+            ("otlp", 'protocol = "grpc"', 'protocol = "http/protobuf"'),
+            ("prometheus", 'port = 5557', 'port = 5558'),
+        )
+        for section, old, new in cases:
+            with self.subTest(section=section):
+                path.write_text(source, encoding="utf-8")
+                self.mutate_document_text(
+                    "distribution/kubernetes/base/manifest.yaml", "ConfigMap", "rocketmq-namesrv-config", old, new
+                )
+                result = self.run_guard(expect_success=False)
+                self.assertIn(f"namesrv.toml observability.{section} file settings drifted", result.stderr)
+
+    def test_telemetry_environment_must_not_override_canonical_files(self) -> None:
+        path = self.root / "distribution/kubernetes/base/manifest.yaml"
+        source = path.read_text(encoding="utf-8")
+        names = (
+            "ROCKETMQ_METRICS_ENABLED", "ROCKETMQ_METRICS_EXPORTER",
+            "ROCKETMQ_METRICS_BIND_ADDR", "ROCKETMQ_METRICS_PATH",
+            "OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_PROTOCOL",
+        )
+        for name in names:
+            with self.subTest(variable=name):
+                path.write_text(source, encoding="utf-8")
+                self.mutate_document_text(
+                    "distribution/kubernetes/base/manifest.yaml", "StatefulSet", "rocketmq-broker",
+                    "- {name: OTEL_SERVICE_NAME, value: rocketmq-broker}",
+                    f'- {{name: "{name}", value: "unexpected-override"}}',
+                )
+                result = self.run_guard(expect_success=False)
+                self.assertIn(f"must not override observability file settings with {name}", result.stderr)
+
+    def test_required_otlp_network_policy_is_still_enforced(self) -> None:
+        self.mutate_text(
+            "distribution/kubernetes/base/manifest.yaml",
+            "name: rocketmq-otel-egress",
+            "name: unrelated-egress",
+        )
+        result = self.run_guard(expect_success=False)
+        self.assertIn("NetworkPolicy set drifted", result.stderr)
+
     def test_nameserver_discovery_must_remain_opt_in_by_default(self) -> None:
         self.mutate_text(
             "distribution/helm/rocketmq-rust/values.yaml",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10445

### Brief Description

The Kubernetes asset guard rejected the canonical Helm/Kustomize profile because it still expected telemetry environment variables and six optional Prometheus resources that the default profile no longer emits.

Validate telemetry settings in all nine service TOML literals, reject workload environment overrides of those settings, and align the expected resource count and NetworkPolicy set with the current 39-resource profile. Retain required OTLP egress validation.

Add regression coverage for missing service endpoints, changed exporter/protocol/Prometheus settings, unintended environment overrides, and removed OTLP egress policy.

### How Did You Test This Change?

- `python scripts/kubernetes_assets_guard.py` - passed.
- `python -m unittest scripts.tests.test_m11_kubernetes_assets scripts.tests.test_m11_service_lifecycle scripts.tests.test_m11_fault_matrix` - all 58 tests passed.
- `python scripts/fault_matrix_guard.py --policy-only` - passed.
- `./scripts/kubernetes-assets-contract.ps1` - passed with the repository-pinned tools: Helm v4.2.3, Kustomize v5.8.1, kubeconform v0.8.0. Helm lint passed, the committed base matched the canonical render, both renders had 39 valid resources with no schema errors or skips, and the deployment policy guard passed.
- `git diff --check` - passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kubernetes asset validation now detects missing or altered observability settings, including metrics, traces, logs, OTLP, and Prometheus configuration.
  * Deployments are rejected when telemetry-related environment variables override the required configuration.
  * Validation now catches incorrect telemetry egress network policy names and unexpected resource changes.
* **Tests**
  * Added coverage for service observability configuration, telemetry overrides, and network policy drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->