### PR TITLE
[ISSUE #10510]✨Redesign reviewed dead-letter operations and persistent results

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/DLQ_RECEIPTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/DLQ_RECEIPTS.md
@@ -4,6 +4,25 @@ Choose one explicit mode. Message ID performs a detail lookup. Key takes precede
 
 Single and batch resend accept optional `clientId`. Missing or blank values preserve automatic client selection. Before direct consumption the backend loads the actual DLQ message, checks that it belongs to the selected group's DLQ, and derives the business Topic and original message ID from its properties. Missing origin metadata or a retry/DLQ original Topic is rejected. Requests cannot nominate an arbitrary original business Topic. A batch is limited to 256 unique group/message identities.
 
-Each receipt retains `requestMessageId` (the selected DLQ identity) separately from the original `msgId`, plus group, Topic, success, consumeResult and safe remark. Refreshing query results does not clear the receipt. Select only failed messages for review selects failed identities currently visible in the same group, excluding successful identities. It sends nothing; Batch resend still requires explicit confirmation including the chosen ClientId. A group change discards that group's display state and invalidates old mutation callbacks.
+Each receipt retains `requestMessageId` (the selected DLQ identity) separately from the original `msgId`, plus group, Topic, success, consumeResult and safe remark. The session-owned action provider preserves the latest completed receipt across query, group, page and connection changes. It records the original environment, connection revision, requested IDs and Client ID. A new completed resend replaces the latest receipt; signing out or changing session clears it. Receipts are not written to browser storage.
 
-Single and selected-message batch CSV exports remain available, including Key and ID result modes. Export scope is the selected messages, not an unbounded full DLQ export.
+Before opening an operation, the selected records' connection context is checked against current settings. Before submitting, the dialog checks that context again. Once a resend is accepted, its result remains owned by that dialog even when the connection changes. Submitting disables duplicate attempts and prevents closing the pending dialog. A network failure does not trigger a retry.
+
+The result table matches each requested group and DLQ ID to exactly one `requestMessageId` acknowledgement. A different original ID is expected; it cannot substitute for the request identity. Duplicate, missing, wrong-group or contradictory acknowledgements remain unknown. A success requires a successful flag, a recognized success consume result and a non-DLQ original identity. Recognized negative consume results are shown as failed. Transport failures and missing consume results remain unknown even when the backend aggregate counts them as failures. The reported safe response is separately inspectable.
+
+**Review failed targets** selects only confirmed failed identities currently visible in the same group and environment. It excludes successes and unknown outcomes and sends nothing. Resend still requires explicit confirmation including the chosen Client ID. Changing a query or page clears selection; manually changing selection clears its review note. Accepted receipts are independent of this query state.
+
+Single and selected-message batch CSV exports remain available, including Key and ID result modes. Export scope is the selected messages, not an unbounded full DLQ export. The export dialog displays partial counts, then offers the returned CSV for download. A connection change invalidates an unfinished export read. **Export results** downloads the latest resend receipt without contacting a Broker; CSV cells are quoted and formula-prefixed values are neutralized. The UI reports a download request, not proof that an operating-system save completed.
+
+## Layout and identity
+
+The dark page uses a query toolbar, selectable results table, batch action bar and persistent result panel. Consumer group input remains available when catalog discovery fails. Time queries use the existing local-date validation and page controller; changing scope invalidates old responses, while a failed refresh preserves the last successful observation and disables stale row actions.
+
+Summary DTOs do not report original Topic or reconsume count. The table therefore labels its actual DLQ Topic and request ID; it does not fabricate the corresponding mockup fields. Inspection preserves summary tags, keys and displayed ID even if a fresh detail read fails. Body, Properties and Delivery use the shared message inspector with a DLQ-specific detail lookup. Original Topic/ID properties and reconsume count are shown only when returned. Generic direct-consume and Trace actions are omitted from this inspector so a DLQ record cannot bypass origin resolution through those entry points.
+
+## Validation
+
+- `npm run build`
+- `npm test -- --run`
+- Focused regressions cover query normalization, time cursor reuse, stale responses, physical IDs, target-context capture, receipt identity, unknown outcomes, failed selection and CSV quoting.
+- Browser checks cover query modes, catalog/read failures, selection, fixed-target confirmation, per-message results, navigation/session isolation and exports. Final visual comparison, Windows WebView2, native downloads and real RocketMQ-Rust DLQ consumption must be recorded separately; a mock response cannot prove delivery to a real Consumer.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/navigation.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/navigation.ts
@@ -35,7 +35,7 @@ export const pageDescriptions: Record<Tab, string> = {
     Producer: 'Discover producer groups and inspect connections',
     Message: 'Find messages by key, ID, or time',
     MessageTrace: 'Follow message publication and consumption',
-    DLQ: 'Inspect dead-letter messages and resend results',
+    DLQ: 'Review failures before replaying messages',
     ACL: 'Broker users and resource policies',
     Storage: 'Local database information and collector diagnostics',
     Monitors: 'Consumer group thresholds for this environment',

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -18,6 +18,7 @@ import {MessageView} from '../../components/MessageView';
 import {MessageActionProvider} from '../../features/message/components/MessageActionProvider';
 import {MessageTraceView} from '../../components/MessageTraceView';
 import {DLQMessageView} from '../../components/DLQMessageView';
+import {DlqActionProvider} from '../../features/dlq/components/DlqActionProvider';
 import {Activity} from 'lucide-react';
 import {StoragePage} from '../../pages/storage/StoragePage';
 import {MonitorPage} from '../../pages/monitor/MonitorPage';
@@ -29,7 +30,7 @@ export const AppRouter = () => {
     const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
     const { activeTab, navigation, sessionId } = useAppStore();
     const key = ['NameServer', 'Proxy', 'Account', 'Sessions', 'Audit'].includes(activeTab) ? activeTab : `${activeTab}:${settings?.revision ?? 0}`;
-    return <BrokerConfigEditorProvider key={sessionId}><TopicActionProvider><ConsumerActionProvider><MessageActionProvider><RouteContent key={`${key}:${navigation.id}`} /></MessageActionProvider></ConsumerActionProvider></TopicActionProvider></BrokerConfigEditorProvider>;
+    return <BrokerConfigEditorProvider key={sessionId}><TopicActionProvider><ConsumerActionProvider><MessageActionProvider><DlqActionProvider><RouteContent key={`${key}:${navigation.id}`} /></DlqActionProvider></MessageActionProvider></ConsumerActionProvider></TopicActionProvider></BrokerConfigEditorProvider>;
 };
 
 const RouteContent = () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
@@ -1,816 +1,118 @@
-import { ConsumerRequestGeneration } from '../features/consumer/scope';
-import { failedDlqSelection, dlqQueryTaskId } from '../features/dlq/receipts';
-import type { DlqBatchResendMessageResponse } from '../features/dlq/types/dlq.types';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { motion } from 'motion/react';
-import { toast } from 'sonner@2.0.3';
-import {
-  AlertCircle,
-  ArrowUpRight,
-  Calendar,
-  Clock,
-  FileText,
-  Hash,
-  Info,
-  Key,
-  Search,
-  Send,
-  Tag,
-  Users,
-} from 'lucide-react';
-import { MessageDetailModal } from './MessageDetailModal';
-import { Pagination } from './Pagination';
-import { Input } from './ui/input';
+import { useCallback, useEffect, useId, useMemo, useState, useSyncExternalStore } from 'react';
+import { Download, Send } from 'lucide-react';
+import { ConnectionStore } from '../services/connection.store';
+import { useNavigationState } from '../stores/app.store';
 import { useConsumerCatalog } from '../features/consumer/hooks/useConsumerCatalog';
+import { buildDlqQuery, createDlqQueryController, dlqGroup, type DlqQueryDraft } from '../features/dlq/dlqQuery';
+import { messageLookup, messageTimestamp, visibleMessageText } from '../features/message/messageModel';
+import { useDlqActions } from '../features/dlq/dlqActionContext';
+import { failedDlqSelection } from '../features/dlq/receipts';
+import { DlqReceiptPanel } from '../features/dlq/components/DlqReceiptPanel';
+import { DlqMessageDialog } from '../features/dlq/components/DlqMessageDialog';
 import type { DlqMessageSummary } from '../features/dlq/types/dlq.types';
-import { DlqService } from '../services/dlq.service';
-import { dashboardErrorMessage } from '../services/invoke';
-
-type DlqTab = 'Consumer' | 'Key' | 'Message ID';
-
-const DEFAULT_PAGE_SIZE = 20;
-
-const defaultPagination = {
-  currentPage: 1,
-  pageSize: DEFAULT_PAGE_SIZE,
-  totalPages: 0,
-  totalElements: 0,
-};
-
-const EMPTY_SELECTED_IDS = new Set<string>();
-
-const pad = (value: number) => value.toString().padStart(2, '0');
-
-const formatDateTimeInput = (date: Date) =>
-  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(
-    date.getMinutes(),
-  )}:${pad(date.getSeconds())}`;
-
-const toSummary = (detail: Awaited<ReturnType<typeof DlqService.viewDlqMessageDetail>>): DlqMessageSummary => ({
-  topic: detail.topic,
-  msgId: detail.properties.UNIQ_KEY?.trim() || detail.msgId,
-  queryMsgId: detail.msgId,
-  tags: detail.properties.TAGS ?? null,
-  keys: detail.properties.KEYS ?? null,
-  storeTimestamp: detail.storeTimestamp ?? 0,
-});
-
-const downloadExportPayload = (fileName: string, mimeType: string, content: string) => {
-  const blob = new Blob([content], { type: mimeType });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = fileName;
-  document.body.appendChild(anchor);
-  anchor.click();
-  document.body.removeChild(anchor);
-  URL.revokeObjectURL(url);
-};
-
-export const DLQMessageView = () => {
-  const [activeTab, setActiveTab] = useState<DlqTab>('Consumer');
-  const [consumerGroup, setConsumerGroup] = useState('');
-  const [messageId, setMessageId] = useState('');
-  const [messageKey, setMessageKey] = useState('');
-  const [clientId, setClientId] = useState('');
-  const [receipt, setReceipt] = useState<DlqBatchResendMessageResponse | null>(null);
-  const queryGeneration = useRef(new ConsumerRequestGeneration());
-  const writeGeneration = useRef(new ConsumerRequestGeneration());
-  useEffect(() => {
-    writeGeneration.current.invalidate(); setReceipt(null);
-    setIsBatchResending(false); setResendingMessageId(null);
-    return () => { writeGeneration.current.invalidate(); queryGeneration.current.invalidate(); };
-  }, [consumerGroup]);
-  const [beginTime, setBeginTime] = useState(formatDateTimeInput(new Date(Date.now() - 3 * 60 * 60 * 1000)));
-  const [endTime, setEndTime] = useState(formatDateTimeInput(new Date()));
-  const [messages, setMessages] = useState<DlqMessageSummary[]>([]);
-  const [selectedMessage, setSelectedMessage] = useState<DlqMessageSummary | null>(null);
-  const [searchError, setSearchError] = useState('');
-  const [hasSearched, setHasSearched] = useState(false);
-  const [isSearching, setIsSearching] = useState(false);
-  const [resendingMessageId, setResendingMessageId] = useState<string | null>(null);
-  const [exportingMessageId, setExportingMessageId] = useState<string | null>(null);
-  const [isBatchResending, setIsBatchResending] = useState(false);
-  const [isBatchExporting, setIsBatchExporting] = useState(false);
-  const [selectedMessageIds, setSelectedMessageIds] = useState<Set<string>>(EMPTY_SELECTED_IDS);
-  const [taskId, setTaskId] = useState('');
-  const [pagination, setPagination] = useState(defaultPagination);
-  const {
-    items: consumerItems,
-    isInitialLoading: isConsumerCatalogLoading,
-    error: consumerCatalogError,
-  } = useConsumerCatalog({ mode: 'name_server' });
-
-  const consumerGroupOptions = useMemo(
-    () =>
-      consumerItems
-        .filter((item) => item.category !== 'SYSTEM')
-        .map((item) => item.rawGroupName),
-    [consumerItems],
-  );
-
-  useEffect(() => {
-    if (!consumerGroup && consumerGroupOptions.length > 0) {
-      setConsumerGroup(consumerGroupOptions[0]);
-    }
-  }, [consumerGroupOptions, consumerGroup]);
-
-  useEffect(() => {
-    setIsSearching(false);
-    setMessages([]);
-    setSelectedMessage(null);
-    setSearchError('');
-    setHasSearched(false);
-    setSelectedMessageIds(EMPTY_SELECTED_IDS);
-    setTaskId('');
-    setPagination(defaultPagination);
-  }, [activeTab]);
-
-  useEffect(() => { queryGeneration.current.invalidate(); return () => queryGeneration.current.invalidate(); }, [activeTab, consumerGroup, messageId, messageKey, beginTime, endTime]);
-
-  const formatTimestamp = (value: number) => {
-    if (!value) {
-      return '-';
-    }
-    return new Date(value).toLocaleString();
-  };
-
-  const parseDateTimeInput = (value: string): number | null => {
-    const normalized = value.trim().replace(' ', 'T');
-    if (!normalized) {
-      return null;
-    }
-
-    const parsed = new Date(normalized);
-    const timestamp = parsed.getTime();
-    return Number.isNaN(timestamp) ? null : timestamp;
-  };
-
-  const resetConsumerPagingState = () => {
-    queryGeneration.current.invalidate();
-    setIsSearching(false);
-    setMessages([]);
-    setSelectedMessage(null);
-    setSearchError('');
-    setHasSearched(false);
-    setSelectedMessageIds(EMPTY_SELECTED_IDS);
-    setTaskId('');
-    setPagination(defaultPagination);
-  };
-
-  const queryDlqPage = async (pageNum = 1) => {
-    if (!consumerGroup.trim()) {
-      setSearchError('Consumer group is required.');
-      return;
-    }
-
-    if (activeTab === 'Key' && !messageKey.trim()) { setSearchError('Message Key is required.'); return; }
-    const begin = activeTab === 'Key' ? 0 : parseDateTimeInput(beginTime);
-    const end = activeTab === 'Key' ? Date.now() : parseDateTimeInput(endTime);
-    if (begin === null || end === null) {
-      setSearchError('Begin and end must be valid date-time strings.');
-      return;
-    }
-    if (end < begin) {
-      setSearchError('End time must be greater than or equal to begin time.');
-      return;
-    }
-
-    const isCurrent = queryGeneration.current.begin();
-    setIsSearching(true);
-    setSearchError('');
-    setHasSearched(true);
-
-    try {
-      const response = await DlqService.queryDlqMessageByConsumerGroup({
-        consumerGroup: consumerGroup.trim(),
-        begin,
-        end,
-        pageNum,
-        pageSize: pagination.pageSize,
-        taskId: dlqQueryTaskId(activeTab, pageNum, taskId),
-        key: activeTab === 'Key' ? messageKey.trim() : undefined,
-      });
-
-      if (!isCurrent()) return;
-      setMessages(response.page.content);
-      setSelectedMessageIds(EMPTY_SELECTED_IDS);
-      setTaskId(response.taskId);
-      setPagination({
-        currentPage: response.page.number + 1,
-        pageSize: response.page.size,
-        totalPages: response.page.totalPages,
-        totalElements: response.page.totalElements,
-      });
-    } catch (error) {
-      if (!isCurrent()) return;
-      setMessages([]);
-      setSearchError(dashboardErrorMessage(error, 'Failed to query DLQ messages.'));
-    } finally {
-      if (isCurrent()) setIsSearching(false);
-    }
-  };
-
-  const queryDlqByMessageId = async () => {
-    if (!consumerGroup.trim()) {
-      setSearchError('Consumer group is required.');
-      return;
-    }
-    if (!messageId.trim()) {
-      setSearchError('Message ID is required.');
-      return;
-    }
-
-    const isCurrent = queryGeneration.current.begin();
-    setIsSearching(true);
-    setSearchError('');
-    setHasSearched(true);
-    setSelectedMessageIds(EMPTY_SELECTED_IDS);
-    setTaskId('');
-    setPagination(defaultPagination);
-
-    try {
-      const detail = await DlqService.viewDlqMessageDetail({
-        consumerGroup: consumerGroup.trim(),
-        messageId: messageId.trim(),
-      });
-      if (!isCurrent()) return;
-      setMessages([toSummary(detail)]);
-    } catch (error) {
-      if (!isCurrent()) return;
-      setMessages([]);
-      setSearchError(dashboardErrorMessage(error, 'Failed to query DLQ message detail.'));
-    } finally {
-      if (isCurrent()) setIsSearching(false);
-    }
-  };
-
-  const handleSearch = async () => {
-    if (activeTab !== 'Message ID') {
-      await queryDlqPage(1);
-      return;
-    }
-
-    await queryDlqByMessageId();
-  };
-
-  const handleResend = async (message: DlqMessageSummary) => {
-    if (isBatchResending || resendingMessageId) return;
-    const normalizedConsumerGroup = consumerGroup.trim();
-    if (!normalizedConsumerGroup) {
-      setSearchError('Consumer group is required.');
-      return;
-    }
-
-    const confirmed = window.confirm(
-      `Request direct consume for DLQ message ${message.msgId} in consumer group ${normalizedConsumerGroup}, ClientId ${clientId.trim() || 'automatic'}?`,
-    );
-    if (!confirmed) {
-      return;
-    }
-
-    const isCurrent = writeGeneration.current.begin();
-    setResendingMessageId(message.queryMsgId);
-    setSearchError('');
-
-    try {
-      const result = await DlqService.resendDlqMessage({
-        consumerGroup: normalizedConsumerGroup,
-        messageId: message.queryMsgId,
-        clientId: clientId.trim() || undefined,
-      });
-
-      if (!isCurrent()) return;
-      setReceipt({ items: [result], total: 1, successCount: Number(result.success), failureCount: Number(!result.success) });
-      if (result.success) {
-        toast.success(result.message);
-      } else {
-        toast.error(result.message);
-      }
-    } catch (error) {
-      if (!isCurrent()) return;
-      const messageText = dashboardErrorMessage(error, 'Failed to resend DLQ message.');
-      toast.error(messageText);
-      setSearchError(messageText);
-    } finally {
-      if (isCurrent()) setResendingMessageId(null);
-    }
-  };
-
-  const isMessageSelected = (message: DlqMessageSummary) => selectedMessageIds.has(message.queryMsgId);
-
-  const allVisibleSelected =
-    messages.length > 0 && messages.every((message) => selectedMessageIds.has(message.queryMsgId));
-
-  const toggleMessageSelection = (message: DlqMessageSummary) => {
-    setSelectedMessageIds((current) => {
-      const next = new Set(current);
-      if (next.has(message.queryMsgId)) {
-        next.delete(message.queryMsgId);
-      } else {
-        next.add(message.queryMsgId);
-      }
-      return next;
-    });
-  };
-
-  const toggleSelectAllVisible = () => {
-    setSelectedMessageIds((current) => {
-      if (messages.length === 0) {
-        return current;
-      }
-
-      const next = new Set(current);
-      if (messages.every((message) => next.has(message.queryMsgId))) {
-        messages.forEach((message) => next.delete(message.queryMsgId));
-      } else {
-        messages.forEach((message) => next.add(message.queryMsgId));
-      }
-      return next;
-    });
-  };
-
-  const handleBatchResend = async () => {
-    if (isBatchResending || resendingMessageId) return;
-    const normalizedConsumerGroup = consumerGroup.trim();
-    if (!normalizedConsumerGroup) {
-      setSearchError('Consumer group is required.');
-      return;
-    }
-
-    const selectedMessages = messages.filter((message) => selectedMessageIds.has(message.queryMsgId));
-    if (selectedMessages.length === 0) {
-      setSearchError('Select at least one DLQ message to resend.');
-      return;
-    }
-
-    const confirmed = window.confirm(
-      `Request direct consume for ${selectedMessages.length} DLQ message(s) in consumer group ${normalizedConsumerGroup}, ClientId ${clientId.trim() || 'automatic'}?`,
-    );
-    if (!confirmed) {
-      return;
-    }
-
-    const isCurrent = writeGeneration.current.begin();
-    setIsBatchResending(true);
-    setSearchError('');
-
-    try {
-      const response = await DlqService.batchResendDlqMessage({
-        messages: selectedMessages.map((message) => ({
-          consumerGroup: normalizedConsumerGroup,
-          messageId: message.queryMsgId,
-          clientId: clientId.trim() || undefined,
-        })),
-      });
-
-      if (!isCurrent()) return;
-      setReceipt(response);
-      if (response.failureCount === 0) {
-        toast.success(`Batch resend completed for ${response.successCount} DLQ message(s).`);
-      } else if (response.successCount === 0) {
-        const failureMessage =
-          response.items.find((item) => !item.success)?.remark ??
-          `Batch resend failed for ${response.failureCount} DLQ message(s).`;
-        toast.error(failureMessage);
-        setSearchError(failureMessage);
-      } else {
-        const firstFailure = response.items.find((item) => !item.success)?.remark;
-        toast.warning(
-          `Batch resend completed with ${response.successCount} success and ${response.failureCount} failure(s).`,
-        );
-        if (firstFailure) {
-          setSearchError(firstFailure);
-        }
-      }
-
-      setSelectedMessageIds(EMPTY_SELECTED_IDS);
-    } catch (error) {
-      if (!isCurrent()) return;
-      const messageText = dashboardErrorMessage(error, 'Failed to batch resend DLQ messages.');
-      toast.error(messageText);
-      setSearchError(messageText);
-    } finally {
-      if (isCurrent()) setIsBatchResending(false);
-    }
-  };
-
-  const handleExport = async (message: DlqMessageSummary) => {
-    const normalizedConsumerGroup = consumerGroup.trim();
-    if (!normalizedConsumerGroup) {
-      setSearchError('Consumer group is required.');
-      return;
-    }
-
-    setExportingMessageId(message.queryMsgId);
-    setSearchError('');
-
-    try {
-      const payload = await DlqService.exportDlqMessage({
-        consumerGroup: normalizedConsumerGroup,
-        messageId: message.queryMsgId,
-      });
-      downloadExportPayload(payload.fileName, payload.mimeType, payload.content);
-      toast.success(`Exported DLQ message ${message.msgId}.`);
-    } catch (error) {
-      const messageText = dashboardErrorMessage(error, 'Failed to export DLQ message.');
-      toast.error(messageText);
-      setSearchError(messageText);
-    } finally {
-      setExportingMessageId(null);
-    }
-  };
-
-  const handleBatchExport = async () => {
-    const normalizedConsumerGroup = consumerGroup.trim();
-    if (!normalizedConsumerGroup) {
-      setSearchError('Consumer group is required.');
-      return;
-    }
-
-    const selectedMessages = messages.filter((message) => selectedMessageIds.has(message.queryMsgId));
-    if (selectedMessages.length === 0) {
-      setSearchError('Select at least one DLQ message to export.');
-      return;
-    }
-
-    setIsBatchExporting(true);
-    setSearchError('');
-
-    try {
-      const payload = await DlqService.batchExportDlqMessage({
-        messages: selectedMessages.map((message) => ({
-          consumerGroup: normalizedConsumerGroup,
-          messageId: message.queryMsgId,
-        })),
-      });
-
-      downloadExportPayload(payload.fileName, payload.mimeType, payload.content);
-
-      if (payload.failureCount === 0) {
-        toast.success(`Batch export completed for ${payload.successCount} DLQ message(s).`);
-      } else if (payload.successCount === 0) {
-        const failureMessage = `Batch export completed with ${payload.failureCount} failure row(s).`;
-        toast.warning(failureMessage);
-        setSearchError(failureMessage);
-      } else {
-        const partialMessage = `Batch export completed with ${payload.successCount} success and ${payload.failureCount} failure row(s).`;
-        toast.warning(partialMessage);
-        setSearchError(partialMessage);
-      }
-
-      setSelectedMessageIds(EMPTY_SELECTED_IDS);
-    } catch (error) {
-      const messageText = dashboardErrorMessage(error, 'Failed to batch export DLQ messages.');
-      toast.error(messageText);
-      setSearchError(messageText);
-    } finally {
-      setIsBatchExporting(false);
-    }
-  };
-
-  const renderEmptyCopy = () => {
-    if (activeTab === 'Consumer') {
-      return 'Enter a consumer group and time range to search DLQ messages.';
-    }
-    return activeTab === 'Key' ? 'Enter a Consumer group and exact message Key.' : 'Enter a consumer group and message id to load the DLQ message detail.';
-  };
-
-  return (
-    <div className="mx-auto max-w-[1600px] space-y-6 pb-12 animate-in fade-in slide-in-from-bottom-4 duration-500">
-      <MessageDetailModal
-        isOpen={!!selectedMessage}
-        onClose={() => setSelectedMessage(null)}
-        message={selectedMessage}
-      />
-
-      {receipt && <section aria-label="DLQ resend receipts" className="rounded border border-blue-300 p-4 mb-4 overflow-auto">
-        <h3>Latest resend receipt: {receipt.successCount} succeeded / {receipt.failureCount} failed</h3>
-        <table className="w-full text-left text-sm"><thead><tr><th>DLQ request ID</th><th>Original ID / Topic</th><th>Group</th><th>Success</th><th>Consume result</th><th>Remark</th></tr></thead><tbody>
-          {receipt.items.map((item, index) => <tr key={`${item.requestMessageId ?? item.msgId}:${index}`}><td>{item.requestMessageId ?? item.msgId}</td><td>{item.msgId} / {item.topic}</td><td>{item.consumerGroup}</td><td>{String(item.success)}</td><td>{item.consumeResult ?? 'Not confirmed'}</td><td>{item.remark || item.message}</td></tr>)}
-        </tbody></table>
-        <button type="button" disabled={isBatchResending || Boolean(resendingMessageId)} onClick={() => {
-          const failed = failedDlqSelection(receipt, consumerGroup.trim(), messages);
-          setSelectedMessageIds(failed);
-          setSearchError(failed.size ? 'Only visible failed messages are selected. Review and confirm Batch resend to retry.' : 'No failed messages from this receipt are visible in the current query. Refresh or query their IDs first.');
-        }}>Select only failed messages for review</button>
-      </section>}
-      <details className="mb-4"><summary>Advanced resend target</summary><label>Optional ClientId <Input value={clientId} onChange={event => setClientId(event.target.value)} placeholder="Automatic client selection when empty" /></label></details>
-      <p className="text-sm mb-3">Select a query mode: Message ID and Key are exact queries with no time-page cursor. Key returns at most 64 matches. CSV exports include only explicitly selected messages.</p>
-      <div className="mb-8 flex justify-center">
-        <div className="inline-flex rounded-xl bg-gray-100 p-1 shadow-inner dark:bg-gray-800">
-          {(['Consumer', 'Key', 'Message ID'] as DlqTab[]).map((tab) => (
-            <button
-              key={tab}
-              onClick={() => setActiveTab(tab)}
-              className={`rounded-lg px-6 py-2 text-sm font-medium transition-all duration-200 ${
-                activeTab === tab
-                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                  : 'text-gray-500 hover:bg-gray-200/50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700/50 dark:hover:text-gray-200'
-              }`}
-            >
-              {tab}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="flex items-start gap-3 rounded-2xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-200">
-        <Info className="mt-0.5 h-4 w-4 shrink-0" />
-          <div>Single-message export and resend are available. Batch resend and batch export are available.</div>
-      </div>
-
-      <div className="sticky top-0 z-20 flex flex-col justify-between gap-4 rounded-2xl border border-gray-100 bg-white/90 p-4 shadow-sm backdrop-blur-xl transition-colors dark:border-gray-800 dark:bg-gray-900/90 xl:flex-row xl:items-center">
-        <div className="flex flex-1 flex-wrap items-center gap-4">
-          <div className="flex min-w-[260px] flex-1 items-center space-x-2">
-            <span className="whitespace-nowrap text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Consumer Group:
-            </span>
-            <div className="relative flex-1">
-              <Input
-                value={consumerGroup}
-                onChange={(event) => {
-                  setConsumerGroup(event.target.value);
-                  writeGeneration.current.invalidate();
-                  resetConsumerPagingState();
-                }}
-                list="dlq-consumer-group-options"
-                placeholder={isConsumerCatalogLoading ? 'Loading consumer groups...' : 'Enter consumer group...'}
-                className="border-gray-200 bg-gray-50 pr-10 font-mono text-gray-900 placeholder:text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-              />
-              <Users className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
-              <datalist id="dlq-consumer-group-options">
-                {consumerGroupOptions.map((item) => (
-                  <option key={item} value={item} />
-                ))}
-              </datalist>
-            </div>
-          </div>
-
-          {activeTab === 'Consumer' ? (
-            <>
-              <div className="flex items-center space-x-2">
-                <span className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">Begin:</span>
-                <div className="relative">
-                  <Input
-                    value={beginTime}
-                    onChange={(event) => {
-                      setBeginTime(event.target.value);
-                      resetConsumerPagingState();
-                    }}
-                    className="w-48 border-gray-200 bg-gray-50 font-mono text-xs text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-                  />
-                  <Calendar className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
-                </div>
-              </div>
-
-              <div className="flex items-center space-x-2">
-                <span className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">End:</span>
-                <div className="relative">
-                  <Input
-                    value={endTime}
-                    onChange={(event) => {
-                      setEndTime(event.target.value);
-                      resetConsumerPagingState();
-                    }}
-                    className="w-48 border-gray-200 bg-gray-50 font-mono text-xs text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-                  />
-                  <Calendar className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="flex min-w-[320px] flex-1 items-center space-x-2">
-              <span className="whitespace-nowrap text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                {activeTab === 'Key' ? 'Message Key:' : 'Message ID:'}
-              </span>
-              <div className="relative flex-1">
-                <Input
-                  value={activeTab === 'Key' ? messageKey : messageId}
-                  onChange={(event) => { if (activeTab === 'Key') setMessageKey(event.target.value); else setMessageId(event.target.value); resetConsumerPagingState(); }}
-                  placeholder={activeTab === 'Key' ? 'Enter Message Key...' : 'Enter Message ID...'}
-                  className="border-gray-200 bg-gray-50 pr-10 font-mono text-gray-900 placeholder:text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-                />
-                <Hash className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="flex flex-wrap items-center gap-3">
-          <button
-            onClick={() => void handleSearch()}
-            disabled={isSearching}
-            className="flex items-center rounded-xl bg-gray-900 px-6 py-2 text-sm font-medium text-white shadow-md transition-all hover:bg-gray-800 hover:shadow-lg active:scale-95 disabled:cursor-not-allowed disabled:opacity-60 dark:border dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800"
-          >
-            <Search className="mr-2 h-4 w-4" />
-            {isSearching ? 'SEARCHING...' : 'SEARCH'}
-          </button>
-
-
-            <>
-              <button
-                onClick={() => void handleBatchResend()}
-                disabled={isBatchResending || Boolean(resendingMessageId) || isBatchExporting || selectedMessageIds.size === 0}
-                className="flex items-center rounded-xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
-              >
-                <Send className="mr-2 h-4 w-4" />
-                {isBatchResending ? 'Batch Resending...' : `Batch Resend${selectedMessageIds.size > 0 ? ` (${selectedMessageIds.size})` : ''}`}
-              </button>
-              <button
-                onClick={() => void handleBatchExport()}
-                disabled={isBatchExporting || isBatchResending || selectedMessageIds.size === 0}
-                className="flex items-center rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all hover:border-blue-200 hover:bg-blue-50 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-800 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
-              >
-                <ArrowUpRight className="mr-2 h-4 w-4" />
-                {isBatchExporting ? 'Batch Exporting...' : `Batch Export${selectedMessageIds.size > 0 ? ` (${selectedMessageIds.size})` : ''}`}
-              </button>
-            </>
-
-        </div>
-      </div>
-
-      {consumerCatalogError ? (
-        <div className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200">
-          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <div>Failed to load consumer groups: {consumerCatalogError}. Manual input is still available.</div>
-        </div>
-      ) : null}
-
-      {searchError ? (
-        <div className="flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-200">
-          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <div>{searchError}</div>
-        </div>
-      ) : null}
-
-      <div>
-        {messages.length > 0 ? (
-          <>
-
-              <div className="mb-4 flex items-center justify-between rounded-2xl border border-gray-100 bg-white px-4 py-3 text-sm text-gray-600 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
-                <label className="flex items-center gap-3">
-                  <input
-                    type="checkbox"
-                    checked={allVisibleSelected}
-                    onChange={toggleSelectAllVisible}
-                    className="h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800"
-                  />
-                  <span>Select all messages on this page</span>
-                </label>
-                <span className="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">
-                  {selectedMessageIds.size} selected
-                </span>
-              </div>
-
-
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 2xl:grid-cols-3">
-            {messages.map((message, index) => (
-              <motion.div
-                key={`${message.topic}-${message.queryMsgId}`}
-                initial={{ opacity: 0, y: 16 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.04 }}
-                className="overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm transition-all duration-200 hover:border-blue-200 hover:shadow-md dark:border-gray-800 dark:bg-gray-900 dark:hover:border-blue-800"
-              >
-                <div className="border-b border-gray-100 bg-gradient-to-br from-gray-50/70 to-white px-5 py-4 dark:border-gray-800 dark:from-gray-800/50 dark:to-gray-900">
-                  <div className="mb-2 flex items-center justify-between">
-                    <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-                      Message ID
-                    </span>
-                    <div className="flex items-center gap-3">
-
-                        <input
-                          type="checkbox"
-                          checked={isMessageSelected(message)}
-                          onChange={() => toggleMessageSelection(message)}
-                          className="h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800"
-                        />
-
-                      <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-500 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
-                        DLQ
-                      </span>
-                    </div>
-                  </div>
-                  <p className="break-all font-mono text-sm font-bold text-gray-900 dark:text-white">{message.msgId}</p>
-                </div>
-
-                <div className="space-y-4 p-5">
-                  <div className="rounded-xl border border-gray-100 bg-gray-50/50 p-3 dark:border-gray-800 dark:bg-gray-800/40">
-                    <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-                      Topic
-                    </div>
-                    <div className="break-all font-mono text-xs text-gray-700 dark:text-gray-300">{message.topic}</div>
-                  </div>
-
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="rounded-xl border border-gray-100 bg-gray-50/50 p-3 dark:border-gray-800 dark:bg-gray-800/40">
-                      <div className="mb-1 flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-                        <Tag className="h-3.5 w-3.5" />
-                        Tags
-                      </div>
-                      <div className="break-all font-mono text-xs text-gray-700 dark:text-gray-300">
-                        {message.tags || '-'}
-                      </div>
-                    </div>
-
-                    <div className="rounded-xl border border-gray-100 bg-gray-50/50 p-3 dark:border-gray-800 dark:bg-gray-800/40">
-                      <div className="mb-1 flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-                        <Key className="h-3.5 w-3.5" />
-                        Keys
-                      </div>
-                      <div className="break-all font-mono text-xs text-gray-700 dark:text-gray-300">
-                        {message.keys || '-'}
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="flex items-center rounded-xl border border-gray-100 bg-gray-50/50 p-3 dark:border-gray-800 dark:bg-gray-800/40">
-                    <Clock className="mr-2.5 h-4 w-4 text-gray-400 dark:text-gray-500" />
-                    <div>
-                      <div className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-                        Store Time
-                      </div>
-                      <div className="font-mono text-sm text-gray-900 dark:text-white">
-                        {formatTimestamp(message.storeTimestamp)}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="border-t border-gray-100 bg-gray-50/30 px-5 py-3 dark:border-gray-800 dark:bg-gray-800/30">
-                  <div className="grid grid-cols-3 gap-3">
-                    <button
-                      onClick={() => void handleResend(message)}
-                      disabled={
-                        resendingMessageId === message.queryMsgId ||
-                        exportingMessageId === message.queryMsgId ||
-                        isBatchResending ||
-                        isBatchExporting
-                      }
-                      className="flex items-center justify-center rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
-                    >
-                      <Send className="mr-1.5 h-4 w-4" />
-                      {resendingMessageId === message.queryMsgId ? 'Resending...' : 'Resend'}
-                    </button>
-                    <button
-                      onClick={() => void handleExport(message)}
-                      disabled={
-                        exportingMessageId === message.queryMsgId ||
-                        resendingMessageId === message.queryMsgId ||
-                        isBatchResending ||
-                        isBatchExporting
-                      }
-                      className="flex items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all hover:border-blue-200 hover:bg-blue-50 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-800 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
-                    >
-                      <ArrowUpRight className="mr-1.5 h-4 w-4" />
-                      {exportingMessageId === message.queryMsgId ? 'Exporting...' : 'Export'}
-                    </button>
-                    <button
-                      onClick={() => setSelectedMessage(message)}
-                      className="flex items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all hover:border-blue-200 hover:bg-blue-50 hover:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-800 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
-                    >
-                      <FileText className="mr-1.5 h-4 w-4" />
-                      Detail
-                    </button>
-                  </div>
-                </div>
-              </motion.div>
-            ))}
-            </div>
-          </>
-        ) : hasSearched ? (
-          <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-gray-200 bg-white py-20 text-center text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400">
-            <div className="mb-4 rounded-full bg-gray-50 p-4 dark:bg-gray-800">
-              <Search className="h-8 w-8 opacity-30" />
-            </div>
-            <p className="text-sm font-medium text-gray-700 dark:text-gray-200">No DLQ messages matched this query.</p>
-            <p className="mt-1 text-xs opacity-70">Check the consumer group, time range, or message id and try again.</p>
-          </div>
-        ) : (
-          <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-gray-200 bg-white py-20 text-center text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400">
-            <div className="mb-4 rounded-full bg-gray-50 p-4 dark:bg-gray-800">
-              <Info className="h-8 w-8 opacity-30" />
-            </div>
-            <p className="text-sm font-medium text-gray-700 dark:text-gray-200">DLQ query is ready.</p>
-            <p className="mt-1 text-xs opacity-70">{renderEmptyCopy()}</p>
-          </div>
-        )}
-
-        {activeTab === 'Consumer' && pagination.totalPages > 1 ? (
-          <div className="mt-6 flex items-center justify-center">
-            <Pagination
-              currentPage={pagination.currentPage}
-              totalPages={pagination.totalPages}
-              onPageChange={(page) => {
-                if (!isSearching) {
-                  void queryDlqPage(page);
-                }
-              }}
-            />
-          </div>
-        ) : null}
-      </div>
-    </div>
-  );
-};
+import { usePageRefresh } from '../app/layout/pageToolbar';
+import { PageSection } from './layout/PageSection';
+import { PageState } from './layout/PageState';
+import { Button } from './ui/LegacyButton';
+import { Input } from './ui/LegacyInput';
+import { Pagination } from './Pagination';
+import '../features/message/message.css';
+import '../features/dlq/dlq.css';
+
+const localTime = (timestamp: number) => new Date(timestamp - new Date(timestamp).getTimezoneOffset() * 60_000).toISOString().slice(0, 19);
+const initialDraft = (): DlqQueryDraft => ({ mode: 'key', consumerGroup: '', key: '', messageId: '', begin: localTime(Date.now() - 3 * 3_600_000), end: localTime(Date.now()) });
+const modes = [['key', 'By Key'], ['id', 'By ID'], ['time', 'By Time']] as const;
+const rowId = (message: DlqMessageSummary) => messageLookup(message).messageId;
+
+export function DLQMessageView() {
+    const [draft, storeDraft] = useNavigationState<DlqQueryDraft>('dlqQuery', initialDraft);
+    const [clientId, setClientId] = useNavigationState<string>('dlqClient', () => '');
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+    const [detail, setDetail] = useState<DlqMessageSummary | null>(null);
+    const [localPage, setLocalPage] = useState(1);
+    const [validation, setValidation] = useState('');
+    const [reviewNote, setReviewNote] = useState('');
+    const [hasSearched, setHasSearched] = useState(false);
+    const catalog = useConsumerCatalog({ mode: 'name_server' });
+    const groupsId = useId();
+    const actions = useDlqActions();
+    const context = useMemo(() => {
+        const settings = ConnectionStore.getSnapshot();
+        return { revision: settings?.revision ?? 0, environmentId: settings?.environmentId ?? null };
+    }, []);
+    const controller = useMemo(() => {
+        return createDlqQueryController(() => {
+            const current = ConnectionStore.getSnapshot();
+            return current?.revision === context.revision && current?.environmentId === context.environmentId;
+        });
+    }, [context]);
+    const state = useSyncExternalStore(controller.subscribe, controller.getSnapshot, controller.getSnapshot);
+    useEffect(() => { controller.start(); return controller.stop; }, [controller]);
+    useEffect(() => { setSelected(new Set()); setReviewNote(''); }, [state.result, actions.receipt]);
+    const update = (patch: Partial<DlqQueryDraft>) => {
+        controller.reset(); setSelected(new Set()); setDetail(null); setLocalPage(1); setValidation(''); setReviewNote(''); setHasSearched(false);
+        storeDraft({ ...draft, ...patch });
+    };
+    const query = useCallback(() => {
+        try {
+            const request = buildDlqQuery(draft);
+            setValidation(''); setHasSearched(true); setLocalPage(1); setDetail(null); setSelected(new Set());
+            void controller.read(request, 1, true);
+        } catch (error) { setValidation((error as Error).message); }
+    }, [controller, draft]);
+    const refresh = useCallback(() => { void catalog.refresh(); if (hasSearched) query(); }, [catalog.refresh, hasSearched, query]);
+    usePageRefresh({ refresh, pending: catalog.pending || state.pending, refreshedAt: state.receivedAt });
+    const result = state.result;
+    const group = result ? dlqGroup(result.query.topic) : '';
+    const timeMode = result?.query.mode === 'time';
+    const pageCount = timeMode ? result.totalPages : Math.ceil((result?.items.length ?? 0) / 12);
+    const page = timeMode ? result.page : Math.min(localPage, Math.max(1, pageCount));
+    const items = result ? timeMode ? result.items : result.items.slice((page - 1) * 12, page * 12) : [];
+    const rows = [...new Map(items.map(message => [rowId(message), message])).values()];
+    const selectedRows = rows.filter(message => selected.has(rowId(message)));
+    const blocked = state.pending || Boolean(state.error);
+    const failed = actions.receipt ? failedDlqSelection(actions.receipt, ConnectionStore.getSnapshot()?.environmentId ?? null, group, rows) : new Set<string>();
+    const allSelected = rows.length > 0 && selectedRows.length === rows.length;
+    return <div className="ops-dlq">
+        <section className="ops-dlq-query" aria-label="Dead-letter query"><form onSubmit={event => { event.preventDefault(); query(); }}>
+            <Input label="Consumer group" list={groupsId} placeholder="Choose or enter a group" value={draft.consumerGroup} onChange={event => update({ consumerGroup: event.target.value })} required />
+            <datalist id={groupsId}>{catalog.data?.items.filter(item => item.category !== 'SYSTEM').map(item => <option key={item.rawGroupName} value={item.rawGroupName} />)}</datalist>
+            <div className="ops-dlq-mode"><span>Query mode</span><div className="ops-message-modes" role="group" aria-label="DLQ query mode">{modes.map(([mode, label]) => <Button key={mode} variant={draft.mode === mode ? 'primary' : 'ghost'} aria-pressed={draft.mode === mode} onClick={() => { if (mode !== draft.mode) update({ mode }); }}>{label}</Button>)}</div></div>
+            {draft.mode === 'key' && <Input label="Key" value={draft.key} onChange={event => update({ key: event.target.value })} required />}
+            {draft.mode === 'id' && <Input label="Message ID" value={draft.messageId} onChange={event => update({ messageId: event.target.value })} required />}
+            {draft.mode === 'time' && <><Input label="Begin" type="datetime-local" step={1} value={draft.begin} onChange={event => update({ begin: event.target.value })} required />
+                <Input label="End" type="datetime-local" step={1} value={draft.end} onChange={event => update({ end: event.target.value })} required /></>}
+            <Input label="Client ID (optional)" placeholder="Selected by Broker" value={clientId} onChange={event => setClientId(event.target.value)} />
+            <Button type="submit" disabled={state.pending}>{state.pending ? 'Querying…' : 'Query'}</Button>
+        </form>
+            <p className="ops-message-note">{draft.mode === 'time' ? `Local time: ${Intl.DateTimeFormat().resolvedOptions().timeZone}. Refresh starts a new scan.` : draft.mode === 'key' ? 'Key lookup returns up to 64 indexed messages.' : 'Query a DLQ physical or unique message ID.'} Client ID applies only to resend.</p>
+            {catalog.error && <p className="ops-message-note">Consumer suggestions are unavailable. Manual group input remains available.</p>}
+            {validation && <PageState kind="error" title="Check query conditions" description={validation} />}
+        </section>
+        <PageSection title={result ? `${result.total.toLocaleString()} messages found` : 'Dead-letter messages'} description={result ? `Consumer group: ${group} · Last successful query: ${new Date(state.receivedAt!).toLocaleString()}` : 'Query a Consumer group to inspect its dead-letter queue.'}>
+            {state.pending && <PageState kind="loading" title="Reading dead-letter messages" />}
+            {state.error && <PageState kind="error" title="DLQ query failed" description={state.error + (result ? ' Showing the last successful result; actions are disabled.' : '')} />}
+            {!hasSearched && <PageState kind="empty" title="No query yet" />}
+            {result && <>
+                <div className="ops-message-scroll" role="region" aria-label="Dead-letter results" tabIndex={0}><table><thead><tr>
+                    <th scope="col" className="ops-dlq-check"><input type="checkbox" aria-label="Select all messages on this page" checked={allSelected} disabled={blocked || !rows.length} onChange={() => { setReviewNote(''); setSelected(allSelected ? new Set() : new Set(rows.map(rowId))); }} /></th>
+                    {['DLQ request ID', 'DLQ Topic', 'Store time', 'Actions'].map(label => <th scope="col" key={label}>{label}</th>)}
+                </tr></thead><tbody>{rows.map(message => <tr key={rowId(message)} data-selected={selected.has(rowId(message))}>
+                    <td className="ops-dlq-check"><input type="checkbox" aria-label={'Select message ' + rowId(message)} checked={selected.has(rowId(message))} disabled={blocked} onChange={() => { setReviewNote(''); setSelected(current => { const next = new Set(current); if (next.has(rowId(message))) next.delete(rowId(message)); else next.add(rowId(message)); return next; }); }} /></td>
+                    <th scope="row"><button type="button" className="ops-message-choice" disabled={blocked} onClick={() => setDetail(message)} title={rowId(message)}>{visibleMessageText(rowId(message))}</button></th>
+                    <td>{visibleMessageText(message.topic)}</td>
+                    <td>{messageTimestamp(message.storeTimestamp)}</td><td><div className="ops-dlq-row-actions"><Button variant="outline" disabled={blocked} onClick={() => setDetail(message)}>Detail</Button>
+                        <Button variant="outline" disabled={blocked} onClick={() => actions.open({ action: 'resend', group, messages: [message], clientId, context })}>Resend</Button>
+                        <Button variant="outline" disabled={blocked} onClick={() => actions.open({ action: 'export', group, messages: [message], clientId: '', context })}>Export</Button></div></td>
+                </tr>)}</tbody></table></div>
+                {!rows.length && <PageState kind="empty" title="No matching dead-letter messages" />}
+                {pageCount > 1 && <Pagination currentPage={page} totalPages={pageCount} disabled={state.pending} onPageChange={value => { setSelected(new Set()); setDetail(null); if (timeMode) void controller.read(result.query, value); else setLocalPage(value); }} />}
+                <div className="ops-dlq-selection"><span>{selectedRows.length} selected</span><div className="ops-message-actions"><Button icon={Send} disabled={blocked || !selectedRows.length} onClick={() => actions.open({ action: 'resend', group, messages: selectedRows, clientId, context })}>Resend selected</Button>
+                    <Button variant="outline" icon={Download} disabled={blocked || !selectedRows.length} onClick={() => actions.open({ action: 'export', group, messages: selectedRows, clientId: '', context })}>Export CSV</Button></div></div>
+                {reviewNote && <p role="status" className="ops-message-note">{reviewNote}</p>}
+            </>}
+        </PageSection>
+        <DlqReceiptPanel receipt={actions.receipt} canReview={!blocked && failed.size > 0} review={() => { setSelected(failed); setReviewNote(`${failed.size} failed targets selected. Review the targets and confirm before resending.`); }} />
+        {detail && <DlqMessageDialog message={detail} group={group} close={() => setDetail(null)} />}
+    </div>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/components/DlqActionProvider.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/components/DlqActionProvider.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useRef, useState, type ReactNode } from 'react';
+import { Download } from 'lucide-react';
+import { toast } from 'sonner';
+import { ConnectionStore } from '../../../services/connection.store';
+import { DlqService } from '../../../services/dlq.service';
+import { useOperationOwner } from '../../../hooks/useOperationOwner';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
+import { Button } from '../../../components/ui/LegacyButton';
+import { PageState } from '../../../components/layout/PageState';
+import { visibleMessageText } from '../../message/messageModel';
+import { DlqActionContext, type OpenDlqAction } from '../dlqActionContext';
+import { captureDlqTargets } from '../dlqTargets';
+import { dlqReceiptRows, type DlqReceipt } from '../receipts';
+import { downloadDlqCsv } from '../download';
+import type { DlqBatchMessageExportPayload } from '../types/dlq.types';
+import '../../message/message.css';
+
+interface Request extends ReturnType<typeof captureDlqTargets> {
+    trigger: HTMLElement | null;
+}
+
+function DlqActionDialog({ request, close, saveReceipt }: { request: Request; close: () => void; saveReceipt: (value: DlqReceipt) => void }) {
+    const owner = useOperationOwner(request.revision, request.environmentId);
+    const attempted = useRef(false);
+    const [submitted, setSubmitted] = useState(false);
+    const [receipt, setReceipt] = useState<DlqReceipt | null>(null);
+    const [exported, setExported] = useState<DlqBatchMessageExportPayload | null>(null);
+    const resend = request.action === 'resend';
+    const submit = async () => {
+        if (attempted.current || owner.blocked) return;
+        attempted.current = true; setSubmitted(true);
+        const startedAt = Date.now();
+        if (resend) {
+            const response = await owner.controller.write(async () => {
+                if (request.messages.length !== 1) return DlqService.batchResendDlqMessage({ messages: request.messages });
+                const result = await DlqService.resendDlqMessage(request.messages[0]);
+                return { items: [result], total: 1, successCount: Number(result.success), failureCount: Number(!result.success) };
+            }, 'Resend was not confirmed. Inspect the Consumer before another attempt.');
+            const completed: DlqReceipt = { requests: request.messages, environmentId: request.environmentId, revision: request.revision,
+                startedAt, completedAt: Date.now(), response, error: owner.controller.getSnapshot().error };
+            setReceipt(completed); saveReceipt(completed);
+        } else {
+            const result = await owner.controller.read(async () => {
+                const messages = request.messages.map(({ consumerGroup, messageId }) => ({ consumerGroup, messageId }));
+                if (messages.length !== 1) return DlqService.batchExportDlqMessage({ messages });
+                return { ...await DlqService.exportDlqMessage(messages[0]), total: 1, successCount: 1, failureCount: 0 };
+            }, 'CSV could not be prepared. Close and review the targets before another request.');
+            if (result) setExported(result);
+        }
+    };
+    const outcomes = receipt ? dlqReceiptRows(receipt) : [];
+    return <Dialog open onOpenChange={open => { if (!open && !owner.busy) close(); }}><DialogContent className="ops-message-operation" showCloseButton={!owner.busy}
+        onEscapeKeyDown={event => { if (owner.busy) event.preventDefault(); }} onInteractOutside={event => { if (owner.busy) event.preventDefault(); }}
+        onCloseAutoFocus={event => {
+            event.preventDefault();
+            // Completing a batch clears its selection, which can disable the original trigger.
+            if (request.trigger?.isConnected && !request.trigger.matches(':disabled, [aria-disabled="true"]')) request.trigger.focus();
+            else document.getElementById('main-content')?.focus();
+        }}>
+        <DialogHeader><DialogTitle>{resend ? 'Resend dead-letter messages' : 'Export dead-letter messages'}</DialogTitle>
+            <DialogDescription>{resend ? 'Review the fixed Consumer and message targets before requesting consumption.' : 'Prepare CSV for these targets, then download the returned file.'}</DialogDescription></DialogHeader>
+        <form className="ops-message-operation-form" onSubmit={event => { event.preventDefault(); void submit(); }}>
+            <div className="ops-message-operation-body">
+                <p className="ops-message-note">Environment {request.environmentId ?? 'Not configured'} · Connection revision {request.revision}</p>
+                {owner.contextChanged && <PageState kind="stale" title="Connection context changed" description="Accepted resend results remain attached to the original environment. No new request can be submitted from this dialog." />}
+                {owner.state.error && <PageState kind="error" title={resend ? 'Resend result is unconfirmed' : 'Export unavailable'} description={owner.state.error} />}
+                <dl className="ops-message-properties"><div><dt>Consumer group</dt><dd>{visibleMessageText(request.messages[0].consumerGroup)}</dd></div>
+                    {resend && <div><dt>Client</dt><dd>{visibleMessageText(request.messages[0].clientId || 'Selected by Broker')}</dd></div>}
+                    <div><dt>{request.messages.length} DLQ request IDs</dt><dd tabIndex={0}>{request.messages.map(item => <div key={item.messageId}>{visibleMessageText(item.messageId)}</div>)}</dd></div></dl>
+                {resend && <p>The Broker resolves each original Topic and message ID from its DLQ record. This can run an already processed message again. The batch is not atomic; no automatic retry is performed.</p>}
+                {owner.busy && <PageState kind="loading" title={resend ? 'Requesting consumption' : 'Preparing CSV'} />}
+                {receipt && <PageState kind={outcomes.every(row => row.outcome === 'success') ? 'empty' : 'partial'} title="Resend outcome"
+                    description={`${outcomes.filter(row => row.outcome === 'success').length} succeeded · ${outcomes.filter(row => row.outcome === 'failed').length} failed · ${outcomes.filter(row => row.outcome === 'unknown').length} unknown. Close to inspect the persistent results table.`} />}
+                {exported && <PageState kind={exported.failureCount ? 'partial' : 'empty'} title="CSV prepared" description={`${exported.successCount} exported · ${exported.failureCount} failed. Review errors included in the CSV. Download does not resend any messages.`} />}
+            </div>
+            <DialogFooter><Button variant="outline" disabled={owner.busy} onClick={close}>Close</Button>
+                {exported ? <Button icon={Download} onClick={() => { downloadDlqCsv(exported); toast.success('CSV download requested'); }}>Download CSV</Button>
+                    : <Button type="submit" variant={resend ? 'danger' : 'primary'} disabled={owner.blocked || submitted}>{resend ? 'Confirm resend' : 'Prepare CSV'}</Button>}
+            </DialogFooter>
+        </form>
+    </DialogContent></Dialog>;
+}
+
+/** Session-owned dialogs and receipts survive route and connection changes, but never sign-out. */
+export function DlqActionProvider({ children }: { children: ReactNode }) {
+    const [request, setRequest] = useState<Request | null>(null);
+    const [receipt, setReceipt] = useState<DlqReceipt | null>(null);
+    const open = useCallback<OpenDlqAction>(input => {
+        try {
+            const captured = captureDlqTargets(input, ConnectionStore.getSnapshot());
+            const trigger = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+            setRequest(current => current ?? { ...captured, trigger });
+        } catch (error) { toast.error(error instanceof Error ? error.message : 'DLQ targets could not be selected.'); }
+    }, []);
+    return <DlqActionContext.Provider value={{ open, receipt }}>{children}{request && <DlqActionDialog request={request} close={() => setRequest(null)} saveReceipt={setReceipt} />}</DlqActionContext.Provider>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/components/DlqMessageDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/components/DlqMessageDialog.tsx
@@ -1,0 +1,21 @@
+import { useCallback, useRef } from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
+import { MessageInspector } from '../../message/components/MessageInspector';
+import { messageLookup, visibleMessageText } from '../../message/messageModel';
+import { DlqService } from '../../../services/dlq.service';
+import type { DlqMessageSummary } from '../types/dlq.types';
+
+export function DlqMessageDialog({ message, group, close }: { message: DlqMessageSummary; group: string; close: () => void }) {
+    const trigger = useRef(document.activeElement instanceof HTMLElement ? document.activeElement : null);
+    const load = useCallback(() => DlqService.viewDlqMessageDetail({ consumerGroup: group, messageId: messageLookup(message).messageId }), [group, message]);
+    return <Dialog open onOpenChange={open => { if (!open) close(); }}><DialogContent className="ops-message-detail-dialog"
+        onCloseAutoFocus={event => { event.preventDefault(); if (trigger.current?.isConnected) trigger.current.focus(); else document.getElementById('main-content')?.focus(); }}>
+        <DialogHeader><DialogTitle>Inspect dead-letter message</DialogTitle><DialogDescription>Consumer group: {group}. Use the DLQ results table to select and review resend targets.</DialogDescription></DialogHeader>
+        <div className="ops-message-dialog-scroll ops-message-stack">
+            <dl className="ops-message-properties" aria-label="Selected query record">{[
+                ['Displayed message ID', message.msgId], ['Tags', message.tags || 'Not reported'], ['Keys', message.keys || 'Not reported'],
+            ].map(([label, value]) => <div key={label}><dt>{label}</dt><dd tabIndex={value.length > 200 ? 0 : undefined}>{visibleMessageText(value)}</dd></div>)}</dl>
+            <MessageInspector message={message} loadDetail={load} actions={null} />
+        </div>
+    </DialogContent></Dialog>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/components/DlqReceiptPanel.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/components/DlqReceiptPanel.tsx
@@ -1,0 +1,43 @@
+import { Download } from 'lucide-react';
+import { toast } from 'sonner';
+import { PageSection } from '../../../components/layout/PageSection';
+import { PageState } from '../../../components/layout/PageState';
+import { Button } from '../../../components/ui/LegacyButton';
+import { dlqReceiptCsv, dlqReceiptRows, type DlqReceipt } from '../receipts';
+import { downloadDlqCsv } from '../download';
+import { visibleMessageText } from '../../message/messageModel';
+
+export function DlqReceiptPanel({ receipt, review, canReview }: { receipt: DlqReceipt | null; review: () => void; canReview: boolean }) {
+    const rows = receipt ? dlqReceiptRows(receipt) : [];
+    const succeeded = rows.filter(row => row.outcome === 'success').length;
+    const failed = rows.filter(row => row.outcome === 'failed').length;
+    const unknown = rows.length - succeeded - failed;
+    return <PageSection title="Resend results" description={receipt
+        ? `${succeeded} succeeded · ${failed} failed · ${unknown} unknown. This batch is not atomic; no automatic retry is performed.`
+        : 'Completed results remain available during this session when you change pages or connections.'}
+        action={receipt && <div className="ops-message-actions"><Button variant="outline" disabled={!canReview} onClick={review}>Review failed targets</Button>
+            <Button variant="outline" icon={Download} onClick={() => { downloadDlqCsv({ fileName: 'dlq-resend-results.csv', mimeType: 'text/csv;charset=utf-8', content: dlqReceiptCsv(receipt) }); toast.success('Results download requested'); }}>Export results</Button></div>}>
+        {!receipt ? <PageState kind="empty" title="No resend results yet" /> : <>
+            <p className="ops-message-note">Environment {receipt.environmentId ?? 'Not configured'} · Revision {receipt.revision} · Completed {new Date(receipt.completedAt).toLocaleString()} · Elapsed {((receipt.completedAt - receipt.startedAt) / 1000).toFixed(1)} s</p>
+            {unknown > 0 && <PageState kind="partial" title="Some outcomes are unknown" description="A missing, conflicting or unconfirmed response does not prove that consumption failed. Check the Consumer before another attempt; unknown targets are excluded from failed-target selection." />}
+            {receipt.error && <p role="alert" className="ops-message-note">{receipt.error}</p>}
+            <div className="ops-message-scroll" role="region" aria-label="Per-message resend results" tabIndex={0}><table><thead><tr>{['DLQ request ID', 'Result', 'Consumer / Client', 'Original message', 'Message'].map(label => <th scope="col" key={label}>{label}</th>)}</tr></thead>
+                <tbody>{rows.map(({ request, result, outcome }) => <tr key={request.consumerGroup + ':' + request.messageId}>
+                    <th scope="row"><ReceiptValue value={request.messageId} /></th><td className="ops-dlq-result"><span className="ops-dlq-outcome" data-outcome={outcome}>{outcome === 'success' ? 'Succeeded' : outcome === 'failed' ? 'Failed' : 'Unknown'}</span><small>{result?.consumeResult || 'Not confirmed'}</small></td>
+                    <td><ReceiptValue value={request.consumerGroup} /><small><ReceiptValue value={request.clientId || 'Selected by Broker'} /></small></td>
+                    <td><ReceiptValue value={result?.topic || 'Not reported'} /><small><ReceiptValue value={result?.msgId || 'Not reported'} /></small></td>
+                    <td><ReceiptValue value={result?.message || 'No unambiguous result for this target.'} /><small><ReceiptValue value={result?.remark || ''} /></small></td>
+                </tr>)}</tbody></table></div>
+            <p className="ops-message-note">Review selects only confirmed failed targets visible in the current group and environment. Selection does not send messages.</p>
+            {receipt.response && <details className="ops-dlq-reported"><summary>Reported response ({receipt.response.items.length} items)</summary>
+                <p className="ops-message-note">Backend totals: {receipt.response.total} requested · {receipt.response.successCount} success · {receipt.response.failureCount} failure. Per-target confirmation above also checks identity and consume outcome.</p>
+                <pre tabIndex={0}>{visibleMessageText(JSON.stringify(receipt.response.items.map(({ requestMessageId, consumerGroup, topic, msgId, success, consumeResult, message, remark }) =>
+                    ({ requestMessageId, consumerGroup, topic, msgId, success, consumeResult, message, remark })), null, 2))}</pre>
+            </details>}
+        </>}
+    </PageSection>;
+}
+
+function ReceiptValue({ value }: { value: string }) {
+    return <span className="ops-dlq-value" tabIndex={value.length > 120 ? 0 : undefined}>{visibleMessageText(value)}</span>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlq.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlq.css
@@ -1,0 +1,28 @@
+.ops-dlq { display: grid; gap: 22px; min-width: 0; }
+.ops-dlq-query { padding: 18px; border: 1px solid var(--ops-border); border-radius: 12px; background: var(--ops-panel); }
+.ops-dlq-query > .ops-message-note { margin: 6px 0 0; }
+.ops-dlq-query form { display: flex; align-items: end; flex-wrap: wrap; gap: 16px; }
+.ops-dlq-query form > .ops-field { flex: 1 1 180px; min-width: 0; }
+.ops-dlq-mode { display: grid; gap: 8px; font-size: 12px; color: var(--ops-muted); }
+.ops-dlq-mode .ops-message-modes > button { min-width: 75px; }
+.ops-dlq .ops-section-header { margin-bottom: 16px; }
+.ops-dlq .ops-message-scroll table { min-width: 850px; }
+.ops-dlq .ops-message-scroll td, .ops-dlq .ops-message-scroll tbody th { padding: 12px 14px; }
+.ops-dlq .ops-message-scroll thead th { font-size: 13px; }
+.ops-dlq .ops-message-scroll small { display: block; color: var(--ops-muted); font-size: 12px; margin-top: 4px; }
+.ops-dlq .ops-message-scroll tbody th { font-family: var(--ops-font-mono); font-size: 13px; }
+.ops-dlq .ops-dlq-check { width: 42px; padding: 12px; }
+.ops-dlq input[type="checkbox"] { width: 17px; height: 17px; accent-color: var(--ops-accent); cursor: pointer; }
+.ops-dlq .ops-dlq-row-actions { display: flex; gap: 4px; }
+.ops-dlq-row-actions button { padding: 4px 8px; min-width: 0; min-height: 32px; font-size: 12px; }
+.ops-dlq-selection { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border: 1px solid var(--ops-border); border-radius: 8px; padding: 14px; margin-top: 16px; font-size: 14px; }
+.ops-dlq .ops-dlq-result { min-width: 140px; }
+.ops-dlq-outcome { display: inline-flex; white-space: nowrap; border-radius: 5px; padding: 3px 9px; background: var(--ops-panel-soft); font-size: 13px; }
+.ops-dlq-outcome[data-outcome="success"] { color: var(--ops-success); background: var(--ops-success-soft); }
+.ops-dlq-outcome[data-outcome="failed"] { color: var(--ops-danger); background: var(--ops-danger-soft); }
+.ops-dlq-outcome[data-outcome="unknown"] { color: var(--ops-warning); background: var(--ops-warning-soft); }
+.ops-dlq-reported { margin-top: 12px; color: var(--ops-muted); font-size: 12px; }
+.ops-dlq-reported summary { cursor: pointer; }
+.ops-dlq-reported pre { max-height: 300px; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; }
+.ops-dlq-value { display: block; max-height: 128px; overflow: auto; overflow-wrap: anywhere; }
+@media (max-width: 900px) { .ops-dlq-query { padding: 16px; } .ops-dlq-query form > .ops-field { flex-basis: 220px; } }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqActionContext.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqActionContext.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+import type { DlqReceipt } from './receipts';
+import type { DlqActionInput } from './dlqTargets';
+
+export type OpenDlqAction = (input: DlqActionInput) => void;
+export const DlqActionContext = createContext<{ open: OpenDlqAction; receipt: DlqReceipt | null }>({ open: () => {}, receipt: null });
+export const useDlqActions = () => useContext(DlqActionContext);

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqQuery.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqQuery.test.ts
@@ -1,0 +1,60 @@
+import { expect, it, vi } from 'vitest';
+import { buildDlqQuery, createDlqQueryController, dlqGroup } from './dlqQuery';
+import type { DlqMessageDetail, DlqMessagePageResponse } from './types/dlq.types';
+
+const page = (number = 0, topic = '%DLQ%g'): DlqMessagePageResponse => ({ taskId: 'scan', page: { content: [{ topic, msgId: 'unique', queryMsgId: 'physical', storeTimestamp: 0 }],
+    number, size: 12, totalPages: 2, totalElements: 13, numberOfElements: 1, first: number === 0, last: number === 1, empty: false } });
+const detail: DlqMessageDetail = { topic: '%DLQ%g', msgId: 'physical', properties: { UNIQ_KEY: 'unique' }, storeTimestamp: 0 };
+const service = () => ({ queryDlqMessageByConsumerGroup: vi.fn(async () => page()), viewDlqMessageDetail: vi.fn(async () => detail) });
+
+it('normalizes prefixed groups and validates only fields required for the active mode', () => {
+    expect(dlqGroup(' %DLQ% g ')).toBe('g');
+    expect(() => dlqGroup('%DLQ% ')).toThrow('Consumer group');
+    expect(buildDlqQuery({ mode: 'key', consumerGroup: '%DLQ%g', key: ' order ', messageId: '', begin: '', end: '' })).toEqual({ mode: 'key', topic: '%DLQ%g', key: 'order' });
+    expect(() => buildDlqQuery({ mode: 'time', consumerGroup: 'g', key: '', messageId: '', begin: '2026-02-30T10:00', end: '2026-03-01T10:00' })).toThrow();
+});
+
+it('uses time cursors only within the same scan and starts explicit refresh from page one', async () => {
+    const api = service();
+    const controller = createDlqQueryController(() => true, api); controller.start();
+    const query = { mode: 'time' as const, topic: '%DLQ%g', begin: 0, end: 100 };
+    await controller.read(query);
+    await controller.read(query, 2);
+    expect(api.queryDlqMessageByConsumerGroup).toHaveBeenLastCalledWith({ consumerGroup: 'g', begin: 0, end: 100, pageNum: 2, pageSize: 12, taskId: 'scan' });
+    await controller.read(query, 1, true);
+    expect(api.queryDlqMessageByConsumerGroup).toHaveBeenLastCalledWith(expect.objectContaining({ pageNum: 1, taskId: undefined }));
+    await controller.read({ mode: 'key', topic: '%DLQ%g', key: 'order' });
+    expect(api.queryDlqMessageByConsumerGroup).toHaveBeenLastCalledWith({ consumerGroup: 'g', key: 'order', begin: 0, end: expect.any(Number), pageNum: 1, pageSize: 64 });
+});
+
+it('resolves ID lookup to a physical DLQ target and rejects wrong identity', async () => {
+    const api = service(); const controller = createDlqQueryController(() => true, api); controller.start();
+    await controller.read({ mode: 'id', topic: '%DLQ%g', messageId: 'unique' });
+    expect(controller.getSnapshot().result?.items[0]).toMatchObject({ queryMsgId: 'physical', msgId: 'unique', topic: '%DLQ%g' });
+    await controller.read({ mode: 'id', topic: '%DLQ%g', messageId: 'unrelated' });
+    expect(controller.getSnapshot().result).toBeNull();
+    expect(controller.getSnapshot().error).not.toBe('');
+});
+
+it('rejects another group and retains the last successful observation on refresh failure', async () => {
+    const api = service(); const controller = createDlqQueryController(() => true, api); controller.start();
+    const query = { mode: 'key' as const, topic: '%DLQ%g', key: 'order' };
+    await controller.read(query); const before = controller.getSnapshot();
+    api.queryDlqMessageByConsumerGroup.mockResolvedValueOnce(page(0, '%DLQ%other'));
+    expect(await controller.read(query, 1, true)).toBe(false);
+    expect(controller.getSnapshot().result).toBe(before.result);
+    expect(controller.getSnapshot().receivedAt).toBe(before.receivedAt);
+});
+
+it('coalesces duplicate queries and drops a late response after reset or context change', async () => {
+    let resolve!: (value: DlqMessagePageResponse) => void;
+    let current = true;
+    const api = service(); api.queryDlqMessageByConsumerGroup.mockImplementation(() => new Promise(done => { resolve = done; }));
+    const controller = createDlqQueryController(() => current, api); controller.start();
+    const query = { mode: 'key' as const, topic: '%DLQ%g', key: 'order' };
+    const first = controller.read(query); const duplicate = controller.read(query); await Promise.resolve();
+    expect(duplicate).toBe(first); expect(api.queryDlqMessageByConsumerGroup).toHaveBeenCalledTimes(1);
+    controller.reset(); resolve(page()); await first; expect(controller.getSnapshot().result).toBeNull();
+    const second = controller.read(query); await Promise.resolve(); current = false; resolve(page()); await second;
+    expect(controller.getSnapshot().result).toBeNull();
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqQuery.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqQuery.ts
@@ -1,0 +1,34 @@
+import { DlqService } from '../../services/dlq.service';
+import { buildMessageQuery, createMessageQueryController, type MessageQueryDraft } from '../message/messageQuery';
+import { checkMessageDetail } from '../message/messageModel';
+
+export interface DlqQueryDraft extends Omit<MessageQueryDraft, 'topic'> { consumerGroup: string; }
+
+export function dlqGroup(value: string) {
+    const group = value.trim().replace(/^%DLQ%/, '').trim();
+    if (!group) throw new Error('Enter a Consumer group.');
+    return group;
+}
+
+export function buildDlqQuery(draft: DlqQueryDraft) {
+    return buildMessageQuery({ ...draft, topic: '%DLQ%' + dlqGroup(draft.consumerGroup) });
+}
+
+/** Reuse message pagination and stale-read ownership, with DLQ-specific authenticated lookups. */
+export function createDlqQueryController(contextIsCurrent: () => boolean,
+    service: Pick<typeof DlqService, 'queryDlqMessageByConsumerGroup' | 'viewDlqMessageDetail'> = DlqService) {
+    return createMessageQueryController({
+        queryMessageByTopicKey: async ({ topic, key }) => {
+            const result = await service.queryDlqMessageByConsumerGroup({ consumerGroup: dlqGroup(topic), key,
+                begin: 0, end: Date.now(), pageNum: 1, pageSize: 64 });
+            return { items: result.page.content, total: result.page.totalElements };
+        },
+        queryMessageById: async ({ topic, messageId }) => {
+            const detail = checkMessageDetail(await service.viewDlqMessageDetail({ consumerGroup: dlqGroup(topic), messageId }),
+                { topic, msgId: messageId, queryMsgId: messageId, storeTimestamp: 0 });
+            return { items: [{ topic: detail.topic, msgId: detail.properties.UNIQ_KEY?.trim() || detail.msgId,
+                queryMsgId: detail.msgId, tags: detail.properties.TAGS, keys: detail.properties.KEYS, storeTimestamp: detail.storeTimestamp ?? 0 }], total: 1 };
+        },
+        queryMessagePageByTopic: ({ topic, ...request }) => service.queryDlqMessageByConsumerGroup({ ...request, consumerGroup: dlqGroup(topic) }),
+    }, contextIsCurrent);
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqTargets.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqTargets.test.ts
@@ -1,0 +1,30 @@
+import { expect, it } from 'vitest';
+import { captureDlqTargets, type DlqActionInput } from './dlqTargets';
+
+const context = { revision: 4, environmentId: 'local' };
+const input = (): DlqActionInput => ({ action: 'resend', context, group: '%DLQ%g', clientId: ' client ',
+    messages: [{ topic: '%DLQ%g', msgId: 'unique', queryMsgId: 'physical', storeTimestamp: 0 }] });
+
+it('captures physical identities once and preserves the chosen client independently of later edits', () => {
+    const draft = input(); draft.messages.push({ ...draft.messages[0] });
+    const captured = captureDlqTargets(draft, context);
+    draft.messages[0].queryMsgId = 'changed'; draft.clientId = 'changed';
+    expect(captured.messages).toEqual([{ consumerGroup: 'g', messageId: 'physical', clientId: 'client' }]);
+});
+
+it('rejects stale results before opening an operation in a different connection', () => {
+    expect(() => captureDlqTargets(input(), { ...context, revision: 5 })).toThrow('connection changed');
+    expect(() => captureDlqTargets(input(), { ...context, environmentId: 'other' })).toThrow('connection changed');
+    expect(() => captureDlqTargets(input(), null)).toThrow('connection changed');
+});
+
+it('rejects wrong-group, empty and oversized target sets', () => {
+    const draft = input(); draft.messages[0].topic = '%DLQ%other';
+    expect(() => captureDlqTargets(draft, context)).toThrow('DLQ record');
+    expect(() => captureDlqTargets({ ...input(), messages: [] }, context)).toThrow('1 and 256');
+    expect(() => captureDlqTargets({ ...input(), messages: Array.from({ length: 257 }, (_, index) => ({ ...input().messages[0], queryMsgId: String(index) })) }, context)).toThrow('1 and 256');
+});
+
+it('preserves explicit automatic-client selection without inventing a target', () => {
+    expect(captureDlqTargets({ ...input(), clientId: ' ' }, context).messages[0].clientId).toBeUndefined();
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqTargets.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/dlqTargets.ts
@@ -1,0 +1,28 @@
+import { messageLookup } from '../message/messageModel';
+import { dlqGroup } from './dlqQuery';
+import type { DlqMessageSummary } from './types/dlq.types';
+
+export interface DlqContext { revision: number; environmentId: string | null; }
+export interface DlqActionInput {
+    action: 'resend' | 'export';
+    group: string;
+    messages: DlqMessageSummary[];
+    clientId: string;
+    context: DlqContext;
+}
+
+export function captureDlqTargets(input: DlqActionInput, current: DlqContext | null) {
+    if (!current || current.revision !== input.context.revision || current.environmentId !== input.context.environmentId) {
+        throw new Error('The connection changed. Query the current environment before selecting targets.');
+    }
+    const group = dlqGroup(input.group);
+    const ids = new Set<string>();
+    for (const message of input.messages) {
+        const id = messageLookup(message).messageId;
+        if (message.topic !== '%DLQ%' + group || !id.trim()) throw new Error('A selected message does not identify this group’s DLQ record.');
+        ids.add(id);
+    }
+    if (!ids.size || ids.size > 256) throw new Error('Select between 1 and 256 distinct DLQ messages.');
+    return { action: input.action, revision: current.revision, environmentId: current.environmentId,
+        messages: [...ids].map(messageId => ({ consumerGroup: group, messageId, clientId: input.clientId.trim() || undefined })) };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/download.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/download.ts
@@ -1,0 +1,11 @@
+import type { DlqMessageExportPayload } from './types/dlq.types';
+
+export function downloadDlqCsv(payload: DlqMessageExportPayload) {
+    const url = URL.createObjectURL(new Blob([payload.content], { type: payload.mimeType }));
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = payload.fileName;
+    document.body.appendChild(link);
+    try { link.click(); }
+    finally { link.remove(); window.setTimeout(() => URL.revokeObjectURL(url), 1_000); }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/receipts.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/receipts.test.ts
@@ -1,16 +1,56 @@
 import { expect, it } from 'vitest';
-import { dlqQueryTaskId, failedDlqSelection } from './receipts';
+import { dlqReceiptCsv, dlqReceiptRows, failedDlqSelection, type DlqReceipt } from './receipts';
+import type { DlqResendMessageResult } from './types/dlq.types';
 
-it('reviews only visible failed DLQ request identities without successful or other-group messages', () => {
-    const row = (id: string, success: boolean, group = 'g') => ({ requestMessageId: id, msgId: `original-${id}`, consumerGroup: group, success, topic: 'orders', message: '' });
-    const receipt = { items: [row('a', true), row('a', false), row('b', false), row('c', false, 'other'), row('missing', false)], total: 5, successCount: 1, failureCount: 4 };
-    const messages = ['a', 'b', 'c'].map(id => ({ queryMsgId: id, msgId: id, topic: '%DLQ%g', storeTimestamp: 0 }));
-    expect([...failedDlqSelection(receipt, 'g', messages)]).toEqual(['b']);
+const item = (id: string, success = false): DlqResendMessageResult => ({ requestMessageId: id, msgId: 'original-' + id,
+    consumerGroup: 'g', success, consumeResult: success ? 'CR_SUCCESS' : 'CR_LATER', topic: 'orders', message: 'Returned outcome' });
+const receipt = (items: DlqResendMessageResult[]): DlqReceipt => ({ requests: ['a', 'b'].map(messageId => ({ consumerGroup: 'g', messageId })),
+    environmentId: 'local', revision: 1, startedAt: 1, completedAt: 2, error: '', response: { items, total: items.length, successCount: 1, failureCount: 1 } });
+const messages = ['a', 'b'].map(id => ({ queryMsgId: id, msgId: 'unique-' + id, topic: '%DLQ%g', storeTimestamp: 0 }));
+
+it('joins by requested DLQ identity, preserving a different original identity', () => {
+    const result = receipt([item('a', true), item('b')]);
+    expect(dlqReceiptRows(result).map(row => [row.request.messageId, row.result?.msgId, row.outcome])).toEqual([
+        ['a', 'original-a', 'success'], ['b', 'original-b', 'failed'],
+    ]);
+    expect([...failedDlqSelection(result, 'local', 'g', messages)]).toEqual(['b']);
 });
 
-it('starts fresh searches and never reuses time pagination in exact modes', () => {
-    expect(dlqQueryTaskId('Consumer', 2, 'task')).toBe('task');
-    expect(dlqQueryTaskId('Consumer', 1, 'task')).toBeUndefined();
-    expect(dlqQueryTaskId('Key', 2, 'task')).toBeUndefined();
-    expect(dlqQueryTaskId('Message ID', 2, 'task')).toBeUndefined();
+it('does not select results from another environment, group or nonvisible page', () => {
+    const result = receipt([item('a', true), item('b')]);
+    expect(failedDlqSelection(result, 'other', 'g', messages).size).toBe(0);
+    expect(failedDlqSelection(result, 'local', 'other', messages).size).toBe(0);
+    expect(failedDlqSelection(result, 'local', 'g', [messages[0]]).size).toBe(0);
+});
+
+it('excludes duplicate and conflicting acknowledgements, including a success and failure for one ID', () => {
+    const result = receipt([item('a', true), item('a'), item('b')]);
+    expect(dlqReceiptRows(result)[0].outcome).toBe('unknown');
+    expect([...failedDlqSelection(result, 'local', 'g', messages)]).toEqual(['b']);
+});
+
+it('cannot mistake an original ID or another group for the requested DLQ identity', () => {
+    const result = receipt([{ ...item('a'), requestMessageId: null, msgId: 'a' }, { ...item('b'), consumerGroup: 'other' }]);
+    expect(dlqReceiptRows(result).every(row => row.outcome === 'unknown')).toBe(true);
+    expect(failedDlqSelection(result, 'local', 'g', messages).size).toBe(0);
+});
+
+it('keeps transport errors and unrecognized consume states unknown even when success is reported', () => {
+    const result = receipt([{ ...item('a'), consumeResult: null, topic: '' }, { ...item('b', true), consumeResult: 'UNKNOWN' }]);
+    expect(dlqReceiptRows(result).every(row => row.outcome === 'unknown')).toBe(true);
+    expect(dlqReceiptRows({ ...result, response: null, error: 'Unavailable' })).toHaveLength(2);
+    expect(failedDlqSelection(result, 'local', 'g', messages).size).toBe(0);
+});
+
+it('does not confirm success for a DLQ Topic or contradictory consume outcome', () => {
+    const result = receipt([{ ...item('a', true), topic: '%DLQ%g' }, { ...item('b', true), consumeResult: 'CR_LATER' }]);
+    expect(dlqReceiptRows(result).every(row => row.outcome === 'unknown')).toBe(true);
+});
+
+it('exports original targets and safe quoted cells without spreadsheet formula execution', () => {
+    const result = receipt([{ ...item('a'), message: '=SUM(1,2)', remark: 'a "quote"\nsecond line' }]);
+    const csv = dlqReceiptCsv(result);
+    expect(csv).toContain('"\'=SUM(1,2)"');
+    expect(csv).toContain('"a ""quote""\nsecond line"');
+    expect(csv).toContain('"local","g","a"');
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/receipts.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/receipts.ts
@@ -1,10 +1,47 @@
-import type { DlqBatchResendMessageResponse, DlqMessageSummary } from './types/dlq.types';
+import type { DlqBatchResendMessageResponse, DlqMessageSummary, DlqResendMessageRequest, DlqResendMessageResult } from './types/dlq.types';
 
-export function failedDlqSelection(receipt: DlqBatchResendMessageResponse, group: string, messages: DlqMessageSummary[]): Set<string> {
-    const visible = new Set(messages.map(message => message.queryMsgId));
-    const successful = new Set(receipt.items.filter(item => item.success && item.consumerGroup === group).map(item => item.requestMessageId ?? item.msgId));
-    return new Set(receipt.items.filter(item => !item.success && item.consumerGroup === group)
-        .map(item => item.requestMessageId ?? item.msgId).filter(id => visible.has(id) && !successful.has(id)));
+export interface DlqReceipt {
+    requests: DlqResendMessageRequest[];
+    environmentId: string | null;
+    revision: number;
+    startedAt: number;
+    completedAt: number;
+    response: DlqBatchResendMessageResponse | null;
+    error: string;
+}
+export interface DlqReceiptRow {
+    request: DlqResendMessageRequest;
+    result?: DlqResendMessageResult;
+    outcome: 'success' | 'failed' | 'unknown';
 }
 
-export const dlqQueryTaskId = (mode: string, page: number, taskId: string) => mode === 'Consumer' && page > 1 ? taskId || undefined : undefined;
+const failures = new Set(['CR_LATER', 'CR_ROLLBACK', 'CR_THROW_EXCEPTION', 'CR_RETURN_NULL']);
+export function dlqReceiptRows(receipt: DlqReceipt): DlqReceiptRow[] {
+    return receipt.requests.map(request => {
+        // The returned original ID differs from the requested DLQ ID. Never join on the original ID.
+        const matches = receipt.response?.items.filter(item => item.consumerGroup === request.consumerGroup && item.requestMessageId === request.messageId) ?? [];
+        const result = matches.length === 1 ? matches[0] : undefined;
+        const origin = result?.topic.trim() && !/^%(DLQ|RETRY)%/.test(result.topic) && result.msgId.trim();
+        const outcome = origin && result
+            ? result.success && ['CR_SUCCESS', 'CR_COMMIT'].includes(result.consumeResult ?? '') ? 'success'
+                : !result.success && failures.has(result.consumeResult ?? '') ? 'failed' : 'unknown'
+            : 'unknown';
+        return { request, result, outcome };
+    });
+}
+
+export function failedDlqSelection(receipt: DlqReceipt, environmentId: string | null, group: string, messages: DlqMessageSummary[]): Set<string> {
+    if (receipt.environmentId !== environmentId) return new Set();
+    const visible = new Set(messages.filter(message => message.topic === '%DLQ%' + group).map(message => message.queryMsgId || message.msgId));
+    return new Set(dlqReceiptRows(receipt).filter(row => row.outcome === 'failed' && row.request.consumerGroup === group && visible.has(row.request.messageId))
+        .map(row => row.request.messageId));
+}
+
+export function dlqReceiptCsv(receipt: DlqReceipt) {
+    // Quoting alone does not neutralize spreadsheet formulas in user-controlled identities.
+    const cell = (value: string) => '"' + (/^[\s]*[=+\-@\t\r\n]/.test(value) ? "'" + value : value).replace(/"/g, '""') + '"';
+    const rows = [['Environment', 'Consumer group', 'Request ID', 'Client ID', 'Outcome', 'Original Topic', 'Original ID', 'Consume result', 'Message', 'Remark'],
+        ...dlqReceiptRows(receipt).map(({ request, result, outcome }) => [receipt.environmentId ?? '', request.consumerGroup, request.messageId,
+            request.clientId ?? '', outcome, result?.topic ?? '', result?.msgId ?? '', result?.consumeResult ?? '', result?.message ?? receipt.error, result?.remark ?? ''])];
+    return '\ufeff' + rows.map(row => row.map(cell).join(',')).join('\r\n');
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message/components/MessageInspector.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message/components/MessageInspector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { Activity, Copy, Play, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { MessageService } from '../../../services/message.service';
@@ -19,18 +19,20 @@ export async function copyMessageValue(value: string, label: string) {
     catch { toast.error(label + ' could not be copied'); }
 }
 
-export function MessageInspector({ message, disabled = false }: { message: MessageSummary; disabled?: boolean }) {
+export function MessageInspector({ message, disabled = false, loadDetail, actions }: {
+    message: MessageSummary; disabled?: boolean; loadDetail?: () => Promise<MessageDetail>; actions?: ReactNode;
+}) {
     const { openTrace } = useAppStore();
     const consume = useDirectConsume();
     const request = messageLookup(message);
-    const load = useCallback(async () => checkMessageDetail(await MessageService.viewMessageDetail(request), message), [request.topic, request.messageId]);
+    const load = useCallback(async () => checkMessageDetail(await (loadDetail ? loadDetail() : MessageService.viewMessageDetail(request)), message), [request.topic, request.messageId, loadDetail]);
     const detail = useReadResource(load, 'Message detail could not be read.');
     const [tab, setTab] = useState('body');
     const blocked = disabled || detail.pending || Boolean(detail.error) || !detail.data;
     return <PageSection title="Message detail" description="Selected message data and delivery metadata." className="ops-message-inspector"
         action={<div className="ops-message-actions"><Button variant="outline" icon={RefreshCw} disabled={detail.pending} onClick={() => { void detail.read(); }}>Refresh detail</Button>
-            <Button variant="outline" icon={Activity} disabled={blocked} onClick={() => { if (detail.data) openTrace(traceMessageIdentity(detail.data, message), message.topic); }}>View trace</Button>
-            <Button variant="outline" icon={Play} disabled={blocked} onClick={() => consume(message)}>Direct consume</Button></div>}>
+            {actions === undefined ? <><Button variant="outline" icon={Activity} disabled={blocked} onClick={() => { if (detail.data) openTrace(traceMessageIdentity(detail.data, message), message.topic); }}>View trace</Button>
+            <Button variant="outline" icon={Play} disabled={blocked} onClick={() => consume(message)}>Direct consume</Button></> : actions}</div>}>
         {detail.pending && <PageState kind="loading" title="Reading message detail" />}
         {detail.error && <PageState kind="error" title="Message detail unavailable" description={detail.error + (detail.data ? ' Showing the last successful read.' : '')} />}
         {detail.data && <>
@@ -42,7 +44,7 @@ export function MessageInspector({ message, disabled = false }: { message: Messa
                 <TabsList className="ops-tabs-underlined" aria-label="Message detail view"><TabsTrigger value="body">Body</TabsTrigger><TabsTrigger value="properties">Properties</TabsTrigger><TabsTrigger value="delivery">Delivery</TabsTrigger></TabsList>
                 <TabsContent value="body"><MessageBody detail={detail.data} /></TabsContent>
                 <TabsContent value="properties"><MessageProperties detail={detail.data} /></TabsContent>
-                <TabsContent value="delivery"><MessageDelivery detail={detail.data} message={message} disabled={blocked} /></TabsContent>
+                <TabsContent value="delivery"><MessageDelivery detail={detail.data} message={message} disabled={blocked} showActions={actions === undefined} /></TabsContent>
             </Tabs>
             <p className="ops-message-note">Last successful detail read: {new Date(detail.receivedAt!).toLocaleString()}</p>
         </>}
@@ -74,7 +76,7 @@ function MessageProperties({ detail }: { detail: MessageDetail }) {
     </div>;
 }
 
-function MessageDelivery({ detail, message, disabled }: { detail: MessageDetail; message: MessageSummary; disabled: boolean }) {
+function MessageDelivery({ detail, message, disabled, showActions }: { detail: MessageDetail; message: MessageSummary; disabled: boolean; showActions: boolean }) {
     const consume = useDirectConsume();
     return <div className="ops-message-stack"><dl className="ops-message-properties">{[
         ['Message ID', detail.msgId], ['Query ID', message.queryMsgId || message.msgId], ['Topic', detail.topic],
@@ -87,9 +89,9 @@ function MessageDelivery({ detail, message, disabled }: { detail: MessageDetail;
     ].map(([label, value]) => <div key={label}><dt>{label}</dt><dd tabIndex={value.length > 200 ? 0 : undefined}>{visibleMessageText(value)}
         {['Message ID', 'Query ID', 'Topic'].includes(label) && <Button variant="ghost" icon={Copy} aria-label={'Copy ' + label} onClick={() => { void copyMessageValue(value, label); }}>Copy</Button>}</dd></div>)}</dl>
         <h3>Consumer delivery records</h3>
-        {detail.messageTrackList?.length ? <div className="ops-message-scroll" role="region" aria-label="Consumer delivery records" tabIndex={0}><table><thead><tr><th scope="col">Consumer group</th><th scope="col">Reported state</th><th scope="col">Detail</th><th scope="col">Action</th></tr></thead><tbody>
+        {detail.messageTrackList?.length ? <div className="ops-message-scroll" role="region" aria-label="Consumer delivery records" tabIndex={0}><table><thead><tr><th scope="col">Consumer group</th><th scope="col">Reported state</th><th scope="col">Detail</th>{showActions && <th scope="col">Action</th>}</tr></thead><tbody>
             {detail.messageTrackList.map((track, index) => <tr key={track.consumerGroup + ':' + index}><th scope="row">{track.consumerGroup}</th><td>{track.trackType || 'Unknown'}</td><td>{track.exceptionDesc || 'None reported'}</td>
-                <td><Button variant="outline" disabled={disabled} onClick={() => consume(message, track.consumerGroup)}>Direct consume</Button></td></tr>)}
+                {showActions && <td><Button variant="outline" disabled={disabled} onClick={() => consume(message, track.consumerGroup)}>Direct consume</Button></td>}</tr>)}
         </tbody></table></div> : <PageState kind="empty" title="No Consumer delivery records returned" description="No delivery state can be inferred from missing records." />}
     </div>;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -85,7 +85,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       case 'MessageTrace':
         return 'Message Trace';
       case 'DLQ':
-        return 'DLQ Message Management';
+        return 'Dead-letter messages';
       case 'ACL':
         return 'ACL Management';
       case 'Audit':


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10510

### Brief Description

Rebuild the Tauri dead-letter page with explicit queries, compact selectable results, reviewed single/batch operations and a session-owned receipt panel. Each outcome retains its DLQ request identity separately from the original message, and only confirmed failures can be selected for another reviewed attempt.

Split query, target capture, inspection, CSV and receipt behavior into focused modules. Preserve completed results across navigation and connection changes, invalidate stale reads/exports, and restore dialog focus even when batch completion disables the opening button.

### How Did You Test This Change?

- `npm run build`: passed.
- `npm test -- --run`: 199 tests passed.
- Headed external Chrome: reference-size and 800 x 600 comparisons, mixed and single resend outcomes, failed-target review, focus restoration, wrong detail identity rejection, delayed export isolation, and actual single/receipt CSV download readback; no console or page errors.
- Local RocketMQ-Rust native app: physical DLQ lookup, exact body/clipboard, offline unknown and online successful consumption with independent Consumer acknowledgement, receipt CSV readback, maximized and restored small-window layouts.
- The final disabled-batch-opener focus refinement passed Chrome and is included in the pending integrated native rebuild. Windows display-DPI certification remains part of final dashboard acceptance. Existing Vite large-chunk warning is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Revamped dead-letter message management with key, ID, and time-based searches.
  * Added paginated results with message selection, resend, CSV export, and detailed message inspection.
  * Added resend receipts showing success, failed, and unknown outcomes with review and export options.
  * Added safeguards to prevent actions against stale connection or environment data.
* **Documentation**
  * Expanded guidance for receipt handling, acknowledgement matching, failed-message review, and CSV exports.
* **Style**
  * Updated DLQ page title and navigation description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->