### PR TITLE
[ISSUE #10449]🐛Preserve spaces in TopicConfig text attributes in rocketmq-model

### DIFF
--- a/rocketmq-model/src/topic.rs
+++ b/rocketmq-model/src/topic.rs
@@ -322,7 +322,7 @@ impl TopicConfig {
     }
 
     pub fn decode(&mut self, input: &str) -> bool {
-        let parts: Vec<&str> = input.split(Self::SEPARATOR).collect();
+        let parts: Vec<&str> = input.splitn(6, Self::SEPARATOR).collect();
         if parts.len() < 5 {
             return false;
         }

--- a/rocketmq-model/tests/topic_config_text_contracts.rs
+++ b/rocketmq-model/tests/topic_config_text_contracts.rs
@@ -1,0 +1,64 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_model::topic::TopicConfig;
+
+#[test]
+fn text_attributes_round_trip_with_spaces_and_escaped_quotes() {
+    let mut original = TopicConfig::new("orders");
+    original.read_queue_nums = 4;
+    original.write_queue_nums = 8;
+    original.perm = 6;
+    original.attributes.insert("description".into(), "hello world".into());
+    original.attributes.insert("label".into(), "say \"hello\" 世界".into());
+    let mut decoded = TopicConfig::default();
+    assert!(decoded.decode(&original.encode()));
+    assert_eq!(decoded.topic_name, original.topic_name);
+    assert_eq!(decoded.read_queue_nums, 4);
+    assert_eq!(decoded.write_queue_nums, 8);
+    assert_eq!(decoded.perm, 6);
+    assert_eq!(decoded.topic_filter_type, original.topic_filter_type);
+    assert_eq!(decoded.attributes, original.attributes);
+}
+
+#[test]
+fn five_field_and_compact_attribute_forms_decode() {
+    let mut decoded = TopicConfig::default();
+    assert!(decoded.decode("orders 4 8 6 SINGLE_TAG"));
+    assert_eq!(decoded.topic_name.as_deref(), Some("orders"));
+    assert_eq!(
+        (decoded.read_queue_nums, decoded.write_queue_nums, decoded.perm),
+        (4, 8, 6)
+    );
+    assert!(decoded.attributes.is_empty());
+    assert!(decoded.decode(r#"orders 4 8 6 SINGLE_TAG {"mode":"fast"}"#));
+    assert_eq!(decoded.attributes, [("mode".into(), "fast".into())].into());
+}
+
+#[test]
+fn optional_json_and_numeric_fallbacks_preserve_existing_behavior() {
+    for suffix in ["", " {invalid json}"] {
+        let mut decoded = TopicConfig::default();
+        decoded.attributes.insert("retained".into(), "value".into());
+        decoded.order = true;
+        decoded.topic_sys_flag = 7;
+        assert!(decoded.decode(&format!("orders invalid invalid invalid SINGLE_TAG{suffix}")));
+        assert_eq!(decoded.read_queue_nums, TopicConfig::default().read_queue_nums);
+        assert_eq!(decoded.write_queue_nums, TopicConfig::default().write_queue_nums);
+        assert_eq!(decoded.perm, TopicConfig::default().perm);
+        assert_eq!(decoded.attributes, [("retained".into(), "value".into())].into());
+        assert!(decoded.order);
+        assert_eq!(decoded.topic_sys_flag, 7);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10449 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed topic configuration decoding when attributes contain spaces or escaped quotes.
  * Preserved existing configuration values when numeric fields or optional attribute data are invalid.

* **Tests**
  * Added coverage for encoding and decoding topic configurations, optional attributes, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->