### PR TITLE
[ISSUE #10455]📝Fix BooleanAttribute constructor documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docs(model):** Fix BooleanAttribute constructor documentation that incorrectly described enum attribute parameters and return type; add accurate Rustdoc with executable examples ([#10455](https://github.com/mxsm/rocketmq-rust/issues/10455)).
 - **fix(model):** Return `0` for CRC32 ranges whose `offset + length` overflows instead of panicking ([#10448](https://github.com/mxsm/rocketmq-rust/issues/10448)).
 - **docs(protocol):** Add missing Apache 2.0 headers to protocol Rust sources and compile-test fixtures ([#10061](https://github.com/mxsm/rocketmq-rust/issues/10061)).
 - **docs(proxy):** Add the missing Apache 2.0 headers to proxy runtime compile-test fixtures ([#10062](https://github.com/mxsm/rocketmq-rust/issues/10062)).

--- a/rocketmq-model/src/common/attribute/bool_attribute.rs
+++ b/rocketmq-model/src/common/attribute/bool_attribute.rs
@@ -38,18 +38,36 @@ pub struct BooleanAttribute {
 }
 
 impl BooleanAttribute {
-    /// Create a new enum attribute with the specified properties
+    /// Create a new boolean attribute with the specified properties
     ///
     /// # Arguments
     ///
     /// * `name` - The name of the attribute
     /// * `changeable` - Whether the attribute can be changed after creation
-    /// * `universe` - Set of valid values this attribute can take
-    /// * `default_value` - Default value for this attribute (must be in universe)
+    /// * `default_value` - Default boolean value for this attribute
     ///
     /// # Returns
     ///
-    /// A new EnumAttribute instance, or an error if the default value is not in the universe
+    /// A new `BooleanAttribute` instance
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cheetah_string::CheetahString;
+    /// use rocketmq_model::common::attribute::bool_attribute::BooleanAttribute;
+    /// use rocketmq_model::common::attribute::Attribute;
+    ///
+    /// let attr = BooleanAttribute::new(
+    ///     CheetahString::from_static_str("enabled"),
+    ///     true,
+    ///     false
+    /// );
+    /// assert_eq!(attr.default_value(), false);
+    ///
+    /// // Verify accepts valid boolean strings
+    /// assert!(attr.verify("true").is_ok());
+    /// assert!(attr.verify("FALSE").is_ok());
+    /// ```
     pub fn new(name: CheetahString, changeable: bool, default_value: bool) -> Self {
         Self {
             attribute: AttributeBase::new(name, changeable),
@@ -65,8 +83,35 @@ impl BooleanAttribute {
 
     /// Parse a string value to boolean
     ///
-    /// Returns Ok(bool) if the string is "true" or "false" (case insensitive),
-    /// or an Err with a descriptive message otherwise.
+    /// Accepts "true" or "false" case-insensitively. Whitespace is not trimmed.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The string value to parse
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(bool)` - The parsed boolean value
+    /// * `Err(String)` - An error message if the value is not "true" or "false"
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input string is not "true" or "false" (case-insensitive).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rocketmq_model::common::attribute::bool_attribute::BooleanAttribute;
+    ///
+    /// // Case-insensitive parsing
+    /// assert_eq!(BooleanAttribute::parse_bool("true").unwrap(), true);
+    /// assert_eq!(BooleanAttribute::parse_bool("TRUE").unwrap(), true);
+    /// assert_eq!(BooleanAttribute::parse_bool("False").unwrap(), false);
+    ///
+    /// // Invalid values return errors
+    /// assert!(BooleanAttribute::parse_bool("yes").is_err());
+    /// assert!(BooleanAttribute::parse_bool(" true").is_err()); // whitespace not trimmed
+    /// ```
     pub fn parse_bool(value: &str) -> Result<bool, String> {
         match value.to_lowercase().as_str() {
             "true" => Ok(true),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10455

### Brief Description

Fixed incorrect Rustdoc for BooleanAttribute::new that was copied from enum attribute:
- Removed references to non-existent 'universe' parameter  
- Changed return type from EnumAttribute to BooleanAttribute
- Removed error mentions (constructor is infallible)
- Added accurate parameter descriptions for changeable and default_value
- Added executable example showing construction and Attribute trait usage

Also improved parse_bool documentation:
- Added # Arguments, # Returns, and # Errors sections
- Clarified case-insensitive behavior and that whitespace is not trimmed
- Added executable example with successful and failure cases

### How Did You Test This Change?

Documentation-only change. Rust cargo toolchain not available in current environment to run `cargo test -p rocketmq-model --doc common::attribute::bool_attribute` validation. The changes follow the existing test patterns in the file and maintain API compatibility.

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the documentation for creating boolean attributes, including the parameter and return value descriptions.
  - Expanded boolean parsing documentation to explain arguments, results, and error behavior.
  - Added executable Rust documentation examples to clarify how these APIs are used.
  - Recorded the documentation fixes in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->