### PR TITLE
[ISSUE #10496]✨Redesign Producer directory and scoped connection inspection

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/PRODUCER_DISCOVERY.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/PRODUCER_DISCOVERY.md
@@ -2,9 +2,11 @@
 
 `list_producer_groups` is an authenticated, connection-revision-checked query backed by `DashboardAdmin::dashboard_list_producers`. Each item contains a group name and a reported connection count. The command does not manufacture Topic associations or client rows.
 
-The directory loads on page entry and supports search, pagination, refresh, and group selection. Selecting a group fills the existing Topic + Group connection lookup; manual group entry starts empty and remains available. Changing either query field invalidates the prior result and any outstanding callbacks or delayed loading indicator. Closing the page also invalidates requests.
+The dark desktop page keeps the searchable group directory beside the Topic + Group query and connection inspector. The directory loads on page entry and supports search, pagination, refresh, and group selection. Selecting a group fills the query without dispatching it. Both fields allow manual entry, including when directory discovery or Topic suggestions fail. Topic suggestions never replace an entered value. Query inputs and directory filters are saved with the navigation entry.
 
-The directory and connection lookup have independent loading, empty, and error states. An item with a reported connection count of zero remains visible. Connection statistics stay unset until a scoped lookup returns.
+Changing either query field immediately clears the prior result and invalidates outstanding callbacks. Duplicate submits share one pending request. Closing the page or changing the connection context invalidates the lookup; a response must match the exact queried Topic and group before it is displayed. A same-input refresh failure preserves the last successful observation and its timestamp with an explicit error. An empty successful lookup and an unavailable lookup have different states.
+
+The directory and connection lookup have independent loading, empty, and error states. An item with a reported connection count of zero remains visible. Connection statistics stay unset until a scoped lookup returns. The page refresh updates discovery, Topic suggestions and any previously submitted input pair; it does not start a new manual lookup. Client selection remains explicit if a refresh removes the selected client. Details expose returned language, version, address and scope; no client Last seen value is invented from the local read time.
 
 ## Coverage limitation
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ProducerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ProducerView.tsx
@@ -1,317 +1,87 @@
+import { useCallback, useEffect, useId, useState, type ReactNode } from 'react';
+import { Search } from 'lucide-react';
+import { useProducerConnections } from '../features/producer/hooks/useProducerConnections';
 import { ProducerGroupDirectory } from '../features/producer/components/ProducerGroupDirectory';
-import React, {useEffect, useMemo, useState} from 'react';
-import {motion} from 'motion/react';
-import {
-    AlertCircle,
-    ChevronDown,
-    Cpu,
-    Database,
-    LoaderCircle,
-    Network,
-    RadioTower,
-    Search,
-    Server,
-    Users,
-} from 'lucide-react';
-import {Pagination} from './Pagination';
-import {useProducerConnections} from '../features/producer/hooks/useProducerConnections';
+import { ProducerService } from '../services/producer.service';
+import { useReadResource } from '../hooks/useReadResource';
+import { usePageRefresh } from '../app/layout/pageToolbar';
+import { PageSection } from './layout/PageSection';
+import { PageState } from './layout/PageState';
+import { Button } from './ui/LegacyButton';
+import { Input } from './ui/LegacyInput';
+import { Pagination } from './Pagination';
+import type { ProducerConnectionItem, ProducerConnectionView } from '../features/producer/types/producer.types';
+import '../features/producer/producer.css';
 
-const PAGE_SIZE = 6;
-
-export const ProducerView = () => {
-    const {
-        topicOptions,
-        selectedTopic,
-        setSelectedTopic,
-        producerGroup,
-        setProducerGroup,
-        result,
-        isTopicLoading,
-        isSearchPending,
-        isSearching,
-        hasSearched,
-        error,
-        search,
-    } = useProducerConnections();
-    const [currentPage, setCurrentPage] = useState(1);
-    const [selectedClientId, setSelectedClientId] = useState('');
-
-    const clients = useMemo(() => result?.connections ?? [], [result]);
-    const totalPages = Math.max(1, Math.ceil(clients.length / PAGE_SIZE));
-    const pagedClients = useMemo(() => {
-        const start = (currentPage - 1) * PAGE_SIZE;
-        return clients.slice(start, start + PAGE_SIZE);
-    }, [clients, currentPage]);
-    const selectedClient = clients.find((client) => client.clientId === selectedClientId) ?? clients[0] ?? null;
-    const languageCount = new Set(clients.map((client) => client.language).filter(Boolean)).size;
-    const versionCount = new Set(clients.map((client) => client.versionDesc).filter(Boolean)).size;
-    const runtimeLabel = selectedClient?.language ?? 'Pending';
-    const versionLabel = selectedClient?.versionDesc ?? 'No client';
-    const connectionCount = result?.connectionCount ?? '—';
-    const canSearch = Boolean(selectedTopic.trim()) && Boolean(producerGroup.trim()) && !isTopicLoading && !isSearchPending;
-
+export function ProducerView() {
+    const lookup = useProducerConnections();
+    const loadDirectory = useCallback(() => ProducerService.listProducerGroups(), []);
+    const directory = useReadResource(loadDirectory, 'Producer group discovery failed.');
+    const [refreshedAt, setRefreshedAt] = useState<number | null>(null);
+    const refresh = useCallback(() => {
+        void directory.read();
+        void lookup.topics.read();
+        if (lookup.hasSearched) void lookup.search();
+    }, [directory.read, lookup.topics.read, lookup.hasSearched, lookup.search]);
+    const pending = directory.pending || lookup.topics.pending || lookup.pending;
     useEffect(() => {
-        if (clients.length === 0) {
-            setSelectedClientId('');
-            return;
-        }
-        if (!clients.some((client) => client.clientId === selectedClientId)) {
-            setSelectedClientId(clients[0].clientId);
-        }
-    }, [clients, selectedClientId]);
-
-    const handleSearch = async () => {
-        const ok = await search();
-        if (ok) {
-            setCurrentPage(1);
-        }
-    };
-
-    return (
-        <div className="producer-page">
-            <section className="producer-summary-grid" aria-label="Producer summary">
-                <div className="topic-summary-card">
-                    <div>
-                        <span>Topics Available</span>
-                        <strong>{isTopicLoading ? '...' : topicOptions.length}</strong>
-                        <small>selectable producer topics</small>
-                    </div>
-                    <span className="topic-summary-icon">
-                        <Database className="topic-icon" aria-hidden="true"/>
-                    </span>
-                </div>
-                <div className="topic-summary-card is-success">
-                    <div>
-                        <span>Connections</span>
-                        <strong>{connectionCount}</strong>
-                        <small>{result ? 'clients from the scoped lookup' : error ? 'lookup unavailable' : 'run a scoped lookup'}</small>
-                    </div>
-                    <span className="topic-summary-icon">
-                        <RadioTower className="topic-icon" aria-hidden="true"/>
-                    </span>
-                </div>
-                <div className="topic-summary-card is-blue">
-                    <div>
-                        <span>Runtime Types</span>
-                        <strong>{languageCount || '-'}</strong>
-                        <small>{runtimeLabel === 'Pending' ? 'waiting for response' : `${runtimeLabel} selected`}</small>
-                    </div>
-                    <span className="topic-summary-icon">
-                        <Cpu className="topic-icon" aria-hidden="true"/>
-                    </span>
-                </div>
-                <div className="topic-summary-card is-warning">
-                    <div>
-                        <span>Client Versions</span>
-                        <strong>{versionCount || '-'}</strong>
-                        <small>{versionLabel}</small>
-                    </div>
-                    <span className="topic-summary-icon">
-                        <Server className="topic-icon" aria-hidden="true"/>
-                    </span>
-                </div>
-            </section>
-
-            <ProducerGroupDirectory selectedGroup={producerGroup} onSelect={setProducerGroup} />
-            <form
-                className="producer-command-panel"
-                aria-label="Producer connection search"
-                onSubmit={(event) => {
-                    event.preventDefault();
-                    void handleSearch();
-                }}
-            >
-                <div className="producer-command-copy">
-                    <strong>Producer scope</strong>
-                </div>
-
-                <div className="producer-query-controls">
-                    <label className="producer-field is-topic">
-                        <span>Topic</span>
-                        <select
-                            value={selectedTopic}
-                            onChange={(event) => setSelectedTopic(event.target.value)}
-                            disabled={isTopicLoading || topicOptions.length === 0}
-                        >
-                            {isTopicLoading && <option>Loading topics...</option>}
-                            {!isTopicLoading && topicOptions.length === 0 && <option>No topics</option>}
-                            {!isTopicLoading && topicOptions.map((topic) => (
-                                <option key={topic} value={topic}>
-                                    {topic}
-                                </option>
-                            ))}
-                        </select>
-                        <ChevronDown className="producer-field-icon" aria-hidden="true"/>
-                    </label>
-
-                    <label className="producer-field is-group">
-                        <span>Producer Group</span>
-                        <Search className="producer-field-icon is-left" aria-hidden="true"/>
-                        <input
-                            type="text"
-                            placeholder="Please enter producer group..."
-                            value={producerGroup}
-                            onChange={(event) => setProducerGroup(event.target.value)}
-                        />
-                    </label>
-
-                    <button type="submit" className="topic-action-button is-status producer-search-button" disabled={!canSearch}>
-                        {isSearching ? (
-                            <LoaderCircle className="topic-icon producer-spin" aria-hidden="true"/>
-                        ) : (
-                            <Search className="topic-icon" aria-hidden="true"/>
-                        )}
-                        <span>{isSearching ? 'Searching' : 'Search'}</span>
-                    </button>
-                </div>
-            </form>
-
-            {error && (
-                <div className="producer-alert" role="alert">
-                    <AlertCircle className="topic-icon" aria-hidden="true"/>
-                    <span>{error}</span>
-                </div>
-            )}
-
-            {result && !error && (
-                <section className="producer-scope-strip" aria-label="Producer query result">
-                    <div>
-                        <span>Topic:</span>
-                        <strong>{result.topic}</strong>
-                        <i aria-hidden="true">/</i>
-                        <span>Producer Group:</span>
-                        <strong>{result.producerGroup}</strong>
-                    </div>
-                    <b>{result.connectionCount} connection{result.connectionCount === 1 ? '' : 's'}</b>
-                </section>
-            )}
-
-            <section className="producer-workspace">
-                <div className="producer-panel producer-list-panel">
-                    <div className="topic-panel-header">
-                        <div>
-                            <h2>Connection Inventory</h2>
-                            <p>Active producer clients returned by the NameServer route lookup.</p>
-                        </div>
-                        <div className="topic-panel-meta">
-                            <span>{clients.length} client{clients.length === 1 ? '' : 's'}</span>
-                        </div>
-                    </div>
-
-                    {hasSearched && !error && result && !isSearching && clients.length === 0 ? (
-                        <div className="producer-empty-state">
-                            <Users className="topic-icon" aria-hidden="true"/>
-                            <strong>No producer connections</strong>
-                            <span>No active producer clients were found for this topic and producer group.</span>
-                        </div>
-                    ) : clients.length === 0 ? (
-                        <div className="producer-empty-state">
-                            <Search className="topic-icon" aria-hidden="true"/>
-                            <strong>No lookup yet</strong>
-                            <span>Select a topic, enter a producer group, and run Search to inspect active clients.</span>
-                        </div>
-                    ) : (
-                        <div className="producer-client-list">
-                            {pagedClients.map((client, index) => {
-                                const selected = selectedClient?.clientId === client.clientId;
-                                return (
-                                    <motion.button
-                                        type="button"
-                                        key={client.clientId}
-                                        initial={{opacity: 0, y: 14}}
-                                        animate={{opacity: 1, y: 0}}
-                                        transition={{duration: 0.24, delay: index * 0.03}}
-                                        className={`producer-client-row ${selected ? 'is-selected' : ''}`}
-                                        onClick={() => setSelectedClientId(client.clientId)}
-                                    >
-                                        <span className="producer-client-main">
-                                            <span className="producer-client-icon">
-                                                <Database className="topic-icon" aria-hidden="true"/>
-                                            </span>
-                                            <span className="producer-client-copy">
-                                                <span>Client</span>
-                                                <strong title={client.clientId}>{client.clientId}</strong>
-                                            </span>
-                                        </span>
-                                        <span className="producer-client-cell">
-                                            <span>Address</span>
-                                            <strong>{client.clientAddr}</strong>
-                                        </span>
-                                        <span className="producer-client-cell">
-                                            <span>Language</span>
-                                            <b>{client.language || '-'}</b>
-                                        </span>
-                                        <span className="producer-client-cell">
-                                            <span>Version</span>
-                                            <strong>{client.versionDesc || client.version}</strong>
-                                        </span>
-                                    </motion.button>
-                                );
-                            })}
-                        </div>
-                    )}
-                </div>
-
-                <aside className="producer-panel producer-inspector-panel" aria-label="Selected producer client">
-                    <div className="producer-inspector-header">
-                        <span>Selected Client</span>
-                        <strong>{selectedClient?.clientId ?? 'No client selected'}</strong>
-                        {selectedClient && (
-                            <div className="producer-badge-row">
-                                <b>{selectedClient.language || 'Unknown'} runtime</b>
-                                <b className="is-connected">Connected</b>
-                            </div>
-                        )}
-                    </div>
-
-                    {selectedClient ? (
-                        <>
-                            <div className="producer-route-card">
-                                <span>Current route</span>
-                                <strong>{result?.topic ?? selectedTopic}</strong>
-                                <small>{result?.producerGroup ?? producerGroup}</small>
-                            </div>
-                            <div className="producer-detail-grid">
-                                <div>
-                                    <span>Client address</span>
-                                    <strong>{selectedClient.clientAddr}</strong>
-                                </div>
-                                <div>
-                                    <span>Client version</span>
-                                    <strong>{selectedClient.versionDesc || selectedClient.version}</strong>
-                                </div>
-                                <div>
-                                    <span>Protocol language</span>
-                                    <strong>{selectedClient.language || '-'}</strong>
-                                </div>
-                                <div>
-                                    <span>Connection state</span>
-                                    <strong>Active</strong>
-                                </div>
-                            </div>
-                            <div className="producer-note">
-                                <Network className="topic-icon" aria-hidden="true"/>
-                                <span>Producer inventory is read-only and reflects the latest query response.</span>
-                            </div>
-                        </>
-                    ) : (
-                        <div className="producer-empty-state is-compact">
-                            <RadioTower className="topic-icon" aria-hidden="true"/>
-                            <strong>Waiting for producer data</strong>
-                            <span>Run a lookup to select a client and inspect endpoint metadata.</span>
-                        </div>
-                    )}
-                </aside>
-            </section>
-
-            <footer className="producer-footer">
-                <span>Producer connection data is read-only. Narrow the query by topic and producer group before inspecting clients.</span>
-                <Pagination
-                    currentPage={currentPage}
-                    totalPages={totalPages}
-                    onPageChange={setCurrentPage}
-                />
-            </footer>
+        if (pending || directory.error || lookup.topics.error || lookup.error || !directory.receivedAt || !lookup.topics.receivedAt) return;
+        setRefreshedAt(Math.min(directory.receivedAt, lookup.topics.receivedAt, lookup.hasSearched ? lookup.receivedAt ?? Infinity : Infinity));
+    }, [pending, directory.error, directory.receivedAt, lookup.topics.error, lookup.topics.receivedAt, lookup.error, lookup.receivedAt, lookup.hasSearched]);
+    usePageRefresh({ refresh, pending, refreshedAt });
+    const suggestionsId = useId();
+    const readState = <>
+        {lookup.pending && <PageState kind="loading" title="Querying Producer connections" />}
+        {lookup.error && <PageState kind="error" title="Connection lookup failed" description={lookup.error + (lookup.result ? ' Showing the last successful read for this input pair.' : '')} />}
+        {!lookup.hasSearched && <PageState kind="empty" title="No lookup yet" description="Choose or enter a Topic and group, then query connections." />}
+    </>;
+    return <div className="ops-producers">
+        <ProducerGroupDirectory directory={directory} refresh={() => { void directory.read(); }} selectedGroup={lookup.producerGroup} onSelect={lookup.setProducerGroup} />
+        <div className="ops-producer-workspace">
+            <PageSection title={lookup.producerGroup.trim() || 'Query connections'} className="ops-producer-query">
+                <form className="ops-producer-query-form" aria-label="Producer connection query" onSubmit={event => { event.preventDefault(); void lookup.search(); }}>
+                    <Input label="Topic" placeholder="Choose or enter a Topic" list={suggestionsId} value={lookup.selectedTopic} onChange={event => lookup.setSelectedTopic(event.target.value)} required />
+                    <datalist id={suggestionsId}>{lookup.topics.data?.topics.map(topic => <option key={topic} value={topic} />)}</datalist>
+                    <Input label="Producer group" placeholder="Enter a Producer group" value={lookup.producerGroup} onChange={event => lookup.setProducerGroup(event.target.value)} required />
+                    <Button type="submit" icon={Search} disabled={lookup.pending || !lookup.selectedTopic.trim() || !lookup.producerGroup.trim()}>{lookup.pending ? 'Querying…' : 'Query connections'}</Button>
+                </form>
+                {lookup.topics.pending && <p className="ops-producer-note">Loading Topic suggestions; manual input remains available.</p>}
+                {lookup.topics.error && <PageState kind="partial" title="Topic suggestions unavailable" description="Enter a Topic manually to query connections." action={<Button variant="outline" disabled={lookup.topics.pending} onClick={() => { void lookup.topics.read(); }}>Retry Topic suggestions</Button>} />}
+            </PageSection>
+            {lookup.result ? <ProducerClients key={JSON.stringify([lookup.result.topic, lookup.result.producerGroup])} result={lookup.result}>
+                {readState}<p className="ops-producer-note">Topic: {lookup.result.topic} · Group: {lookup.result.producerGroup} · Last successful read: {new Date(lookup.receivedAt!).toLocaleString()}</p>
+            </ProducerClients> : <PageSection title="Connections" description="Clients reported for the exact Topic and Producer group query.">{readState}</PageSection>}
         </div>
-    );
-};
+    </div>;
+}
+
+function ProducerClients({ result, children }: { result: ProducerConnectionView; children: ReactNode }) {
+    const [selectedId, setSelectedId] = useState<string | null>(result.connections[0]?.clientId ?? null);
+    const [page, setPage] = useState(1);
+    const selected = result.connections.find(client => client.clientId === selectedId);
+    const pageCount = Math.max(1, Math.ceil(result.connections.length / 6));
+    const currentPage = Math.min(page, pageCount);
+    return <div className="ops-producer-clients">
+        <PageSection title={`Connections (${result.connectionCount})`} description="Clients reported for the exact Topic and Producer group query.">
+        {children}
+        {!result.connections.length && <PageState kind="empty" title="No connections returned" description="The lookup succeeded without reporting connected clients for this Topic and group." />}
+        {result.connections.length > 0 && <div className="ops-producer-scroll" role="region" aria-label="Producer connection list" tabIndex={0}><table><thead><tr>
+            {['Client ID', 'Language', 'Version', 'Address'].map(label => <th scope="col" key={label}>{label}</th>)}
+        </tr></thead><tbody>{result.connections.slice((currentPage - 1) * 6, currentPage * 6).map(client => <tr key={client.clientId} data-selected={selectedId === client.clientId}>
+            <th scope="row"><button type="button" className="ops-producer-choice" title={client.clientId} aria-pressed={selectedId === client.clientId} onClick={() => setSelectedId(client.clientId)}>{client.clientId}</button></th>
+            <td>{client.language || 'Unknown'}</td><td>{producerVersion(client)}</td><td>{client.clientAddr || 'Not reported'}</td>
+        </tr>)}</tbody></table></div>}
+        {pageCount > 1 && <Pagination currentPage={currentPage} totalPages={pageCount} onPageChange={setPage} />}
+        </PageSection>
+        <PageSection title="Client details" description="Metadata returned for the selected Producer connection.">
+            {selected ? <dl className="ops-producer-properties">{[
+                ['Client ID', selected.clientId], ['Language', selected.language || 'Unknown'], ['Version', producerVersion(selected)],
+                ['Address', selected.clientAddr || 'Not reported'], ['Producer group', result.producerGroup], ['Topic', result.topic],
+            ].map(([label, value]) => <div key={label}><dt>{label}</dt><dd tabIndex={String(value).length > 200 ? 0 : undefined}>{value}</dd></div>)}</dl>
+                : <PageState kind="empty" title={selectedId ? 'Selected client is no longer in this result' : 'Select a client'} description="Select a returned client explicitly to inspect its metadata." />}
+        </PageSection>
+    </div>;
+}
+function producerVersion(client: ProducerConnectionItem) {
+    return client.versionDesc || (Number.isFinite(client.version) && client.version >= 0 ? String(client.version) : 'Unknown');
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/components/ProducerGroupDirectory.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/components/ProducerGroupDirectory.tsx
@@ -1,50 +1,44 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { ProducerService } from '../../../services/producer.service';
-import { dashboardErrorMessage } from '../../../services/invoke';
-import { Pagination } from '../../../components/Pagination';
-import { ProducerRequestGuard } from '../requestGuard';
+import { useMemo } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { useNavigationState } from '../../../stores/app.store';
+import type { ReadState } from '../../../hooks/readResource';
 import type { ProducerGroupItem } from '../types/producer.types';
+import { PageSection } from '../../../components/layout/PageSection';
+import { PageState } from '../../../components/layout/PageState';
+import { Input } from '../../../components/ui/LegacyInput';
+import { Button } from '../../../components/ui/LegacyButton';
+import { Pagination } from '../../../components/Pagination';
 
-export function ProducerGroupDirectory({ selectedGroup, onSelect }: { selectedGroup: string; onSelect: (group: string) => void }) {
-    const [items, setItems] = useState<ProducerGroupItem[] | null>(null);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState('');
-    const [query, setQuery] = useState('');
-    const [page, setPage] = useState(1);
-    const guard = useRef(new ProducerRequestGuard());
-    const load = async () => {
-        const isCurrent = guard.current.begin();
-        setLoading(true);
-        setError('');
-        setItems(null);
-        try {
-            const groups = await ProducerService.listProducerGroups();
-            if (!isCurrent()) return;
-            setItems(groups);
-            setPage(1);
-        } catch (error) {
-            if (isCurrent()) setError(dashboardErrorMessage(error, 'Unable to read the Producer directory.'));
-        } finally { if (isCurrent()) setLoading(false); }
-    };
-    useEffect(() => { void load(); return () => guard.current.invalidate(); }, []);
-    const filtered = useMemo(() => (items ?? []).filter(item => item.producerGroup.toLowerCase().includes(query.trim().toLowerCase())), [items, query]);
+interface Props {
+    directory: ReadState<ProducerGroupItem[]>;
+    refresh: () => void;
+    selectedGroup: string;
+    onSelect: (group: string) => void;
+}
+export function ProducerGroupDirectory({ directory, refresh, selectedGroup, onSelect }: Props) {
+    const [query, setQuery] = useNavigationState('producerDirectorySearch', '');
+    const [page, setPage] = useNavigationState('producerDirectoryPage', 1);
+    const filtered = useMemo(() => (directory.data ?? []).filter(item => item.producerGroup.toLowerCase().includes(query.trim().toLowerCase())), [directory.data, query]);
     const totalPages = Math.max(1, Math.ceil(filtered.length / 8));
-    return <section aria-label="Discovered Producer groups" className="rounded-xl border bg-white p-5 dark:border-gray-800 dark:bg-gray-900">
-        <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
-            <h2 className="font-semibold">Discovered Producer groups</h2>
-            <input aria-label="Search Producer groups" placeholder="Search group name" value={query} onChange={event => { setQuery(event.target.value); setPage(1); }} className="rounded border bg-transparent px-3 py-2 text-sm" />
-            <button type="button" disabled={loading} onClick={() => void load()} className="rounded border px-3 py-2 text-sm">{loading ? 'Loading…' : 'Refresh directory'}</button>
-        </header>
-        <p className="mb-3 text-sm text-gray-500">Discovery reports group names and Broker connection counts, not a complete client list. Coverage is not reported; counts can overlap across Brokers. Select a group, then query its Topic connections below. Manual group input remains available.</p>
-        {error && <p role="alert" className="text-red-600">{error}</p>}
-        {!loading && !error && items === null && <p>Directory has not been queried.</p>}
-        {!loading && items?.length === 0 && <p>No Producer groups were reported. Discovery coverage is unavailable.</p>}
-        {!loading && Boolean(items?.length) && filtered.length === 0 && <p>No group matches this search.</p>}
-        <div className="grid gap-2 sm:grid-cols-2">{filtered.slice((page - 1) * 8, page * 8).map(item => <button key={item.producerGroup} type="button"
-            aria-pressed={selectedGroup === item.producerGroup} onClick={() => onSelect(item.producerGroup)}
-            className={`flex items-center justify-between gap-3 rounded border p-3 text-left text-sm ${selectedGroup === item.producerGroup ? 'border-blue-500 bg-blue-50 dark:bg-blue-950' : ''}`}>
-            <span className="break-all font-mono">{item.producerGroup}</span><span>{item.reportedConnectionCount} reported connections</span>
-        </button>)}</div>
-        {totalPages > 1 && <Pagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />}
-    </section>;
+    const currentPage = Math.min(page, totalPages);
+    return <PageSection title="Producer groups" className="ops-producer-directory">
+        <div className="ops-producer-directory-controls">
+            <Input aria-label="Search Producer groups" placeholder="Search Producer groups…" value={query} onChange={event => { setQuery(event.target.value); setPage(1); }} />
+            <Button variant="outline" icon={RefreshCw} disabled={directory.pending} onClick={refresh} aria-label="Refresh Producer directory">Refresh</Button>
+        </div>
+        {directory.pending && <PageState kind="loading" title={directory.data ? 'Refreshing directory' : 'Discovering Producer groups'} />}
+        {directory.error && <PageState kind="error" title="Producer directory unavailable" description={directory.error + (directory.data ? ' Showing the last successful directory.' : '') + ' Manual connection lookup remains available.'} />}
+        <div className="ops-producer-scroll ops-producer-directory-table" role="region" aria-label="Producer group directory" tabIndex={0}>
+            <table><thead><tr><th scope="col">Producer group</th><th scope="col">Reported connections</th></tr></thead><tbody>
+                {filtered.slice((currentPage - 1) * 8, currentPage * 8).map(item => <tr key={item.producerGroup} data-selected={selectedGroup.trim() === item.producerGroup}>
+                    <th scope="row"><button className="ops-producer-choice" type="button" title={item.producerGroup} aria-pressed={selectedGroup.trim() === item.producerGroup} onClick={() => onSelect(item.producerGroup)}>{item.producerGroup}</button></th>
+                    <td>{Number.isFinite(item.reportedConnectionCount) && item.reportedConnectionCount >= 0 ? item.reportedConnectionCount.toLocaleString() : 'Unknown'}</td>
+                </tr>)}
+            </tbody></table>
+            {!directory.pending && directory.data && !filtered.length && <PageState kind="empty" title={query.trim() ? 'No groups match this search' : 'No Producer groups reported'} description="Discovery coverage is unavailable. You can still query a group manually." />}
+        </div>
+        {totalPages > 1 && <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setPage} disabled={directory.pending} />}
+        <p className="ops-producer-note">Directory counts come from Broker reports and may overlap. Coverage is unavailable; these are not a complete client list.</p>
+        {directory.receivedAt && <p className="ops-producer-note">Last successful directory read: {new Date(directory.receivedAt).toLocaleString()}</p>}
+    </PageSection>;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/hooks/useProducerConnections.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/hooks/useProducerConnections.ts
@@ -1,129 +1,26 @@
-import { ProducerRequestGuard } from '../requestGuard';
-import { useEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
 import { ProducerService } from '../../../services/producer.service';
-import { dashboardErrorMessage } from '../../../services/invoke';
-import type { ProducerConnectionView } from '../types/producer.types';
-const SEARCH_INDICATOR_DELAY_MS = 180;
+import { ConnectionStore } from '../../../services/connection.store';
+import { useNavigationState } from '../../../stores/app.store';
+import { useReadResource } from '../../../hooks/useReadResource';
+import { createProducerLookup } from '../producerLookup';
 
-
-export const useProducerConnections = () => {
-    const [topicOptions, setTopicOptions] = useState<string[]>([]);
-    const [selectedTopic, storeSelectedTopic] = useState('');
-    const [producerGroup, storeProducerGroup] = useState('');
-    const [result, setResult] = useState<ProducerConnectionView | null>(null);
-    const [isTopicLoading, setIsTopicLoading] = useState(true);
-    const [isSearchPending, setIsSearchPending] = useState(false);
-    const [isSearching, setIsSearching] = useState(false);
-    const [hasSearched, setHasSearched] = useState(false);
-    const [error, setError] = useState('');
-    const guard = useRef(new ProducerRequestGuard());
-    const indicator = useRef<number | null>(null);
-    const invalidate = () => {
-        guard.current.invalidate();
-        if (indicator.current !== null) window.clearTimeout(indicator.current);
-        setIsSearchPending(false);
-        setIsSearching(false);
-        setResult(null);
-        setHasSearched(false);
-        setError('');
-    };
-    const setSelectedTopic = (topic: string) => { invalidate(); storeSelectedTopic(topic); };
-    const setProducerGroup = (group: string) => { invalidate(); storeProducerGroup(group); };
-
-
-    useEffect(() => {
-        let cancelled = false;
-        const loadTopics = async () => {
-            setIsTopicLoading(true);
-            setError('');
-
-            try {
-                const response = await ProducerService.getProducerTopicOptions();
-                if (cancelled) return;
-                setTopicOptions(response.topics);
-                storeSelectedTopic((current) => {
-                    if (current && response.topics.includes(current)) {
-                        return current;
-                    }
-                    return response.topics[0] ?? '';
-                });
-            } catch (loadError) {
-                if (cancelled) return;
-                setError(dashboardErrorMessage(loadError, 'Failed to load producer topics'));
-            } finally {
-                if (!cancelled) setIsTopicLoading(false);
-            }
-        };
-
-        void loadTopics();
-        return () => {
-            cancelled = true;
-            guard.current.invalidate();
-            if (indicator.current !== null) window.clearTimeout(indicator.current);
-        };
+export function useProducerConnections() {
+    const [selectedTopic, storeTopic] = useNavigationState('producerTopic', '');
+    const [producerGroup, storeGroup] = useNavigationState('producerGroup', '');
+    const loadTopics = useCallback(() => ProducerService.getProducerTopicOptions(), []);
+    const topics = useReadResource(loadTopics, 'Topic suggestions could not be read. Enter a Topic manually.');
+    const controller = useMemo(() => {
+        const original = ConnectionStore.getSnapshot();
+        return createProducerLookup(request => ProducerService.queryProducerConnections(request), () => {
+            const current = ConnectionStore.getSnapshot();
+            return current?.revision === original?.revision && current?.environmentId === original?.environmentId;
+        });
     }, []);
-
-    const search = async () => {
-        const topic = selectedTopic.trim();
-        const group = producerGroup.trim();
-
-        if (!topic) {
-            setError('Please select a topic first.');
-            return false;
-        }
-        if (!group) {
-            setError('Please enter a producer group.');
-            return false;
-        }
-
-        const isCurrent = guard.current.begin();
-        if (indicator.current !== null) window.clearTimeout(indicator.current);
-        let searchIndicatorTimer: number | null = null;
-        setIsSearchPending(true);
-        searchIndicatorTimer = window.setTimeout(() => {
-            if (isCurrent()) setIsSearching(true);
-        }, SEARCH_INDICATOR_DELAY_MS);
-        indicator.current = searchIndicatorTimer;
-        setError('');
-
-        try {
-            const response = await ProducerService.queryProducerConnections({
-                topic,
-                producerGroup: group,
-            });
-            if (!isCurrent()) return false;
-            setResult(response);
-            setHasSearched(true);
-            return true;
-        } catch (searchError) {
-            if (!isCurrent()) return false;
-            setResult(null);
-            setHasSearched(true);
-            setError(dashboardErrorMessage(searchError, 'Failed to query producer connections'));
-            return false;
-        } finally {
-            if (searchIndicatorTimer !== null) {
-                window.clearTimeout(searchIndicatorTimer);
-            }
-            if (isCurrent()) {
-                setIsSearchPending(false);
-                setIsSearching(false);
-            }
-        }
-    };
-
-    return {
-        topicOptions,
-        selectedTopic,
-        setSelectedTopic,
-        producerGroup,
-        setProducerGroup,
-        result,
-        isTopicLoading,
-        isSearchPending,
-        isSearching,
-        hasSearched,
-        error,
-        search,
-    };
-};
+    const lookup = useSyncExternalStore(controller.subscribe, controller.getSnapshot, controller.getSnapshot);
+    useEffect(() => { controller.start(); return controller.stop; }, [controller]);
+    const setSelectedTopic = (value: string) => { controller.reset(); storeTopic(value); };
+    const setProducerGroup = (value: string) => { controller.reset(); storeGroup(value); };
+    const search = useCallback(() => controller.search({ topic: selectedTopic, producerGroup }), [controller, selectedTopic, producerGroup]);
+    return { topics, selectedTopic, setSelectedTopic, producerGroup, setProducerGroup, ...lookup, search };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/producer.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/producer.css
@@ -1,0 +1,29 @@
+.ops-producers { display: grid; grid-template-columns: minmax(280px, 0.37fr) minmax(0, 0.63fr); align-items: stretch; gap: 16px; min-width: 0; }
+.ops-producer-workspace, .ops-producer-clients { display: grid; gap: 16px; min-width: 0; align-content: start; }
+.ops-producer-workspace > .ops-page-section { min-width: 0; }
+.ops-producer-directory { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
+.ops-producer-directory > .ops-section-header { margin-bottom: 0; }
+.ops-producer-directory-controls { display: flex; align-items: center; gap: 10px; }
+.ops-producer-directory-controls .ops-field { flex: 1; min-width: 0; }
+.ops-producer-directory .ops-producer-directory-table { flex: 1; min-height: 280px; }
+.ops-producer-query > .ops-section-header h2 { overflow-wrap: anywhere; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.ops-producer-query-form { display: flex; flex-wrap: wrap; align-items: end; gap: 14px; }
+.ops-producer-query-form > .ops-field { flex: 1 1 160px; min-width: 0; }
+.ops-producer-note { margin: 10px 0 0; color: var(--ops-muted); font-size: 12px; line-height: 1.6; overflow-wrap: anywhere; }
+.ops-producer-scroll { overflow: auto; max-width: 100%; border: 1px solid var(--ops-border); border-radius: 8px; }
+.ops-producer-scroll table { width: 100%; min-width: 500px; border-collapse: collapse; font-size: 14px; text-align: left; }
+.ops-producer-directory-table table { min-width: 300px; }
+.ops-producer-scroll th, .ops-producer-scroll td { padding: 12px 14px; border-bottom: 1px solid var(--ops-border); max-width: 280px; overflow-wrap: anywhere; vertical-align: top; }
+.ops-producer-scroll thead th { background: var(--ops-panel-soft); color: var(--ops-muted); font-size: 12px; font-weight: 500; }
+.ops-producer-scroll tbody th { font-weight: 500; }
+.ops-producer-scroll tbody tr:last-child > * { border-bottom: 0; }
+.ops-producer-scroll tr[data-selected="true"] > * { background: var(--ops-accent-soft); }
+.ops-producer-choice { border: 0; padding: 0; color: var(--ops-text); background: transparent; text-align: left; font: inherit; cursor: pointer; overflow-wrap: anywhere; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.ops-producer-clients .ops-producer-scroll { margin-top: 16px; }
+.ops-producer-properties { margin: 0; border: 1px solid var(--ops-border); border-radius: 8px; font-size: 14px; }
+.ops-producer-properties > div { display: grid; grid-template-columns: minmax(95px, 30%) minmax(0, 1fr); border-bottom: 1px solid var(--ops-border); }
+.ops-producer-properties > div:last-child { border-bottom: 0; }
+.ops-producer-properties dt, .ops-producer-properties dd { padding: 10px 14px; margin: 0; overflow-wrap: anywhere; }
+.ops-producer-properties dt { color: var(--ops-muted); border-right: 1px solid var(--ops-border); }
+.ops-producer-properties dd { max-height: 180px; overflow: auto; }
+@media (max-width: 1150px) { .ops-producers { grid-template-columns: minmax(0, 1fr); } .ops-producer-directory .ops-producer-directory-table { min-height: 0; } }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/producerLookup.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/producerLookup.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createProducerLookup } from './producerLookup';
+import type { ProducerConnectionQueryRequest, ProducerConnectionView } from './types/producer.types';
+
+const request = { topic: 'orders.events', producerGroup: 'orders-producer' };
+const response = (scope: ProducerConnectionQueryRequest = request): ProducerConnectionView => ({ ...scope, connectionCount: 0, connections: [] });
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(complete => { resolve = complete; });
+    return { promise, resolve };
+}
+
+describe('Producer connection lookup', () => {
+    it('coalesces duplicate submits and accepts a successful empty response', async () => {
+        const pending = deferred<ProducerConnectionView>();
+        const query = vi.fn(() => pending.promise);
+        const lookup = createProducerLookup(query, () => true);
+        lookup.start();
+        const first = lookup.search(request);
+        expect(lookup.search(request)).toBe(first);
+        await Promise.resolve();
+        expect(query).toHaveBeenCalledTimes(1);
+        pending.resolve(response());
+        expect(await first).toBe(true);
+        expect(lookup.getSnapshot()).toMatchObject({ pending: false, error: '', hasSearched: true, result: response() });
+    });
+
+    it('discards an old input response after a new scope finishes', async () => {
+        const old = deferred<ProducerConnectionView>();
+        const query = vi.fn().mockReturnValueOnce(old.promise).mockResolvedValueOnce(response({ topic: 'payments.events', producerGroup: 'payments-producer' }));
+        const lookup = createProducerLookup(query, () => true);
+        lookup.start();
+        const first = lookup.search(request);
+        await Promise.resolve();
+        lookup.reset();
+        await lookup.search({ topic: 'payments.events', producerGroup: 'payments-producer' });
+        old.resolve(response());
+        expect(await first).toBe(false);
+        expect(lookup.getSnapshot().result?.producerGroup).toBe('payments-producer');
+    });
+
+    it('keeps the last successful observation on a refresh failure', async () => {
+        const query = vi.fn().mockResolvedValueOnce(response()).mockRejectedValueOnce(new Error('unavailable'));
+        const lookup = createProducerLookup(query, () => true);
+        lookup.start();
+        await lookup.search(request);
+        const observed = lookup.getSnapshot().receivedAt;
+        expect(await lookup.search(request)).toBe(false);
+        expect(lookup.getSnapshot()).toMatchObject({ result: response(), receivedAt: observed, pending: false, hasSearched: true });
+        expect(lookup.getSnapshot().error).not.toBe('');
+        lookup.reset();
+        expect(lookup.getSnapshot()).toMatchObject({ result: null, receivedAt: null, error: '', hasSearched: false });
+    });
+
+    it('rejects a mismatched response without presenting it as an empty success', async () => {
+        const lookup = createProducerLookup(async () => response({ ...request, producerGroup: 'another-group' }), () => true);
+        lookup.start();
+        expect(await lookup.search(request)).toBe(false);
+        expect(lookup.getSnapshot()).toMatchObject({ result: null, receivedAt: null, hasSearched: true });
+        expect(lookup.getSnapshot().error).not.toBe('');
+    });
+
+    it('invalidates on page disposal and ignores changed-environment results', async () => {
+        const pending = deferred<ProducerConnectionView>();
+        let current = true;
+        const lookup = createProducerLookup(() => pending.promise, () => current);
+        lookup.start();
+        const first = lookup.search(request);
+        await Promise.resolve();
+        current = false;
+        pending.resolve(response());
+        expect(await first).toBe(false);
+        expect(lookup.getSnapshot().result).toBeNull();
+        lookup.stop();
+        expect(lookup.getSnapshot().pending).toBe(false);
+        expect(await lookup.search(request)).toBe(false);
+    });
+
+    it('validates empty fields and never dispatches a disposed preflight', async () => {
+        const query = vi.fn(async () => response());
+        const lookup = createProducerLookup(query, () => true);
+        lookup.start();
+        expect(await lookup.search({ ...request, topic: ' ' })).toBe(false);
+        const pending = lookup.search(request);
+        lookup.stop();
+        lookup.start();
+        expect(await pending).toBe(false);
+        expect(query).not.toHaveBeenCalled();
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/producerLookup.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/producer/producerLookup.ts
@@ -1,0 +1,59 @@
+import { dashboardErrorMessage } from '../../services/invoke';
+import { ProducerRequestGuard } from './requestGuard';
+import type { ProducerConnectionQueryRequest, ProducerConnectionView } from './types/producer.types';
+
+interface LookupState {
+    result: ProducerConnectionView | null;
+    pending: boolean;
+    hasSearched: boolean;
+    error: string;
+    receivedAt: number | null;
+}
+
+/** A lookup belongs to one page and input pair; editing either field invalidates its callbacks. */
+export function createProducerLookup(query: (request: ProducerConnectionQueryRequest) => Promise<ProducerConnectionView>, contextIsCurrent: () => boolean) {
+    const empty = (): LookupState => ({ result: null, pending: false, hasSearched: false, error: '', receivedAt: null });
+    let state = empty();
+    let active = false;
+    let flight: Promise<boolean> | null = null;
+    const guard = new ProducerRequestGuard();
+    const listeners = new Set<() => void>();
+    const publish = (next: LookupState) => { state = next; listeners.forEach(listener => listener()); };
+    const reset = () => { guard.invalidate(); flight = null; publish(empty()); };
+    const search = (input: ProducerConnectionQueryRequest): Promise<boolean> => {
+        if (!active || !contextIsCurrent()) return Promise.resolve(false);
+        if (flight) return flight;
+        const request = { topic: input.topic.trim(), producerGroup: input.producerGroup.trim() };
+        if (!request.topic || !request.producerGroup) {
+            publish({ ...state, error: 'Enter both a Topic and a Producer group.' });
+            return Promise.resolve(false);
+        }
+        const ownsRequest = guard.begin();
+        const isCurrent = () => active && ownsRequest() && contextIsCurrent();
+        publish({ ...state, pending: true, hasSearched: true, error: '' });
+        flight = (async () => {
+            await Promise.resolve();
+            if (!isCurrent()) return false;
+            try {
+                const result = await query(request);
+                if (!isCurrent()) return false;
+                if (result.topic !== request.topic || result.producerGroup !== request.producerGroup) throw new Error('The returned Producer scope does not match the query.');
+                publish({ result, pending: false, hasSearched: true, error: '', receivedAt: Date.now() });
+                return true;
+            } catch (error) {
+                if (isCurrent()) publish({ ...state, pending: false, error: dashboardErrorMessage(error, 'Producer connection lookup failed.') });
+                return false;
+            } finally {
+                if (ownsRequest()) flight = null;
+            }
+        })();
+        return flight;
+    };
+    return {
+        search, reset,
+        start: () => { active = true; },
+        stop: () => { active = false; reset(); },
+        getSnapshot: () => state,
+        subscribe: (listener: () => void) => { listeners.add(listener); return () => { listeners.delete(listener); }; },
+    };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -77,7 +77,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       case 'Consumer':
         return 'Consumers';
       case 'Producer':
-        return 'Producer Management';
+        return 'Producers';
       case 'Message':
         return 'Message Query';
       case 'MessageTrace':


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10496

### Brief Description

Place the Producer directory beside the Topic and group query, returned clients and selected-client details. Both query fields support manual input even when discovery is unavailable. Preserve directory coverage notes and omit the unsupported client Last seen field.

Give each input pair an explicit lookup owner: duplicate submits share one request, input changes invalidate prior callbacks, mismatched responses are rejected, and a same-input refresh failure retains the last observation and timestamp. Removing a selected client no longer silently selects a different client. Update the discovery documentation and add focused regression coverage.

### How Did You Test This Change?

- `npm run build` passed from `rocketmq-dashboard/rocketmq-dashboard-tauri`; the existing Vite large-chunk advisory remains.
- `npm test -- src/features/producer src/features/dashboard/readResource.test.ts src/stores/navigation.test.ts` passed: 19 tests in 4 files.
- Compared the source and browser-rendered normal state at 1487 x 1058. Selecting a directory group and submitting a manually entered Topic by keyboard returned the expected scoped clients and details.
- Remaining browser checks cover discovery failures with manual fallback, rapid query changes, removed-client selection, pagination, long values and an 800 x 600 viewport. The browser control channel is currently unavailable, so these checks are not yet claimed as passed.
- Native Windows WebView2 and real RocketMQ-Rust cluster acceptance remain for final integration verification. No backend or dependency changes; local browser fixtures are excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the Producers page with a searchable, paginated producer-group directory.
  - Added free-text Topic entry with Topic suggestions and manual group entry.
  - Added producer connection tables with selectable clients and detailed language, version, address, and scope information.
  - Added refresh controls and clearer loading, empty, error, and unavailable states.
  - Preserved query inputs and directory filters when navigating.

- **Bug Fixes**
  - Prevented stale or mismatched lookup results from replacing current results.
  - Avoided duplicate submissions and preserved the last successful result when refresh fails.
  - Updated the page title to “Producers.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->