### PR TITLE
[ISSUE #10451]🧪 Cover property-string parsing contracts in rocketmq-model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **test(model):** Add direct property codec contract coverage ([#10451](https://github.com/mxsm/rocketmq-rust/issues/10451)).
 - **test(remoting):** Add comprehensive test coverage for `QueryMessageResponseHeader` including integration with RemotingCommand, boundary checks, and error handling
 - **feat(tools):** Add `broker` command group with `GetBrokerConfigSubCommand` for querying broker configuration by broker address or cluster, with optional `--keyPattern` regex filtering
 - **feat(tools):** Add `CleanExpiredCQSubCommand` under broker commands with broker/cluster/topic target scan, dry-run preview, and cleanup summary reporting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **test(model):** Add direct property codec contract coverage ([#10451](https://github.com/mxsm/rocketmq-rust/issues/10451)).
 - **test(remoting):** Add comprehensive test coverage for `QueryMessageResponseHeader` including integration with RemotingCommand, boundary checks, and error handling
 - **feat(tools):** Add `broker` command group with `GetBrokerConfigSubCommand` for querying broker configuration by broker address or cluster, with optional `--keyPattern` regex filtering
 - **feat(tools):** Add `CleanExpiredCQSubCommand` under broker commands with broker/cluster/topic target scan, dry-run preview, and cleanup summary reporting

--- a/rocketmq-model/tests/property_codec_contracts.rs
+++ b/rocketmq-model/tests/property_codec_contracts.rs
@@ -1,0 +1,78 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+use rocketmq_model::codec::message_properties_to_string;
+use rocketmq_model::codec::string_to_message_properties;
+use rocketmq_model::codec::NAME_VALUE_SEPARATOR;
+use rocketmq_model::codec::PROPERTY_SEPARATOR;
+
+#[test]
+fn properties_round_trip_without_relying_on_serialization_order() {
+    let properties = HashMap::from([
+        (CheetahString::from("topic"), CheetahString::from("orders")),
+        (CheetahString::from("empty"), CheetahString::from("")),
+        (
+            CheetahString::from("description"),
+            CheetahString::from("hello world 世界"),
+        ),
+    ]);
+
+    let serialized = message_properties_to_string(&properties);
+
+    assert_eq!(string_to_message_properties(Some(&serialized)), properties);
+}
+
+#[test]
+fn none_and_empty_property_strings_produce_empty_maps() {
+    let empty = CheetahString::from("");
+
+    assert!(string_to_message_properties(None).is_empty());
+    assert!(string_to_message_properties(Some(&empty)).is_empty());
+}
+
+#[test]
+fn malformed_entries_are_skipped_while_valid_entries_survive() {
+    let input = CheetahString::from(format!(
+        "malformed{PROPERTY_SEPARATOR}{NAME_VALUE_SEPARATOR}empty-name{PROPERTY_SEPARATOR}valid{NAME_VALUE_SEPARATOR}value"
+    ));
+    let expected = HashMap::from([(CheetahString::from("valid"), CheetahString::from("value"))]);
+
+    assert_eq!(string_to_message_properties(Some(&input)), expected);
+}
+
+#[test]
+fn empty_values_final_entries_and_empty_entries_are_preserved_as_defined() {
+    let input = CheetahString::from(format!(
+        "empty{NAME_VALUE_SEPARATOR}{PROPERTY_SEPARATOR}{PROPERTY_SEPARATOR}final{NAME_VALUE_SEPARATOR}value"
+    ));
+    let expected = HashMap::from([
+        (CheetahString::from("empty"), CheetahString::from("")),
+        (CheetahString::from("final"), CheetahString::from("value")),
+    ]);
+
+    assert_eq!(string_to_message_properties(Some(&input)), expected);
+}
+
+#[test]
+fn repeated_names_keep_the_last_value_and_split_only_once() {
+    let input = CheetahString::from(format!(
+        "key{NAME_VALUE_SEPARATOR}first{PROPERTY_SEPARATOR}key{NAME_VALUE_SEPARATOR}second{NAME_VALUE_SEPARATOR}part{PROPERTY_SEPARATOR}"
+    ));
+    let expected = HashMap::from([(CheetahString::from("key"), CheetahString::from("second\u{0001}part"))]);
+
+    assert_eq!(string_to_message_properties(Some(&input)), expected);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10451

### Brief Description

Adds direct contract coverage for property round trips, malformed entries, empty values, repeated keys, and first-separator splitting without depending on map serialization order.

### How Did You Test This Change?

- `cargo test -p rocketmq-model --test property_codec_contracts`
- `cargo fmt -p rocketmq-model -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for message-property serialization and parsing, including round trips, empty inputs, malformed entries, empty values, trailing entries, repeated keys, and separator-containing values.

- **Documentation**
  - Added an unreleased changelog entry documenting the new contract test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->