### PR TITLE
[ISSUE #10458]🐛Fix test module ordering in the admin topic adapter

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/topic.rs
@@ -692,6 +692,30 @@ mod query;
 
 use query::*;
 
+impl crate::core::topic::TopicSkipMutationAdmin for AdminSession {
+    fn skip_accumulated<'a>(
+        &'a mut self,
+        request: &'a crate::core::topic::SkipTopicAccumulatedRequest,
+    ) -> AdminFuture<'a, TopicMutationOutcome> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let affected_queues = rocketmq_client_rust::MQAdminMutationExt::skip_accumulated_message(
+                &self.inner,
+                request.cluster_name().map(CheetahString::from),
+                CheetahString::from(request.topic()),
+                CheetahString::from(request.consumer_group()),
+                request.force(),
+            )
+            .await
+            .map_err(|error| backend_error("skip_accumulated_message", error))?;
+            Ok(TopicMutationOutcome {
+                message: "Accumulated messages were skipped to the latest offsets.".into(),
+                target_count: affected_queues,
+            })
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::build_order_conf;
@@ -751,29 +775,5 @@ mod tests {
         assert_eq!(build_order_conf(&brokers, 8), "broker-a:8;broker-b:8");
         assert_eq!(normalize_message_type(None), "NORMAL");
         assert_eq!(normalize_message_type(Some("transaction")), "TRANSACTION");
-    }
-}
-
-impl crate::core::topic::TopicSkipMutationAdmin for AdminSession {
-    fn skip_accumulated<'a>(
-        &'a mut self,
-        request: &'a crate::core::topic::SkipTopicAccumulatedRequest,
-    ) -> AdminFuture<'a, TopicMutationOutcome> {
-        Box::pin(async move {
-            self.ensure_open()?;
-            let affected_queues = rocketmq_client_rust::MQAdminMutationExt::skip_accumulated_message(
-                &self.inner,
-                request.cluster_name().map(CheetahString::from),
-                CheetahString::from(request.topic()),
-                CheetahString::from(request.consumer_group()),
-                request.force(),
-            )
-            .await
-            .map_err(|error| backend_error("skip_accumulated_message", error))?;
-            Ok(TopicMutationOutcome {
-                message: "Accumulated messages were skipped to the latest offsets.".into(),
-                target_count: affected_queues,
-            })
-        })
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10458 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal topic administration implementation without changing user-visible behavior.
  * Skip-accumulated message handling continues to validate sessions, report errors, and return affected queue counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->