### PR TITLE
[ISSUE #10529]🧪Cover ControllableOffset freeze and overwrite semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **test(client):** Cover `ControllableOffset` freeze and overwrite semantics: unfrozen increase-only vs. unconditional updates, `update_and_freeze` locking out later updates, `new_frozen` rejecting both update modes, and re-freezing to a new value ([#10529](https://github.com/mxsm/rocketmq-rust/issues/10529)).
 - **docs(model):** Fix BooleanAttribute constructor documentation that incorrectly described enum attribute parameters and return type; add accurate Rustdoc with executable examples ([#10455](https://github.com/mxsm/rocketmq-rust/issues/10455)).
 - **fix(model):** Return `0` for CRC32 ranges whose `offset + length` overflows instead of panicking ([#10448](https://github.com/mxsm/rocketmq-rust/issues/10448)).
 - **docs(protocol):** Add missing Apache 2.0 headers to protocol Rust sources and compile-test fixtures ([#10061](https://github.com/mxsm/rocketmq-rust/issues/10061)).

--- a/rocketmq-client/src/consumer/store/controllable_offset.rs
+++ b/rocketmq-client/src/consumer/store/controllable_offset.rs
@@ -79,3 +79,59 @@ impl ControllableOffset {
         self.value.load(Ordering::SeqCst)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unfrozen_offset_accepts_lower_value_only_without_increase_only() {
+        let offset = ControllableOffset::new(10);
+
+        offset.update(5, true);
+        assert_eq!(offset.get_offset(), 10);
+
+        offset.update(5, false);
+        assert_eq!(offset.get_offset(), 5);
+    }
+
+    #[test]
+    fn update_and_freeze_locks_the_value_against_later_updates() {
+        let offset = ControllableOffset::new(10);
+
+        offset.update_and_freeze(20);
+        assert_eq!(offset.get_offset(), 20);
+
+        offset.update(30, true);
+        assert_eq!(offset.get_offset(), 20);
+
+        offset.update(5, false);
+        assert_eq!(offset.get_offset(), 20);
+
+        offset.update_unconditionally(40);
+        assert_eq!(offset.get_offset(), 20);
+    }
+
+    #[test]
+    fn new_frozen_rejects_both_update_modes_immediately() {
+        let offset = ControllableOffset::new_frozen(10);
+
+        offset.update(20, true);
+        assert_eq!(offset.get_offset(), 10);
+
+        offset.update(5, false);
+        assert_eq!(offset.get_offset(), 10);
+    }
+
+    #[test]
+    fn second_update_and_freeze_changes_the_frozen_value() {
+        let offset = ControllableOffset::new(10);
+
+        offset.update_and_freeze(20);
+        offset.update_and_freeze(7);
+        assert_eq!(offset.get_offset(), 7);
+
+        offset.update_unconditionally(100);
+        assert_eq!(offset.get_offset(), 7);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10529

### Brief Description

Adds an inline `tests` module to `rocketmq-client/src/consumer/store/controllable_offset.rs` covering the freeze contract that had no dedicated coverage:

- An unfrozen offset accepts a lower value with `increase_only = false` but retains it under a lower increase-only update.
- `update_and_freeze(20)` locks the value so later `update(30, true)`, `update(5, false)`, and `update_unconditionally(40)` all leave it at 20.
- `new_frozen(10)` rejects both update modes immediately.
- A second `update_and_freeze(7)` changes the frozen value to 7, and it remains locked against ordinary updates afterward.

No production code changed.

### How Did You Test This Change?

```bash
cargo test -p rocketmq-client-rust --lib consumer::store::controllable_offset::tests
cargo fmt -p rocketmq-client-rust -- --check
```

All commands pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for offset freezing, overwriting, conditional updates, immediately frozen offsets, and repeated update-and-freeze operations.
- **Documentation**
  - Added an unreleased changelog entry documenting the new client test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->