### PR TITLE
[ISSUE #10526]✨Reset dashboard page scroll and cover enforced TLS administration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -67,6 +67,7 @@ docs/
 *.seed
 *.pid.lock
 rocketmq-ai/rocketmq-sre/deploy/dev/fixtures/*.pem
+rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/tls/certs/
 
 # Rust specific
 **/*.rs.bk

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/tls/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/deploy/dev/tls/README.md
@@ -55,6 +55,20 @@ Broker listener:
 '' | openssl s_client -connect 127.0.0.1:33911 -CAfile certs/ca.pem -verify_return_error -brief
 ```
 
+To verify the desktop's Rust connection path, run from `src-tauri/` after both
+services are healthy:
+
+```powershell
+$env:SSL_CERT_FILE = (Resolve-Path ../deploy/dev/tls/certs/ca.pem).Path
+cargo test --locked --lib local_tls_cluster_queries_require_encryption -- --ignored
+```
+
+The test reads the registered TLS Broker, its configuration and runtime status
+using the desktop connection builder, then confirms plaintext administration is
+rejected by the enforcing Broker. It does not change Broker configuration or
+disable certificate verification. This transport check does not replace the
+Windows UI walkthrough.
+
 Stop with `docker compose down`; named data volumes are retained. This fixture
 verifies server TLS, not mutual TLS or ACL. Use the [ACL fixture](../acl/README.md)
 for credential and policy tests.

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection.rs
@@ -15,6 +15,8 @@
 mod admin;
 pub(crate) mod commands;
 mod db;
+#[cfg(test)]
+mod live_tests;
 mod service;
 mod types;
 pub(crate) use service::ConnectionManager;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/live_tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/connection/live_tests.rs
@@ -1,0 +1,85 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{AdminConnectionConfig, AdminPurpose};
+use rocketmq_admin_core::client_adapter::{ClientRuntime, ClientRuntimeConfig, TelemetryHandle};
+use rocketmq_admin_core::core::dashboard::{DashboardAdmin, DashboardBrokerTarget};
+use rocketmq_dashboard_common::NameServerConfigSnapshot;
+use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
+
+#[test]
+#[ignore = "requires deploy/dev/tls with SSL_CERT_FILE pointing to its ca.pem"]
+fn local_tls_cluster_queries_require_encryption() {
+    let owner = RuntimeOwner::plan(RuntimeConfig::server_default("tauri-tls-smoke"))
+        .unwrap()
+        .build()
+        .unwrap();
+    let runtime = ClientRuntime::try_new(
+        owner.root_context().component("client"),
+        ClientRuntimeConfig::default(),
+        TelemetryHandle::noop(),
+    )
+    .unwrap();
+    let outcomes = owner.block_on(async {
+        let mut outcomes = Vec::new();
+        for use_tls in [true, false] {
+            let snapshot = NameServerConfigSnapshot {
+                current_namesrv: Some("127.0.0.1:39786".into()),
+                namesrv_addr_list: vec!["127.0.0.1:39786".into()],
+                use_vip_channel: false,
+                use_tls,
+            };
+            let outcome = match AdminConnectionConfig::default()
+                .builder(runtime.clone(), &snapshot, "127.0.0.1:39786", AdminPurpose::Cluster)
+                .build_and_start()
+                .await
+            {
+                Ok(mut session) => {
+                    let result = async {
+                        let brokers = session.dashboard_list_brokers().await?;
+                        let target = DashboardBrokerTarget {
+                            broker_name: "tauri-tls-broker".into(),
+                            broker_addr: Some("127.0.0.1:33911".into()),
+                        };
+                        let config = session.dashboard_broker_config(&target).await?;
+                        let status = session.dashboard_broker_runtime(&target).await?;
+                        Ok::<_, rocketmq_admin_core::core::AdminError>((brokers, config, status))
+                    }
+                    .await;
+                    session.shutdown().await;
+                    result
+                }
+                Err(error) => Err(error),
+            };
+            outcomes.push(outcome);
+        }
+        runtime.shutdown().await;
+        outcomes
+    });
+    owner.shutdown_runtime_blocking().unwrap();
+
+    let (brokers, config, status) = outcomes[0].as_ref().expect("trusted TLS queries must succeed");
+    assert!(brokers.items.iter().any(|broker| {
+        broker.cluster_name == "TauriTlsDebugCluster"
+            && broker.broker_name == "tauri-tls-broker"
+            && broker.address == "127.0.0.1:33911"
+            && broker.runtime_error.is_none()
+    }));
+    assert!(!config.entries.is_empty());
+    assert!(!status.entries.is_empty());
+    assert!(
+        outcomes[1].is_err(),
+        "the enforcing Broker must reject plaintext administration"
+    );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useSyncExternalStore, type ReactNode } from 'react';
+import { useLayoutEffect, useRef, useState, useSyncExternalStore, type ReactNode } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { Toaster } from '../../components/ui/sonner';
@@ -16,6 +16,14 @@ export function MainLayout({ children }: { children: ReactNode }) {
     const { logout } = useAuth();
     const [confirmSignOut, setConfirmSignOut] = useState(false);
     const [signingOut, setSigningOut] = useState(false);
+    const contentRef = useRef<HTMLElement>(null);
+    useLayoutEffect(() => {
+        // The shared scroll container survives navigation; each page starts at its heading.
+        if (contentRef.current) {
+            contentRef.current.scrollTop = 0;
+            contentRef.current.scrollLeft = 0;
+        }
+    }, [activeTab]);
     const target = navigation.target;
     // Message and trace links prefill editable queries; their current identity lives in the page.
     const targetName = target && target.kind !== 'trace' && target.kind !== 'message' ? ('name' in target ? target.name : target.address) : null;
@@ -36,7 +44,7 @@ export function MainLayout({ children }: { children: ReactNode }) {
             <AppSidebar onSignOut={() => setConfirmSignOut(true)} signingOut={signingOut} />
             <section className="desktop-main">
                 <EnvironmentToolbar settings={settings} />
-                <main className="desktop-content" id="main-content" tabIndex={-1}>
+                <main ref={contentRef} className="desktop-content" id="main-content" tabIndex={-1}>
                     <div className="desktop-page-heading">
                         {canGoBack && <button type="button" className="desktop-back" onClick={goBack} aria-label="Back"><ArrowLeft /></button>}
                         <div><h1>{pageTitle}</h1><p>{pageDescriptions[activeTab]}</p>


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10526

### Brief Description

Reset the shared dashboard content scroll when the active page changes, so navigating from a long message or receipt exposes the new page heading. Same-page refresh and detail updates keep their position.

Add an opt-in live test through the production desktop administration builder: trusted TLS discovery, Broker configuration and runtime reads must succeed, while plaintext administration against the enforcing Broker must fail. Document the fixture command and exclude generated certificates from Docker build contexts.

### How Did You Test This Change?

- Final integrated frontend: `npm run build` and `npm test -- --run` passed; 239 tests across 43 files.
- `cargo test --locked --lib`: 141 passed, with four opt-in tests ignored. The just-built test executable then passed all four `local_ --ignored --test-threads=1` ACL/TLS tests against the healthy local Rust containers.
- Package formatting and `git diff --check` passed. `cargo fmt --all -- --check` hit Windows error 206 while expanding path dependencies; the package-scoped format check passed without changing configuration.
- Final headed external Chrome suites for DLQ, ACL, Storage, Monitors, Audit, Sessions and Account passed, covering captured mutation targets, delayed responses, cursor failures, keyboard focus and narrow/wide/restored layouts. Reference comparisons were repeated after style consolidation. No final console warnings or errors.
- Embedded Windows build and actual 100%, 125% and 150% representative display scaling were checked; original 150% was restored. All 15 pages have maximized native evidence and the real message/Trace/DLQ/Audit journey is recorded separately.
- The user manually confirmed NameServer-to-Dashboard navigation in the native exclusive-fullscreen window at 2560 x 1440 without a title bar. This is manual interaction evidence; Windows automation could capture the image but could not obtain usable input geometry. It does not represent automated coverage of every page action in exclusive fullscreen.
- CI is not used as a merge gate, as requested; the local validation above supplies the acceptance evidence.
