### PR TITLE
[ISSUE #10516]✨Redesign version-aware consumer monitor rules

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/MONITOR_RULES_UI.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/MONITOR_RULES_UI.md
@@ -1,0 +1,25 @@
+# Consumer monitor rules
+
+The Monitors page edits local threshold configuration for the selected NameServer environment. It does not evaluate alerts or send notifications. The table reports consumer group, minimum online clients, maximum total lag, rule revision and last update time from the stored records.
+
+## Editing and conflicts
+
+Open one inline editor at a time. Cancel closes it before another rule is selected. Group names are immutable for existing rules. Thresholds accept whole numbers from zero through JavaScript's maximum safe integer; empty, fractional, exponential and out-of-range input is rejected. Group names use the backend's 255-byte UTF-8 limit and exclude whitespace and control characters.
+
+Save sends the displayed expected rule revision. A version conflict retains the entered group, thresholds and old revision. The page invalidates any read started before the write, then reloads the current environment. Reviewing a successfully loaded current rule explicitly adopts its revision while keeping the entered thresholds. When the group has been deleted, the review action prepares a new rule with revision zero. Neither refresh nor review submits a write.
+
+Delete requires a dialog showing the original environment, group and expected rule revision. It removes the saved rule only. The consumer group and messages are unaffected.
+
+## Request ownership and outcomes
+
+The signed-in session owns accepted mutations and the latest result. Leaving the route or changing the connection cannot relabel a receipt as belonging to another environment. Stale targets are rejected before dispatch; the existing authenticated command and backend mutation lease enforce the connection revision.
+
+Only the documented local commit receipt is shown as committed. Conflicts are explicit; missing or failed acknowledgements remain unconfirmed and require reading the original environment before another attempt. Requests never retry automatically. Signing out clears the session's retained result.
+
+Each mounted environment owns its list and observation time. Failed refreshes preserve the previous observation and disable editing until a current read succeeds. A completed write invalidates earlier list requests before refreshing. Drafts saved in navigation history are scoped by environment and connection revision.
+
+## Validation
+
+Run the frontend build and the focused monitor model/action tests, plus the existing read-resource, page-toolbar and navigation suites. Native storage coverage lives in `monitor::repository::tests::monitor_rules_reopen_isolate_compare_and_swap_and_audit_atomically`.
+
+Chrome visual comparison, keyboard/focus checks, narrow-window layouts and real Tauri CRUD/conflict checks are separate acceptance evidence. Passing model tests does not establish those results.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -23,6 +23,7 @@ import {DlqActionProvider} from '../../features/dlq/components/DlqActionProvider
 import {Activity} from 'lucide-react';
 import {StoragePage} from '../../pages/storage/StoragePage';
 import {MonitorPage} from '../../pages/monitor/MonitorPage';
+import {MonitorActionProvider} from '../../pages/monitor/MonitorActionProvider';
 import {AuditPage} from '../../pages/audit/AuditPage';
 import {SessionsPanel} from '../../pages/account/SessionsPanel';
 import {AccountPage} from '../../pages/account/AccountPage';
@@ -31,7 +32,7 @@ export const AppRouter = () => {
     const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
     const { activeTab, navigation, sessionId } = useAppStore();
     const key = ['NameServer', 'Proxy', 'Account', 'Sessions', 'Audit'].includes(activeTab) ? activeTab : `${activeTab}:${settings?.revision ?? 0}`;
-    return <BrokerConfigEditorProvider key={sessionId}><TopicActionProvider><ConsumerActionProvider><MessageActionProvider><DlqActionProvider><AclActionProvider><RouteContent key={`${key}:${navigation.id}`} /></AclActionProvider></DlqActionProvider></MessageActionProvider></ConsumerActionProvider></TopicActionProvider></BrokerConfigEditorProvider>;
+    return <BrokerConfigEditorProvider key={sessionId}><TopicActionProvider><ConsumerActionProvider><MessageActionProvider><DlqActionProvider><AclActionProvider><MonitorActionProvider><RouteContent key={`${key}:${navigation.id}`} /></MonitorActionProvider></AclActionProvider></DlqActionProvider></MessageActionProvider></ConsumerActionProvider></TopicActionProvider></BrokerConfigEditorProvider>;
 };
 
 const RouteContent = () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorActionProvider.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorActionProvider.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, useLayoutEffect, useMemo, useSyncExternalStore, type ReactNode } from 'react';
