### PR TITLE
[ISSUE #10514]✨Redesign read-only storage and collector diagnostics

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/STORAGE_DIAGNOSTICS_UI.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/STORAGE_DIAGNOSTICS_UI.md
@@ -1,0 +1,49 @@
+# Storage diagnostics UI
+
+Storage & diagnostics is a read-only view of the local SQLite database, storage
+activity, history collector and saved connection context. It does not establish
+Broker reachability or provide cleanup, vacuum, backup or restore operations.
+
+The environment toolbar refreshes the existing storage and history status reads.
+Each region retains its own last successful observation when another read fails.
+Failures and stale observations remain visible rather than being converted into
+zero measurements or current availability. Shared read ownership prevents an
+unmounted page's response from updating a replacement page.
+
+Allocated and reusable values describe database pages; they exclude WAL and
+filesystem overhead. Display units use decimal KB/MB/GB, with exact byte counts
+available on the measurement. Null capacity values mean not measured, including
+filesystem free space. The page does not derive a disk-usage percentage.
+
+Activity timestamps come from the backend. Rendering or refreshing diagnostics
+does not substitute the current time for the latest committed write. Null sample
+and write timestamps mean not observed. A status check at least one minute old
+is marked stale; an invalid or future observation time has unknown age.
+
+Collector intervals, retention, sample/write times and errors come from the
+collector status. No error being reported is not proof of a running sampler or
+healthy Brokers. The status DTO does not identify the sampled environment, so
+the view does not assign its activity to the currently selected NameServer.
+
+Connection context uses the current connection store and retains NameServer
+settings and Cluster navigation. Database availability, saved configuration and
+remote connectivity are separate observations.
+
+Frontend validation runs from the app directory:
+
+```text
+npm run build
+npm test -- --run src/pages/storage src/features/dashboard/readResource.test.ts src/app/layout/pageToolbar.test.ts src/stores/navigation.test.ts
+```
+
+Existing backend contract tests in `src-tauri/src/ops.rs` verify that reads and
+rolled-back writes do not advance committed-write activity, that missing
+databases are not created by a read, and that unavailable capacity stays unknown.
+
+```text
+cargo test --locked --lib ops::tests
+```
+
+Visual acceptance still requires comparison with the selected Storage reference,
+keyboard and narrow-window checks, and inspection of normal, unavailable, stale,
+unmeasured and collector-error states.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/navigation.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/navigation.ts
@@ -37,7 +37,7 @@ export const pageDescriptions: Record<Tab, string> = {
     MessageTrace: 'Follow message publication and consumption',
     DLQ: 'Review failures before replaying messages',
     ACL: 'Broker users and resource policies',
-    Storage: 'Local database information and collector diagnostics',
+    Storage: 'Local SQLite database information and diagnostics (read-only)',
     Monitors: 'Consumer group thresholds for this environment',
     Audit: 'Review actions and their recorded outcomes',
     Sessions: 'Manage your local dashboard sessions',

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/DiagnosticSection.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/DiagnosticSection.tsx
@@ -1,0 +1,10 @@
+import { useId, type ReactNode } from 'react';
+
+export function DiagnosticSection({ title, rows, note, children }: { title: string; rows?: Array<[string, ReactNode]>; note?: ReactNode; children?: ReactNode }) {
+    const id = useId();
+    return <section className="ops-storage-section" aria-labelledby={id}><h2 id={id}>{title}</h2>
+        {rows && <dl>{rows.map(([label, value]) => <div key={label}><dt>{label}</dt><dd>{value}</dd></div>)}</dl>}
+        {children}
+        {note && <div className="ops-storage-footnote">{note}</div>}
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/StoragePage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/StoragePage.tsx
@@ -1,69 +1,97 @@
-import React, { useEffect, useRef, useState, useSyncExternalStore } from 'react';
-import { StorageService, type StorageStatus } from '../../services/storage.service';
-import { HistoryService, type CollectorStatus } from '../../services/history.service';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import { ArrowRight, CircleCheck, CircleHelp, CircleX } from 'lucide-react';
+import { StorageService } from '../../services/storage.service';
+import { HistoryService } from '../../services/history.service';
 import { ConnectionStore } from '../../services/connection.store';
-import { dashboardErrorMessage } from '../../services/invoke';
+import { getConnectionSettings } from '../../services/connection.service';
+import { useReadResource } from '../../hooks/useReadResource';
+import { usePageRefresh } from '../../app/layout/pageToolbar';
 import { useAppStore } from '../../stores/app.store';
+import { Button } from '../../components/ui/LegacyButton';
+import { PageState } from '../../components/layout/PageState';
+import { DiagnosticSection } from './DiagnosticSection';
+import { diagnosticBytes, diagnosticCount, diagnosticTime, observationAge } from './storageModel';
+import './storage.css';
 
-const time = (value: number | null) => value === null ? 'Not observed' : new Date(value).toLocaleString();
-const bytes = (value: number | null) => value === null ? 'Unknown / unavailable' : `${value.toLocaleString()} bytes`;
+function Bytes({ value }: { value: number | null }) {
+    const measurement = diagnosticBytes(value);
+    return <span title={measurement.exact}>{measurement.display}</span>;
+}
 
 export const StoragePage = () => {
-    const [status, setStatus] = useState<StorageStatus | null>(null);
-    const [collector, setCollector] = useState<CollectorStatus | null>(null);
-    const [error, setError] = useState('');
-    const [collectorError, setCollectorError] = useState('');
-    const [busy, setBusy] = useState(false);
-    const [now, setNow] = useState(Date.now());
-    const generation = useRef(0);
+    const storage = useReadResource(StorageService.status, 'Storage status could not be read.');
+    const history = useReadResource(HistoryService.status, 'History collector status could not be read.');
     const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
+    const connection = useReadResource(settings ? null : getConnectionSettings, 'Connection settings could not be read.');
     const { setActiveTab } = useAppStore();
-    const refresh = async () => {
-        const current = ++generation.current;
-        setBusy(true); setError(''); setCollectorError('');
-        const [storage, history] = await Promise.allSettled([StorageService.status(), HistoryService.status()]);
-        if (current !== generation.current) return;
-        if (storage.status === 'fulfilled') setStatus(storage.value);
-        else setError(dashboardErrorMessage(storage.reason, 'Storage status could not be read.'));
-        if (history.status === 'fulfilled') setCollector(history.value);
-        else setCollectorError(dashboardErrorMessage(history.reason, 'Collector status could not be read.'));
-        setNow(Date.now()); setBusy(false);
-    };
+    const [, updateClock] = useState(0);
+    const now = Date.now();
+    const [refreshedAt, setRefreshedAt] = useState<number | null>(null);
+    const refresh = useCallback(() => { void storage.read(); void history.read(); if (!settings) void connection.read(); }, [storage.read, history.read, connection.read, settings]);
     useEffect(() => {
-        void refresh();
-        const timer = window.setInterval(() => setNow(Date.now()), 15_000);
-        return () => { generation.current++; window.clearInterval(timer); };
+        const timer = window.setInterval(() => updateClock(value => value + 1), 15_000);
+        return () => window.clearInterval(timer);
     }, []);
-    const stale = status && (Boolean(error) || now - status.checkedAtMs >= 60_000);
-    return <section className="p-6 space-y-5">
-        <div className="flex justify-between"><h2 className="text-xl font-semibold">Storage and diagnostics</h2><button disabled={busy} onClick={() => void refresh()}>{busy ? 'Checking…' : 'Refresh / retry'}</button></div>
-        {error && <p role="alert" className="text-red-600">{error}</p>}
-        {stale && <p role="status" className="text-amber-600">This is an older snapshot. Refresh before relying on these values.</p>}
-        {status && <div className="rounded border p-4 space-y-2">
-            <h3 className="font-semibold">Local database: {status.available ? 'Available' : 'Unavailable'}</h3>
-            {status.error && <p role="alert" className="text-red-600">{status.error}</p>}
-            <dl className="grid grid-cols-2 gap-2 text-sm">
-                <dt>Backend / mode</dt><dd>{status.backend} / {status.mode}</dd>
-                <dt>Schema version</dt><dd>{status.schemaVersion ?? 'Unknown'}</dd>
-                <dt>Observation started</dt><dd>{time(status.observedSinceMs)}</dd>
-                <dt>Last check</dt><dd>{time(status.checkedAtMs)}</dd>
-                <dt>Latest committed write</dt><dd>{time(status.lastWriteMs)}</dd>
-                <dt>Allocated database pages</dt><dd>{bytes(status.databaseBytes)}</dd>
-                <dt>Reusable database pages</dt><dd>{bytes(status.reusableBytes)}</dd>
-                <dt>Filesystem free space</dt><dd>{bytes(status.diskFreeBytes)}</dd>
-            </dl>
-            <p className="text-sm text-gray-500">Page sizes describe the SQLite database, excluding WAL and filesystem overhead. Free disk space is not measured. Refreshing diagnostics does not create a write.</p>
-        </div>}
-        <div className="rounded border p-4 space-y-2">
-            <h3 className="font-semibold">History collector</h3>
-            {collectorError && <p role="alert" className="text-red-600">{collectorError}{collector ? ' Previously loaded values are shown below.' : ''}</p>}
-            {collector && <><p>Interval {collector.intervalSeconds}s · Retention {collector.retentionDays} days</p><p>Last sample: {time(collector.lastSampleMs)} · Last write: {time(collector.lastWriteMs)}</p>{collector.lastError && <p className="text-amber-600">{collector.lastError}</p>}</>}
-        </div>
-        <div className="rounded border p-4 space-y-2">
-            <h3 className="font-semibold">Connection configuration</h3>
-            <p>{settings?.environmentId ? `Environment selected · configuration revision ${settings.revision}` : 'No NameServer environment selected'}</p>
-            <p className="text-sm text-gray-500">Database availability and saved connection settings do not establish Broker reachability. Use Dashboard or Cluster to query the cluster.</p>
-            <div className="flex gap-4"><button onClick={() => setActiveTab('NameServer')}>NameServer settings</button><button onClick={() => setActiveTab('Cluster')}>Query Cluster</button></div>
-        </div>
-    </section>;
+    useEffect(() => {
+        if (!storage.pending && !history.pending && !storage.error && !history.error && storage.receivedAt !== null && history.receivedAt !== null) {
+            setRefreshedAt(Math.min(storage.receivedAt, history.receivedAt));
+        }
+    }, [storage.pending, history.pending, storage.error, history.error, storage.receivedAt, history.receivedAt]);
+    usePageRefresh({ refresh, pending: storage.pending || history.pending || connection.pending, refreshedAt });
+    const status = storage.data;
+    const collector = history.data;
+    const age = observationAge(status?.checkedAtMs, now);
+    const previous = Boolean(storage.error || age !== 'current');
+    const available = status?.available === true;
+    const HealthIcon = previous ? CircleHelp : available ? CircleCheck : CircleX;
+    const endpoint = settings?.endpoints.find(endpoint => endpoint.endpointId === settings.currentNameserverId && endpoint.kind === 'name_server')?.address ?? settings?.nameserver.currentNamesrv;
+    const collectorAge = observationAge(history.receivedAt, now);
+    return <div className="ops-storage">
+        {storage.pending && <PageState kind="loading" title={status ? 'Refreshing local diagnostics' : 'Reading local diagnostics'} />}
+        {storage.error && <PageState kind="error" title="Storage diagnostics could not be refreshed" description={storage.error + (status ? ' The last successful observation is retained.' : '')}
+            action={<Button variant="outline" disabled={storage.pending} onClick={() => { void storage.read(); }}>Retry storage</Button>} />}
+        {status && <>
+            <section className="ops-storage-health" data-tone={previous ? 'warning' : !available ? 'danger' : status.error ? 'warning' : 'success'} aria-label="Local database availability">
+                <HealthIcon aria-hidden="true" /><div><h2>{previous ? available ? 'Local database available at last check' : 'Local database unavailable at last check' : available ? 'Local database available' : 'Local database unavailable'}</h2>
+                    <p>{status.backend === 'sqlite' ? 'SQLite' : status.backend || 'Unknown backend'} / {status.mode === 'singleNode' ? 'Single node' : status.mode || 'Unknown mode'} · Schema version {diagnosticCount(status.schemaVersion)}</p>
+                </div>
+            </section>
+            {status.error && <PageState kind="error" title="Local database check reported an error" description={status.error} />}
+            {age === 'stale' && <PageState kind="stale" title="Older storage observation" description="This check is at least one minute old. Refresh before relying on these values." />}
+            {age === 'unknown' && <PageState kind="partial" title="Observation age is unknown" description="The reported check time is unavailable or ahead of the local clock." />}
+            <DiagnosticSection title="Storage" rows={[
+                ['Allocated database pages', <Bytes value={status.databaseBytes} />],
+                ['Reusable pages', <Bytes value={status.reusableBytes} />],
+                ['Filesystem free space', <Bytes value={status.diskFreeBytes} />],
+            ]} note="Page allocation excludes WAL and filesystem overhead. An unmeasured value is not a zero or a disk-usage percentage." />
+            <DiagnosticSection title="Activity" rows={[
+                ['Observed since', diagnosticTime(status.observedSinceMs)], ['Last check', diagnosticTime(status.checkedAtMs)],
+                ['Latest committed write', diagnosticTime(status.lastWriteMs)],
+            ]} note="Refreshing diagnostics does not create a write. The committed-write time comes from local storage activity." />
+        </>}
+        <DiagnosticSection title="History collector" rows={collector ? [
+            ['Interval', diagnosticCount(collector.intervalSeconds, 's')], ['Retention', diagnosticCount(collector.retentionDays, 'days')],
+            ['Last sample', diagnosticTime(collector.lastSampleMs)], ['Last write', diagnosticTime(collector.lastWriteMs)],
+        ] : undefined} note={<>
+            {collector && !history.error && !collector.lastError && (collector.lastSampleMs === null ? 'No sample observed yet. ' : 'No collector error reported. ')}
+            These are local collector observations. The status does not identify the sampled environment.
+        </>}>
+            {history.pending && <PageState kind="loading" title="Reading collector status" />}
+            {history.error && <PageState kind="error" title="Collector status could not be refreshed" description={history.error + (collector ? ' Previously observed values remain above.' : '')}
+                action={<Button variant="outline" disabled={history.pending} onClick={() => { void history.read(); }}>Retry collector</Button>} />}
+            {collector?.lastError && <PageState kind="partial" title="History collection reported an error" description={collector.lastError} />}
+            {collector && collectorAge === 'stale' && <PageState kind="stale" title="Older collector observation" description="Refresh to read the current collector status." />}
+        </DiagnosticSection>
+        <DiagnosticSection title="Connection context" rows={settings ? [
+            ['Environment', <span className="ops-storage-value" tabIndex={(settings.environmentId?.length ?? 0) > 160 ? 0 : undefined}>{settings.environmentId ?? 'No environment selected'}</span>],
+            ['NameServer', <span className="ops-storage-value ops-storage-address" tabIndex={(endpoint?.length ?? 0) > 160 ? 0 : undefined}>{endpoint || 'Not configured'}</span>],
+            ['Configuration revision', diagnosticCount(settings.revision)],
+        ] : undefined} note={<>
+            Database availability and saved connection settings do not establish Broker reachability.
+            <div className="ops-storage-actions"><Button variant="ghost" icon={ArrowRight} onClick={() => setActiveTab('NameServer')}>NameServer settings</Button><Button variant="ghost" icon={ArrowRight} onClick={() => setActiveTab('Cluster')}>Open cluster</Button></div>
+        </>}>
+            {connection.pending && <PageState kind="loading" title="Reading connection context" />}
+            {connection.error && <PageState kind="error" title="Connection context unavailable" description={connection.error} action={<Button variant="outline" onClick={() => { void connection.read(); }}>Retry connection</Button>} />}
+        </DiagnosticSection>
+    </div>;
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/storage.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/storage.css
@@ -1,0 +1,24 @@
+.ops-storage { display: grid; gap: 12px; min-width: 0; }
+.ops-storage-health { display: flex; align-items: center; gap: 16px; padding: 12px 20px; border: 1px solid var(--ops-border); border-radius: 12px; background: var(--ops-panel); }
+.ops-storage-health > svg { width: 28px; height: 28px; flex-shrink: 0; color: var(--ops-muted); }
+.ops-storage-health[data-tone="success"] > svg { color: var(--ops-success); }
+.ops-storage-health[data-tone="danger"] > svg { color: var(--ops-danger); }
+.ops-storage-health[data-tone="warning"] > svg { color: var(--ops-warning); }
+.ops-storage-health > div { min-width: 0; }
+.ops-storage-health h2 { margin: 0; color: var(--ops-text); font-size: 20px; line-height: 1.4; font-weight: 600; }
+.ops-storage-health p { margin: 3px 0 0; color: var(--ops-muted); font-size: 14px; line-height: 1.5; overflow-wrap: anywhere; }
+.ops-storage-section { min-width: 0; border: 1px solid var(--ops-border); border-radius: 12px; background: var(--ops-panel); overflow: hidden; }
+.ops-storage-section h2 { margin: 0; padding: 10px 18px 8px; border-bottom: 1px solid var(--ops-border); font-size: 18px; line-height: 1.4; font-weight: 600; color: var(--ops-text); }
+.ops-storage-section dl { margin: 0; font-size: 14px; line-height: 1.5; }
+.ops-storage-section dl > div { display: grid; grid-template-columns: minmax(180px, 36%) minmax(0, 1fr); gap: 18px; padding: 4px 18px; border-bottom: 1px solid var(--ops-border); }
+.ops-storage-section dl > div:last-child { border-bottom: 0; }
+.ops-storage-section dt { min-width: 0; color: var(--ops-muted); overflow-wrap: anywhere; }
+.ops-storage-section dd { min-width: 0; margin: 0; color: var(--ops-text); font-variant-numeric: tabular-nums; overflow-wrap: anywhere; }
+.ops-storage-value { display: block; max-height: 100px; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; }
+.ops-storage-address { font-family: var(--ops-font-mono); font-size: 13px; }
+.ops-storage-footnote { padding: 8px 18px; border-top: 1px solid var(--ops-border); color: var(--ops-muted); font-size: 12px; line-height: 1.6; }
+.ops-storage-actions { display: flex; flex-wrap: wrap; gap: 8px 24px; margin-top: 8px; }
+.ops-storage-actions .ops-button { color: var(--ops-accent-strong); padding-inline: 0; }
+.ops-storage-section > .ops-page-state { margin: 12px 16px; }
+@media (max-width: 700px) { .ops-storage-section dl > div { grid-template-columns: minmax(130px, 42%) minmax(0, 1fr); gap: 12px; } .ops-storage-health { align-items: start; } }
+@media (max-width: 450px) { .ops-storage-section dl > div { grid-template-columns: minmax(0, 1fr); gap: 3px; padding-block: 10px; } }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/storageModel.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/storageModel.test.ts
@@ -1,0 +1,25 @@
+import { expect, it } from 'vitest';
+import { diagnosticBytes, diagnosticTime, observationAge } from './storageModel';
+
+it('keeps unmeasured storage distinct from a measured zero and preserves exact byte counts', () => {
+    expect(diagnosticBytes(null).display).toBe('Not measured');
+    expect(diagnosticBytes(0).display).toBe('0 bytes');
+    const bytes = diagnosticBytes(8_400_000);
+    expect(bytes.display).toContain('MB');
+    expect(bytes.exact).toBe(`${(8_400_000).toLocaleString()} bytes`);
+    for (const value of [-1, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1]) expect(diagnosticBytes(value).display).toBe('Unknown / unavailable');
+});
+
+it('does not turn absent or invalid timestamps into the current time', () => {
+    expect(diagnosticTime(null)).toBe('Not observed');
+    expect(diagnosticTime(Number.NaN)).toBe('Unknown / unavailable');
+    expect(diagnosticTime(Number.MAX_VALUE)).toBe('Unknown / unavailable');
+    expect(diagnosticTime(0)).toBe(new Date(0).toLocaleString());
+});
+
+it('identifies stale and future observations without assuming a fresh check from local rendering', () => {
+    expect(observationAge(100_000, 159_999)).toBe('current');
+    expect(observationAge(100_000, 160_000)).toBe('stale');
+    expect(observationAge(200_000, 100_000)).toBe('unknown');
+    expect(observationAge(null, 100_000)).toBe('unknown');
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/storageModel.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/storage/storageModel.ts
@@ -1,0 +1,22 @@
+const units = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+const number = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
+
+export function diagnosticBytes(value: number | null | undefined): { display: string; exact: string | undefined } {
+    if (value == null) return { display: 'Not measured', exact: undefined };
+    if (!Number.isSafeInteger(value) || value < 0) return { display: 'Unknown / unavailable', exact: undefined };
+    const unit = value === 0 ? 0 : Math.min(Math.floor(Math.log10(value) / 3), units.length - 1);
+    return { display: `${number.format(value / 1000 ** unit)} ${units[unit]}`, exact: `${value.toLocaleString()} bytes` };
+}
+
+export function diagnosticTime(value: number | null | undefined): string {
+    if (value == null) return 'Not observed';
+    const date = new Date(value);
+    return Number.isFinite(value) && Number.isFinite(date.getTime()) ? date.toLocaleString() : 'Unknown / unavailable';
+}
+
+export function observationAge(checkedAt: number | null | undefined, now: number): 'current' | 'stale' | 'unknown' {
+    if (checkedAt == null || !Number.isFinite(checkedAt) || !Number.isFinite(now) || checkedAt > now) return 'unknown';
+    return now - checkedAt >= 60_000 ? 'stale' : 'current';
+}
+
+export const diagnosticCount = (value: number | null | undefined, unit = '') => value != null && Number.isSafeInteger(value) && value >= 0 ? `${value.toLocaleString()}${unit ? ` ${unit}` : ''}` : 'Unknown / unavailable';

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -88,6 +88,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         return 'Dead-letter messages';
       case 'ACL':
         return 'Access control';
+      case 'Storage':
+        return 'Storage & diagnostics';
       case 'Audit':
         return 'Audit Events';
       case 'Sessions':


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10514

### Brief Description

Rebuild Storage as a compact read-only diagnostic page covering local SQLite health, page allocation, write activity, collector observations and connection context. Preserve previous observations on failure, label stale or unmeasured data accurately, and keep refresh time independent from committed-write time.

Extract diagnostic rendering and format helpers, provide responsive long-value scrolling, and connect the shared refresh and navigation controls.

### How Did You Test This Change?

- `npm run build`: passed after integration with main.
- 20 focused storage, navigation, read ownership and toolbar tests passed.
- Two existing backend storage-contract tests passed during implementation.
- Headed external Chrome: source comparison at 1487 x 1058, 800 x 600 long context, unavailable/stale/failed observations, collector failures/no samples, read-only request log, pending refresh and route recovery; no console/page errors.
- Native app: actual SQLite refresh values and distinct timestamps, small-window actions, maximum-window layout and Storage-to-Cluster navigation. Whole-product Windows DPI remains part of final acceptance. Existing Vite large-chunk warning is unchanged.
