### PR TITLE
[ISSUE #10522]✨Redesign account and authentication flows for the dark desktop

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ACCOUNT_AUTH_UI.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/doc/ACCOUNT_AUTH_UI.md
@@ -1,0 +1,11 @@
+# Account and authentication UI
+
+The account page uses the dashboard's shared dark tokens, controls and status badges. Missing account data does not imply an active account. A failed refresh retains the previous details and identifies them as an earlier observation. There is one password-change action and one current-session sign-out action; session management remains embedded with its own refresh control.
+
+The password dialog uses the shared modal primitive for focus containment, return focus, Escape and backdrop behavior. A required initial password change cannot be dismissed into the dashboard. Current/new/confirmation fields have associated labels and autocomplete metadata. Pending changes disable inputs and dismissal; repeated submissions are guarded synchronously. Password fields clear when the dialog closes or succeeds and never enter navigation state.
+
+Login retains the existing local-account and required-password-change behavior. Labels are associated with their inputs, and the sign-in button names its pending state. The login view uses the existing RocketMQ image and shared theme tokens; illustrative throughput and health claims have been removed. No animation is required to operate sign-in or restore a session.
+
+Authentication hooks prevent overlapping submissions and ignore login results after their view closes or another session becomes current. Password changes must still belong to the captured local sign-in. Signing out preserves the established behavior of clearing the local sign-in even when the service cannot acknowledge logout.
+
+This change does not alter backend password policy, persisted session contracts or the default native window size. Windows DPI, minimum-window layouts, modal focus and the complete live authentication flow require browser/native acceptance in addition to automated checks.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/App.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/App.tsx
@@ -10,9 +10,8 @@ const AppContent = () => {
 
   if (isBootstrappingAuth) {
     return (
-      <div className="auth-boot">
-        <div className="auth-boot-panel">
-          <div className="auth-boot-spinner" />
+      <div className="ops-auth-layout">
+        <div className="ops-auth-restoring" role="status">
           <p>Restoring session</p>
         </div>
       </div>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/AuthLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/AuthLayout.tsx
@@ -1,16 +1,6 @@
-import React from 'react';
+import type { ReactNode } from 'react';
+import '../../styles/auth.css';
 
-interface AuthLayoutProps {
-  children: React.ReactNode;
+export function AuthLayout({ children }: { children: ReactNode }) {
+    return <main className="ops-auth-layout"><div className="ops-auth-shell">{children}</div></main>;
 }
-
-export const AuthLayout = ({ children }: AuthLayoutProps) => {
-  return (
-    <div className="auth-console">
-      <div className="auth-console-grid" aria-hidden="true" />
-      <div className="auth-shell">
-        {children}
-      </div>
-    </div>
-  );
-};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/components/ChangePasswordDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/components/ChangePasswordDialog.tsx
@@ -1,229 +1,69 @@
-import React, { useEffect, useState } from 'react';
-import { motion, AnimatePresence } from 'motion/react';
-import { toast } from 'sonner@2.0.3';
-import { KeyRound, Loader2, ShieldAlert, X } from 'lucide-react';
+import { useEffect, useRef, useState, type FormEvent } from 'react';
+import { toast } from 'sonner';
 import { useAuth } from '../hooks/useAuth';
-import { ErrorAlert } from './ErrorAlert';
 import { useAppStore } from '../../../stores/app.store';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../../../components/ui/dialog';
+import { Button } from '../../../components/ui/LegacyButton';
+import { Input } from '../../../components/ui/LegacyInput';
+import { PageState } from '../../../components/layout/PageState';
 
 interface ChangePasswordDialogProps {
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
     onPasswordChanged?: () => void;
 }
-
-export const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = ({
-    open = false,
-    onOpenChange,
-    onPasswordChanged,
-}) => {
+export function ChangePasswordDialog({ open = false, onOpenChange, onPasswordChanged }: ChangePasswordDialogProps) {
     const [oldPassword, setOldPassword] = useState('');
     const [newPassword, setNewPassword] = useState('');
-    const [confirmPassword, setConfirmPassword] = useState('');
+    const [confirmation, setConfirmation] = useState('');
+    const [operation, setOperation] = useState<'change' | 'logout' | null>(null);
+    const inFlight = useRef(false);
     const { currentUser, isLoggedIn, mustChangePassword } = useAppStore();
     const { changePassword, clearError, error, isLoading, logout } = useAuth();
-
-    const isRequiredFlow = isLoggedIn && mustChangePassword;
-    const isOpen = isRequiredFlow || open;
-
-    const closeDialog = () => {
-        if (isRequiredFlow) {
-            return;
-        }
-
-        clearError();
-        setOldPassword('');
-        setNewPassword('');
-        setConfirmPassword('');
-        onOpenChange?.(false);
+    const required = isLoggedIn && mustChangePassword;
+    const isOpen = required || open;
+    const busy = isLoading || operation !== null;
+    const clearPasswords = () => { setOldPassword(''); setNewPassword(''); setConfirmation(''); };
+    const close = () => {
+        if (required || inFlight.current) return;
+        clearError(); clearPasswords(); onOpenChange?.(false);
     };
-
-    useEffect(() => {
-        if (!isOpen) {
-            clearError();
-            setOldPassword('');
-            setNewPassword('');
-            setConfirmPassword('');
-        }
-    }, [isOpen]);
-
-    const handleSubmit = async (event: React.FormEvent) => {
+    useEffect(() => { if (!isOpen) { clearError(); clearPasswords(); } }, [isOpen]);
+    const mismatch = confirmation && confirmation !== newPassword ? 'New password confirmation does not match.' : '';
+    const submit = async (event: FormEvent) => {
         event.preventDefault();
-        clearError();
-
-        if (newPassword !== confirmPassword) {
-            return;
-        }
-
-        const result = await changePassword({
-            oldPassword,
-            newPassword,
-        });
-
-        if (result.success) {
-            toast.success('Password updated. Sign in again with your new password.');
-            setOldPassword('');
-            setNewPassword('');
-            setConfirmPassword('');
-            onPasswordChanged?.();
-
-            onOpenChange?.(false);
-        }
+        if (inFlight.current || !oldPassword || newPassword.length < 8 || confirmation !== newPassword) return;
+        inFlight.current = true; setOperation('change');
+        try {
+            const result = await changePassword({ oldPassword, newPassword });
+            if (result.success) {
+                clearPasswords();
+                toast.success('Password updated. Sign in again with your new password.');
+                onPasswordChanged?.(); onOpenChange?.(false);
+            }
+        } finally { inFlight.current = false; setOperation(null); }
     };
-
-    const confirmPasswordError =
-        confirmPassword.length > 0 && newPassword !== confirmPassword
-            ? 'New password confirmation does not match'
-            : '';
-
-    const title = isRequiredFlow ? 'Change initial password' : 'Change password';
-    const description = isRequiredFlow
-        ? `${currentUser?.username ?? 'Admin'} must update the bootstrap password before entering the dashboard.`
-        : 'Changing your password signs out all sessions, including this one.';
-
-    return (
-        <AnimatePresence>
-            {isOpen && (
-                <motion.div
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    onClick={closeDialog}
-                    className="fixed inset-0 z-50 bg-[radial-gradient(circle_at_top,_rgba(96,165,250,0.18),_transparent_34%),linear-gradient(180deg,rgba(3,7,18,0.58),rgba(2,6,23,0.86))] backdrop-blur-xl flex items-center justify-center p-4 overflow-hidden"
-                >
-                    <div className="absolute -top-24 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-cyan-300/12 blur-3xl" />
-                    <div className="absolute bottom-[-6rem] right-[-3rem] h-64 w-64 rounded-full bg-blue-500/10 blur-3xl" />
-                    <motion.div
-                        initial={{ opacity: 0, y: 20, scale: 0.96 }}
-                        animate={{ opacity: 1, y: 0, scale: 1 }}
-                        exit={{ opacity: 0, y: 20, scale: 0.96 }}
-                        transition={{ duration: 0.2, ease: 'easeOut' }}
-                        onClick={(event) => event.stopPropagation()}
-                        className="relative w-full max-w-lg overflow-hidden rounded-[28px] border border-white/18 bg-white/10 backdrop-blur-3xl text-white shadow-[0_30px_120px_rgba(15,23,42,0.5)]"
-                    >
-                        <div className="absolute inset-0 bg-[linear-gradient(135deg,rgba(255,255,255,0.2),rgba(255,255,255,0.06)_28%,rgba(15,23,42,0.16)_100%)]" />
-                        <div className="absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent" />
-                        <div className="absolute inset-x-0 top-0 h-32 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_72%)]" />
-
-                        {!isRequiredFlow ? (
-                            <button
-                                type="button"
-                                onClick={closeDialog}
-                                className="absolute right-5 top-5 z-10 rounded-full border border-white/12 bg-black/15 p-2 text-white/70 transition-colors hover:bg-white/10 hover:text-white"
-                                aria-label="Close change password dialog"
-                            >
-                                <X className="h-4 w-4" />
-                            </button>
-                        ) : null}
-
-                        <div className="relative border-b border-white/12 bg-black/10 p-8">
-                            <div className="flex items-start gap-4">
-                                <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/15 bg-white/10 text-amber-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]">
-                                    <ShieldAlert className="h-6 w-6" />
-                                </div>
-                                <div className="space-y-2 pr-8">
-                                    <h2 className="text-2xl font-semibold">{title}</h2>
-                                    <p className="text-sm text-white/75">{description}</p>
-                                </div>
-                            </div>
-                        </div>
-
-                        <form onSubmit={handleSubmit} className="relative space-y-5 p-8">
-                            <div className="space-y-2">
-                                <label className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
-                                    Current password
-                                </label>
-                                <div className="relative">
-                                    <KeyRound className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/35" />
-                                    <input
-                                        type="password"
-                                        value={oldPassword}
-                                        onChange={(event) => setOldPassword(event.target.value)}
-                                        className="w-full rounded-2xl border border-white/12 bg-white/8 py-3 pl-10 pr-4 text-sm text-white outline-none backdrop-blur-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] placeholder:text-white/35 focus:border-cyan-300/55 focus:bg-white/12"
-                                        placeholder="Enter the current password"
-                                        required
-                                        disabled={isLoading}
-                                    />
-                                </div>
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
-                                    New password
-                                </label>
-                                <div className="relative">
-                                    <KeyRound className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/35" />
-                                    <input
-                                        type="password"
-                                        value={newPassword}
-                                        onChange={(event) => setNewPassword(event.target.value)}
-                                        className="w-full rounded-2xl border border-white/12 bg-white/8 py-3 pl-10 pr-4 text-sm text-white outline-none backdrop-blur-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] placeholder:text-white/35 focus:border-cyan-300/55 focus:bg-white/12"
-                                        placeholder="At least 8 characters"
-                                        required
-                                        minLength={8}
-                                        disabled={isLoading}
-                                    />
-                                </div>
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
-                                    Confirm new password
-                                </label>
-                                <div className="relative">
-                                    <KeyRound className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/35" />
-                                    <input
-                                        type="password"
-                                        value={confirmPassword}
-                                        onChange={(event) => setConfirmPassword(event.target.value)}
-                                        className="w-full rounded-2xl border border-white/12 bg-white/8 py-3 pl-10 pr-4 text-sm text-white outline-none backdrop-blur-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] placeholder:text-white/35 focus:border-cyan-300/55 focus:bg-white/12"
-                                        placeholder="Repeat the new password"
-                                        required
-                                        minLength={8}
-                                        disabled={isLoading}
-                                    />
-                                </div>
-                            </div>
-
-                            <ErrorAlert
-                                message={confirmPasswordError || error}
-                                title="Password Change Failed"
-                                onClose={clearError}
-                            />
-
-                            <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row sm:justify-between">
-                                {isRequiredFlow ? (
-                                    <button
-                                        type="button"
-                                        onClick={() => void logout()}
-                                        className="rounded-2xl border border-white/12 bg-black/10 px-4 py-3 text-white/75 backdrop-blur-xl transition-colors hover:bg-white/10 hover:text-white"
-                                        disabled={isLoading}
-                                    >
-                                        Sign out
-                                    </button>
-                                ) : (
-                                    <button
-                                        type="button"
-                                        onClick={closeDialog}
-                                        className="rounded-2xl border border-white/12 bg-black/10 px-4 py-3 text-white/75 backdrop-blur-xl transition-colors hover:bg-white/10 hover:text-white"
-                                        disabled={isLoading}
-                                    >
-                                        Cancel
-                                    </button>
-                                )}
-                                <button
-                                    type="submit"
-                                    disabled={isLoading || Boolean(confirmPasswordError)}
-                                    className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/30 bg-white/80 px-5 py-3 font-semibold text-black backdrop-blur-xl shadow-[0_12px_40px_rgba(255,255,255,0.14)] hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
-                                >
-                                    {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-                                    Update password
-                                </button>
-                            </div>
-                        </form>
-                    </motion.div>
-                </motion.div>
-            )}
-        </AnimatePresence>
-    );
-};
+    const signOut = async () => {
+        if (inFlight.current) return;
+        inFlight.current = true; setOperation('logout');
+        try { await logout(); clearPasswords(); }
+        finally { inFlight.current = false; setOperation(null); }
+    };
+    return <Dialog open={isOpen} onOpenChange={next => { if (!next) close(); }}>
+        <DialogContent showCloseButton={!required && !busy}
+            onEscapeKeyDown={event => { if (required || inFlight.current) event.preventDefault(); }}
+            onInteractOutside={event => { if (required || inFlight.current) event.preventDefault(); }}>
+            <DialogHeader><DialogTitle>{required ? 'Change initial password' : 'Change password'}</DialogTitle>
+                <DialogDescription>{required ? `${currentUser?.username ?? 'This account'} must update the initial password before entering the dashboard.` : 'Changing your password signs out all sessions, including this one.'}</DialogDescription>
+            </DialogHeader>
+            <form className="ops-auth-password-form" onSubmit={submit}>
+                <Input label="Current password" type="password" autoComplete="current-password" required disabled={busy} value={oldPassword} onChange={event => setOldPassword(event.target.value)} />
+                <Input label="New password" type="password" autoComplete="new-password" required minLength={8} placeholder="At least 8 characters" disabled={busy} value={newPassword} onChange={event => setNewPassword(event.target.value)} />
+                <Input label="Confirm new password" type="password" autoComplete="new-password" required minLength={8} disabled={busy} value={confirmation} error={mismatch || undefined} onChange={event => setConfirmation(event.target.value)} />
+                {error && <PageState kind="error" title="Password change failed" description={error} />}
+                <DialogFooter><Button variant="outline" disabled={busy} onClick={required ? () => { void signOut(); } : close}>{operation === 'logout' ? 'Signing out…' : required ? 'Sign out' : 'Cancel'}</Button>
+                    <Button type="submit" disabled={busy || Boolean(mismatch)}>{operation === 'change' ? 'Updating password…' : 'Update password'}</Button></DialogFooter>
+            </form>
+        </DialogContent>
+    </Dialog>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/components/LoginForm.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/components/LoginForm.tsx
@@ -1,126 +1,21 @@
-import React, { useState } from 'react';
-import { motion } from 'motion/react';
-import { User, Lock, ArrowRight, Loader2 } from 'lucide-react';
+import { useState } from 'react';
 import { useAuth } from '../hooks/useAuth';
-import { ErrorAlert } from './ErrorAlert';
+import { Input } from '../../../components/ui/LegacyInput';
+import { Button } from '../../../components/ui/LegacyButton';
+import { PageState } from '../../../components/layout/PageState';
 
-export const LoginForm: React.FC = () => {
+export function LoginForm() {
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
-    const { isLoading, error, shake, login, clearError } = useAuth();
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        await login({ username, password });
-    };
-
-    return (
-        <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{
-                opacity: 1,
-                y: 0,
-                x: shake ? [0, -10, 10, -10, 10, -5, 5, 0] : 0,
-            }}
-            transition={{
-                opacity: { duration: 0.8, delay: 0.2, ease: 'easeOut' },
-                y: { duration: 0.8, delay: 0.2, ease: 'easeOut' },
-                x: { duration: 0.65 },
-            }}
-            className="auth-form-wrap"
-        >
-            <div className="auth-card">
-                <span className="auth-card-light" aria-hidden="true" />
-                <div className="auth-card-header">
-                    <div className="auth-form-kicker-row">
-                        <span className="auth-form-kicker">Admin access</span>
-                        <span className="auth-form-chip">Local session</span>
-                    </div>
-                    <h1>
-                        Sign in to your account
-                    </h1>
-                    <p>
-                        Use the local administrator credentials to access the dashboard.
-                    </p>
-                </div>
-
-                <form onSubmit={handleSubmit} className="auth-form">
-                    <div className="auth-fields">
-                        <div className="auth-field">
-                            <label>
-                                Username
-                            </label>
-                            <div className="relative">
-                                <div className="auth-field-icon">
-                                    <User className="h-4 w-4" />
-                                </div>
-                                <input
-                                    type="text"
-                                    value={username}
-                                    onChange={(e) => {
-                                        setUsername(e.target.value);
-                                        if (error) {
-                                            clearError();
-                                        }
-                                    }}
-                                    className="auth-input"
-                                    placeholder="Enter your username"
-                                    required
-                                    disabled={isLoading}
-                                />
-                            </div>
-                        </div>
-
-                        <div className="auth-field">
-                            <label>
-                                Password
-                            </label>
-                            <div className="relative">
-                                <div className="auth-field-icon">
-                                    <Lock className="h-4 w-4" />
-                                </div>
-                                <input
-                                    type="password"
-                                    value={password}
-                                    onChange={(e) => {
-                                        setPassword(e.target.value);
-                                        if (error) {
-                                            clearError();
-                                        }
-                                    }}
-                                    className="auth-input"
-                                    placeholder="Enter your password"
-                                    required
-                                    disabled={isLoading}
-                                />
-                            </div>
-                        </div>
-                    </div>
-
-                    <ErrorAlert message={error} title="Login Failed" onClose={clearError} />
-
-                    <button
-                        type="submit"
-                        disabled={isLoading}
-                        className="auth-submit"
-                    >
-                        {isLoading ? (
-                            <Loader2 className="w-5 h-5 animate-spin" />
-                        ) : (
-                            <>
-                                Sign In
-                                <ArrowRight className="ml-2 w-4 h-4" />
-                            </>
-                        )}
-                    </button>
-                </form>
-
-                <div className="auth-footnote">
-                    <p>
-                        First-time login requires a password change before the dashboard becomes available.
-                    </p>
-                </div>
-            </div>
-        </motion.div>
-    );
-};
+    const { isLoading, error, login, clearError } = useAuth();
+    return <section className="ops-auth-card" aria-labelledby="login-title">
+        <h1 id="login-title">Sign in</h1><p>Use your local dashboard account.</p>
+        <form onSubmit={event => { event.preventDefault(); if (!isLoading) void login({ username, password }); }}>
+            <Input label="Username" autoComplete="username" required disabled={isLoading} value={username} onChange={event => { setUsername(event.target.value); clearError(); }} />
+            <Input label="Password" type="password" autoComplete="current-password" required disabled={isLoading} value={password} onChange={event => { setPassword(event.target.value); clearError(); }} />
+            {error && <PageState kind="error" title="Sign-in failed" description={error} />}
+            <Button type="submit" disabled={isLoading}>{isLoading ? 'Signing in…' : 'Sign in'}</Button>
+        </form>
+        <p className="ops-auth-footnote">First-time sign-in requires a password change before the dashboard becomes available.</p>
+    </section>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/hooks/useAuth.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/auth/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AuthService } from '../../../services/auth.service';
 import { dashboardErrorMessage } from '../../../services/invoke';
 import { SessionStorageService } from '../../../services/session.storage';
@@ -8,80 +8,57 @@ import type { ChangePasswordPayload, LoginCredentials } from '../types/auth.type
 export const useAuth = () => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
-    const [shake, setShake] = useState(false);
     const { sessionId, setAuthSession } = useAppStore();
-
+    const active = useRef(true);
+    const pending = useRef(false);
+    useEffect(() => { active.current = true; return () => { active.current = false; }; }, []);
+    const begin = () => {
+        if (!active.current || pending.current) return false;
+        pending.current = true; setIsLoading(true); setError('');
+        return true;
+    };
+    const finish = () => { pending.current = false; if (active.current) setIsLoading(false); };
     const login = async (credentials: LoginCredentials) => {
-        setIsLoading(true);
-        setError('');
-        setShake(false);
-
+        if (!begin()) return { success: false };
+        const previousSession = SessionStorageService.getSessionId();
         try {
             const result = await AuthService.login(credentials);
-
+            if (!active.current || SessionStorageService.getSessionId() !== previousSession) return { success: false };
             SessionStorageService.setSessionId(result.sessionId);
             setAuthSession(result.sessionId, result.currentUser);
             return { success: true, mustChangePassword: result.currentUser.mustChangePassword };
-        } catch (err) {
-            const errorMessage = dashboardErrorMessage(err, 'Failed to connect to authentication service');
-            setError(errorMessage);
-            triggerShake();
-            return { success: false, error: errorMessage };
-        } finally {
-            setIsLoading(false);
-        }
+        } catch (failure) {
+            const message = dashboardErrorMessage(failure, 'Failed to connect to authentication service.');
+            if (active.current) setError(message);
+            return { success: false, error: message };
+        } finally { finish(); }
     };
-
     const changePassword = async (payload: ChangePasswordPayload) => {
-        if (!sessionId) {
-            const errorMessage = 'Session not found';
-            setError(errorMessage);
-            return { success: false, error: errorMessage };
+        if (!sessionId || SessionStorageService.getSessionId() !== sessionId) {
+            const message = 'The sign-in session changed. Reopen the password dialog.';
+            if (active.current) setError(message);
+            return { success: false, error: message };
         }
-
-        setIsLoading(true);
-        setError('');
-
+        if (!begin()) return { success: false };
         try {
             await AuthService.changePassword(payload);
             return { success: true };
-        } catch (err) {
-            const errorMessage = dashboardErrorMessage(err, 'Failed to update password');
-            setError(errorMessage);
-            return { success: false, error: errorMessage };
-        } finally {
-            setIsLoading(false);
-        }
+        } catch (failure) {
+            const message = dashboardErrorMessage(failure, 'Failed to update password.');
+            if (active.current) setError(message);
+            return { success: false, error: message };
+        } finally { finish(); }
     };
-
     const logout = async () => {
+        if (!begin()) return;
         try {
-            if (sessionId) {
-                await AuthService.logout(sessionId);
-            }
+            if (sessionId) await AuthService.logout(sessionId);
         } catch {
-            // Local session state must still be cleared when the backend session is unavailable.
+            // Signing out locally remains possible when the service cannot acknowledge logout.
         } finally {
             SessionStorageService.reportAuthenticationFailure(sessionId, 'invalid');
+            finish();
         }
     };
-
-    const triggerShake = () => {
-        setShake(true);
-        setTimeout(() => setShake(false), 650);
-    };
-
-    const clearError = () => {
-        setError('');
-    };
-
-    return {
-        isLoading,
-        error,
-        shake,
-        login,
-        changePassword,
-        logout,
-        clearError,
-    };
+    return { isLoading, error, login, changePassword, logout, clearError: () => setError('') };
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/Login.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/Login.tsx
@@ -1,137 +1,14 @@
-import React from 'react';
-import { motion, useReducedMotion } from 'motion/react';
-import { Activity, Database, Radar, ShieldCheck, Waypoints } from 'lucide-react';
 import rocketImage from 'rocketmq-rust:asset/rocketmq-rust.png';
 import { AuthLayout } from '../app/layout/AuthLayout';
 import { ChangePasswordDialog, LoginForm } from '../features/auth';
 
-export const Login = () => {
-    const reduceMotion = useReducedMotion();
-
-    return (
-        <>
-            <AuthLayout>
-                <motion.div
-                    initial={{ opacity: 0, x: -50 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    transition={{ duration: 0.8, ease: 'easeOut' }}
-                    className="auth-hero"
-                >
-                    <div className="auth-hero-copy">
-                        <span className="auth-kicker">
-                            <Radar className="auth-kicker-icon" />
-                            RocketMQ Rust Operations
-                        </span>
-                        <h1>RocketMQ-Rust Control Plane</h1>
-                        <p>
-                            A dimensional desktop console for brokers, topics, consumers, producers, traces, and access control.
-                        </p>
-                    </div>
-
-                    <div className="auth-signal-grid">
-                        <div>
-                            <Activity className="auth-signal-icon" />
-                            <span>Broker health</span>
-                            <strong>Live</strong>
-                        </div>
-                        <div>
-                            <Waypoints className="auth-signal-icon" />
-                            <span>Trace query</span>
-                            <strong>Ready</strong>
-                        </div>
-                        <div>
-                            <ShieldCheck className="auth-signal-icon" />
-                            <span>ACL posture</span>
-                            <strong>Guarded</strong>
-                        </div>
-                    </div>
-
-                    <div className="auth-3d-scene" aria-label="RocketMQ Rust 3D control module">
-                        <div className="auth-stage-glow" />
-                        <motion.div
-                            className="auth-console-rig"
-                            animate={
-                                reduceMotion
-                                    ? undefined
-                                    : { rotateX: [58, 55, 58], rotateZ: [-9, -7, -9], y: [0, -7, 0] }
-                            }
-                            transition={
-                                reduceMotion
-                                    ? undefined
-                                    : { duration: 7.5, repeat: Infinity, ease: 'easeInOut' }
-                            }
-                        >
-                            <div className="auth-device-top">
-                                <div className="auth-device-screen">
-                                    <div className="auth-screen-header">
-                                        <span />
-                                        <span />
-                                        <span />
-                                    </div>
-                                    <div className="auth-screen-bars">
-                                        <i />
-                                        <i />
-                                        <i />
-                                        <i />
-                                    </div>
-                                    <div className="auth-screen-chart">
-                                        <span />
-                                        <span />
-                                        <span />
-                                        <span />
-                                    </div>
-                                </div>
-                                <div className="auth-device-node auth-device-node-a">
-                                    <Database className="auth-device-icon" />
-                                </div>
-                                <div className="auth-device-node auth-device-node-b">
-                                    <Activity className="auth-device-icon" />
-                                </div>
-                                <img src={rocketImage} alt="" className="auth-device-emblem" aria-hidden="true" />
-                            </div>
-                            <div className="auth-device-front" />
-                            <div className="auth-device-side" />
-                        </motion.div>
-
-                        <motion.div
-                            className="auth-floating-module auth-floating-module-a"
-                            animate={
-                                reduceMotion
-                                    ? undefined
-                                    : { y: [0, -12, 0], rotateY: [-14, -8, -14] }
-                            }
-                            transition={
-                                reduceMotion
-                                    ? undefined
-                                    : { duration: 5.8, repeat: Infinity, ease: 'easeInOut' }
-                            }
-                        >
-                            <span>TPS</span>
-                            <strong>48.2k</strong>
-                        </motion.div>
-                        <motion.div
-                            className="auth-floating-module auth-floating-module-b"
-                            animate={
-                                reduceMotion
-                                    ? undefined
-                                    : { y: [0, 10, 0], rotateY: [14, 8, 14] }
-                            }
-                            transition={
-                                reduceMotion
-                                    ? undefined
-                                    : { duration: 6.4, repeat: Infinity, ease: 'easeInOut' }
-                            }
-                        >
-                            <span>Topics</span>
-                            <strong>2.1k</strong>
-                        </motion.div>
-                        <div className="auth-stage-floor" />
-                    </div>
-                </motion.div>
-
-                <LoginForm />
-            </AuthLayout>
-            <ChangePasswordDialog />
-        </>
-    );
-};
+export function Login() {
+    return <><AuthLayout>
+        <section className="ops-auth-brand" aria-label="RocketMQ-Rust Dashboard">
+            <img src={rocketImage} alt="" width={64} height={64} />
+            <h2>RocketMQ-Rust<br />Dashboard</h2>
+            <p>Inspect broker health, follow messages and manage your local RocketMQ environments.</p>
+        </section>
+        <LoginForm />
+    </AuthLayout><ChangePasswordDialog /></>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/AccountPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/AccountPage.tsx
@@ -1,315 +1,66 @@
-import React, { useEffect, useState } from 'react';
-import {
-    CalendarDays,
-    KeyRound,
-    LogOut,
-    RefreshCw,
-    ShieldCheck,
-    ShieldAlert,
-    UserRound,
-} from 'lucide-react';
-import { toast } from 'sonner@2.0.3';
-import { AuthService } from '../../services/auth.service';
-import { dashboardErrorMessage } from '../../services/invoke';
-import { SessionsPanel } from './SessionsPanel';
+import { useCallback, useRef, useState } from 'react';
+import { KeyRound, LogOut, UserRound } from 'lucide-react';
 import { useAppStore } from '../../stores/app.store';
-import { SignOutConfirmDialog, useAuth } from '../../features/auth';
+import { AuthService } from '../../services/auth.service';
+import { useReadResource } from '../../hooks/useReadResource';
+import { usePageRefresh } from '../../app/layout/pageToolbar';
+import { useAuth } from '../../features/auth/hooks/useAuth';
 import { ChangePasswordDialog } from '../../features/auth/components/ChangePasswordDialog';
-import type { UserProfile } from '../../features/auth/types/auth.types';
-import { Badge } from '../../components/ui/badge';
-import { Button } from '../../components/ui/button';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '../../components/ui/card';
+import { SignOutConfirmDialog } from '../../features/auth/components/SignOutConfirmDialog';
+import { Button } from '../../components/ui/LegacyButton';
+import { PageState } from '../../components/layout/PageState';
+import { StatusBadge } from '../../components/layout/StatusBadge';
+import { SessionsPanel } from './SessionsPanel';
+import { accountStatus, accountTimestamp } from './accountModel';
+import './account.css';
 
-const glassCardClass =
-    'ops-card account-card';
-const secondaryActionButtonClass =
-    'ops-button ops-button-outline account-action-button';
-const dangerActionButtonClass =
-    'ops-button ops-button-danger account-action-button';
-
-const formatTimestamp = (value: string | null | undefined) => {
-    if (!value) {
-        return 'Never';
-    }
-
-    const parsed = new Date(value);
-    if (Number.isNaN(parsed.getTime())) {
-        return value;
-    }
-
-    return new Intl.DateTimeFormat('en-US', {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-    }).format(parsed);
-};
-
-const DetailRow = ({
-    label,
-    value,
-    mono = false,
-}: {
-    label: string;
-    value: string;
-    mono?: boolean;
-}) => (
-    <div className="flex items-start justify-between gap-4 rounded-2xl border border-black/5 bg-black/[0.02] px-4 py-3 dark:border-white/6 dark:bg-white/[0.025]">
-        <span className="text-sm text-gray-500 dark:text-gray-400">{label}</span>
-        <span className={`text-right text-sm text-gray-900 dark:text-white ${mono ? 'font-mono text-xs sm:text-sm' : ''}`}>
-            {value}
-        </span>
-    </div>
-);
-
-export const AccountPage = () => {
+function Detail({ label, value }: { label: string; value: string }) {
+    return <div><dt>{label}</dt><dd tabIndex={0}>{value}</dd></div>;
+}
+export function AccountPage() {
     const { currentUser, sessionId } = useAppStore();
+    const profile = useReadResource(AuthService.getCurrentUserProfile, 'Account details could not be loaded.');
     const { logout } = useAuth();
-    const [profile, setProfile] = useState<UserProfile | null>(null);
-    const [error, setError] = useState('');
-    const [isLoading, setIsLoading] = useState(true);
-    const [reloadKey, setReloadKey] = useState(0);
-    const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
-    const [isLogoutDialogOpen, setIsLogoutDialogOpen] = useState(false);
-    const [isLoggingOut, setIsLoggingOut] = useState(false);
-
-    useEffect(() => {
-        let isMounted = true;
-
-        if (!sessionId) {
-            return () => {
-                isMounted = false;
-            };
-        }
-
-        const loadProfile = async () => {
-            setIsLoading(true);
-            setError('');
-
-            try {
-                const result = await AuthService.getCurrentUserProfile();
-                if (!isMounted) {
-                    return;
-                }
-
-                setProfile(result);
-            } catch (loadError) {
-                if (!isMounted) {
-                    return;
-                }
-
-                setProfile(null);
-                setError(dashboardErrorMessage(loadError, 'Failed to load user profile'));
-            } finally {
-                if (isMounted) {
-                    setIsLoading(false);
-                }
-            }
-        };
-
-        void loadProfile();
-
-        return () => {
-            isMounted = false;
-        };
-    }, [currentUser?.mustChangePassword, reloadKey, sessionId]);
-
-    const username = profile?.username ?? currentUser?.username ?? 'Admin';
-    const initials = username.slice(0, 2).toUpperCase();
-    const unresolvedValue = isLoading && !profile ? 'Loading...' : 'Unavailable';
-
-    const handleLogout = async () => {
-        setIsLogoutDialogOpen(false);
-        setIsLoggingOut(true);
-
-        try {
-            await logout();
-            toast.success('Logged out successfully');
-        } finally {
-            setIsLoggingOut(false);
-        }
+    const [passwordOpen, setPasswordOpen] = useState(false);
+    const [signOutOpen, setSignOutOpen] = useState(false);
+    const [signingOut, setSigningOut] = useState(false);
+    const inFlight = useRef(false);
+    const refresh = useCallback(() => { void profile.read(); }, [profile.read]);
+    usePageRefresh({ refresh, pending: profile.pending, refreshedAt: profile.receivedAt });
+    const username = profile.data?.username ?? currentUser?.username ?? 'Account';
+    const status = accountStatus(profile.data, Boolean(profile.error));
+    const unavailable = profile.pending ? 'Loading…' : 'Not available';
+    const signOut = async () => {
+        if (inFlight.current) return;
+        inFlight.current = true; setSigningOut(true);
+        try { await logout(); }
+        finally { inFlight.current = false; setSigningOut(false); }
     };
-
-    return (
-        <>
-            <div className="mx-auto max-w-6xl space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
-                <Card className={glassCardClass}>
-                    <CardContent className="flex flex-col gap-6 px-6 py-6 !pb-12 sm:px-8 sm:py-8 lg:flex-row lg:items-start lg:justify-between">
-                        <div className="flex items-center gap-4">
-                            <div className="flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-700 text-lg font-semibold text-white shadow-[0_16px_40px_rgba(15,23,42,0.28)]">
-                                {initials}
-                            </div>
-                            <div className="space-y-2">
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <h2 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
-                                        {username}
-                                    </h2>
-                                    <Badge
-                                        variant="outline"
-                                        className="border-emerald-200/80 bg-emerald-500/10 text-emerald-700 dark:border-emerald-400/20 dark:bg-emerald-400/10 dark:text-emerald-300"
-                                    >
-                                        <ShieldCheck className="h-3 w-3" />
-                                        {profile?.isActive ?? true ? 'Active' : 'Disabled'}
-                                    </Badge>
-                                    {profile?.mustChangePassword ? (
-                                        <Badge
-                                            variant="outline"
-                                            className="border-amber-200/80 bg-amber-500/10 text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300"
-                                        >
-                                            <ShieldAlert className="h-3 w-3" />
-                                            Password update required
-                                        </Badge>
-                                    ) : null}
-                                </div>
-                                <p className="max-w-2xl text-sm leading-6 text-gray-500 dark:text-gray-400">
-                                    Review the local administrator account, session security posture, and account lifecycle
-                                    details for this dashboard instance.
-                                </p>
-                            </div>
-                        </div>
-
-                        <div className="flex flex-wrap items-center pt-4 pb-8 lg:pt-0" style={{ gap: '24px', paddingBottom: '16px' }}>
-                            <Button
-                                type="button"
-                                variant="outline"
-                                onClick={() => setReloadKey((value) => value + 1)}
-                                className={secondaryActionButtonClass}
-                                style={{ paddingLeft: '24px', paddingRight: '24px' }}
-                            >
-                                <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
-                                Refresh
-                            </Button>
-                            <Button
-                                type="button"
-                                variant="outline"
-                                onClick={() => setIsPasswordDialogOpen(true)}
-                                className={secondaryActionButtonClass}
-                                style={{ paddingLeft: '24px', paddingRight: '24px' }}
-                            >
-                                <KeyRound className="h-4 w-4" />
-                                Change Password
-                            </Button>
-                        </div>
-                    </CardContent>
-                </Card>
-
-                {error ? (
-                    <Card className={`${glassCardClass} border-rose-200/70 dark:border-rose-500/20`}>
-                        <CardHeader>
-                            <CardTitle className="text-gray-900 dark:text-white">Profile unavailable</CardTitle>
-                            <CardDescription className="text-rose-600 dark:text-rose-300">
-                                {error}
-                            </CardDescription>
-                        </CardHeader>
-                    </Card>
-                ) : null}
-
-                <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
-                    <Card className={glassCardClass}>
-                        <CardHeader className="pb-4">
-                            <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
-                                <UserRound className="h-4 w-4 text-sky-500" />
-                                Basic details
-                            </CardTitle>
-                            <CardDescription>Persistent account fields stored by the local auth database.</CardDescription>
-                        </CardHeader>
-                        <CardContent className="!pb-8">
-                            <div className="space-y-4 mb-2">
-                                <DetailRow label="Username" value={profile?.username ?? username} />
-                                <DetailRow label="User ID" value={profile ? String(profile.userId) : unresolvedValue} mono />
-                                <DetailRow label="Created At" value={profile ? formatTimestamp(profile.createdAt) : unresolvedValue} />
-                                <DetailRow label="Updated At" value={profile ? formatTimestamp(profile.updatedAt) : unresolvedValue} />
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    <Card className={glassCardClass}>
-                        <CardHeader className="pb-4">
-                            <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
-                                <ShieldCheck className="h-4 w-4 text-sky-500" />
-                                Security status
-                            </CardTitle>
-                            <CardDescription>Current access posture and login hygiene for this administrator.</CardDescription>
-                        </CardHeader>
-                        <CardContent className="!pb-8">
-                            <div className="space-y-4 mb-2">
-                                <DetailRow
-                                    label="Account Status"
-                                    value={profile ? (profile.isActive ? 'Enabled' : 'Disabled') : unresolvedValue}
-                                />
-                                <DetailRow
-                                    label="Password Status"
-                                    value={profile ? (profile.mustChangePassword ? 'Change required' : 'Up to date') : unresolvedValue}
-                                />
-                                <DetailRow label="Last Login" value={profile ? formatTimestamp(profile.lastLoginAt) : unresolvedValue} />
-                                <div className="rounded-2xl border border-sky-200/70 bg-sky-500/[0.08] px-4 py-3 text-sm text-sky-700 dark:border-sky-400/15 dark:bg-sky-400/[0.08] dark:text-sky-200">
-                                    The dashboard keeps authentication local to this workstation. Changing the password signs out all sessions immediately.
-                                </div>
-                            </div>
-                        </CardContent>
-                    </Card>
-                </div>
-
-                <SessionsPanel key={sessionId} username={username} />
-
-                <Card className={glassCardClass}>
-                    <CardHeader className="pb-4">
-                        <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-white">
-                            <CalendarDays className="h-4 w-4 text-sky-500" />
-                            Session & actions
-                        </CardTitle>
-                        <CardDescription>Manage the authenticated local account lifecycle.</CardDescription>
-                    </CardHeader>
-                    <CardContent className="space-y-4 !pb-14">
-                        <div className="rounded-2xl border border-black/5 bg-black/[0.02] px-4 py-4 dark:border-white/6 dark:bg-white/[0.025]">
-                            <div className="text-sm font-medium text-gray-900 dark:text-white">Authenticated locally</div>
-                            <div className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                                Session credentials remain private and are never displayed or copied.
-                            </div>
-                        </div>
-
-                        <div className="flex flex-wrap gap-6 pt-6 pb-4">
-                            <Button
-                                type="button"
-                                variant="outline"
-                                onClick={() => setIsPasswordDialogOpen(true)}
-                                className={secondaryActionButtonClass}
-                            >
-                                <KeyRound className="h-4 w-4" />
-                                Change Password
-                            </Button>
-                            <Button
-                                type="button"
-                                variant="outline"
-                                onClick={() => setIsLogoutDialogOpen(true)}
-                                className={dangerActionButtonClass}
-                            >
-                                <LogOut className="h-4 w-4" />
-                                Sign Out
-                            </Button>
-                        </div>
-                    </CardContent>
-                </Card>
-            </div>
-
-            <ChangePasswordDialog
-                open={isPasswordDialogOpen}
-                onOpenChange={setIsPasswordDialogOpen}
-                onPasswordChanged={() => setReloadKey((value) => value + 1)}
-            />
-
-            <SignOutConfirmDialog
-                open={isLogoutDialogOpen}
-                isSubmitting={isLoggingOut}
-                title="Sign out of this workstation?"
-                description="Your local session will be removed from this device. You can sign back in at any time with your administrator credentials."
-                onCancel={() => setIsLogoutDialogOpen(false)}
-                onConfirm={() => void handleLogout()}
-            />
-        </>
-    );
-};
+    return <div className="ops-account">
+        <section className="ops-account-summary" aria-label="Account overview">
+            <div className="ops-account-identity"><span className="ops-account-avatar" aria-hidden="true"><UserRound size={26} /></span><div><h2>{username}</h2>
+                <p className="ops-account-note">Local dashboard account</p></div><StatusBadge tone={status.tone}>{status.label}</StatusBadge></div>
+            <div className="ops-account-actions"><Button variant="outline" icon={KeyRound} onClick={() => setPasswordOpen(true)}>Change password</Button>
+                <Button variant="danger" icon={LogOut} onClick={() => setSignOutOpen(true)}>Sign out</Button></div>
+        </section>
+        {profile.error && <PageState kind="error" title={profile.data ? 'Account refresh failed; previous details retained' : 'Account details unavailable'} description={profile.error} action={<Button variant="outline" disabled={profile.pending} onClick={refresh}>Retry account details</Button>} />}
+        <div className="ops-account-columns">
+            <section className="ops-account-section" aria-labelledby="account-details"><h2 id="account-details">Basic details</h2><dl>
+                <Detail label="Username" value={username} /><Detail label="User ID" value={profile.data ? String(profile.data.userId) : unavailable} />
+                <Detail label="Created" value={profile.data ? accountTimestamp(profile.data.createdAt) : unavailable} />
+                <Detail label="Updated" value={profile.data ? accountTimestamp(profile.data.updatedAt) : unavailable} /></dl>
+            </section>
+            <section className="ops-account-section" aria-labelledby="account-security"><h2 id="account-security">Security status</h2><dl>
+                <Detail label="Account" value={profile.data ? profile.data.isActive ? 'Enabled' : 'Disabled' : unavailable} />
+                <Detail label="Password" value={profile.data ? profile.data.mustChangePassword ? 'Change required' : 'No change required' : unavailable} />
+                <Detail label="Last login" value={profile.data ? accountTimestamp(profile.data.lastLoginAt) : unavailable} /></dl>
+                <p className="ops-account-notice">Authentication is local to this dashboard. Changing the password signs out all sessions. Session credentials are never displayed or copied.</p>
+            </section>
+        </div>
+        {currentUser && <SessionsPanel key={sessionId} username={currentUser.username} />}
+        <ChangePasswordDialog open={passwordOpen} onOpenChange={setPasswordOpen} />
+        <SignOutConfirmDialog open={signOutOpen} isSubmitting={signingOut} title="Sign out of this dashboard?"
+            description="Your local sign-in will be cleared. Sign in again to continue. If the dashboard service is unavailable, the local sign-in is still removed."
+            onCancel={() => { if (!inFlight.current) setSignOutOpen(false); }} onConfirm={signOut} />
+    </div>;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/account.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/account.css
@@ -1,0 +1,17 @@
+.ops-account { display: grid; gap: 22px; min-width: 0; }
+.ops-account-summary, .ops-account-section { padding: 22px; min-width: 0; border: 1px solid var(--ops-border); border-radius: var(--ops-radius); background: var(--ops-panel); }
+.ops-account-summary { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 20px; align-items: center; }
+.ops-account-identity { display: flex; flex-wrap: wrap; align-items: center; gap: 14px; min-width: 0; }
+.ops-account-avatar { display: grid; place-items: center; width: 52px; height: 52px; background: var(--ops-panel-strong); border: 1px solid var(--ops-border); border-radius: 12px; flex: none; }
+.ops-account-identity h2 { font-size: 22px; font-weight: 600; max-width: min(450px, 70vw); overflow-wrap: anywhere; }
+.ops-account-note { color: var(--ops-muted); font-size: 13px; }
+.ops-account-actions { display: flex; gap: 12px; flex-wrap: wrap; }
+.ops-account-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 22px; }
+.ops-account-section h2 { font-size: 16px; font-weight: 600; margin-bottom: 20px; }
+.ops-account-section dl { display: grid; gap: 16px; font-size: 14px; }
+.ops-account-section dl > div { display: grid; grid-template-columns: 100px minmax(0, 1fr); gap: 18px; }
+.ops-account-section dt { color: var(--ops-muted); }
+.ops-account-section dd { margin: 0; overflow-wrap: anywhere; max-height: 120px; overflow: auto; font-variant-numeric: tabular-nums; }
+.ops-account-notice { font-size: 13px; line-height: 1.6; color: var(--ops-muted); margin-top: 20px; }
+@media (max-width: 1000px) { .ops-account-columns { grid-template-columns: minmax(0, 1fr); } }
+@media (max-width: 600px) { .ops-account-summary, .ops-account-section { padding: 16px; } }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/accountModel.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/accountModel.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import type { UserProfile } from '../../features/auth/types/auth.types';
+import { accountStatus, accountTimestamp } from './accountModel';
+
+const profile: UserProfile = { userId: 1, username: 'admin', isActive: true, mustChangePassword: false, createdAt: '2026-09-11T00:00:00Z', updatedAt: '2026-09-11T00:00:00Z', lastLoginAt: null };
+describe('account observations', () => {
+    it('does not infer an active account from a missing or failed profile read', () => {
+        expect(accountStatus(null, false).tone).toBe('neutral');
+        expect(accountStatus(null, true).label).toBe('Status not available');
+        expect(accountStatus(profile, true)).toEqual({ label: 'Previous observation', tone: 'neutral' });
+        expect(accountStatus(profile, false).label).toBe('Active');
+        expect(accountStatus({ ...profile, isActive: false }, false).label).toBe('Disabled');
+    });
+    it('keeps missing or malformed dates distinct from a recorded timestamp', () => {
+        expect(accountTimestamp(null)).toBe('Not recorded');
+        expect(accountTimestamp('not a timestamp')).toBe('Not recorded');
+        expect(accountTimestamp('2026-09-11T00:00:00Z')).not.toBe('Not recorded');
+    });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/accountModel.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/pages/account/accountModel.ts
@@ -1,0 +1,11 @@
+import type { UserProfile } from '../../features/auth/types/auth.types';
+export function accountStatus(profile: UserProfile | null, stale: boolean): { label: string; tone: 'neutral' | 'success' | 'warning' } {
+    if (!profile) return { label: 'Status not available', tone: 'neutral' };
+    if (stale) return { label: 'Previous observation', tone: 'neutral' };
+    return profile.isActive ? { label: 'Active', tone: 'success' } : { label: 'Disabled', tone: 'warning' };
+}
+export function accountTimestamp(value: string | null): string {
+    if (!value) return 'Not recorded';
+    const time = new Date(value);
+    return Number.isNaN(time.getTime()) ? 'Not recorded' : time.toLocaleString();
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/auth.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/styles/auth.css
@@ -1,0 +1,21 @@
+.ops-auth-layout { min-height: 100dvh; padding: 40px 24px; display: grid; place-items: center; background: var(--ops-bg); color: var(--ops-text); }
+.ops-auth-shell { width: min(920px, 100%); min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 420px); gap: 64px; align-items: center; }
+.ops-auth-brand img { object-fit: contain; margin-bottom: 24px; }
+.ops-auth-brand h2 { font-size: clamp(28px, 3vw, 40px); font-weight: 600; line-height: 1.2; letter-spacing: -.025em; }
+.ops-auth-brand p { margin-top: 20px; color: var(--ops-muted); font-size: 15px; line-height: 1.7; }
+.ops-auth-card { min-width: 0; padding: 28px; border: 1px solid var(--ops-border); border-radius: var(--ops-radius); background: var(--ops-panel); }
+.ops-auth-card h1 { font-size: 26px; font-weight: 600; line-height: 1.3; }
+.ops-auth-card > p { margin-top: 8px; color: var(--ops-muted); font-size: 14px; }
+.ops-auth-card form, .ops-auth-password-form { display: grid; gap: 20px; }
+.ops-auth-card form { margin-top: 26px; }
+.ops-auth-card > .ops-auth-footnote { margin-top: 22px; font-size: 12px; line-height: 1.6; }
+.ops-auth-restoring { padding: 24px; color: var(--ops-muted); border: 1px solid var(--ops-border); border-radius: var(--ops-radius); background: var(--ops-panel); }
+@media (max-width: 780px) {
+  .ops-auth-layout { padding: 24px 16px; }
+  .ops-auth-shell { grid-template-columns: minmax(0, 440px); justify-content: center; gap: 28px; }
+  .ops-auth-brand { display: grid; grid-template-columns: 48px 1fr; gap: 8px 16px; align-items: center; }
+  .ops-auth-brand img { width: 48px; height: 48px; margin: 0; }
+  .ops-auth-brand h2 { font-size: 24px; }
+  .ops-auth-brand h2 br { display: none; }
+  .ops-auth-brand p { grid-column: 1 / -1; margin: 4px 0 0; font-size: 13px; }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10522

### Brief Description

Move Account, Login and password changes into the shared dark desktop layout. Show unavailable or previously observed profile information accurately, retain embedded session management and use the existing RocketMQ asset without illustrative operational claims.

Use the shared password modal with required-change dismissal rules, secret clearing and pending protection. Authentication requests reject overlapping submissions and ignore completions belonging to an old view or session. Backend authentication policy is unchanged.

### How Did You Test This Change?

- `npm run build` and `npm test -- --run`: passed after integration with current main; 239 tests across 43 files.
- Headed external Google Chrome: profile failure/stale/disabled states, password validation/failure/required change, focus containment/restoration, field clearing, login failure and duplicate protection, delayed password and logout completion passed without console errors.
- Account and password layouts passed at 800 by 600, 1024 by 768, 1280 by 800, reference and wide/restored sizes, including reduced-motion mode.
- Windows WebView2: real account/session views inspected at actual 100%, 125% and 150% display scaling; representative monitor form and confirmation checked, and original 150% scaling restored. Native password submission was not automated; destructive authentication branches used an isolated browser fixture.
- CI was not used as a merge gate, as requested. Temporary fixtures, screenshots and local account data are excluded.
