### PR TITLE
[ISSUE #10471]✨Unify persistent Tauri document themes

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/index.html
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/index.html
@@ -1,15 +1,13 @@
-
-  <!DOCTYPE html>
-  <html lang="en">
-    <head>
-      <meta charset="UTF-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>Rocketmq-Rust</title>
-    </head>
-
-    <body>
-      <div id="root"></div>
-      <script type="module" src="/src/main.tsx"></script>
-    </body>
-  </html>
-  
+<!DOCTYPE html>
+<html lang="en" class="dark" data-theme="dark" style="background-color: #171719; color-scheme: dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="/theme.js"></script>
+    <title>RocketMQ-Rust Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/public/theme.js
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/public/theme.js
@@ -1,0 +1,14 @@
+// Runs before styles or React so saved preferences also apply to the first paint.
+(function () {
+  var theme = 'dark';
+  try {
+    if (localStorage.getItem('rocketmq-dashboard-theme') === 'light') theme = 'light';
+  } catch (_) {
+    // A restricted WebView can still use the default theme without persistence.
+  }
+  var root = document.documentElement;
+  root.dataset.theme = theme;
+  root.classList.toggle('dark', theme === 'dark');
+  root.style.colorScheme = theme;
+  root.style.backgroundColor = theme === 'dark' ? '#171719' : '#f5f5f7';
+})();

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
@@ -115,7 +115,7 @@ export const MainLayout = ({children}: MainLayoutProps) => {
     };
 
     return (
-        <div className={`app-shell ${isDark ? 'dark' : ''}`}>
+        <div className="app-shell">
             <Toaster position="bottom-right" theme={isDark ? 'dark' : 'light'}/>
 
             <aside className="app-sidebar">

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/sonner.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/sonner.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useTheme } from "next-themes@0.4.6";
+import { useTheme } from "../../hooks/useTheme";
 import { Toaster as Sonner, ToasterProps } from "sonner@2.0.3";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
+  const { theme } = useTheme();
 
   return (
     <Sonner

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/hooks/useTheme.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/hooks/useTheme.ts
@@ -1,24 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
+import { ThemeStore } from '../stores/theme';
 
 export function useTheme() {
-  const [isDark, setIsDark] = useState(false);
-
-  useEffect(() => {
-    // Check initial preference
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      setIsDark(true);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (isDark) {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-  }, [isDark]);
-
-  const toggleTheme = () => setIsDark(!isDark);
-
-  return { isDark, toggleTheme };
+  const theme = useSyncExternalStore(ThemeStore.subscribe, ThemeStore.getSnapshot, ThemeStore.getServerSnapshot);
+  return { theme, isDark: theme === 'dark', toggleTheme: ThemeStore.toggle, setTheme: ThemeStore.setTheme };
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/main.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/main.tsx
@@ -3,6 +3,7 @@
   import App from "./App.tsx";
   import "./index.css";
   import "./styles/redesign.css";
+  import "./styles/tokens.css";
 
   createRoot(document.getElementById("root")!).render(<App />);
   

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/theme.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/theme.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ThemeStore } from './theme';
+
+const bootstrap = readFileSync(new URL('../../public/theme.js', import.meta.url), 'utf8');
+
+function environment(saved: string | null = null, restricted = false) {
+    const root = { dataset: {} as Record<string, string>, style: {} as Record<string, string>, classList: { toggle: vi.fn() } };
+    const storage = {
+        getItem: vi.fn(() => { if (restricted) throw new Error('Unavailable'); return saved; }),
+        setItem: vi.fn(() => { if (restricted) throw new Error('Unavailable'); }),
+    };
+    const window = { localStorage: storage, addEventListener: vi.fn(), removeEventListener: vi.fn() };
+    const document = { documentElement: root };
+    runInNewContext(bootstrap, { localStorage: storage, document });
+    vi.stubGlobal('document', document);
+    vi.stubGlobal('window', window);
+    return { root, storage, window };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('document theme lifecycle', () => {
+    it.each([null, 'invalid', 'system', 'dark'])('defaults to dark before React for preference %s', saved => {
+        const { root } = environment(saved);
+        expect(ThemeStore.getSnapshot()).toBe('dark');
+        expect(root.style.colorScheme).toBe('dark');
+        expect(root.classList.toggle).toHaveBeenLastCalledWith('dark', true);
+    });
+
+    it('restores an explicit light preference before React subscribes', () => {
+        const { root, storage } = environment('light');
+        expect(ThemeStore.getSnapshot()).toBe('light');
+        expect(root.style.colorScheme).toBe('light');
+        expect(storage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('notifies all mounted theme consumers without remounting them and persists the selection', () => {
+        const { root, storage } = environment();
+        const first = vi.fn();
+        const second = vi.fn();
+        const unsubscribeFirst = ThemeStore.subscribe(first);
+        const unsubscribeSecond = ThemeStore.subscribe(second);
+        try {
+            ThemeStore.toggle();
+            expect(ThemeStore.getSnapshot()).toBe('light');
+            expect(root.classList.toggle).toHaveBeenLastCalledWith('dark', false);
+            expect(first).toHaveBeenCalledTimes(1);
+            expect(second).toHaveBeenCalledTimes(1);
+            expect(storage.setItem).toHaveBeenCalledWith('rocketmq-dashboard-theme', 'light');
+            ThemeStore.toggle();
+            expect(ThemeStore.getSnapshot()).toBe('dark');
+        } finally {
+            unsubscribeFirst();
+            unsubscribeSecond();
+        }
+    });
+
+    it('can start and change theme when preference reads and writes fail', () => {
+        environment(null, true);
+        expect(ThemeStore.getSnapshot()).toBe('dark');
+        expect(() => ThemeStore.toggle()).not.toThrow();
+        expect(ThemeStore.getSnapshot()).toBe('light');
+    });
+
+    it('syncs another window, resets on preference removal, and cleans up the listener', () => {
+        const { window, storage } = environment();
+        const unsubscribe = ThemeStore.subscribe(vi.fn());
+        try {
+            const onStorage = window.addEventListener.mock.calls[0][1] as (event: Partial<StorageEvent>) => void;
+            onStorage({ key: 'unrelated', newValue: 'light' });
+            expect(ThemeStore.getSnapshot()).toBe('dark');
+            onStorage({ key: 'rocketmq-dashboard-theme', newValue: 'light' });
+            expect(ThemeStore.getSnapshot()).toBe('light');
+            onStorage({ key: null, newValue: null });
+            expect(ThemeStore.getSnapshot()).toBe('dark');
+            expect(storage.setItem).not.toHaveBeenCalled();
+        } finally {
+            unsubscribe();
+        }
+        expect(window.removeEventListener).toHaveBeenCalledWith('storage', window.addEventListener.mock.calls[0][1]);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/theme.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/theme.ts
@@ -1,0 +1,49 @@
+export type Theme = 'dark' | 'light';
+
+const storageKey = 'rocketmq-dashboard-theme';
+const listeners = new Set<() => void>();
+
+function getSnapshot(): Theme {
+    return typeof document !== 'undefined' && document.documentElement.dataset.theme === 'light' ? 'light' : 'dark';
+}
+
+function apply(theme: Theme) {
+    const root = document.documentElement;
+    root.dataset.theme = theme;
+    root.classList.toggle('dark', theme === 'dark');
+    root.style.colorScheme = theme;
+    root.style.backgroundColor = theme === 'dark' ? '#171719' : '#f5f5f7';
+    listeners.forEach(listener => listener());
+}
+
+function onStorage(event: StorageEvent) {
+    if (event.key === storageKey || event.key === null) {
+        apply(event.newValue === 'light' ? 'light' : 'dark');
+    }
+}
+
+function subscribe(listener: () => void) {
+    if (listeners.size === 0) window.addEventListener('storage', onStorage);
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) window.removeEventListener('storage', onStorage);
+    };
+}
+
+function setTheme(theme: Theme) {
+    apply(theme);
+    try {
+        window.localStorage.setItem(storageKey, theme);
+    } catch {
+        // The current window remains usable when preference storage is unavailable.
+    }
+}
+
+export const ThemeStore = {
+    getSnapshot,
+    getServerSnapshot: (): Theme => 'dark',
+    subscribe,
+    setTheme,
+    toggle: () => setTheme(getSnapshot() === 'dark' ? 'light' : 'dark'),
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/redesign.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/redesign.css
@@ -32,81 +32,11 @@ body {
 }
 
 .app-shell {
-  --ops-bg: #eef2f7;
-  --ops-panel: #ffffff;
-  --ops-panel-soft: #f8fafc;
-  --ops-panel-strong: #edf3f8;
-  --ops-text: #111827;
-  --ops-muted: #5f6f85;
-  --ops-subtle: #8a99ad;
-  --ops-border: #d7e0ea;
-  --ops-border-strong: #c5d1df;
-  --ops-border-muted: rgba(215, 224, 234, 0.68);
-  --ops-grid-x: rgba(215, 224, 234, 0.34);
-  --ops-grid-y: rgba(215, 224, 234, 0.3);
-  --ops-header-bg: rgba(238, 242, 247, 0.86);
-  --ops-sidebar: #151a21;
-  --ops-sidebar-panel: #1d242d;
-  --ops-sidebar-text: #e9eef5;
-  --ops-sidebar-muted: #9aa8ba;
-  --ops-accent: #0891b2;
-  --ops-accent-strong: #0e7490;
-  --ops-accent-soft: #dff7fb;
-  --ops-accent-border: rgba(8, 145, 178, 0.62);
-  --ops-accent-hover: rgba(223, 247, 251, 0.54);
-  --ops-accent-ring: rgba(8, 145, 178, 0.18);
-  --ops-accent-shadow: rgba(8, 145, 178, 0.24);
-  --ops-success: #047857;
-  --ops-success-soft: #ddf7ef;
-  --ops-warning: #b45309;
-  --ops-warning-soft: #fff3cd;
-  --ops-danger: #be123c;
-  --ops-danger-soft: #ffe4e6;
-  --ops-danger-border: rgba(190, 18, 60, 0.34);
-  --ops-shadow: 0 12px 34px rgba(15, 23, 42, 0.08);
-  --ops-shadow-strong: 0 22px 54px rgba(15, 23, 42, 0.14);
   display: flex;
   height: 100vh;
   overflow: hidden;
   background: var(--ops-bg);
   color: var(--ops-text);
-}
-
-.app-shell.dark {
-  color-scheme: dark;
-  --ops-bg: #0e1116;
-  --ops-panel: #151a21;
-  --ops-panel-soft: #10151c;
-  --ops-panel-strong: #1d242d;
-  --ops-text: #edf2f7;
-  --ops-muted: #a4b0c0;
-  --ops-subtle: #758397;
-  --ops-border: #27313d;
-  --ops-border-strong: #344150;
-  --ops-border-muted: rgba(39, 49, 61, 0.68);
-  --ops-grid-x: rgba(39, 49, 61, 0.34);
-  --ops-grid-y: rgba(39, 49, 61, 0.3);
-  --ops-header-bg: rgba(14, 17, 22, 0.86);
-  --ops-sidebar: #0f1318;
-  --ops-sidebar-panel: #1a2028;
-  --ops-sidebar-text: #f3f6fa;
-  --ops-sidebar-muted: #9aa8ba;
-  --ops-accent: #22d3ee;
-  --ops-accent-strong: #67e8f9;
-  --ops-accent-soft: rgba(34, 211, 238, 0.13);
-  --ops-accent-border: rgba(34, 211, 238, 0.62);
-  --ops-accent-hover: rgba(34, 211, 238, 0.08);
-  --ops-accent-ring: rgba(34, 211, 238, 0.18);
-  --ops-accent-shadow: rgba(34, 211, 238, 0.24);
-  --ops-success: #34d399;
-  --ops-success-soft: rgba(52, 211, 153, 0.14);
-  --ops-warning: #fbbf24;
-  --ops-warning-soft: rgba(251, 191, 36, 0.14);
-  --ops-danger: #fb7185;
-  --ops-danger-soft: rgba(251, 113, 133, 0.15);
-  --ops-danger-border: rgba(251, 113, 133, 0.34);
-  --ops-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
-  --ops-shadow-strong: 0 24px 72px rgba(0, 0, 0, 0.42);
 }
 
 .app-sidebar {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/tokens.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/tokens.css
@@ -1,0 +1,137 @@
+/* Document-scoped tokens also reach Radix portals and authentication screens. */
+:root {
+  color-scheme: dark;
+  --ops-bg: #171719;
+  --ops-sidebar: #202023;
+  --ops-panel: #242427;
+  --ops-panel-soft: #1c1c1f;
+  --ops-panel-strong: #2c2c30;
+  --ops-text: #f5f5f7;
+  --ops-muted: #b0b0b8;
+  --ops-subtle: #9898a3;
+  --ops-border: #38383d;
+  --ops-border-strong: #56565f;
+  --ops-border-muted: #303034;
+  --ops-accent: #0a84ff;
+  --ops-accent-strong: #71b7ff;
+  --ops-accent-soft: #162f49;
+  --ops-accent-border: #275e94;
+  --ops-accent-hover: #1e2c3c;
+  --ops-accent-ring: #71b7ff;
+  --ops-accent-shadow: transparent;
+  --ops-primary-fill: #0065cf;
+  --ops-primary-hover: #0057b5;
+  --ops-success: #30d158;
+  --ops-success-soft: #183822;
+  --ops-warning: #ff9f0a;
+  --ops-warning-soft: #3b2d16;
+  --ops-danger: #ff6961;
+  --ops-danger-soft: #3f2324;
+  --ops-danger-border: #704044;
+  --ops-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+  --ops-shadow-strong: 0 12px 36px rgb(0 0 0 / 28%);
+  --ops-grid-x: transparent;
+  --ops-grid-y: transparent;
+  --ops-header-bg: var(--ops-bg);
+  --ops-sidebar-panel: var(--ops-panel-strong);
+  --ops-sidebar-text: var(--ops-text);
+  --ops-sidebar-muted: var(--ops-muted);
+  --ops-font: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ops-font-mono: ui-monospace, "Cascadia Code", Consolas, monospace;
+  --ops-radius: 12px;
+  --ops-control-radius: 8px;
+  --ops-space: 24px;
+  --ops-control-height: 38px;
+  --ops-row-height: 46px;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --ops-bg: #f5f5f7;
+  --ops-sidebar: #eaeaee;
+  --ops-panel: #ffffff;
+  --ops-panel-soft: #f1f1f4;
+  --ops-panel-strong: #e9e9ee;
+  --ops-text: #1d1d1f;
+  --ops-muted: #606069;
+  --ops-subtle: #686873;
+  --ops-border: #d5d5dc;
+  --ops-border-strong: #b6b6c0;
+  --ops-border-muted: #e3e3e8;
+  --ops-accent: #0065cf;
+  --ops-accent-strong: #0057b5;
+  --ops-accent-soft: #e0efff;
+  --ops-accent-border: #94bce8;
+  --ops-accent-hover: #edf4fc;
+  --ops-accent-ring: #0065cf;
+  --ops-success: #21752f;
+  --ops-success-soft: #e2f2e5;
+  --ops-warning: #875000;
+  --ops-warning-soft: #fff0d8;
+  --ops-danger: #c7352e;
+  --ops-danger-soft: #ffebe9;
+  --ops-danger-border: #e9aba8;
+  --ops-shadow: 0 2px 8px rgb(0 0 0 / 4%);
+  --ops-shadow-strong: 0 12px 36px rgb(0 0 0 / 14%);
+}
+
+/* Bridge existing Radix/Tailwind controls while pages migrate incrementally. */
+:root {
+  --background: var(--ops-bg);
+  --foreground: var(--ops-text);
+  --card: var(--ops-panel);
+  --card-foreground: var(--ops-text);
+  --popover: var(--ops-panel);
+  --popover-foreground: var(--ops-text);
+  --primary: var(--ops-primary-fill);
+  --primary-foreground: #ffffff;
+  --secondary: var(--ops-panel-strong);
+  --secondary-foreground: var(--ops-text);
+  --muted: var(--ops-panel-soft);
+  --muted-foreground: var(--ops-muted);
+  --accent: var(--ops-accent-soft);
+  --accent-foreground: var(--ops-text);
+  --destructive: var(--ops-danger);
+  --destructive-foreground: #ffffff;
+  --border: var(--ops-border);
+  --input: var(--ops-border);
+  --input-background: var(--ops-panel-soft);
+  --switch-background: var(--ops-border-strong);
+  --ring: var(--ops-accent-ring);
+  --radius: var(--ops-radius);
+  --chart-1: var(--ops-accent);
+  --chart-2: var(--ops-success);
+  --chart-3: var(--ops-warning);
+  --chart-4: #bf8aff;
+  --chart-5: #ff719c;
+  --sidebar: var(--ops-sidebar);
+  --sidebar-foreground: var(--ops-text);
+  --sidebar-primary: var(--ops-primary-fill);
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: var(--ops-accent-soft);
+  --sidebar-accent-foreground: var(--ops-text);
+  --sidebar-border: var(--ops-border);
+  --sidebar-ring: var(--ops-accent-ring);
+}
+
+body {
+  background: var(--ops-bg);
+  color: var(--ops-text);
+  font-family: var(--ops-font);
+  -webkit-font-smoothing: antialiased;
+}
+
+:focus-visible {
+  outline: 2px solid var(--ops-accent-ring);
+  outline-offset: 3px;
+}
+
+/* These controls render in portals, outside legacy page-scoped color rules. */
+:where([data-slot="dialog-content"], [data-slot="alert-dialog-content"],
+       [data-slot="sheet-content"], [data-slot="dropdown-menu-content"],
+       [data-slot="dropdown-menu-sub-content"], [data-slot="popover-content"],
+       [data-slot="select-content"]) {
+  background: var(--ops-panel);
+  color: var(--ops-text);
+  border-color: var(--ops-border);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10471

### Brief Description

Initialize the Tauri dashboard theme before React renders, default to the selected graphite palette, and persist explicit dark/light choices. A shared theme store keeps mounted consumers and notifications synchronized while document-level tokens reach portal surfaces.

### How Did You Test This Change?

- `npm run build` passed.
- `npm test -- src/stores/theme.test.ts` passed (8 tests).
- Browser component fixture: dark/light switching, preference restoration after reload, portal colors, and notification colors checked. The fixture isolates colors; shared-control positioning remains part of the subsequent layout work.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent dark and light theme support across the dashboard.
  - The dashboard now starts in dark mode by default and applies the selected theme before the interface loads.
  - Theme preferences are saved and synchronized across open dashboard windows.
  - Added unified styling for dialogs, menus, popovers, selects, and other interface elements.
  - Updated the page title to “RocketMQ-Rust Dashboard.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->