### PR TITLE
[ISSUE #10504]🐛Fix Broker persistence probe and shutdown deadline races

### DIFF
--- a/rocketmq-broker/src/broker_runtime/lifecycle.rs
+++ b/rocketmq-broker/src/broker_runtime/lifecycle.rs
@@ -83,9 +83,17 @@ impl BrokerRuntime {
         &mut self,
         deadline: ShutdownDeadline,
     ) -> BrokerBasicServiceShutdownReport {
+        let started = Instant::now();
         let progress = BrokerShutdownProgress::new();
         match await_shutdown_deadline(deadline, self.shutdown_basic_service_inner(deadline, progress.clone())).await {
-            Ok(report) => report,
+            Ok(mut report) => {
+                // An inner deadline can resolve before the outer timer is polled. Preserve
+                // the component reports, but still account for the exhausted total budget.
+                if deadline.is_expired() {
+                    report.deadline = BrokerShutdownComponentReport::timed_out("shutdown_deadline", started.elapsed());
+                }
+                report
+            }
             Err(elapsed) => {
                 warn!(
                     elapsed_ms = elapsed.as_millis(),

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -1081,24 +1081,31 @@ pub mod bench_support {
             .expect("schedule message service should be configured")
             .clone();
 
-        crate::schedule::schedule_message_service::ScheduleMessageService::start_persist_task_for_probe(
-            service.clone(),
-            Duration::ZERO,
-        )
-        .await
-        .expect("broker schedule persist task should start");
+        let first_persist =
+            crate::schedule::schedule_message_service::ScheduleMessageService::start_persist_task_for_probe(
+                service.clone(),
+                Duration::ZERO,
+            )
+            .await
+            .expect("broker schedule persist task should start");
 
-        let mut snapshots = service.schedule_snapshot();
-        for _ in 0..100 {
-            if snapshots
-                .iter()
-                .any(|snapshot| snapshot.runs > 0 && snapshot.active_runs == 0)
-            {
-                break;
+        // Wait for the actual write, then let the scheduler account for its completed run.
+        // The timeout bounds a broken probe; it is not a fixed warm-up period.
+        let completed_snapshots = tokio::time::timeout(Duration::from_secs(5), async {
+            first_persist.await.ok()?.ok()?;
+            loop {
+                let snapshots = service.schedule_snapshot();
+                if snapshots.iter().any(|snapshot| snapshot.runs > 0) {
+                    return Some(snapshots);
+                }
+                tokio::task::yield_now().await;
             }
-            tokio::time::sleep(Duration::from_millis(1)).await;
-            snapshots = service.schedule_snapshot();
-        }
+        })
+        .await
+        .ok()
+        .flatten();
+        let first_persist_completed = completed_snapshots.is_some();
+        let snapshots = completed_snapshots.unwrap_or_else(|| service.schedule_snapshot());
 
         let scheduled_runs = snapshots.iter().map(|snapshot| snapshot.runs).sum();
         let scheduled_skips = snapshots.iter().map(|snapshot| snapshot.skips).sum();
@@ -1113,7 +1120,8 @@ pub mod bench_support {
             .expect("broker schedule persist task should shutdown");
         let shutdown_elapsed_us = shutdown_started_at.elapsed().as_micros();
         let task_count_after_shutdown = service.task_count();
-        let healthy = scheduled_runs > 0
+        let healthy = first_persist_completed
+            && scheduled_runs > 0
             && scheduled_overlaps == 0
             && scheduled_failures == 0
             && task_count_before_shutdown > 0
@@ -1198,11 +1206,9 @@ mod bench_support_tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn broker_schedule_persistence_lifecycle_probe_reports_clean_shutdown() {
-        let root = std::env::temp_dir().join(format!(
-            "rocketmq-rust-broker-schedule-persist-probe-{}",
-            rocketmq_runtime::common::time_utils::current_millis()
-        ));
-        let probe = super::bench_support::run_broker_schedule_persistence_lifecycle_probe(root).await;
+        let root = tempfile::tempdir().expect("schedule persistence probe temp directory");
+        let probe =
+            super::bench_support::run_broker_schedule_persistence_lifecycle_probe(root.path().to_path_buf()).await;
 
         assert!(probe.healthy, "{probe:?}");
         assert!(probe.persisted_offset_file, "{probe:?}");

--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -67,6 +67,7 @@ use rocketmq_store::BrokerWriteStore;
 use rocketmq_store::MessageStoreConfig;
 use rocketmq_store::PutMessageResult;
 use rocketmq_store::PutMessageStatus;
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
 use tokio::sync::OwnedMutexGuard;
@@ -502,14 +503,24 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
         this: Arc<Self>,
         persist_initial_delay: Duration,
     ) -> Result<()> {
-        Self::start_internal(this, persist_initial_delay, true).await
+        Self::start_internal(this, persist_initial_delay, true, None).await
     }
 
-    pub(crate) async fn start_persist_task_for_probe(this: Arc<Self>, persist_initial_delay: Duration) -> Result<()> {
-        Self::start_internal(this, persist_initial_delay, false).await
+    pub(crate) async fn start_persist_task_for_probe(
+        this: Arc<Self>,
+        persist_initial_delay: Duration,
+    ) -> Result<oneshot::Receiver<Result<()>>> {
+        let (first_persist, completion) = oneshot::channel();
+        Self::start_internal(this, persist_initial_delay, false, Some(first_persist)).await?;
+        Ok(completion)
     }
 
-    async fn start_internal(this: Arc<Self>, persist_initial_delay: Duration, start_delivery: bool) -> Result<()> {
+    async fn start_internal(
+        this: Arc<Self>,
+        persist_initial_delay: Duration,
+        start_delivery: bool,
+        first_persist: Option<oneshot::Sender<Result<()>>>,
+    ) -> Result<()> {
         let mut lifecycle = this.lifecycle.lock().await;
         if lifecycle.finalized {
             return Err(schedule_message_service_startup_failed("service is already finalized"));
@@ -587,6 +598,7 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
                 &scheduled_tasks,
                 activation_rx,
                 persist_initial_delay,
+                first_persist,
             )
         }
         .await;
@@ -621,6 +633,7 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
         scheduled_tasks: &ScheduledTaskGroup,
         activation: watch::Receiver<bool>,
         initial_delay: Duration,
+        mut first_persist: Option<oneshot::Sender<Result<()>>>,
     ) -> Result<()> {
         let service = Arc::downgrade(this);
         let context = run_context.clone();
@@ -634,6 +647,7 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
                 let service = service.clone();
                 let context = context.clone();
                 let mut activation = activation.clone();
+                let first_persist = first_persist.take();
                 async move {
                     if !wait_for_schedule_activation(&mut activation, &context.cancellation).await {
                         return;
@@ -641,12 +655,16 @@ impl<MS: BrokerWriteStore> ScheduleMessageService<MS> {
                     let Some(service) = service.upgrade() else {
                         return;
                     };
-                    if let Err(error) = service.persist_generation(&context).await {
+                    let result = service.persist_generation(&context).await;
+                    if let Err(error) = &result {
                         warn!(
                             ?error,
                             generation = context.generation,
                             "failed to persist schedule offsets"
                         );
+                    }
+                    if let Some(completion) = first_persist {
+                        let _ = completion.send(result);
                     }
                 }
             })
@@ -2392,6 +2410,58 @@ mod tests {
             let persisted: DelayOffsetSerializeWrapper = serde_json::from_str(&encoded).unwrap();
             assert_eq!(persisted.offset_table().unwrap().get(&1), Some(&11));
         }
+    }
+
+    #[tokio::test]
+    async fn persistence_probe_completion_waits_for_the_offset_write() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path().to_string_lossy().into_owned();
+        let mut runtime = BrokerRuntime::new(
+            Arc::new(BrokerConfig {
+                store_path_root_dir: root.clone().into(),
+                ..BrokerConfig::default()
+            }),
+            Arc::new(MessageStoreConfig {
+                store_path_root_dir: root.into(),
+                ..MessageStoreConfig::default()
+            }),
+        );
+        let service = runtime
+            .runtime_state_mut()
+            .schedule_message_service_for_test()
+            .unwrap()
+            .clone();
+        service.offset_state.update_offset(1, 7, 1, 0);
+        let release = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
+        let writer_release = Arc::clone(&release);
+        let (entered_tx, entered_rx) = oneshot::channel();
+        *service.before_persist_write.lock() = Some(Box::new(move || {
+            let _ = entered_tx.send(());
+            let (lock, ready) = &*writer_release;
+            let guard = lock.lock().unwrap();
+            drop(ready.wait_while(guard, |released| !*released).unwrap());
+        }));
+        let mut completion = ScheduleMessageService::start_persist_task_for_probe(service.clone(), Duration::ZERO)
+            .await
+            .unwrap();
+        let entered = tokio::time::timeout(Duration::from_secs(5), entered_rx).await;
+        let pending = completion.try_recv();
+        // Release the writer before any assertion so a failed test cannot strand it.
+        let (lock, ready) = &*release;
+        *lock.lock().unwrap() = true;
+        ready.notify_all();
+        let completed = tokio::time::timeout(Duration::from_secs(5), completion).await;
+        // Read before shutdown can create the file through its final persistence pass.
+        let encoded = std::fs::read_to_string(service.config_file_path());
+        let shutdown = service.shutdown().await;
+
+        assert!(entered.is_ok_and(|result| result.is_ok()));
+        assert!(matches!(pending, Err(oneshot::error::TryRecvError::Empty)));
+        completed.unwrap().unwrap().unwrap();
+        let persisted: DelayOffsetSerializeWrapper = serde_json::from_str(&encoded.unwrap()).unwrap();
+        assert_eq!(persisted.offset_table().unwrap().get(&1), Some(&7));
+        shutdown.unwrap();
+        assert_eq!(service.task_count(), 0);
     }
 
     #[tokio::test]

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -1107,8 +1107,9 @@ async fn blocking_shutdown_hook_cannot_extend_the_absolute_deadline() {
     signal.notify_all();
 
     let report = result.expect("shutdown must return while the hook remains blocked");
-    assert!(report.deadline.timed_out);
     let _ = context.shutdown_tasks(Duration::from_secs(1)).await;
+    assert!(report.deadline.timed_out, "{report:?}");
+    assert!(!report.is_healthy(), "{report:?}");
 }
 
 #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10504

### Brief Description

The Broker persistence probe can finish its fixed polling window before the first offset write completes. It now waits for the first scheduled write result, then observes the completed run and verifies the file before shutdown. A bounded timeout still detects a stalled probe. The test uses an isolated temporary directory, and synchronized regression coverage verifies that completion is not reported while the writer is blocked.

Broker shutdown can return from an inner timeout before the outer timer is polled. Recheck the absolute deadline on the completed-report path, preserving component details while recording an exhausted total budget. The blocking-hook regression still requires a timed-out, unhealthy report and cleans up the owned work before its assertions.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --lib`: 1098 passed, 0 failed, 3 existing ignored tests on Windows with Rust 1.95.0.
- Repeated each of these tests 20 times using the compiled test binary with `--exact`: all 60 executions passed.
  - `bench_support_tests::broker_schedule_persistence_lifecycle_probe_reports_clean_shutdown`
  - `broker_runtime::tests::blocking_shutdown_hook_cannot_extend_the_absolute_deadline`
  - `schedule::schedule_message_service::tests::persistence_probe_completion_waits_for_the_offset_write`
- `cargo fmt -p rocketmq-broker -- --check`: passed.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Shutdown operations now correctly report a timeout when the deadline is exceeded, including cases where shutdown completes afterward.
  - Broker health checks now wait for the first persistence operation and its offset write to finish before reporting success.
  - Persistence completion detection is more reliable, reducing premature healthy-status results.

- **Tests**
  - Added coverage for shutdown deadline reporting and persistence probe completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->