### PR TITLE
[ISSUE #10512]✨Redesign scoped Broker ACL administration

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ACL_OPERATIONS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ACL_OPERATIONS.md
@@ -1,0 +1,87 @@
+# Broker access control
+
+The Access control page manages RocketMQ-Rust Broker identities and resource
+policies. Dashboard login accounts are a separate identity system.
+
+## Broker selection and reads
+
+Select a Cluster and an explicit master Broker. Discovery identifies the target
+by Cluster name, Broker name and address. Switching that target clears the old
+selection and details. Each mounted scope owns its user and policy reads; a
+late response cannot populate a replacement scope or connection revision.
+
+Users and policies load independently. A denied or failed query remains visible
+with its reason. The page may retain its last successful observation, but disables
+mutation controls until the corresponding directory refresh succeeds. A failed
+read is not presented as an empty directory.
+
+The environment toolbar refreshes the selected Broker's users and policies.
+Before scope selection it refreshes Broker discovery. The separate Refresh Brokers
+action updates available scopes. Returning through navigation restores the selected
+Cluster and Broker, then reads fresh directories. After a write, outstanding older
+reads are invalidated before the post-write refresh.
+
+The Users section combines a directory, selected-user details and resource
+policies for the exact `User:<username>` subject. Policies can also be inspected
+and edited independently in the Policies section. The page does not infer or
+display account creation times, update times or saved passwords.
+
+## User changes
+
+Create, edit, password change and deletion retain the selected Broker scope.
+Creation enables the new user. An update cannot rename the existing username.
+Unrecognized type or status values require an explicit selection in Edit; they
+are not replaced with permissive defaults.
+
+The current Broker API requires a new password for every user update. Password
+change preserves the recognized type and status. Passwords start empty and are
+never loaded from a user record. Confirmation metadata and retained receipts
+exclude password values and raw request or response objects. The editable form
+is disposed after submission or dialog closure.
+
+## Resource policy changes
+
+Policy identity consists of subject, policy type and resource. Editing preserves
+all original resource identities and exposes actions, source IPs and the Allow or
+Deny decision. Removing an existing resource uses its separate deletion action.
+Duplicate resource identities, missing resources/actions and malformed subjects
+are rejected before dispatch. A deletion never substitutes the current row index
+for the resource identity.
+
+## Confirmation and outcomes
+
+Confirmation fixes the original environment, connection revision, Broker and
+requested identities. A connection change prevents a new submission from that
+dialog. Once accepted, a write remains owned by the session until it settles,
+even when navigation or connection settings change. Pending writes block dialog
+dismissal; each confirmation submits at most once and has no automatic retry.
+
+A receipt confirms success only when the returned operation, Broker scope and
+username or subject match and the acknowledgement explicitly succeeds. A
+transport failure or mismatched result is unconfirmed. A successful write whose
+follow-up directory read fails remains acknowledged, with a separate read-back
+warning. The current directory can be refreshed without resubmitting the write.
+
+The latest receipt survives route and connection changes and displays its original
+scope. A new authenticated session disposes that receipt. A later write replaces
+it only when the later operation settles.
+
+## Validation
+
+Frontend validation runs from the Tauri app root:
+
+```text
+npm run build
+npm test -- --run
+```
+
+Focused model coverage exercises immutable usernames and policy resources,
+unknown user enums, password exclusion, fixed Broker scopes and the distinction
+between unconfirmed writes and acknowledged writes with failed read-back.
+Shared read and operation controllers cover cancellation and accepted-write
+ownership.
+
+Visual acceptance uses the selected ACL reference, including narrow-window and
+keyboard checks. Live ACL acceptance uses the isolated
+[RocketMQ-Rust ACL fixture](../deploy/dev/acl/README.md); frontend fixture data
+does not establish real Broker authorization coverage.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -5,6 +5,7 @@ import {DashboardPage} from '../../pages/dashboard/DashboardPage';
 
 // Import Views
 import {ACLView} from '../../components/ACLView';
+import {AclActionProvider} from '../../features/acl/components/AclActionProvider';
 import {NameServerView} from '../../components/NameServerView';
 import {ProxyView} from '../../components/ProxyView';
 import {ClusterView} from '../../components/ClusterView';
@@ -30,7 +31,7 @@ export const AppRouter = () => {
     const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
     const { activeTab, navigation, sessionId } = useAppStore();
     const key = ['NameServer', 'Proxy', 'Account', 'Sessions', 'Audit'].includes(activeTab) ? activeTab : `${activeTab}:${settings?.revision ?? 0}`;
-    return <BrokerConfigEditorProvider key={sessionId}><TopicActionProvider><ConsumerActionProvider><MessageActionProvider><DlqActionProvider><RouteContent key={`${key}:${navigation.id}`} /></DlqActionProvider></MessageActionProvider></ConsumerActionProvider></TopicActionProvider></BrokerConfigEditorProvider>;
+    return <BrokerConfigEditorProvider key={sessionId}><TopicActionProvider><ConsumerActionProvider><MessageActionProvider><DlqActionProvider><AclActionProvider><RouteContent key={`${key}:${navigation.id}`} /></AclActionProvider></DlqActionProvider></MessageActionProvider></ConsumerActionProvider></TopicActionProvider></BrokerConfigEditorProvider>;
 };
 
 const RouteContent = () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ACLView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ACLView.tsx
@@ -1,39 +1,68 @@
-import { AclPolicies } from '../features/acl/components/AclPolicies';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import { Info, RefreshCw } from 'lucide-react';
 import { ClusterService } from '../services/cluster.service';
+import { ConnectionStore } from '../services/connection.store';
+import { getConnectionSettings } from '../services/connection.service';
 import { dashboardErrorMessage } from '../services/invoke';
-import { AclUsers } from '../features/acl/components/AclUsers';
+import { useNavigationState } from '../stores/app.store';
+import { usePageRefresh } from '../app/layout/pageToolbar';
+import type { AclContext } from '../features/acl/aclActions';
+import { Button } from './ui/LegacyButton';
+import { PageState } from './layout/PageState';
 import { aclScopeKey, type AclScope } from '../features/acl/types';
+import { useAclRead } from '../features/acl/hooks/useAclRead';
+import { useAclActions } from '../features/acl/aclActionContext';
+import { AclWorkspace } from '../features/acl/components/AclWorkspace';
+import { AclReceiptPanel } from '../features/acl/components/AclReceiptPanel';
+import '../features/acl/acl.css';
 
 export const ACLView = () => {
-    const [tab, setTab] = useState<'users' | 'policies'>('users');
-    const [scopes, setScopes] = useState<AclScope[]>([]);
-    const [selected, setSelected] = useState('');
-    const [scope, setScope] = useState<AclScope | null>(null);
+    const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
     const [error, setError] = useState('');
-    const [loading, setLoading] = useState(true);
+    const [attempt, setAttempt] = useState(0);
     useEffect(() => {
-        let cancelled = false;
-        void ClusterService.getClusterHomePage({ forceRefresh: true }).then(result => {
-            if (!cancelled) setScopes(result.items.filter(broker => broker.brokerId === 0).map(broker => ({ clusterName: broker.clusterName, brokerName: broker.brokerName, brokerAddr: broker.address })));
-        }).catch(error => { if (!cancelled) setError(dashboardErrorMessage(error, 'Unable to discover ACL Brokers.')); })
-            .finally(() => { if (!cancelled) setLoading(false); });
-        return () => { cancelled = true; };
-    }, []);
-    return <div className="space-y-6 text-gray-900 dark:text-gray-100">
-        <section className="space-y-4 rounded-xl border bg-white p-6 dark:border-gray-800 dark:bg-gray-900">
-            <h1 className="text-xl font-semibold">Broker access control</h1><p className="text-sm text-gray-500">Manage RocketMQ Broker ACL identities. Dashboard login accounts are managed separately in Account settings.</p>
-            {error && <p role="alert" className="text-red-600">{error}</p>}
-            <div className="flex flex-wrap gap-3"><select aria-label="ACL Broker scope" disabled={loading} className="min-w-64 rounded border bg-transparent p-2" value={selected}
-                onChange={event => { setSelected(event.target.value); setScope(null); setTab('users'); }}>
-                <option value="">{loading ? 'Loading Brokers…' : 'Select a master Broker'}</option>
-                {scopes.map(scope => <option key={aclScopeKey(scope)} value={aclScopeKey(scope)}>{scope.clusterName} / {scope.brokerName} · {scope.brokerAddr}</option>)}
-            </select><button disabled={!selected} onClick={() => setScope(scopes.find(scope => aclScopeKey(scope) === selected) ?? null)} className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50">Confirm scope</button></div>
-            {!loading && !error && scopes.length === 0 && <p>No master Brokers are available in the current environment.</p>}
-        </section>
-        <section className="rounded-xl border bg-white p-6 dark:border-gray-800 dark:bg-gray-900">
-            {scope ? <><nav aria-label="ACL sections" className="mb-5 flex gap-5 border-b pb-3"><button aria-pressed={tab === 'users'} onClick={() => setTab('users')}>Users</button><button aria-pressed={tab === 'policies'} onClick={() => setTab('policies')}>Policies</button></nav>
-                {tab === 'users' ? <AclUsers key={aclScopeKey(scope)} scope={scope} /> : <AclPolicies key={aclScopeKey(scope)} scope={scope} />}</> : <p>Select and confirm a Broker scope to load access control.</p>}
-        </section>
-    </div>;
+        let active = true;
+        if (!settings) {
+            setError('');
+            void getConnectionSettings().catch(error => { if (active) setError(dashboardErrorMessage(error, 'Connection settings could not be read.')); });
+        }
+        return () => { active = false; };
+    }, [settings, attempt]);
+    if (!settings) return <PageState kind={error ? 'error' : 'loading'} title={error ? 'Connection settings could not be read' : 'Reading connection settings'} description={error}
+        action={error ? <Button variant="outline" onClick={() => setAttempt(value => value + 1)}>Retry connection</Button> : undefined} />;
+    return <AclPage key={settings.revision} context={settings} />;
 };