+import { MonitorService } from '../../services/monitor.service';
+import { ConnectionStore } from '../../services/connection.store';
+import { createMonitorActions } from './monitorActions';
+
+const Context = createContext<ReturnType<typeof createMonitorActions> | null>(null);
+export function MonitorActionProvider({ children }: { children: ReactNode }) {
+    const controller = useMemo(() => createMonitorActions(() => {
+        const settings = ConnectionStore.getSnapshot();
+        return settings?.environmentId ? { revision: settings.revision, environmentId: settings.environmentId } : null;
+    }, target => target.kind === 'save'
+        ? MonitorService.save(target.request)
+        : MonitorService.delete({ consumerGroup: target.request.consumerGroup, revision: target.request.expectedRevision })), []);
+    useLayoutEffect(() => { controller.start(); return controller.stop; }, [controller]);
+    return <Context.Provider value={controller}>{children}</Context.Provider>;
+}
+export function useMonitorActions() {
+    const controller = useContext(Context);
+    if (!controller) throw new Error('MonitorActionProvider is required.');
+    const state = useSyncExternalStore(controller.subscribe, controller.getSnapshot, controller.getSnapshot);
+    return { ...state, submit: controller.submit };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorDeleteDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorDeleteDialog.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { Button } from '../../components/ui/LegacyButton';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../../components/ui/dialog';
+import { PageState } from '../../components/layout/PageState';
+import { MonitorTargetDetails } from './MonitorResult';
+import type { MonitorTarget } from './monitorModel';
+
+export function MonitorDeleteDialog({ target, pending, current, close, submit }: {
+    target: MonitorTarget; pending: boolean; current: boolean; close: () => void; submit: () => Promise<void>;
+}) {
+    const [attempted, setAttempted] = useState(false);
+    return <Dialog open onOpenChange={open => { if (!open && !pending) close(); }}>
+        <DialogContent className="ops-monitor-delete-dialog" showCloseButton={!pending}
+            onEscapeKeyDown={event => { if (pending) event.preventDefault(); }}
+            onInteractOutside={event => { if (pending) event.preventDefault(); }}>
+            <DialogHeader><DialogTitle>Delete consumer monitor rule</DialogTitle><DialogDescription>This removes the saved thresholds for the exact group and version shown below.</DialogDescription></DialogHeader>
+            <MonitorTargetDetails target={target} />
+            {!current && <PageState kind="stale" title="The target changed" description="Close this dialog, refresh and review the current rule before deletion." />}
+            <p className="ops-monitor-note">The consumer group and its messages are unaffected. The deletion submits once.</p>
+            <DialogFooter><Button variant="outline" disabled={pending} onClick={close}>Cancel</Button>
+                <Button variant="danger" disabled={pending || !current || attempted} onClick={() => { setAttempted(true); void submit(); }}>{pending ? 'Deleting…' : 'Confirm deletion'}</Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorEditor.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorEditor.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+import { Info } from 'lucide-react';
+import { Button } from '../../components/ui/LegacyButton';
+import { Input } from '../../components/ui/LegacyInput';
+import { PageState } from '../../components/layout/PageState';
+import type { MonitorRule } from '../../services/monitor.service';
+import { monitorDraftError, reviewMonitorDraft, type MonitorDraft } from './monitorModel';
+
+export const monitorNotice = 'Rules are saved locally for this environment. Alert evaluation and notifications are not enabled.';
+
+export function MonitorEditor({ draft, current, ready, pending, onChange, onSave, onDelete, onCancel }: {
+    draft: MonitorDraft; current: MonitorRule | null; ready: boolean; pending: boolean;
+    onChange: (draft: MonitorDraft) => void; onSave: () => void; onDelete: () => void; onCancel: () => void;
+}) {
+    const firstInput = useRef<HTMLInputElement>(null);
+    const [showErrors, setShowErrors] = useState(false);
+    useEffect(() => { firstInput.current?.focus(); }, [draft.id]);
+    const error = monitorDraftError(draft);
+    const changed = ready && (draft.expectedRevision === 0 ? current !== null : current?.revision !== draft.expectedRevision);
+    const needsReview = draft.needsReview || changed;
+    const disabled = pending || !ready;
+    return <section className="ops-monitor-editor" aria-labelledby="monitor-editor-heading">
+        <h2 id="monitor-editor-heading">{draft.expectedRevision === 0 ? 'New consumer monitor rule' : 'Edit consumer monitor rule'}</h2>
+        <p className="ops-monitor-note">Update the threshold configuration for the selected consumer group.</p>
+        <form noValidate onSubmit={event => { event.preventDefault(); setShowErrors(true); if (!error && !disabled && !needsReview) onSave(); }}>
+            <div className="ops-monitor-fields">
+                <Input ref={firstInput} label="Consumer group" required maxLength={255} readOnly={draft.expectedRevision !== 0 || needsReview} disabled={pending}
+                    value={draft.consumerGroup} onChange={event => onChange({ ...draft, consumerGroup: event.target.value })} />
+                <Input label="Minimum online clients" type="number" min="0" max={Number.MAX_SAFE_INTEGER} step="1" required disabled={pending}
+                    value={draft.minCount} onChange={event => onChange({ ...draft, minCount: event.target.value })} />
+                <Input label="Maximum lag" type="number" min="0" max={Number.MAX_SAFE_INTEGER} step="1" required disabled={pending}
+                    value={draft.maxDiffTotal} onChange={event => onChange({ ...draft, maxDiffTotal: event.target.value })} />
+                <Input label="Revision" readOnly value={draft.expectedRevision === 0 ? 'New rule (0)' : draft.expectedRevision} />
+            </div>
+            {showErrors && error && <PageState kind="error" title="Check the rule values" description={error} />}
+            {needsReview && <div className="ops-monitor-review" role="status">
+                <h3>Review the current rule before saving</h3>
+                <p>Your entered thresholds are retained. Refreshing the list does not change this draft or resubmit it.</p>
+                {ready ? <>
+                    <p>{current ? `Current stored rule: minimum ${current.minCount}, maximum lag ${current.maxDiffTotal}, revision ${current.revision}.` : 'No rule currently exists for this group.'}</p>
+                    <Button variant="outline" disabled={pending} onClick={() => onChange(reviewMonitorDraft(draft, current))}>
+                        {current ? `Keep my values and review against revision ${current.revision}` : 'Review my values as a new rule'}
+                    </Button>
+                </> : <p>Refresh must complete successfully before a new revision can be selected.</p>}
+            </div>}
+            <div className="ops-monitor-editor-actions">
+                <Button type="submit" disabled={disabled || needsReview}>{pending ? 'Applying…' : 'Save changes'}</Button>
+                <Button variant="outline" disabled={pending} onClick={onCancel}>Cancel</Button>
+                {draft.expectedRevision > 0 && <span className="ops-monitor-danger-action"><Button variant="danger" disabled={disabled || needsReview} onClick={onDelete}>Delete rule</Button></span>}
+            </div>
+        </form>
+        <p className="ops-monitor-notice"><Info aria-hidden="true" size={18} />{monitorNotice}</p>
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorPage.tsx
@@ -1,87 +1,103 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { MonitorService, type MonitorRule, type SaveMonitorRule } from '../../services/monitor.service';
-import { dashboardErrorMessage, isDashboardClientError } from '../../services/invoke';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { Plus, Info } from 'lucide-react';
+import { ConnectionStore } from '../../services/connection.store';
+import { getConnectionSettings } from '../../services/connection.service';
+import { useReadResource } from '../../hooks/useReadResource';
+import { useNavigationState } from '../../stores/app.store';
+import { usePageRefresh } from '../../app/layout/pageToolbar';
+import { Button } from '../../components/ui/LegacyButton';
+import { Input } from '../../components/ui/LegacyInput';
+import { PageState } from '../../components/layout/PageState';
+import { useMonitorActions } from './MonitorActionProvider';
+import { useMonitorRules } from './useMonitorRules';
+import { MonitorEditor, monitorNotice } from './MonitorEditor';
+import { MonitorResult } from './MonitorResult';
+import { MonitorDeleteDialog } from './MonitorDeleteDialog';
+import { applyMonitorReceipt, monitorContextMatches, monitorDraft, monitorSaveRequest, type MonitorContext, type MonitorDraft, type MonitorTarget } from './monitorModel';
+import './monitor.css';
 
-const emptyDraft = (): SaveMonitorRule => ({ consumerGroup: '', minCount: 0, maxDiffTotal: 0, expectedRevision: 0 });
-
-export const MonitorPage = () => {
-    const [rules, setRules] = useState<MonitorRule[]>([]);
-    const [filter, setFilter] = useState('');
-    const [draft, setDraft] = useState<SaveMonitorRule | null>(null);
-    const [deleting, setDeleting] = useState<MonitorRule | null>(null);
-    const [busy, setBusy] = useState(false);
+function MonitorWorkspace({ context }: { context: MonitorContext }) {
+    const rules = useMonitorRules(context);
+    const actions = useMonitorActions();
+    const [filter, setFilter] = useNavigationState('monitorFilter', '');
+    // Revision-scoped drafts cannot be restored under a different connection configuration.
+    const [draft, setDraft] = useNavigationState<MonitorDraft | null>(`monitorDraft:${context.environmentId}:${context.revision}`, null);
+    const [deleting, setDeleting] = useState<MonitorTarget | null>(null);
     const [error, setError] = useState('');
-    const [notice, setNotice] = useState('');
+    const appliedReceipt = useRef<string | null>(null);
     const alive = useRef(true);
-    const generation = useRef(0);
-    const refresh = async () => {
-        const request = ++generation.current;
-        setBusy(true);
+    const newButton = useRef<HTMLButtonElement>(null);
+    useEffect(() => { alive.current = true; return () => { alive.current = false; }; }, []);
+    useEffect(() => {
+        const receipt = actions.receipt;
+        if (!receipt || appliedReceipt.current === receipt.target.id || !monitorContextMatches(context, receipt.target.context)) return;
+        appliedReceipt.current = receipt.target.id;
+        setDraft(previous => applyMonitorReceipt(previous, receipt, context));
+        // Invalidate the read started before the write; never reuse its stale in-flight result.
+        void rules.afterWrite();
+    }, [actions.receipt, context.environmentId, context.revision, rules.afterWrite]);
+    usePageRefresh({ refresh: rules.refresh, pending: rules.pending || Boolean(actions.pending), refreshedAt: rules.receivedAt });
+    const busy = Boolean(actions.pending);
+    const current = rules.data?.find(rule => rule.consumerGroup === draft?.consumerGroup) ?? null;
+    const filtered = (rules.data ?? []).filter(rule => rule.consumerGroup.toLowerCase().includes(filter.toLowerCase()));
+    const closeEditor = () => { setDraft(null); setError(''); newButton.current?.focus(); };
+    const submit = async (target: MonitorTarget) => {
+        if (busy || !rules.ready || !monitorContextMatches(context, ConnectionStore.getSnapshot())) return;
         setError('');
         try {
-            const current = await MonitorService.list();
-            if (alive.current && request === generation.current) setRules(current);
+            setDraft(previous => previous?.id === target.draftId ? { ...previous, lastAttemptId: target.id } : previous);
+            await actions.submit(target);
         } catch (failure) {
-            if (alive.current && request === generation.current) setError(dashboardErrorMessage(failure, 'Rules could not be loaded.'));
+            if (alive.current) setError(failure instanceof Error ? failure.message : 'The rule operation could not be started.');
         } finally {
-            if (alive.current && request === generation.current) setBusy(false);
+            if (alive.current) setDeleting(null);
         }
     };
-    useEffect(() => { alive.current = true; void refresh(); return () => { alive.current = false; generation.current++; }; }, []);
+    const save = () => {
+        if (!draft) return;
+        try {
+            const request = monitorSaveRequest(draft);
+            void submit({ kind: 'save', id: crypto.randomUUID(), draftId: draft.id, context, request });
+        } catch (failure) { setError(failure instanceof Error ? failure.message : 'Check the rule values.'); }
+    };
+    const deletionCurrent = deleting && rules.ready && monitorContextMatches(deleting.context, ConnectionStore.getSnapshot()) &&
+        rules.data?.some(rule => rule.consumerGroup === deleting.request.consumerGroup && rule.revision === deleting.request.expectedRevision);
+    return <div className="ops-monitors">
+        <section className="ops-monitor-controls" aria-label="Monitor rule filters">
+            <div className="ops-monitor-environment"><small>Environment</small><strong tabIndex={0}>{context.environmentId}</strong></div>
+            <Input aria-label="Search consumer group" type="search" placeholder="Search consumer group…" value={filter} onChange={event => setFilter(event.target.value)} />
+            <Button ref={newButton} icon={Plus} disabled={!rules.ready || busy || Boolean(draft)} onClick={() => { setDraft(monitorDraft(null)); setError(''); }}>New rule</Button>
+        </section>
+        {actions.pending && <PageState kind="loading" title="Applying monitor rule change" description={`Target: ${actions.pending.request.consumerGroup} · Environment: ${actions.pending.context.environmentId}. The request will not retry automatically.`} />}
+        {error && <PageState kind="error" title="Rule change could not start" description={error} />}
+        {rules.pending && !rules.data && <PageState kind="loading" title="Loading monitor rules" />}
+        {rules.error && <PageState kind="error" title={rules.data ? 'Rule refresh failed; previous observation retained' : 'Rules could not be loaded'} description={rules.error}
+            action={<Button variant="outline" disabled={busy || rules.pending} onClick={() => { void rules.refresh(); }}>Retry rule list</Button>} />}
+        {rules.data && <div className="ops-monitor-table-wrap" tabIndex={0} role="region" aria-label="Consumer monitor rules" aria-busy={rules.pending}>
+            <table className="ops-monitor-table"><thead><tr><th scope="col">Consumer group</th><th scope="col">Minimum online clients</th><th scope="col">Maximum lag</th><th scope="col">Revision</th><th scope="col">Updated</th><th scope="col">Actions</th></tr></thead>
+                <tbody>{filtered.map(rule => <tr key={rule.consumerGroup} data-selected={draft?.consumerGroup === rule.consumerGroup}>
+                    <td><div className="ops-monitor-group" tabIndex={0}>{rule.consumerGroup}</div></td><td>{rule.minCount}</td><td>{rule.maxDiffTotal}</td><td>{rule.revision}</td>
+                    <td>{Number.isFinite(rule.updatedAtMs) && !Number.isNaN(new Date(rule.updatedAtMs).getTime()) ? <time dateTime={new Date(rule.updatedAtMs).toISOString()}>{new Date(rule.updatedAtMs).toLocaleString()}</time> : 'Unknown'}</td>
+                    <td><Button variant="outline" disabled={!rules.ready || busy || Boolean(draft)} aria-label={`Edit ${rule.consumerGroup}`} onClick={() => { setDraft(monitorDraft(rule)); setError(''); }}>Edit</Button></td>
+                </tr>)}</tbody>
+            </table>
+        </div>}
+        {rules.ready && filtered.length === 0 && <PageState kind="empty" title={rules.data?.length ? 'No matching consumer groups' : 'No rules in this environment'} description={rules.data?.length ? 'Change the search to see other rules.' : 'Create a rule to store thresholds for a consumer group.'} />}
+        {draft ? <MonitorEditor draft={draft} current={current} ready={rules.ready} pending={busy} onChange={setDraft} onSave={save} onCancel={closeEditor}
+            onDelete={() => setDeleting({ kind: 'delete', id: crypto.randomUUID(), draftId: draft.id, context: { ...context },
+                request: { consumerGroup: draft.consumerGroup, expectedRevision: draft.expectedRevision } })} /> :
+            <p className="ops-monitor-notice"><Info aria-hidden="true" size={18} />{monitorNotice}</p>}
+        {actions.receipt && <MonitorResult receipt={actions.receipt} context={context} />}
+        {deleting && <MonitorDeleteDialog target={deleting} current={Boolean(deletionCurrent)} pending={busy} close={() => setDeleting(null)} submit={() => submit(deleting)} />}
+    </div>;
+}
 
-    const mutate = async (operation: () => Promise<unknown>) => {
-        setBusy(true);
-        setError('');
-        setNotice('');
-        try {
-            await operation();
-            if (!alive.current) return;
-            setDraft(null);
-            setDeleting(null);
-            setNotice('Rule change saved.');
-            await refresh();
-        } catch (failure) {
-            if (!alive.current) return;
-            if (isDashboardClientError(failure) && failure.code === 'dashboard.monitor_conflict') {
-                // Refresh the table, retaining the draft and its old revision until explicit review.
-                await refresh();
-                if (!alive.current) return;
-                setDeleting(null);
-                setNotice('The rule changed. Your draft is retained. Choose Edit on the current row to load its version, or New rule if it was deleted.');
-            }
-            setError(dashboardErrorMessage(failure, 'The rule change failed.'));
-        } finally {
-            if (alive.current) setBusy(false);
-        }
-    };
-    const valid = draft && draft.consumerGroup.length > 0 && draft.consumerGroup.length <= 255 && !/\s/.test(draft.consumerGroup) &&
-        Number.isSafeInteger(draft.minCount) && draft.minCount >= 0 && Number.isSafeInteger(draft.maxDiffTotal) && draft.maxDiffTotal >= 0;
-    const inputClass = 'rounded border bg-transparent px-3 py-2';
-    return <section className="p-6 space-y-4">
-        <h2 className="text-xl font-semibold">Consumer Monitor rules</h2>
-        <p className="text-sm text-gray-500">Rules belong to the selected NameServer environment. This page manages thresholds; it does not evaluate alerts or send notifications.</p>
-        <div className="flex gap-3 items-center">
-            <input className={inputClass} aria-label="Filter Consumer group" placeholder="Filter Consumer group" value={filter} onChange={event => setFilter(event.target.value)} />
-            <button disabled={busy} onClick={() => void refresh()}>Refresh</button>
-            <button disabled={busy} onClick={() => { setDraft(emptyDraft()); setDeleting(null); setNotice(''); }}>New rule</button>
-        </div>
-        {busy && <p role="status">Loading…</p>}
-        {error && <p role="alert" className="text-red-600">{error}</p>}
-        {notice && <p role="status" className="text-amber-600">{notice}</p>}
-        <table className="w-full text-left text-sm"><thead><tr><th>Consumer group</th><th>Min count</th><th>Max total lag</th><th>Revision</th><th>Updated</th><th>Actions</th></tr></thead>
-            <tbody>{rules.filter(rule => rule.consumerGroup.toLowerCase().includes(filter.toLowerCase())).map(rule => <tr key={rule.consumerGroup} className="border-t">
-                <td className="py-3">{rule.consumerGroup}</td><td>{rule.minCount}</td><td>{rule.maxDiffTotal}</td><td>{rule.revision}</td><td>{new Date(rule.updatedAtMs).toLocaleString()}</td>
-                <td className="space-x-3"><button disabled={busy} onClick={() => { setDraft({ consumerGroup: rule.consumerGroup, minCount: rule.minCount, maxDiffTotal: rule.maxDiffTotal, expectedRevision: rule.revision }); setDeleting(null); setNotice('Current version loaded for review.'); }}>Edit</button><button disabled={busy} onClick={() => { setDeleting(rule); setDraft(null); }}>Delete</button></td>
-            </tr>)}</tbody>
-        </table>
-        {!busy && !error && rules.length === 0 && <p>No rules in this environment.</p>}
-        {draft && <form className="rounded border p-4 space-y-3" onSubmit={event => { event.preventDefault(); if (valid && !busy) void mutate(() => MonitorService.save(draft)); }}>
-            <h3 className="font-semibold">{draft.expectedRevision === 0 ? 'New rule' : `Edit revision ${draft.expectedRevision}`}</h3>
-            <label className="flex gap-3 items-center">Consumer group<input required maxLength={255} disabled={busy || draft.expectedRevision !== 0} className={inputClass} value={draft.consumerGroup} onChange={event => setDraft({ ...draft, consumerGroup: event.target.value })} /></label>
-            <label className="flex gap-3 items-center">Min count<input required disabled={busy} className={inputClass} type="number" min="0" step="1" value={Number.isNaN(draft.minCount) ? '' : draft.minCount} onChange={event => setDraft({ ...draft, minCount: event.target.valueAsNumber })} /></label>
-            <label className="flex gap-3 items-center">Max total lag<input required disabled={busy} className={inputClass} type="number" min="0" step="1" value={Number.isNaN(draft.maxDiffTotal) ? '' : draft.maxDiffTotal} onChange={event => setDraft({ ...draft, maxDiffTotal: event.target.valueAsNumber })} /></label>
-            <div className="flex gap-3"><button type="submit" disabled={busy || !valid}>Save rule</button><button type="button" disabled={busy} onClick={() => setDraft(null)}>Cancel</button></div>
-        </form>}
-        {deleting && <div role="alertdialog" aria-label="Confirm rule deletion" className="rounded border p-4 space-y-3"><p>Delete {deleting.consumerGroup}, revision {deleting.revision}, from this environment?</p><div className="flex gap-3"><button disabled={busy} onClick={() => void mutate(() => MonitorService.delete(deleting))}>Confirm delete</button><button disabled={busy} onClick={() => setDeleting(null)}>Cancel</button></div></div>}
-    </section>;
-};
+export function MonitorPage() {
+    const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
+    const bootstrap = useReadResource(settings ? null : getConnectionSettings, 'Connection settings could not be loaded.');
+    if (!settings) return bootstrap.error
+        ? <PageState kind="error" title="Environment unavailable" description={bootstrap.error} action={<Button variant="outline" onClick={() => { void bootstrap.read(); }}>Retry connection</Button>} />
+        : <PageState kind="loading" title="Loading environment" />;
+    if (!settings.environmentId) return <PageState kind="empty" title="Select a NameServer environment" description="Monitor rules are stored separately for each environment. Select one using the environment toolbar." />;
+    return <MonitorWorkspace key={`${settings.environmentId}:${settings.revision}`} context={{ environmentId: settings.environmentId, revision: settings.revision }} />;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorResult.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/MonitorResult.tsx
@@ -1,0 +1,24 @@
+import { StatusBadge } from '../../components/layout/StatusBadge';
+import { monitorContextMatches, type MonitorContext, type MonitorReceipt, type MonitorTarget } from './monitorModel';
+
+export function MonitorTargetDetails({ target }: { target: MonitorTarget }) {
+    return <dl className="ops-monitor-target">
+        <div><dt>Environment</dt><dd tabIndex={0}>{target.context.environmentId}</dd></div>
+        <div><dt>Consumer group</dt><dd tabIndex={0}>{target.request.consumerGroup}</dd></div>
+        <div><dt>Expected rule revision</dt><dd>{target.request.expectedRevision}</dd></div>
+        <div><dt>Connection revision</dt><dd>{target.context.revision}</dd></div>
+        {target.kind === 'save' && <><div><dt>Minimum online clients</dt><dd>{target.request.minCount}</dd></div><div><dt>Maximum lag</dt><dd>{target.request.maxDiffTotal}</dd></div></>}
+    </dl>;
+}
+export function MonitorResult({ receipt, context }: { receipt: MonitorReceipt; context: MonitorContext }) {
+    const matches = monitorContextMatches(receipt.target.context, context);
+    return <section className="ops-monitor-result" aria-label="Latest monitor rule result" role="status">
+        <div className="ops-monitor-result-heading"><h2>{receipt.target.kind === 'delete' ? 'Delete rule result' : 'Save rule result'}</h2>
+            <StatusBadge tone={receipt.outcome === 'success' ? 'success' : 'warning'}>{receipt.outcome === 'success' ? 'Committed' : receipt.outcome === 'conflict' ? 'Version conflict' : 'Not confirmed'}</StatusBadge>
+        </div>
+        <p>{receipt.message}</p>
+        {!matches && <p className="ops-monitor-note">This result belongs to the original connection shown below. It does not update the current environment’s rules.</p>}
+        <MonitorTargetDetails target={receipt.target} />
+        <p className="ops-monitor-note">Completed {new Date(receipt.completedAt).toLocaleString()}</p>
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitor.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitor.css
@@ -1,0 +1,45 @@
+.ops-monitors { display: grid; gap: 22px; min-width: 0; }
+.ops-monitor-controls, .ops-monitor-editor, .ops-monitor-result {
+  min-width: 0; padding: 22px; border: 1px solid var(--ops-border); border-radius: var(--ops-radius); background: var(--ops-panel);
+}
+.ops-monitor-controls { display: grid; grid-template-columns: minmax(180px, .65fr) minmax(220px, 1fr) auto; align-items: center; gap: 24px; }
+.ops-monitor-controls .ops-monitor-environment { min-width: 0; display: grid; gap: 4px; }
+.ops-monitor-environment small, .ops-monitor-note { color: var(--ops-muted); font-size: 13px; }
+.ops-monitor-environment strong { display: block; max-height: 90px; overflow: auto; overflow-wrap: anywhere; font-size: 14px; font-weight: 500; }
+.ops-monitor-table-wrap { min-width: 0; overflow: auto; border: 1px solid var(--ops-border); border-radius: var(--ops-radius); background: var(--ops-panel); }
+.ops-monitor-table { width: 100%; min-width: 860px; border-collapse: collapse; font-size: 14px; text-align: left; }
+.ops-monitor-table th { padding: 18px 22px; color: var(--ops-muted); font-weight: 500; font-size: 13px; white-space: nowrap; }
+.ops-monitor-table td { padding: 12px 22px; border-top: 1px solid var(--ops-border); font-variant-numeric: tabular-nums; }
+.ops-monitor-table tr[data-selected="true"] { background: var(--ops-accent-soft); }
+.ops-monitor-table td:first-child { width: 25%; font-weight: 600; }
+.ops-monitor-group { max-width: 280px; max-height: 100px; overflow: auto; overflow-wrap: anywhere; }
+.ops-monitor-table time { white-space: nowrap; color: var(--ops-muted); font-size: 13px; }
+.ops-monitor-editor h2, .ops-monitor-result h2 { margin: 0; font-size: 16px; font-weight: 600; }
+.ops-monitor-editor > .ops-monitor-note { margin: 5px 0 22px; }
+.ops-monitor-editor form { display: grid; gap: 22px; }
+.ops-monitor-fields { display: grid; grid-template-columns: 1.15fr 1fr 1fr 1fr; gap: 24px; align-items: start; }
+.ops-monitor-fields > * { min-width: 0; }
+.ops-monitor-editor-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; }
+.ops-monitor-danger-action { margin-left: 12px; padding-left: 24px; border-left: 1px solid var(--ops-border-strong); }
+.ops-monitor-notice { display: flex; align-items: flex-start; gap: 10px; margin: 24px 0 0; font-size: 13px; color: var(--ops-muted); }
+.ops-monitor-notice svg { flex: none; }
+.ops-monitor-review { padding: 16px; border: 1px solid var(--ops-accent-border); border-radius: 8px; background: var(--ops-accent-soft); display: grid; gap: 10px; font-size: 13px; }
+.ops-monitor-review h3 { font-size: 14px; font-weight: 600; }
+.ops-monitor-review button { justify-self: start; white-space: normal; height: auto; min-height: 38px; text-align: left; }
+.ops-monitor-result { display: grid; gap: 12px; font-size: 13px; }
+.ops-monitor-result-heading { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; }
+.ops-monitor-target { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px 24px; font-size: 13px; }
+.ops-monitor-target dt { color: var(--ops-muted); }
+.ops-monitor-target dd { margin: 4px 0 0; font-variant-numeric: tabular-nums; max-height: 110px; overflow: auto; overflow-wrap: anywhere; }
+.ops-monitor-delete-dialog { width: min(620px, calc(100vw - 32px)); max-width: 620px; max-height: calc(100dvh - 32px); overflow: auto; }
+@media (max-width: 1100px) {
+  .ops-monitor-controls { grid-template-columns: minmax(0, 1fr) auto; gap: 16px; }
+  .ops-monitor-environment { grid-column: 1 / -1; }
+  .ops-monitor-fields { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+}
+@media (max-width: 650px) {
+  .ops-monitor-controls, .ops-monitor-editor, .ops-monitor-result { padding: 16px; }
+  .ops-monitor-controls, .ops-monitor-fields, .ops-monitor-target { grid-template-columns: minmax(0, 1fr); }
+  .ops-monitor-controls > button { justify-self: start; }
+  .ops-monitor-danger-action { margin-left: 0; padding-left: 12px; }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitorActions.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitorActions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DashboardClientError } from '../../services/invoke';
+import { createMonitorActions } from './monitorActions';
+import type { MonitorTarget } from './monitorModel';
+
+const context = { environmentId: 'env-a', revision: 7 };
+const target: MonitorTarget = { id: 'attempt', draftId: 'draft', context, kind: 'save', request: { consumerGroup: 'orders', minCount: 2, maxDiffTotal: 500, expectedRevision: 3 } };
+const deferred = () => {
+    let resolve!: (value: unknown) => void;
+    const promise = new Promise<unknown>(done => { resolve = done; });
+    return { promise, resolve };
+};
+describe('session-owned monitor writes', () => {
+    it('retains an accepted receipt in the original environment and prevents overlapping submissions', async () => {
+        let current = { ...context };
+        const write = deferred();
+        const dispatch = vi.fn(() => write.promise);
+        const actions = createMonitorActions(() => current, dispatch);
+        actions.start();
+        const pending = actions.submit(target);
+        expect(await actions.submit(target)).toBeNull();
+        current = { environmentId: 'env-b', revision: 8 };
+        write.resolve({ message: 'Monitor rule saved.' });
+        expect(await pending).toMatchObject({ outcome: 'success', target: { context } });
+        expect(actions.getSnapshot().receipt?.target.context.environmentId).toBe('env-a');
+        expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+    it('rejects a stale target before dispatch', async () => {
+        const dispatch = vi.fn();
+        const actions = createMonitorActions(() => ({ ...context, revision: 8 }), dispatch);
+        actions.start();
+        await expect(actions.submit(target)).rejects.toThrow('environment changed');
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+    it('recognizes a compare-and-swap conflict without retrying or changing the expected revision', async () => {
+        const dispatch = vi.fn().mockRejectedValue(new DashboardClientError({ code: 'dashboard.monitor_conflict', category: 'validation', retryable: false, message: 'conflict' }));
+        const actions = createMonitorActions(() => context, dispatch);
+        actions.start();
+        expect(await actions.submit(target)).toMatchObject({ outcome: 'conflict', target: { request: { expectedRevision: 3 } } });
+        expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+    it('requires a commit receipt and does not expose arbitrary thrown details', async () => {
+        const dispatch = vi.fn().mockResolvedValueOnce({ message: 'unexpected' }).mockRejectedValueOnce(new Error('private connection details'));
+        const actions = createMonitorActions(() => context, dispatch);
+        actions.start();
+        expect(await actions.submit(target)).toMatchObject({ outcome: 'unconfirmed' });
+        const receipt = await actions.submit({ ...target, id: 'explicit-next-attempt' });
+        expect(receipt?.outcome).toBe('unconfirmed');
+        expect(receipt?.message).not.toContain('private');
+    });
+    it('clears session results on disposal and ignores an old completion after a new session starts', async () => {
+        const old = deferred();
+        const actions = createMonitorActions(() => context, () => old.promise);
+        expect(await actions.submit(target)).toBeNull();
+        actions.start();
+        const pending = actions.submit(target);
+        actions.stop();
+        actions.start();
+        old.resolve({ message: 'Monitor rule saved.' });
+        expect(await pending).toBeNull();
+        expect(actions.getSnapshot()).toEqual({ pending: null, receipt: null });
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitorActions.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitorActions.ts
@@ -1,0 +1,45 @@
+import { dashboardErrorMessage, isDashboardClientError } from '../../services/invoke';
+import { captureMonitorTarget, type MonitorContext, type MonitorReceipt, type MonitorTarget } from './monitorModel';
+
+interface Snapshot { pending: MonitorTarget | null; receipt: MonitorReceipt | null }
+/** The signed-in session owns accepted writes, even when navigation or the environment changes. */
+export function createMonitorActions(current: () => MonitorContext | null, dispatch: (target: MonitorTarget) => Promise<unknown>) {
+    let state: Snapshot = { pending: null, receipt: null };
+    let active = false;
+    let generation = 0;
+    const listeners = new Set<() => void>();
+    const publish = (next: Snapshot) => { state = next; listeners.forEach(listener => listener()); };
+    return {
+        start: () => { active = true; },
+        stop: () => { active = false; generation++; state = { pending: null, receipt: null }; },
+        getSnapshot: () => state,
+        subscribe: (listener: () => void) => { listeners.add(listener); return () => { listeners.delete(listener); }; },
+        submit: async (input: MonitorTarget): Promise<MonitorReceipt | null> => {
+            if (!active || state.pending) return null;
+            const target = captureMonitorTarget(input, current());
+            const request = ++generation;
+            publish({ ...state, pending: target });
+            let outcome: MonitorReceipt['outcome'] = 'unconfirmed';
+            let message = 'The write was not confirmed. Read the original environment before deciding whether another change is needed.';
+            try {
+                const result = await dispatch(target);
+                // The local command emits this receipt only after committing both the rule and its audit record.
+                if (result && typeof result === 'object' && 'message' in result && result.message === 'Monitor rule saved.') {
+                    outcome = 'success';
+                    message = target.kind === 'delete' ? 'Rule deletion committed.' : 'Rule change committed.';
+                }
+            } catch (error) {
+                if (isDashboardClientError(error) && error.code === 'dashboard.monitor_conflict') {
+                    outcome = 'conflict';
+                    message = 'The rule changed or was deleted. Your draft is retained for review.';
+                } else {
+                    message = dashboardErrorMessage(error, message);
+                }
+            }
+            if (!active || generation !== request) return null;
+            const receipt = { target, outcome, message, completedAt: Date.now() };
+            publish({ pending: null, receipt });
+            return receipt;
+        },
+    };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitorModel.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitorModel.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { MonitorRule } from '../../services/monitor.service';
+import { applyMonitorReceipt, captureMonitorTarget, monitorDraft, monitorDraftError, monitorSaveRequest, reviewMonitorDraft, type MonitorReceipt, type MonitorTarget } from './monitorModel';
+
+const context = { environmentId: 'env-a', revision: 7 };
+const rule: MonitorRule = { consumerGroup: 'orders', minCount: 2, maxDiffTotal: 500, revision: 3, createdAtMs: 1, updatedAtMs: 2 };
+describe('monitor rule drafts', () => {
+    it('preserves empty and invalid numeric input instead of coercing it to zero', () => {
+        const draft = monitorDraft(rule);
+        for (const value of ['', '-1', '1.5', '1e3', 'Infinity', 'NaN', '9007199254740992']) {
+            expect(monitorDraftError({ ...draft, minCount: value })).not.toBeNull();
+            expect(() => monitorSaveRequest({ ...draft, maxDiffTotal: value })).toThrow();
+        }
+        expect(monitorSaveRequest({ ...draft, minCount: '0', maxDiffTotal: '9007199254740991' })).toMatchObject({ minCount: 0, maxDiffTotal: Number.MAX_SAFE_INTEGER });
+    });
+    it('matches the backend UTF-8 identity and revision boundaries', () => {
+        const draft = monitorDraft(rule);
+        expect(monitorDraftError({ ...draft, consumerGroup: '中'.repeat(85) })).toBeNull();
+        for (const group of ['', 'a'.repeat(256), '中'.repeat(86), 'has space', 'line\nfeed', 'a\u0085b', 'a\u0000b', '\ud800']) {
+            expect(monitorDraftError({ ...draft, consumerGroup: group })).not.toBeNull();
+        }
+        expect(monitorDraftError({ ...draft, consumerGroup: 'orders🚀' })).toBeNull();
+        for (const revision of [-1, 0.5, Number.MAX_SAFE_INTEGER, NaN]) expect(monitorDraftError({ ...draft, expectedRevision: revision })).not.toBeNull();
+    });
+    it('retains the entire conflicted draft until an explicit revision review', () => {
+        const draft = { ...monitorDraft(rule), minCount: '17', maxDiffTotal: '', lastAttemptId: 'attempt' };
+        const target: MonitorTarget = { id: 'attempt', draftId: draft.id, context, kind: 'save', request: { consumerGroup: rule.consumerGroup, minCount: 17, maxDiffTotal: 500, expectedRevision: 3 } };
+        const receipt: MonitorReceipt = { target, outcome: 'conflict', completedAt: 20, message: 'conflict' };
+        const conflicted = applyMonitorReceipt(draft, receipt, context)!;
+        expect(conflicted).toMatchObject({ minCount: '17', maxDiffTotal: '', expectedRevision: 3, needsReview: true, lastAttemptId: null });
+        const reviewed = reviewMonitorDraft(conflicted, { ...rule, revision: 4, minCount: 9 });
+        expect(reviewed).toMatchObject({ minCount: '17', maxDiffTotal: '', expectedRevision: 4, needsReview: false });
+        expect(reviewMonitorDraft(conflicted, null)).toMatchObject({ consumerGroup: 'orders', minCount: '17', expectedRevision: 0 });
+        expect(() => reviewMonitorDraft(conflicted, { ...rule, consumerGroup: 'another' })).toThrow();
+    });
+    it('does not clear another environment, connection revision or replacement draft', () => {
+        const draft = { ...monitorDraft(rule), lastAttemptId: 'attempt' };
+        const receipt: MonitorReceipt = { target: { id: 'attempt', draftId: draft.id, context, kind: 'delete', request: { consumerGroup: 'orders', expectedRevision: 3 } }, outcome: 'success', completedAt: 20, message: 'ok' };
+        expect(applyMonitorReceipt(draft, receipt, context)).toBeNull();
+        for (const other of [{ ...context, environmentId: 'env-b' }, { ...context, revision: 8 }]) expect(applyMonitorReceipt(draft, receipt, other)).toBe(draft);
+        const replacement = { ...draft, id: 'replacement' };
+        expect(applyMonitorReceipt(replacement, receipt, context)).toBe(replacement);
+    });
+    it('captures the exact target and rejects stale contexts or invalid deletions', () => {
+        const target: MonitorTarget = { id: 'attempt', draftId: 'draft', context: { ...context }, kind: 'delete', request: { consumerGroup: 'orders', expectedRevision: 3 } };
+        const captured = captureMonitorTarget(target, context);
+        target.request.consumerGroup = 'replacement';
+        target.context.environmentId = 'env-b';
+        expect(captured.request.consumerGroup).toBe('orders');
+        expect(captured.context.environmentId).toBe('env-a');
+        expect(() => captureMonitorTarget(captured, { ...context, revision: 8 })).toThrow();
+        expect(() => captureMonitorTarget({ ...captured, kind: 'delete', request: { ...captured.request, expectedRevision: 0 } }, context)).toThrow();
+        expect(() => monitorSaveRequest({ ...monitorDraft(rule), needsReview: true })).toThrow();
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitorModel.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/monitorModel.ts
@@ -1,0 +1,79 @@
+import type { MonitorRule, SaveMonitorRule } from '../../services/monitor.service';
+
+export interface MonitorContext { environmentId: string; revision: number }
+export interface MonitorDraft {
+    id: string;
+    consumerGroup: string;
+    minCount: string;
+    maxDiffTotal: string;
+    expectedRevision: number;
+    lastAttemptId: string | null;
+    needsReview: boolean;
+}
+export type MonitorTarget = {
+    id: string;
+    draftId: string;
+    context: MonitorContext;
+} & ({ kind: 'save'; request: SaveMonitorRule } | {
+    kind: 'delete'; request: Pick<SaveMonitorRule, 'consumerGroup' | 'expectedRevision'>;
+});
+export interface MonitorReceipt {
+    target: MonitorTarget;
+    outcome: 'success' | 'conflict' | 'unconfirmed';
+    completedAt: number;
+    message: string;
+}
+export function monitorContextMatches(expected: MonitorContext, current: { environmentId: string | null; revision: number } | null) {
+    return current?.environmentId === expected.environmentId && current.revision === expected.revision;
+}
+export function monitorDraft(rule: MonitorRule | null): MonitorDraft {
+    return {
+        id: crypto.randomUUID(), consumerGroup: rule?.consumerGroup ?? '',
+        minCount: String(rule?.minCount ?? 0), maxDiffTotal: String(rule?.maxDiffTotal ?? 0),
+        expectedRevision: rule?.revision ?? 0, lastAttemptId: null, needsReview: false,
+    };
+}
+function identityError(group: string, revision: number): string | null {
+    if (!group || new TextEncoder().encode(group).length > 255 || /[\p{White_Space}\p{Cc}\p{Cs}]/u.test(group)) {
+        return 'Use a group name of 1–255 UTF-8 bytes without whitespace or control characters.';
+    }
+    if (!Number.isSafeInteger(revision) || revision < 0 || revision >= Number.MAX_SAFE_INTEGER) {
+        return 'This rule revision cannot be changed safely. Reload the current rule.';
+    }
+    return null;
+}
+function threshold(value: string): number | null {
+    if (!/^\d+$/.test(value)) return null;
+    const number = Number(value);
+    return Number.isSafeInteger(number) && number >= 0 ? number : null;
+}
+export function monitorDraftError(draft: MonitorDraft): string | null {
+    return identityError(draft.consumerGroup, draft.expectedRevision) ??
+        (threshold(draft.minCount) === null || threshold(draft.maxDiffTotal) === null
+            ? 'Thresholds must be whole numbers from 0 to 9007199254740991.' : null);
+}
+export function monitorSaveRequest(draft: MonitorDraft): SaveMonitorRule {
+    const error = monitorDraftError(draft);
+    if (error) throw new Error(error);
+    if (draft.needsReview) throw new Error('Read and review the current rule before saving this draft.');
+    return { consumerGroup: draft.consumerGroup, minCount: Number(draft.minCount), maxDiffTotal: Number(draft.maxDiffTotal), expectedRevision: draft.expectedRevision };
+}
+export function captureMonitorTarget(target: MonitorTarget, current: { environmentId: string | null; revision: number } | null): MonitorTarget {
+    if (!target.context.environmentId || !monitorContextMatches(target.context, current)) throw new Error('The environment changed. Reopen the rule in the current environment.');
+    const error = identityError(target.request.consumerGroup, target.request.expectedRevision);
+    if (error) throw new Error(error);
+    if (target.kind === 'delete' && target.request.expectedRevision === 0) throw new Error('Only a stored rule can be deleted.');
+    if (target.kind === 'save' && (!Number.isSafeInteger(target.request.minCount) || target.request.minCount < 0 ||
+        !Number.isSafeInteger(target.request.maxDiffTotal) || target.request.maxDiffTotal < 0)) throw new Error('Invalid monitor thresholds.');
+    return { ...target, context: { ...target.context }, request: { ...target.request } } as MonitorTarget;
+}
+/** A write receipt may affect only the draft that submitted it, in the same environment and connection. */
+export function applyMonitorReceipt(draft: MonitorDraft | null, receipt: MonitorReceipt, context: MonitorContext): MonitorDraft | null {
+    if (!draft || !monitorContextMatches(context, receipt.target.context) || draft.id !== receipt.target.draftId || draft.lastAttemptId !== receipt.target.id) return draft;
+    return receipt.outcome === 'success' ? null : { ...draft, lastAttemptId: null, needsReview: true };
+}
+/** Keep user-entered thresholds; adopting a new compare-and-swap version is an explicit action. */
+export function reviewMonitorDraft(draft: MonitorDraft, current: MonitorRule | null): MonitorDraft {
+    if (current && current.consumerGroup !== draft.consumerGroup) throw new Error('The current rule belongs to a different group.');
+    return { ...draft, expectedRevision: current?.revision ?? 0, lastAttemptId: null, needsReview: false };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/useMonitorRules.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/monitor/useMonitorRules.ts
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
+import { ConnectionStore } from '../../services/connection.store';
+import { MonitorService } from '../../services/monitor.service';
+import { createReadResource } from '../../hooks/readResource';
+import { monitorContextMatches, type MonitorContext } from './monitorModel';
+
+export function useMonitorRules(context: MonitorContext) {
+    const resource = useMemo(() => createReadResource(MonitorService.list, 'Monitor rules could not be loaded.'), [context.revision, context.environmentId]);
+    const state = useSyncExternalStore(resource.subscribe, resource.getSnapshot, resource.getSnapshot);
+    const refresh = useCallback(() => monitorContextMatches(context, ConnectionStore.getSnapshot())
+        ? resource.read() : Promise.resolve(false), [resource, context.revision, context.environmentId]);
+    const afterWrite = useCallback(() => { resource.invalidate(); return refresh(); }, [resource, refresh]);
+    useEffect(() => {
+        const unsubscribe = ConnectionStore.subscribe(() => {
+            if (!monitorContextMatches(context, ConnectionStore.getSnapshot())) resource.invalidate();
+        });
+        void refresh();
+        return () => { unsubscribe(); resource.invalidate(); };
+    }, [resource, refresh, context.revision, context.environmentId]);
+    return { ...state, refresh, afterWrite, ready: state.data !== null && !state.pending && !state.error && monitorContextMatches(context, ConnectionStore.getSnapshot()) };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/monitor.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/monitor.service.ts
@@ -17,5 +17,5 @@ export interface SaveMonitorRule {
 export const MonitorService = {
     list: (): Promise<MonitorRule[]> => invokeAuthenticatedCommand('list_consumer_monitor_rules'),
     save: (request: SaveMonitorRule): Promise<{ message: string }> => invokeAuthenticatedCommand('save_consumer_monitor_rule', { request }),
-    delete: (rule: MonitorRule): Promise<{ message: string }> => invokeAuthenticatedCommand('delete_consumer_monitor_rule', { request: { consumerGroup: rule.consumerGroup, expectedRevision: rule.revision } }),
+    delete: (rule: Pick<MonitorRule, 'consumerGroup' | 'revision'>): Promise<{ message: string }> => invokeAuthenticatedCommand('delete_consumer_monitor_rule', { request: { consumerGroup: rule.consumerGroup, expectedRevision: rule.revision } }),
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -92,6 +92,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         return 'Storage & diagnostics';
       case 'Audit':
         return 'Audit Events';
+      case 'Monitors':
+        return 'Consumer monitors';
       case 'Sessions':
         return 'Account Sessions';
       case 'Account':


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10516

### Brief Description

Redesign consumer monitor rules with environment search, a compact directory, an inline editor and versioned deletion. Preserve entered thresholds after conflicts or unconfirmed writes and require explicit review of the current revision before another attempt.

Separate rule models, scoped reads, operation ownership and receipts. A delayed original-environment write cannot update the newly selected environment, and the page clearly describes stored thresholds without claiming alert evaluation or notifications.

### How Did You Test This Change?

- `npm run build`: passed after integration with main.
- 27 focused monitor, navigation, read ownership and toolbar tests passed.
- Existing backend persistence/environment/CAS/audit rollback regression passed during implementation.
- Headed external Chrome passed reference/800 x 600 comparisons, CRUD, stale revisions and external deletion, explicit review with retained draft, invalid thresholds, failed/unconfirmed writes without automatic repeats, delayed environment isolation and focus restoration; no console/page errors.
- Native app created and saved a real rule through revision 2, read the exact values back, and verified negative-input rejection, Cancel/reopen, keyboard order, deletion-confirmation Escape and maximized/small-window layout. Windows DPI remains part of final dashboard acceptance. Existing Vite large-chunk warning is unchanged.
