### PR TITLE
[ISSUE #10520]✨Redesign local session management and confirmed revocation

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ACCOUNT_SESSIONS_UI.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ACCOUNT_SESSIONS_UI.md
@@ -1,0 +1,11 @@
+# Account sessions
+
+Sessions shows the signed-in local account's safe session records, with a distinct Current badge. Created, expiry, last visit and revocation times come from the backend. Activity does not extend expiry; no fixed TTL is assumed. Expired and revoked records remain distinguishable. The table updates its expiry presentation without fetching or writing session data.
+
+Only the public UUID record label is shown. Login tokens, token digests, devices, locations and other extra fields have no rendering path. Unknown or malformed metadata is not presented as an active session.
+
+The list uses the backend's opaque cursors and reports only the current page and its record count. Toolbar Refresh returns to the first page. Failed reads remain retryable; a failed later page can return to the previous page. The same component works within Account with its own local refresh controls.
+
+Sign out all sessions names the account and explicitly includes the current session. The dialog and accepted operation belong to the signed-in session, so page or environment changes do not retarget or duplicate the request. Pending confirmation cannot be dismissed. Failures retain a safe error in the dialog and do not perform an optimistic logout. A strict confirmed current-session revocation follows the existing authentication-invalid event. A late response for an older token cannot log out a newer login.
+
+Validation covers expiry, redaction, cursor history and service-level success/failure/late-session behavior, plus shared read-resource, toolbar and navigation tests. Native session tests cover pagination, redaction, account isolation, expiry and authoritative revocation. External Chrome visual/keyboard comparison and the live Windows sign-out workflow remain separate acceptance evidence.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -26,13 +26,14 @@ import {MonitorPage} from '../../pages/monitor/MonitorPage';
 import {MonitorActionProvider} from '../../pages/monitor/MonitorActionProvider';
 import {AuditPage} from '../../pages/audit/AuditPage';
 import {SessionsPanel} from '../../pages/account/SessionsPanel';
+import {SessionRevokeProvider} from '../../pages/account/SessionRevokeProvider';
 import {AccountPage} from '../../pages/account/AccountPage';
 
 export const AppRouter = () => {
     const settings = useSyncExternalStore(ConnectionStore.subscribe, ConnectionStore.getSnapshot, () => null);
     const { activeTab, navigation, sessionId } = useAppStore();
     const key = ['NameServer', 'Proxy', 'Account', 'Sessions', 'Audit'].includes(activeTab) ? activeTab : `${activeTab}:${settings?.revision ?? 0}`;
-    return <BrokerConfigEditorProvider key={sessionId}><TopicActionProvider><ConsumerActionProvider><MessageActionProvider><DlqActionProvider><AclActionProvider><MonitorActionProvider><RouteContent key={`${key}:${navigation.id}`} /></MonitorActionProvider></AclActionProvider></DlqActionProvider></MessageActionProvider></ConsumerActionProvider></TopicActionProvider></BrokerConfigEditorProvider>;
+    return <BrokerConfigEditorProvider key={sessionId}><TopicActionProvider><ConsumerActionProvider><MessageActionProvider><DlqActionProvider><AclActionProvider><MonitorActionProvider><SessionRevokeProvider><RouteContent key={`${key}:${navigation.id}`} /></SessionRevokeProvider></MonitorActionProvider></AclActionProvider></DlqActionProvider></MessageActionProvider></ConsumerActionProvider></TopicActionProvider></BrokerConfigEditorProvider>;
 };
 
 const RouteContent = () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/components/SignOutConfirmDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/components/SignOutConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { LogOut } from 'lucide-react';
 import { Button } from '../../../components/ui/button';
+import { PageState } from '../../../components/layout/PageState';
 import {
     AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription,
     AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
@@ -11,12 +12,14 @@ interface SignOutConfirmDialogProps {
     title: string;
     description: string;
     isSubmitting?: boolean;
+    error?: string;
+    confirmLabel?: string;
     onConfirm: () => void | Promise<void>;
     onCancel: () => void;
 }
 
 export const SignOutConfirmDialog = ({
-    open, title, description, isSubmitting = false, onConfirm, onCancel,
+    open, title, description, isSubmitting = false, error, confirmLabel = 'Sign Out', onConfirm, onCancel,
 }: SignOutConfirmDialogProps) => (
     <AlertDialog open={open} onOpenChange={nextOpen => { if (!nextOpen && !isSubmitting) onCancel(); }}>
         <AlertDialogContent aria-busy={isSubmitting}
@@ -32,12 +35,13 @@ export const SignOutConfirmDialog = ({
                 <AlertDialogTitle>{title}</AlertDialogTitle>
                 <AlertDialogDescription>{description}</AlertDialogDescription>
             </AlertDialogHeader>
+            {error && <PageState kind="error" title="Sign out was not confirmed" description={error} />}
             <AlertDialogFooter>
                 <AlertDialogCancel disabled={isSubmitting}>Cancel</AlertDialogCancel>
                 <Button variant="destructive" disabled={isSubmitting} aria-busy={isSubmitting}
                     onClick={() => { if (!isSubmitting) void onConfirm(); }}>
                     <LogOut aria-hidden="true" />
-                    {isSubmitting ? 'Signing Out...' : 'Sign Out'}
+                    {isSubmitting ? 'Signing Out...' : confirmLabel}
                 </Button>
             </AlertDialogFooter>
         </AlertDialogContent>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/SessionRevokeProvider.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/SessionRevokeProvider.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useAppStore } from '../../stores/app.store';
+import { AuthService } from '../../services/auth.service';
+import { dashboardErrorMessage } from '../../services/invoke';
+import { SignOutConfirmDialog } from '../../features/auth';
+
+const Context = createContext<{ open: (username: string) => void; pending: boolean } | null>(null);
+/** Keep account revocation attached to the signed-in session across page and environment changes. */
+export function SessionRevokeProvider({ children }: { children: ReactNode }) {
+    const { currentUser } = useAppStore();
+    const [username, setUsername] = useState<string | null>(null);
+    const [pending, setPending] = useState(false);
+    const [error, setError] = useState('');
+    const inFlight = useRef(false);
+    const active = useRef(true);
+    useEffect(() => { active.current = true; return () => { active.current = false; }; }, []);
+    const confirm = async () => {
+        if (!username || username !== currentUser?.username || inFlight.current) return;
+        inFlight.current = true;
+        setPending(true); setError('');
+        try {
+            const receipt = await AuthService.revokeUserSessions(username);
+            if (active.current && receipt.currentSessionRevoked !== true) setError('Current-session revocation was not confirmed. Refresh the sessions before another attempt.');
+            // A confirmed current-session revocation uses AuthService's existing authentication-invalid event.
+        } catch (failure) {
+            if (active.current) setError(dashboardErrorMessage(failure, 'Could not revoke sessions. No automatic retry was performed.'));
+        } finally {
+            inFlight.current = false;
+            if (active.current) setPending(false);
+        }
+    };
+    return <Context.Provider value={{ open: target => {
+        if (!inFlight.current && target === currentUser?.username) { setError(''); setUsername(target); }
+    }, pending }}>{children}
+        <SignOutConfirmDialog open={username !== null} title="Sign out all sessions?"
+            description={`All local dashboard sessions for ${username ?? ''}, including the current session, will be revoked. Sign in again to continue.`}
+            error={error} confirmLabel="Sign out all sessions" isSubmitting={pending}
+            onConfirm={confirm} onCancel={() => { if (!inFlight.current) setUsername(null); }} />
+    </Context.Provider>;
+}
+export function useSessionRevoke() {
+    const value = useContext(Context);
+    if (!value) throw new Error('SessionRevokeProvider is required.');
+    return value;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/SessionTable.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/SessionTable.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import type { SessionView } from '../../services/auth.service';
+import { StatusBadge } from '../../components/layout/StatusBadge';
+import { sessionLabel, sessionStatus, sessionTimestamp } from './sessionModel';
+
+export function SessionTable({ items, username }: { items: SessionView[]; username: string }) {
+    const [, tick] = useState(0);
+    useEffect(() => { const timer = window.setInterval(() => tick(value => value + 1), 1000); return () => window.clearInterval(timer); }, []);
+    const now = Date.now();
+    return <table className="ops-session-table"><caption className="sr-only">Local dashboard sessions for {username}</caption>
+        <thead><tr>{['Session', 'Created', 'Expires', 'Last visit', 'Status'].map(label => <th key={label} scope="col">{label}</th>)}</tr></thead>
+        <tbody>{items.map(session => {
+            const status = sessionStatus(session, now);
+            return <tr key={session.id} data-current={session.current === true}>
+                <td><div className="ops-session-identity"><span className="ops-session-id">{sessionLabel(session.id)}</span>{session.current === true && <StatusBadge tone="accent">Current</StatusBadge>}</div></td>
+                <td>{sessionTimestamp(session.createdAtMs)}</td><td>{sessionTimestamp(session.expiresAtMs)}</td><td>{sessionTimestamp(session.lastSeenAtMs)}</td>
+                <td><StatusBadge tone={status.tone}>{status.label}</StatusBadge>{status.label === 'Revoked' && <span className="ops-session-revoked-at">{status.note}</span>}</td>
+            </tr>;
+        })}</tbody>
+    </table>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/SessionsPanel.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/SessionsPanel.tsx
@@ -1,94 +1,52 @@
-import { useEffect, useRef, useState } from 'react';
-import { AuthService, type SessionPage } from '../../services/auth.service';
-import { dashboardErrorMessage } from '../../services/invoke';
-import { Button } from '../../components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
-import { SignOutConfirmDialog } from '../../features/auth';
+import { useCallback } from 'react';
+import { ArrowRight, Info, LogOut } from 'lucide-react';
+import { AuthService } from '../../services/auth.service';
+import { useReadResource } from '../../hooks/useReadResource';
+import { useAppStore, useNavigationState } from '../../stores/app.store';
+import { usePageRefresh } from '../../app/layout/pageToolbar';
+import { Button } from '../../components/ui/LegacyButton';
+import { PageState } from '../../components/layout/PageState';
+import { useSessionRevoke } from './SessionRevokeProvider';
+import { SessionTable } from './SessionTable';
+import { sessionCursorHistory } from './sessionModel';
+import './sessions.css';
 
-const timestamp = (value: number) => new Date(value).toLocaleString();
-
-export const SessionsPanel = ({ username }: { username: string }) => {
-    const [page, setPage] = useState<SessionPage | null>(null);
-    const [cursors, setCursors] = useState<Array<string | undefined>>([undefined]);
-    const [refresh, setRefresh] = useState(0);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState('');
-    const [confirm, setConfirm] = useState(false);
-    const [revoking, setRevoking] = useState(false);
-    const mounted = useRef(false);
-    const cursor = cursors[cursors.length - 1];
-
-    useEffect(() => {
-        mounted.current = true;
-        return () => { mounted.current = false; };
-    }, []);
-
-    useEffect(() => {
-        let active = true;
-        setLoading(true);
-        setError('');
-        setPage(null);
-        void AuthService.listSessions(username, cursor).then((result) => {
-            if (active) setPage(result);
-        }).catch((failure: unknown) => {
-            if (active) setError(dashboardErrorMessage(failure, 'Could not load sessions.'));
-        }).finally(() => { if (active) setLoading(false); });
-        return () => { active = false; };
-    }, [username, cursor, refresh]);
-
-    const revoke = async () => {
-        setRevoking(true);
-        setError('');
-        try {
-            await AuthService.revokeUserSessions(username);
-        } catch (failure) {
-            if (mounted.current) setError(dashboardErrorMessage(failure, 'Could not revoke sessions.'));
-        } finally {
-            if (mounted.current) { setRevoking(false); setConfirm(false); }
-        }
-    };
-
-    return (
-        <Card className="ops-card account-card" id="sessions">
-            <CardHeader>
-                <CardTitle>Sessions</CardTitle>
-                <CardDescription>Sessions for {username}. Activity updates the last visit, without extending expiry.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4 !pb-8">
-                <div className="flex flex-wrap gap-3">
-                    <Button variant="outline" disabled={loading || revoking} onClick={() => { setCursors([undefined]); setRefresh((value) => value + 1); }}>Refresh sessions</Button>
-                    <Button variant="outline" className="ops-button ops-button-danger" disabled={revoking} onClick={() => setConfirm(true)}>Sign out all sessions</Button>
-                </div>
-                {error && <p role="alert" className="text-sm text-red-600">{error}</p>}
-                {loading ? <p role="status">Loading sessions¡­</p> : page && (
-                    <>
-                        <div className="overflow-x-auto">
-                            <table className="w-full text-left text-sm">
-                                <caption className="sr-only">Local account sessions for {username}</caption>
-                                <thead><tr>{['Session', 'Created', 'Expires', 'Last visit', 'Status'].map((label) => <th key={label} scope="col" className="p-3">{label}</th>)}</tr></thead>
-                                <tbody>{page.items.map((session) => (
-                                    <tr key={session.id} className="border-t border-gray-200 dark:border-gray-700">
-                                        <td className="p-3"><span className="font-mono" title={session.id}>{session.id.slice(0, 8)}</span>{session.current && <span className="ml-2 text-sky-600">Current</span>}</td>
-                                        <td className="p-3 whitespace-nowrap">{timestamp(session.createdAtMs)}</td>
-                                        <td className="p-3 whitespace-nowrap">{timestamp(session.expiresAtMs)}</td>
-                                        <td className="p-3 whitespace-nowrap">{timestamp(session.lastSeenAtMs)}</td>
-                                        <td className="p-3">{session.revokedAtMs !== null ? `Revoked ${timestamp(session.revokedAtMs)}` : session.expiresAtMs <= Date.now() ? 'Expired' : 'Active'}</td>
-                                    </tr>
-                                ))}</tbody>
-                            </table>
-                            {page.items.length === 0 && <p className="p-3">No sessions found.</p>}
-                        </div>
-                        <div className="flex items-center gap-3">
-                            <Button variant="outline" disabled={cursors.length === 1} onClick={() => setCursors((values) => values.slice(0, -1))}>Previous</Button>
-                            <span>Page {cursors.length}</span>
-                            <Button variant="outline" disabled={!page.nextCursor} onClick={() => { if (page.nextCursor) setCursors((values) => [...values, page.nextCursor!]); }}>Next</Button>
-                        </div>
-                    </>
-                )}
-                <SignOutConfirmDialog open={confirm} isSubmitting={revoking} title="Sign out all sessions?"
-                    description={`All sessions for ${username}, including this one, will be revoked. Sign in again to continue.`}
-                    onCancel={() => { if (!revoking) setConfirm(false); }} onConfirm={() => void revoke()} />
-            </CardContent>
-        </Card>
-    );
-};
+function SessionsToolbar({ refresh, pending, refreshedAt, username }: { refresh: () => void; pending: boolean; refreshedAt: number | null; username: string }) {
+    const revoke = useSessionRevoke();
+    usePageRefresh({ refresh, pending, refreshedAt, actions: <Button variant="danger" icon={LogOut} disabled={revoke.pending} onClick={() => revoke.open(username)}>Sign out all sessions</Button> });
+    return null;
+}
+function SessionList({ username }: { username: string }) {
+    const app = useAppStore();
+    const isPage = app.activeTab === 'Sessions';
+    const revoke = useSessionRevoke();
+    const [location, setLocation] = useNavigationState(`sessions:${username}`, () => ({ cursors: [undefined] as Array<string | undefined>, generation: 0 }));
+    const cursor = location.cursors[location.cursors.length - 1];
+    const load = useCallback(() => AuthService.listSessions(username, cursor), [username, cursor, location.generation]);
+    const page = useReadResource(load, 'Account sessions could not be loaded.');
+    const refresh = useCallback(() => setLocation(previous => ({ cursors: [undefined], generation: previous.generation + 1 })), [setLocation]);
+    const next = page.data?.nextCursor ?? null;
+    const busy = page.pending || revoke.pending;
+    return <section className={`ops-sessions ${isPage ? 'ops-sessions-page' : ''}`} id="sessions" aria-label="Account sessions">
+        {isPage ? <SessionsToolbar refresh={refresh} pending={busy} refreshedAt={page.receivedAt} username={username} /> :
+            <><h2 className="ops-session-embedded-heading">Sessions</h2><div className="ops-session-inline-actions"><Button variant="outline" disabled={busy} onClick={refresh}>Refresh sessions</Button><Button variant="danger" icon={LogOut} disabled={revoke.pending} onClick={() => revoke.open(username)}>Sign out all sessions</Button></div></>}
+        <div className="ops-session-note"><Info aria-hidden="true" size={22} /><p>Local dashboard sessions for <strong>{username}</strong>. Activity updates the last visit without extending expiry. Signing out all sessions includes this session.</p></div>
+        {page.pending && <PageState kind="loading" title="Loading account sessions" />}
+        {page.error && <PageState kind="error" title="Session query failed" description={page.error} action={<Button variant="outline" disabled={busy} onClick={() => { void page.read(); }}>Retry this page</Button>} />}
+        {(page.data || location.cursors.length > 1) && <div className="ops-session-panel">
+            {page.data && <div className="ops-session-table-scroll" role="region" tabIndex={0} aria-label="Session records" aria-busy={page.pending}><SessionTable items={page.data.items} username={username} /></div>}
+            {!page.pending && !page.error && page.data?.items.length === 0 && <PageState kind="empty" title="No sessions on this page" description="Refresh to load the current session records." />}
+            <nav className="ops-session-pagination" aria-label="Session pagination">
+                <Button variant="outline" disabled={busy || location.cursors.length === 1} onClick={() => setLocation(previous => ({ ...previous, cursors: previous.cursors.slice(0, -1) }))}>Previous</Button>
+                <span>Page {location.cursors.length}</span>
+                <Button variant="outline" disabled={busy || Boolean(page.error) || !next || location.cursors.includes(next)} onClick={() => setLocation(previous => ({ ...previous, cursors: sessionCursorHistory(previous.cursors, next) }))}>Next</Button>
+                {page.data && <span className="ops-session-count">{page.data.items.length} {page.data.items.length === 1 ? 'record' : 'records'} on this page</span>}
+            </nav>
+        </div>}
+        {isPage && <div className="ops-session-account"><div><h2>Account</h2><p>Manage your account password and security settings.</p></div>
+            <Button variant="ghost" icon={ArrowRight} onClick={() => app.setActiveTab('Account')}>Manage account</Button></div>}
+    </section>;
+}
+export function SessionsPanel({ username }: { username: string }) {
+    return <SessionList key={username} username={username} />;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/sessionModel.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/sessionModel.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionView } from '../../services/auth.service';
+import { SessionTable } from './SessionTable';
+import { sessionCursorHistory, sessionLabel, sessionStatus, sessionTimestamp } from './sessionModel';
+
+const session: SessionView = { id: 'a81f32c0-1234-4234-a234-123456789012', username: 'admin', createdAtMs: 1, expiresAtMs: 200, lastSeenAtMs: 100, revokedAtMs: null, current: true };
+describe('safe account session display', () => {
+    it('uses absolute expiry, with revocation taking priority over current and active states', () => {
+        expect(sessionStatus(session, 199).label).toBe('Active');
+        expect(sessionStatus(session, 200).label).toBe('Expired');
+        expect(sessionStatus({ ...session, revokedAtMs: 150 }, 175).label).toBe('Revoked');
+        expect(sessionStatus({ ...session, expiresAtMs: NaN }, 1).label).toBe('Unknown');
+        expect(sessionTimestamp(undefined)).toBe('Not recorded');
+        expect(sessionTimestamp(0)).not.toBe('Not recorded');
+    });
+    it('shows only the safe record label and never renders token/digest extras', () => {
+        vi.spyOn(Date, 'now').mockReturnValue(150);
+        try {
+            const row = { ...session, token: 'SECRET_TOKEN', tokenDigest: 'SECRET_DIGEST', device: 'FAKE_DEVICE', location: 'FAKE_LOCATION' };
+            const html = renderToStaticMarkup(<SessionTable username="admin" items={[row]} />);
+            expect(html).toContain('a81f32c0');
+            expect(html).toContain('Current');
+            expect(html).toContain('Active');
+            expect(html).not.toMatch(/SECRET_|FAKE_/);
+            expect(html).not.toContain(session.id);
+            expect(sessionLabel('not-a-public-uuid-token')).toBe('Unrecognized ID');
+        } finally { vi.restoreAllMocks(); }
+    });
+    it('keeps opaque cursor history and ignores missing or repeated cursors', () => {
+        const first = [undefined];
+        const second = sessionCursorHistory(first, 'opaque-a');
+        expect(second).toEqual([undefined, 'opaque-a']);
+        expect(first).toEqual([undefined]);
+        expect(sessionCursorHistory(second, 'opaque-a')).toBe(second);
+        expect(sessionCursorHistory(second, null)).toBe(second);
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/sessionModel.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/sessionModel.ts
@@ -1,0 +1,17 @@
+import type { SessionView } from '../../services/auth.service';
+
+export function sessionTimestamp(value: unknown): string {
+    return typeof value === 'number' && Number.isSafeInteger(value) && !Number.isNaN(new Date(value).getTime()) ? new Date(value).toLocaleString() : 'Not recorded';
+}
+export function sessionStatus(session: SessionView, now: number): { label: string; tone: 'success' | 'neutral'; note?: string } {
+    if (session.revokedAtMs !== null) return { label: sessionTimestamp(session.revokedAtMs) === 'Not recorded' ? 'Unknown' : 'Revoked', tone: 'neutral', note: sessionTimestamp(session.revokedAtMs) };
+    if (sessionTimestamp(session.expiresAtMs) === 'Not recorded') return { label: 'Unknown', tone: 'neutral' };
+    return session.expiresAtMs <= now ? { label: 'Expired', tone: 'neutral' } : { label: 'Active', tone: 'success' };
+}
+export function sessionLabel(id: string): string {
+    // This UUID is the public record identifier, never the login token or its digest.
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id) ? id.slice(0, 8) : 'Unrecognized ID';
+}
+export function sessionCursorHistory(cursors: Array<string | undefined>, next: string | null): Array<string | undefined> {
+    return next && !cursors.includes(next) ? [...cursors, next] : cursors;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/sessions.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/sessions.css
@@ -1,0 +1,24 @@
+.ops-sessions { display: flex; flex-direction: column; gap: 20px; min-width: 0; }
+.ops-sessions-page { min-height: calc(100dvh - 210px); }
+.ops-session-note { display: flex; align-items: flex-start; gap: 14px; padding: 20px; background: var(--ops-panel); border: 1px solid var(--ops-border); border-radius: var(--ops-radius); color: var(--ops-muted); font-size: 14px; }
+.ops-session-note svg { flex: none; color: var(--ops-text); }
+.ops-session-note strong { color: var(--ops-text); font-weight: 500; overflow-wrap: anywhere; }
+.ops-session-panel { min-width: 0; border: 1px solid var(--ops-border); border-radius: var(--ops-radius); background: var(--ops-panel); overflow: hidden; }
+.ops-session-table-scroll { overflow: auto; min-width: 0; }
+.ops-session-table { width: 100%; min-width: 860px; border-collapse: collapse; font-size: 13px; text-align: left; }
+.ops-session-table th { padding: 17px 20px; color: var(--ops-muted); font-weight: 500; }
+.ops-session-table td { padding: 15px 20px; border-top: 1px solid var(--ops-border); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.ops-session-table tr[data-current="true"] { background: var(--ops-panel-strong); }
+.ops-session-identity { display: flex; gap: 14px; align-items: center; }
+.ops-session-id { font-family: var(--ops-font-mono); font-weight: 600; }
+.ops-session-revoked-at { display: block; margin-top: 5px; font-size: 12px; color: var(--ops-muted); }
+.ops-session-pagination { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; padding: 14px 18px; border-top: 1px solid var(--ops-border); color: var(--ops-muted); font-size: 13px; }
+.ops-session-pagination .ops-session-count { margin-left: auto; }
+.ops-session-account { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; justify-content: space-between; margin-top: auto; padding-top: 22px; border-top: 1px solid var(--ops-border); }
+.ops-session-account h2, .ops-session-embedded-heading { font-size: 16px; font-weight: 600; }
+.ops-session-account p { color: var(--ops-muted); font-size: 13px; margin-top: 4px; }
+.ops-session-inline-actions { display: flex; gap: 12px; flex-wrap: wrap; }
+@media (max-width: 650px) {
+  .ops-session-note { padding: 16px; }
+  .ops-session-pagination .ops-session-count { width: 100%; margin-left: 0; }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth-session.test.ts
@@ -73,6 +73,28 @@ describe('authoritative session lifecycle', () => {
         } finally { unsubscribe(); }
     });
 
+    it('does not log out on failed or unconfirmed revocation', async () => {
+        vi.mocked(invoke).mockRejectedValueOnce({ code: 'dashboard.storage_unavailable', message: 'Storage unavailable.', category: 'unavailable', retryable: false });
+        await expect(AuthService.revokeUserSessions('admin')).rejects.toBeDefined();
+        expect(SessionStorageService.getSessionId()).toBe('current-token');
+        for (const currentSessionRevoked of [false, 'false', undefined]) {
+            vi.mocked(invoke).mockResolvedValueOnce({ revokedCount: 0, currentSessionRevoked });
+            await AuthService.revokeUserSessions('admin');
+            expect(SessionStorageService.getSessionId()).toBe('current-token');
+        }
+    });
+
+    it('does not invalidate a newer login when an old revocation completes', async () => {
+        let resolve!: (value: unknown) => void;
+        vi.mocked(invoke).mockImplementation(() => new Promise(complete => { resolve = complete; }));
+        const pending = AuthService.revokeUserSessions('admin');
+        SessionStorageService.setSessionId('new-token');
+        resolve({ revokedCount: 2, currentSessionRevoked: true });
+        await pending;
+        expect(SessionStorageService.getSessionId()).toBe('new-token');
+        expect(invoke).toHaveBeenCalledTimes(1);
+    });
+
     it('successful password changes require a new login', async () => {
         vi.mocked(invoke).mockResolvedValue({ message: 'Password changed' });
         await AuthService.changePassword({ oldPassword: 'old-secret', newPassword: 'new-secret' });

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/auth.service.ts
@@ -46,7 +46,7 @@ export class AuthService {
     static async revokeUserSessions(username: string): Promise<RevokeSessionsResponse> {
         const sessionId = SessionStorageService.getSessionId();
         const result = await invokeAuthenticatedCommand<RevokeSessionsResponse>('revoke_user_sessions', { username });
-        if (result.currentSessionRevoked) SessionStorageService.reportAuthenticationFailure(sessionId, 'invalid');
+        if (result.currentSessionRevoked === true) SessionStorageService.reportAuthenticationFailure(sessionId, 'invalid');
         return result;
     }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -95,7 +95,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       case 'Monitors':
         return 'Consumer monitors';
       case 'Sessions':
-        return 'Account Sessions';
+        return 'Sessions';
       case 'Account':
         return 'Account Overview';
       default:


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10520

### Brief Description

Present local dashboard sessions in the shared dark desktop layout, with public record identifiers, current-session markers, absolute expiry, revocation times and cursor pagination. Failed later pages retain previous-page navigation, and the embedded Account list owns its own controls.

Keep account-wide revocation attached to the authenticated session across route and connection changes. Confirmation protects pending operations and reports failures without optimistic logout. Only a literal current-session acknowledgement invalidates authentication; late responses cannot clear a newer login.

### How Did You Test This Change?

- `npm run build`: passed after integration with current main.
- `npm test -- --run`: 237 tests across 42 files passed.
- External Chrome: reference comparison, 800 by 600 confirmation and table, wide/restored views, 25/25/7 cursor pages and failure recovery, focus containment/restoration, failed/unconfirmed revocation, delayed read ownership, account toolbar navigation and empty results passed.
- Pending revocation blocked duplicate submission and dismissal, retained its target through an environment change and returned to signed-out state after acknowledgement. A controlled clock verified fixed expiry without refreshing the server. No console warnings or errors.
- Seven existing backend session checks previously passed. Final native sign-out and Windows scaling remain in the integrated acceptance task. CI was not used as a merge gate, as requested.
