### PR TITLE
[ISSUE #10502]✨Redesign trace timeline and scoped message inspection

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/MESSAGE_TRACE.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/MESSAGE_TRACE.md
@@ -1,0 +1,55 @@
+# Message trace inspection
+
+The Trace page uses the shared desktop theme and presents a query above an event
+timeline and the selected event's detail. It preserves the existing authenticated
+Tauri commands; no tracing collector or retry operation is introduced.
+
+## Query identity
+
+- ID mode calls `query_message_trace_by_id` with the selected Trace Topic and the
+  producer unique message ID.
+- Key mode calls the existing business Topic/Key lookup, then lets the operator
+  inspect each returned unique identity. Physical copies with the same Topic and
+  unique ID share a trace candidate. The Key lookup retains its existing limit of
+  64 indexed messages.
+- Event detail calls `view_message_trace_detail` with the candidate's `msgId`,
+  not its physical `queryMsgId`. The returned unique ID, Trace Topic and any
+  reported business Topic must match the selection.
+- Topic discovery supplies suggestions only. Manual input remains available when
+  discovery is loading, fails, or does not include a custom Trace Topic.
+- Changing mode, inputs or connection context invalidates previous reads.
+  Duplicate candidate requests are coalesced. A failed same-query refresh retains
+  its last successful observation with a visible error and paused message navigation.
+
+## Events and navigation
+
+All events, Consumer groups and Transactions use the returned timeline, grouped
+consumer nodes and transaction nodes respectively. There is no inferred delivery
+result when a view is empty. Unrecognized status values remain explicitly unknown.
+Event timestamps retain milliseconds and identify the local time zone; absent or
+invalid timestamps are not replaced with the current time. Reported zero costs
+and retry counts remain zero.
+
+The DTO has no event ID. Selection uses the reported event fields and an occurrence
+number for identical duplicates. Inserting unrelated events does not move selection.
+If the selected record disappears or its fields change, the operator must choose
+an event again. Identical duplicates cannot be distinguished beyond their returned
+occurrence order.
+
+Message and producer metadata remain available in the expandable summary.
+Observed span is the span of returned timestamps, not end-to-end delivery latency
+or evidence of complete trace coverage.
+
+View message prefills the Messages ID query with the business Topic and unique ID;
+it does not submit automatically. The action is unavailable without a reported
+business Topic or while a read is pending or failed. Back restores the source
+query draft. Copy ID reports success only after the clipboard write resolves.
+
+## Validation
+
+`traceModel.test.ts`, `traceQuery.test.ts` and navigation tests cover query fields,
+identity validation, duplicate physical candidates, millisecond timestamps, unknown
+states, selection stability, request coalescing, stale responses and navigation.
+Browser checks exercise the real React components through isolated services.
+Native Windows/WebView2 and real RocketMQ-Rust trace ingestion remain part of the
+full dashboard integration acceptance; isolated browser data does not prove them.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
@@ -17,7 +17,8 @@ export function MainLayout({ children }: { children: ReactNode }) {
     const [confirmSignOut, setConfirmSignOut] = useState(false);
     const [signingOut, setSigningOut] = useState(false);
     const target = navigation.target;
-    const targetName = target ? ('name' in target ? target.name : target.address) : null;
+    // Message and trace links prefill editable queries; their current identity lives in the page.
+    const targetName = target && target.kind !== 'trace' && target.kind !== 'message' ? ('name' in target ? target.name : target.address) : null;
     const handleSignOut = async () => {
         if (signingOut) return;
         setSigningOut(true);

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageTraceView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageTraceView.tsx
@@ -1,730 +1,89 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { AnimatePresence, motion } from 'motion/react';
-import {
-  Activity,
-  AlertCircle,
-  CheckCircle2,
-  ChevronDown,
-  Clock,
-  Copy,
-  Database,
-  Hash,
-  Info,
-  Key,
-  MessageSquare,
-  RefreshCw,
-  Search,
-  Server,
-  Users,
-  X,
-} from 'lucide-react';
-import { toast } from 'sonner@2.0.3';
-import { useTopicCatalog } from '../features/topic/hooks/useTopicCatalog';
-import type { MessageSummary } from '../features/message/types/message.types';
-import type { MessageTraceDetail, MessageTraceNode } from '../features/message-trace/types/message-trace.types';
+import { useCallback, useEffect, useId, useMemo, useState, useSyncExternalStore } from 'react';
+import { Search } from 'lucide-react';
+import { ConnectionStore } from '../services/connection.store';
 import { MessageService } from '../services/message.service';
 import { MessageTraceService } from '../services/message-trace.service';
-import { dashboardErrorMessage } from '../services/invoke';
-import { useAppStore } from '../stores/app.store';
+import { useAppStore, useNavigationState } from '../stores/app.store';
+import { useTopicCatalog } from '../features/topic/hooks/useTopicCatalog';
+import { buildTraceQuery, traceCandidateIdentity, type TraceQueryDraft } from '../features/message-trace/traceModel';
+import { createTraceQueryController } from '../features/message-trace/traceQuery';
+import { TraceWorkspace } from '../features/message-trace/components/TraceWorkspace';
+import { usePageRefresh } from '../app/layout/pageToolbar';
+import { PageState } from './layout/PageState';
+import { Button } from './ui/LegacyButton';
+import { Input } from './ui/LegacyInput';
+import '../features/message-trace/trace.css';
 
 const DEFAULT_TRACE_TOPIC = 'RMQ_SYS_TRACE_TOPIC';
 
-type TraceSearchTab = 'MessageKey' | 'MessageID';
-
-interface TraceDetailModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  traceTopic: string;
-  message: MessageSummary | null;
-}
-
-const formatTimestamp = (value?: number | null) => {
-  if (!value) {
-    return '-';
-  }
-  return new Date(value).toLocaleString();
-};
-
-const formatSpan = (value?: number | null) => {
-  if (value === null || value === undefined) {
-    return '-';
-  }
-  return `${value} ms`;
-};
-
-const roleBadgeClass = (role: string) => {
-  if (role === 'PRODUCER') {
-    return 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-300 dark:border-blue-900/40';
-  }
-  if (role === 'TRANSACTION') {
-    return 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-300 dark:border-amber-900/40';
-  }
-  return 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-300 dark:border-emerald-900/40';
-};
-
-const statusBadgeClass = (status: string) => {
-  if (status === 'success') {
-    return 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-300 dark:border-emerald-900/40';
-  }
-  return 'bg-red-50 text-red-700 border-red-200 dark:bg-red-900/20 dark:text-red-300 dark:border-red-900/40';
-};
-
-const copyToClipboard = (value: string) => {
-  navigator.clipboard.writeText(value);
-  toast.success('Copied to clipboard');
-};
-
-const TraceStatCard = ({ label, value }: { label: string; value: string }) => (
-  <div className="rounded-2xl border border-gray-200 bg-white px-4 py-4 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-    <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">{label}</div>
-    <div className="mt-2 font-mono text-lg font-semibold text-gray-900 dark:text-white">{value}</div>
-  </div>
-);
-
-const TraceNodeCard = ({ node }: { node: MessageTraceNode }) => (
-  <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-    <div className="flex flex-wrap items-center gap-2">
-      <span className={`rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider ${roleBadgeClass(node.role)}`}>
-        {node.role}
-      </span>
-      <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-        {node.traceType}
-      </span>
-      <span className={`rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider ${statusBadgeClass(node.status)}`}>
-        {node.status}
-      </span>
-      <span className="ml-auto font-mono text-xs text-gray-500 dark:text-gray-400">{formatTimestamp(node.timestamp)}</span>
-    </div>
-
-    <div className="mt-4 grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
-      <div>
-        <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Group</div>
-        <div className="mt-1 font-mono text-xs text-gray-900 dark:text-white">{node.groupName || '-'}</div>
-      </div>
-      <div>
-        <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Client Host</div>
-        <div className="mt-1 font-mono text-xs text-gray-900 dark:text-white">{node.clientHost || '-'}</div>
-      </div>
-      <div>
-        <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Store Host</div>
-        <div className="mt-1 font-mono text-xs text-gray-900 dark:text-white">{node.storeHost || '-'}</div>
-      </div>
-      <div>
-        <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Cost / Retry</div>
-        <div className="mt-1 font-mono text-xs text-gray-900 dark:text-white">
-          {node.costTime} ms / {node.retryTimes}
-        </div>
-      </div>
-      <div>
-        <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Transaction Check</div>
-        <div className="mt-1 text-xs text-gray-900 dark:text-white">{node.fromTransactionCheck ? 'Yes' : 'No'}</div>
-      </div>
-    </div>
-  </div>
-);
-
-const TraceDetailModal = ({ isOpen, onClose, traceTopic, message }: TraceDetailModalProps) => {
-  const [detail, setDetail] = useState<MessageTraceDetail | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState('');
-
-  useEffect(() => {
-    if (!isOpen || !message) {
-      setDetail(null);
-      setIsLoading(false);
-      setError('');
-      return;
-    }
-
-    let cancelled = false;
-    setDetail(null);
-    setError('');
-    setIsLoading(true);
-
-    void MessageTraceService.viewMessageTraceDetail({
-      traceTopic,
-      messageId: message.msgId,
-    })
-      .then((result) => {
-        if (!cancelled) {
-          setDetail(result);
-        }
-      })
-      .catch((loadError) => {
-        if (!cancelled) {
-          setError(dashboardErrorMessage(loadError, 'Failed to load trace detail'));
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
+export function MessageTraceView() {
+    const { navigation } = useAppStore();
+    const target = navigation.target?.kind === 'trace' ? navigation.target : null;
+    const [draft, storeDraft] = useNavigationState<TraceQueryDraft>('traceQuery', () => ({
+        mode: 'id', traceTopic: DEFAULT_TRACE_TOPIC, messageId: target?.name ?? '', topic: target?.topic ?? '', key: '',
+    }));
+    const [selection, setSelection] = useState<string | null>(null);
+    const [validation, setValidation] = useState('');
+    const [hasSearched, setHasSearched] = useState(false);
+    const topics = useTopicCatalog();
+    const topicsId = useId();
+    const traceTopics = useMemo(() => [...new Set([DEFAULT_TRACE_TOPIC, ...(topics.data?.items ?? []).map(item => item.topic)])], [topics.data]);
+    const controller = useMemo(() => {
+        const original = ConnectionStore.getSnapshot();
+        return createTraceQueryController({ queryMessageByTopicKey: MessageService.queryMessageByTopicKey, queryMessageTraceById: MessageTraceService.queryMessageTraceById }, () => {
+            const current = ConnectionStore.getSnapshot();
+            return current?.revision === original?.revision && current?.environmentId === original?.environmentId;
+        });
+    }, []);
+    const state = useSyncExternalStore(controller.subscribe, controller.getSnapshot, controller.getSnapshot);
+    useEffect(() => { controller.start(); return controller.stop; }, [controller]);
+    const update = (patch: Partial<TraceQueryDraft>) => {
+        controller.reset(); setSelection(null); setValidation(''); setHasSearched(false);
+        storeDraft({ ...draft, ...patch });
     };
-  }, [isOpen, message, traceTopic]);
-
-  return (
-    <AnimatePresence>
-      {isOpen ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={onClose}
-            className="absolute inset-0 bg-gray-900/40 backdrop-blur-sm"
-          />
-
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95, y: 20 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: 20 }}
-            transition={{ duration: 0.2 }}
-            className="relative flex max-h-[90vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-2xl dark:border-gray-800 dark:bg-gray-950"
-          >
-            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-gray-100 bg-white px-6 py-4 dark:border-gray-800 dark:bg-gray-950">
-              <div>
-                <div className="flex items-center gap-2 text-lg font-bold text-gray-900 dark:text-white">
-                  <Activity className="h-5 w-5 text-blue-500" />
-                  Message Trace Detail
-                </div>
-                <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  Trace Topic: <span className="font-mono">{traceTopic}</span>
-                </div>
-              </div>
-              <button
-                onClick={onClose}
-                className="rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-              >
-                <X className="h-5 w-5" />
-              </button>
-            </div>
-
-            <div className="flex-1 overflow-y-auto bg-gray-50/50 p-6 dark:bg-gray-900/40">
-              {isLoading ? (
-                <div className="flex flex-col items-center justify-center rounded-2xl border border-gray-200 bg-white px-6 py-20 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900">
-                  <RefreshCw className="mb-4 h-8 w-8 animate-spin text-blue-500" />
-                  <p className="text-sm font-medium text-gray-700 dark:text-gray-200">Loading trace detail...</p>
-                </div>
-              ) : error ? (
-                <div className="flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-800 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-200">
-                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                  <div>{error}</div>
-                </div>
-              ) : detail ? (
-                <div className="space-y-6">
-                  <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-                    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                      <div className="space-y-3">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className="rounded-full border border-blue-200 bg-blue-50 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-blue-700 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-300">
-                            {detail.topic || message?.topic || '-'}
-                          </span>
-                          {detail.tags ? (
-                            <span className="rounded-full border border-purple-200 bg-purple-50 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-purple-700 dark:border-purple-900/40 dark:bg-purple-900/20 dark:text-purple-300">
-                              Tag {detail.tags}
-                            </span>
-                          ) : null}
-                          {detail.keys ? (
-                            <span className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-amber-700 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-300">
-                              Key {detail.keys}
-                            </span>
-                          ) : null}
-                        </div>
-
-                        <div>
-                          <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Message ID</div>
-                          <div className="mt-2 flex flex-wrap items-center gap-3">
-                            <div className="font-mono text-sm font-semibold text-gray-900 dark:text-white">{detail.msgId}</div>
-                            <button
-                              onClick={() => copyToClipboard(detail.msgId)}
-                              className="inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:border-blue-200 hover:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-900/40 dark:hover:text-blue-300"
-                            >
-                              <Copy className="h-3.5 w-3.5" />
-                              Copy
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className="grid min-w-full grid-cols-2 gap-3 sm:min-w-[360px]">
-                        <TraceStatCard label="Total Span" value={formatSpan(detail.totalSpanMs)} />
-                        <TraceStatCard label="Timeline Nodes" value={String(detail.timeline.length)} />
-                        <TraceStatCard label="Consumer Groups" value={String(detail.consumerGroups.length)} />
-                        <TraceStatCard label="Transactions" value={String(detail.transactionChecks.length)} />
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.1fr_0.9fr]">
-                    <div className="space-y-6">
-                      <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-                        <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                          <Database className="h-4 w-4 text-blue-500" />
-                          Producer Summary
-                        </div>
-                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                          <div>
-                            <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Producer Group</div>
-                            <div className="mt-1 font-mono text-sm text-gray-900 dark:text-white">{detail.producerGroup || '-'}</div>
-                          </div>
-                          <div>
-                            <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Trace Type</div>
-                            <div className="mt-1 text-sm text-gray-900 dark:text-white">{detail.producerTraceType || '-'}</div>
-                          </div>
-                          <div>
-                            <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Client Host</div>
-                            <div className="mt-1 font-mono text-xs text-gray-900 dark:text-white">{detail.producerClientHost || '-'}</div>
-                          </div>
-                          <div>
-                            <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Store Host</div>
-                            <div className="mt-1 font-mono text-xs text-gray-900 dark:text-white">{detail.producerStoreHost || detail.storeHost || '-'}</div>
-                          </div>
-                          <div>
-                            <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Timestamp</div>
-                            <div className="mt-1 font-mono text-xs text-gray-900 dark:text-white">{formatTimestamp(detail.producerTimestamp)}</div>
-                          </div>
-                          <div>
-                            <div className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Cost / Status</div>
-                            <div className="mt-1 text-sm text-gray-900 dark:text-white">
-                              {detail.producerCostTime ?? '-'} ms / {detail.producerStatus || '-'}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-                        <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                          <Activity className="h-4 w-4 text-blue-500" />
-                          Timeline
-                        </div>
-                        <div className="space-y-4">
-                          {detail.timeline.map((node, index) => (
-                            <TraceNodeCard key={`${node.groupName}-${node.traceType}-${node.timestamp}-${index}`} node={node} />
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="space-y-6">
-                      <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-                        <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                          <Users className="h-4 w-4 text-emerald-500" />
-                          Consumer Groups
-                        </div>
-                        {detail.consumerGroups.length > 0 ? (
-                          <div className="space-y-4">
-                            {detail.consumerGroups.map((group) => (
-                              <div key={group.consumerGroup} className="rounded-2xl border border-gray-200 bg-gray-50/70 p-4 dark:border-gray-800 dark:bg-gray-800/40">
-                                <div className="mb-3 flex items-center justify-between">
-                                  <div className="font-mono text-sm font-semibold text-gray-900 dark:text-white">{group.consumerGroup}</div>
-                                  <span className="rounded-full bg-emerald-50 px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300">
-                                    {group.nodes.length} node(s)
-                                  </span>
-                                </div>
-                                <div className="space-y-3">
-                                  {group.nodes.map((node, index) => (
-                                    <TraceNodeCard key={`${group.consumerGroup}-${node.timestamp}-${index}`} node={node} />
-                                  ))}
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                        ) : (
-                          <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-800/30 dark:text-gray-400">
-                            No consumer trace nodes were returned for this message.
-                          </div>
-                        )}
-                      </div>
-
-                      <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-                        <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                          <Server className="h-4 w-4 text-amber-500" />
-                          Transaction Checks
-                        </div>
-                        {detail.transactionChecks.length > 0 ? (
-                          <div className="space-y-3">
-                            {detail.transactionChecks.map((node, index) => (
-                              <TraceNodeCard key={`${node.traceType}-${node.timestamp}-${index}`} node={node} />
-                            ))}
-                          </div>
-                        ) : (
-                          <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-800/30 dark:text-gray-400">
-                            No transaction check nodes were returned for this message.
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </motion.div>
-        </div>
-      ) : null}
-    </AnimatePresence>
-  );
-};
-
-export const MessageTraceView = () => {
-  const { navigation } = useAppStore();
-  const target = navigation.target?.kind === 'trace' ? navigation.target : null;
-  const [subTab, setSubTab] = useState<TraceSearchTab>(target ? 'MessageID' : 'MessageKey');
-  const [traceTopic, setTraceTopic] = useState(DEFAULT_TRACE_TOPIC);
-  const [topic, setTopic] = useState(target?.topic ?? '');
-  const [key, setKey] = useState('');
-  const [msgId, setMsgId] = useState(target?.name ?? '');
-  const [searchResults, setSearchResults] = useState<MessageSummary[]>([]);
-  const [selectedTrace, setSelectedTrace] = useState<MessageSummary | null>(null);
-  const [isSearching, setIsSearching] = useState(false);
-  const [searchError, setSearchError] = useState('');
-  const [hasSearched, setHasSearched] = useState(false);
-
-  const { data: topicCatalog, isLoading: isTopicCatalogLoading, error: topicCatalogError } = useTopicCatalog();
-
-  const availableTopics = useMemo(
-    () =>
-      (topicCatalog?.items ?? [])
-        .filter((item) => !item.systemTopic && item.category !== 'RETRY' && item.category !== 'DLQ')
-        .map((item) => item.topic)
-        .filter((value, index, array) => array.indexOf(value) === index),
-    [topicCatalog],
-  );
-
-  const availableTraceTopics = useMemo(() => {
-    const topics = (topicCatalog?.items ?? [])
-      .map((item) => item.topic)
-      .filter((value) => value === DEFAULT_TRACE_TOPIC || value.toUpperCase().includes('TRACE'))
-      .filter((value, index, array) => array.indexOf(value) === index);
-
-    if (!topics.includes(DEFAULT_TRACE_TOPIC)) {
-      topics.unshift(DEFAULT_TRACE_TOPIC);
-    }
-
-    return topics;
-  }, [topicCatalog]);
-
-  useEffect(() => {
-    if (!topic && availableTopics.length > 0) {
-      setTopic(availableTopics[0]);
-    }
-  }, [availableTopics, topic]);
-
-  useEffect(() => {
-    if (!availableTraceTopics.includes(traceTopic)) {
-      setTraceTopic(availableTraceTopics[0] || DEFAULT_TRACE_TOPIC);
-    }
-  }, [availableTraceTopics, traceTopic]);
-
-  useEffect(() => {
-    setSearchResults([]);
-    setSelectedTrace(null);
-    setSearchError('');
-    setHasSearched(false);
-  }, [subTab]);
-
-  const handleSearch = async () => {
-    if (subTab === 'MessageKey' && !topic.trim()) {
-      setSearchError('Topic is required for Message Key trace search.');
-      return;
-    }
-
-    if (subTab === 'MessageKey' && !key.trim()) {
-      setSearchError('Message Key is required.');
-      return;
-    }
-
-    if (subTab === 'MessageID' && !msgId.trim()) {
-      setSearchError('Message ID is required.');
-      return;
-    }
-
-    setIsSearching(true);
-    setSearchError('');
-    setHasSearched(true);
-    setSelectedTrace(null);
-
-    try {
-      const response = subTab === 'MessageKey'
-        ? await MessageService.queryMessageByTopicKey({
-            topic: topic.trim(),
-            key: key.trim(),
-          })
-        : await MessageTraceService.queryMessageTraceById({
-            traceTopic: traceTopic.trim(),
-            messageId: msgId.trim(),
-          });
-
-      setSearchResults(response.items);
-    } catch (error) {
-      setSearchResults([]);
-      setSearchError(dashboardErrorMessage(error, 'Failed to search message trace'));
-    } finally {
-      setIsSearching(false);
-    }
-  };
-
-  const emptyStateCopy = subTab === 'MessageKey'
-    ? 'Enter a business topic and key to resolve matching messages, then open trace detail by message id.'
-    : 'Enter a message id to query trace directly from the selected trace topic.';
-
-  return (
-    <div className="mx-auto max-w-[1600px] space-y-6 pb-12 animate-in fade-in slide-in-from-bottom-4 duration-500">
-      <TraceDetailModal
-        isOpen={!!selectedTrace}
-        onClose={() => setSelectedTrace(null)}
-        traceTopic={traceTopic}
-        message={selectedTrace}
-      />
-
-      <div className="mb-2 flex items-center justify-between px-2">
-        <div className="flex items-center space-x-3">
-          <div className="rounded-lg bg-blue-50 p-2 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">
-            <Activity className="h-5 w-5" />
-          </div>
-          <div>
-            <h2 className="text-lg font-bold text-gray-900 dark:text-white">Message Trace</h2>
-              <p className="text-xs text-gray-500 dark:text-gray-400">Query lifecycle events from the selected trace topic.</p>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">Trace Topic</span>
-          <div className="relative">
-            <select
-              value={traceTopic}
-              onChange={(event) => setTraceTopic(event.target.value)}
-              className="cursor-pointer appearance-none rounded-lg border border-gray-200 bg-white py-1.5 pl-3 pr-8 text-xs font-medium text-gray-700 transition-all focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
-            >
-              {availableTraceTopics.map((item) => (
-                <option key={item} value={item}>
-                  {item}
-                </option>
-              ))}
-            </select>
-            <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
-          </div>
-        </div>
-      </div>
-
-      <div className="mb-6 flex justify-center">
-        <div className="inline-flex rounded-xl border border-gray-200 bg-white p-1 shadow-sm transition-colors dark:border-gray-800 dark:bg-gray-900">
-          <button
-            onClick={() => setSubTab('MessageKey')}
-            className={`rounded-lg px-6 py-2 text-sm font-medium transition-all ${
-              subTab === 'MessageKey'
-                ? 'bg-blue-50 text-blue-600 shadow-sm dark:bg-blue-900/30 dark:text-blue-400'
-                : 'text-gray-500 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200'
-            }`}
-          >
-            Message Key
-          </button>
-          <button
-            onClick={() => setSubTab('MessageID')}
-            className={`rounded-lg px-6 py-2 text-sm font-medium transition-all ${
-              subTab === 'MessageID'
-                ? 'bg-blue-50 text-blue-600 shadow-sm dark:bg-blue-900/30 dark:text-blue-400'
-                : 'text-gray-500 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200'
-            }`}
-          >
-            Message ID
-          </button>
-        </div>
-      </div>
-
-      <div className="sticky top-0 z-20 rounded-2xl border border-gray-100 bg-white/90 p-5 shadow-sm backdrop-blur-xl transition-colors dark:border-gray-800 dark:bg-gray-900/90">
-        <div className="flex flex-col gap-5 xl:flex-row xl:items-end">
-          {subTab === 'MessageKey' ? (
-            <>
-              <div className="min-w-[220px] flex-1 space-y-1.5">
-                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">Topic</label>
-                <div className="group relative">
-                  <MessageSquare className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 transition-colors group-focus-within:text-blue-500 dark:text-gray-500" />
-                  <select
-                    value={topic}
-                    onChange={(event) => setTopic(event.target.value)}
-                    className="w-full cursor-pointer appearance-none rounded-xl border border-gray-200 bg-gray-50 py-2.5 pl-10 pr-8 text-sm transition-all focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-                  >
-                    {availableTopics.length === 0 ? (
-                      <option value="">{isTopicCatalogLoading ? 'Loading topics...' : 'No topics'}</option>
-                    ) : (
-                      availableTopics.map((item) => (
-                        <option key={item} value={item}>
-                          {item}
-                        </option>
-                      ))
-                    )}
-                  </select>
-                  <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-                </div>
-              </div>
-
-              <div className="min-w-[240px] flex-[2] space-y-1.5">
-                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">Message Key</label>
-                <div className="group relative">
-                  <Key className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 transition-colors group-focus-within:text-blue-500 dark:text-gray-500" />
-                  <input
-                    type="text"
-                    value={key}
-                    onChange={(event) => setKey(event.target.value)}
-                    placeholder="Enter Message Key..."
-                    className="w-full rounded-xl border border-gray-200 bg-gray-50 py-2.5 pl-10 pr-4 text-sm transition-all focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
-                  />
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="min-w-[320px] flex-1 space-y-1.5">
-              <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">Message ID</label>
-              <div className="group relative">
-                <Hash className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 transition-colors group-focus-within:text-blue-500 dark:text-gray-500" />
-                <input
-                  type="text"
-                  value={msgId}
-                  onChange={(event) => setMsgId(event.target.value)}
-                  placeholder="Enter Message ID..."
-                  className="w-full rounded-xl border border-gray-200 bg-gray-50 py-2.5 pl-10 pr-4 text-sm font-mono transition-all focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
-                />
-              </div>
-            </div>
-          )}
-
-          <div className="flex items-center gap-3 pb-0.5">
-            <button
-              onClick={() => void handleSearch()}
-              disabled={isSearching || (subTab === 'MessageKey' && isTopicCatalogLoading)}
-              className="whitespace-nowrap rounded-xl bg-gray-900 px-8 py-2.5 text-sm font-medium text-white shadow-md transition-all hover:bg-gray-800 hover:shadow-lg active:scale-95 disabled:cursor-not-allowed disabled:opacity-70 dark:border dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800"
-            >
-              <div className="flex items-center">
-                <Search className="mr-2 h-4 w-4" />
-                {isSearching ? 'Searching...' : 'Search'}
-              </div>
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {topicCatalogError ? (
-        <div className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200">
-          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <div>Failed to load topic catalog: {topicCatalogError}</div>
-        </div>
-      ) : null}
-
-      {searchError ? (
-        <div className="flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-200">
-          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <div>{searchError}</div>
-        </div>
-      ) : null}
-
-      <div className="flex items-center justify-between rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-600 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
-        <div className="flex items-center gap-2">
-          <Info className="h-4 w-4 text-blue-500" />
-          <span>
-            {subTab === 'MessageKey'
-              ? 'Message Key mode first resolves matching messages, then loads trace detail by message id.'
-              : 'Message ID mode queries trace data directly from the selected trace topic.'}
-          </span>
-        </div>
-        <span className="font-mono text-xs text-gray-400 dark:text-gray-500">{hasSearched ? `${searchResults.length} result(s)` : 'ready'}</span>
-      </div>
-
-      {isSearching ? (
-        <div className="flex flex-col items-center justify-center rounded-[28px] border border-gray-200 bg-white px-6 py-20 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <RefreshCw className="mb-4 h-10 w-10 animate-spin text-blue-500" />
-          <p className="text-sm font-medium text-gray-700 dark:text-gray-200">Searching trace data...</p>
-        </div>
-      ) : searchResults.length > 0 ? (
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 2xl:grid-cols-3">
-          {searchResults.map((row, index) => (
-            <motion.div
-              key={row.msgId}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: index * 0.05 }}
-              className="group flex flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm transition-all duration-200 hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
-            >
-              <div className="flex items-start justify-between border-b border-gray-50 bg-gradient-to-br from-gray-50/50 to-white px-5 py-4 dark:border-gray-800 dark:from-gray-800/50 dark:to-gray-900">
-                <div className="min-w-0 flex-1">
-                  <div className="mb-1 flex items-center gap-2">
-                    <div className="rounded-lg bg-indigo-50 p-2 text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-400">
-                      <Hash className="h-4 w-4" />
-                    </div>
-                    <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">Message ID</span>
-                  </div>
-                  <p className="truncate font-mono text-sm font-bold text-gray-900 dark:text-white" title={row.msgId}>
-                    {row.msgId}
-                  </p>
-                </div>
-                <button
-                  onClick={() => copyToClipboard(row.msgId)}
-                  className="rounded-lg p-2 text-gray-300 transition-colors hover:bg-gray-100 hover:text-blue-600 dark:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-blue-400"
-                >
-                  <Copy className="h-3.5 w-3.5" />
-                </button>
-              </div>
-
-              <div className="flex-1 space-y-4 p-5">
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                  <div className="rounded-xl border border-gray-100 bg-gray-50/50 p-3 dark:border-gray-800 dark:bg-gray-800/50">
-                    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Topic</p>
-                    <p className="font-mono text-xs font-medium text-gray-700 dark:text-gray-300">{row.topic || '-'}</p>
-                  </div>
-                  <div className="rounded-xl border border-gray-100 bg-gray-50/50 p-3 dark:border-gray-800 dark:bg-gray-800/50">
-                    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Store Time</p>
-                    <div className="flex items-center text-xs text-gray-500 dark:text-gray-400">
-                      <Clock className="mr-1.5 h-3.5 w-3.5 text-gray-400 dark:text-gray-500" />
-                      {formatTimestamp(row.storeTimestamp)}
-                    </div>
-                  </div>
-                  <div className="rounded-xl border border-gray-100 bg-gray-50/50 p-3 dark:border-gray-800 dark:bg-gray-800/50">
-                    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Tag</p>
-                    <span className="inline-flex rounded border border-purple-200 bg-purple-50 px-2 py-0.5 text-xs font-medium text-purple-700 dark:border-purple-900/40 dark:bg-purple-900/20 dark:text-purple-300">
-                      {row.tags || '-'}
-                    </span>
-                  </div>
-                  <div className="rounded-xl border border-gray-100 bg-gray-50/50 p-3 dark:border-gray-800 dark:bg-gray-800/50">
-                    <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Key</p>
-                    <p className="truncate font-mono text-xs font-medium text-gray-700 dark:text-gray-300" title={row.keys || '-'}>
-                      {row.keys || '-'}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex justify-end border-t border-gray-100 bg-gray-50/30 px-5 py-3 dark:border-gray-800 dark:bg-gray-800/30">
-                <button
-                  onClick={() => setSelectedTrace(row)}
-                  className="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 shadow-sm transition-all hover:border-blue-200 hover:bg-blue-50 hover:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-900/40 dark:hover:bg-blue-900/20 dark:hover:text-blue-300"
-                >
-                  <Activity className="mr-1.5 h-3.5 w-3.5" />
-                  Trace Detail
-                </button>
-              </div>
-            </motion.div>
-          ))}
-        </div>
-      ) : hasSearched ? (
-        <div className="flex flex-col items-center justify-center rounded-[28px] border border-dashed border-gray-200 bg-white px-6 py-20 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <Search className="mb-4 h-10 w-10 text-gray-300 dark:text-gray-600" />
-          <p className="text-sm font-medium text-gray-700 dark:text-gray-200">No trace candidates found</p>
-          <p className="mt-2 max-w-2xl text-sm text-gray-500 dark:text-gray-400">
-            {emptyStateCopy}
-          </p>
-        </div>
-      ) : (
-        <div className="flex flex-col items-center justify-center rounded-[28px] border border-dashed border-gray-200 bg-white px-6 py-20 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <CheckCircle2 className="mb-4 h-10 w-10 text-gray-300 dark:text-gray-600" />
-          <p className="text-sm font-medium text-gray-700 dark:text-gray-200">Trace search is ready</p>
-          <p className="mt-2 max-w-2xl text-sm text-gray-500 dark:text-gray-400">
-            {emptyStateCopy}
-          </p>
-        </div>
-      )}
-    </div>
-  );
-};
+    const query = useCallback(() => {
+        try {
+            const request = buildTraceQuery(draft);
+            setValidation(''); setHasSearched(true);
+            void controller.read(request);
+        } catch (error) { setValidation((error as Error).message); }
+    }, [controller, draft]);
+    const refresh = useCallback(() => { void topics.refresh(); if (hasSearched) query(); }, [topics.refresh, hasSearched, query]);
+    usePageRefresh({ refresh, pending: topics.pending || state.pending, refreshedAt: state.receivedAt });
+    const result = state.result;
+    useEffect(() => { if (selection === null && result?.items[0]) setSelection(traceCandidateIdentity(result.items[0])); }, [selection, result]);
+    const selected = result?.items.find(item => traceCandidateIdentity(item) === selection);
+    return <div className="ops-trace">
+        <section className="ops-trace-query" aria-label="Trace query">
+            <div className="ops-trace-query-heading"><div className="ops-trace-modes" role="group" aria-label="Trace query mode">
+                {(['id', 'key'] as const).map(mode => <Button key={mode} variant={draft.mode === mode ? 'primary' : 'ghost'} aria-pressed={draft.mode === mode} onClick={() => { if (mode !== draft.mode) update({ mode }); }}>{mode === 'id' ? 'Message ID' : 'Message Key'}</Button>)}
+            </div><p className="ops-trace-note">{draft.mode === 'id' ? 'Events correlated by producer unique ID.' : 'Resolve up to 64 indexed messages from a business Topic and Key.'}</p></div>
+            <form className="ops-trace-fields" onSubmit={event => { event.preventDefault(); query(); }}>
+                <Input label="Trace Topic" list={topicsId} value={draft.traceTopic} onChange={event => update({ traceTopic: event.target.value })} required />
+                <datalist id={topicsId}>{traceTopics.map(topic => <option key={topic} value={topic} />)}</datalist>
+                {draft.mode === 'id' ? <Input label="Message ID (producer unique ID)" value={draft.messageId} onChange={event => update({ messageId: event.target.value })} required /> : <>
+                    <Input label="Business Topic" list={topicsId} value={draft.topic} onChange={event => update({ topic: event.target.value })} required />
+                    <Input label="Message Key" value={draft.key} onChange={event => update({ key: event.target.value })} required />
+                </>}
+                <Button type="submit" icon={Search} disabled={state.pending}>{state.pending ? 'Querying…' : 'Query trace'}</Button>
+            </form>
+            {topics.error && <p className="ops-trace-note">Topic suggestions are unavailable. Enter the Trace Topic and business Topic manually.</p>}
+            {validation && <PageState kind="error" title="Check trace query" description={validation} />}
+        </section>
+        {state.pending && <PageState kind="loading" title="Querying trace candidates" description={result ? 'Showing the last successful query while refreshing.' : undefined} />}
+        {state.error && <PageState kind="error" title="Trace query unavailable" description={state.error + (result ? ' Showing the last successful query; message navigation is paused.' : ' Check the Trace Topic and whether tracing was enabled for this message.')} />}
+        {!hasSearched && <PageState kind="empty" title="Query a message trace" description="Enter a producer unique ID, or use a business Topic and Key to find candidate messages. No query runs until you submit." />}
+        {result && result.items.length === 0 && <PageState kind="empty" title="No trace candidates returned" description="The query completed without matching records. Missing trace data does not prove that a message was not delivered." />}
+        {result && result.items.length > 0 && (result.items.length > 1 || selection && !selected) && <div className="ops-trace-candidates">
+            <label className="ops-trace-select">Message to inspect
+                <select value={selected ? selection! : ''} disabled={state.pending} onChange={event => setSelection(event.target.value)}>
+                    <option value="" disabled>Select a returned message</option>
+                    {result.items.map(message => <option key={traceCandidateIdentity(message)} value={traceCandidateIdentity(message)}>{message.msgId} · {message.topic || 'Topic not reported'}</option>)}
+                </select>
+            </label><p className="ops-trace-note">{result.items.length} unique message identities returned. Physical copies with the same Topic and unique ID share a trace.</p>
+        </div>}
+        {selected && result && <TraceWorkspace key={traceCandidateIdentity(selected)} message={selected} traceTopic={result.query.traceTopic} queryResult={result} disabled={state.pending || Boolean(state.error)} />}
+        {result && result.items.length > 0 && selection && !selected && <PageState kind="empty" title="Selected message is no longer reported" description="Choose a returned message to continue; selection has not moved to another identity." />}
+        {state.receivedAt != null && <p className="ops-trace-note">Last successful candidate query: {new Date(state.receivedAt).toLocaleString()}</p>}
+    </div>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useId, useMemo, useState, useSyncExternalStore 
 import { Copy, Search } from 'lucide-react';
 import { ConnectionStore } from '../services/connection.store';
 import { MessageService } from '../services/message.service';
-import { useNavigationState } from '../stores/app.store';
+import { useAppStore, useNavigationState } from '../stores/app.store';
 import { useTopicCatalog } from '../features/topic/hooks/useTopicCatalog';
 import { buildMessageQuery, createMessageQueryController, type MessageQueryDraft } from '../features/message/messageQuery';
 import { messageIdentity, messageTimestamp, visibleMessageText } from '../features/message/messageModel';
@@ -23,7 +23,10 @@ const initialDraft = (): MessageQueryDraft => ({ mode: 'key', topic: '', key: ''
 const modes = [['key', 'By Key'], ['id', 'By ID'], ['time', 'By Time']] as const;
 
 export function MessageView() {
-    const [draft, storeDraft] = useNavigationState<MessageQueryDraft>('messageQuery', initialDraft);
+    const { navigation } = useAppStore();
+    const target = navigation.target?.kind === 'message' ? navigation.target : null;
+    const [draft, storeDraft] = useNavigationState<MessageQueryDraft>('messageQuery', () => target
+        ? { ...initialDraft(), mode: 'id', topic: target.topic, messageId: target.name } : initialDraft());
     const [selection, setSelection] = useState<string | null>(null);
     const [localPage, setLocalPage] = useState(1);
     const [validation, setValidation] = useState('');

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/components/TraceWorkspace.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/components/TraceWorkspace.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowRight, Check, CircleHelp, Copy, RefreshCw, X } from 'lucide-react';
+import { PageSection } from '../../../components/layout/PageSection';
+import { PageState } from '../../../components/layout/PageState';
+import { StatusBadge } from '../../../components/layout/StatusBadge';
+import { Button } from '../../../components/ui/LegacyButton';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../../components/ui/tabs';
+import { useReadResource } from '../../../hooks/useReadResource';
+import { MessageTraceService } from '../../../services/message-trace.service';
+import { useAppStore } from '../../../stores/app.store';
+import { copyMessageValue } from '../../message/components/MessageInspector';
+import { messageNumber, visibleMessageText } from '../../message/messageModel';
+import type { MessageSummary } from '../../message/types/message.types';
+import { checkTraceDetail, traceDuration, traceEvents, traceStatus, traceTimestamp } from '../traceModel';
+import type { TraceResult } from '../traceQuery';
+import type { MessageTraceDetail, MessageTraceNode } from '../types/message-trace.types';
+
+type EventView = 'timeline' | 'consumers' | 'transactions';
+type TraceEvent = ReturnType<typeof traceEvents>[number];
+
+export function TraceWorkspace({ message, traceTopic, queryResult, disabled }: {
+    message: MessageSummary; traceTopic: string; queryResult: TraceResult; disabled: boolean;
+}) {
+    const load = useCallback(async () => checkTraceDetail(await MessageTraceService.viewMessageTraceDetail({ traceTopic, messageId: message.msgId }), traceTopic, message), [traceTopic, message.msgId, message.topic, queryResult]);
+    const resource = useReadResource(load, 'Trace events could not be read.');
+    const [view, setView] = useState<EventView>('timeline');
+    const [selection, setSelection] = useState<string | null>(null);
+    const data = resource.data;
+    const groups = useMemo(() => data ? [
+        { key: 'timeline', label: '', events: traceEvents(data.timeline) },
+        ...data.consumerGroups.map((group, index) => ({ key: `consumer:${index}`, label: group.consumerGroup || 'Group not reported', events: traceEvents(group.nodes) })),
+        { key: 'transactions', label: '', events: traceEvents(data.transactionChecks) },
+    ] : [], [data]);
+    const visibleGroups = groups.filter(group => view === 'consumers' ? group.key.startsWith('consumer:') : group.key === view);
+    const events = visibleGroups.flatMap(group => group.events);
+    useEffect(() => { if (selection === null && events[0]) setSelection(events[0].id); }, [selection, events]);
+    const selected = events.find(event => event.id === selection);
+    const blocked = disabled || resource.pending || Boolean(resource.error);
+    const topic = data?.topic || message.topic;
+    return <>
+        {resource.pending && <PageState kind="loading" title="Reading trace events" description={data ? 'Showing the last successful event read while refreshing.' : undefined} />}
+        {resource.error && <PageState kind="error" title="Trace events unavailable" description={resource.error + (data ? ' Showing the last successful read; message navigation is paused.' : '')} />}
+        <div className="ops-trace-workspace">
+            <PageSection title="Trace timeline" description={<span title={message.msgId}>Events for message <span className="ops-trace-identity">{visibleMessageText(message.msgId)}</span></span>}
+                action={<Button variant="ghost" icon={RefreshCw} aria-label="Refresh trace events" disabled={disabled || resource.pending} onClick={() => { void resource.read(); }} />}>
+                <Tabs value={view} onValueChange={value => { setView(value as EventView); setSelection(null); }}>
+                    <TabsList className="ops-tabs-underlined" aria-label="Trace event view"><TabsTrigger value="timeline">All events</TabsTrigger><TabsTrigger value="consumers">Consumer groups</TabsTrigger><TabsTrigger value="transactions">Transactions</TabsTrigger></TabsList>
+                    {(['timeline', 'consumers', 'transactions'] as const).map(value => <TabsContent key={value} value={value}>
+                        <div className="ops-trace-event-list">
+                            {visibleGroups.map(group => <div key={group.key}>{group.label && <h3 className="ops-trace-group-heading">{visibleMessageText(group.label)} <span>{group.events.length} events</span></h3>}
+                                <ol aria-label={group.label || (view === 'transactions' ? 'Transaction events' : 'All trace events')}>
+                                    {group.events.map(event => <TraceEventItem key={event.id} event={event} selected={selection === event.id} topic={topic} onSelect={() => setSelection(event.id)} />)}
+                                </ol>
+                            </div>)}
+                            {data && !events.length && <PageState kind="empty" title="No events returned in this view" description="No delivery outcome can be inferred from missing trace records." />}
+                        </div>
+                    </TabsContent>)}
+                </Tabs>
+            </PageSection>
+            <PageSection title="Event details" description="Details for the selected event.">
+                {selected && data ? <EventDetails node={selected.node} detail={data} topic={topic} disabled={blocked} /> : <PageState kind="empty" title={selection ? 'Selected event is no longer reported' : 'Select an event'} description="Choose an event in the timeline to inspect its reported fields." />}
+            </PageSection>
+        </div>
+        {data && <details className="ops-trace-summary"><summary>Message and producer summary</summary><TraceSummary detail={data} />
+            <p className="ops-trace-note">Observed span covers returned event timestamps. It is not an end-to-end delivery latency or proof of complete trace coverage.</p>
+        </details>}
+        {resource.receivedAt != null && <p className="ops-trace-note">Last successful event read: {new Date(resource.receivedAt).toLocaleString()} · Event times: {Intl.DateTimeFormat().resolvedOptions().timeZone}</p>}
+    </>;
+}
+
+function TraceStatus({ status }: { status?: string | null }) {
+    const kind = traceStatus(status);
+    return <StatusBadge tone={kind === 'success' ? 'success' : kind === 'failed' ? 'danger' : 'neutral'}>{kind === 'success' ? 'Success' : kind === 'failed' ? 'Failed' : status ? `Unknown (${visibleMessageText(status)})` : 'Unknown'}</StatusBadge>;
+}
+
+function TraceEventItem({ event, selected, topic, onSelect }: { event: TraceEvent; selected: boolean; topic: string; onSelect: () => void }) {
+    const { node } = event;
+    const kind = traceStatus(node.status), Icon = kind === 'success' ? Check : kind === 'failed' ? X : CircleHelp;
+    return <li className="ops-trace-event" data-selected={selected} data-status={kind}>
+        <button type="button" aria-pressed={selected} className="ops-trace-event-button" onClick={onSelect}>
+            <span className="ops-trace-marker"><Icon aria-hidden="true" /></span>
+            <span className="ops-trace-event-content"><span className="ops-trace-event-heading"><strong>{visibleMessageText(node.traceType || 'Unreported event')}</strong><TraceStatus status={node.status} /></span>
+                <time>{traceTimestamp(node.timestamp)}</time>
+                <span className="ops-trace-event-fields">{[['Group', node.groupName], ['Topic', topic], ['Client', node.clientHost]].map(([label, value]) => <span key={label}><span>{label}</span><span title={value}>{visibleMessageText(value || 'Not reported')}</span></span>)}</span>
+            </span>
+        </button>
+    </li>;
+}
+
+function EventDetails({ node, detail, topic, disabled }: { node: MessageTraceNode; detail: MessageTraceDetail; topic: string; disabled: boolean }) {
+    const { openMessage } = useAppStore();
+    return <div className="ops-trace-detail">
+        <dl className="ops-trace-properties">{[['Event', node.traceType], ['Group', node.groupName], ['Topic', topic], ['Client', node.clientHost], ['Timestamp', traceTimestamp(node.timestamp)]].map(([label, value]) => <div key={label}><dt>{label}</dt><dd tabIndex={value.length > 200 ? 0 : undefined}>{visibleMessageText(value || 'Not reported')}</dd></div>)}
+            <div><dt>Status</dt><dd><TraceStatus status={node.status} /></dd></div>
+        </dl>
+        <div className="ops-trace-actions"><Button variant="ghost" disabled={disabled || !topic} onClick={() => { if (topic) openMessage(detail.msgId, topic); }}>View message<ArrowRight aria-hidden="true" /></Button>
+            <Button variant="ghost" icon={Copy} onClick={() => { void copyMessageValue(detail.msgId, 'Trace message ID'); }}>Copy ID</Button></div>
+        {!topic && <p className="ops-trace-note">The business Topic was not reported, so message navigation is unavailable.</p>}
+        <details className="ops-trace-metadata"><summary>Event metadata</summary><dl className="ops-trace-properties">{[
+            ['Role', node.role], ['Store host', node.storeHost], ['Cost time', traceDuration(node.costTime)], ['Retry count', messageNumber(node.retryTimes)],
+            ['From transaction check', node.fromTransactionCheck ? 'Yes' : 'No'],
+        ].map(([label, value]) => <div key={label}><dt>{label}</dt><dd tabIndex={value.length > 200 ? 0 : undefined}>{visibleMessageText(value || 'Not reported')}</dd></div>)}</dl></details>
+    </div>;
+}
+
+function TraceSummary({ detail }: { detail: MessageTraceDetail }) {
+    return <dl className="ops-trace-properties ops-trace-summary-fields">{[
+        ['Message ID', detail.msgId], ['Trace Topic', detail.traceTopic], ['Business Topic', detail.topic], ['Tags', detail.tags], ['Keys', detail.keys],
+        ['Store host', detail.storeHost], ['First event', traceTimestamp(detail.minTimestamp)], ['Last event', traceTimestamp(detail.maxTimestamp)],
+        ['Observed span', traceDuration(detail.totalSpanMs)], ['Producer group', detail.producerGroup], ['Producer event', detail.producerTraceType],
+        ['Producer client', detail.producerClientHost], ['Producer store host', detail.producerStoreHost], ['Producer timestamp', traceTimestamp(detail.producerTimestamp)],
+        ['Producer cost time', traceDuration(detail.producerCostTime)], ['Timeline events', String(detail.timeline.length)],
+        ['Consumer groups', String(detail.consumerGroups.length)], ['Transaction events', String(detail.transactionChecks.length)],
+    ].map(([label, value]) => <div key={label}><dt>{label}</dt><dd tabIndex={value && value.length > 200 ? 0 : undefined}>{visibleMessageText(value || 'Not reported')}</dd></div>)}<div><dt>Producer status</dt><dd><TraceStatus status={detail.producerStatus} /></dd></div></dl>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/trace.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/trace.css
@@ -1,0 +1,57 @@
+.ops-trace { display: grid; gap: 16px; min-width: 0; }
+.ops-trace-query, .ops-trace-summary { min-width: 0; padding: 18px; border: 1px solid var(--ops-border); border-radius: 12px; background: var(--ops-panel); }
+.ops-trace-query-heading { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 10px; margin-bottom: 8px; }
+.ops-trace-query { padding: 16px; }
+.ops-trace-note { margin: 0; color: var(--ops-muted); font-size: 12px; line-height: 1.6; overflow-wrap: anywhere; }
+.ops-trace-modes { display: flex; gap: 2px; padding: 2px; border: 1px solid var(--ops-border); border-radius: 8px; background: var(--ops-panel-soft); }
+.ops-trace-modes button { min-height: 32px; height: 32px; }
+.ops-trace-fields { display: flex; flex-wrap: wrap; align-items: end; gap: 16px; }
+.ops-trace-fields > .ops-field { min-width: 0; flex: 1 1 250px; }
+.ops-trace-fields > .ops-field:first-child { flex: 0.8 1 220px; }
+.ops-trace-query > .ops-trace-note { margin-top: 10px; }
+.ops-trace-workspace { display: grid; grid-template-columns: minmax(0, 1.08fr) minmax(0, 1fr); align-items: stretch; gap: 16px; }
+.ops-trace-workspace > .ops-page-section { min-width: 0; }
+.ops-trace-workspace .ops-section-header { margin-bottom: 12px; }
+.ops-trace-workspace .ops-section-header > div:first-child { min-width: 0; }
+.ops-trace-workspace .ops-section-header p { overflow-wrap: anywhere; }
+.ops-trace-identity { font-family: var(--ops-font-mono); }
+.ops-trace [data-slot="tabs-list"] { max-width: 100%; overflow-x: auto; justify-content: flex-start; }
+.ops-trace [data-slot="tabs-content"] { min-width: 0; }
+.ops-trace-event-list { min-width: 0; max-height: 640px; overflow-y: auto; padding: 2px; }
+.ops-trace-event-list ol { list-style: none; padding: 0; margin: 0; }
+.ops-trace-event { position: relative; min-width: 0; border-left: 3px solid transparent; border-radius: 0 8px 8px 0; }
+.ops-trace-event + .ops-trace-event { margin-top: 4px; }
+.ops-trace-event:not(:last-child)::after { content: ''; position: absolute; pointer-events: none; left: 25px; top: 50px; bottom: -17px; border-left: 1px solid var(--ops-border-strong); }
+.ops-trace-event[data-selected="true"] { background: var(--ops-accent-soft); border-left-color: var(--ops-accent); }
+.ops-trace-event-button { display: flex; gap: 20px; width: 100%; min-width: 0; padding: 14px 16px 14px 10px; border: 0; border-radius: inherit; background: transparent; color: var(--ops-text); cursor: pointer; text-align: left; font: inherit; }
+.ops-trace-event:not([data-selected="true"]) .ops-trace-event-button:hover { background: var(--ops-panel-strong); }
+.ops-trace-marker { display: flex; align-items: center; justify-content: center; flex: 0 0 32px; height: 32px; border-radius: 50%; background: var(--ops-panel-strong); color: var(--ops-muted); }
+.ops-trace-marker svg { width: 21px; height: 21px; }
+.ops-trace-event[data-status="success"] .ops-trace-marker { color: var(--ops-success); background: var(--ops-success-soft); }
+.ops-trace-event[data-status="failed"] .ops-trace-marker { color: var(--ops-danger); background: var(--ops-danger-soft); }
+.ops-trace-event-content { display: block; flex: 1; min-width: 0; }
+.ops-trace-event-heading { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.ops-trace-event-heading strong { font-size: 16px; font-weight: 600; overflow-wrap: anywhere; }
+.ops-trace-event-heading .ops-status-badge { white-space: normal; overflow-wrap: anywhere; }
+.ops-trace-event time { display: block; margin-top: 5px; color: var(--ops-muted); font-size: 13px; }
+.ops-trace-event-fields { display: grid; gap: 6px; margin-top: 14px; font-size: 13px; }
+.ops-trace-event-fields > span { display: grid; grid-template-columns: 64px minmax(0, 1fr); gap: 12px; }
+.ops-trace-event-fields > span > span:first-child { color: var(--ops-muted); }
+.ops-trace-event-fields > span > span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ops-trace-group-heading { margin: 16px 10px 6px; font-size: 14px; overflow-wrap: anywhere; }
+.ops-trace-group-heading span { display: block; margin-top: 5px; font-size: 12px; font-weight: 400; color: var(--ops-muted); }
+.ops-trace-detail { min-width: 0; padding: 4px 16px 12px; border: 1px solid var(--ops-border); border-radius: 8px; }
+.ops-trace-properties { margin: 0; font-size: 14px; }
+.ops-trace-properties > div { display: grid; grid-template-columns: minmax(100px, 34%) minmax(0, 1fr); gap: 16px; padding: 16px 4px; border-bottom: 1px solid var(--ops-border); }
+.ops-trace-properties dt { color: var(--ops-muted); font-size: 12px; overflow-wrap: anywhere; }
+.ops-trace-properties dd { margin: 0; max-height: 160px; overflow: auto; overflow-wrap: anywhere; }
+.ops-trace-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin: 16px 0; }
+.ops-trace-actions button { padding-left: 4px; }
+.ops-trace-actions button:first-child { color: var(--ops-accent-strong); }
+.ops-trace-metadata summary, .ops-trace-summary summary { cursor: pointer; font-size: 13px; color: var(--ops-muted); padding: 5px 0; }
+.ops-trace-summary-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); column-gap: 24px; margin: 12px 0; }
+.ops-trace-candidates { min-width: 0; display: grid; gap: 8px; }
+.ops-trace-select { display: grid; gap: 8px; color: var(--ops-muted); font-size: 12px; min-width: 0; }
+.ops-trace-select select { width: 100%; min-width: 0; border: 1px solid var(--ops-border); border-radius: 8px; background: var(--ops-panel-soft); color: var(--ops-text); padding: 8px 12px; min-height: 38px; font-size: 14px; }
+@media (max-width: 1100px) { .ops-trace-workspace, .ops-trace-summary-fields { grid-template-columns: minmax(0, 1fr); } .ops-trace-event-list { max-height: 420px; } }
+@media (max-width: 800px) { .ops-trace-event-button { gap: 12px; padding-right: 10px; } .ops-trace-properties > div { grid-template-columns: minmax(80px, 30%) minmax(0, 1fr); gap: 12px; } }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/traceModel.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/traceModel.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { buildTraceQuery, checkTraceDetail, traceCandidates, traceCandidateIdentity, traceDuration, traceEvents, traceStatus, traceTimestamp, type TraceQueryDraft } from './traceModel';
+import type { MessageSummary } from '../message/types/message.types';
+import type { MessageTraceDetail, MessageTraceNode } from './types/message-trace.types';
+
+const draft: TraceQueryDraft = { mode: 'id', traceTopic: ' custom.trace ', topic: ' orders.events ', messageId: ' unique-1 ', key: ' order-1 ' };
+const message: MessageSummary = { topic: 'orders.events', msgId: 'unique-1', queryMsgId: 'physical-1', storeTimestamp: 1000 };
+const detail: MessageTraceDetail = { msgId: 'unique-1', traceTopic: 'custom.trace', topic: 'orders.events', timeline: [], consumerGroups: [], transactionChecks: [] };
+const node: MessageTraceNode = { traceType: 'SubAfter', role: 'CONSUMER', groupName: 'workers', clientHost: 'client-a', storeHost: 'broker-a', timestamp: 1000, costTime: 0, status: 'failed', retryTimes: 0, fromTransactionCheck: false };
+
+describe('Trace query and identity', () => {
+    it('requires only the selected mode fields and supports explicit Trace Topics', () => {
+        expect(buildTraceQuery({ ...draft, topic: '', key: '' })).toEqual({ mode: 'id', traceTopic: 'custom.trace', messageId: 'unique-1' });
+        expect(buildTraceQuery({ ...draft, mode: 'key', messageId: '' })).toEqual({ mode: 'key', traceTopic: 'custom.trace', topic: 'orders.events', key: 'order-1' });
+        for (const invalid of [{ ...draft, traceTopic: ' ' }, { ...draft, messageId: '' }, { ...draft, mode: 'key' as const, topic: '' }, { ...draft, mode: 'key' as const, key: ' ' }]) {
+            expect(() => buildTraceQuery(invalid)).toThrow();
+        }
+    });
+    it('deduplicates physical copies by unique ID without confusing the Trace Topic with the business Topic', () => {
+        const copies = [message, { ...message, queryMsgId: 'physical-2' }, { ...message, msgId: 'unique-2' }];
+        expect(traceCandidates(buildTraceQuery({ ...draft, mode: 'key' }), copies)).toEqual([copies[0], copies[2]]);
+        expect(traceCandidates(buildTraceQuery(draft), [message])).toEqual([message]);
+        expect(traceCandidateIdentity(copies[0])).toBe(traceCandidateIdentity(copies[1]));
+        expect(() => traceCandidates(buildTraceQuery(draft), [copies[2]])).toThrow('identity');
+        expect(() => traceCandidates(buildTraceQuery({ ...draft, mode: 'key' }), [{ ...message, topic: 'other' }])).toThrow('identity');
+        expect(() => traceCandidates(buildTraceQuery({ ...draft, mode: 'key' }), [{ ...message, msgId: '' }])).toThrow('identity');
+    });
+    it('rejects wrong detail identities and allows an unreported business Topic', () => {
+        expect(checkTraceDetail(detail, 'custom.trace', message)).toBe(detail);
+        expect(() => checkTraceDetail({ ...detail, msgId: message.queryMsgId }, 'custom.trace', message)).toThrow();
+        expect(() => checkTraceDetail(detail, 'other.trace', message)).toThrow();
+        expect(() => checkTraceDetail({ ...detail, topic: 'other' }, 'custom.trace', message)).toThrow();
+        expect(checkTraceDetail({ ...detail, topic: null }, 'custom.trace', { ...message, topic: '' }).topic).toBeNull();
+    });
+});
+
+describe('Trace event presentation', () => {
+    it('preserves millisecond differences and rejects missing or invalid event timestamps', () => {
+        const start = new Date(2026, 8, 11, 6, 38, 12, 102).getTime();
+        expect(traceTimestamp(start)).not.toBe(traceTimestamp(start + 6));
+        expect(traceTimestamp(start)).toContain('102');
+        expect(traceTimestamp(start + 6)).toContain('108');
+        for (const timestamp of [null, undefined, 0, -1, NaN, Infinity, 1e20]) expect(traceTimestamp(timestamp)).toBe('Not reported');
+    });
+    it('does not turn unrecognized states or missing durations into failure or zero', () => {
+        expect(traceStatus('success')).toBe('success');
+        expect(traceStatus('failed')).toBe('failed');
+        for (const status of ['', null, undefined, 'pending', 'future-status']) expect(traceStatus(status)).toBe('unknown');
+        expect(traceDuration(0)).toBe('0 ms');
+        for (const duration of [null, undefined, NaN, Infinity, -1]) expect(traceDuration(duration)).toBe('Not reported');
+    });
+    it('keeps distinct duplicate events and preserves selection identity when unrelated events are inserted', () => {
+        const original = traceEvents([node, { ...node }]);
+        expect(original[0].id).not.toBe(original[1].id);
+        const refreshed = traceEvents([{ ...node, groupName: 'another-group' }, node, { ...node }]);
+        expect(refreshed.slice(1).map(event => event.id)).toEqual(original.map(event => event.id));
+        expect(traceEvents([{ ...node, status: 'success' }])[0].id).not.toBe(original[0].id);
+        expect(traceEvents([]).find(event => event.id === original[0].id)).toBeUndefined();
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/traceModel.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/traceModel.ts
@@ -1,0 +1,79 @@
+import type { MessageSummary } from '../message/types/message.types';
+import type { MessageTraceDetail, MessageTraceNode } from './types/message-trace.types';
+
+export type TraceQuery =
+    | { mode: 'id'; traceTopic: string; messageId: string }
+    | { mode: 'key'; traceTopic: string; topic: string; key: string };
+
+export interface TraceQueryDraft {
+    mode: TraceQuery['mode'];
+    traceTopic: string;
+    messageId: string;
+    topic: string;
+    key: string;
+}
+
+export function buildTraceQuery(draft: TraceQueryDraft): TraceQuery {
+    const traceTopic = draft.traceTopic.trim();
+    if (!traceTopic) throw new Error('Enter a Trace Topic.');
+    if (draft.mode === 'id') {
+        const messageId = draft.messageId.trim();
+        if (!messageId) throw new Error('Enter a producer unique message ID.');
+        return { mode: 'id', traceTopic, messageId };
+    }
+    const topic = draft.topic.trim(), key = draft.key.trim();
+    if (!topic || !key) throw new Error('Enter a business Topic and message Key.');
+    return { mode: 'key', traceTopic, topic, key };
+}
+
+export const traceCandidateIdentity = (message: MessageSummary) => JSON.stringify([message.topic, message.msgId]);
+
+/** Physical copies of one unique ID resolve to the same trace, not separate timelines. */
+export function traceCandidates(query: TraceQuery, items: MessageSummary[]): MessageSummary[] {
+    const candidates = new Map<string, MessageSummary>();
+    for (const item of items) {
+        if (!item.msgId.trim() || (query.mode === 'id' ? item.msgId !== query.messageId : item.topic !== query.topic)) {
+            throw new Error('The trace candidates do not match the requested message identity.');
+        }
+        const identity = traceCandidateIdentity(item);
+        if (!candidates.has(identity)) candidates.set(identity, item);
+    }
+    return [...candidates.values()];
+}
+
+export function checkTraceDetail(detail: MessageTraceDetail, traceTopic: string, message: MessageSummary): MessageTraceDetail {
+    if (detail.traceTopic !== traceTopic || detail.msgId !== message.msgId ||
+        (message.topic && detail.topic && detail.topic !== message.topic)) {
+        throw new Error('The trace detail does not match the selected message and Trace Topic.');
+    }
+    return detail;
+}
+
+export function traceStatus(status?: string | null): 'success' | 'failed' | 'unknown' {
+    if (status === 'success') return 'success';
+    if (status === 'failed') return 'failed';
+    return 'unknown';
+}
+
+export const traceDuration = (value?: number | null) =>
+    value != null && Number.isFinite(value) && value >= 0 ? `${value.toLocaleString()} ms` : 'Not reported';
+
+export function traceTimestamp(value?: number | null): string {
+    if (value == null || !Number.isFinite(value) || value <= 0) return 'Not reported';
+    const date = new Date(value);
+    if (!Number.isFinite(date.getTime())) return 'Not reported';
+    const pad = (part: number) => String(part).padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${String(date.getMilliseconds()).padStart(3, '0')}`;
+}
+
+/** There is no event ID in the DTO. Preserve identical events and never transfer selection to a changed event. */
+export function traceEvents(nodes: readonly MessageTraceNode[]) {
+    const occurrences = new Map<string, number>();
+    return nodes.map(node => {
+        const signature = JSON.stringify([node.traceType, node.role, node.groupName, node.clientHost, node.storeHost,
+            node.timestamp, node.costTime, node.status, node.retryTimes, node.fromTransactionCheck]);
+        const occurrence = occurrences.get(signature) ?? 0;
+        occurrences.set(signature, occurrence + 1);
+        return { id: JSON.stringify([signature, occurrence]), node };
+    });
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/traceQuery.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/traceQuery.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTraceQueryController } from './traceQuery';
+import type { TraceQuery } from './traceModel';
+import type { MessageKeyQueryRequest, MessageSummaryListResponse } from '../message/types/message.types';
+import type { MessageTraceQueryRequest } from './types/message-trace.types';
+
+const response: MessageSummaryListResponse = { items: [{ topic: 'orders', msgId: 'unique-1', queryMsgId: 'physical-1', storeTimestamp: 1000 }], total: 1 };
+const id: TraceQuery = { mode: 'id', traceTopic: 'custom.trace', messageId: 'unique-1' };
+const key: TraceQuery = { mode: 'key', traceTopic: 'custom.trace', topic: 'orders', key: 'order-1' };
+function service() {
+    return {
+        queryMessageByTopicKey: vi.fn(async (_request: MessageKeyQueryRequest) => response),
+        queryMessageTraceById: vi.fn(async (_request: MessageTraceQueryRequest) => response),
+    };
+}
+function deferred<T>() { let resolve!: (value: T) => void; const promise = new Promise<T>(complete => { resolve = complete; }); return { promise, resolve }; }
+
+describe('Trace request ownership', () => {
+    it('routes Key and ID queries to their existing APIs with only relevant fields', async () => {
+        const api = service(), controller = createTraceQueryController(api, () => true);
+        controller.start();
+        await controller.read(id); await controller.read(key);
+        expect(api.queryMessageTraceById).toHaveBeenCalledExactlyOnceWith({ traceTopic: 'custom.trace', messageId: 'unique-1' });
+        expect(api.queryMessageByTopicKey).toHaveBeenCalledExactlyOnceWith({ topic: 'orders', key: 'order-1' });
+        expect(controller.getSnapshot().result?.items[0].msgId).toBe('unique-1');
+    });
+    it('coalesces duplicate requests and discards a late response after changing the input scope', async () => {
+        const api = service(), delayed = deferred<MessageSummaryListResponse>();
+        api.queryMessageTraceById.mockReturnValueOnce(delayed.promise);
+        const controller = createTraceQueryController(api, () => true); controller.start();
+        const pending = controller.read(id);
+        expect(controller.read(id)).toBe(pending);
+        await Promise.resolve(); controller.reset();
+        await controller.read({ ...key, traceTopic: 'another.trace' });
+        delayed.resolve({ items: [], total: 0 });
+        expect(await pending).toBe(false);
+        expect(controller.getSnapshot().result?.query).toEqual({ ...key, traceTopic: 'another.trace' });
+        expect(api.queryMessageTraceById).toHaveBeenCalledTimes(1);
+    });
+    it('retains same-query observations on failure, but clears them for a different query', async () => {
+        const api = service(), controller = createTraceQueryController(api, () => true); controller.start();
+        await controller.read(id); const before = controller.getSnapshot();
+        api.queryMessageTraceById.mockRejectedValue(new Error('unavailable'));
+        expect(await controller.read(id)).toBe(false);
+        expect(controller.getSnapshot()).toMatchObject({ result: before.result, receivedAt: before.receivedAt, pending: false });
+        expect(controller.getSnapshot().error).not.toBe('');
+        await controller.read({ ...id, traceTopic: 'another.trace' });
+        expect(controller.getSnapshot()).toMatchObject({ result: null, receivedAt: null });
+    });
+    it('rejects mismatched candidates and distinguishes successful empty results from failure', async () => {
+        const api = service(), controller = createTraceQueryController(api, () => true); controller.start();
+        expect(await controller.read({ ...id, messageId: 'another-id' })).toBe(false);
+        expect(controller.getSnapshot().result).toBeNull();
+        api.queryMessageTraceById.mockResolvedValueOnce({ items: [], total: 0 });
+        expect(await controller.read(id)).toBe(true);
+        expect(controller.getSnapshot()).toMatchObject({ error: '', result: { items: [] } });
+    });
+    it('prevents queued dispatch after disposal and ignores responses from an old environment', async () => {
+        const api = service(); let current = true;
+        const controller = createTraceQueryController(api, () => current); controller.start();
+        const queued = controller.read(id); controller.stop();
+        expect(await queued).toBe(false); expect(api.queryMessageTraceById).not.toHaveBeenCalled();
+        controller.start(); const delayed = deferred<MessageSummaryListResponse>();
+        api.queryMessageTraceById.mockReturnValueOnce(delayed.promise);
+        const pending = controller.read(id); await Promise.resolve(); current = false;
+        delayed.resolve(response); expect(await pending).toBe(false);
+        expect(controller.getSnapshot().result).toBeNull();
+        controller.stop();
+        expect(controller.getSnapshot().pending).toBe(false);
+        expect(await controller.read(key)).toBe(false);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/traceQuery.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message-trace/traceQuery.ts
@@ -1,0 +1,57 @@
+import { dashboardErrorMessage } from '../../services/invoke';
+import type { MessageService } from '../../services/message.service';
+import type { MessageTraceService } from '../../services/message-trace.service';
+import type { MessageSummary } from '../message/types/message.types';
+import { traceCandidates, type TraceQuery } from './traceModel';
+
+type QueryService = Pick<typeof MessageService, 'queryMessageByTopicKey'> & Pick<typeof MessageTraceService, 'queryMessageTraceById'>;
+export interface TraceResult { query: TraceQuery; items: MessageSummary[]; }
+interface QueryState { result: TraceResult | null; pending: boolean; error: string; receivedAt: number | null; }
+
+/** A mounted connection owns candidate reads; input changes invalidate both dispatched and queued requests. */
+export function createTraceQueryController(service: QueryService, contextIsCurrent: () => boolean) {
+    const empty = (): QueryState => ({ result: null, pending: false, error: '', receivedAt: null });
+    let state = empty();
+    let active = false;
+    let generation = 0;
+    let flight: { key: string; promise: Promise<boolean> } | null = null;
+    const listeners = new Set<() => void>();
+    const publish = (next: QueryState) => { state = next; listeners.forEach(listener => listener()); };
+    const reset = () => { generation++; flight = null; publish(empty()); };
+    const read = (query: TraceQuery): Promise<boolean> => {
+        if (!active || !contextIsCurrent()) return Promise.resolve(false);
+        const key = JSON.stringify(query);
+        if (flight?.key === key) return flight.promise;
+        const previous = JSON.stringify(state.result?.query) === key ? state.result : null;
+        const request = ++generation;
+        const isCurrent = () => active && request === generation && contextIsCurrent();
+        publish({ result: previous, pending: true, error: '', receivedAt: previous ? state.receivedAt : null });
+        const promise = (async () => {
+            await Promise.resolve();
+            if (!isCurrent()) return false;
+            try {
+                const response = query.mode === 'key'
+                    ? await service.queryMessageByTopicKey({ topic: query.topic, key: query.key })
+                    : await service.queryMessageTraceById({ traceTopic: query.traceTopic, messageId: query.messageId });
+                if (!isCurrent()) return false;
+                const items = traceCandidates(query, response.items);
+                publish({ result: { query, items }, pending: false, error: '', receivedAt: Date.now() });
+                return true;
+            } catch (error) {
+                if (isCurrent()) publish({ ...state, pending: false, error: dashboardErrorMessage(error, 'Trace query failed.') });
+                return false;
+            } finally {
+                if (request === generation) flight = null;
+            }
+        })();
+        flight = { key, promise };
+        return promise;
+    };
+    return {
+        read, reset,
+        start: () => { active = true; },
+        stop: () => { active = false; reset(); },
+        getSnapshot: () => state,
+        subscribe: (listener: () => void) => { listeners.add(listener); return () => { listeners.delete(listener); }; },
+    };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -23,6 +23,7 @@ interface AppState {
   openConsumer: (name: string, detail?: Extract<EntityTarget, { kind: 'consumer' }>['detail'], scope?: ConsumerQueryScope) => void;
   openBroker: (address: string, detail?: Extract<EntityTarget, { kind: 'broker' }>['detail']) => void;
   openTrace: (messageId: string, topic: string) => void;
+  openMessage: (messageId: string, topic: string) => void;
   pageStates: React.MutableRefObject<Map<number, Record<string, unknown>>>;
   setActiveTab: (tab: Tab) => void;
   setAuthSession: (sessionId: string, currentUser: SessionUser) => void;
@@ -142,6 +143,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         },
         openBroker: (address, detail = 'overview') => navigate({ type: 'open', tab: 'Cluster', target: { kind: 'broker', address, detail }, environmentId }),
         openTrace: (name, topic) => navigate({ type: 'open', tab: 'MessageTrace', target: { kind: 'trace', name, topic }, environmentId }),
+        openMessage: (name, topic) => navigate({ type: 'open', tab: 'Message', target: { kind: 'message', name, topic }, environmentId }),
         pageStates, consumerQueryMode, setConsumerQueryMode,
         setActiveTab,
         setAuthSession,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { findEntity, initialNavigation, navigationReducer } from './navigation';
 
 describe('entity navigation', () => {
+    it('opens the business message from a trace and returns to that exact trace entry', () => {
+        const trace = navigationReducer(initialNavigation, { type: 'open', tab: 'MessageTrace', environmentId: 'env-a', target: { kind: 'trace', name: 'unique-1', topic: 'orders' } });
+        const message = navigationReducer(trace, { type: 'open', tab: 'Message', environmentId: 'env-a', target: { kind: 'message', name: 'unique-1', topic: 'orders' } });
+        expect(message.current.target).toEqual({ kind: 'message', name: 'unique-1', topic: 'orders' });
+        expect(navigationReducer(message, { type: 'back' }).current).toEqual(trace.current);
+        expect(navigationReducer(message, { type: 'reset', environmentId: 'env-b' }).current.target).toBeNull();
+    });
     it('returns from Trace to the original message query and clears Trace identity across environments', () => {
         const messages = navigationReducer(initialNavigation, { type: 'open', tab: 'Message', environmentId: 'env-a' });
         const trace = navigationReducer(messages, { type: 'open', tab: 'MessageTrace', environmentId: 'env-a', target: { kind: 'trace', name: 'unique-1', topic: 'orders.events' } });

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/navigation.ts
@@ -7,7 +7,8 @@ export type EntityTarget =
     | { kind: 'topic'; name: string; detail: 'overview' | 'status' | 'route' | 'consumers' | 'config' }
     | { kind: 'consumer'; name: string; detail: 'overview' | 'progress' | 'clients' | 'config'; scope: ConsumerQueryScope }
     | { kind: 'broker'; address: string; detail: 'overview' | 'status' | 'config' }
-    | { kind: 'trace'; name: string; topic: string };
+    | { kind: 'trace'; name: string; topic: string }
+    | { kind: 'message'; name: string; topic: string };
 
 export interface NavigationLocation {
     id: number;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10502

### Brief Description

The Tauri Trace page now keeps the event timeline beside the selected event details, with Key/ID queries, manual Trace Topic input, consumer-group and transaction views, and expandable producer metadata. Event timestamps retain milliseconds; unrecognized states remain unknown.

Candidate requests are scoped to the query and connection, duplicate physical copies share their unique trace identity, and mismatched details are rejected. Message navigation carries the business Topic and unique ID, while Back restores the source draft. Failed refreshes retain their original observation and pause navigation; disappearing events require explicit reselection. The layout supports keyboard access and bounded scrolling for long values and event lists.

### How Did You Test This Change?

- `npm run build` passed in `rocketmq-dashboard/rocketmq-dashboard-tauri`.
- `npm test` passed: 185 tests across 31 files, including 11 new trace tests and a message-navigation regression.
- Isolated browser verification: ID/Key/manual queries, physical-copy deduplication, consumer and transaction views, millisecond/zero/unknown fields, clipboard copy/paste, message navigation and Back, failed/empty/mismatched results, removed events, delayed responses and environment changes.
- Compared the rendered 1487 x 1058 page with the design reference; checked 800 x 600 with 120 events and long fields. Final cold-start console had no warnings or errors. The existing Vite chunk-size advisory remains.
- Native Windows Tauri/WebView2 and live RocketMQ-Rust trace ingestion are pending the full integration acceptance; isolated browser fixtures do not prove those paths. No backend contract or dependency changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned message trace view with a query form, mode switching, event timeline, event details, and loading/error/empty states.
  * Added navigation from trace results to the related message, with the message view prefilled when opened this way.
  * Updated page headings so trace and message pages no longer show a target name in the title.

* **Bug Fixes**
  * Improved trace result handling so stale or mismatched results are ignored, and duplicate message copies are grouped consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->