### PR TITLE
[ISSUE #10463]🐛Align client tests with canonical error contracts

### DIFF
--- a/rocketmq-client/src/admin/mq_admin_read_ext.rs
+++ b/rocketmq-client/src/admin/mq_admin_read_ext.rs
@@ -897,6 +897,7 @@ fn sanitize_broker_logical_target(target: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::assert_invalid_argument;
     use std::collections::HashMap;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
@@ -1058,7 +1059,7 @@ mod tests {
         )]);
 
         let error = parse_allowlisted_value::<u64>(&properties, "flushDelayOffsetInterval").unwrap_err();
-        assert!(error.to_string().contains("flushDelayOffsetInterval"));
+        assert_invalid_argument(&error);
     }
 
     #[test]

--- a/rocketmq-client/src/base/validators.rs
+++ b/rocketmq-client/src/base/validators.rs
@@ -180,6 +180,7 @@ impl Validators {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::client_exception;
     use std::collections::HashMap;
 
     use bytes::Bytes;
@@ -226,8 +227,7 @@ mod tests {
         let too_long_group = "a".repeat(Validators::GROUP_MAX_LENGTH + 1);
         let result = Validators::check_group(&too_long_group);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
+        assert!(client_exception(&result.unwrap_err())
             .to_string()
             .contains("longer than group max length: 120."));
     }

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -3600,6 +3600,7 @@ pub async fn run_lite_pull_assignment_registry_probe(iterations: usize) -> LiteP
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::client_exception;
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicU64;
     use std::sync::atomic::AtomicUsize;
@@ -3947,7 +3948,7 @@ mod tests {
             .await
             .expect_err("missing self-reference should return an error");
 
-        assert!(error
+        assert!(client_exception(&error)
             .to_string()
             .contains("default_lite_pull_consumer_impl is not initialized"));
     }
@@ -3969,7 +3970,9 @@ mod tests {
             .check_config()
             .expect_err("Java LitePull rejects legacy consumeFromWhere values");
 
-        assert!(error.to_string().contains("Invalid ConsumeFromWhere Value"));
+        assert!(client_exception(&error)
+            .to_string()
+            .contains("Invalid ConsumeFromWhere Value"));
     }
 
     #[test]
@@ -3987,7 +3990,7 @@ mod tests {
             .check_config()
             .expect_err("Java LitePull rejects DEFAULT_CONSUMER_GROUP");
 
-        assert!(error
+        assert!(client_exception(&error)
             .to_string()
             .contains("consumerGroup can not equal DEFAULT_CONSUMER"));
     }
@@ -4009,7 +4012,7 @@ mod tests {
             .check_config()
             .expect_err("Java LitePull rejects consumer suspend timeout below broker suspend timeout");
 
-        assert!(error.to_string().contains(
+        assert!(client_exception(&error).to_string().contains(
             "Long polling mode, the consumer consumerTimeoutMillisWhenSuspend must greater than \
              brokerSuspendMaxTimeMillis"
         ));
@@ -4031,7 +4034,9 @@ mod tests {
             .check_config()
             .expect_err("zero concurrent pull RPCs cannot make progress");
 
-        assert!(error.to_string().contains("pullThreadNums must be greater than 0"));
+        assert!(client_exception(&error)
+            .to_string()
+            .contains("pullThreadNums must be greater than 0"));
     }
 
     #[tokio::test]
@@ -4102,7 +4107,7 @@ mod tests {
         let error = impl_
             .try_set_pull_thread_nums(4)
             .expect_err("running concurrency update should be rejected");
-        assert!(error
+        assert!(client_exception(&error)
             .to_string()
             .contains("pullThreadNums can not be changed after the lite pull consumer has started"));
         assert_eq!(impl_.pull_thread_nums(), 3);
@@ -4135,7 +4140,7 @@ mod tests {
             .set_consumer_group(CheetahString::from_static_str("lite_pull_late_group"))
             .expect_err("consumer group changes after running should be rejected");
 
-        assert!(error
+        assert!(client_exception(&error)
             .to_string()
             .contains("consumerGroup can not be changed after the lite pull consumer has started"));
         assert_eq!(impl_.consumer_group_config().as_str(), "lite_pull_updated_group");
@@ -4222,7 +4227,7 @@ mod tests {
             .set_offset_store(Some(Arc::new(OffsetStore::new_test())))
             .expect_err("offset store changes after running should be rejected");
 
-        assert!(error
+        assert!(client_exception(&error)
             .to_string()
             .contains("offsetStore can not be changed after the lite pull consumer has started"));
     }
@@ -4517,7 +4522,7 @@ mod tests {
             .set_sub_expression_for_assign(topic.clone(), " ")
             .await
             .expect_err("Java LitePull rejects blank assign filter expressions");
-        assert!(blank_error
+        assert!(client_exception(&blank_error)
             .to_string()
             .contains("subExpression can not be null or empty."));
         assert_eq!(*impl_.subscription_type.read().await, SubscriptionType::None);
@@ -4548,7 +4553,7 @@ mod tests {
             .set_sub_expression_for_assign(topic, "TagA")
             .await
             .expect_err("Java LitePull only allows assign filters before start");
-        assert!(running_error
+        assert!(client_exception(&running_error)
             .to_string()
             .contains("setAssignTag only can be called before start."));
     }
@@ -4596,7 +4601,7 @@ mod tests {
             .await
             .expect_err("Java LitePull rejects unassigned queues before querying offsets");
 
-        let message = error.to_string();
+        let message = client_exception(&error).to_string();
         assert!(message.contains("The message queue is not in assigned list"));
         assert!(!message.contains("Client instance not initialized"));
     }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -2422,6 +2422,7 @@ impl MQConsumerInner for DefaultMQPushConsumerImpl {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::client_exception;
     use std::sync::Arc;
 
     use bytes::Bytes;
@@ -2676,7 +2677,7 @@ mod tests {
 
         assert!(result
             .err()
-            .is_some_and(|error| error.to_string().contains("has been created before")));
+            .is_some_and(|error| client_exception(&error).to_string().contains("has been created before")));
         assert_eq!(duplicate_consumer.service_state(), ServiceState::CreateJust);
         assert!(duplicate_consumer
             .consume_message_service()
@@ -2778,7 +2779,7 @@ mod tests {
             .check_config()
             .expect_err("invalid consume timestamp should fail before start");
 
-        let message = error.to_string();
+        let message = client_exception(&error).to_string();
         assert!(message.contains("consumeTimestamp is invalid"));
         assert!(message.contains("yyyyMMddHHmmss"));
     }
@@ -2791,7 +2792,9 @@ mod tests {
             .check_config()
             .expect_err("missing consume timestamp should return a typed config error");
 
-        assert!(error.to_string().contains("consumeTimestamp is invalid"));
+        assert!(client_exception(&error)
+            .to_string()
+            .contains("consumeTimestamp is invalid"));
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -1313,6 +1313,7 @@ fn pull_message_service_shutdown_signal_failed() -> ClientError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::error_assertions::assert_invalid_state;
 
     fn test_pop_request(queue_id: i32) -> PopRequest {
         PopRequest::new(
@@ -1416,11 +1417,7 @@ mod tests {
     fn pull_message_service_request_type_mismatch_uses_client_invalid_state() {
         let error = pull_message_service_request_type_mismatch("PullRequest");
 
-        assert_eq!(
-            error.descriptor().code(),
-            rocketmq_error::CLIENT_LIFECYCLE_INVALID_STATE.code()
-        );
-        assert!(error.to_string().contains("PullRequest"));
+        assert_invalid_state(&error, "PullRequest", "message request payload type mismatch");
     }
 
     struct MismatchedMessageRequest {
@@ -1456,22 +1453,14 @@ mod tests {
     async fn process_request_reports_pull_downcast_mismatch_as_client_invalid_state() {
         let error = process_mismatched_request(MessageRequestMode::Pull).await;
 
-        assert_eq!(
-            error.descriptor().code(),
-            rocketmq_error::CLIENT_LIFECYCLE_INVALID_STATE.code()
-        );
-        assert!(error.to_string().contains("PullRequest"));
+        assert_invalid_state(&error, "PullRequest", "message request payload type mismatch");
     }
 
     #[tokio::test]
     async fn process_request_reports_pop_downcast_mismatch_as_client_invalid_state() {
         let error = process_mismatched_request(MessageRequestMode::Pop).await;
 
-        assert_eq!(
-            error.descriptor().code(),
-            rocketmq_error::CLIENT_LIFECYCLE_INVALID_STATE.code()
-        );
-        assert!(error.to_string().contains("PopRequest"));
+        assert_invalid_state(&error, "PopRequest", "message request payload type mismatch");
     }
 
     #[test]

--- a/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
+++ b/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
@@ -1854,6 +1854,8 @@ impl MQConsumer for DefaultLitePullConsumer {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::assert_not_initialized;
+    use crate::test_support::error_assertions::client_exception;
     use std::any::Any;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
@@ -1958,7 +1960,7 @@ mod tests {
             .await
             .expect_err("assignment before start should fail");
 
-        assert!(error.to_string().contains("DefaultLitePullConsumer not started"));
+        assert_not_initialized(&error, "DefaultLitePullConsumer not started. Call start() first.");
     }
 
     #[tokio::test]
@@ -1970,7 +1972,7 @@ mod tests {
             .await
             .expect_err("running info before start should fail");
 
-        assert!(error.to_string().contains("DefaultLitePullConsumer not started"));
+        assert_not_initialized(&error, "DefaultLitePullConsumer not started. Call start() first.");
     }
 
     #[tokio::test]
@@ -2038,9 +2040,7 @@ mod tests {
             .expect_err("earliestMsgStoreTime should enter LitePull path and fail because the consumer is not started");
 
         for error in [search_error, max_error, min_error, earliest_error] {
-            let message = error.to_string();
-            assert!(message.contains("DefaultLitePullConsumer not started"));
-            assert!(!message.contains("not supported by this MQConsumer implementation"));
+            assert_not_initialized(&error, "DefaultLitePullConsumer not started. Call start() first.");
         }
     }
 
@@ -2077,9 +2077,7 @@ mod tests {
                 .expect_err("viewMessage should enter LitePull path and fail because the consumer is not started");
 
         for error in [create_error, create_with_flag_error, query_error, view_error] {
-            let message = error.to_string();
-            assert!(message.contains("DefaultLitePullConsumer not started"));
-            assert!(!message.contains("not supported by this MQConsumer implementation"));
+            assert_not_initialized(&error, "DefaultLitePullConsumer not started. Call start() first.");
         }
     }
 
@@ -2131,7 +2129,9 @@ mod tests {
             .await
             .expect_err("empty manual assignment should be rejected");
 
-        assert!(error.to_string().contains("Message queues can not be null or empty."));
+        assert!(client_exception(&error)
+            .to_string()
+            .contains("Message queues can not be null or empty."));
     }
 
     #[tokio::test]
@@ -2152,11 +2152,12 @@ mod tests {
             .await
             .expect_err("min offset before start should fail");
 
-        assert!(earliest_error
-            .to_string()
-            .contains("DefaultLitePullConsumer not started"));
-        assert!(max_error.to_string().contains("DefaultLitePullConsumer not started"));
-        assert!(min_error.to_string().contains("DefaultLitePullConsumer not started"));
+        assert_not_initialized(
+            &earliest_error,
+            "DefaultLitePullConsumer not started. Call start() first.",
+        );
+        assert_not_initialized(&max_error, "DefaultLitePullConsumer not started. Call start() first.");
+        assert_not_initialized(&min_error, "DefaultLitePullConsumer not started. Call start() first.");
     }
 
     #[tokio::test]
@@ -2270,7 +2271,9 @@ mod tests {
             .set_sub_expression_for_assign("TopicA", " ")
             .await
             .expect_err("blank assign filter should be rejected");
-        assert!(error.to_string().contains("subExpression can not be null or empty."));
+        assert!(client_exception(&error)
+            .to_string()
+            .contains("subExpression can not be null or empty."));
 
         consumer
             .set_sub_expression_for_assign("TopicA", "TagA")
@@ -2503,7 +2506,9 @@ mod tests {
             .set_consume_from_where(ConsumeFromWhere::ConsumeFromMaxOffset)
             .await
             .expect_err("Java LitePull rejects legacy consumeFromWhere values");
-        assert!(error.to_string().contains("Invalid ConsumeFromWhere Value"));
+        assert!(client_exception(&error)
+            .to_string()
+            .contains("Invalid ConsumeFromWhere Value"));
         assert_eq!(
             consumer.consume_from_where().await,
             ConsumeFromWhere::ConsumeFromFirstOffset

--- a/rocketmq-client/src/consumer/default_lite_pull_consumer_builder.rs
+++ b/rocketmq-client/src/consumer/default_lite_pull_consumer_builder.rs
@@ -465,6 +465,7 @@ impl DefaultLitePullConsumerBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::error_assertions::client_exception;
 
     fn test_runtime() -> Arc<ClientRuntime> {
         crate::runtime::test_client_runtime("lite-pull-consumer-builder-test")
@@ -475,7 +476,9 @@ mod tests {
         let result = DefaultLitePullConsumerBuilder::new(test_runtime()).build();
         match result {
             Ok(_) => panic!("builder should reject missing consumer group"),
-            Err(error) => assert!(error.to_string().contains("consumer_group is required")),
+            Err(error) => assert!(client_exception(&error)
+                .to_string()
+                .contains("consumer_group is required")),
         }
     }
 
@@ -522,7 +525,9 @@ mod tests {
 
         match result {
             Ok(_) => panic!("Java LitePull rejects legacy consumeFromWhere values"),
-            Err(error) => assert!(error.to_string().contains("Invalid ConsumeFromWhere Value")),
+            Err(error) => assert!(client_exception(&error)
+                .to_string()
+                .contains("Invalid ConsumeFromWhere Value")),
         }
     }
 

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -1427,6 +1427,7 @@ impl DefaultMQPushConsumer {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::assert_not_initialized;
     use std::any::Any;
     use std::collections::HashSet;
     use std::sync::atomic::AtomicUsize;
@@ -1562,7 +1563,7 @@ mod tests {
             .await
             .expect_err("subscribe without impl should fail");
 
-        assert!(error.to_string().contains("DefaultMQPushConsumerImpl"));
+        assert_not_initialized(&error, "DefaultMQPushConsumerImpl");
     }
 
     #[tokio::test]
@@ -1583,9 +1584,9 @@ mod tests {
             .await
             .expect_err("viewMessage without impl should fail");
 
-        assert!(max_error.to_string().contains("DefaultMQPushConsumerImpl"));
-        assert!(query_error.to_string().contains("DefaultMQPushConsumerImpl"));
-        assert!(view_error.to_string().contains("DefaultMQPushConsumerImpl"));
+        assert_not_initialized(&max_error, "DefaultMQPushConsumerImpl");
+        assert_not_initialized(&query_error, "DefaultMQPushConsumerImpl");
+        assert_not_initialized(&view_error, "DefaultMQPushConsumerImpl");
     }
 
     #[tokio::test]
@@ -1600,7 +1601,7 @@ mod tests {
             .await
             .expect_err("running info without impl should fail");
 
-        assert!(error.to_string().contains("DefaultMQPushConsumerImpl"));
+        assert_not_initialized(&error, "DefaultMQPushConsumerImpl");
     }
 
     #[tokio::test]
@@ -1860,7 +1861,7 @@ mod tests {
             .register_consume_message_hook(TestConsumeHook)
             .expect_err("hook registration without impl should fail");
 
-        assert!(error.to_string().contains("DefaultMQPushConsumerImpl"));
+        assert_not_initialized(&error, "DefaultMQPushConsumerImpl");
     }
 
     #[test]

--- a/rocketmq-client/src/consumer/mq_consumer.rs
+++ b/rocketmq-client/src/consumer/mq_consumer.rs
@@ -116,6 +116,7 @@ pub trait MQConsumer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::error_assertions::assert_invalid_argument;
 
     struct CustomConsumer;
 
@@ -144,7 +145,6 @@ mod tests {
             .await
             .expect_err("default MQAdmin facade should be unsupported");
 
-        assert!(error.to_string().contains("maxOffset"));
-        assert!(error.to_string().contains("MQConsumer implementation"));
+        assert_invalid_argument(&error);
     }
 }

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -3005,6 +3005,8 @@ pub fn run_heartbeat_route_index_probe(
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::assert_invalid_state;
+    use crate::test_support::error_assertions::client_exception;
     use std::collections::VecDeque;
     use std::future::Future;
     use std::pin::Pin;
@@ -3278,13 +3280,11 @@ mod tests {
     fn sync_pull_result_missing_uses_client_invalid_state() {
         let error = sync_pull_result_missing("MQClientInstance::pull_message");
 
-        assert_eq!(
-            error.descriptor().code(),
-            rocketmq_error::CLIENT_LIFECYCLE_INVALID_STATE.code()
+        assert_invalid_state(
+            &error,
+            "PullResultExt returned by sync pull_message",
+            "MQClientInstance::pull_message returned None",
         );
-        assert!(error
-            .to_string()
-            .contains("MQClientInstance::pull_message returned None"));
     }
 
     #[tokio::test]
@@ -3578,7 +3578,9 @@ mod tests {
             .start()
             .await
             .expect_err("a client whose registration admission is closed must not start");
-        assert!(error.to_string().contains("producer registration admission is closed"));
+        assert!(client_exception(&error)
+            .to_string()
+            .contains("producer registration admission is closed"));
         assert_eq!(instance.service_state(), ServiceState::CreateJust);
     }
 

--- a/rocketmq-client/src/implementation/mq_admin_impl.rs
+++ b/rocketmq-client/src/implementation/mq_admin_impl.rs
@@ -608,6 +608,8 @@ impl MQAdminImpl {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::assert_invalid_argument;
+    use crate::test_support::error_assertions::client_exception;
     use std::collections::VecDeque;
     use std::future::Future;
     use std::pin::Pin;
@@ -823,7 +825,7 @@ mod tests {
         assert_eq!(after.0 - before.0, 1, "outer route discovery remains one request");
         assert_eq!(after.1 - before.1, CREATE_TOPIC_ATTEMPTS as usize);
         assert!(
-            error.to_string().contains("terminal-attempt-5"),
+            client_exception(&error).to_string().contains("terminal-attempt-5"),
             "budget exhaustion must return the last broker response: {error}"
         );
 
@@ -916,9 +918,7 @@ mod tests {
         )
         .expect_err("begin timestamp outside Java long range should fail");
 
-        assert!(error
-            .to_string()
-            .contains("queryMessage begin timestamp exceeds Java long range"));
+        assert_invalid_argument(&error);
     }
 
     #[test]
@@ -931,9 +931,7 @@ mod tests {
         let error = MQAdminImpl::timestamp_to_java_long("searchOffset", i64::MAX as u64 + 1)
             .expect_err("timestamp outside Java long range should fail");
 
-        assert!(error
-            .to_string()
-            .contains("searchOffset timestamp exceeds Java long range"));
+        assert_invalid_argument(&error);
     }
 
     #[test]
@@ -947,9 +945,7 @@ mod tests {
         let error = MQAdminImpl::java_long_to_u64("queryMessage", "indexLastUpdateTimestamp", -1)
             .expect_err("negative timestamp should not wrap");
 
-        assert!(error
-            .to_string()
-            .contains("queryMessage indexLastUpdateTimestamp is negative and cannot be represented as Rust u64"));
+        assert_invalid_argument(&error);
     }
 
     #[test]

--- a/rocketmq-client/src/implementation/mq_client_api_factory.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_factory.rs
@@ -324,6 +324,7 @@ pub async fn run_namesrv_refresh_lifecycle_probe(service_context: ChildServiceCo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::error_assertions::assert_invalid_argument;
     use std::future::pending;
 
     struct DropFlag(Arc<AtomicBool>);
@@ -343,7 +344,7 @@ mod tests {
         let error = validate_nameserver_access_config(&NameserverAccessConfig::default())
             .expect_err("missing namesrvAddr and namesrvDomain should be invalid");
 
-        assert!(error.to_string().contains("NamesrvAddr is not configured"));
+        assert_invalid_argument(&error);
     }
 
     #[test]
@@ -372,7 +373,7 @@ mod tests {
             Err(error) => error,
         };
 
-        assert!(error.to_string().contains("requires at least one MQClientAPIImpl"));
+        assert_invalid_argument(&error);
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/implementation/mq_client_manager.rs
+++ b/rocketmq-client/src/implementation/mq_client_manager.rs
@@ -312,6 +312,7 @@ impl ClientPool {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::client_exception;
     use cheetah_string::CheetahString;
     use rocketmq_protocol::protocol::SerializeType;
 
@@ -386,7 +387,7 @@ mod tests {
             Err(error) => error,
         };
 
-        assert!(error
+        assert!(client_exception(&error)
             .to_string()
             .contains("ClientPool configuration conflicts with an existing client-id owner"));
     }

--- a/rocketmq-client/src/legacy.rs
+++ b/rocketmq-client/src/legacy.rs
@@ -661,6 +661,8 @@ impl ConsumeRequest {
 #[allow(deprecated)]
 mod tests {
     use super::*;
+    use crate::test_support::error_assertions::assert_invalid_argument;
+    use crate::test_support::error_assertions::assert_not_initialized;
 
     #[tokio::test]
     async fn legacy_pull_consumer_fails_closed_without_runtime() {
@@ -675,9 +677,10 @@ mod tests {
             .await
             .expect_err("detached pull consumer should not start");
 
-        assert!(error.to_string().contains("DefaultMQPullConsumer"));
-        assert!(error.to_string().contains("builder"));
-        assert!(!error.to_string().contains("not supported"));
+        assert_not_initialized(
+            &error,
+            "DefaultMQPullConsumer has no ClientRuntime; create it with DefaultMQPullConsumer::builder",
+        );
     }
 
     #[test]
@@ -699,8 +702,10 @@ mod tests {
             .register_pull_task_callback("TopicA", Callback)
             .expect_err("detached schedule service should require runtime");
 
-        assert!(error.to_string().contains("with_client_runtime"));
-        assert!(!error.to_string().contains("not supported"));
+        assert_not_initialized(
+            &error,
+            "MQPullConsumerScheduleService has no ClientRuntime; use with_client_runtime",
+        );
     }
 
     #[test]
@@ -728,8 +733,7 @@ mod tests {
             .check_local_transaction_state(&MessageExt::default())
             .expect_err("deprecated transaction listener should reject checks");
 
-        assert!(error.to_string().contains("TransactionCheckListener"));
-        assert!(error.to_string().contains("TransactionListener"));
+        assert_invalid_argument(&error);
     }
 
     #[test]
@@ -737,11 +741,11 @@ mod tests {
         assert!(DoNothingClientRemotingProcessor::new().process_request().is_none());
 
         let rebalance_error = RebalanceImpl::new().expect_err("impl-package RebalanceImpl should be unsupported");
-        assert!(rebalance_error.to_string().contains("impl-package type"));
+        assert_invalid_argument(&rebalance_error);
 
         let consume_error = ConsumeRequest::new()
             .run()
             .expect_err("impl-package ConsumeRequest should be unsupported");
-        assert!(consume_error.to_string().contains("ConsumeRequest"));
+        assert_invalid_argument(&consume_error);
     }
 }

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -2616,6 +2616,8 @@ mod facade_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::error_assertions::assert_invalid_argument;
+    use crate::test_support::error_assertions::client_exception;
     use crate::ClientResult;
     use bytes::Bytes;
     use rocketmq_model::common::message::message_single::Message;
@@ -2724,11 +2726,7 @@ mod tests {
         let result = producer.send_batch(vec![msg1, msg2]).await;
 
         let err = result.expect_err("delayed batch message should be rejected before send");
-        assert!(
-            err.to_string()
-                .contains("Delayed messages are not supported for batching"),
-            "unexpected error message: {err}"
-        );
+        assert_invalid_argument(&err);
     }
 
     #[tokio::test]
@@ -2748,7 +2746,8 @@ mod tests {
 
         let err = result.expect_err("DefaultMQProducer should reject transaction sends");
         assert!(
-            err.to_string()
+            client_exception(&err)
+                .to_string()
                 .contains("sendMessageInTransaction not implement, please use TransactionMQProducer class"),
             "unexpected error message: {err}"
         );

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -1029,6 +1029,7 @@ pub async fn run_produce_accumulator_guard_lifecycle_probe(
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::error_assertions::client_exception;
     use std::future::pending;
     use std::sync::atomic::Ordering;
 
@@ -1609,7 +1610,7 @@ mod tests {
 
         let error = split_send_results(&send_result, 2).expect_err("mismatched per-message ids are illegal");
 
-        assert!(error.to_string().contains("sendResult is illegal"));
+        assert!(client_exception(&error).to_string().contains("sendResult is illegal"));
     }
 
     #[test]
@@ -1624,7 +1625,7 @@ mod tests {
 
         let error = split_send_results(&send_result, 2).expect_err("per-message msg id requires offset msg id");
 
-        assert!(error.to_string().contains("sendResult is illegal"));
+        assert!(client_exception(&error).to_string().contains("sendResult is illegal"));
     }
 
     #[test]
@@ -1639,7 +1640,7 @@ mod tests {
 
         let error = split_send_results(&send_result, 2).expect_err("missing msg id is illegal");
 
-        assert!(error.to_string().contains("sendResult is illegal"));
+        assert!(client_exception(&error).to_string().contains("sendResult is illegal"));
     }
 }
 

--- a/rocketmq-client/src/test_support.rs
+++ b/rocketmq-client/src/test_support.rs
@@ -17,6 +17,9 @@
 //! This module is excluded from default production builds. Consumers must opt
 //! in with the `test-support` feature.
 
+#[cfg(test)]
+pub(crate) mod error_assertions;
+
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;

--- a/rocketmq-client/src/test_support/error_assertions.rs
+++ b/rocketmq-client/src/test_support/error_assertions.rs
@@ -1,0 +1,74 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::{fields, ErrorContext, ErrorDescriptor, ViewValueRef};
+
+use crate::{ClientError, MQClientException};
+
+#[track_caller]
+pub(crate) fn assert_error(error: &ClientError, descriptor: &'static ErrorDescriptor) {
+    assert_eq!(error.code(), descriptor.code());
+    assert_eq!(
+        error.to_string(),
+        format!("{}: {}", descriptor.code(), descriptor.public_message())
+    );
+    error.public_view().expect("valid public error context");
+    error.diagnostic_view().expect("valid diagnostic error context");
+}
+
+#[track_caller]
+pub(crate) fn assert_context_field(error: &ClientError, name: &str, expected: ViewValueRef<'_>) {
+    let view = error.diagnostic_view().expect("valid diagnostic error context");
+    let actual = view
+        .fields()
+        .find(|field| field.name() == name)
+        .map(|field| field.value());
+    assert_eq!(actual, Some(expected), "unexpected context field {name}");
+}
+
+#[track_caller]
+pub(crate) fn assert_invalid_argument(error: &ClientError) {
+    assert_error(error, &rocketmq_error::CORE_ARGUMENT_INVALID);
+    assert_context_field(error, fields::MESSAGE_PRESENT.schema().name(), ViewValueRef::Redacted);
+    assert_eq!(error.public_view().unwrap().fields().count(), 0);
+}
+
+#[track_caller]
+pub(crate) fn assert_not_initialized(error: &ClientError, component: &str) {
+    assert_error(error, &rocketmq_error::CORE_LIFECYCLE_NOT_INITIALIZED);
+    assert_eq!(
+        error.context(),
+        &ErrorContext::new().with_text(fields::COMPONENT_NAME, component)
+    );
+}
+
+#[track_caller]
+pub(crate) fn assert_invalid_state(error: &ClientError, expected: &str, actual: &str) {
+    assert_error(error, &rocketmq_error::CLIENT_LIFECYCLE_INVALID_STATE);
+    assert_eq!(
+        error.context(),
+        &ErrorContext::new()
+            .with_text(fields::EXPECTED_STATE, expected)
+            .with_text(fields::ACTUAL_STATE, actual)
+    );
+}
+
+#[track_caller]
+pub(crate) fn client_exception(error: &ClientError) -> &MQClientException {
+    assert_invalid_argument(error);
+    // Java compatibility text belongs to the typed source, outside public rendering.
+    error
+        .source_ref::<MQClientException>()
+        .expect("retained Java client exception")
+}

--- a/rocketmq-client/src/trace/async_trace_dispatcher.rs
+++ b/rocketmq-client/src/trace/async_trace_dispatcher.rs
@@ -1099,6 +1099,8 @@ pub async fn run_trace_worker_lifecycle_probe(service_context: ChildServiceConte
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::error_assertions::assert_context_field;
+    use crate::test_support::error_assertions::assert_error;
 
     fn test_runtime() -> Arc<ClientRuntime> {
         crate::runtime::test_client_runtime("async-trace-dispatcher-test")
@@ -1127,11 +1129,17 @@ mod tests {
     fn trace_dispatcher_flush_timeout_uses_timeout_descriptor() {
         let error = trace_dispatcher_flush_timeout();
 
-        assert_eq!(
-            error.descriptor().code(),
-            rocketmq_error::CORE_OPERATION_TIMED_OUT.code()
+        assert_error(&error, &rocketmq_error::CORE_OPERATION_TIMED_OUT);
+        assert_context_field(
+            &error,
+            "operation",
+            rocketmq_error::ViewValueRef::Text("trace_dispatcher_flush"),
         );
-        assert!(error.to_string().contains("trace_dispatcher_flush"));
+        assert_context_field(
+            &error,
+            "timeout_ms",
+            rocketmq_error::ViewValueRef::U64(TRACE_WORKER_FLUSH_TIMEOUT.as_millis() as u64),
+        );
     }
 
     #[test]

--- a/rocketmq-client/src/utils/message_util.rs
+++ b/rocketmq-client/src/utils/message_util.rs
@@ -103,6 +103,7 @@ impl MessageUtil {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::error_assertions::client_exception;
 
     #[test]
     fn create_reply_message_uses_java_reply_topic_and_copies_request_properties() {
@@ -152,6 +153,11 @@ mod tests {
         let error =
             MessageUtil::create_reply_message(&request, b"reply-body").expect_err("missing cluster should fail");
 
-        assert!(error.to_string().contains(MessageConst::PROPERTY_CLUSTER));
+        let exception = client_exception(&error);
+        assert_eq!(
+            exception.response_code(),
+            ClientErrorCode::CREATE_REPLY_MESSAGE_EXCEPTION
+        );
+        assert!(exception.to_string().contains(MessageConst::PROPERTY_CLUSTER));
     }
 }

--- a/rocketmq-client/tests/admin/default_mq_admin_ext_impl/unit.rs
+++ b/rocketmq-client/tests/admin/default_mq_admin_ext_impl/unit.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::test_support::error_assertions::assert_context_field;
+use crate::test_support::error_assertions::assert_error;
+use crate::test_support::error_assertions::assert_invalid_argument;
+use crate::test_support::error_assertions::assert_invalid_state;
+
 #[allow(unused_imports)]
 use super::admin_api::*;
 #[allow(unused_imports)]
@@ -85,21 +90,19 @@ use super::DefaultMQAdminExtImpl;
 fn admin_route_not_found_uses_route_descriptor() {
     let error = admin_route_not_found(&CheetahString::from_static_str("RouteTopic"));
 
-    assert_eq!(error.descriptor().code(), rocketmq_error::ROUTE_TOPIC_NOT_FOUND.code());
-    assert!(error.to_string().contains("RouteTopic"));
+    assert_error(&error, &rocketmq_error::ROUTE_TOPIC_NOT_FOUND);
+    assert_context_field(&error, "topic", rocketmq_error::ViewValueRef::Text("RouteTopic"));
 }
 
 #[test]
 fn sync_pull_result_missing_uses_client_invalid_state() {
     let error = sync_pull_result_missing("DefaultMQAdminExtImpl::pull_message_from_queue");
 
-    assert_eq!(
-        error.descriptor().code(),
-        rocketmq_error::CLIENT_LIFECYCLE_INVALID_STATE.code()
+    assert_invalid_state(
+        &error,
+        "PullResultExt returned by sync pull_message",
+        "DefaultMQAdminExtImpl::pull_message_from_queue returned None",
     );
-    assert!(error
-        .to_string()
-        .contains("DefaultMQAdminExtImpl::pull_message_from_queue returned None"));
 }
 
 fn new_unstarted_admin() -> DefaultMQAdminExtImpl {
@@ -306,7 +309,7 @@ fn lite_pull_topic_config_update_requires_explicit_positive_queue_nums() {
     let error = lite_pull_topic_config(CheetahString::from("LiteTopic"), 0, 0, 0, 8, true)
         .expect_err("update lite topic should not use queueNum fallback");
 
-    assert!(error.to_string().contains("readQueueNums must be positive"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -314,7 +317,7 @@ fn lite_pull_topic_config_rejects_negative_topic_sys_flag() {
     let error = lite_pull_topic_config(CheetahString::from("LiteTopic"), 8, -1, 0, 0, false)
         .expect_err("negative topicSysFlag should be rejected");
 
-    assert!(error.to_string().contains("topicSysFlag must be non-negative"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -327,9 +330,7 @@ fn timestamp_to_java_long_rejects_values_outside_java_range() {
     let error = timestamp_to_java_long("resetOffsetNewConcurrent", i64::MAX as u64 + 1)
         .expect_err("value larger than Java long should be rejected");
 
-    assert!(error
-        .to_string()
-        .contains("resetOffsetNewConcurrent timestamp exceeds Java long range"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -342,9 +343,7 @@ fn timeout_millis_to_u64_rejects_values_outside_rust_range() {
     let error = timeout_millis_to_u64(Duration::from_secs(u64::MAX))
         .expect_err("duration larger than u64 milliseconds should be rejected");
 
-    assert!(error
-        .to_string()
-        .contains("DefaultMQAdminExt timeoutMillis exceeds Rust u64 millisecond range"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -357,9 +356,7 @@ fn master_flush_offset_to_java_long_rejects_values_outside_java_range() {
     let error = master_flush_offset_to_java_long(i64::MAX as u64 + 1)
         .expect_err("value larger than Java long should be rejected");
 
-    assert!(error
-        .to_string()
-        .contains("resetMasterFlushOffset offset exceeds Java long range"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -372,9 +369,7 @@ fn query_consume_queue_index_to_java_long_rejects_values_outside_java_range() {
     let error = query_consume_queue_index_to_java_long(i64::MAX as u64 + 1)
         .expect_err("value larger than Java long should be rejected");
 
-    assert!(error
-        .to_string()
-        .contains("queryConsumeQueue offset exceeds Java long range"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -387,9 +382,7 @@ fn search_offset_timestamp_to_java_long_rejects_values_outside_java_range() {
     let error = search_offset_timestamp_to_java_long(i64::MAX as u64 + 1)
         .expect_err("value larger than Java long should be rejected");
 
-    assert!(error
-        .to_string()
-        .contains("searchOffset timestamp exceeds Java long range"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -401,9 +394,7 @@ fn java_long_to_u64_rejects_negative_values_from_broker() {
 
     let error = java_long_to_u64("searchOffset", "offset", -1).expect_err("negative broker offset must not wrap");
 
-    assert!(error
-        .to_string()
-        .contains("searchOffset offset is negative and cannot be represented as Rust u64"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -843,7 +834,7 @@ fn update_consume_offset_request_header_rejects_offsets_outside_java_long_range(
     let error = update_consume_offset_request_header(CheetahString::from("group-a"), &mq, i64::MAX as u64 + 1)
         .expect_err("offset larger than Java long should be rejected");
 
-    assert!(error.to_string().contains("offset exceeds Java long range"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -873,7 +864,7 @@ fn lite_pull_update_consumer_offset_rejects_offsets_outside_java_long_range() {
     )
     .expect_err("offset larger than Java long should be rejected");
 
-    assert!(error.to_string().contains("offset exceeds Java long range"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -898,7 +889,7 @@ fn notify_min_broker_id_change_request_header_rejects_blank_min_broker_addr() {
     let error = notify_min_broker_id_change_request_header(1, CheetahString::new(), None, None)
         .expect_err("blank min broker address should be rejected before remoting");
 
-    assert!(error.to_string().contains("requires minBrokerAddr"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -1095,9 +1086,7 @@ fn reset_offset_by_queue_id_rejects_offsets_outside_java_long_range() {
     )
     .expect_err("offset larger than Java long should be rejected");
 
-    assert!(error
-        .to_string()
-        .contains("resetOffsetByQueueId offset exceeds Java long range"));
+    assert_invalid_argument(&error);
 }
 
 #[tokio::test]

--- a/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
+++ b/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::test_support::error_assertions::assert_invalid_argument;
+use crate::test_support::error_assertions::client_exception;
+
 #[allow(unused_imports)]
 use super::admin::*;
 #[allow(unused_imports)]
@@ -231,9 +234,7 @@ fn java_long_to_u64_field_rejects_negative_protocol_values() {
     let error =
         java_long_to_u64_field("pullMessage", "nextBeginOffset", -1).expect_err("negative broker offset must not wrap");
 
-    assert!(error
-        .to_string()
-        .contains("pullMessage nextBeginOffset is negative and cannot be represented as Rust u64"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -271,9 +272,7 @@ fn duration_millis_to_u64_rejects_values_outside_rust_range() {
     let error = duration_millis_to_u64("probeNameServer", Duration::from_secs(u64::MAX))
         .expect_err("duration larger than u64 millis should fail");
 
-    assert!(error
-        .to_string()
-        .contains("probeNameServer timeout exceeds Rust u64 millisecond range"));
+    assert_invalid_argument(&error);
 }
 
 #[test]
@@ -289,7 +288,9 @@ fn controller_leader_address_requires_controller_metadata_leader_like_java() {
     let error = controller_leader_address(GetMetaDataResponseHeader::default())
         .expect_err("controller metadata without leader should be rejected");
 
-    assert!(error.to_string().contains("Controller leader address"));
+    assert!(client_exception(&error)
+        .to_string()
+        .contains("Controller leader address"));
 }
 
 #[test]
@@ -477,7 +478,7 @@ fn create_topic_request_header_rejects_values_outside_java_int_range() {
     let error = create_topic_request_header_like_java(CheetahString::from_static_str("TBW102"), &topic_config)
         .expect_err("Java int overflow should be rejected before encoding");
 
-    assert!(error.to_string().contains("readQueueNums value"));
+    assert_invalid_argument(&error);
 }
 
 #[cfg(feature = "admin-mutation")]
@@ -1132,7 +1133,7 @@ fn consumer_offset_json_from_response_rejects_success_without_body() {
     let error =
         consumer_offset_json_from_response(&response).expect_err("success response without body should be rejected");
 
-    assert!(error
+    assert!(client_exception(&error)
         .to_string()
         .contains("get_all_consumer_offset response body is empty"));
 }
@@ -1227,7 +1228,7 @@ fn decode_cluster_acl_version_info_response_body_rejects_success_without_body() 
     let error = decode_cluster_acl_version_info_response_body(None)
         .expect_err("SUCCESS cluster ACL version response must include a body");
 
-    assert!(error
+    assert!(client_exception(&error)
         .to_string()
         .contains("get_broker_cluster_acl_version_info response body is empty"));
 }
@@ -1239,7 +1240,9 @@ fn reset_offset_table_from_response_rejects_success_without_body_like_java() {
     let error = reset_offset_table_from_response(&response)
         .expect_err("Java invokeBrokerToResetOffset throws when SUCCESS has no body");
 
-    assert!(error.to_string().contains("reset offset response body is empty"));
+    assert!(client_exception(&error)
+        .to_string()
+        .contains("reset offset response body is empty"));
 }
 
 #[test]

--- a/rocketmq-client/tests/producer/default_mq_producer_impl/unit.rs
+++ b/rocketmq-client/tests/producer/default_mq_producer_impl/unit.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::test_support::error_assertions::assert_context_field;
+use crate::test_support::error_assertions::assert_error;
+use crate::test_support::error_assertions::assert_invalid_argument;
+use crate::test_support::error_assertions::client_exception;
+
 #[allow(unused_imports)]
 use super::lifecycle::*;
 #[allow(unused_imports)]
@@ -282,17 +287,23 @@ async fn running_is_published_only_after_async_start_initialization() {
 
 #[test]
 fn request_cause_from_error_uses_typed_error() {
-    let error = DefaultMQProducerImpl::request_cause_from_error(&ClientError::from_shared(Arc::new(
-        rocketmq_error::Error::caused_by(
-            &rocketmq_error::TRANSPORT_CONNECTION_FAILED,
-            std::io::Error::other("send failed"),
-        ),
+    let source = ClientError::from_shared(Arc::new(rocketmq_error::Error::caused_by(
+        &rocketmq_error::TRANSPORT_CONNECTION_FAILED,
+        std::io::Error::other("send failed"),
     )));
+    let error = DefaultMQProducerImpl::request_cause_from_error(&source);
 
-    assert!(error.is(&rocketmq_error::PROTOCOL_RESPONSE_FAILED));
+    assert_error(&error, &rocketmq_error::PROTOCOL_RESPONSE_FAILED);
+    assert_context_field(
+        &error,
+        "operation",
+        rocketmq_error::ViewValueRef::Text("request_response_callback"),
+    );
+    let retained = error.source_ref::<ClientError>().expect("retained client error");
+    assert!(Arc::ptr_eq(source.shared_error(), retained.shared_error()));
     assert_eq!(
-        error.to_string(),
-        "Response request_response_callback failed: transport.connection.failed: Transport connection operation failed"
+        error.source_ref::<std::io::Error>().expect("retained I/O cause").kind(),
+        std::io::ErrorKind::Other
     );
 }
 
@@ -473,7 +484,7 @@ impl TransactionListener for ThreadRecordingTransactionListener {
 }
 
 struct CapturingSendHook {
-    exception_message: Arc<std::sync::Mutex<Option<String>>>,
+    exception: Arc<std::sync::Mutex<Option<Arc<ClientError>>>>,
 }
 
 impl SendMessageHook for CapturingSendHook {
@@ -487,37 +498,39 @@ impl SendMessageHook for CapturingSendHook {
         let Some(exception) = context.as_ref().and_then(|context| context.exception.as_ref()) else {
             return;
         };
-        *self
-            .exception_message
-            .lock()
-            .expect("exception message lock should not be poisoned") = Some(exception.to_string());
+        *self.exception.lock().expect("exception lock should not be poisoned") = Some(exception.clone());
     }
 }
 
 #[test]
 fn send_message_after_hook_observes_exception_like_java() {
     let producer = running_producer_without_client();
-    let exception_message = Arc::new(std::sync::Mutex::new(None));
+    let exception = Arc::new(std::sync::Mutex::new(None));
     let hook: Arc<dyn SendMessageHook> = Arc::new(CapturingSendHook {
-        exception_message: exception_message.clone(),
+        exception: exception.clone(),
     });
     *producer.send_message_hook_list.write() = vec![hook].into();
+    let original = DefaultMQProducerImpl::context_error("sendKernelImpl exception".to_string());
     let context = Some(SendMessageContext {
-        exception: Some(DefaultMQProducerImpl::context_error(
-            "sendKernelImpl exception".to_string(),
-        )),
+        exception: Some(original.clone()),
         ..Default::default()
     });
 
     producer.execute_send_message_hook_after(&context);
 
-    assert_eq!(
-        exception_message
-            .lock()
-            .expect("exception message lock should not be poisoned")
-            .as_deref(),
-        Some("Response send_message failed: sendKernelImpl exception")
+    let captured = exception
+        .lock()
+        .expect("exception lock should not be poisoned")
+        .clone()
+        .expect("hook must observe the exception");
+    assert!(Arc::ptr_eq(&captured, &original));
+    assert_error(&captured, &rocketmq_error::PROTOCOL_RESPONSE_FAILED);
+    assert_context_field(
+        &captured,
+        "operation",
+        rocketmq_error::ViewValueRef::Text("send_message"),
     );
+    assert_context_field(&captured, "reason", rocketmq_error::ViewValueRef::Redacted);
 }
 
 #[tokio::test]
@@ -595,9 +608,9 @@ async fn producer_selector_paths_without_client_return_error_instead_of_panickin
 
     let fetch_result = producer.fetch_publish_message_queues(&"TopicTest".into()).await;
     assert!(fetch_result.is_err());
-    assert!(fetch_result
-        .err()
-        .is_some_and(|error| error.to_string().contains("MQClientInstance is not available")));
+    assert!(fetch_result.err().is_some_and(|error| client_exception(&error)
+        .to_string()
+        .contains("MQClientInstance is not available")));
 }
 
 #[tokio::test]
@@ -1139,8 +1152,12 @@ async fn send_oneway_with_message_queue_does_not_reject_topic_mismatch_before_ke
     let result = producer.send_oneway_with_message_queue(msg, mq).await;
 
     let error = result.expect_err("kernel path should fail without a client instance");
-    assert!(error.to_string().contains("MQClientInstance is not available"));
-    assert!(!error.to_string().contains("is not equal with message queue topic"));
+    assert!(client_exception(&error)
+        .to_string()
+        .contains("MQClientInstance is not available"));
+    assert!(!client_exception(&error)
+        .to_string()
+        .contains("is not equal with message queue topic"));
 }
 
 #[tokio::test]
@@ -1154,21 +1171,23 @@ async fn sync_send_to_queue_topic_mismatch_uses_java_error_message() {
         .await
         .expect_err("topic mismatch should fail before broker lookup");
 
-    assert!(error.to_string().contains("message's topic not equal mq's topic"));
+    assert!(client_exception(&error)
+        .to_string()
+        .contains("message's topic not equal mq's topic"));
 }
 
 #[tokio::test]
 async fn async_send_to_queue_validates_message_before_kernel_like_java() {
     let producer = running_producer_arc_with_self_inner();
     let notify = Arc::new(tokio::sync::Notify::new());
-    let seen_error = Arc::new(std::sync::Mutex::new(None::<String>));
+    let seen_error = Arc::new(std::sync::Mutex::new(None::<ClientError>));
     let notify_for_callback = notify.clone();
     let seen_for_callback = seen_error.clone();
     let callback: ArcSendCallback = Arc::new(move |_result: Option<&SendResult>, error: Option<&ClientError>| {
         if let Some(error) = error {
             *seen_for_callback
                 .lock()
-                .expect("seen error lock should not be poisoned") = Some(error.to_string());
+                .expect("seen error lock should not be poisoned") = Some(error.clone());
             notify_for_callback.notify_one();
         }
     });
@@ -1188,22 +1207,23 @@ async fn async_send_to_queue_validates_message_before_kernel_like_java() {
         .expect("seen error lock should not be poisoned")
         .clone()
         .expect("callback should record validation error");
-    assert!(error.contains("message body is null") || error.contains("message body length is zero"));
-    assert!(!error.contains("MQClientInstance is not available"));
+    let exception = client_exception(&error);
+    let message = exception.error_message().expect("message validation detail");
+    assert!(message.contains("message body is null") || message.contains("message body length is zero"));
 }
 
 #[tokio::test]
 async fn async_send_to_queue_topic_mismatch_uses_java_callback_error_message() {
     let producer = running_producer_arc_with_self_inner();
     let notify = Arc::new(tokio::sync::Notify::new());
-    let seen_error = Arc::new(std::sync::Mutex::new(None::<String>));
+    let seen_error = Arc::new(std::sync::Mutex::new(None::<ClientError>));
     let notify_for_callback = notify.clone();
     let seen_for_callback = seen_error.clone();
     let callback: ArcSendCallback = Arc::new(move |_result: Option<&SendResult>, error: Option<&ClientError>| {
         if let Some(error) = error {
             *seen_for_callback
                 .lock()
-                .expect("seen error lock should not be poisoned") = Some(error.to_string());
+                .expect("seen error lock should not be poisoned") = Some(error.clone());
             notify_for_callback.notify_one();
         }
     });
@@ -1223,25 +1243,24 @@ async fn async_send_to_queue_topic_mismatch_uses_java_callback_error_message() {
         .expect("seen error lock should not be poisoned")
         .clone()
         .expect("callback should record topic mismatch");
-    assert!(
-        error.contains("Topic of the message does not match its target message queue"),
-        "unexpected callback error: {error}"
+    assert_eq!(
+        client_exception(&error).error_message(),
+        Some("Topic of the message does not match its target message queue")
     );
-    assert!(!error.contains("MQClientInstance is not available"));
 }
 
 #[tokio::test]
 async fn async_send_with_callback_reports_kernel_error_to_callback() {
     let producer = running_producer_arc_with_self_inner();
     let notify = Arc::new(tokio::sync::Notify::new());
-    let seen_error = Arc::new(std::sync::Mutex::new(None::<String>));
+    let seen_error = Arc::new(std::sync::Mutex::new(None::<ClientError>));
     let notify_for_callback = notify.clone();
     let seen_for_callback = seen_error.clone();
     let callback: ArcSendCallback = Arc::new(move |_result: Option<&SendResult>, error: Option<&ClientError>| {
         if let Some(error) = error {
             *seen_for_callback
                 .lock()
-                .expect("seen error lock should not be poisoned") = Some(error.to_string());
+                .expect("seen error lock should not be poisoned") = Some(error.clone());
             notify_for_callback.notify_one();
         }
     });
@@ -1263,7 +1282,10 @@ async fn async_send_with_callback_reports_kernel_error_to_callback() {
         .expect("seen error lock should not be poisoned")
         .clone()
         .expect("callback should record kernel error");
-    assert!(error.contains("MQClientInstance is not available"));
+    assert!(client_exception(&error)
+        .error_message()
+        .unwrap()
+        .contains("MQClientInstance is not available"));
 }
 
 #[tokio::test]
@@ -1410,9 +1432,9 @@ async fn producer_request_prepare_without_client_returns_error_instead_of_panick
     let result = producer.prepare_send_request(&mut msg, 3000).await;
 
     assert!(result.is_err());
-    assert!(result
-        .err()
-        .is_some_and(|error| error.to_string().contains("MQClientInstance is not available")));
+    assert!(result.err().is_some_and(|error| client_exception(&error)
+        .to_string()
+        .contains("MQClientInstance is not available")));
 }
 
 #[test]
@@ -1548,19 +1570,19 @@ fn transaction_env_rejects_invalid_java_executor_config() {
     let producer = running_producer_without_client();
 
     let min_over_max = producer.init_transaction_env(2, 1, 3);
-    assert!(min_over_max
-        .err()
-        .is_some_and(|error| error.to_string().contains("min size cannot exceed max size")));
+    assert!(min_over_max.err().is_some_and(|error| client_exception(&error)
+        .to_string()
+        .contains("min size cannot exceed max size")));
 
     let zero_pool = producer.init_transaction_env(0, 1, 3);
     assert!(zero_pool
         .err()
-        .is_some_and(|error| error.to_string().contains("must be greater than 0")));
+        .is_some_and(|error| client_exception(&error).to_string().contains("must be greater than 0")));
 
     let zero_hold = producer.init_transaction_env(1, 1, 0);
-    assert!(zero_hold
-        .err()
-        .is_some_and(|error| error.to_string().contains("hold max must be greater than 0")));
+    assert!(zero_hold.err().is_some_and(|error| client_exception(&error)
+        .to_string()
+        .contains("hold max must be greater than 0")));
 }
 
 #[tokio::test]
@@ -1572,7 +1594,7 @@ async fn transaction_send_without_impl_listener_fails_before_send_like_java() {
 
     assert!(result
         .err()
-        .is_some_and(|error| error.to_string().contains("tranExecutor is null")));
+        .is_some_and(|error| client_exception(&error).to_string().contains("tranExecutor is null")));
 }
 
 #[test]
@@ -1598,7 +1620,7 @@ async fn transaction_send_delay_millis_fails_before_send_like_java() {
     let result = producer.send_message_in_transaction(msg, None).await;
 
     assert!(result.err().is_some_and(|error| {
-        error
+        client_exception(&error)
             .to_string()
             .contains("Transactional messages do not support delayed delivery")
     }));
@@ -1713,9 +1735,7 @@ fn end_transaction_send_result_queue_offset_must_fit_java_long() {
         DefaultMQProducerImpl::u64_to_java_long_field("endTransaction", "tranStateTableOffset", i64::MAX as u64 + 1)
             .expect_err("queue offsets larger than Java long must not wrap");
 
-    assert!(error
-        .to_string()
-        .contains("endTransaction tranStateTableOffset exceeds Java long range"));
+    assert_invalid_argument(&error);
 }
 
 #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10463

### Brief Description

Fix 87 client unit-test failures caused by assertions against legacy dynamic error strings after the canonical error migration. Tests now check stable error identities, structured context, redaction, and retained `MQClientException` details through private test helpers.

Callback and Hook fixtures retain typed errors and verify shared identity and source-chain preservation. Reply-message validation also checks its Java exception response code. Production error behavior and public rendering remain unchanged.

### How Did You Test This Change?

- Reproduced the failure: 1038 passed, 87 failed, 1 ignored.
- `cargo test -p rocketmq-client-rust --lib`: 1125 passed, 0 failed, 1 existing ignored test; revalidated against the latest `main` base.
- `cargo fmt -p rocketmq-client-rust -- --check`: passed.
- `git diff --check`: passed.

The ignored test requires an external online consumer. CI completion is not a merge prerequisite for this PR, as requested by the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Standardized client error assertions across the test suite using shared, typed helpers.
  - Added validation for error descriptors, diagnostic context fields, and retained client exceptions.
  - Replaced fragile error-message string matching with checks for specific error categories and states.
  - Improved async callback and send-hook tests to retain structured errors for validation.
- **Refactor**
  - Centralized reusable error assertion utilities for test builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->