### PR TITLE
[ISSUE #10528]🐛Return None instead of panicking when last slash follows first dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **fix(client):** Return `None` instead of panicking in `NameServerAddressUtils::parse_instance_id_from_endpoint` when the last slash occurs after the first dot ([#10528](https://github.com/mxsm/rocketmq-rust/issues/10528)).
 - **docs(model):** Fix BooleanAttribute constructor documentation that incorrectly described enum attribute parameters and return type; add accurate Rustdoc with executable examples ([#10455](https://github.com/mxsm/rocketmq-rust/issues/10455)).
 - **fix(model):** Return `0` for CRC32 ranges whose `offset + length` overflows instead of panicking ([#10448](https://github.com/mxsm/rocketmq-rust/issues/10448)).
 - **docs(protocol):** Add missing Apache 2.0 headers to protocol Rust sources and compile-test fixtures ([#10061](https://github.com/mxsm/rocketmq-rust/issues/10061)).

--- a/rocketmq-client/src/config_support/name_server_address_utils.rs
+++ b/rocketmq-client/src/config_support/name_server_address_utils.rs
@@ -101,7 +101,7 @@ impl NameServerAddressUtils {
         } else {
             let start = endpoint.rfind('/').map_or(0, |index| index + 1);
             let dot_pos = endpoint.find('.').unwrap_or(endpoint.len());
-            Some(endpoint[start..dot_pos].to_string())
+            endpoint.get(start..dot_pos).map(str::to_owned)
         }
     }
 
@@ -148,6 +148,18 @@ mod tests {
             Some("MQ_INST_abc_def")
         );
         assert_eq!(NameServerAddressUtils::parse_instance_id_from_endpoint(""), None);
+    }
+
+    #[test]
+    fn parse_instance_id_from_endpoint_returns_none_instead_of_panicking_when_last_slash_is_after_first_dot() {
+        assert_eq!(
+            NameServerAddressUtils::parse_instance_id_from_endpoint("http://example.com/MQ_INST_abc_def"),
+            None
+        );
+        assert_eq!(
+            NameServerAddressUtils::parse_instance_id_from_endpoint("http://example.com/"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10528

### Brief Description

`NameServerAddressUtils::parse_instance_id_from_endpoint` computed `start` from the last `/` and `dot_pos` from the first `.` across the whole input. When a dotted host is followed by a path (e.g. `http://example.com/MQ_INST_abc_def`), `start` lands after `dot_pos`, and the unchecked `endpoint[start..dot_pos]` slice panics.

Replaced the unchecked range index with `endpoint.get(start..dot_pos).map(str::to_owned)`, returning `None` for an invalid range instead of panicking. Ordinary bare and HTTP instance endpoints, the empty-input case, and no-dot inputs keep their existing results.

Added regression tests in the file's existing `tests` module for both reproduction inputs from the issue.

### How Did You Test This Change?

```bash
cargo test -p rocketmq-client-rust --lib config_support::name_server_address_utils::tests
cargo fmt -p rocketmq-client-rust -- --check
```

All commands pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where parsing certain instance IDs could cause a client panic.
  - The client now safely returns no instance ID when endpoint formatting is invalid, including endpoints with trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->