+
+function AclPage({ context }: { context: AclContext }) {
+    const catalogue = useAclRead(async () => (await ClusterService.getClusterHomePage({ forceRefresh: true })).items.filter(broker => broker.brokerId === 0).map(broker => ({ clusterName: broker.clusterName, brokerName: broker.brokerName, brokerAddr: broker.address })), context, 'Unable to discover ACL Brokers.');
+    const [cluster, setCluster] = useNavigationState('aclCluster', '');
+    const [scopeKey, setScopeKey] = useNavigationState('aclBroker', '');
+    const { receipt } = useAclActions();
+    const scopes: AclScope[] = [...new Map((catalogue.data ?? []).map(scope => [aclScopeKey(scope), scope])).values()];
+    const clusters = [...new Set(scopes.map(scope => scope.clusterName))].sort();
+    const scope = scopes.find(scope => scope.clusterName === cluster && aclScopeKey(scope) === scopeKey) ?? null;
+    return <div className="ops-acl">
+        <section className="ops-acl-scope" aria-label="ACL Broker scope">
+            <label className="ops-acl-select">Cluster<select disabled={!catalogue.ready} value={cluster} onChange={event => { setCluster(event.target.value); setScopeKey(''); }}><option value="">Choose a Cluster</option>{clusters.map(name => <option key={name}>{name}</option>)}</select></label>
+            <label className="ops-acl-select">Master Broker<select disabled={!catalogue.ready || !cluster} value={scope?.clusterName === cluster ? scopeKey : ''} onChange={event => setScopeKey(event.target.value)}>
+                <option value="">Choose a master Broker</option>{scopes.filter(scope => scope.clusterName === cluster).map(scope => <option key={aclScopeKey(scope)} value={aclScopeKey(scope)}>{scope.brokerName} · {scope.brokerAddr}</option>)}
+            </select></label>
+            {scope && <Button variant="outline" icon={RefreshCw} disabled={catalogue.loading} onClick={() => { void catalogue.refresh(); }}>Refresh Brokers</Button>}
+        </section>
+        <p className="ops-acl-account-note"><Info aria-hidden="true" />Broker ACL users are separate from your local Dashboard account.</p>
+        {catalogue.loading && <PageState kind="loading" title="Discovering master Brokers" />}
+        {catalogue.error && <PageState kind="error" title="ACL Broker discovery failed" description={catalogue.error} />}
+        {catalogue.ready && !scopes.length && <PageState kind="empty" title="No master Brokers are available" description="Connect to a RocketMQ-Rust environment and refresh the Broker catalogue." />}
+        {scope ? <AclWorkspace key={aclScopeKey(scope)} scope={scope} context={context} scopeReady={catalogue.ready} scopePending={catalogue.loading} refreshScope={catalogue.refresh} /> : <>
+            <AclCatalogueToolbar refresh={catalogue.refresh} pending={catalogue.loading} observedAt={catalogue.observedAt} />
+            {catalogue.ready && scopes.length > 0 && <PageState kind="empty" title="Choose a Broker scope" description="Select a Cluster and master Broker to load its users and policies." />}
+        </>}
+        {receipt && <AclReceiptPanel receipt={receipt} />}
+    </div>;
+}
+
+function AclCatalogueToolbar({ refresh, pending, observedAt }: { refresh: () => Promise<boolean>; pending: boolean; observedAt: number | null }) {
+    const read = useCallback(() => { void refresh(); }, [refresh]);
+    usePageRefresh({ refresh: read, pending, refreshedAt: observedAt });
+    return null;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/tabs.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/tabs.tsx
@@ -34,12 +34,13 @@ function TabsList({
   );
 }
 
-function TabsTrigger({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(function TabsTrigger({ className, ...props }, ref) {
   return (
     <TabsPrimitive.Trigger
+      ref={ref}
       data-slot="tabs-trigger"
       className={cn(
         "data-[state=active]:bg-card dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-xl border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -48,7 +49,7 @@ function TabsTrigger({
       {...props}
     />
   );
-}
+});
 
 function TabsContent({
   className,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/acl.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/acl.css
@@ -1,0 +1,54 @@
+.ops-acl { display: grid; gap: 20px; min-width: 0; }
+.ops-acl-panel, .ops-acl-scope { min-width: 0; padding: 14px; border: 1px solid var(--ops-border); border-radius: 12px; background: var(--ops-panel); }
+.ops-acl-scope { display: grid; grid-template-columns: minmax(160px, 2fr) minmax(200px, 3fr) auto; align-items: end; gap: 24px; padding: 18px 22px; }
+.ops-acl-scope > .ops-acl-select:first-child { border-right: 1px solid var(--ops-border-strong); padding-right: 24px; }
+.ops-acl-select { display: grid; gap: 8px; color: var(--ops-muted); font-size: 13px; min-width: 0; }
+.ops-acl-select select, .ops-acl-select textarea { width: 100%; min-width: 0; max-width: 100%; min-height: 38px; color: var(--ops-text); background: var(--ops-panel-soft); border: 1px solid var(--ops-border-strong); border-radius: 8px; padding: 8px 12px; font: 14px/1.5 var(--ops-font); }
+.ops-acl-select textarea { resize: vertical; }
+.ops-acl-account-note { display: flex; gap: 10px; align-items: start; margin: 0; color: var(--ops-muted); font-size: 14px; }
+.ops-acl-account-note svg { width: 18px; height: 18px; flex-shrink: 0; }
+.ops-acl-toolbar, .ops-acl-filter { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px; min-width: 0; }
+.ops-acl-filter > .ops-field { flex: 1 1 200px; max-width: 360px; }
+.ops-acl-filter > p { flex: 1 1 160px; text-align: right; }
+.ops-acl-split { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr); align-items: stretch; gap: 16px; min-width: 0; }
+.ops-acl-directory, .ops-acl-detail { min-width: 0; min-height: 330px; border: 1px solid var(--ops-border); border-radius: 9px; background: var(--ops-panel-soft); }
+.ops-acl-detail { display: flex; flex-direction: column; gap: 16px; padding: 16px; }
+.ops-acl-detail .ops-section-header { align-items: center; margin-bottom: 6px; }
+.ops-acl-panel > .ops-section-header { padding: 2px 4px; margin-bottom: 14px; }
+.ops-acl-panel .ops-section-header h2 { font-size: 18px; overflow-wrap: anywhere; }
+.ops-acl-scroll { width: 100%; max-width: 100%; overflow: auto; border-radius: 8px; }
+.ops-acl-directory .ops-acl-scroll { max-height: 450px; }
+.ops-acl-scroll table { width: 100%; min-width: 480px; border-collapse: collapse; text-align: left; font-size: 14px; }
+.ops-acl-scroll th, .ops-acl-scroll td { max-width: 280px; padding: 12px 14px; border-bottom: 1px solid var(--ops-border); vertical-align: middle; overflow-wrap: anywhere; }
+.ops-acl-scroll thead th { background: var(--ops-panel-strong); color: var(--ops-muted); font-size: 13px; font-weight: 500; }
+.ops-acl-scroll tbody th { font-weight: 600; }
+.ops-acl-scroll tbody tr:last-child > * { border-bottom: 0; }
+.ops-acl-scroll tr[data-selected="true"] > * { background: var(--ops-accent-soft); }
+.ops-acl-resource-table { border: 1px solid var(--ops-border); }
+.ops-acl-resource-table table { min-width: 850px; }
+.ops-acl-detail .ops-acl-resource-table { margin-top: 8px; }
+.ops-acl-choice { display: block; width: 100%; padding: 0; border: 0; background: transparent; color: var(--ops-text); font: inherit; text-align: left; cursor: pointer; }
+.ops-acl-choice > span { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; overflow-wrap: anywhere; }
+.ops-acl-row-actions { display: flex; align-items: center; gap: 4px; }
+.ops-acl-properties { margin: 0; color: var(--ops-text); font-size: 14px; line-height: 1.5; }
+.ops-acl-properties > div { display: grid; grid-template-columns: minmax(85px, 30%) minmax(0, 1fr); gap: 12px; padding: 9px 0; }
+.ops-acl-properties dt { color: var(--ops-muted); }
+.ops-acl-properties dd { min-width: 0; margin: 0; }
+.ops-acl-value { display: block; max-height: 128px; overflow: auto; overflow-wrap: anywhere; white-space: pre-wrap; }
+.ops-acl-note { color: var(--ops-muted); font-size: 12px; line-height: 1.6; margin: 0; overflow-wrap: anywhere; }
+.ops-acl-password { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px; padding: 18px 0; border-block: 1px solid var(--ops-border); }
+.ops-acl-password strong { font-size: 13px; font-weight: 500; }
+.ops-acl-password p { margin-top: 5px; }
+.ops-acl-receipt { display: grid; gap: 12px; min-width: 0; padding: 16px; border: 1px solid var(--ops-border); border-radius: 10px; background: var(--ops-panel); }
+.ops-acl-dialog[data-slot="dialog-content"] { width: min(760px, calc(100vw - 32px)); max-width: calc(100vw - 32px); overflow: hidden; }
+.ops-acl-dialog-body { display: grid; gap: 16px; min-height: 0; overflow: auto; padding: 2px; }
+.ops-acl-dialog-body h3 { margin: 0; font-size: 17px; }
+.ops-acl-form, .ops-acl-fields { display: grid; gap: 16px; min-width: 0; }
+.ops-acl-fields { border: 0; margin: 0; padding: 0; }
+.ops-acl-form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+.ops-acl-form-actions { display: flex; justify-content: end; }
+.ops-acl-entry { display: grid; gap: 14px; min-width: 0; padding: 14px; border: 1px solid var(--ops-border); border-radius: 8px; }
+.ops-acl-entry legend { color: var(--ops-muted); padding: 0 6px; font-size: 13px; }
+.ops-acl-dialog [data-slot="dialog-footer"] { flex-shrink: 0; align-items: center; }
+@media (max-width: 1100px) { .ops-acl-split { grid-template-columns: minmax(0, 1fr); } .ops-acl-directory, .ops-acl-detail { min-height: 0; } }
+@media (max-width: 800px) { .ops-acl-scope, .ops-acl-form-grid { grid-template-columns: minmax(0, 1fr); } .ops-acl-scope > .ops-acl-select:first-child { border: 0; padding: 0; } .ops-acl-filter > p { text-align: left; } }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/aclActionContext.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/aclActionContext.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+import type { AclAction, AclContext, AclReceipt } from './aclActions';
+import type { AclScope } from './types';
+
+interface AclActions { open: (action: AclAction, scope: AclScope, context: AclContext) => void; receipt: AclReceipt | null }
+export const AclActionContext = createContext<AclActions>({ open: () => undefined, receipt: null });
+export const useAclActions = () => useContext(AclActionContext);

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/aclActions.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/aclActions.test.ts
@@ -1,0 +1,53 @@
+import { expect, it } from 'vitest';
+import { aclWriteReceipt, aclWriteTarget, captureAclAction, type AclWrite } from './aclActions';
+import type { AclUserResult } from './types';
+
+const scope = { clusterName: 'cluster', brokerName: 'broker-a', brokerAddr: '127.0.0.1:10911' };
+const context = { environmentId: 'local', revision: 12 };
+const user = { username: 'reader', userType: 'Normal', userStatus: 'Enable' };
+const write: AclWrite = { kind: 'user_update', request: { scope, username: 'reader', password: 'fixture-private-value', userType: 'normal', userStatus: 'disable' } };
+const result: AclUserResult = { scope, username: 'reader', operation: 'update', success: true, users: [user], readBackError: null };
+
+it('refuses stale actions and freezes the selected Broker identity', () => {
+    expect(() => captureAclAction({ kind: 'user_delete', user }, scope, context, { ...context, revision: 13 })).toThrow('Connection settings');
+    expect(() => captureAclAction({ kind: 'user_delete', user }, scope, context, { ...context, environmentId: 'other' })).toThrow('Connection settings');
+    const input = { ...user }, broker = { ...scope };
+    const captured = captureAclAction({ kind: 'user_delete', user: input }, broker, context, context);
+    input.username = 'other'; broker.brokerAddr = 'other:10911';
+    expect(captured.action).toEqual({ kind: 'user_delete', user });
+    expect(captured.scope).toEqual(scope);
+});
+
+it('does not transplant a resource deletion to another Broker', () => {
+    expect(() => captureAclAction({ kind: 'policy_delete', request: { scope: { ...scope, brokerName: 'broker-b' }, subject: 'User:reader', policyType: 'Default', resource: 'Topic:orders' } }, scope, context, context)).toThrow('different Broker');
+});
+
+it('stores only explicit confirmation metadata, never the password or a raw response', () => {
+    const target = aclWriteTarget(write);
+    const receipt = aclWriteReceipt(target, context, { ...result, password: 'unexpected-secret' } as AclUserResult, 500);
+    expect(receipt).toMatchObject({ acknowledged: true, readBackAvailable: true, finishedAt: 500, context });
+    expect(JSON.stringify({ target, receipt })).not.toMatch(/fixture-private-value|unexpected-secret|password/i);
+});
+
+it('retains acknowledged writes when the follow-up read fails', () => {
+    const receipt = aclWriteReceipt(aclWriteTarget(write), context, { ...result, users: null, readBackError: 'private diagnostic' });
+    expect(receipt.acknowledged).toBe(true);
+    expect(receipt.readBackAvailable).toBe(false);
+    expect(receipt.message).toContain('could not be read back');
+    expect(JSON.stringify(receipt)).not.toContain('private diagnostic');
+});
+
+it('does not turn a transport failure, failed acknowledgement or mismatched identity into success', () => {
+    const target = aclWriteTarget(write);
+    for (const response of [null, { ...result, success: false }, { ...result, username: 'another-user' }, { ...result, operation: 'delete' as const }, { ...result, scope: { ...scope, brokerAddr: 'other:10911' } }]) {
+        expect(aclWriteReceipt(target, context, response)).toMatchObject({ acknowledged: false, readBackAvailable: false });
+    }
+    expect(aclWriteReceipt(target, context, {} as AclUserResult).acknowledged).toBe(false);
+    expect(aclWriteReceipt(target, context, { ...result, users: undefined }).readBackAvailable).toBe(false);
+});
+
+it('preserves the policy type, decisions and source restrictions in confirmation metadata', () => {
+    const target = aclWriteTarget({ kind: 'policy_update', request: { scope, subject: 'User:reader', policies: [{ policyType: 'Default', entries: [{ resources: ['Topic:a', 'Topic:b'], actions: ['Sub'], sourceIps: ['10.0.0.0/8'], decision: 'Deny' }] }] } });
+    expect(target).toMatchObject({ policyType: 'Default', resources: ['Topic:a', 'Topic:b'], entries: [{ resources: ['Topic:a', 'Topic:b'], actions: ['Sub'], sourceIps: ['10.0.0.0/8'], decision: 'Deny' }] });
+    expect(aclWriteReceipt(target, context, { scope, subject: 'User:reader', operation: 'update', success: true, policies: [], readBackError: null }).acknowledged).toBe(true);
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/aclActions.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/aclActions.ts
@@ -1,0 +1,54 @@
+import type { AclPolicy, AclPolicyChange, AclPolicyDelete, AclPolicyDraftEntry, AclPolicyResult, AclScope, AclUser, AclUserChange, AclUserResult } from './types';
+import { aclScopeKey } from './types';
+
+export interface AclContext { revision: number; environmentId: string | null }
+export type AclAction =
+    | { kind: 'user_create' }
+    | { kind: 'user_update' | 'user_password' | 'user_delete'; user: AclUser }
+    | { kind: 'policy_create'; subject?: string }
+    | { kind: 'policy_update'; policy: AclPolicy }
+    | { kind: 'policy_delete'; request: AclPolicyDelete };
+export type AclWrite =
+    | { kind: 'user_create' | 'user_update'; request: AclUserChange }
+    | { kind: 'user_delete'; request: { scope: AclScope; username: string } }
+    | { kind: 'policy_create' | 'policy_update'; request: AclPolicyChange }
+    | { kind: 'policy_delete'; request: AclPolicyDelete };
+export interface AclTarget {
+    kind: AclWrite['kind']; scope: AclScope; identity: string; policyType?: string; resources?: string[];
+    userType?: string; userStatus?: string; entries?: AclPolicyDraftEntry[];
+}
+export interface AclReceipt {
+    target: AclTarget; context: AclContext; finishedAt: number;
+    acknowledged: boolean; readBackAvailable: boolean; message: string;
+}
+
+export const aclContextMatches = (expected: AclContext, current: AclContext | null) => Boolean(current && expected.revision === current.revision && expected.environmentId === current.environmentId);
+export function captureAclAction(action: AclAction, scope: AclScope, expected: AclContext, current: AclContext | null) {
+    if (!aclContextMatches(expected, current)) throw new Error('Connection settings changed. Refresh the Broker scope before opening an action.');
+    if (!scope.clusterName.trim() || !scope.brokerName.trim() || !scope.brokerAddr.trim()) throw new Error('Choose an explicit master Broker.');
+    if ('user' in action && (!action.user.username.trim() || action.user.username !== action.user.username.trim() || /[\u0000-\u001f\u007f-\u009f]/.test(action.user.username))) throw new Error('The selected Broker username is incomplete or malformed. Refresh the directory.');
+    if (action.kind === 'policy_delete' && aclScopeKey(action.request.scope) !== aclScopeKey(scope)) throw new Error('The resource belongs to a different Broker scope.');
+    return { action: structuredClone(action), scope: { ...scope }, context: { ...expected } };
+}
+
+/** Receipts and confirmation metadata deliberately exclude the user password and the full write request. */
+export function aclWriteTarget(write: AclWrite): AclTarget {
+    const scope = { ...write.request.scope };
+    switch (write.kind) {
+        case 'user_create': case 'user_update': return { kind: write.kind, scope, identity: write.request.username, userType: write.request.userType, userStatus: write.request.userStatus };
+        case 'user_delete': return { kind: write.kind, scope, identity: write.request.username };
+        case 'policy_create': case 'policy_update': return { kind: write.kind, scope, identity: write.request.subject, policyType: write.request.policies.map(policy => policy.policyType).join(', '), resources: write.request.policies.flatMap(policy => policy.entries.flatMap(entry => entry.resources)), entries: write.request.policies.flatMap(policy => policy.entries.map(entry => ({ resources: [...entry.resources], actions: [...entry.actions], sourceIps: [...entry.sourceIps], decision: entry.decision }))) };
+        case 'policy_delete': return { kind: write.kind, scope, identity: write.request.subject, policyType: write.request.policyType, resources: [write.request.resource] };
+    }
+}
+
+export function aclWriteReceipt(target: AclTarget, context: AclContext, result: AclUserResult | AclPolicyResult | null, finishedAt = Date.now()): AclReceipt {
+    const operation = target.kind.split('_')[1];
+    const user = target.kind.startsWith('user_');
+    const matches = Boolean(result?.scope && aclScopeKey(result.scope) === aclScopeKey(target.scope) && result.operation === operation &&
+        (user ? 'username' in result && result.username === target.identity : 'subject' in result && result.subject === target.identity));
+    const acknowledged = matches && result?.success === true;
+    const readBackAvailable = Boolean(acknowledged && result && !result.readBackError && (user ? 'users' in result && Array.isArray(result.users) : 'policies' in result && Array.isArray(result.policies)));
+    return { target: structuredClone(target), context: { ...context }, finishedAt, acknowledged, readBackAvailable,
+        message: acknowledged ? readBackAvailable ? 'The Broker acknowledged this change and returned a refreshed directory.' : 'The Broker acknowledged this change, but its directory could not be read back. Refresh before another operation.' : 'The write outcome is unconfirmed. Inspect the original Broker before retrying; this operation will not submit again.' };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclActionProvider.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclActionProvider.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { toast } from 'sonner';
+import { ConnectionStore } from '../../../services/connection.store';
+import { AclService } from '../../../services/acl.service';
+import { useOperationOwner } from '../../../hooks/useOperationOwner';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
+import { Button } from '../../../components/ui/LegacyButton';
+import { PageState } from '../../../components/layout/PageState';
+import { AclActionContext } from '../aclActionContext';
+import { aclWriteReceipt, aclWriteTarget, captureAclAction, type AclAction, type AclContext, type AclReceipt, type AclTarget, type AclWrite } from '../aclActions';
+import { policyDraft } from '../policies';
+import type { AclPolicyResult, AclScope, AclUserResult } from '../types';
+import { AclUserForm } from './AclUserForm';
+import { AclPolicyForm } from './AclPolicyForm';
+import { AclReceiptPanel, AclTargetDetails } from './AclReceiptPanel';
+import '../acl.css';
+
+interface Request { action: AclAction; scope: AclScope; context: AclContext; trigger: HTMLElement | null }
+const titles: Record<AclAction['kind'], string> = {
+    user_create: 'Create Broker ACL user', user_update: 'Edit Broker ACL user', user_password: 'Change Broker ACL password', user_delete: 'Delete Broker ACL user',
+    policy_create: 'Create resource policy', policy_update: 'Edit resource policy', policy_delete: 'Delete policy resource',
+};
+function dispatch(write: AclWrite): Promise<AclUserResult | AclPolicyResult> {
+    switch (write.kind) {
+        case 'user_create': return AclService.createUser(write.request);
+        case 'user_update': return AclService.updateUser(write.request);
+        case 'user_delete': return AclService.deleteUser(write.request.scope, write.request.username);
+        case 'policy_create': return AclService.createPolicy(write.request);
+        case 'policy_update': return AclService.updatePolicy(write.request);
+        case 'policy_delete': return AclService.deletePolicy(write.request);
+    }
+}
+function deletion(request: Request): AclWrite | null {
+    if (request.action.kind === 'user_delete') return { kind: 'user_delete', request: { scope: request.scope, username: request.action.user.username } };
+    if (request.action.kind === 'policy_delete') return { kind: 'policy_delete', request: request.action.request };
+    return null;
+}
+
+function AclActionDialog({ request, close, applied }: { request: Request; close: () => void; applied: (receipt: AclReceipt) => void }) {
+    const owner = useOperationOwner(request.context.revision, request.context.environmentId);
+    const [review, setReview] = useState<AclWrite | null>(() => deletion(request));
+    const [submitted, setSubmitted] = useState<AclTarget | null>(null);
+    const [receipt, setReceipt] = useState<AclReceipt | null>(null);
+    const attempted = useRef(false);
+    const active = useRef(true);
+    const body = useRef<HTMLDivElement>(null);
+    useEffect(() => { active.current = true; return () => { active.current = false; }; }, []);
+    useEffect(() => { body.current?.scrollTo({ top: 0 }); }, [review, submitted, receipt, owner.contextChanged, owner.state.error]);
+    const confirm = async () => {
+        if (!review || attempted.current || owner.blocked || !owner.controller.isCurrent()) return;
+        attempted.current = true;
+        const target = aclWriteTarget(review);
+        setSubmitted(target);
+        const writing = owner.controller.write(() => dispatch(review), 'ACL write was not confirmed. Inspect the original Broker before another operation.');
+        setReview(null);
+        const result = await writing;
+        if (!active.current) return;
+        const outcome = aclWriteReceipt(target, request.context, result);
+        setReceipt(outcome);
+        applied(outcome);
+    };
+    const action = request.action;
+    const target = submitted ?? (review ? aclWriteTarget(review) : null);
+    const user = action.kind === 'user_update' || action.kind === 'user_password' ? action.user : null;
+    const isDelete = action.kind === 'user_delete' || action.kind === 'policy_delete';
+    return <Dialog open onOpenChange={open => { if (!open && !owner.busy) close(); }}>
+        <DialogContent className="ops-acl-dialog" showCloseButton={!owner.busy}
+            onEscapeKeyDown={event => { if (owner.busy) event.preventDefault(); }} onInteractOutside={event => { if (owner.busy) event.preventDefault(); }}
+            onCloseAutoFocus={event => { event.preventDefault(); if (request.trigger?.isConnected) request.trigger.focus(); else document.getElementById('main-content')?.focus(); }}>
+            <DialogHeader><DialogTitle>{titles[action.kind]}</DialogTitle><DialogDescription>Review the exact Broker identity and change before applying it.</DialogDescription></DialogHeader>
+            <div className="ops-acl-dialog-body" ref={body}>
+                <p className="ops-acl-note">Environment {request.context.environmentId ?? 'Not configured'} · Connection revision {request.context.revision}</p>
+                {!target && <p className="ops-acl-note">{request.scope.clusterName} / {request.scope.brokerName} · {request.scope.brokerAddr}</p>}
+                {owner.contextChanged && <PageState kind="stale" title="Connection context changed" description="This operation remains attached to the original Broker. Reopen from the current scope to start another change." />}
+                {owner.state.error && <PageState kind="error" title="ACL operation could not complete" description={owner.state.error} />}
+                {!submitted && <div hidden={Boolean(review)}>
+                    {(action.kind === 'user_create' || action.kind === 'user_update' || action.kind === 'user_password') && <AclUserForm scope={request.scope} user={user} passwordOnly={action.kind === 'user_password'} disabled={owner.blocked} onReview={setReview} />}
+                    {(action.kind === 'policy_create' || action.kind === 'policy_update') && <AclPolicyForm scope={request.scope} policy={action.kind === 'policy_update' ? action.policy : null} initialSubject={action.kind === 'policy_create' ? action.subject ?? '' : ''} disabled={owner.blocked} onReview={setReview} />}
+                </div>}
+                {target && !receipt && <section className="ops-acl-form" aria-label="ACL change target"><h3>{submitted ? 'Submitted target' : 'Confirm change'}</h3><AclTargetDetails target={target} />
+                    {(target.kind === 'user_create' || target.kind === 'user_update') && <p className="ops-acl-note">A new password was provided. Its value is excluded from this confirmation and the receipt.</p>}
+                    <p className="ops-acl-note">{isDelete ? 'This removes access at the specified Broker. Verify the exact identity before deletion.' : 'This changes Broker access. Verify permissions and resource decisions before applying.'} The operation will submit once and will not retry automatically.</p>
+                </section>}
+                {receipt && <AclReceiptPanel receipt={receipt} />}
+            </div>
+            <DialogFooter><Button variant="outline" disabled={owner.busy} onClick={close}>{receipt ? 'Close result' : 'Cancel'}</Button>
+                {review && !isDelete && <Button variant="outline" disabled={owner.blocked} onClick={() => setReview(null)}>Back to edit</Button>}
+                {review && <Button variant={isDelete ? 'danger' : 'primary'} disabled={owner.blocked} onClick={() => { void confirm(); }}>{isDelete ? 'Confirm deletion' : 'Apply change'}</Button>}
+                {owner.busy && <span role="status" className="ops-acl-note">Applying change…</span>}
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>;
+}
+
+/** The session owns accepted writes and their receipt, even if the page or connection changes. */
+export function AclActionProvider({ children }: { children: ReactNode }) {
+    const [request, setRequest] = useState<Request | null>(null);
+    const [receipt, setReceipt] = useState<AclReceipt | null>(null);
+    const open = useCallback((action: AclAction, scope: AclScope, context: AclContext) => {
+        try {
+            const captured = captureAclAction(action, scope, context, ConnectionStore.getSnapshot());
+            if (action.kind === 'policy_update') policyDraft(action.policy);
+            const trigger = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+            setRequest(current => current ?? { ...captured, trigger });
+        } catch (error) { toast.error(error instanceof Error ? error.message : 'The ACL action could not be opened.'); }
+    }, []);
+    return <AclActionContext.Provider value={{ open, receipt }}>{children}
+        {request && <AclActionDialog request={request} close={() => setRequest(null)} applied={setReceipt} />}
+    </AclActionContext.Provider>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclPolicies.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclPolicies.tsx
@@ -1,105 +1,52 @@
-import { useEffect, useRef, useState } from 'react';
-import { AclService } from '../../../services/acl.service';
-import { dashboardErrorMessage } from '../../../services/invoke';
-import { policyDeleteRequest, policyDraft, policyIdentity } from '../policies';
-import type { AclScope, AclPolicy, AclPolicyDraft, AclPolicyDraftEntry, AclPolicyDelete, AclPolicyResult } from '../types';
-const field = 'w-full rounded border bg-transparent px-3 py-2 text-sm';
-const tokens = (text: string) => text.split(/[,\n]/).map(value => value.trim()).filter(Boolean);
-const emptyEntry = (): AclPolicyDraftEntry => ({ resources: [], actions: ['Pub', 'Sub'], sourceIps: [], decision: 'Allow' });
+import { useState } from 'react';
+import { Pencil, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '../../../components/ui/LegacyButton';
+import { PageState } from '../../../components/layout/PageState';
+import { StatusBadge } from '../../../components/layout/StatusBadge';
+import { useAclActions } from '../aclActionContext';
+import { policyDeleteRequest, policyIdentity } from '../policies';
+import type { AclContext } from '../aclActions';
+import type { AclPolicy, AclScope } from '../types';
+import { AclValue } from './AclReceiptPanel';
 
-export function AclPolicies({ scope }: { scope: AclScope }) {
-    const [policies, setPolicies] = useState<AclPolicy[] | null>(null);
-    const [loading, setLoading] = useState(false); const [error, setError] = useState(''); const [query, setQuery] = useState('');
-    const [editor, setEditor] = useState<{ subject: string; draft: AclPolicyDraft; update: boolean } | null>(null);
-    const [deleting, setDeleting] = useState<AclPolicyDelete | null>(null);
-    const [receipt, setReceipt] = useState<AclPolicyResult | null>(null);
-    const generation = useRef(0);
-    const load = async () => {
-        const current = ++generation.current; setLoading(true); setError(''); setPolicies(null);
-        try { const policies = await AclService.listPolicies(scope); if (current === generation.current) setPolicies(policies); }
-        catch (error) { if (current === generation.current) setError(dashboardErrorMessage(error, 'Unable to read ACL policies.')); }
-        finally { if (current === generation.current) setLoading(false); }
-    };
-    useEffect(() => { void load(); return () => { generation.current++; }; }, []);
-    const applied = (result: AclPolicyResult) => { generation.current++; setLoading(false); setReceipt(result); setPolicies(result.policies); setError(result.readBackError ?? ''); setEditor(null); setDeleting(null); };
-    const edit = (policy: AclPolicy) => {
-        try { setEditor({ subject: policy.subject ?? '', draft: policyDraft(policy), update: true }); setReceipt(null); }
-        catch (error) { setError(error instanceof Error ? error.message : 'Policy cannot be edited.'); }
-    };
-    const filtered = (policies ?? []).filter(policy => [policy.subject, ...policy.entries.map(entry => entry.resource)].some(value => value?.toLowerCase().includes(query.trim().toLowerCase())));
-    return <section className="space-y-4"><header className="flex flex-wrap items-center justify-between gap-3"><h2 className="font-semibold">Broker ACL policies</h2>
-        <input className={field + ' max-w-xs'} aria-label="Search ACL policies" placeholder="Search subject or resource" value={query} onChange={event => setQuery(event.target.value)} />
-        <button disabled={loading} onClick={() => void load()} className="rounded border px-3 py-2 text-sm">Refresh policies</button>
-        <button disabled={loading || policies === null} onClick={() => { setReceipt(null); setEditor({ subject: '', draft: { policyType: 'Custom', entries: [emptyEntry()] }, update: false }); }} className="rounded bg-blue-600 px-3 py-2 text-sm text-white">Add policy</button>
-    </header>
-    {receipt && <p role="status">Broker acknowledged ACL {receipt.operation} for {receipt.subject} at {receipt.scope.brokerAddr}.</p>}
-    {error && <p role="alert" className="text-red-600">{error}</p>}{loading && <p>Loading ACL policies…</p>}
-    {!loading && policies?.length === 0 && <p>No ACL policies were returned for this Broker.</p>}
-    {filtered.map((policy, index) => <article key={JSON.stringify([policy.subject, policy.policyType, index])} className="space-y-3 rounded border p-4">
-        <header className="flex justify-between gap-3"><strong>{policy.subject ?? 'Unknown subject'} · {policy.policyType ?? 'Unknown policy type'}</strong><button onClick={() => edit(policy)}>Edit entries</button></header>
-        <div className="overflow-auto"><table className="w-full text-left text-sm"><thead><tr><th>Resource</th><th>Actions</th><th>Source IPs</th><th>Decision</th><th>Action</th></tr></thead><tbody>
-            {policy.entries.map((entry, index) => <tr key={policyIdentity(policy, entry) + index} className="border-t"><td className="p-2 font-mono">{entry.resource ?? 'Unknown resource'}</td><td>{entry.actions.join(', ')}</td><td>{entry.sourceIps.join(', ') || 'Any source'}</td><td>{entry.decision ?? 'Unknown'}</td>
-                <td><button className="text-red-600" onClick={() => { try { setDeleting(policyDeleteRequest(scope, policy, entry)); setReceipt(null); } catch (error) { setError(error instanceof Error ? error.message : 'Policy identity is invalid.'); } }}>Delete resource</button></td></tr>)}
-        </tbody></table></div>
-    </article>)}
-    {editor && <PolicyEditor scope={scope} initial={editor} onClose={() => setEditor(null)} onApplied={applied} />}
-    {deleting && <PolicyDeleteDialog request={deleting} onClose={() => setDeleting(null)} onApplied={applied} />}
-    </section>;
+const identity = (policy: AclPolicy) => JSON.stringify([policy.subject, policy.policyType]);
+
+export function AclPolicies({ scope, context, policies, disabled, showEmpty }: { scope: AclScope; context: AclContext; policies: AclPolicy[]; disabled: boolean; showEmpty: boolean }) {
+    const [selectedKey, setSelectedKey] = useState('');
+    const selected = policies.find(policy => identity(policy) === selectedKey) ?? null;
+    const { open } = useAclActions();
+    return <div className="ops-acl-split">
+        <div className="ops-acl-directory"><div className="ops-acl-scroll" role="region" aria-label="Broker ACL policies" tabIndex={0}>
+            <table><thead><tr><th scope="col">Subject</th><th scope="col">Policy type</th><th scope="col">Resources</th></tr></thead><tbody>
+                {policies.map((policy, index) => <tr key={`${identity(policy)}:${index}`} data-selected={policy === selected}><th scope="row"><button className="ops-acl-choice" aria-pressed={policy === selected} onClick={() => setSelectedKey(identity(policy))}><span>{policy.subject || 'Unknown subject'}</span></button></th>
+                    <td>{policy.policyType || 'Unknown'}</td><td>{policy.entries.length}</td></tr>)}
+            </tbody></table>
+            {showEmpty && !policies.length && <PageState kind="empty" title="No matching policies" description="Change the filter or create a resource policy." />}
+        </div></div>
+        <section className="ops-acl-detail" aria-label="Policy details"><header className="ops-section-header"><h2>Policy details</h2>
+            {selected && <Button icon={Pencil} disabled={disabled} onClick={() => open({ kind: 'policy_update', policy: selected }, scope, context)}>Edit entries</Button>}
+        </header>{selected ? <><dl className="ops-acl-properties"><div><dt>Subject</dt><dd><AclValue value={selected.subject || 'Unknown'} /></dd></div><div><dt>Policy type</dt><dd>{selected.policyType || 'Unknown'}</dd></div></dl>
+            <AclPolicyResources scope={scope} context={context} policies={[selected]} disabled={disabled} />
+        </> : <PageState kind="empty" title="Select a policy" description="Inspect resource permissions and source IP restrictions." />}</section>
+    </div>;
 }
-function PolicyEditor({ scope, initial, onClose, onApplied }: { scope: AclScope; initial: { subject: string; draft: AclPolicyDraft; update: boolean }; onClose: () => void; onApplied: (result: AclPolicyResult) => void }) {
-    const [subject, setSubject] = useState(initial.subject); const [draft, setDraft] = useState(initial.draft);
-    const entryIds = useRef(initial.draft.entries.map((_, index) => index));
-    const nextEntryId = useRef(initial.draft.entries.length);
-    const [busy, setBusy] = useState(false); const [error, setError] = useState(''); const active = useRef(true);
-    useEffect(() => { active.current = true; return () => { active.current = false; }; }, []);
-    const changeEntry = (index: number, patch: Partial<AclPolicyDraftEntry>) => setDraft(current => ({ ...current, entries: current.entries.map((entry, position) => position === index ? { ...entry, ...patch } : entry) }));
-    const save = async () => {
-        if (busy) return;
-        if (!subject.trim() || !draft.entries.length || draft.entries.some(entry => !entry.resources.length || !entry.actions.length)) { setError('Subject, resources and actions are required.'); return; }
-        setBusy(true); setError('');
-        try { const request = { scope, subject, policies: [draft] }; const result = await (initial.update ? AclService.updatePolicy(request) : AclService.createPolicy(request)); if (active.current) onApplied(result); }
-        catch (error) { if (active.current) setError(dashboardErrorMessage(error, 'ACL policy write was not confirmed.')); }
-        finally { if (active.current) setBusy(false); }
-    };
-    return <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-5"><section role="dialog" aria-modal="true" aria-label="Edit ACL policy" className="max-h-[90vh] w-full max-w-3xl space-y-4 overflow-auto rounded-xl bg-white p-6 dark:bg-gray-900">
-        <h2 className="text-lg font-semibold">{initial.update ? 'Update' : 'Create'} ACL policy</h2><p className="font-mono text-sm">{scope.clusterName} / {scope.brokerName} · {scope.brokerAddr}</p>
-        {error && <p role="alert" className="text-red-600">{error}</p>}
-        <label className="block text-sm">Subject<input className={field} placeholder="User:username" value={subject} disabled={initial.update || busy} onChange={event => setSubject(event.target.value)} /></label>
-        <label className="block text-sm">Policy type<select className={field} disabled={initial.update || busy} value={draft.policyType} onChange={event => setDraft({ ...draft, policyType: event.target.value as 'Custom' | 'Default' })}><option>Custom</option><option>Default</option></select></label>
-        <p className="text-sm text-gray-500">Updates modify the listed resources. Use the resource deletion action to remove an existing entry.</p>
-        {draft.entries.map((entry, index) => <fieldset key={entryIds.current[index]} disabled={busy} className="space-y-3 rounded border p-4"><legend>Entry {index + 1}</legend>
-            <PolicyEntryForm entry={entry} readOnlyResources={initial.update} onChange={patch => changeEntry(index, patch)} />
-            {!initial.update && <button type="button" onClick={() => { entryIds.current.splice(index, 1); setDraft({ ...draft, entries: draft.entries.filter((_, position) => position !== index) }); }}>Remove draft entry</button>}
-        </fieldset>)}
-        {!initial.update && <button disabled={busy} onClick={() => { entryIds.current.push(nextEntryId.current++); setDraft({ ...draft, entries: [...draft.entries, emptyEntry()] }); }}>Add another entry</button>}
-        <footer className="flex justify-end gap-3"><button onClick={onClose}>Cancel</button><button disabled={busy} onClick={() => void save()} className="rounded bg-blue-600 px-4 py-2 text-white">{busy ? 'Applying…' : 'Apply policy change'}</button></footer>
-    </section></div>;
-}
-function PolicyEntryForm({ entry, readOnlyResources, onChange }: { entry: AclPolicyDraftEntry; readOnlyResources: boolean; onChange: (patch: Partial<AclPolicyDraftEntry>) => void }) {
-    const [resources, setResources] = useState(entry.resources.join('\n'));
-    const [actions, setActions] = useState(entry.actions.join(', '));
-    const [sourceIps, setSourceIps] = useState(entry.sourceIps.join(', '));
-    return <>
-        <label className="block text-sm">Resources · one per line<textarea className={field} placeholder="Topic:orders" value={resources} readOnly={readOnlyResources}
-            onChange={event => { setResources(event.target.value); onChange({ resources: tokens(event.target.value) }); }} /></label>
-        <label className="block text-sm">Actions · comma separated<input className={field} value={actions}
-            onChange={event => { setActions(event.target.value); onChange({ actions: tokens(event.target.value) }); }} /></label>
-        <label className="block text-sm">Source IPs / CIDRs · blank means any source<input className={field} value={sourceIps}
-            onChange={event => { setSourceIps(event.target.value); onChange({ sourceIps: tokens(event.target.value) }); }} /></label>
-        <label className="block text-sm">Decision<select className={field} value={entry.decision} onChange={event => onChange({ decision: event.target.value as 'Allow' | 'Deny' })}><option>Allow</option><option>Deny</option></select></label>
-    </>;
-}
-function PolicyDeleteDialog({ request, onClose, onApplied }: { request: AclPolicyDelete; onClose: () => void; onApplied: (result: AclPolicyResult) => void }) {
-    const [busy, setBusy] = useState(false); const [error, setError] = useState(''); const active = useRef(true);
-    useEffect(() => { active.current = true; return () => { active.current = false; }; }, []);
-    const remove = async () => {
-        if (busy) return; setBusy(true); setError('');
-        try { const result = await AclService.deletePolicy(request); if (active.current) onApplied(result); }
-        catch (error) { if (active.current) setError(dashboardErrorMessage(error, 'ACL resource deletion was not confirmed.')); }
-        finally { if (active.current) setBusy(false); }
-    };
-    return <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-5"><section role="dialog" aria-modal="true" aria-label="Delete ACL resource" className="w-full max-w-xl space-y-4 rounded-xl bg-white p-6 dark:bg-gray-900">
-        <h2 className="font-semibold">Delete ACL resource</h2><p>{request.subject} / {request.policyType} / <strong>{request.resource}</strong></p><p className="text-sm">Broker: {request.scope.clusterName} / {request.scope.brokerName} · {request.scope.brokerAddr}</p>
-        {error && <p role="alert" className="text-red-600">{error}</p>}<footer className="flex justify-end gap-3"><button onClick={onClose}>Cancel</button><button disabled={busy} onClick={() => void remove()} className="rounded bg-red-600 px-4 py-2 text-white">{busy ? 'Deleting…' : 'Confirm resource deletion'}</button></footer>
-    </section></div>;
+
+export function AclPolicyResources({ scope, context, policies, disabled }: { scope: AclScope; context: AclContext; policies: AclPolicy[]; disabled: boolean }) {
+    const { open } = useAclActions();
+    return <div className="ops-acl-scroll ops-acl-resource-table" role="region" aria-label="Resource policy entries" tabIndex={0}>
+        <table><thead><tr>{['Subject / type', 'Resource', 'Actions', 'Source IPs', 'Decision', 'Actions'].map((label, index) => <th key={index} scope="col">{label}</th>)}</tr></thead>
+            <tbody>{policies.flatMap((policy, policyIndex) => policy.entries.map((entry, index) => <tr key={`${policyIdentity(policy, entry)}:${policyIndex}:${index}`}>
+                <td><AclValue value={policy.subject || 'Unknown subject'} /><span className="ops-acl-note">{policy.policyType || 'Unknown type'}</span></td>
+                <td><AclValue value={entry.resource || 'Unknown resource'} /></td><td><AclValue value={entry.actions.join(', ') || 'Not reported'} /></td><td><AclValue value={entry.sourceIps.join(', ') || 'Any source'} /></td>
+                <td><StatusBadge tone={entry.decision?.toLowerCase() === 'allow' ? 'success' : entry.decision?.toLowerCase() === 'deny' ? 'danger' : 'neutral'}>{entry.decision || 'Unknown'}</StatusBadge></td>
+                <td><div className="ops-acl-row-actions"><Button variant="ghost" icon={Pencil} className="ops-button-icon-only" aria-label={`Edit policy ${policy.subject ?? ''} ${policy.policyType ?? ''}`} disabled={disabled} onClick={() => open({ kind: 'policy_update', policy }, scope, context)} />
+                    <Button variant="ghost" icon={Trash2} className="ops-button-icon-only" aria-label={`Delete resource ${entry.resource ?? ''} from ${policy.subject ?? ''} ${policy.policyType ?? ''}`} disabled={disabled} onClick={() => {
+                        try { open({ kind: 'policy_delete', request: policyDeleteRequest(scope, policy, entry) }, scope, context); }
+                        catch (error) { toast.error(error instanceof Error ? error.message : 'The resource identity is incomplete.'); }
+                    }} /></div></td>
+            </tr>))}</tbody>
+        </table>
+        {!policies.some(policy => policy.entries.length) && <PageState kind="empty" title="No resource entries returned" />}
+    </div>;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclPolicyForm.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclPolicyForm.tsx
@@ -1,0 +1,49 @@
+import { useRef, useState } from 'react';
+import { Button } from '../../../components/ui/LegacyButton';
+import { Input } from '../../../components/ui/LegacyInput';
+import { PageState } from '../../../components/layout/PageState';
+import { policyDraft } from '../policies';
+import { buildAclPolicyChange, emptyPolicyEntry, policyTokens } from '../policyDraft';
+import type { AclWrite } from '../aclActions';
+import type { AclPolicy, AclPolicyDraftEntry, AclScope } from '../types';
+
+export function AclPolicyForm({ scope, policy, initialSubject, disabled, onReview }: {
+    scope: AclScope; policy: AclPolicy | null; initialSubject: string; disabled: boolean; onReview: (write: AclWrite) => void;
+}) {
+    const [subject, setSubject] = useState(policy?.subject ?? initialSubject);
+    const [draft, setDraft] = useState(() => policy ? policyDraft(policy) : { policyType: 'Custom' as const, entries: [emptyPolicyEntry()] });
+    const [error, setError] = useState('');
+    const entryIds = useRef(draft.entries.map((_, index) => index));
+    const nextId = useRef(draft.entries.length);
+    return <form className="ops-acl-form" onSubmit={event => {
+        event.preventDefault();
+        if (disabled) return;
+        try { onReview({ kind: policy ? 'policy_update' : 'policy_create', request: buildAclPolicyChange(scope, subject, draft, policy) }); }
+        catch (error) { setError(error instanceof Error ? error.message : 'Check the policy fields.'); }
+    }}>
+        {error && <PageState kind="error" title="Check the policy fields" description={error} />}
+        <fieldset disabled={disabled} className="ops-acl-fields">
+            <div className="ops-acl-form-grid"><Input label="Subject" placeholder="User:username" readOnly={Boolean(policy)} value={subject} onChange={event => setSubject(event.target.value)} />
+                <label className="ops-acl-select">Policy type<select disabled={Boolean(policy)} value={draft.policyType} onChange={event => setDraft({ ...draft, policyType: event.target.value as 'Custom' | 'Default' })}><option>Custom</option><option>Default</option></select></label></div>
+            <p className="ops-acl-note">Changes apply to the listed resources. Delete an existing resource through its separate deletion action.</p>
+            {draft.entries.map((entry, index) => <fieldset key={entryIds.current[index]} className="ops-acl-entry"><legend>Entry {index + 1}</legend>
+                <PolicyEntryForm entry={entry} resourcesReadOnly={Boolean(policy)} onChange={patch => setDraft(current => ({ ...current, entries: current.entries.map((value, position) => position === index ? { ...value, ...patch } : value) }))} />
+                {!policy && <Button variant="ghost" disabled={draft.entries.length === 1} onClick={() => { entryIds.current.splice(index, 1); setDraft({ ...draft, entries: draft.entries.filter((_, position) => position !== index) }); }}>Remove draft entry</Button>}
+            </fieldset>)}
+            {!policy && <Button variant="outline" onClick={() => { entryIds.current.push(nextId.current++); setDraft({ ...draft, entries: [...draft.entries, emptyPolicyEntry()] }); }}>Add another entry</Button>}
+        </fieldset>
+        <footer className="ops-acl-form-actions"><Button type="submit" disabled={disabled}>Review policy change</Button></footer>
+    </form>;
+}
+
+function PolicyEntryForm({ entry, resourcesReadOnly, onChange }: { entry: AclPolicyDraftEntry; resourcesReadOnly: boolean; onChange: (patch: Partial<AclPolicyDraftEntry>) => void }) {
+    const [resources, setResources] = useState(entry.resources.join('\n'));
+    const [actions, setActions] = useState(entry.actions.join(', '));
+    const [sourceIps, setSourceIps] = useState(entry.sourceIps.join(', '));
+    return <div className="ops-acl-fields">
+        <label className="ops-acl-select">Resources · one per line<textarea rows={3} readOnly={resourcesReadOnly} value={resources} onChange={event => { setResources(event.target.value); onChange({ resources: policyTokens(event.target.value) }); }} /></label>
+        <Input label="Actions · comma separated" value={actions} onChange={event => { setActions(event.target.value); onChange({ actions: policyTokens(event.target.value) }); }} />
+        <Input label="Source IPs / CIDRs · blank means any source" value={sourceIps} onChange={event => { setSourceIps(event.target.value); onChange({ sourceIps: policyTokens(event.target.value) }); }} />
+        <label className="ops-acl-select">Decision<select value={entry.decision} onChange={event => onChange({ decision: event.target.value as 'Allow' | 'Deny' })}><option>Allow</option><option>Deny</option></select></label>
+    </div>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclReceiptPanel.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclReceiptPanel.tsx
@@ -1,0 +1,29 @@
+import { PageState } from '../../../components/layout/PageState';
+import { StatusBadge } from '../../../components/layout/StatusBadge';
+import type { AclReceipt, AclTarget } from '../aclActions';
+
+export function AclTargetDetails({ target }: { target: AclTarget }) {
+    return <><dl className="ops-acl-properties">{[
+        ['Broker', `${target.scope.clusterName} / ${target.scope.brokerName} · ${target.scope.brokerAddr}`],
+        [target.kind.startsWith('user_') ? 'Username' : 'Subject', target.identity],
+        ...(target.userType ? [['User type', target.userType]] : []), ...(target.userStatus ? [['Status', target.userStatus]] : []),
+        ...(target.policyType ? [['Policy type', target.policyType]] : []), ...(target.resources ? [['Resources', target.resources.join('\n')]] : []),
+    ].map(([label, value]) => <div key={label}><dt>{label}</dt><dd><AclValue value={value} /></dd></div>)}</dl>
+        {target.entries?.map((entry, index) => <section className="ops-acl-entry" key={index} aria-label={`Policy change entry ${index + 1}`}><dl className="ops-acl-properties">{[
+            ['Resources', entry.resources.join('\n')], ['Actions', entry.actions.join(', ')], ['Source IPs', entry.sourceIps.join(', ') || 'Any source'], ['Decision', entry.decision],
+        ].map(([label, value]) => <div key={label}><dt>{label}</dt><dd><AclValue value={value} /></dd></div>)}</dl></section>)}
+    </>;
+}
+
+export function AclValue({ value }: { value: string }) {
+    return <span className="ops-acl-value" tabIndex={value.length > 160 ? 0 : undefined}>{value}</span>;
+}
+
+export function AclReceiptPanel({ receipt }: { receipt: AclReceipt }) {
+    return <section className="ops-acl-receipt" aria-label="Latest ACL operation">
+        {receipt.acknowledged && receipt.readBackAvailable ? <div role="status"><StatusBadge tone="success">ACL change acknowledged</StatusBadge><p className="ops-acl-note">{receipt.message}</p></div>
+            : <PageState kind="partial" title={receipt.acknowledged ? 'ACL change acknowledged · read-back unavailable' : 'ACL outcome unconfirmed'} description={receipt.message} />}
+        <p className="ops-acl-note">{receipt.target.kind.replace('_', ' ')} · Environment {receipt.context.environmentId ?? 'Not configured'} · Revision {receipt.context.revision} · {new Date(receipt.finishedAt).toLocaleString()}</p>
+        <AclTargetDetails target={receipt.target} />
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclUserForm.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclUserForm.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { Button } from '../../../components/ui/LegacyButton';
+import { Input } from '../../../components/ui/LegacyInput';
+import { PageState } from '../../../components/layout/PageState';
+import { buildAclUserChange, newAclUserDraft, type AclUserDraft } from '../userDraft';
+import type { AclWrite } from '../aclActions';
+import type { AclScope, AclUser } from '../types';
+
+export function AclUserForm({ scope, user, passwordOnly, disabled, onReview }: {
+    scope: AclScope; user: AclUser | null; passwordOnly: boolean; disabled: boolean; onReview: (write: AclWrite) => void;
+}) {
+    const [draft, setDraft] = useState(() => newAclUserDraft(user));
+    const [error, setError] = useState('');
+    return <form className="ops-acl-form" onSubmit={event => {
+        event.preventDefault();
+        if (disabled) return;
+        try { onReview({ kind: user ? 'user_update' : 'user_create', request: buildAclUserChange(scope, draft, user) }); }
+        catch (error) { setError(error instanceof Error ? error.message : 'Check the user fields.'); }
+    }}>
+        {error && <PageState kind="error" title="Check the user fields" description={error} />}
+        <fieldset disabled={disabled} className="ops-acl-fields">
+            <Input label="Username" autoComplete="off" readOnly={Boolean(user)} value={draft.username} onChange={event => setDraft({ ...draft, username: event.target.value })} />
+            <Input label="New password" type="password" autoComplete="new-password" value={draft.password} onChange={event => setDraft({ ...draft, password: event.target.value })} />
+            <p className="ops-acl-note">Saved passwords are never loaded. {user ? 'This Broker API requires a new password with every user update.' : 'New Broker ACL users are enabled.'}</p>
+            <div className="ops-acl-form-grid">
+                <label className="ops-acl-select">User type<select disabled={passwordOnly} value={draft.userType} onChange={event => setDraft({ ...draft, userType: event.target.value as AclUserDraft['userType'] })}>
+                    <option value="" disabled>Choose a user type</option><option value="normal">Normal</option><option value="super">Super</option>
+                </select></label>
+                {user && <label className="ops-acl-select">Status<select disabled={passwordOnly} value={draft.userStatus} onChange={event => setDraft({ ...draft, userStatus: event.target.value as AclUserDraft['userStatus'] })}>
+                    <option value="" disabled>Choose a user status</option><option value="enable">Enabled</option><option value="disable">Disabled</option>
+                </select></label>}
+            </div>
+            {passwordOnly && <p className="ops-acl-note">The selected user type and status are preserved. If either value is unknown, refresh the user or use Edit to choose explicit values.</p>}
+        </fieldset>
+        <footer className="ops-acl-form-actions"><Button type="submit" disabled={disabled}>Review user change</Button></footer>
+    </form>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclUsers.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclUsers.tsx
@@ -1,92 +1,41 @@
-import { useEffect, useRef, useState } from 'react';
-import { AclService } from '../../../services/acl.service';
-import { dashboardErrorMessage } from '../../../services/invoke';
-import type { AclScope, AclUser, AclUserChange, AclUserResult } from '../types';
+import { Pencil, Trash2 } from 'lucide-react';
+import { Button } from '../../../components/ui/LegacyButton';
+import { PageState } from '../../../components/layout/PageState';
+import { StatusBadge } from '../../../components/layout/StatusBadge';
+import { useAclActions } from '../aclActionContext';
+import type { AclContext } from '../aclActions';
+import type { AclScope, AclUser } from '../types';
+import { AclValue } from './AclReceiptPanel';
 
-const field = 'w-full rounded border bg-transparent px-3 py-2 text-sm';
-export function AclUsers({ scope }: { scope: AclScope }) {
-    const [users, setUsers] = useState<AclUser[] | null>(null);
-    const [error, setError] = useState('');
-    const [loading, setLoading] = useState(false);
-    const [query, setQuery] = useState('');
-    const [editor, setEditor] = useState<{ user: AclUser | null } | null>(null);
-    const [deleting, setDeleting] = useState<AclUser | null>(null);
-    const [receipt, setReceipt] = useState<AclUserResult | null>(null);
-    const generation = useRef(0);
-    const load = async () => {
-        const current = ++generation.current;
-        setLoading(true); setError(''); setUsers(null);
-        try { const users = await AclService.listUsers(scope); if (current === generation.current) setUsers(users); }
-        catch (error) { if (current === generation.current) setError(dashboardErrorMessage(error, 'Unable to read ACL users.')); }
-        finally { if (current === generation.current) setLoading(false); }
-    };
-    useEffect(() => { void load(); return () => { generation.current++; }; }, []);
-    const applied = (result: AclUserResult) => {
-        generation.current++;
-        setReceipt(result); setUsers(result.users); setError(result.readBackError ?? '');
-        setLoading(false); setEditor(null); setDeleting(null);
-    };
-    const filtered = (users ?? []).filter(user => user.username.toLowerCase().includes(query.trim().toLowerCase()));
-    return <section className="space-y-4">
-        <header className="flex flex-wrap items-center justify-between gap-3"><h2 className="font-semibold">Broker ACL users</h2>
-            <input className={field + ' max-w-xs'} aria-label="Search ACL users" placeholder="Search username" value={query} onChange={event => setQuery(event.target.value)} />
-            <button disabled={loading} onClick={() => void load()} className="rounded border px-3 py-2 text-sm">Refresh users</button>
-            <button disabled={loading || users === null} onClick={() => { setReceipt(null); setEditor({ user: null }); }} className="rounded bg-blue-600 px-3 py-2 text-sm text-white">Add user</button>
+export function AclUserStatus({ status }: { status: string | null }) {
+    const value = status?.toLowerCase();
+    return <StatusBadge tone={value === 'enable' ? 'success' : value === 'disable' ? 'warning' : 'neutral'}>{value === 'enable' ? 'Enabled' : value === 'disable' ? 'Disabled' : status || 'Unknown'}</StatusBadge>;
+}
+
+export function AclUsers({ scope, context, users, selected, onSelect, disabled, showEmpty }: {
+    scope: AclScope; context: AclContext; users: AclUser[]; selected: AclUser | null; onSelect: (user: AclUser) => void; disabled: boolean; showEmpty: boolean;
+}) {
+    const { open } = useAclActions();
+    return <div className="ops-acl-split">
+        <div className="ops-acl-directory"><div className="ops-acl-scroll" role="region" aria-label="Broker ACL users" tabIndex={0}>
+            <table><thead><tr><th scope="col">User</th><th scope="col">Type</th><th scope="col">Status</th><th scope="col">Actions</th></tr></thead>
+                <tbody>{users.map(user => <tr key={user.username} data-selected={user.username === selected?.username}>
+                    <th scope="row"><button className="ops-acl-choice" aria-pressed={user.username === selected?.username} onClick={() => onSelect(user)}><span>{user.username}</span></button></th>
+                    <td><AclValue value={user.userType || 'Unknown'} /></td><td><AclUserStatus status={user.userStatus} /></td>
+                    <td><Button variant="ghost" className="ops-button-icon-only" icon={Trash2} aria-label={`Delete ACL user ${user.username}`} disabled={disabled} onClick={() => open({ kind: 'user_delete', user }, scope, context)} /></td>
+                </tr>)}</tbody>
+            </table>
+            {showEmpty && !users.length && <PageState kind="empty" title="No matching users" description="Refresh the directory or change the username filter." />}
+        </div></div>
+        <section className="ops-acl-detail" aria-label="User details"><header className="ops-section-header"><h2>User details</h2>
+            {selected && <Button icon={Pencil} disabled={disabled} onClick={() => open({ kind: 'user_update', user: selected }, scope, context)}>Edit</Button>}
         </header>
-        {receipt && <p role="status">Broker acknowledged ACL {receipt.operation} for {receipt.username} at {receipt.scope.brokerAddr}.</p>}
-        {error && <p role="alert" className="text-red-600 dark:text-red-400">{error}</p>}
-        {loading && <p>Loading ACL users…</p>}
-        {!loading && users?.length === 0 && <p>No ACL users were returned for this Broker.</p>}
-        <div className="overflow-auto"><table className="w-full text-left text-sm"><thead><tr><th>Username</th><th>Type</th><th>Status</th><th>Actions</th></tr></thead>
-            <tbody>{filtered.map(user => <tr key={user.username} className="border-t"><td className="p-3 font-mono">{user.username}</td><td>{user.userType ?? 'Unknown'}</td><td>{user.userStatus ?? 'Unknown'}</td>
-                <td className="space-x-3"><button onClick={() => { setReceipt(null); setEditor({ user }); }}>Edit</button><button className="text-red-600" onClick={() => { setReceipt(null); setDeleting(user); }}>Delete</button></td></tr>)}</tbody>
-        </table></div>
-        {editor && <AclUserEditor scope={scope} user={editor.user} onClose={() => setEditor(null)} onApplied={applied} />}
-        {deleting && <AclUserDeleteDialog scope={scope} user={deleting} onClose={() => setDeleting(null)} onApplied={applied} />}
-    </section>;
-}
-function AclUserEditor({ scope, user, onClose, onApplied }: { scope: AclScope; user: AclUser | null; onClose: () => void; onApplied: (result: AclUserResult) => void }) {
-    const [username, setUsername] = useState(user?.username ?? '');
-    const [password, setPassword] = useState('');
-    const [userType, setUserType] = useState<'normal' | 'super'>(user?.userType?.toLowerCase() === 'super' ? 'super' : 'normal');
-    const [userStatus, setUserStatus] = useState<'enable' | 'disable'>(user?.userStatus?.toLowerCase() === 'disable' ? 'disable' : 'enable');
-    const [error, setError] = useState('');
-    const [busy, setBusy] = useState(false);
-    const active = useRef(true);
-    useEffect(() => { active.current = true; return () => { active.current = false; }; }, []);
-    const save = async () => {
-        if (busy) return;
-        if (!username.trim() || username !== username.trim() || !password.trim()) { setError('Username and password are required.'); return; }
-        setBusy(true); setError('');
-        const request: AclUserChange = { scope, username, password, userType, userStatus: user ? userStatus : 'enable' };
-        try { const result = await (user ? AclService.updateUser(request) : AclService.createUser(request)); if (active.current) { setPassword(''); onApplied(result); } }
-        catch (error) { if (active.current) setError(dashboardErrorMessage(error, 'ACL user write was not confirmed.')); }
-        finally { if (active.current) setBusy(false); }
-    };
-    return <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-5"><section role="dialog" aria-modal="true" aria-label={user ? 'Edit ACL user' : 'Create ACL user'} className="w-full max-w-xl space-y-4 rounded-xl bg-white p-6 shadow-xl dark:bg-gray-900">
-        <h2 className="text-lg font-semibold">{user ? 'Edit' : 'Create'} Broker ACL user</h2><p className="break-all font-mono text-sm">{scope.clusterName} / {scope.brokerName} · {scope.brokerAddr}</p>
-        {error && <p role="alert" className="text-red-600">{error}</p>}
-        <label className="block text-sm">Username<input className={field} autoComplete="off" disabled={Boolean(user) || busy} value={username} onChange={event => setUsername(event.target.value)} /></label>
-        <label className="block text-sm">Password<input className={field} type="password" autoComplete="new-password" disabled={busy} value={password} onChange={event => setPassword(event.target.value)} /></label>
-        <p className="text-sm text-gray-500">{user ? 'Enter the password to apply with this update. The current API requires a value; leaving it blank is not supported.' : 'New ACL users are enabled. Their status can be changed after creation.'} Saved passwords are never loaded into this form.</p>
-        <label className="block text-sm">User type<select className={field} disabled={busy} value={userType} onChange={event => setUserType(event.target.value as 'normal' | 'super')}><option value="normal">Normal</option><option value="super">Super</option></select></label>
-        {user && <label className="block text-sm">Status<select className={field} disabled={busy} value={userStatus} onChange={event => setUserStatus(event.target.value as 'enable' | 'disable')}><option value="enable">Enable</option><option value="disable">Disable</option></select></label>}
-        <footer className="flex justify-end gap-3"><button onClick={onClose}>Cancel</button><button disabled={busy} onClick={() => void save()} className="rounded bg-blue-600 px-4 py-2 text-white">{busy ? 'Applying…' : 'Apply user change'}</button></footer>
-    </section></div>;
-}
-function AclUserDeleteDialog({ scope, user, onClose, onApplied }: { scope: AclScope; user: AclUser; onClose: () => void; onApplied: (result: AclUserResult) => void }) {
-    const [busy, setBusy] = useState(false); const [error, setError] = useState('');
-    const active = useRef(true);
-    useEffect(() => { active.current = true; return () => { active.current = false; }; }, []);
-    const remove = async () => {
-        if (busy) return; setBusy(true); setError('');
-        try { const result = await AclService.deleteUser(scope, user.username); if (active.current) onApplied(result); }
-        catch (error) { if (active.current) setError(dashboardErrorMessage(error, 'ACL user deletion was not confirmed.')); }
-        finally { if (active.current) setBusy(false); }
-    };
-    return <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-5"><section role="dialog" aria-modal="true" aria-label="Delete ACL user" className="w-full max-w-lg space-y-4 rounded-xl bg-white p-6 dark:bg-gray-900">
-        <h2 className="font-semibold">Delete Broker ACL user</h2><p>Delete <strong>{user.username}</strong> from {scope.clusterName} / {scope.brokerName} at {scope.brokerAddr}?</p>
-        {error && <p role="alert" className="text-red-600">{error}</p>}
-        <footer className="flex justify-end gap-3"><button onClick={onClose}>Cancel</button><button disabled={busy} onClick={() => void remove()} className="rounded bg-red-600 px-4 py-2 text-white">{busy ? 'Deleting…' : 'Confirm deletion'}</button></footer>
-    </section></div>;
+            {selected ? <><dl className="ops-acl-properties">
+                <div><dt>User</dt><dd><AclValue value={selected.username} /></dd></div><div><dt>Type</dt><dd><AclValue value={selected.userType || 'Unknown'} /></dd></div>
+                <div><dt>Status</dt><dd><AclUserStatus status={selected.userStatus} /></dd></div>
+            </dl><div className="ops-acl-password"><div><strong>Password</strong><p className="ops-acl-note">Saved passwords are never returned.</p></div>
+                <Button variant="secondary" disabled={disabled} onClick={() => open({ kind: 'user_password', user: selected }, scope, context)}>Change password</Button>
+            </div><p className="ops-acl-note">Broker ACL identity · {scope.brokerName}</p></> : <PageState kind="empty" title="Select a user" description="Inspect its type, status and related resource policies." />}
+        </section>
+    </div>;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclWorkspace.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/components/AclWorkspace.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowRight, Plus } from 'lucide-react';
+import { AclService } from '../../../services/acl.service';
+import { Button } from '../../../components/ui/LegacyButton';
+import { Input } from '../../../components/ui/LegacyInput';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../../components/ui/tabs';
+import { PageState } from '../../../components/layout/PageState';
+import { usePageRefresh } from '../../../app/layout/pageToolbar';
+import { useAclActions } from '../aclActionContext';
+import { aclContextMatches, type AclContext } from '../aclActions';
+import { aclScopeKey, type AclScope } from '../types';
+import { useAclRead } from '../hooks/useAclRead';
+import { AclUsers } from './AclUsers';
+import { AclPolicies, AclPolicyResources } from './AclPolicies';
+
+export function AclWorkspace({ scope, context, scopeReady, scopePending, refreshScope }: { scope: AclScope; context: AclContext; scopeReady: boolean; scopePending: boolean; refreshScope: () => Promise<boolean> }) {
+    const users = useAclRead(() => AclService.listUsers(scope), context, 'Unable to read ACL users.');
+    const policies = useAclRead(() => AclService.listPolicies(scope), context, 'Unable to read ACL policies.');
+    const { open, receipt } = useAclActions();
+    const [tab, setTab] = useState('users');
+    const [query, setQuery] = useState('');
+    const [selectedName, setSelectedName] = useState('');
+    const policiesTab = useRef<HTMLButtonElement>(null);
+    const selected = users.data?.find(user => user.username === selectedName) ?? null;
+    const refresh = useCallback(() => {
+        if (!scopeReady) { void refreshScope(); return; }
+        void users.refresh(); void policies.refresh();
+    }, [scopeReady, refreshScope, users.refresh, policies.refresh]);
+    const [refreshedAt, setRefreshedAt] = useState<number | null>(null);
+    useEffect(() => {
+        if (scopeReady && users.ready && policies.ready) setRefreshedAt(Math.min(users.observedAt!, policies.observedAt!));
+    }, [scopeReady, users.ready, policies.ready, users.observedAt, policies.observedAt]);
+    usePageRefresh({ refresh, pending: scopePending || users.loading || policies.loading, refreshedAt });
+    const currentScopeKey = aclScopeKey(scope);
+    useEffect(() => {
+        if (receipt && aclContextMatches(context, receipt.context) && currentScopeKey === aclScopeKey(receipt.target.scope)) {
+            void users.refreshAfterWrite(); void policies.refreshAfterWrite();
+        }
+    }, [receipt, currentScopeKey, context, users.refreshAfterWrite, policies.refreshAfterWrite]);
+    const search = query.trim().toLowerCase();
+    const shownUsers = (users.data ?? []).filter(user => user.username.toLowerCase().includes(search));
+    const shownPolicies = (policies.data ?? []).filter(policy => [policy.subject, policy.policyType, ...policy.entries.map(entry => entry.resource)].some(value => value?.toLowerCase().includes(search)));
+    const visibleUser = selected && shownUsers.some(user => user.username === selected.username) ? selected : null;
+    const subject = visibleUser ? `User:${visibleUser.username}` : null;
+    const related = (policies.data ?? []).filter(policy => policy.subject === subject);
+    const directory = tab === 'users' ? users : policies;
+    return <>
+        <section className="ops-acl-panel"><Tabs value={tab} onValueChange={value => { setTab(value); setQuery(''); }}>
+            <div className="ops-acl-toolbar"><TabsList aria-label="ACL sections"><TabsTrigger value="users">Users</TabsTrigger><TabsTrigger value="policies" ref={policiesTab}>Policies</TabsTrigger></TabsList>
+                <Button icon={Plus} disabled={!scopeReady || !directory.ready} onClick={() => open(tab === 'users' ? { kind: 'user_create' } : { kind: 'policy_create' }, scope, context)}>Create {tab === 'users' ? 'user' : 'policy'}</Button></div>
+            <div className="ops-acl-filter"><Input aria-label={tab === 'users' ? 'Search ACL users' : 'Search ACL policies'} placeholder={tab === 'users' ? 'Search username' : 'Search subject, type or resource'} value={query} onChange={event => setQuery(event.target.value)} />
+                <p className="ops-acl-note">{directory.data?.length ?? '—'} {tab} · {directory.observedAt ? `Observed ${new Date(directory.observedAt).toLocaleTimeString()}` : 'No observation'}</p></div>
+            {directory.loading && <PageState kind="loading" title={`Reading ACL ${tab}`} description="Actions become available after the current directory is loaded." />}
+            {directory.error && <PageState kind="error" title={`ACL ${tab} could not be refreshed`} description={directory.error} action={<Button variant="outline" disabled={!scopeReady} onClick={() => { void directory.refresh(); }}>Retry {tab}</Button>} />}
+            <TabsContent value="users"><AclUsers scope={scope} context={context} users={shownUsers} selected={visibleUser} onSelect={user => setSelectedName(user.username)} disabled={!scopeReady || !users.ready} showEmpty={users.ready} /></TabsContent>
+            <TabsContent value="policies"><AclPolicies scope={scope} context={context} policies={shownPolicies} disabled={!scopeReady || !policies.ready} showEmpty={policies.ready} /></TabsContent>
+        </Tabs></section>
+        {tab === 'users' && <section className="ops-acl-panel"><header className="ops-section-header"><div><h2>Resource policies</h2><p>{visibleUser ? `Resource access policies for ${visibleUser.username}.` : 'Select a user to inspect related resource policies.'}</p></div>
+            <Button variant="ghost" icon={ArrowRight} onClick={() => { setTab('policies'); setQuery(subject ?? ''); policiesTab.current?.focus(); }}>Manage policies</Button></header>
+            {policies.loading && <PageState kind="loading" title="Reading resource policies" />}
+            {policies.error && <PageState kind="error" title="Resource policies could not be refreshed" description={policies.error} action={<Button variant="outline" disabled={!scopeReady} onClick={() => { void policies.refresh(); }}>Retry policies</Button>} />}
+            {visibleUser && policies.data && <AclPolicyResources scope={scope} context={context} policies={related} disabled={!scopeReady || !users.ready || !policies.ready} />}
+        </section>}
+    </>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/hooks/useAclRead.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/hooks/useAclRead.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import { ConnectionStore } from '../../../services/connection.store';
+import { createReadResource } from '../../../hooks/readResource';
+import { aclContextMatches, type AclContext } from '../aclActions';
+
+/** A mounted Broker scope owns its requests and last successful observations. */
+export function useAclRead<T>(load: () => Promise<T>, context: AclContext, fallback: string) {
+    const loader = useRef(load);
+    loader.current = load;
+    const resource = useMemo(() => createReadResource(() => loader.current(), fallback), [context.environmentId, context.revision, fallback]);
+    const state = useSyncExternalStore(resource.subscribe, resource.getSnapshot, resource.getSnapshot);
+    const refresh = useCallback(() => aclContextMatches(context, ConnectionStore.getSnapshot()) ? resource.read() : Promise.resolve(false), [resource, context.environmentId, context.revision]);
+    const refreshAfterWrite = useCallback(() => { resource.invalidate(); return refresh(); }, [resource, refresh]);
+    useEffect(() => {
+        const unsubscribe = ConnectionStore.subscribe(() => {
+            if (!aclContextMatches(context, ConnectionStore.getSnapshot())) resource.invalidate();
+        });
+        void refresh();
+        return () => { unsubscribe(); resource.invalidate(); };
+    }, [resource, refresh, context.environmentId, context.revision]);
+    return { data: state.data, loading: state.pending, error: state.error, observedAt: state.receivedAt, refresh, refreshAfterWrite,
+        ready: state.data !== null && !state.pending && !state.error && aclContextMatches(context, ConnectionStore.getSnapshot()) };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/policies.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/policies.ts
@@ -4,7 +4,7 @@ export const policyIdentity = (policy: AclPolicy, entry: AclPolicyEntry) => JSON
 export function policyDeleteRequest(scope: AclScope, policy: AclPolicy, entry: AclPolicyEntry): AclPolicyDelete {
     const kind = policyType(policy.policyType);
     if (!policy.subject?.trim() || !entry.resource?.trim() || !kind) throw new Error('An exact subject, policy type and resource are required.');
-    return { scope, subject: policy.subject, policyType: kind, resource: entry.resource };
+    return { scope: { ...scope }, subject: policy.subject, policyType: kind, resource: entry.resource };
 }
 export function policyDraft(policy: AclPolicy): AclPolicyDraft {
     const kind = policyType(policy.policyType);

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/policyDraft.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/policyDraft.test.ts
@@ -1,0 +1,42 @@
+import { expect, it } from 'vitest';
+import { buildAclPolicyChange, policyTokens } from './policyDraft';
+import { policyDraft } from './policies';
+import type { AclPolicy } from './types';
+
+const scope = { clusterName: 'cluster', brokerName: 'broker-a', brokerAddr: '127.0.0.1:10911' };
+const policy: AclPolicy = { subject: 'User:reader', policyType: 'Custom', entries: [
+    { resource: 'Topic:orders', actions: ['Sub'], sourceIps: ['10.1.0.0/16'], decision: 'Allow' },
+    { resource: 'Topic:payments', actions: ['Pub'], sourceIps: [], decision: 'Deny' },
+] };
+
+it('preserves multi-resource updates and copies the reviewed payload', () => {
+    const draft = policyDraft(policy);
+    draft.entries[0].decision = 'Deny';
+    const request = buildAclPolicyChange(scope, policy.subject!, draft, policy);
+    draft.entries[0].sourceIps.push('127.0.0.1');
+    expect(request.policies[0].entries[0]).toEqual({ resources: ['Topic:orders'], actions: ['Sub'], sourceIps: ['10.1.0.0/16'], decision: 'Deny' });
+    expect(request.policies[0].entries[1].resources).toEqual(['Topic:payments']);
+});
+
+it('rejects renaming, dropping or adding update resources, subject and type changes', () => {
+    const draft = policyDraft(policy);
+    expect(() => buildAclPolicyChange(scope, 'User:other', draft, policy)).toThrow('Retain');
+    expect(() => buildAclPolicyChange(scope, policy.subject!, { ...draft, policyType: 'Default' }, policy)).toThrow('Retain');
+    expect(() => buildAclPolicyChange(scope, policy.subject!, { ...draft, entries: draft.entries.slice(1) }, policy)).toThrow('Retain');
+    draft.entries[0].resources = ['Topic:replacement'];
+    expect(() => buildAclPolicyChange(scope, policy.subject!, draft, policy)).toThrow('Retain');
+});
+
+it('rejects duplicate resources, empty actions and malformed subjects before dispatch', () => {
+    const draft = policyDraft(policy);
+    expect(() => buildAclPolicyChange(scope, 'User:reader\n', draft, null)).toThrow('exact subject');
+    draft.entries[1].resources = ['Topic:orders'];
+    expect(() => buildAclPolicyChange(scope, policy.subject!, draft, null)).toThrow('only once');
+    draft.entries.pop(); draft.entries[0].actions = [];
+    expect(() => buildAclPolicyChange(scope, policy.subject!, draft, null)).toThrow('explicit resources and actions');
+});
+
+it('parses editing separators without changing resource and network identifiers', () => {
+    expect(policyTokens(' Topic:orders,\nTopic:payments\n ')).toEqual(['Topic:orders', 'Topic:payments']);
+    expect(policyTokens('10.1.0.0/16, ::1')).toEqual(['10.1.0.0/16', '::1']);
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/policyDraft.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/policyDraft.ts
@@ -1,0 +1,31 @@
+import { policyDraft } from './policies';
+import type { AclPolicy, AclPolicyChange, AclPolicyDraft, AclPolicyDraftEntry, AclScope } from './types';
+
+export const policyTokens = (text: string) => text.split(/[,\n]/).map(value => value.trim()).filter(Boolean);
+export const emptyPolicyEntry = (): AclPolicyDraftEntry => ({ resources: [], actions: ['Pub', 'Sub'], sourceIps: [], decision: 'Allow' });
+
+/** Updates retain every resource identity; deletion is a separate, explicitly targeted operation. */
+export function buildAclPolicyChange(scope: AclScope, subject: string, draft: AclPolicyDraft, existing: AclPolicy | null): AclPolicyChange {
+    if (!scope.clusterName.trim() || !scope.brokerName.trim() || !scope.brokerAddr.trim()) throw new Error('Select an explicit master Broker scope.');
+    if (!subject.trim() || subject !== subject.trim() || /[\u0000-\u001f\u007f-\u009f]/.test(subject)) throw new Error('Enter an exact subject without surrounding whitespace or control characters.');
+    if (!['Custom', 'Default'].includes(draft.policyType) || !draft.entries.length) throw new Error('Choose a policy type and provide at least one entry.');
+    const resources = new Set<string>();
+    for (const entry of draft.entries) {
+        if (!entry.resources.length || !entry.actions.length || [...entry.resources, ...entry.actions, ...entry.sourceIps].some(value => !value.trim() || value !== value.trim() || /[\u0000-\u001f\u007f-\u009f]/.test(value))) {
+            throw new Error('Every entry requires explicit resources and actions. Remove empty or malformed values.');
+        }
+        if (!['Allow', 'Deny'].includes(entry.decision)) throw new Error('Choose Allow or Deny for every entry.');
+        for (const resource of entry.resources) {
+            if (resources.has(resource)) throw new Error('A resource can appear only once within a policy type.');
+            resources.add(resource);
+        }
+    }
+    if (existing) {
+        const original = policyDraft(existing);
+        const before = original.entries.flatMap(entry => entry.resources).sort();
+        if (subject !== existing.subject || draft.policyType !== original.policyType || JSON.stringify(before) !== JSON.stringify([...resources].sort())) {
+            throw new Error('Retain the selected subject, policy type and resources. Use resource deletion to remove an entry.');
+        }
+    }
+    return { scope: { ...scope }, subject, policies: [structuredClone(draft)] };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/userDraft.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/userDraft.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from 'vitest';
+import { buildAclUserChange, newAclUserDraft } from './userDraft';
+
+const scope = { clusterName: 'cluster', brokerName: 'broker', brokerAddr: '127.0.0.1:10911' };
+const existing = { username: 'reader', userType: 'Normal', userStatus: 'Disable' };
+
+it('starts an existing-user edit without a password and preserves recognized Broker state', () => {
+    expect(newAclUserDraft(existing)).toEqual({ username: 'reader', password: '', userType: 'normal', userStatus: 'disable' });
+    expect(() => buildAclUserChange(scope, newAclUserDraft(existing), existing)).toThrow('new password');
+});
+
+it('does not convert unknown type or status into broader defaults', () => {
+    const user = { ...existing, userType: 'FutureType', userStatus: null };
+    const draft = { ...newAclUserDraft(user), password: 'test-only-value' };
+    expect(draft.userType).toBe(''); expect(draft.userStatus).toBe('');
+    expect(() => buildAclUserChange(scope, draft, user)).toThrow('explicit user type');
+    expect(() => buildAclUserChange(scope, { ...draft, userType: 'normal' }, user)).toThrow('explicit user status');
+});
+
+it('preserves the new password exactly, without trimming or storing a copy in the user model', () => {
+    const draft = { ...newAclUserDraft(existing), password: ' value with spaces ' };
+    expect(buildAclUserChange(scope, draft, existing).password).toBe(' value with spaces ');
+    expect(existing).not.toHaveProperty('password');
+});
+
+it('rejects username changes, control characters and disabled creation', () => {
+    const draft = { ...newAclUserDraft(existing), password: 'test-only-value' };
+    expect(() => buildAclUserChange(scope, { ...draft, username: 'other' }, existing)).toThrow('selected username');
+    expect(() => buildAclUserChange(scope, { ...draft, username: ' reader' }, null)).toThrow('whitespace');
+    expect(() => buildAclUserChange(scope, { ...draft, username: 'read\ner' }, null)).toThrow('control');
+    expect(() => buildAclUserChange(scope, draft, null)).toThrow('enabled');
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/userDraft.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/acl/userDraft.ts
@@ -1,0 +1,30 @@
+import type { AclScope, AclUser, AclUserChange } from './types';
+
+export interface AclUserDraft {
+    username: string;
+    password: string;
+    userType: AclUserChange['userType'] | '';
+    userStatus: NonNullable<AclUserChange['userStatus']> | '';
+}
+
+export function newAclUserDraft(user: AclUser | null): AclUserDraft {
+    if (!user) return { username: '', password: '', userType: 'normal', userStatus: 'enable' };
+    const type = user.userType?.toLowerCase();
+    const status = user.userStatus?.toLowerCase();
+    return { username: user.username, password: '', userType: type === 'normal' || type === 'super' ? type : '',
+        userStatus: status === 'enable' || status === 'disable' ? status : '' };
+}
+
+/** A missing Broker enum is not permission to silently replace it with a default. */
+export function buildAclUserChange(scope: AclScope, draft: AclUserDraft, existing: AclUser | null): AclUserChange {
+    if (!scope.clusterName.trim() || !scope.brokerName.trim() || !scope.brokerAddr.trim()) throw new Error('Select an explicit master Broker scope.');
+    if (!draft.username.trim() || draft.username !== draft.username.trim() || /[\u0000-\u001f\u007f-\u009f]/.test(draft.username)) {
+        throw new Error('Enter a username without surrounding whitespace or control characters.');
+    }
+    if (existing && existing.username !== draft.username) throw new Error('The update must retain the selected username.');
+    if (!draft.password.trim()) throw new Error('Enter a new password. The Broker API requires it for this change.');
+    if (!draft.userType || !['normal', 'super'].includes(draft.userType)) throw new Error('Choose an explicit user type; the current type was not recognized.');
+    if (!draft.userStatus || !['enable', 'disable'].includes(draft.userStatus)) throw new Error('Choose an explicit user status; the current status was not recognized.');
+    if (!existing && draft.userStatus !== 'enable') throw new Error('New ACL users are enabled. Change status after creation.');
+    return { scope: { ...scope }, username: draft.username, password: draft.password, userType: draft.userType, userStatus: draft.userStatus };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -87,7 +87,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       case 'DLQ':
         return 'Dead-letter messages';
       case 'ACL':
-        return 'ACL Management';
+        return 'Access control';
       case 'Audit':
         return 'Audit Events';
       case 'Sessions':


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10512

### Brief Description

Redesign Broker ACL administration around explicit Cluster/master scope, Users/Policies directories, selected details and reviewed changes. Keep passwords out of confirmations and retained receipts, preserve exact resource identities, and distinguish denied or unconfirmed writes from acknowledged changes whose read-back failed.

Extract scoped reads, drafts, operation ownership and receipt components. Forward tab-trigger refs so Manage policies moves keyboard focus correctly. Integrate the latest DLQ provider without replacing either feature's session-owned results.

### How Did You Test This Change?

- `npm run build` and the complete frontend test suite passed after the ref fix and integration with the current main branch.
- Headed external Chrome passed reference-size and 800 x 600 visual checks, user/policy CRUD, explicit unknown-enum validation, permission denial, read-back failure, mismatched receipt, password redaction, focus restoration, and pending writes across environment changes. No console warnings/errors or page errors.
- Three existing real local RocketMQ-Rust ACL tests passed for user CRUD, precise policy resource updates/deletion and correct/anonymous/wrong credentials.
- Native maximized read-only ACL layout was inspected. The final ref refinement awaits the integrated native rebuild; Windows DPI certification remains part of final dashboard acceptance. Existing Vite large-chunk warning is unchanged.
