### PR TITLE
[ISSUE #10473]✨Modernize the Tauri navigation shell

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/AppSidebar.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/AppSidebar.tsx
@@ -1,0 +1,42 @@
+import { Moon, Sun, ChevronRight, LogOut, UserRound } from 'lucide-react';
+import rocketLogo from 'rocketmq-rust:asset/rocketmq-rust-logo.png';
+import { useTheme } from '../../hooks/useTheme';
+import { useAppStore } from '../../stores/app.store';
+import { SidebarItem } from '../../components/ui/SidebarItem';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } from '../../components/ui/dropdown-menu';
+import { navigationSections } from './navigation';
+
+export function AppSidebar({ onSignOut, signingOut }: { onSignOut: () => void; signingOut: boolean }) {
+    const { activeTab, currentUser, setActiveTab } = useAppStore();
+    const { isDark, toggleTheme } = useTheme();
+    const username = currentUser?.username ?? 'Account';
+    return <aside className="desktop-sidebar">
+        <div className="desktop-brand"><img src={rocketLogo} alt="" /><strong>RocketMQ-Rust</strong></div>
+        <nav className="desktop-navigation" aria-label="Primary navigation">
+            {navigationSections.map(section => <section key={section.title}>
+                <h2>{section.title}</h2>
+                {section.items.map(item => <SidebarItem key={item.tab} icon={item.icon} label={item.label}
+                    active={activeTab === item.tab} onClick={() => setActiveTab(item.tab)} />)}
+            </section>)}
+        </nav>
+        <div className="desktop-sidebar-footer">
+            <button type="button" className="desktop-theme" onClick={toggleTheme} aria-label="Toggle theme">
+                {isDark ? <Sun /> : <Moon />}<span>Theme</span><ChevronRight />
+            </button>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild><button type="button" className="desktop-account" disabled={signingOut} aria-label="Open account menu">
+                    <span className="desktop-avatar">{username.slice(0, 2).toUpperCase()}</span>
+                    <span><strong>{username}</strong><small>Account</small></span><ChevronRight />
+                </button></DropdownMenuTrigger>
+                <DropdownMenuContent side="top" align="start" sideOffset={8} className="desktop-account-menu">
+                    <DropdownMenuLabel>{username}</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onSelect={() => setActiveTab('Account')}><UserRound />Account settings</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => setActiveTab('Sessions')}>Sessions</DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem variant="destructive" onSelect={onSignOut}><LogOut />Sign out</DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    </aside>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/EnvironmentToolbar.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/EnvironmentToolbar.tsx
@@ -1,0 +1,27 @@
+import { Clock3, Globe, Monitor, RefreshCw } from 'lucide-react';
+import { useAppStore } from '../../stores/app.store';
+import type { ConnectionSettingsView } from '../../services/connection.store';
+import { usePageToolbar } from './pageToolbar';
+
+export function EnvironmentToolbar({ settings }: { settings: ConnectionSettingsView | null }) {
+    const { setActiveTab } = useAppStore();
+    const toolbar = usePageToolbar();
+    const endpoint = settings?.endpoints.find(value => value.endpointId === settings.currentNameserverId);
+    return <header className="desktop-toolbar" aria-label="Environment toolbar">
+        <span className="desktop-environment" title={settings?.environmentId ?? 'No environment selected'}>
+            <Monitor /><span>{settings?.environmentId ? 'Local environment' : 'No environment'}</span>
+        </span>
+        <button type="button" className="desktop-endpoint" onClick={() => setActiveTab('NameServer')}
+            title={endpoint?.address ?? 'Configure a NameServer'}>
+            <Globe /><span>NameServer {endpoint?.address ?? 'not configured'}</span>
+        </button>
+        <div className="desktop-toolbar-status">
+            {toolbar?.refreshedAt != null && <span className="desktop-observed" title="Last successful page refresh">
+                <Clock3 /><time dateTime={new Date(toolbar.refreshedAt).toISOString()}>{new Date(toolbar.refreshedAt).toLocaleTimeString()}</time>
+            </span>}
+            {toolbar && <button type="button" className="desktop-refresh" disabled={toolbar.pending} onClick={toolbar.refresh}>
+                <RefreshCw className={toolbar.pending ? 'is-refreshing' : undefined} /><span>{toolbar.pending ? 'Refreshing…' : 'Refresh'}</span>
+            </button>}
+        </div>
+    </header>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
@@ -1,274 +1,55 @@
-import React, {useState} from 'react';
-import {
-    LayoutDashboard,
-    Settings,
-    Server,
-    Database,
-    MessageSquare,
-    Users,
-    FileText,
-    Shield,
-    Activity,
-    Network,
-    RefreshCw,
-    Moon,
-    Sun,
-    ChevronDown,
-    LogOut,
-    UserRound,
-    CheckCircle2,
-    MonitorDot,
-    ArrowRight
-} from 'lucide-react';
-import {Toaster, toast} from 'sonner@2.0.3';
-import {SidebarItem} from '../../components/ui/SidebarItem';
-import rocketLogo from 'rocketmq-rust:asset/rocketmq-rust-logo.png';
-import {useTheme} from '../../hooks/useTheme';
-import {useAppStore} from '../../stores/app.store';
-import {SignOutConfirmDialog, useAuth} from '../../features/auth';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger
-} from '../../components/ui/dropdown-menu';
+import { useState, useSyncExternalStore, type ReactNode } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { toast } from 'sonner';
+import { Toaster } from '../../components/ui/sonner';
+import { useAppStore } from '../../stores/app.store';
+import { ConnectionStore } from '../../services/connection.store';
+import { SignOutConfirmDialog, useAuth } from '../../features/auth';
+import { AppSidebar } from './AppSidebar';
+import { EnvironmentToolbar } from './EnvironmentToolbar';
+import { PageToolbarProvider } from './pageToolbar';
+import { pageDescriptions } from './navigation';
 
