### PR TITLE
[ISSUE #10447]🐛Fix literal separator parsing for POP retry topics in rocketmq-model

### DIFF
--- a/rocketmq-model/src/common/key_builder.rs
+++ b/rocketmq-model/src/common/key_builder.rs
@@ -64,7 +64,7 @@ impl KeyBuilder {
 
     pub fn parse_normal_topic_default(retry_topic: &str) -> String {
         if KeyBuilder::is_pop_retry_topic_v2(retry_topic) {
-            let result: Vec<&str> = retry_topic.split(POP_RETRY_REGEX_SEPARATOR_V2).collect();
+            let result: Vec<&str> = retry_topic.split(POP_RETRY_SEPARATOR_V2).collect();
             if result.len() == 2 {
                 return result[1].to_string();
             }
@@ -74,7 +74,7 @@ impl KeyBuilder {
 
     pub fn parse_group(retry_topic: &str) -> String {
         if KeyBuilder::is_pop_retry_topic_v2(retry_topic) {
-            let result: Vec<&str> = retry_topic.split(POP_RETRY_REGEX_SEPARATOR_V2).collect();
+            let result: Vec<&str> = retry_topic.split(POP_RETRY_SEPARATOR_V2).collect();
             if result.len() == 2 {
                 return result[0][RETRY_GROUP_TOPIC_PREFIX.len()..].to_string();
             }
@@ -112,5 +112,40 @@ impl KeyBuilder {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KeyBuilder;
+
+    #[test]
+    fn pop_retry_v2_builder_round_trips() {
+        let retry = KeyBuilder::build_pop_retry_topic_v2("orders", "workers");
+        assert_eq!(retry, "%RETRY%workers+orders");
+        assert_eq!(KeyBuilder::parse_normal_topic_default(&retry), "orders");
+        assert_eq!(KeyBuilder::parse_group(&retry), "workers");
+    }
+
+    #[test]
+    fn literal_v2_topic_is_parsed() {
+        assert_eq!(
+            KeyBuilder::parse_normal_topic_default("%RETRY%workers+orders"),
+            "orders"
+        );
+        assert_eq!(KeyBuilder::parse_group("%RETRY%workers+orders"), "workers");
+    }
+
+    #[test]
+    fn non_v2_and_multiple_separator_fallbacks_are_preserved() {
+        for topic in ["orders", "%RETRY%workers_orders", "%RETRY%workers+orders+extra"] {
+            assert_eq!(KeyBuilder::parse_normal_topic_default(topic), topic);
+        }
+        assert_eq!(KeyBuilder::parse_group("%RETRY%workers"), "workers");
+        assert_eq!(KeyBuilder::parse_group("%RETRY%workers_orders"), "workers_orders");
+        assert_eq!(
+            KeyBuilder::parse_group("%RETRY%workers+orders+extra"),
+            "workers+orders+extra"
+        );
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10447 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of retry topics that use the V2 separator.
  * Added fallback handling for non-V2 and topics containing multiple separators.

* **Tests**
  * Added coverage for V2 topic building and parsing, literal topic parsing, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->