### PR TITLE
[ISSUE #10481]✨Redesign Proxy endpoint and Consumer scope management

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_SCOPE.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/CONSUMER_SCOPE.md
@@ -18,6 +18,28 @@ Consumer configuration reads still take a separate direct Broker address. The
 DLQ group picker explicitly uses NameServer discovery. Neither treats a direct
 Broker target as a Proxy scope.
 
+## Proxy settings workflow
+
+The Proxy page separates the current endpoint, the saved endpoint list, and the
+Consumer query mode. Choosing **Use** changes the saved selection without
+changing the mode. **Open Consumers** starts a new catalog entry in the selected
+mode, using the current endpoint identity for Proxy queries. The Consumer page
+labels the actual source; a saved Proxy address alone does not imply Proxy mode.
+
+Proxy refresh reloads connection configuration, not endpoint health. The page
+coalesces configuration reads and rejects stale responses. An external revision
+or a configuration conflict blocks further changes until the user reloads and
+reviews the current settings. Add/delete dialogs preserve the proposed target;
+reviewing settings does not automatically retry a rejected mutation. An accepted
+change keeps its revision and receipt even when the following read fails.
+
+Deleting the current Proxy uses the backend's returned selection (the first
+remaining saved endpoint, or no selection). The confirmation identifies this
+effect. Removing the last endpoint keeps the user's mode preference, disables
+Proxy queries, and offers an explicit switch to NameServer mode. It does not
+stop a Proxy process. Submission disables repeated actions and keeps the dialog
+open until the mutation resolves.
+
 Validation: `cargo test --lib consumer::` from `src-tauri`, and `npm run build`
 plus focused Consumer scope, navigation, and authenticated invocation tests from
 the app root. The development cluster's Proxy is `127.0.0.1:8080`; select it in

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/navigation.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/navigation.ts
@@ -28,7 +28,7 @@ export const navigationSections = [
 export const pageDescriptions: Record<Tab, string> = {
     Dashboard: 'Operational overview of your RocketMQ cluster',
     NameServer: 'Manage routing endpoints and connection settings',
-    Proxy: 'Proxy endpoints and query configuration',
+    Proxy: 'Manage endpoints for scoped Consumer queries',
     Cluster: 'Brokers, runtime status, and configuration',
     Topic: 'Manage topics, queues, and message operations',
     Consumer: 'Consumer groups, progress, and client diagnostics',

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
@@ -250,7 +250,7 @@ const ConsumerCatalog = ({ scope, proxyAddress, changeMode }: { scope: ConsumerQ
           <span>Scope</span>
           <div className="consumer-scope-pills" aria-label="Consumer catalog filter scope">
             <b>Local filters</b>
-            <b>Proxy source</b>
+            <b>{enableProxy ? 'Proxy source' : 'NameServer source'}</b>
           </div>
         </div>
 
@@ -283,7 +283,7 @@ const ConsumerCatalog = ({ scope, proxyAddress, changeMode }: { scope: ConsumerQ
           </div>
 
           <div className="consumer-proxy-control">
-            <span>Proxy</span>
+            <span>{enableProxy ? 'Proxy' : 'Saved Proxy'}</span>
             <span>{proxyAddress ?? 'Not configured'}</span>
             <button type="button" className="underline" onClick={() => setActiveTab('Proxy')}>Configure</button>
           </div>
@@ -291,6 +291,7 @@ const ConsumerCatalog = ({ scope, proxyAddress, changeMode }: { scope: ConsumerQ
           <button
             type="button"
             className={`consumer-proxy-toggle ${enableProxy ? 'is-on' : ''}`}
+            aria-pressed={enableProxy}
             disabled={!proxyAddress && !enableProxy}
             onClick={() => changeMode(enableProxy ? 'name_server' : 'proxy')}
           >

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ProxyView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ProxyView.tsx
@@ -1,253 +1,160 @@
-import React from 'react';
-import { AnimatePresence, motion } from 'motion/react';
-import { Activity, CheckCircle2, Network, Plus, RefreshCw, Server, Trash2 } from 'lucide-react';
-import { toast } from 'sonner@2.0.3';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { ArrowRight, CheckCircle2, Info, Plus, Trash2 } from 'lucide-react';
 import { useProxyCatalog } from '../features/proxy/hooks/useProxyCatalog';
-import { dashboardErrorMessage } from '../services/invoke';
-import { Card } from '../components/ui/LegacyCard';
-import { Button } from '../components/ui/LegacyButton';
-import { Input } from '../components/ui/LegacyInput';
+import { describeProxyChange } from '../features/proxy/proxyController';
+import { resolveConsumerScope } from '../features/consumer/scope';
+import { useAppStore } from '../stores/app.store';
+import { usePageRefresh } from '../app/layout/pageToolbar';
+import { Button } from './ui/LegacyButton';
+import { Input } from './ui/LegacyInput';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './ui/dialog';
+import { PageSection } from './layout/PageSection';
+import { PageState } from './layout/PageState';
+import { StatusBadge } from './layout/StatusBadge';
+import '../features/proxy/proxy.css';
+
+function ProxyAddress({ address }: { address: string }) {
+    return <div className="ops-proxy-address"><span>{address}</span>{address.length > 60 &&
+        <details><summary>View full address</summary><code>{address}</code></details>}</div>;
+}
 
 export const ProxyView = () => {
-    const {
-        snapshot,
-        isLoading,
-        loadError,
-        pendingAction,
-        newAddress,
-        setNewAddress,
-        loadHomePage,
-        addProxy,
-        switchProxy,
-        deleteProxy,
-    } = useProxyCatalog();
+    const { settings, refreshing, refreshedAt, pendingChange, needsReview, loadError, changeError,
+        failedChange, receipt, refresh, submit, dismissChangeError } = useProxyCatalog();
+    const { consumerQueryMode, setConsumerQueryMode, setActiveTab } = useAppStore();
+    const [adding, setAdding] = useState(false);
+    const [newAddress, setNewAddress] = useState('');
+    const [addressError, setAddressError] = useState('');
+    const [deleting, setDeleting] = useState<string | null>(null);
+    const addTrigger = useRef<HTMLButtonElement>(null);
+    const addressInput = useRef<HTMLInputElement>(null);
+    const deleteTrigger = useRef<HTMLButtonElement | null>(null);
+    const busy = pendingChange !== null;
+    const blocked = busy || needsReview || !settings;
+    const proxies = settings?.proxy.proxyAddrList ?? [];
+    const current = settings?.proxy.currentProxyAddr ?? null;
+    const proxyScope = resolveConsumerScope(settings, 'proxy');
+    const scope = resolveConsumerScope(settings, consumerQueryMode);
+    const fallback = proxies.find(address => address !== deleting);
+    const openAdd = useCallback(() => { dismissChangeError(); setAddressError(''); setAdding(true); }, [dismissChangeError]);
+    const actions = useMemo(() => <Button ref={addTrigger} icon={Plus} onClick={openAdd} disabled={busy || !settings}>Add Proxy</Button>, [busy, settings, openAdd]);
+    usePageRefresh({ refresh, pending: refreshing || busy, refreshedAt, actions });
 
-    const proxies = snapshot?.proxyAddrList ?? [];
-    const currentProxy = snapshot?.currentProxyAddr ?? null;
-    const isBusy = pendingAction !== null;
+    const reviewNotice = needsReview && <PageState kind="stale" title="Review changed connection settings"
+        description="Your draft is preserved. Reload the current configuration, review it, then submit the change again."
+        action={<Button variant="outline" onClick={refresh} disabled={refreshing || busy}>{refreshing ? 'Reloading…' : 'Reload settings'}</Button>} />;
+    const actionError = changeError && <PageState kind="error"
+        title={failedChange && !adding && deleting === null ? describeProxyChange(failedChange) : 'Change not completed'} description={changeError} />;
 
-    const handleAsyncAction = async (action: () => Promise<string | undefined>) => {
-        try {
-            const message = await action();
-            if (message) {
-                toast.success(message);
-            }
-        } catch (error) {
-            toast.error(dashboardErrorMessage(error, 'Proxy operation failed'));
-        }
-    };
+    return <div className="ops-proxy">
+        {reviewNotice}
+        {loadError && <PageState kind="error" title={settings ? 'Refresh failed' : 'Could not load Proxy settings'} description={loadError}
+            action={!needsReview && <Button variant="outline" onClick={refresh} disabled={refreshing || busy}>Retry refresh</Button>} />}
+        {!settings && !loadError && <PageState kind="loading" title="Loading Proxy settings" />}
+        {receipt && <div className="ops-proxy-receipt" role="status"><CheckCircle2 aria-hidden="true" />
+            <div><strong>{receipt.message}</strong><p>{describeProxyChange(receipt.change)} · Saved at revision {receipt.revision}.</p></div>
+        </div>}
+        {!adding && deleting === null && changeError && <div>
+            {actionError}
+            {failedChange && <div className="ops-proxy-error-actions">
+                <Button variant="outline" disabled={blocked || refreshing} onClick={() => {
+                    if (failedChange.kind === 'add') { setNewAddress(failedChange.address); setAdding(true); }
+                    else if (failedChange.kind === 'delete') setDeleting(failedChange.address);
+                    else void submit(failedChange);
+                }}>{failedChange.kind === 'switch' ? 'Retry change' : 'Review change'}</Button>
+                <Button variant="ghost" disabled={busy} onClick={dismissChangeError}>Dismiss</Button>
+            </div>}
+        </div>}
 
-    const statusLabel = currentProxy ? 'Configured' : 'Not Set';
-
-    return (
-        <div className="max-w-4xl mx-auto space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div className="bg-white dark:bg-gray-900 rounded-2xl p-5 border border-gray-100 dark:border-gray-800 shadow-sm flex items-center space-x-4">
-                    <div className="w-10 h-10 rounded-full bg-green-50 dark:bg-green-900/30 flex items-center justify-center">
-                        <CheckCircle2 className="w-5 h-5 text-green-600 dark:text-green-400"/>
-                    </div>
-                    <div>
-                        <div className="text-sm text-gray-500 dark:text-gray-400">Stored Proxies</div>
-                        <div className="text-xl font-bold text-gray-900 dark:text-white">{proxies.length}</div>
-                    </div>
-                </div>
-                <div className="bg-white dark:bg-gray-900 rounded-2xl p-5 border border-gray-100 dark:border-gray-800 shadow-sm flex items-center space-x-4">
-                    <div className="w-10 h-10 rounded-full bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center">
-                        <Activity className="w-5 h-5 text-blue-600 dark:text-blue-400"/>
-                    </div>
-                    <div>
-                        <div className="text-sm text-gray-500 dark:text-gray-400">Status</div>
-                        <div className="text-xl font-bold text-gray-900 dark:text-white">{statusLabel}</div>
-                    </div>
-                </div>
-                <div className="bg-white dark:bg-gray-900 rounded-2xl p-5 border border-gray-100 dark:border-gray-800 shadow-sm flex items-center space-x-4">
-                    <div className="w-10 h-10 rounded-full bg-purple-50 dark:bg-purple-900/30 flex items-center justify-center">
-                        <Network className="w-5 h-5 text-purple-600 dark:text-purple-400"/>
-                    </div>
-                    <div>
-                        <div className="text-sm text-gray-500 dark:text-gray-400">Traffic Mode</div>
-                        <div className="text-xl font-bold text-gray-900 dark:text-white">Local Catalog</div>
-                    </div>
-                </div>
+        <PageSection title="Current Proxy" className="ops-proxy-current"
+            description="Used for Consumer queries only when Proxy mode is selected."
+            action={<span className="ops-proxy-revision">Configuration revision <strong>{settings?.revision ?? '—'}</strong></span>}>
+            <div className="ops-proxy-current-value">
+                <ProxyAddress address={settings ? current ?? 'Not selected' : 'Not loaded'} />
+                {current && <StatusBadge tone="accent">{needsReview ? 'Review required' : 'Current'}</StatusBadge>}
             </div>
+        </PageSection>
 
-            <Card
-                title="Proxy Server Address List"
-                description="Manage the local proxy address catalog used by dashboard proxy-aware queries."
-                headerAction={
-                    <Button
-                        variant="outline"
-                        icon={RefreshCw}
-                        onClick={() => void handleAsyncAction(async () => {
-                            await loadHomePage();
-                            return 'Proxy settings reloaded';
-                        })}
-                        disabled={isBusy || isLoading}
-                    >
-                        Refresh
-                    </Button>
-                }
-            >
-                <div className="space-y-8">
-                    {loadError ? (
-                        <div className="flex items-center justify-between gap-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
-                            <span>{loadError}</span>
-                            <Button
-                                variant="outline"
-                                onClick={() => void handleAsyncAction(async () => {
-                                    await loadHomePage();
-                                    return 'Proxy settings reloaded';
-                                })}
-                                disabled={isBusy}
-                                className="shrink-0"
-                            >
-                                Retry
-                            </Button>
-                        </div>
-                    ) : null}
+        <PageSection title="Saved Proxies" description="Manage saved Proxy addresses. Select an endpoint for queries in Proxy mode.">
+            <div className="ops-proxy-table-scroll" tabIndex={0} role="region" aria-label="Saved Proxy endpoints">
+                <table className="ops-proxy-table">
+                    <thead><tr><th scope="col">Proxy address</th><th scope="col">Selection</th><th scope="col">Actions</th></tr></thead>
+                    <tbody>{proxies.map(address => <tr key={address}>
+                        <th scope="row"><ProxyAddress address={address} /></th>
+                        <td><StatusBadge tone={address === current ? 'accent' : 'neutral'}>{address === current ? 'Current' : 'Saved'}</StatusBadge></td>
+                        <td><div className="ops-proxy-row-actions">
+                            {address !== current && <Button disabled={blocked}
+                                aria-label={`Use ${address}`} onClick={() => void submit({ kind: 'switch', address })}>Use</Button>}
+                            <Button variant="outline" className="ops-proxy-delete" icon={Trash2} disabled={blocked}
+                                aria-label={`Delete ${address}`} onClick={event => {
+                                    deleteTrigger.current = event.currentTarget; dismissChangeError(); setDeleting(address);
+                                }}>Delete</Button>
+                        </div></td>
+                    </tr>)}</tbody>
+                </table>
+            </div>
+            {settings && proxies.length === 0 && <PageState kind="empty" title="No saved Proxies"
+                description="Add a host:port endpoint to make Proxy mode available. NameServer mode remains available." />}
+        </PageSection>
 
-                    <div className="bg-gray-50/50 dark:bg-gray-900/50 rounded-xl p-5 border border-gray-100 dark:border-gray-800">
-                        <label className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3 block">Add New Proxy</label>
-                        <div className="flex gap-3">
-                            <div className="flex-1">
-                                <Input
-                                    placeholder="Enter proxy address (e.g. 192.168.1.50:8080)"
-                                    value={newAddress}
-                                    onChange={(event) => setNewAddress(event.target.value)}
-                                    disabled={isBusy}
-                                    className="bg-white dark:bg-gray-800 dark:text-white dark:border-gray-700 shadow-sm"
-                                />
-                            </div>
-                            <Button
-                                onClick={() => void handleAsyncAction(addProxy)}
-                                icon={Plus}
-                                disabled={isBusy}
-                                className="dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
-                            >
-                                {pendingAction === 'add' ? 'Adding...' : 'Add Server'}
-                            </Button>
-                        </div>
-                    </div>
+        <PageSection title="Consumer query scope" description="Choose the mode used when opening Consumers.">
+            <fieldset className="ops-proxy-scope" disabled={blocked}>
+                <legend className="sr-only">Consumer query mode</legend>
+                <label data-selected={consumerQueryMode === 'name_server'}><input type="radio" name="proxy-consumer-mode"
+                    value="name_server" checked={consumerQueryMode === 'name_server'} onChange={() => setConsumerQueryMode('name_server')} />NameServer</label>
+                <label data-selected={consumerQueryMode === 'proxy'} data-disabled={!proxyScope}><input type="radio" name="proxy-consumer-mode"
+                    value="proxy" checked={consumerQueryMode === 'proxy'} disabled={!proxyScope} onChange={() => setConsumerQueryMode('proxy')} />Proxy</label>
+            </fieldset>
+            <p className="ops-proxy-scope-description">{consumerQueryMode === 'proxy'
+                ? 'Consumer queries use the selected Proxy in Proxy mode. Other dashboard queries keep their own scope.'
+                : 'Consumer queries use NameServer discovery. Selecting a saved Proxy does not change this mode.'}</p>
+            {consumerQueryMode === 'proxy' && !proxyScope && <PageState kind="partial" title="Select a Proxy before querying"
+                description="Add or select an endpoint above, or choose NameServer mode." />}
+            <div className="ops-proxy-scope-footer"><Info aria-hidden="true" /><p>Running Info and JStack require NameServer/Broker scope.</p>
+                <Button variant="ghost" className="ops-proxy-open" disabled={blocked || !scope}
+                    onClick={() => setActiveTab('Consumer')}>Open Consumers <ArrowRight aria-hidden="true" /></Button>
+            </div>
+        </PageSection>
+        <p className="ops-proxy-note">Refresh reloads saved configuration. A selected endpoint does not indicate Proxy health.</p>
+        {busy && <p className="ops-proxy-pending" role="status">Saving: {describeProxyChange(pendingChange)}…</p>}
 
-                    <div>
-                        <div className="flex items-center justify-between mb-4">
-                            <h4 className="text-sm font-semibold text-gray-900 dark:text-white">Configured Servers</h4>
-                            <span
-                                className="text-xs text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-full">{proxies.length} total</span>
-                        </div>
-
-                        {isLoading && !snapshot ? (
-                            <div className="rounded-xl border border-gray-100 bg-white px-4 py-8 text-sm text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400">
-                                Loading Proxy settings...
-                            </div>
-                        ) : proxies.length === 0 ? (
-                            <div className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-10 text-center dark:border-gray-800 dark:bg-gray-900">
-                                <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800">
-                                    <Server className="h-5 w-5 text-gray-500 dark:text-gray-400" />
-                                </div>
-                                <div className="text-sm font-medium text-gray-900 dark:text-white">No proxy address configured</div>
-                                <div className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                                    Add a host:port address to make it available for proxy-aware dashboard queries.
-                                </div>
-                            </div>
-                        ) : (
-                            <div className="space-y-3">
-                                <AnimatePresence mode="popLayout">
-                                    {proxies.map((proxy) => {
-                                        const isCurrent = proxy === currentProxy;
-                                        const isSwitching = pendingAction === `switch:${proxy}`;
-                                        const isDeleting = pendingAction === `delete:${proxy}`;
-
-                                        return (
-                                            <motion.div
-                                                layout
-                                                key={proxy}
-                                                initial={{ opacity: 0, y: 10, scale: 0.98 }}
-                                                animate={{ opacity: 1, y: 0, scale: 1 }}
-                                                exit={{ opacity: 0, scale: 0.95, transition: { duration: 0.2 } }}
-                                                transition={{ type: 'spring', stiffness: 500, damping: 30 }}
-                                                className={`group flex items-center justify-between p-4 border rounded-xl hover:border-blue-200 dark:hover:border-blue-800 hover:shadow-md transition-all duration-200 ${
-                                                    isCurrent
-                                                        ? 'bg-blue-50/60 border-blue-100 dark:bg-blue-950/20 dark:border-blue-900/50'
-                                                        : 'bg-white border-gray-100 dark:bg-gray-900 dark:border-gray-800'
-                                                }`}
-                                            >
-                                                <div className="flex min-w-0 items-center space-x-4">
-                                                    <div
-                                                        className={`w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${
-                                                            isCurrent
-                                                                ? 'bg-blue-100 dark:bg-blue-900/40'
-                                                                : 'bg-gray-100 dark:bg-gray-800 group-hover:bg-blue-50 dark:group-hover:bg-blue-900/30'
-                                                        }`}
-                                                    >
-                                                        <Server
-                                                            className={`w-4 h-4 ${
-                                                                isCurrent
-                                                                    ? 'text-blue-600 dark:text-blue-300'
-                                                                    : 'text-gray-500 dark:text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-400'
-                                                            }`}
-                                                        />
-                                                    </div>
-                                                    <div className="min-w-0">
-                                                        <div className="truncate text-sm font-medium text-gray-900 dark:text-white font-mono">
-                                                            {proxy}
-                                                        </div>
-                                                        <div className="mt-0.5 flex items-center text-xs text-gray-500 dark:text-gray-400">
-                                                            <span
-                                                                className={`mr-1.5 h-1.5 w-1.5 rounded-full ${
-                                                                    isCurrent ? 'bg-blue-500' : 'bg-gray-400 dark:bg-gray-500'
-                                                                }`}
-                                                            />
-                                                            {isCurrent ? 'Current proxy address' : 'Stored proxy address'}
-                                                        </div>
-                                                    </div>
-                                                </div>
-
-                                                <div className="flex shrink-0 items-center space-x-2">
-                                                    {isCurrent ? (
-                                                        <span className="inline-flex items-center rounded-full border border-blue-200 bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-200">
-                                                            Current
-                                                        </span>
-                                                    ) : (
-                                                        <Button
-                                                            variant="outline"
-                                                            onClick={() => void handleAsyncAction(() => switchProxy(proxy))}
-                                                            disabled={isBusy}
-                                                            className="h-8 px-3"
-                                                        >
-                                                            {isSwitching ? 'Using...' : 'Use'}
-                                                        </Button>
-                                                    )}
-                                                    <button
-                                                        type="button"
-                                                        onClick={() => void handleAsyncAction(() => deleteProxy(proxy))}
-                                                        disabled={isBusy}
-                                                        className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-rose-200 bg-rose-50 text-rose-600 transition-colors hover:bg-rose-100 hover:border-rose-300 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-200 dark:hover:bg-slate-700 dark:hover:border-rose-500/60"
-                                                        aria-label={`Delete proxy ${proxy}`}
-                                                    >
-                                                        {isDeleting ? (
-                                                            <RefreshCw className="h-4 w-4 animate-spin" />
-                                                        ) : (
-                                                            <Trash2 className="h-4 w-4" />
-                                                        )}
-                                                    </button>
-                                                </div>
-                                            </motion.div>
-                                        );
-                                    })}
-                                </AnimatePresence>
-                            </div>
-                        )}
-                    </div>
-
-                    {currentProxy ? (
-                        <div className="rounded-xl border border-gray-100 bg-gray-50/70 px-4 py-3 text-sm text-gray-600 dark:border-gray-800 dark:bg-gray-900/50 dark:text-gray-300">
-                            Current Proxy:
-                            <span className="ml-2 font-mono font-medium text-gray-900 dark:text-white">{currentProxy}</span>
-                        </div>
-                    ) : null}
-                </div>
-            </Card>
-        </div>
-    );
+        <Dialog open={adding} onOpenChange={open => { if (!busy) setAdding(open); }}>
+            <DialogContent showCloseButton={!busy} onCloseAutoFocus={event => { event.preventDefault(); addTrigger.current?.focus(); }}
+                onEscapeKeyDown={event => { if (busy) event.preventDefault(); }} onInteractOutside={event => { if (busy) event.preventDefault(); }}>
+                <DialogHeader><DialogTitle>Add Proxy</DialogTitle><DialogDescription>Enter one Proxy remoting endpoint in host:port form.</DialogDescription></DialogHeader>
+                <form className="ops-proxy-form" onSubmit={event => {
+                    event.preventDefault(); addressInput.current?.focus();
+                    if (!newAddress.trim()) { setAddressError('Enter a Proxy address.'); return; }
+                    if (blocked) return;
+                    void submit({ kind: 'add', address: newAddress.trim() }).then(saved => { if (saved) { setNewAddress(''); setAdding(false); } });
+                }}>
+                    <Input ref={addressInput} label="Proxy address" placeholder="127.0.0.1:8080" autoComplete="off" value={newAddress}
+                        error={addressError} readOnly={busy} onChange={event => { setNewAddress(event.target.value); setAddressError(''); }} />
+                    <p className="ops-proxy-form-revision">Configuration revision {settings?.revision ?? '—'}</p>
+                    {reviewNotice}{actionError}
+                    {loadError && <p role="alert">{loadError}</p>}
+                    <DialogFooter><Button variant="outline" disabled={busy} onClick={() => setAdding(false)}>Cancel</Button>
+                        <Button type="submit" disabled={blocked}>{busy ? 'Saving…' : 'Add endpoint'}</Button></DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+        <Dialog open={deleting !== null} onOpenChange={open => { if (!open && !busy) setDeleting(null); }}>
+            <DialogContent showCloseButton={!busy} onCloseAutoFocus={event => {
+                event.preventDefault(); (deleteTrigger.current?.isConnected ? deleteTrigger.current : addTrigger.current)?.focus();
+            }} onEscapeKeyDown={event => { if (busy) event.preventDefault(); }} onInteractOutside={event => { if (busy) event.preventDefault(); }}>
+                <DialogHeader><DialogTitle>Delete saved Proxy?</DialogTitle><DialogDescription>This removes the address from this dashboard. It does not stop the Proxy.</DialogDescription></DialogHeader>
+                <p className="ops-proxy-delete-address">{deleting}</p>
+                {deleting !== null && deleting === current && <PageState kind="partial" title="This is the selected Proxy"
+                    description={fallback ? <>Subsequent Proxy queries will use <span className="ops-proxy-delete-address">{fallback}</span>.</>
+                        : 'No Proxy will remain selected. Proxy queries will require a new endpoint; the query mode will not change automatically.'} />}
+                {deleting !== null && !proxies.includes(deleting) && <PageState kind="partial" title="This endpoint is no longer saved" description="Close this dialog and review the current list." />}
+                {reviewNotice}{actionError}
+                <DialogFooter><Button variant="outline" autoFocus disabled={busy} onClick={() => setDeleting(null)}>Cancel</Button>
+                    <Button variant="danger" disabled={blocked || deleting === null || !proxies.includes(deleting)} onClick={event => {
+                        event.currentTarget.closest<HTMLElement>('[role="dialog"]')?.focus();
+                        if (deleting !== null) void submit({ kind: 'delete', address: deleting }).then(saved => { if (saved) setDeleting(null); });
+                    }}>{busy ? 'Deleting…' : 'Delete endpoint'}</Button></DialogFooter>
+            </DialogContent>
+        </Dialog>
+    </div>;
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/hooks/useProxyCatalog.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/hooks/useProxyCatalog.ts
@@ -1,110 +1,22 @@
-import { useCallback, useEffect, useState } from 'react';
-import { ProxyService } from '../../../services/proxy.service';
-import { dashboardErrorMessage } from '../../../services/invoke';
-import type { ProxyHomePageInfo } from '../types/proxy.types';
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
+import { ConnectionStore } from '../../../services/connection.store';
+import { createProxyController } from '../proxyController';
 
 export const useProxyCatalog = () => {
-    const [snapshot, setSnapshot] = useState<ProxyHomePageInfo | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [loadError, setLoadError] = useState('');
-    const [pendingAction, setPendingAction] = useState<string | null>(null);
-    const [newAddress, setNewAddress] = useState('');
-
-    const loadHomePage = useCallback(async () => {
-        try {
-            const nextSnapshot = await ProxyService.getHomePageInfo();
-            setSnapshot(nextSnapshot);
-            setLoadError('');
-            return nextSnapshot;
-        } catch (error) {
-            const errorMessage = dashboardErrorMessage(error, 'Proxy operation failed');
-            setLoadError(errorMessage);
-            throw error;
-        }
-    }, []);
-
+    const controller = useMemo(createProxyController, []);
+    const state = useSyncExternalStore(controller.subscribe, controller.getSnapshot, controller.getSnapshot);
+    const shared = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
     useEffect(() => {
-        let isMounted = true;
-
-        const loadInitialState = async () => {
-            try {
-                await loadHomePage();
-            } catch (error) {
-                if (isMounted) {
-                    setLoadError(dashboardErrorMessage(error, 'Proxy operation failed'));
-                }
-            } finally {
-                if (isMounted) {
-                    setIsLoading(false);
-                }
-            }
-        };
-
-        void loadInitialState();
-
-        return () => {
-            isMounted = false;
-        };
-    }, [loadHomePage]);
-
-    const addProxy = async () => {
-        const address = newAddress.trim();
-        if (!address) {
-            throw new Error('Please enter a valid Proxy address');
-        }
-
-        setPendingAction('add');
-
-        try {
-            const result = await ProxyService.addProxyAddr(address, snapshot?.settings.revision ?? -1);
-            setSnapshot({ ...result.settings.proxy, settings: result.settings });
-            setNewAddress('');
-            return result.message;
-        } catch (error) {
-            throw error;
-        } finally {
-            setPendingAction(null);
-        }
-    };
-
-    const switchProxy = async (address: string) => {
-        setPendingAction(`switch:${address}`);
-
-        try {
-            const result = await ProxyService.switchProxyAddr(address, snapshot?.settings.revision ?? -1);
-            setSnapshot({ ...result.settings.proxy, settings: result.settings });
-            return result.message;
-        } catch (error) {
-            throw error;
-        } finally {
-            setPendingAction(null);
-        }
-    };
-
-    const deleteProxy = async (address: string) => {
-        setPendingAction(`delete:${address}`);
-
-        try {
-            const result = await ProxyService.deleteProxyAddr(address, snapshot?.settings.revision ?? -1);
-            setSnapshot({ ...result.settings.proxy, settings: result.settings });
-            return result.message;
-        } catch (error) {
-            throw error;
-        } finally {
-            setPendingAction(null);
-        }
-    };
-
-    return {
-        snapshot,
-        isLoading,
-        loadError,
-        pendingAction,
-        newAddress,
-        setNewAddress,
-        loadHomePage,
-        addProxy,
-        switchProxy,
-        deleteProxy,
-    };
+        controller.start();
+        void controller.refresh();
+        const interval = window.setInterval(() => { void controller.refresh(); }, 5_000);
+        return () => { window.clearInterval(interval); controller.stop(); };
+    }, [controller]);
+    useEffect(() => {
+        controller.observeRevision(shared?.revision);
+    }, [controller, shared?.revision, state.settings?.revision, state.pendingChange]);
+    const refresh = useCallback(() => { void controller.refresh(true); }, [controller]);
+    const externalChange = Boolean(shared && state.settings && shared.revision > state.settings.revision && !state.pendingChange);
+    return { ...state, needsReview: state.needsReview || externalChange, refresh,
+        submit: controller.submit, dismissChangeError: controller.dismissChangeError };
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/proxy.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/proxy.css
@@ -1,0 +1,49 @@
+.ops-proxy { display: flex; flex-direction: column; gap: 22px; min-width: 0; }
+.ops-proxy .ops-page-section { padding: 18px; }
+.ops-proxy .ops-section-header { margin-bottom: 16px; }
+.ops-proxy-revision { color: var(--ops-muted); font-size: 12px; white-space: nowrap; }
+.ops-proxy-revision strong { color: var(--ops-text); font-weight: 500; margin-left: 8px; font-variant-numeric: tabular-nums; }
+.ops-proxy-current-value { display: flex; align-items: center; flex-wrap: wrap; gap: 16px; min-width: 0; }
+.ops-proxy-address { min-width: 0; max-width: 100%; font-family: var(--ops-font-mono); font-size: 14px; }
+.ops-proxy-address > span { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; overflow-wrap: anywhere; }
+.ops-proxy-current-value > .ops-proxy-address { font-family: inherit; font-size: 26px; line-height: 1.3; font-weight: 600; }
+.ops-proxy-address details { margin-top: 8px; font-family: var(--ops-font); font-size: 12px; line-height: 1.5; font-weight: 400; }
+.ops-proxy-address summary { color: var(--ops-accent-strong); cursor: pointer; }
+.ops-proxy-address code { display: block; max-height: 120px; overflow: auto; overflow-wrap: anywhere; margin-top: 8px; font-family: var(--ops-font-mono); }
+.ops-proxy .ops-status-badge { font-size: 13px; padding: 4px 10px; }
+.ops-proxy-table-scroll { position: relative; overflow: auto; border: 1px solid var(--ops-border); border-radius: 8px; }
+.ops-proxy-table { width: 100%; table-layout: fixed; border-collapse: collapse; font-size: 14px; }
+.ops-proxy-table th, .ops-proxy-table td { padding: 12px 16px; border-bottom: 1px solid var(--ops-border); text-align: left; vertical-align: middle; }
+.ops-proxy-table thead th { background: var(--ops-panel-strong); color: var(--ops-muted); font-weight: 400; }
+.ops-proxy-table thead th:first-child { width: 44%; }
+.ops-proxy-table thead th:nth-child(2) { width: 26%; }
+.ops-proxy-table tbody th { font-weight: 400; background: transparent; }
+.ops-proxy-table tbody tr:last-child > * { border-bottom: 0; }
+.ops-proxy-row-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+.ops-proxy-row-actions .ops-proxy-delete { color: var(--ops-danger); border-color: var(--ops-danger); }
+.ops-proxy-scope { position: relative; display: flex; width: 380px; max-width: 100%; padding: 3px; border: 1px solid var(--ops-border-strong); border-radius: 8px; background: var(--ops-panel-soft); }
+.ops-proxy-scope label { position: relative; flex: 1; padding: 9px 16px; border-radius: 6px; font-size: 14px; text-align: center; color: var(--ops-muted); cursor: pointer; }
+.ops-proxy-scope label[data-selected="true"] { background: var(--ops-primary-fill); color: #fff; }
+.ops-proxy-scope label[data-disabled="true"], .ops-proxy-scope:disabled label { opacity: .55; cursor: default; }
+.ops-proxy-scope label:focus-within { outline: 2px solid var(--ops-accent-ring); outline-offset: 2px; }
+.ops-proxy-scope input { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); }
+.ops-proxy-scope-description { color: var(--ops-muted); font-size: 14px; line-height: 1.6; margin: 16px 0 20px; }
+.ops-proxy-scope-footer { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; border-top: 1px solid var(--ops-border); padding-top: 16px; }
+.ops-proxy-scope-footer > svg, .ops-proxy-receipt > svg { width: 20px; height: 20px; flex-shrink: 0; color: var(--ops-accent-strong); }
+.ops-proxy-scope-footer p { color: var(--ops-muted); font-size: 13px; margin: 0; flex: 1; }
+.ops-proxy-scope-footer .ops-proxy-open { color: var(--ops-accent-strong); margin-left: auto; }
+.ops-proxy-receipt { display: flex; align-items: center; gap: 12px; padding: 16px 18px; border: 1px solid var(--ops-border); border-radius: 10px; background: var(--ops-panel); font-size: 13px; }
+.ops-proxy-receipt > svg { color: var(--ops-success); }
+.ops-proxy-receipt > div { min-width: 0; overflow-wrap: anywhere; }
+.ops-proxy-receipt strong { font-size: 13px; font-weight: 500; }
+.ops-proxy-receipt p { margin: 4px 0 0; color: var(--ops-muted); }
+.ops-proxy-form { display: grid; gap: 16px; min-width: 0; }
+.ops-proxy-delete-address { overflow-wrap: anywhere; font-family: var(--ops-font-mono); font-size: 13px; }
+.ops-proxy-form-revision, .ops-proxy-note, .ops-proxy-pending { color: var(--ops-muted); font-size: 13px; }
+.ops-proxy-note { margin: 0; line-height: 1.5; }
+.ops-proxy-error-actions { display: flex; gap: 8px; margin-top: 8px; }
+@media (max-width: 1000px) {
+    .ops-proxy-table { min-width: 620px; }
+    .ops-proxy-current-value > .ops-proxy-address { font-size: 22px; }
+    .ops-proxy-scope-footer .ops-proxy-open { margin-left: 28px; }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/proxyController.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/proxyController.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { createProxyController } from './proxyController';
+import type { ConnectionSettingsView } from '../../services/connection.store';
+import type { ProxyHomePageInfo, ProxyMutationResult } from './types/proxy.types';
+import { DashboardClientError } from '../../services/invoke';
+import { resolveConsumerScope } from '../consumer/scope';
+
+function settings(revision = 1, current: string | null = 'a:8080'): ConnectionSettingsView {
+    const addresses = current === null ? [] : ['a:8080', 'b:8080'];
+    return { revision, credentialsConfigured: false, currentNameserverId: null, environmentId: 'env-a',
+        nameserver: { currentNamesrv: null, namesrvAddrList: [], useTLS: false, useVIPChannel: false },
+        currentProxyId: current, proxy: { currentProxyAddr: current, proxyAddrList: addresses },
+        endpoints: addresses.map(address => ({ endpointId: address, kind: 'proxy', address, environmentId: null })) };
+}
+function home(revision = 1): ProxyHomePageInfo {
+    const config = settings(revision);
+    return { ...config.proxy, settings: config };
+}
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+    return { promise, resolve, reject };
+}
+function setup() {
+    const service = {
+        getHomePageInfo: vi.fn<() => Promise<ProxyHomePageInfo>>().mockResolvedValue(home()),
+        addProxyAddr: vi.fn<(address: string, revision: number) => Promise<ProxyMutationResult>>(),
+        switchProxyAddr: vi.fn<(address: string, revision: number) => Promise<ProxyMutationResult>>(),
+        deleteProxyAddr: vi.fn<(address: string, revision: number) => Promise<ProxyMutationResult>>(),
+    };
+    const controller = createProxyController(service);
+    controller.start();
+    return { service, controller };
+}
+const conflict = () => new DashboardClientError({ code: 'dashboard.configuration_conflict', message: 'Settings changed.', category: 'validation', retryable: false });
+afterEach(() => vi.restoreAllMocks());
+
+it('coalesces overlapping configuration refreshes', async () => {
+    const { controller, service } = setup();
+    const pending = deferred<ProxyHomePageInfo>();
+    service.getHomePageInfo.mockReturnValue(pending.promise);
+    const first = controller.refresh();
+    expect(controller.refresh(true)).toBe(first);
+    await Promise.resolve();
+    expect(service.getHomePageInfo).toHaveBeenCalledTimes(1);
+    pending.resolve(home());
+    expect(await first).toBe(true);
+    expect(controller.getSnapshot()).toMatchObject({ settings: { revision: 1 }, refreshing: false });
+});
+
+it('preserves configuration and its observation time after refresh failure without exposing raw errors', async () => {
+    const { controller, service } = setup();
+    vi.spyOn(Date, 'now').mockReturnValue(100);
+    await controller.refresh();
+    service.getHomePageInfo.mockRejectedValue(new Error('secret details'));
+    expect(await controller.refresh()).toBe(false);
+    expect(controller.getSnapshot()).toMatchObject({ refreshedAt: 100, settings: { revision: 1 }, loadError: 'Could not refresh Proxy settings.' });
+});
+
+it('does not let an old read undo a newer shared revision requiring review', async () => {
+    const { controller, service } = setup();
+    await controller.refresh();
+    const pending = deferred<ProxyHomePageInfo>();
+    service.getHomePageInfo.mockReturnValueOnce(pending.promise).mockResolvedValue(home(2));
+    const old = controller.refresh();
+    await Promise.resolve();
+    controller.observeRevision(2);
+    expect(await controller.submit({ kind: 'delete', address: 'a:8080' })).toBe(false);
+    pending.resolve(home());
+    expect(await old).toBe(false);
+    expect(controller.getSnapshot()).toMatchObject({ settings: { revision: 1 }, needsReview: true, refreshedAt: null });
+    expect(await controller.refresh(true)).toBe(true);
+    expect(controller.getSnapshot()).toMatchObject({ settings: { revision: 2 }, needsReview: false });
+    expect(service.deleteProxyAddr).not.toHaveBeenCalled();
+});
+
+it('keeps a conflicted intention until explicit retry at the reviewed revision', async () => {
+    const { controller, service } = setup();
+    await controller.refresh();
+    const change = { kind: 'add', address: 'new:8080' } as const;
+    service.addProxyAddr.mockRejectedValueOnce(conflict()).mockResolvedValueOnce({ message: 'Saved', settings: settings(3) });
+    expect(await controller.submit(change)).toBe(false);
+    expect(controller.getSnapshot()).toMatchObject({ failedChange: change, needsReview: true, settings: { revision: 1 } });
+    service.getHomePageInfo.mockResolvedValue(home(2));
+    await controller.refresh(true);
+    expect(controller.getSnapshot().failedChange).toEqual(change);
+    expect(service.addProxyAddr).toHaveBeenCalledTimes(1);
+    expect(await controller.submit(change)).toBe(true);
+    expect(service.addProxyAddr.mock.calls).toEqual([['new:8080', 1], ['new:8080', 2]]);
+});
+
+it('retains a successful selection and its scoped endpoint when readback fails', async () => {
+    const { controller, service } = setup();
+    await controller.refresh();
+    service.switchProxyAddr.mockResolvedValue({ message: 'Selected', settings: settings(2, 'b:8080') });
+    service.getHomePageInfo.mockRejectedValue(new Error('unavailable'));
+    expect(await controller.submit({ kind: 'switch', address: 'b:8080' })).toBe(true);
+    await controller.refresh();
+    expect(controller.getSnapshot()).toMatchObject({ settings: { revision: 2 }, receipt: { revision: 2, message: 'Selected' }, changeError: '', refreshedAt: null });
+    expect(resolveConsumerScope(controller.getSnapshot().settings, 'proxy')).toEqual({ mode: 'proxy', endpointId: 'b:8080' });
+});
+
+it('serializes writes and invalidates a read that started before a mutation', async () => {
+    const { controller, service } = setup();
+    await controller.refresh();
+    const oldRead = deferred<ProxyHomePageInfo>();
+    service.getHomePageInfo.mockReturnValueOnce(oldRead.promise).mockResolvedValue(home(2));
+    const reading = controller.refresh();
+    await Promise.resolve();
+    const pending = deferred<ProxyMutationResult>();
+    service.deleteProxyAddr.mockReturnValue(pending.promise);
+    const writing = controller.submit({ kind: 'delete', address: 'b:8080' });
+    expect(await controller.submit({ kind: 'delete', address: 'b:8080' })).toBe(false);
+    expect(await controller.refresh()).toBe(false);
+    oldRead.resolve(home());
+    expect(await reading).toBe(false);
+    pending.resolve({ message: 'Deleted', settings: settings(2) });
+    expect(await writing).toBe(true);
+    expect(service.deleteProxyAddr).toHaveBeenCalledExactlyOnceWith('b:8080', 1);
+});
+
+it('preserves the accepted receipt if another revision arrives during the write', async () => {
+    const { controller, service } = setup();
+    await controller.refresh();
+    const pending = deferred<ProxyMutationResult>();
+    service.switchProxyAddr.mockReturnValue(pending.promise);
+    const writing = controller.submit({ kind: 'switch', address: 'b:8080' });
+    controller.observeRevision(3);
+    pending.resolve({ message: 'Selected', settings: settings(2, 'b:8080') });
+    expect(await writing).toBe(true);
+    expect(controller.getSnapshot()).toMatchObject({ receipt: { revision: 2 }, needsReview: true, settings: { revision: 2 } });
+    expect(service.getHomePageInfo).toHaveBeenCalledTimes(1);
+});
+
+it('uses the backend fallback after deleting a selected Proxy and allows an empty catalog', async () => {
+    const { controller, service } = setup();
+    await controller.refresh();
+    const fallback = settings(2, 'b:8080');
+    fallback.proxy.proxyAddrList = ['b:8080'];
+    service.deleteProxyAddr.mockResolvedValueOnce({ message: 'Deleted', settings: fallback }).mockResolvedValueOnce({ message: 'Deleted', settings: settings(3, null) });
+    service.getHomePageInfo.mockResolvedValueOnce({ settings: fallback, ...fallback.proxy });
+    await controller.submit({ kind: 'delete', address: 'a:8080' });
+    await controller.refresh();
+    expect(resolveConsumerScope(controller.getSnapshot().settings, 'proxy')).toEqual({ mode: 'proxy', endpointId: 'b:8080' });
+    await controller.submit({ kind: 'delete', address: 'b:8080' });
+    expect(resolveConsumerScope(controller.getSnapshot().settings, 'proxy')).toBeNull();
+    expect(resolveConsumerScope(controller.getSnapshot().settings, 'name_server')).toEqual({ mode: 'name_server' });
+});
+
+it('ignores late callbacks after disposal and supports Strict Mode restart', async () => {
+    const { controller, service } = setup();
+    const oldRead = deferred<ProxyHomePageInfo>();
+    service.getHomePageInfo.mockReturnValueOnce(oldRead.promise).mockResolvedValue(home(2));
+    const old = controller.refresh();
+    await Promise.resolve();
+    controller.stop();
+    controller.start();
+    const current = controller.refresh();
+    oldRead.reject(new Error('old'));
+    expect(await old).toBe(false);
+    expect(await current).toBe(true);
+    expect(controller.getSnapshot()).toMatchObject({ settings: { revision: 2 }, loadError: '' });
+});
+
+it('does not dispatch a read stopped before the first microtask', async () => {
+    const { controller, service } = setup();
+    const pending = controller.refresh();
+    controller.stop();
+    expect(await pending).toBe(false);
+    expect(service.getHomePageInfo).not.toHaveBeenCalled();
+});
+
+it('does not apply a late mutation receipt to an unmounted page', async () => {
+    const { controller, service } = setup();
+    await controller.refresh();
+    const pending = deferred<ProxyMutationResult>();
+    service.addProxyAddr.mockReturnValue(pending.promise);
+    const writing = controller.submit({ kind: 'add', address: 'b:8080' });
+    controller.stop();
+    const stopped = controller.getSnapshot();
+    pending.resolve({ message: 'Added', settings: settings(2) });
+    expect(await writing).toBe(false);
+    expect(controller.getSnapshot()).toBe(stopped);
+    expect(service.getHomePageInfo).toHaveBeenCalledTimes(1);
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/proxyController.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/proxy/proxyController.ts
@@ -1,0 +1,137 @@
+import type { ConnectionSettingsView } from '../../services/connection.store';
+import { dashboardErrorMessage, isDashboardClientError } from '../../services/invoke';
+import { ProxyService } from '../../services/proxy.service';
+
+export interface ProxyChange {
+    readonly kind: 'add' | 'switch' | 'delete';
+    readonly address: string;
+}
+
+interface ProxyState {
+    settings: ConnectionSettingsView | null;
+    refreshing: boolean;
+    refreshedAt: number | null;
+    pendingChange: ProxyChange | null;
+    needsReview: boolean;
+    loadError: string;
+    changeError: string;
+    failedChange: ProxyChange | null;
+    receipt: { change: ProxyChange; message: string; revision: number } | null;
+}
+
+const isConflict = (error: unknown) =>
+    isDashboardClientError(error) && error.code === 'dashboard.configuration_conflict';
+
+export function describeProxyChange(change: ProxyChange): string {
+    const verbs = { add: 'Add', switch: 'Use', delete: 'Delete' };
+    return `${verbs[change.kind]} ${change.address}`;
+}
+
+/** The catalog owns configuration reads; it does not probe Proxy health. */
+export function createProxyController(service: Omit<typeof ProxyService, 'prototype'> = ProxyService) {
+    let state: ProxyState = { settings: null, refreshing: false, refreshedAt: null,
+        pendingChange: null, needsReview: false, loadError: '', changeError: '', failedChange: null, receipt: null };
+    const listeners = new Set<() => void>();
+    let active = false;
+    let generation = 0;
+    let knownRevision = -1;
+    let reading: Promise<boolean> | null = null;
+    const publish = (patch: Partial<ProxyState>) => {
+        state = { ...state, ...patch };
+        listeners.forEach(listener => listener());
+    };
+    const observeRevision = (revision: number | undefined) => {
+        if (revision === undefined) return;
+        knownRevision = Math.max(knownRevision, revision);
+        if (active && state.settings && knownRevision > state.settings.revision && !state.pendingChange && !state.needsReview) {
+            publish({ needsReview: true, refreshedAt: null });
+        }
+    };
+
+    const refresh = (review = false): Promise<boolean> => {
+        if (!active || state.pendingChange || (state.needsReview && !review)) return Promise.resolve(false);
+        if (reading) return reading;
+        const request = ++generation;
+        publish({ refreshing: true });
+        reading = (async () => {
+            await Promise.resolve();
+            if (!active || request !== generation) return false;
+            try {
+                const result = await service.getHomePageInfo();
+                if (!active || request !== generation) return false;
+                const revision = result.settings.revision;
+                if (revision < knownRevision || (!review && state.settings && revision !== state.settings.revision)) {
+                    observeRevision(revision);
+                    publish({ needsReview: true, refreshedAt: null, loadError: '' });
+                    return false;
+                }
+                knownRevision = revision;
+                publish({ settings: result.settings, refreshedAt: Date.now(), needsReview: false, loadError: '' });
+                return true;
+            } catch (error) {
+                if (active && request === generation) publish({
+                    loadError: dashboardErrorMessage(error, 'Could not refresh Proxy settings.'),
+                    ...(isConflict(error) ? { needsReview: true, refreshedAt: null } : {}),
+                });
+                return false;
+            } finally {
+                if (active && request === generation) {
+                    reading = null;
+                    publish({ refreshing: false });
+                }
+            }
+        })();
+        return reading;
+    };
+
+    const submit = async (change: ProxyChange): Promise<boolean> => {
+        if (!active || !state.settings || state.pendingChange || state.needsReview) return false;
+        const revision = state.settings.revision;
+        const request = ++generation;
+        reading = null;
+        publish({ pendingChange: change, refreshing: false, changeError: '', failedChange: null });
+        try {
+            const result = await (() => {
+                switch (change.kind) {
+                    case 'add': return service.addProxyAddr(change.address, revision);
+                    case 'switch': return service.switchProxyAddr(change.address, revision);
+                    case 'delete': return service.deleteProxyAddr(change.address, revision);
+                }
+            })();
+            if (!active || request !== generation) return false;
+            knownRevision = Math.max(knownRevision, result.settings.revision);
+            publish({
+                settings: result.settings, pendingChange: null, refreshedAt: null, loadError: '',
+                needsReview: result.settings.revision < knownRevision,
+                receipt: { change, message: result.message, revision: result.settings.revision },
+            });
+            // The accepted snapshot and receipt remain visible if this read fails.
+            void refresh();
+            return true;
+        } catch (error) {
+            if (active && request === generation) publish({
+                pendingChange: null, failedChange: change,
+                changeError: dashboardErrorMessage(error, 'The Proxy change could not be completed.'),
+                needsReview: isConflict(error) || knownRevision > revision,
+            });
+            return false;
+        }
+    };
+
+    return {
+        getSnapshot: () => state,
+        subscribe: (listener: () => void) => {
+            listeners.add(listener);
+            return () => { listeners.delete(listener); };
+        },
+        start: () => { active = true; },
+        stop: () => {
+            active = false;
+            generation++;
+            reading = null;
+            state = { ...state, refreshing: false, pendingChange: null };
+        },
+        observeRevision, refresh, submit,
+        dismissChangeError: () => publish({ failedChange: null, changeError: '' }),
+    };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -67,7 +67,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       case 'NameServer':
         return 'NameServer';
       case 'Proxy':
-        return 'Proxy Management';
+        return 'Proxy';
       case 'Dashboard':
         return 'System Dashboard';
       case 'Cluster':


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10481

### Brief Description

Rebuild Proxy settings with separate current-endpoint, saved-endpoint and Consumer query-mode sections. Endpoint selection preserves the query mode; deleting the current or last endpoint explains the resulting selection. Consumers now labels its actual request scope.

A focused controller coalesces configuration reads, rejects stale completions, serializes writes and requires explicit revision review while preserving drafts. Accepted mutations retain their receipt when readback fails. Dialogs protect pending submissions and restore keyboard focus.

### How Did You Test This Change?

From `rocketmq-dashboard/rocketmq-dashboard-tauri`:

- `npm run build`: passed; the existing large-bundle warning remains.
- `npm test -- src/features/proxy src/features/consumer/scope.test.ts src/stores/navigation.test.ts src/app/layout/pageToolbar.test.ts src/services/invoke.test.ts`: 25 tests passed, including 11 Proxy controller regressions.
- `git diff --check`: passed.
- Browser verification with production pages and isolated services: design comparison at 1488 x 1058; dialogs and long addresses at 800 x 600; add/use/delete, empty configuration, conflicts, external revisions, pending submission protection, write success with readback failure, focus restoration, keyboard radios and full-address disclosure.
- Verified actual Consumer navigation and scope parameters, including a delayed old refresh after switching endpoints. Browser warning/error log was empty.
- Native WebView2, Windows DPI combinations and real-cluster integration remain part of the final application-wide verification; the browser fixture does not establish those results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dialog-based Proxy management experience for adding, switching, and deleting Proxy addresses.
  * Added Consumer query scope selection between Proxy and NameServer sources.
  * Added refresh controls, change confirmations, conflict review, and clearer success/error feedback.
  * Proxy settings now remain consistent during concurrent updates and refreshes.

* **Improvements**
  * Updated Proxy page labels and descriptions for clarity.
  * Added responsive styling and accessibility support for Proxy controls.

* **Documentation**
  * Documented the Proxy settings workflow, including refresh, conflicts, deletion, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->