### PR TITLE
[ISSUE #10448]🐛Return zero for overflowing CRC32 ranges in rocketmq-model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **fix(model):** Return `0` for CRC32 ranges whose `offset + length` overflows instead of panicking ([#10448](https://github.com/mxsm/rocketmq-rust/issues/10448)).
 - **docs(protocol):** Add missing Apache 2.0 headers to protocol Rust sources and compile-test fixtures ([#10061](https://github.com/mxsm/rocketmq-rust/issues/10061)).
 - **docs(proxy):** Add the missing Apache 2.0 headers to proxy runtime compile-test fixtures ([#10062](https://github.com/mxsm/rocketmq-rust/issues/10062)).
 - **docs(store):** Add the missing Apache 2.0 header to the store context compile-test fixture ([#10069](https://github.com/mxsm/rocketmq-rust/issues/10069)).

--- a/rocketmq-model/src/utils/crc32_utils.rs
+++ b/rocketmq-model/src/utils/crc32_utils.rs
@@ -65,7 +65,7 @@ pub fn crc32(array: &[u8]) -> u32 {
 ///
 /// CRC32 checksum as u32 (masked with 0x7FFFFFFF)
 ///
-/// # Panics
+/// # Returns
 ///
 /// Returns 0 if offset or length are invalid (instead of panicking)
 ///
@@ -80,7 +80,7 @@ pub fn crc32(array: &[u8]) -> u32 {
 /// ```
 #[inline]
 pub fn crc32_range(array: &[u8], offset: usize, length: usize) -> u32 {
-    if array.is_empty() || offset >= array.len() || offset + length > array.len() {
+    if array.is_empty() || offset >= array.len() || length > array.len() - offset {
         return 0;
     }
 
@@ -303,6 +303,15 @@ mod tests {
         assert_eq!(crc32_range(&buf, 0, 0), 0);
     }
 
+    #[test]
+    fn test_crc32_range_overflowing_length_returns_zero() {
+        // offset in bounds, length = usize::MAX -> offset + length overflows;
+        // must return 0 instead of panicking.
+        let buf = [1, 2, 3, 4, 5];
+        assert_eq!(crc32_range(&buf, 1, usize::MAX), 0);
+        assert_eq!(crc32_range(&[1, 2], 1, usize::MAX), 0);
+    }
+
     // ========== crc32_bytes() tests ==========
 
     #[test]
@@ -365,6 +374,11 @@ mod tests {
         let buf = [1, 2, 3, 4, 5];
         assert_eq!(crc32_bytes_offset(&buf, 0, 10), 0);
         assert_eq!(crc32_bytes_offset(&buf, 10, 1), 0);
+    }
+
+    #[test]
+    fn test_crc32_bytes_offset_overflowing_length_returns_zero() {
+        assert_eq!(crc32_bytes_offset(&[1, 2], 1, usize::MAX), 0);
     }
 
     // ========== crc32_bytebuffer() tests ==========


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10448

### Brief Description

`crc32_range()` documents that it returns `0` for invalid ranges, but its bounds
check evaluated `offset + length` with unchecked arithmetic. When `offset` is in
bounds and `length` is large enough to overflow `usize` (e.g. `usize::MAX`), the
addition panics in debug builds, and in release builds it wraps to an end index
below `offset`, which then panics on the slice index. `crc32_bytes_offset()`
forwards to `crc32_range()`, so it was affected the same way.

The fix replaces the unchecked comparison with the overflow-free form:

```rust
if array.is_empty()
    || offset >= array.len()
    || length > array.len() - offset
{
    return 0;
}
```

`array.len() - offset` cannot underflow because `offset >= array.len()` is
checked first and short-circuits. Valid ranges are unaffected; an overflowing
range now simply returns `0` as documented.

The function's rustdoc `# Panics` heading is also corrected to `# Returns`, since
the section describes the non-panicking `0`-return contract rather than a panic.

### How Did You Test This Change?

Two focused regression tests were added to the existing inline test module in
`rocketmq-model/src/utils/crc32_utils.rs`:

- `test_crc32_range_overflowing_length_returns_zero`
- `test_crc32_bytes_offset_overflowing_length_returns_zero`

Both assert that `crc32_range(&[1, 2], 1, usize::MAX)` and
`crc32_bytes_offset(&[1, 2], 1, usize::MAX)` return `0`.

Commands run from the repository root:

- `cargo test -p rocketmq-model --lib crc32` -> 37 passed, 0 failed
- `cargo test -p rocketmq-model --lib` -> 483 passed, 0 failed
- `cargo fmt -p rocketmq-model -- --check` -> passes

Mutation check (proving the tests guard the fix): reverting only the bounds
check to the original `offset + length > array.len()` makes both new tests fail
with `attempt to add with overflow` reported at the original line. Restoring the
fix returns the suite to green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CRC32 range calculations now safely return `0` for invalid ranges with overflowing lengths instead of triggering a panic.
  - Added coverage for oversized-length inputs to ensure reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->