### PR TITLE
[ISSUE #10454]🧪Restore nonempty attribute serialization coverage in rocketmq-model

### DIFF
--- a/rocketmq-model/src/common/attribute/attribute_parser.rs
+++ b/rocketmq-model/src/common/attribute/attribute_parser.rs
@@ -126,17 +126,26 @@ mod tests {
         assert_eq!(result, "");
     }
 
-    // #[test]
-    // fn test_parse_to_string_valid_map() {
-    //     let mut attributes = HashMap::new();
-    //     attributes.insert("+key1".to_string(), "value1".to_string());
-    //     attributes.insert("+key2".to_string(), "value2".to_string());
-    //     attributes.insert("-key3".to_string(), "".to_string());
-
-    //     let result = AttributeParser::parse_to_string(&attributes);
-    //     assert!(
-    //         result == "+key1=value1,+key2=value2,-key3"
-    //             || result == "+key2=value2,+key1=value1,-key3"
-    //     );
-    // }
+    #[test]
+    fn test_parse_to_string_nonempty_operations_round_trip() {
+        for (operations, mut expected) in [
+            (
+                vec![("+key1", "hello 世界"), ("+key2", "value2"), ("-key3", "")],
+                vec!["+key1=hello 世界", "+key2=value2", "-key3"],
+            ),
+            (vec![("+key1", "hello 世界")], vec!["+key1=hello 世界"]),
+            (vec![("-key3", "")], vec!["-key3"]),
+        ] {
+            let attributes = operations
+                .iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect();
+            let result = AttributeParser::parse_to_string(&attributes);
+            let mut tokens: Vec<_> = result.split(',').collect();
+            tokens.sort_unstable();
+            expected.sort_unstable();
+            assert_eq!(tokens, expected);
+            assert_eq!(AttributeParser::parse_to_map(&result).unwrap(), attributes);
+        }
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10454 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for serializing and deserializing non-empty attribute operation sets.
  * Verified round-trip conversion preserves attribute values across multiple operation combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->