-interface MainLayoutProps {
-    children: React.ReactNode;
-}
-
-const NAV_SECTIONS = [
-    {
-        title: 'Platform',
-        items: [
-            {tab: 'Dashboard', label: 'Dashboard', icon: LayoutDashboard},
-            {tab: 'NameServer', label: 'NameServer', icon: Settings},
-            {tab: 'Proxy', label: 'Proxy', icon: Network},
-            {tab: 'Cluster', label: 'Cluster', icon: Server}
-        ]
-    },
-    {
-        title: 'Messaging',
-        items: [
-            {tab: 'Topic', label: 'Topics', icon: FileText},
-            {tab: 'Consumer', label: 'Consumers', icon: Users},
-            {tab: 'Producer', label: 'Producers', icon: Database},
-            {tab: 'Message', label: 'Messages', icon: MessageSquare},
-            {tab: 'MessageTrace', label: 'Trace', icon: Activity},
-            {tab: 'DLQ', label: 'DLQ Message', icon: RefreshCw}
-        ]
-    },
-    {
-        title: 'Governance',
-        items: [
-            {tab: 'ACL', label: 'ACL', icon: Shield},
-            {tab: 'Storage', label: 'Storage', icon: Database},
-            {tab: 'Monitors', label: 'Monitors', icon: MonitorDot},
-            {tab: 'Audit', label: 'Audit', icon: Shield},
-            {tab: 'Sessions', label: 'Sessions', icon: UserRound}
-        ]
-    }
-] as const;
-
-const PAGE_SUMMARIES: Record<string, string> = {
-    Dashboard: 'Live broker health, throughput trends, topic distribution, and queue pressure.',
-    NameServer: 'Connection endpoints, TLS/VIP posture, and active NameServer selection.',
-    Proxy: 'Proxy endpoint catalog, reachability, and lifecycle controls.',
-    Cluster: 'Broker topology, role details, and operational broker metadata.',
-    Topic: 'Topic catalog, queue topology, permissions, and topic lifecycle actions.',
-    Consumer: 'Consumer groups, subscriptions, retry policy, and client inspection.',
-    Producer: 'Producer group discovery and client connection inventory.',
-    Message: 'Message lookup by topic, key, ID, and time range.',
-    MessageTrace: 'End-to-end trace timeline for produced and consumed messages.',
-    DLQ: 'Dead-letter queue search, retry context, and payload inspection.',
-    ACL: 'Access-control resources, credentials, and permission posture.',
-    Storage: 'Local database and collector diagnostics.',
-    Monitors: 'Environment-scoped Consumer group thresholds.',
-    Audit: 'Operation history, outcomes, and audit receipts.',
-    Sessions: 'Active, expired, and revoked sessions for your account.',
-    Account: 'Local administrator profile, active session, and account security.'
-};
-
-export const MainLayout = ({children}: MainLayoutProps) => {
-    const {isDark, toggleTheme} = useTheme();
-    const {activeTab, currentUser, pageTitle, setActiveTab} = useAppStore();
-    const {logout} = useAuth();
-    const [isAccountMenuOpen, setIsAccountMenuOpen] = useState(false);
-    const [isLogoutDialogOpen, setIsLogoutDialogOpen] = useState(false);
-    const [isLoggingOut, setIsLoggingOut] = useState(false);
-    const initials = (currentUser?.username ?? 'AD').slice(0, 2).toUpperCase();
-    const pageSummary = PAGE_SUMMARIES[activeTab] ?? 'Operational workspace for RocketMQ-Rust.';
-
-    const handleLogout = async () => {
-        setIsLogoutDialogOpen(false);
-        setIsAccountMenuOpen(false);
-        setIsLoggingOut(true);
-
+export function MainLayout({ children }: { children: ReactNode }) {
+    const { activeTab, pageTitle, navigation, canGoBack, goBack } = useAppStore();
+    const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
+    const { logout } = useAuth();
+    const [confirmSignOut, setConfirmSignOut] = useState(false);
+    const [signingOut, setSigningOut] = useState(false);
+    const target = navigation.target;
+    const targetName = target ? ('name' in target ? target.name : target.address) : null;
+    const handleSignOut = async () => {
+        if (signingOut) return;
+        setSigningOut(true);
         try {
             await logout();
-            toast.success('Logged out successfully');
+            toast.success('Signed out');
         } finally {
-            setIsLoggingOut(false);
+            setSigningOut(false);
+            setConfirmSignOut(false);
         }
     };
-
-    return (
-        <div className="app-shell">
-            <Toaster position="bottom-right" theme={isDark ? 'dark' : 'light'}/>
-
-            <aside className="app-sidebar">
-                <div className="app-brand">
-                    <div className="app-brand-mark">
-                        <img src={rocketLogo} alt="RocketMQ-Rust" />
-                    </div>
-                    <div className="app-brand-copy">
-                        <span className="app-brand-name">RocketMQ-Rust</span>
-                        <span className="app-brand-meta">Control plane</span>
-                    </div>
-                </div>
-
-                <nav className="app-nav" aria-label="Primary navigation">
-                    {NAV_SECTIONS.map((section) => (
-                        <div className="app-nav-section" key={section.title}>
-                            <div className="app-nav-section-title">{section.title}</div>
-                            <div className="app-nav-items">
-                                {section.items.map((item) => (
-                                    <SidebarItem
-                                        key={item.tab}
-                                        icon={item.icon}
-                                        label={item.label}
-                                        active={activeTab === item.tab}
-                                        onClick={() => setActiveTab(item.tab)}
-                                    />
-                                ))}
-                            </div>
+    return <PageToolbarProvider scope={navigation.id + ':' + (settings?.revision ?? 0)}>
+        <div className="app-shell desktop-shell">
+            <Toaster position="bottom-right" />
+            <AppSidebar onSignOut={() => setConfirmSignOut(true)} signingOut={signingOut} />
+            <section className="desktop-main">
+                <EnvironmentToolbar settings={settings} />
+                <main className="desktop-content dashboard-main" id="main-content">
+                    <div className="desktop-page-heading">
+                        {canGoBack && <button type="button" className="desktop-back" onClick={goBack} aria-label="Back"><ArrowLeft /></button>}
+                        <div><h1>{pageTitle}</h1><p>{pageDescriptions[activeTab]}</p>
+                            {targetName && <p className="desktop-target" title={targetName}>{target?.kind}: {targetName}</p>}
                         </div>
-                    ))}
-                </nav>
-
-                <div className="app-sidebar-footer">
-                    <button
-                        onClick={toggleTheme}
-                        className="app-sidebar-tool"
-                        title="Theme"
-                        aria-label="Toggle theme"
-                    >
-                        {isDark ? <Sun className="w-4 h-4"/> : <Moon className="w-4 h-4"/>}
-                    </button>
-                    <div className="app-version">
-                        <span>Desktop</span>
-                        <strong>v0.1.0</strong>
                     </div>
-                </div>
-            </aside>
-
-            <section className="app-main">
-                <header className="app-header">
-                    <div className="app-page-heading">
-                        <div className="app-page-kicker">
-                            <span className="app-live-dot" />
-                            Local session
-                        </div>
-                        <h1>{pageTitle}</h1>
-                        <p>{pageSummary}</p>
-                    </div>
-
-                    <div className="app-header-actions">
-                        <div className="app-status-pill">
-                            <Shield className="w-4 h-4" />
-                            <span>Secured</span>
-                        </div>
-                        <DropdownMenu open={isAccountMenuOpen} onOpenChange={setIsAccountMenuOpen}>
-                            <DropdownMenuTrigger asChild>
-                                <button
-                                    className="app-user-trigger"
-                                    disabled={isLoggingOut}
-                                    aria-label="Open account menu"
-                                >
-                                    <span className="app-avatar">{initials}</span>
-                                    <span className="app-user-copy">
-                                        <strong>{currentUser?.username ?? 'Admin'}</strong>
-                                        <span>Account</span>
-                                    </span>
-                                    <ChevronDown
-                                        className={`app-user-chevron ${isAccountMenuOpen ? 'is-open' : ''}`}
-                                    />
-                                </button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent
-                                side="bottom"
-                                align="end"
-                                sideOffset={12}
-                                className="app-account-menu"
-                            >
-                                <DropdownMenuLabel className="app-account-label">
-                                    <div className="app-account-identity">
-                                        <span className="app-account-avatar">{initials}</span>
-                                        <span className="app-account-copy">
-                                            <span className="app-account-name">{currentUser?.username ?? 'Admin'}</span>
-                                            <span className="app-account-subtitle">Local dashboard administrator</span>
-                                        </span>
-                                        <span className="app-account-session-chip">
-                                            <span />
-                                            Active
-                                        </span>
-                                    </div>
-                                </DropdownMenuLabel>
-                                <div className="app-menu-session-card">
-                                    <div>
-                                        <span>Session</span>
-                                        <strong>Local secured session</strong>
-                                    </div>
-                                    <CheckCircle2 className="h-4 w-4" />
-                                </div>
-                                <DropdownMenuSeparator className="app-menu-separator" />
-                                <DropdownMenuItem
-                                    onSelect={() => setActiveTab('Account')}
-                                    className="app-menu-item"
-                                >
-                                    <span className="app-menu-item-icon">
-                                        <UserRound className="h-4 w-4" />
-                                    </span>
-                                    <span className="app-menu-item-copy">
-                                        <span className="app-menu-item-title">View Profile</span>
-                                        <span className="app-menu-item-meta">Account details</span>
-                                    </span>
-                                    <ArrowRight className="app-menu-item-arrow h-4 w-4" />
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                    variant="destructive"
-                                    onSelect={() => setIsLogoutDialogOpen(true)}
-                                    className="app-menu-item app-menu-item-danger"
-                                >
-                                    <span className="app-menu-item-icon">
-                                        <LogOut className="h-4 w-4" />
-                                    </span>
-                                    <span className="app-menu-item-copy">
-                                        <span className="app-menu-item-title">Sign Out</span>
-                                        <span className="app-menu-item-meta">End this workstation session</span>
-                                    </span>
-                                    <MonitorDot className="app-menu-item-arrow h-4 w-4" />
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                    </div>
-                </header>
-
-                <main className="app-content dashboard-main">
                     {children}
                 </main>
-
-                <SignOutConfirmDialog
-                    open={isLogoutDialogOpen}
-                    isSubmitting={isLoggingOut}
-                    title="Sign out of RocketMQ-Rust Dashboard?"
-                    description="This removes the active local session from the current workstation. You can sign back in at any time."
-                    onCancel={() => setIsLogoutDialogOpen(false)}
-                    onConfirm={() => void handleLogout()}
-                />
             </section>
+            <SignOutConfirmDialog open={confirmSignOut} isSubmitting={signingOut}
+                title="Sign out of RocketMQ-Rust Dashboard?"
+                description="This ends the local dashboard session on this workstation."
+                onCancel={() => { if (!signingOut) setConfirmSignOut(false); }}
+                onConfirm={() => void handleSignOut()} />
         </div>
-    );
-};
+    </PageToolbarProvider>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/navigation.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/navigation.ts
@@ -1,0 +1,45 @@
+import { Activity, Database, FileText, Globe, LayoutDashboard, MonitorDot, Network, RefreshCw, Server, Shield, Users, UserRound, MessageSquare, Send, ScrollText } from 'lucide-react';
+import type { Tab } from '../../stores/navigation';
+
+export const navigationSections = [
+    { title: 'Platform', items: [
+        { tab: 'Dashboard', label: 'Dashboard', icon: LayoutDashboard },
+        { tab: 'NameServer', label: 'NameServer', icon: Globe },
+        { tab: 'Proxy', label: 'Proxy', icon: Network },
+        { tab: 'Cluster', label: 'Cluster', icon: Server },
+    ] },
+    { title: 'Messaging', items: [
+        { tab: 'Topic', label: 'Topics', icon: FileText },
+        { tab: 'Consumer', label: 'Consumers', icon: Users },
+        { tab: 'Producer', label: 'Producers', icon: Send },
+        { tab: 'Message', label: 'Messages', icon: MessageSquare },
+        { tab: 'MessageTrace', label: 'Trace', icon: Activity },
+        { tab: 'DLQ', label: 'DLQ Message', icon: RefreshCw },
+    ] },
+    { title: 'Governance', items: [
+        { tab: 'ACL', label: 'ACL', icon: Shield },
+        { tab: 'Storage', label: 'Storage', icon: Database },
+        { tab: 'Monitors', label: 'Monitors', icon: MonitorDot },
+        { tab: 'Audit', label: 'Audit', icon: ScrollText },
+        { tab: 'Sessions', label: 'Sessions', icon: UserRound },
+    ] },
+] as const;
+
+export const pageDescriptions: Record<Tab, string> = {
+    Dashboard: 'Operational overview of your RocketMQ cluster',
+    NameServer: 'Connection endpoints and client settings',
+    Proxy: 'Proxy endpoints and query configuration',
+    Cluster: 'Brokers, runtime status, and configuration',
+    Topic: 'Manage topics, queues, and message operations',
+    Consumer: 'Consumer groups, progress, and client diagnostics',
+    Producer: 'Discover producer groups and inspect connections',
+    Message: 'Find messages by key, ID, or time',
+    MessageTrace: 'Follow message publication and consumption',
+    DLQ: 'Inspect dead-letter messages and resend results',
+    ACL: 'Broker users and resource policies',
+    Storage: 'Local database information and collector diagnostics',
+    Monitors: 'Consumer group thresholds for this environment',
+    Audit: 'Review actions and their recorded outcomes',
+    Sessions: 'Manage your local dashboard sessions',
+    Account: 'Local account details and password settings',
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/pageToolbar.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/pageToolbar.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPageToolbarStore } from './pageToolbar';
+
+describe('page toolbar ownership', () => {
+    it('does not let an old page unmount clear the next refresh action', () => {
+        const store = createPageToolbarStore();
+        const oldRefresh = vi.fn();
+        const currentRefresh = vi.fn();
+        const removeOld = store.register({ refresh: oldRefresh, pending: false });
+        const removeCurrent = store.register({ refresh: currentRefresh, pending: false });
+        removeOld();
+        store.getSnapshot()?.refresh();
+        expect(oldRefresh).not.toHaveBeenCalled();
+        expect(currentRefresh).toHaveBeenCalledTimes(1);
+        removeCurrent();
+        expect(store.getSnapshot()).toBeNull();
+    });
+
+    it('isolates navigation and connection scopes without retaining old refresh state', () => {
+        const oldScope = createPageToolbarStore();
+        oldScope.register({ refresh: vi.fn(), pending: true, refreshedAt: 1000 });
+        const currentScope = createPageToolbarStore();
+        expect(currentScope.getSnapshot()).toBeNull();
+        expect(oldScope.getSnapshot()?.pending).toBe(true);
+    });
+
+    it('publishes refresh state and releases subscriptions', () => {
+        const store = createPageToolbarStore();
+        const listener = vi.fn();
+        const unsubscribe = store.subscribe(listener);
+        const release = store.register({ refresh: vi.fn(), pending: false });
+        expect(listener).toHaveBeenCalledTimes(1);
+        release();
+        expect(listener).toHaveBeenCalledTimes(2);
+        unsubscribe();
+        store.register({ refresh: vi.fn(), pending: true });
+        expect(listener).toHaveBeenCalledTimes(2);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/pageToolbar.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/pageToolbar.tsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, useLayoutEffect, useMemo, useSyncExternalStore, type ReactNode } from 'react';
+
+export interface PageToolbarState {
+    refresh: () => void;
+    pending: boolean;
+    refreshedAt?: number | null;
+}
+
+export function createPageToolbarStore() {
+    let snapshot: PageToolbarState | null = null;
+    let owner: symbol | null = null;
+    const listeners = new Set<() => void>();
+    const notify = () => listeners.forEach(listener => listener());
+    return {
+        getSnapshot: () => snapshot,
+        subscribe: (listener: () => void) => {
+            listeners.add(listener);
+            return () => { listeners.delete(listener); };
+        },
+        register: (value: PageToolbarState) => {
+            const token = Symbol('page-toolbar');
+            owner = token;
+            snapshot = value;
+            notify();
+            return () => {
+                // A delayed unmount cannot remove a newer page's refresh action.
+                if (owner !== token) return;
+                owner = null;
+                snapshot = null;
+                notify();
+            };
+        },
+    };
+}
+
+const ToolbarContext = createContext<ReturnType<typeof createPageToolbarStore> | null>(null);
+
+export function PageToolbarProvider({ scope, children }: { scope: string; children: ReactNode }) {
+    const store = useMemo(createPageToolbarStore, [scope]);
+    return <ToolbarContext.Provider value={store}>{children}</ToolbarContext.Provider>;
+}
+
+/** Register the current page's existing read action, never an unrelated global reload. */
+export function usePageRefresh({ refresh, pending, refreshedAt }: PageToolbarState) {
+    const store = useContext(ToolbarContext);
+    useLayoutEffect(() => store?.register({ refresh, pending, refreshedAt }), [store, refresh, pending, refreshedAt]);
+}
+
+export function usePageToolbar() {
+    const store = useContext(ToolbarContext);
+    return useSyncExternalStore(store?.subscribe ?? (() => () => {}), store?.getSnapshot ?? (() => null), () => null);
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -23,12 +23,9 @@ import {AccountPage} from '../../pages/account/AccountPage';
 
 export const AppRouter = () => {
     const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
-    const { activeTab, navigation, canGoBack, goBack } = useAppStore();
+    const { activeTab, navigation } = useAppStore();
     const key = ['NameServer', 'Proxy', 'Account', 'Sessions', 'Audit'].includes(activeTab) ? activeTab : `${activeTab}:${settings?.revision ?? 0}`;
-    return <><div className="flex items-center gap-3 px-6 py-2">
-        {canGoBack && <button type="button" className="text-sm underline" onClick={goBack}>Back</button>}
-        {navigation.target && <span className="text-sm text-gray-500">{navigation.target.kind}: {'name' in navigation.target ? navigation.target.name : navigation.target.address}</span>}
-    </div><RouteContent key={`${key}:${navigation.id}`} /></>;
+    return <RouteContent key={`${key}:${navigation.id}`} />;
 };
 
 const RouteContent = () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/SidebarItem.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/SidebarItem.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { motion } from 'motion/react';
 
 interface SidebarItemProps {
   icon: React.ElementType;
@@ -10,17 +9,12 @@ interface SidebarItemProps {
 
 export const SidebarItem = ({ icon: Icon, label, active, onClick }: SidebarItemProps) => (
   <button
+    type="button"
     onClick={onClick}
     className={`app-nav-item ${active ? 'is-active' : ''}`}
     aria-current={active ? 'page' : undefined}
   >
     <Icon className="app-nav-icon" />
     <span className="app-nav-label">{label}</span>
-    {active && (
-      <motion.div
-        layoutId="active-indicator"
-        className="app-nav-marker"
-      />
-    )}
   </button>
 );

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/main.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/main.tsx
@@ -4,6 +4,7 @@
   import "./index.css";
   import "./styles/redesign.css";
   import "./styles/tokens.css";
+  import "./styles/shell.css";
 
   createRoot(document.getElementById("root")!).render(<App />);
   

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/shell.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/shell.css
@@ -1,0 +1,61 @@
+.desktop-shell { height: 100dvh; min-height: 0; }
+.desktop-sidebar { display: flex; flex-direction: column; width: 240px; min-width: 240px; background: var(--ops-sidebar); border-right: 1px solid var(--ops-border); }
+.desktop-brand { display: flex; align-items: center; gap: 10px; padding: 20px 18px; min-height: 72px; }
+.desktop-brand img { width: 30px; height: 34px; object-fit: contain; }
+.desktop-brand strong { font-size: 18px; font-weight: 650; letter-spacing: -.4px; }
+.desktop-navigation { flex: 1; min-height: 0; overflow-y: auto; padding: 0 12px 12px; }
+.desktop-navigation section + section { margin-top: 22px; }
+.desktop-navigation h2 { font-size: 12px; font-weight: 400; color: var(--ops-muted); margin: 0 10px 8px; }
+.desktop-navigation .app-nav-item { display: flex; align-items: center; gap: 12px; width: 100%; min-height: 38px; margin: 3px 0; padding: 8px 12px; border: 0; border-radius: 8px; background: transparent; color: var(--ops-text); font-size: 14px; font-weight: 400; cursor: pointer; }
+.desktop-navigation .app-nav-item:hover { background: var(--ops-panel-strong); }
+.desktop-navigation .app-nav-item.is-active { background: var(--ops-primary-fill); color: #fff; }
+.desktop-navigation .app-nav-icon { width: 18px; height: 18px; color: inherit; flex-shrink: 0; }
+.desktop-sidebar-footer { padding: 12px; border-top: 1px solid var(--ops-border); }
+.desktop-theme, .desktop-account { display: flex; align-items: center; gap: 12px; width: 100%; padding: 10px 8px; border: 0; border-radius: 8px; background: transparent; color: var(--ops-text); text-align: left; cursor: pointer; }
+.desktop-theme:hover, .desktop-account:hover { background: var(--ops-panel-strong); }
+.desktop-theme svg, .desktop-account > svg { width: 18px; height: 18px; flex-shrink: 0; }
+.desktop-theme > svg:last-child, .desktop-account > svg:last-child { margin-left: auto; width: 14px; }
+.desktop-account > span:nth-child(2) { min-width: 0; }
+.desktop-account strong { display: block; overflow: hidden; text-overflow: ellipsis; font-size: 14px; }
+.desktop-account small { color: var(--ops-muted); font-size: 12px; }
+.desktop-avatar { display: grid; place-items: center; flex-shrink: 0; width: 34px; height: 34px; border-radius: 50%; background: var(--ops-border-strong); color: var(--ops-text); font-size: 12px; }
+.desktop-main { display: flex; flex-direction: column; flex: 1; min-width: 0; overflow: hidden; }
+.desktop-toolbar { display: flex; align-items: center; gap: 18px; min-height: 56px; padding: 10px 24px; border-bottom: 1px solid var(--ops-border); }
+.desktop-toolbar svg { width: 16px; height: 16px; flex-shrink: 0; }
+.desktop-environment, .desktop-endpoint, .desktop-observed { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+.desktop-environment { flex-shrink: 0; }
+.desktop-endpoint { min-width: 0; border: 0; border-left: 1px solid var(--ops-border); background: transparent; padding-left: 18px; color: var(--ops-muted); cursor: pointer; }
+.desktop-endpoint span { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.desktop-toolbar-status { display: flex; align-items: center; gap: 16px; margin-left: auto; flex-shrink: 0; }
+.desktop-observed { color: var(--ops-muted); font-variant-numeric: tabular-nums; }
+.desktop-refresh { display: flex; align-items: center; justify-content: center; gap: 8px; min-height: 36px; padding: 8px 14px; border: 0; border-radius: 8px; background: var(--ops-primary-fill); color: #fff; font-size: 14px; cursor: pointer; }
+.desktop-refresh:hover { background: var(--ops-primary-hover); }
+.desktop-refresh:disabled { opacity: .6; cursor: default; }
+.desktop-content { flex: 1; min-height: 0; overflow: auto; padding: 24px; }
+.desktop-page-heading { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 24px; }
+.desktop-page-heading > div { min-width: 0; }
+.desktop-page-heading h1 { font-size: 28px; line-height: 1.2; font-weight: 650; letter-spacing: -.5px; margin: 0 0 6px; }
+.desktop-page-heading p { color: var(--ops-muted); font-size: 14px; margin: 0; }
+.desktop-page-heading .desktop-target { margin-top: 8px; overflow-wrap: anywhere; font-family: var(--ops-font-mono); font-size: 12px; }
+.desktop-back { display: grid; place-items: center; width: 30px; height: 32px; border: 0; border-radius: 6px; background: transparent; color: var(--ops-muted); cursor: pointer; flex-shrink: 0; }
+.desktop-back svg { width: 18px; height: 18px; }
+.desktop-back:hover { background: var(--ops-panel); color: var(--ops-text); }
+.desktop-account-menu { width: 218px; padding: 6px; border: 1px solid var(--ops-border); border-radius: 10px; box-shadow: var(--ops-shadow-strong); }
+.desktop-account-menu [data-slot="dropdown-menu-label"] { padding: 8px; font-size: 13px; color: var(--ops-muted); }
+.desktop-account-menu [data-slot="dropdown-menu-item"] { display: flex; gap: 10px; align-items: center; padding: 9px; border-radius: 6px; font-size: 14px; cursor: pointer; }
+.desktop-account-menu [data-slot="dropdown-menu-item"]:focus { background: var(--ops-accent-soft); outline: none; }
+.desktop-account-menu [data-slot="dropdown-menu-item"] svg { width: 16px; height: 16px; }
+.desktop-account-menu [data-variant="destructive"] { color: var(--ops-danger); }
+.desktop-account-menu [data-slot="dropdown-menu-separator"] { height: 1px; margin: 4px; background: var(--ops-border); }
+.is-refreshing { animation: spin 1s linear infinite; }
+@media (max-width: 1100px) { .desktop-environment span, .desktop-observed { display: none; } .desktop-toolbar { gap: 12px; } }
+@media (max-width: 860px) {
+  .desktop-sidebar { width: 184px; min-width: 184px; }
+  .desktop-brand { padding: 16px 12px; gap: 6px; }
+  .desktop-brand strong { font-size: 15px; }
+  .desktop-brand img { width: 24px; }
+  .desktop-content { padding: 18px; }
+  .desktop-toolbar { padding: 10px 18px; }
+  .desktop-navigation .app-nav-item { padding: 8px; gap: 8px; }
+}
+@media (prefers-reduced-motion: reduce) { .is-refreshing { animation: none; } }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10473

### Brief Description

Replace the Tauri shell with grouped graphite navigation, a sidebar account menu, a compact connection toolbar, and a single page heading with entity-aware Back navigation. Remove unsupported secured/health labels. A scoped refresh store prevents a previous page from retaining control of the toolbar.

### How Did You Test This Change?

- `npm run build` passed.
- `npm test -- src/app/layout/pageToolbar.test.ts src/stores/navigation.test.ts src/services/auth-session.test.ts src/services/invoke.test.ts` passed (32 tests).
- Browser shell fixture: Topic to Consumer navigation and Back, current refresh callback, account-menu Sessions navigation, and scrollable sidebar with persistent footer checked.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded sidebar with sectioned navigation, theme controls, account options, and sign-out confirmation.
  * Added an environment toolbar showing the selected environment, NameServer endpoint, refresh time, and refresh status.
  * Added shared page toolbar support for page refresh actions and status updates.
  * Added responsive desktop-shell styling with reduced-motion support.
  * Added descriptive labels for dashboard pages and navigation sections.

* **Bug Fixes**
  * Improved refresh-state handling during navigation and component transitions.
  * Prevented account actions from being triggered while sign-out is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->