### PR TITLE
[ISSUE #10534]🧪Cover malformed and failed client offset responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **test(client):** Cover malformed and failed client offset responses: invalid UTF-8 bodies, non-success responses with inspectable response codes, and malformed reset-offset JSON with and without a remark ([#10534](https://github.com/mxsm/rocketmq-rust/issues/10534)).
 - **docs(model):** Fix BooleanAttribute constructor documentation that incorrectly described enum attribute parameters and return type; add accurate Rustdoc with executable examples ([#10455](https://github.com/mxsm/rocketmq-rust/issues/10455)).
 - **fix(model):** Return `0` for CRC32 ranges whose `offset + length` overflows instead of panicking ([#10448](https://github.com/mxsm/rocketmq-rust/issues/10448)).
 - **docs(protocol):** Add missing Apache 2.0 headers to protocol Rust sources and compile-test fixtures ([#10061](https://github.com/mxsm/rocketmq-rust/issues/10061)).

--- a/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
+++ b/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
@@ -1258,6 +1258,73 @@ fn reset_offset_table_from_response_decodes_java_body() {
 }
 
 #[test]
+fn consumer_offset_json_from_response_rejects_invalid_utf8_body() {
+    let response = RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+        .set_body(bytes::Bytes::from_static(&[0xff, 0xfe, 0xfd]));
+
+    let error = consumer_offset_json_from_response(&response).expect_err("invalid UTF-8 body should be rejected");
+
+    assert!(error.is(&rocketmq_error::PROTOCOL_RESPONSE_FAILED));
+    assert!(error.source_ref::<std::str::Utf8Error>().is_some());
+}
+
+#[test]
+fn consumer_offset_json_from_response_passes_through_raw_non_json_utf8_text() {
+    let response =
+        RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_body("just plain text, not json");
+
+    let json = consumer_offset_json_from_response(&response)
+        .expect("raw valid utf8 text should pass through without json validation");
+
+    assert_eq!(json.as_str(), "just plain text, not json");
+}
+
+#[test]
+fn consumer_offset_json_from_response_rejects_non_success_with_inspectable_code() {
+    let response = RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemError, "broker busy");
+
+    let error = consumer_offset_json_from_response(&response).expect_err("non-success response should be rejected");
+
+    let exception = client_exception(&error);
+    assert_eq!(exception.response_code(), ResponseCode::SystemError.to_i32());
+}
+
+#[test]
+fn reset_offset_table_from_response_rejects_non_success_with_inspectable_code() {
+    let response = RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemError, "broker busy");
+
+    let error = reset_offset_table_from_response(&response).expect_err("non-success response should be rejected");
+
+    let exception = client_exception(&error);
+    assert_eq!(exception.response_code(), ResponseCode::SystemError.to_i32());
+}
+
+#[test]
+fn reset_offset_table_from_response_rejects_malformed_json_without_remark() {
+    let response =
+        RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_body("{not valid json");
+
+    let error = reset_offset_table_from_response(&response)
+        .expect_err("malformed reset offset body should be rejected, not panic");
+
+    assert!(client_exception(&error)
+        .to_string()
+        .contains("decode ResetOffsetBody failed"));
+}
+
+#[test]
+fn reset_offset_table_from_response_rejects_malformed_json_with_remark() {
+    let response =
+        RemotingCommand::create_response_command_with_code_remark(ResponseCode::Success, "broker diagnostic")
+            .set_body("{not valid json");
+
+    let error = reset_offset_table_from_response(&response)
+        .expect_err("malformed reset offset body should be rejected, not panic");
+
+    assert!(client_exception(&error).to_string().contains("broker diagnostic"));
+}
+
+#[test]
 fn async_retry_request_reuses_final_attempt_after_first_failure() {
     let retry_key = CheetahString::from_static_str("retry-key");
     let retry_value = CheetahString::from_static_str("retry-value");


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10534

### Brief Description

Extends `rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs` with decoder-level coverage for `consumer_offset_json_from_response` and `reset_offset_table_from_response` in `response_decoder.rs`:

- Invalid UTF-8 response bodies fail with `PROTOCOL_RESPONSE_FAILED` and retain a typed `std::str::Utf8Error` source.
- Non-success responses are rejected by both decoders, with the original broker response code inspectable through the existing `client_exception` test helper (`MQClientException::response_code`).
- Malformed reset-offset JSON is rejected without panicking, covering both an absent and a present remark.
- Raw valid UTF-8 text that isn't JSON-shaped still passes through `consumer_offset_json_from_response` unchanged (no JSON validation added there).

No production decoding logic was changed.

### How Did You Test This Change?

```bash
cargo test -p rocketmq-client-rust --lib consumer_offset_json_from_response
cargo test -p rocketmq-client-rust --lib reset_offset_table_from_response
cargo fmt -p rocketmq-client-rust -- --check
```

All commands pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog coverage for client handling of malformed responses and inspectable error status codes.

* **Tests**
  * Added unit tests for invalid UTF-8 response bodies.
  * Added coverage for failed responses with accessible status codes.
  * Added tests for malformed reset-offset JSON responses, with and without broker remarks.
  * Added coverage for preserving raw non-JSON UTF-8 response text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->