### PR TITLE
[ISSUE #10518]✨Redesign exact audit queries and safe operation details

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUDIT_LOG_UI.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/AUDIT_LOG_UI.md
@@ -1,0 +1,11 @@
+# Audit log
+
+The Audit page queries the local audit log. Actor, action and environment are exact-value inputs; the connection toolbar does not implicitly restrict the results. The page has no fuzzy search or fabricated actor/action directory. Five supported outcomes can be filtered: success, rejected, failed, partial and unknown.
+
+Times are entered in the computer's local time zone and converted to milliseconds. Invalid calendar values and reversed ranges are rejected. Boundaries are inclusive. Draft filter changes do not change the displayed query until Apply filters is selected.
+
+Each applied query owns its result and opaque cursor history. New filters, Reset and toolbar Refresh start from page one. Previous uses the stored cursor history; Next uses only the cursor returned by the backend. The page displays its current page number without inventing a total. Applying filters during a pending read invalidates the previous request. Failed queries can be retried, and a failed later page can return to the previous page.
+
+The selected record displays request ID, time, actor, action, resource type/name, recorded environment, outcome and the explicit safe detail fields. Missing environment and counts remain Not recorded; explicit zero stays zero. Invalid counts are Unknown. Only an error code matching the bounded identifier format is displayed. Raw exceptions, request bodies, passwords, tokens and extra detail fields have no rendering path. Unknown flags and unrecognized outcomes cannot render a success badge.
+
+Frontend validation covers filter parsing, cursor reset/history, safe projection and rendered detail redaction, together with the shared read-resource/toolbar/navigation tests. Existing native tests cover exact filtering, stable cursor order for identical timestamps, safe terminal outcomes and audit persistence. Chrome layout/keyboard comparison and live Tauri interaction are separate acceptance work.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditDetails.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditDetails.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { expect, it } from 'vitest';
+import { AuditDetails } from './AuditDetails';
+import type { AuditEvent } from '../../services/audit.service';
+
+it('renders safe audit metadata without spreading raw details or treating missing counts as zero', () => {
+    const event: AuditEvent = {
+        eventId: 'event-1', requestId: 'request-1', actor: 'admin', action: 'message.resend_dlq',
+        resourceType: 'consumer_group', resourceName: 'orders', environmentId: null, outcome: 'unknown', createdAtMs: 1,
+        detail: { resultUnknown: true, rawError: 'SECRET_RAW_ERROR', password: 'SECRET_PASSWORD', body: 'SECRET_BODY', accessToken: 'SECRET_TOKEN' } as AuditEvent['detail'],
+    };
+    const html = renderToStaticMarkup(<AuditDetails event={event} />);
+    expect(html).toContain('request-1');
+    expect(html).toContain('Not recorded');
+    expect(html).toContain('Unknown');
+    expect(html).not.toContain('SECRET_');
+    expect(html).not.toContain('Target count');
+    expect(html).not.toContain('data-tone="success"');
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditDetails.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditDetails.tsx
@@ -1,0 +1,31 @@
+import { Copy, Info } from 'lucide-react';
+import { toast } from 'sonner';
+import type { AuditEvent } from '../../services/audit.service';
+import { Button } from '../../components/ui/LegacyButton';
+import { StatusBadge } from '../../components/layout/StatusBadge';
+import { auditDetail, auditOutcome, auditTimestamp } from './auditModel';
+
+export function AuditDetails({ event }: { event: AuditEvent }) {
+    const detail = auditDetail(event.detail);
+    const outcome = auditOutcome(event.outcome, detail.resultUnknown);
+    const copy = async () => {
+        try { await navigator.clipboard.writeText(event.requestId); toast.success('Request ID copied'); }
+        catch { toast.error('Request ID could not be copied'); }
+    };
+    return <section className="ops-audit-details" aria-labelledby="audit-details-heading">
+        <h2 id="audit-details-heading">Audit record details</h2>
+        <p className="ops-audit-note">Recorded metadata for the selected operation.</p>
+        <div className="ops-audit-detail-columns">
+            <dl><div><dt>Time</dt><dd>{auditTimestamp(event.createdAtMs)}</dd></div><div><dt>Actor</dt><dd tabIndex={0}>{event.actor ?? 'Not recorded'}</dd></div>
+                <div><dt>Action</dt><dd tabIndex={0}>{event.action}</dd></div><div><dt>Resource type</dt><dd tabIndex={0}>{event.resourceType}</dd></div>
+                <div><dt>Resource</dt><dd tabIndex={0}>{event.resourceName ?? 'Not recorded'}</dd></div><div><dt>Environment</dt><dd tabIndex={0}>{event.environmentId ?? 'Not recorded'}</dd></div>
+                <div><dt>Request ID</dt><dd className="ops-audit-copy"><span tabIndex={0}>{event.requestId || 'Not recorded'}</span><Button variant="ghost" icon={Copy} aria-label="Copy request ID" disabled={!event.requestId} onClick={() => { void copy(); }} /></dd></div>
+            </dl>
+            <dl><div><dt>Outcome</dt><dd><StatusBadge tone={outcome.tone}>{outcome.label}</StatusBadge></dd></div>
+                <div><dt>Success count</dt><dd>{detail.successCount}</dd></div><div><dt>Failure count</dt><dd>{detail.failureCount}</dd></div>
+                <div><dt>Error code</dt><dd tabIndex={0}>{detail.errorCode}</dd></div>
+            </dl>
+        </div>
+        <p className="ops-audit-notice"><Info aria-hidden="true" size={18} />{outcome.label === 'Unknown' ? 'The outcome could not be confirmed. Inspect the original resource before another operation.' : 'Unknown means the outcome could not be confirmed. Missing counts are not treated as zero.'}</p>
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditFilters.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditFilters.tsx
@@ -1,0 +1,29 @@
+import { useId } from 'react';
+import { Button } from '../../components/ui/LegacyButton';
+import { Input } from '../../components/ui/LegacyInput';
+import { PageState } from '../../components/layout/PageState';
+import { auditOutcomes, type AuditFilters as Filters } from './auditModel';
+
+export function AuditFilters({ filters, pending, error, changed, onChange, apply, reset }: {
+    filters: Filters; pending: boolean; error: string; changed: boolean;
+    onChange: (filters: Filters) => void; apply: () => void; reset: () => void;
+}) {
+    const outcomeId = useId();
+    return <form className="ops-audit-filters" noValidate onSubmit={event => { event.preventDefault(); apply(); }} aria-label="Audit filters">
+        <div className="ops-audit-filter-fields">
+            <Input label="Actor" placeholder="Exact username" value={filters.actor} onChange={event => onChange({ ...filters, actor: event.target.value })} />
+            <Input label="Action" placeholder="Exact action, e.g. topic.delete" value={filters.action} onChange={event => onChange({ ...filters, action: event.target.value })} />
+            <div className="ops-field"><label className="ops-field-label" htmlFor={outcomeId}>Outcome</label><select id={outcomeId} value={filters.outcome} onChange={event => onChange({ ...filters, outcome: event.target.value })}>
+                <option value="">All outcomes</option>{auditOutcomes.map(outcome => <option value={outcome} key={outcome}>{outcome[0].toUpperCase() + outcome.slice(1)}</option>)}
+            </select></div>
+            <Input label="Environment ID" placeholder="Exact ID, if recorded" value={filters.environmentId} onChange={event => onChange({ ...filters, environmentId: event.target.value })} />
+            <Input label="From (local time)" type="datetime-local" step="1" value={filters.from} onChange={event => onChange({ ...filters, from: event.target.value })} />
+            <Input label="To (local time)" type="datetime-local" step="1" value={filters.to} onChange={event => onChange({ ...filters, to: event.target.value })} />
+        </div>
+        {error && <PageState kind="error" title="Check the audit filters" description={error} />}
+        <div className="ops-audit-filter-actions"><Button type="submit">Apply filters</Button><Button variant="outline" onClick={reset}>Reset</Button>
+            <p className="ops-audit-note">{changed ? 'Showing the last applied filters. Apply to run this selection.' : pending ? 'Loading the applied filters…' : 'Exact matching · newest first · up to 50 events per page'}</p>
+        </div>
+        <p className="ops-audit-note">These filters query the local audit log across recorded environments. The connection toolbar does not restrict the results.</p>
+    </form>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/AuditPage.tsx
@@ -1,65 +1,68 @@
-import { useEffect, useState, type FormEvent } from 'react';
-import { queryAuditEvents, type AuditPage as AuditResultPage, type AuditQuery, type AuditOutcome } from '../../services/audit.service';
-import { dashboardErrorMessage } from '../../services/invoke';
-import { Button } from '../../components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { useCallback, useState } from 'react';
+import { ArrowDown, ChevronRight } from 'lucide-react';
+import { queryAuditEvents } from '../../services/audit.service';
+import { useReadResource } from '../../hooks/useReadResource';
+import { useNavigationState } from '../../stores/app.store';
+import { usePageRefresh } from '../../app/layout/pageToolbar';
+import { Button } from '../../components/ui/LegacyButton';
+import { PageState } from '../../components/layout/PageState';
+import { StatusBadge } from '../../components/layout/StatusBadge';
+import { AuditFilters } from './AuditFilters';
+import { AuditDetails } from './AuditDetails';
+import { auditOutcome, auditQuery, auditTimestamp, emptyAuditFilters, initialAuditLocation, navigateAudit } from './auditModel';
+import './audit.css';
 
-export const AuditPage = () => {
-    const [query, setQuery] = useState<AuditQuery>({ limit: 50 });
-    const [cursors, setCursors] = useState<Array<string | undefined>>([undefined]);
-    const [refresh, setRefresh] = useState(0);
-    const [page, setPage] = useState<AuditResultPage | null>(null);
-    const [error, setError] = useState('');
-    const [loading, setLoading] = useState(true);
-    const cursor = cursors[cursors.length - 1];
-    useEffect(() => {
-        let active = true;
-        setLoading(true); setError(''); setPage(null);
-        void queryAuditEvents({ ...query, cursor }).then((result) => { if (active) setPage(result); })
-            .catch((failure: unknown) => { if (active) setError(dashboardErrorMessage(failure, 'Could not load audit events.')); })
-            .finally(() => { if (active) setLoading(false); });
-        return () => { active = false; };
-    }, [query, cursor, refresh]);
+const initialView = () => ({ draft: emptyAuditFilters(), applied: emptyAuditFilters(), location: initialAuditLocation(), selected: null as string | null });
 
-    const apply = (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        const data = new FormData(event.currentTarget);
-        const text = (key: string) => String(data.get(key) ?? '').trim() || undefined;
-        const from = text('from'); const to = text('to');
-        const fromMs = from ? new Date(from).getTime() : undefined;
-        const toMs = to ? new Date(to).getTime() : undefined;
-        if ((fromMs !== undefined && !Number.isFinite(fromMs)) || (toMs !== undefined && !Number.isFinite(toMs)) || (fromMs !== undefined && toMs !== undefined && fromMs > toMs)) {
-            setError('Choose a valid time range.'); return;
-        }
-        setCursors([undefined]);
-        setQuery({ fromMs, toMs, actor: text('actor'), action: text('action'), outcome: text('outcome') as AuditOutcome | undefined, environmentId: text('environmentId'), limit: 50 });
+export function AuditPage() {
+    const [view, setView] = useNavigationState('auditView', initialView);
+    const [validation, setValidation] = useState('');
+    const cursor = view.location.cursors[view.location.cursors.length - 1];
+    const load = useCallback(() => queryAuditEvents({ ...view.location.query, cursor }), [view.location.query, view.location.generation, cursor]);
+    const page = useReadResource(load, 'Audit events could not be loaded.');
+    const refresh = useCallback(() => setView(previous => ({ ...previous, location: navigateAudit(previous.location, { kind: 'refresh' }), selected: null })), [setView]);
+    usePageRefresh({ refresh, pending: page.pending, refreshedAt: page.receivedAt });
+    const apply = () => {
+        try {
+            const query = auditQuery(view.draft);
+            setValidation('');
+            setView(previous => ({ ...previous, applied: { ...previous.draft }, location: navigateAudit(previous.location, { kind: 'apply', query }), selected: null }));
+        } catch (error) { setValidation(error instanceof Error ? error.message : 'Choose valid audit filters.'); }
     };
-    const inputClass = 'mt-1 w-full rounded-lg border border-gray-300 bg-transparent px-3 py-2 dark:border-gray-600';
-    return <Card className="ops-card">
-        <CardHeader><CardTitle>Audit events</CardTitle><CardDescription>Terminal outcomes of local and RocketMQ administration. Unknown means the remote result could not be confirmed; review the actual resource before resubmitting.</CardDescription></CardHeader>
-        <CardContent className="space-y-5">
-            <form onSubmit={apply} className="grid gap-3 md:grid-cols-3">
-                <label className="text-sm">From<input name="from" type="datetime-local" className={inputClass} /></label>
-                <label className="text-sm">To<input name="to" type="datetime-local" className={inputClass} /></label>
-                <label className="text-sm">Actor<input name="actor" placeholder="Exact username" className={inputClass} /></label>
-                <label className="text-sm">Action<input name="action" placeholder="e.g. topic.delete" className={inputClass} /></label>
-                <label className="text-sm">Outcome<select name="outcome" className={inputClass}><option value="">All outcomes</option>{['success', 'rejected', 'failed', 'partial', 'unknown'].map((outcome) => <option key={outcome}>{outcome}</option>)}</select></label>
-                <label className="text-sm">Environment ID<input name="environmentId" placeholder="Exact ID, if recorded" className={inputClass} /></label>
-                <div className="flex gap-3"><Button type="submit" disabled={loading}>Apply filters</Button><Button type="button" variant="outline" disabled={loading} onClick={() => { setCursors([undefined]); setRefresh((value) => value + 1); }}>Refresh</Button></div>
-            </form>
-            {error && <p role="alert" className="text-red-600">{error}</p>}
-            {loading ? <p role="status">Loading audit events¡­</p> : page && <>
-                <div className="overflow-x-auto"><table className="w-full text-left text-sm">
-                    <caption className="sr-only">Filtered audit events, newest first</caption>
-                    <thead><tr>{['Time', 'Actor', 'Action', 'Resource', 'Environment', 'Outcome', 'Details'].map((label) => <th scope="col" className="p-3" key={label}>{label}</th>)}</tr></thead>
-                    <tbody>{page.items.map((event) => <tr key={event.eventId} className="border-t border-gray-200 dark:border-gray-700">
-                        <td className="p-3 whitespace-nowrap">{new Date(event.createdAtMs).toLocaleString()}</td><td className="p-3">{event.actor ?? 'Unauthenticated'}</td><td className="p-3 font-mono">{event.action}</td>
-                        <td className="p-3">{event.resourceType}{event.resourceName && `: ${event.resourceName}`}</td><td className="p-3">{event.environmentId ?? 'Not recorded'}</td><td className="p-3 font-medium">{event.outcome}</td>
-                        <td className="p-3"><details><summary className="cursor-pointer">View receipt</summary><p className="mt-2 break-all font-mono text-xs">Request: {event.requestId}</p>{event.detail.resultUnknown && <p className="text-amber-700">Remote outcome unknown. No automatic retry was performed.</p>}{event.detail.errorCode && <p>{event.detail.errorCode}</p>}{event.detail.successCount !== undefined && <p>Succeeded: {event.detail.successCount}</p>}{event.detail.failureCount !== undefined && <p>Failed: {event.detail.failureCount}</p>}</details></td>
-                    </tr>)}</tbody>
-                </table>{page.items.length === 0 && <p className="p-3">No matching audit events.</p>}</div>
-                <div className="flex items-center gap-3"><Button variant="outline" disabled={cursors.length === 1} onClick={() => setCursors((values) => values.slice(0, -1))}>Previous</Button><span>Page {cursors.length}</span><Button variant="outline" disabled={!page.nextCursor} onClick={() => { const next = page.nextCursor; if (next) setCursors((values) => [...values, next]); }}>Next</Button></div>
-            </>}
-        </CardContent>
-    </Card>;
-};
+    const reset = () => {
+        setValidation('');
+        setView(previous => ({ ...initialView(), location: navigateAudit(previous.location, { kind: 'apply', query: { limit: 50 } }) }));
+    };
+    const selected = page.data?.items.find(event => event.eventId === view.selected) ?? null;
+    const usable = Boolean(page.data) && !page.pending && !page.error;
+    const next = page.data?.nextCursor ?? null;
+    return <div className="ops-audit">
+        <AuditFilters filters={view.draft} pending={page.pending} error={validation} changed={JSON.stringify(view.draft) !== JSON.stringify(view.applied)}
+            onChange={draft => setView(previous => ({ ...previous, draft }))} apply={apply} reset={reset} />
+        {page.pending && <PageState kind="loading" title="Loading audit events" />}
+        {page.error && <PageState kind="error" title="Audit query failed" description={page.error} action={<Button variant="outline" onClick={() => { void page.read(); }}>Retry this page</Button>} />}
+        {page.data && <div className="ops-audit-table-wrap" role="region" tabIndex={0} aria-label="Audit events" aria-busy={page.pending}>
+            <table className="ops-audit-table"><caption className="sr-only">Filtered audit records, newest first</caption>
+                <thead><tr><th scope="col">Time <ArrowDown aria-hidden="true" size={14} style={{ display: 'inline', verticalAlign: 'middle' }} /></th>
+                    <th scope="col">Actor</th><th scope="col">Action</th><th scope="col">Resource</th><th scope="col">Outcome</th><th scope="col">Details</th></tr></thead>
+                <tbody>{page.data.items.map(event => {
+                    const outcome = auditOutcome(event.outcome, event.detail?.resultUnknown === true);
+                    return <tr key={event.eventId} data-selected={event.eventId === view.selected}>
+                        <td>{auditTimestamp(event.createdAtMs)}</td><td><span className="ops-audit-cell" tabIndex={0}>{event.actor ?? 'Not recorded'}</span></td>
+                        <td><span className="ops-audit-cell" tabIndex={0}>{event.action}</span></td><td><span className="ops-audit-cell" tabIndex={0}>{event.resourceName ?? 'Not recorded'}</span></td>
+                        <td><StatusBadge tone={outcome.tone}>{outcome.label}</StatusBadge></td>
+                        <td><Button variant="ghost" icon={ChevronRight} disabled={!usable} aria-label={`View ${event.action} audit record ${event.eventId}`} aria-expanded={event.eventId === view.selected}
+                            onClick={() => setView(previous => ({ ...previous, selected: event.eventId }))}>View</Button></td>
+                    </tr>;
+                })}</tbody>
+            </table>
+        </div>}
+        {usable && page.data?.items.length === 0 && <PageState kind="empty" title="No matching audit events" description="Change the exact filters or time range to inspect other records." />}
+        {selected && <AuditDetails event={selected} />}
+        {(page.data || view.location.cursors.length > 1) && <nav className="ops-audit-pagination" aria-label="Audit pagination">
+            <Button variant="outline" disabled={page.pending || view.location.cursors.length === 1} onClick={() => setView(previous => ({ ...previous, location: navigateAudit(previous.location, { kind: 'previous' }), selected: null }))}>Previous</Button>
+            <span>Page {view.location.cursors.length}</span>
+            <Button variant="outline" disabled={!usable || !next || view.location.cursors.includes(next)} onClick={() => setView(previous => ({ ...previous, location: navigateAudit(previous.location, { kind: 'next', cursor: next }), selected: null }))}>Next</Button>
+        </nav>}
+    </div>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/audit.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/audit.css
@@ -1,0 +1,41 @@
+.ops-audit { display: grid; min-width: 0; gap: 20px; }
+.ops-audit-filters, .ops-audit-details { min-width: 0; padding: 20px; background: var(--ops-panel); border: 1px solid var(--ops-border); border-radius: var(--ops-radius); }
+.ops-audit-filters { display: grid; gap: 12px; padding: 16px 20px; }
+.ops-audit-filter-fields { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px 18px; }
+.ops-audit-filter-fields > * { min-width: 0; }
+.ops-audit-filter-fields .ops-field:nth-last-child(-n+2) { grid-column: span 2; }
+.ops-audit-filter-fields select { display: block; min-width: 0; width: 100%; height: var(--ops-control-height); border: 1px solid var(--ops-border-strong); border-radius: var(--ops-control-radius); background: var(--ops-panel-soft); color: var(--ops-text); padding: 0 12px; font: inherit; font-size: 14px; }
+.ops-audit-filter-actions { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+.ops-audit-note { font-size: 13px; color: var(--ops-muted); }
+.ops-audit-table-wrap { min-width: 0; overflow: auto; border: 1px solid var(--ops-border); border-radius: var(--ops-radius); background: var(--ops-panel); }
+.ops-audit-table { width: 100%; min-width: 900px; border-collapse: collapse; text-align: left; font-size: 13px; }
+.ops-audit-table th { padding: 16px 18px; color: var(--ops-muted); font-weight: 500; white-space: nowrap; }
+.ops-audit-table td { padding: 8px 18px; border-top: 1px solid var(--ops-border); }
+.ops-audit-table tr[data-selected="true"] { background: var(--ops-accent-soft); }
+.ops-audit-table td:first-child { white-space: nowrap; font-variant-numeric: tabular-nums; }
+.ops-audit-cell { display: block; max-width: 230px; max-height: 100px; overflow: auto; overflow-wrap: anywhere; }
+.ops-audit-details h2 { font-size: 18px; font-weight: 600; }
+.ops-audit-details > .ops-audit-note { margin: 5px 0 20px; }
+.ops-audit-detail-columns { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 32px; }
+.ops-audit-detail-columns dl { display: grid; align-content: start; gap: 14px; min-width: 0; font-size: 13px; }
+.ops-audit-detail-columns dl + dl { border-left: 1px solid var(--ops-border); padding-left: 32px; }
+.ops-audit-detail-columns dl > div { display: grid; grid-template-columns: 125px minmax(0, 1fr); gap: 12px; }
+.ops-audit-detail-columns dt { color: var(--ops-muted); }
+.ops-audit-detail-columns dd { margin: 0; min-width: 0; max-height: 120px; overflow: auto; overflow-wrap: anywhere; font-variant-numeric: tabular-nums; }
+.ops-audit-copy { display: flex; gap: 8px; align-items: flex-start; }
+.ops-audit-copy > span { min-width: 0; max-height: 100px; overflow: auto; }
+.ops-audit-copy > button { flex: none; }
+.ops-audit-notice { display: flex; align-items: flex-start; gap: 10px; margin-top: 22px; padding: 14px; border: 1px solid var(--ops-border); border-radius: 8px; background: var(--ops-panel-soft); font-size: 13px; color: var(--ops-muted); }
+.ops-audit-notice svg { flex: none; }
+.ops-audit-pagination { display: flex; gap: 12px; align-items: center; justify-content: flex-end; flex-wrap: wrap; font-size: 13px; color: var(--ops-muted); }
+@media (max-width: 1100px) {
+  .ops-audit-filter-fields { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ops-audit-filter-fields .ops-field:nth-last-child(-n+2) { grid-column: auto; }
+  .ops-audit-detail-columns { grid-template-columns: minmax(0, 1fr); gap: 20px; }
+  .ops-audit-detail-columns dl + dl { padding: 20px 0 0; border-left: 0; border-top: 1px solid var(--ops-border); }
+}
+@media (max-width: 600px) {
+  .ops-audit-filters, .ops-audit-details { padding: 16px; }
+  .ops-audit-filter-fields { grid-template-columns: minmax(0, 1fr); }
+  .ops-audit-detail-columns dl > div { grid-template-columns: 105px minmax(0, 1fr); gap: 8px; }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/auditModel.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/auditModel.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { auditDetail, auditOutcome, auditQuery, emptyAuditFilters, initialAuditLocation, navigateAudit } from './auditModel';
+
+describe('audit filters and page identity', () => {
+    it('preserves exact actor/action/environment strings and rejects unsupported outcomes', () => {
+        const query = auditQuery({ ...emptyAuditFilters(), actor: ' admin ', action: 'topic.delete', environmentId: 'env-a', outcome: 'partial' });
+        expect(query).toMatchObject({ actor: ' admin ', action: 'topic.delete', environmentId: 'env-a', outcome: 'partial', limit: 50 });
+        expect(query.cursor).toBeUndefined();
+        expect(() => auditQuery({ ...emptyAuditFilters(), outcome: 'completed' })).toThrow();
+    });
+    it('rejects impossible local dates, malformed dates and reversed ranges while allowing inclusive equal endpoints', () => {
+        for (const from of ['2026-02-30T12:00', '2026-13-01T12:00', '2026-09-11T25:00', 'not-a-date', '2026-09-11']) {
+            expect(() => auditQuery({ ...emptyAuditFilters(), from })).toThrow();
+        }
+        expect(() => auditQuery({ ...emptyAuditFilters(), from: '2026-09-12T12:00', to: '2026-09-11T12:00' })).toThrow();
+        const query = auditQuery({ ...emptyAuditFilters(), from: '2024-02-29T12:00:20', to: '2024-02-29T12:00:20' });
+        expect(query.fromMs).toBe(query.toMs);
+        expect(query.fromMs).toBe(new Date('2024-02-29T12:00:20').getTime());
+    });
+    it('resets opaque cursor history when filters change and refreshes from the newest page', () => {
+        let page = navigateAudit(initialAuditLocation(), { kind: 'next', cursor: 'opaque-a' });
+        page = navigateAudit(page, { kind: 'next', cursor: 'opaque-b' });
+        expect(navigateAudit(page, { kind: 'previous' }).cursors).toEqual([undefined, 'opaque-a']);
+        expect(navigateAudit(page, { kind: 'next', cursor: 'opaque-a' })).toBe(page);
+        expect(navigateAudit(page, { kind: 'next', cursor: null })).toBe(page);
+        const changed = navigateAudit(page, { kind: 'apply', query: { actor: 'other', cursor: 'old-cursor', limit: 50 } });
+        expect(changed.cursors).toEqual([undefined]);
+        expect(changed.query).toEqual({ actor: 'other', limit: 50 });
+        expect(navigateAudit(page, { kind: 'refresh' })).toMatchObject({ cursors: [undefined], generation: 1 });
+    });
+});
+describe('safe audit details', () => {
+    it('retains explicit zero, distinguishes missing/invalid counts and omits non-whitelisted fields', () => {
+        const detail = auditDetail({ resultUnknown: false, successCount: 0, password: 'secret', error: 'raw exception', body: 'message text', token: 'token' } as Parameters<typeof auditDetail>[0]);
+        expect(detail).toEqual({ resultUnknown: false, successCount: '0', failureCount: 'Not recorded', errorCode: 'Not recorded' });
+        expect(JSON.stringify(detail)).not.toMatch(/secret|exception|message text|token/);
+        expect(auditDetail({ resultUnknown: true, successCount: -1, failureCount: Number.MAX_SAFE_INTEGER + 1 }).successCount).toBe('Unknown');
+        expect(auditDetail({ resultUnknown: false, errorCode: 'password: secret' }).errorCode).toBe('Not recorded');
+        expect(auditDetail({ resultUnknown: false, errorCode: 'dashboard.monitor_conflict' }).errorCode).toBe('dashboard.monitor_conflict');
+    });
+    it('never labels unrecognized or explicitly unknown results as success', () => {
+        expect(auditOutcome('success')).toEqual({ label: 'Success', tone: 'success' });
+        for (const value of ['unknown', 'unexpected', '', 'SUCCESS']) expect(auditOutcome(value).tone).not.toBe('success');
+        expect(auditOutcome('success', true).label).toBe('Unknown');
+        expect(['rejected', 'failed', 'partial'].map(value => auditOutcome(value).label)).toEqual(['Rejected', 'Failed', 'Partial']);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/auditModel.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/audit/auditModel.ts
@@ -1,0 +1,62 @@
+import type { AuditEvent, AuditOutcome, AuditQuery } from '../../services/audit.service';
+
+export interface AuditFilters { from: string; to: string; actor: string; action: string; outcome: string; environmentId: string }
+export const emptyAuditFilters = (): AuditFilters => ({ from: '', to: '', actor: '', action: '', outcome: '', environmentId: '' });
+export const auditOutcomes: AuditOutcome[] = ['success', 'rejected', 'failed', 'partial', 'unknown'];
+function localTime(value: string): number | undefined {
+    if (!value) return undefined;
+    const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(value);
+    if (!match) throw new Error('Choose a valid local date and time.');
+    const [, year, month, day, hour, minute, second = '00'] = match;
+    const date = new Date(value);
+    if (!Number.isSafeInteger(date.getTime()) || date.getFullYear() !== Number(year) || date.getMonth() + 1 !== Number(month) ||
+        date.getDate() !== Number(day) || date.getHours() !== Number(hour) || date.getMinutes() !== Number(minute) || date.getSeconds() !== Number(second)) {
+        throw new Error('Choose a valid local date and time.');
+    }
+    return date.getTime();
+}
+export function auditQuery(filters: AuditFilters): AuditQuery {
+    const fromMs = localTime(filters.from), toMs = localTime(filters.to);
+    if (fromMs !== undefined && toMs !== undefined && fromMs > toMs) throw new Error('The start time must be before or equal to the end time.');
+    if (filters.outcome && !auditOutcomes.includes(filters.outcome as AuditOutcome)) throw new Error('Choose one of the supported outcomes.');
+    return { fromMs, toMs, actor: filters.actor || undefined, action: filters.action || undefined,
+        outcome: filters.outcome as AuditOutcome || undefined, environmentId: filters.environmentId || undefined, limit: 50 };
+}
+export interface AuditLocation { query: AuditQuery; cursors: Array<string | undefined>; generation: number }
+export const initialAuditLocation = (): AuditLocation => ({ query: { limit: 50 }, cursors: [undefined], generation: 0 });
+export type AuditNavigation = { kind: 'apply'; query: AuditQuery } | { kind: 'refresh' } | { kind: 'previous' } | { kind: 'next'; cursor: string | null };
+export function navigateAudit(location: AuditLocation, action: AuditNavigation): AuditLocation {
+    switch (action.kind) {
+        case 'apply': {
+            // A cursor belongs only to its applied filters, never the editable draft.
+            const { cursor: _cursor, ...query } = action.query;
+            return { query, cursors: [undefined], generation: location.generation + 1 };
+        }
+        case 'refresh': return { ...location, cursors: [undefined], generation: location.generation + 1 };
+        case 'previous': return location.cursors.length > 1 ? { ...location, cursors: location.cursors.slice(0, -1) } : location;
+        case 'next': return action.cursor && !location.cursors.includes(action.cursor) ? { ...location, cursors: [...location.cursors, action.cursor] } : location;
+    }
+}
+export function auditOutcome(value: string, resultUnknown = false): { label: string; tone: 'neutral' | 'success' | 'warning' | 'danger' } {
+    if (resultUnknown) return { label: 'Unknown', tone: 'neutral' };
+    switch (value) {
+        case 'success': return { label: 'Success', tone: 'success' };
+        case 'rejected': return { label: 'Rejected', tone: 'warning' };
+        case 'failed': return { label: 'Failed', tone: 'danger' };
+        case 'partial': return { label: 'Partial', tone: 'warning' };
+        default: return { label: 'Unknown', tone: 'neutral' };
+    }
+}
+export function auditTimestamp(value: number): string {
+    return Number.isSafeInteger(value) && !Number.isNaN(new Date(value).getTime()) ? new Date(value).toLocaleString() : 'Not recorded';
+}
+const count = (value: unknown): string => value === undefined || value === null ? 'Not recorded' :
+    typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? String(value) : 'Unknown';
+/** Deliberately project only the safe detail fields; raw request/exception payloads have no display path. */
+export function auditDetail(detail: AuditEvent['detail']) {
+    return {
+        successCount: count(detail?.successCount), failureCount: count(detail?.failureCount),
+        resultUnknown: detail?.resultUnknown === true,
+        errorCode: typeof detail?.errorCode === 'string' && /^[a-z0-9][a-z0-9._-]{0,127}$/i.test(detail.errorCode) ? detail.errorCode : 'Not recorded',
+    };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/audit.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/audit.service.ts
@@ -7,7 +7,7 @@ export interface AuditQuery {
 export interface AuditEvent {
     eventId: string; requestId: string; actor: string | null; action: string;
     resourceType: string; resourceName: string | null; environmentId: string | null;
-    outcome: AuditOutcome; createdAtMs: number;
+    outcome: string; createdAtMs: number;
     detail: { resultUnknown: boolean; errorCode?: string; successCount?: number; failureCount?: number };
 }
 export interface AuditPage { items: AuditEvent[]; nextCursor: string | null }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -91,7 +91,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       case 'Storage':
         return 'Storage & diagnostics';
       case 'Audit':
-        return 'Audit Events';
+        return 'Audit log';
       case 'Monitors':
         return 'Consumer monitors';
       case 'Sessions':

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/controls.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/controls.css
@@ -48,6 +48,7 @@
   background: var(--ops-panel-soft);
   color: var(--ops-text);
   font: 400 14px/1.4 var(--ops-font);
+  color-scheme: inherit;
 }
 .ops-input, [data-slot="textarea"] { display: block; width: 100%; }
 .ops-input::placeholder, [data-slot="textarea"]::placeholder { color: var(--ops-subtle); }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10518

### Brief Description

Rework the Tauri audit log into exact filters, selectable records and safe operation details. Editable filters remain separate from the applied query; delayed responses cannot replace newer results, and a failed later cursor page can return to its predecessor. Missing counts stay distinct from zero, unrecognized outcomes render as unknown, and only approved detail fields are displayed.

The page uses the shared dark desktop controls, scrollable long metadata and clear clipboard feedback. Native date controls inherit the active color scheme. Document the local log scope and cursor behavior.

### How Did You Test This Change?

- `npm run build`: passed after integration with current main.
- `npm test -- --run`: 232 tests across 41 files passed.
- External Chrome: reference comparison at 1487 by 1058, narrow 800 by 600 layout, wide and restored views; cursor pages and failures, exact filters and date validation, delayed query isolation, global environment semantics, empty results, safe metadata projection and clipboard success/failure passed with no console warnings or errors.
- Earlier native checks covered real audit filtering, unknown detail fields and request ID clipboard output. Final integrated native rebuild and Windows scaling remain in the overall acceptance task. CI was not used as a merge gate, as requested.
