### PR TITLE
[ISSUE #10508]🐛Strict Broker smoke test expects discarded error text

### DIFF
--- a/rocketmq-client/tests/broker_backed_smoke.rs
+++ b/rocketmq-client/tests/broker_backed_smoke.rs
@@ -417,9 +417,12 @@ fn strict_skip_error_fails_when_broker_smoke_is_required() {
     let error = strict_skip_error("missing smoke env", true)
         .expect_err("strict broker-backed smoke mode should fail on missing environment");
 
-    let message = error.to_string();
-    assert!(message.contains("missing smoke env"));
-    assert!(message.contains(REQUIRE_BROKER_BACKED_SMOKE));
+    let descriptor = &rocketmq_error::CORE_ARGUMENT_INVALID;
+    assert!(error.is(descriptor));
+    assert_eq!(
+        error.to_string(),
+        format!("{}: {}", descriptor.code(), descriptor.public_message())
+    );
 }
 
 struct CommitTransactionListener;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10508 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated broker smoke-test validation to check structured invalid-argument errors and their standardized messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->