### PR TITLE
[ISSUE #10530]🧪Cover offset snapshot round trips and malformed queue keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **test(client):** Cover `OffsetSerialize`/`OffsetSerializeWrapper` round trips: full JSON persistence with signed and `i32::MAX`-exceeding offsets, discarding one invalid queue key while keeping valid entries, and an empty table round-tripping under the `offsetTable` field ([#10530](https://github.com/mxsm/rocketmq-rust/issues/10530)).
 - **docs(model):** Fix BooleanAttribute constructor documentation that incorrectly described enum attribute parameters and return type; add accurate Rustdoc with executable examples ([#10455](https://github.com/mxsm/rocketmq-rust/issues/10455)).
 - **fix(model):** Return `0` for CRC32 ranges whose `offset + length` overflows instead of panicking ([#10448](https://github.com/mxsm/rocketmq-rust/issues/10448)).
 - **docs(protocol):** Add missing Apache 2.0 headers to protocol Rust sources and compile-test fixtures ([#10061](https://github.com/mxsm/rocketmq-rust/issues/10061)).

--- a/rocketmq-client/src/consumer/store/offset_serialize_wrapper.rs
+++ b/rocketmq-client/src/consumer/store/offset_serialize_wrapper.rs
@@ -64,3 +64,99 @@ impl From<OffsetSerialize> for OffsetSerializeWrapper {
         Self { offset_table }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocketmq_protocol::protocol::RemotingSerializable;
+
+    fn queue_key(topic: &str, broker: &str, queue_id: i32) -> String {
+        MessageQueue::from_parts(topic, broker, queue_id)
+            .serialize_json()
+            .expect("queue should serialize to JSON")
+    }
+
+    #[test]
+    fn offset_table_round_trips_through_json_with_signed_offsets_and_keys() {
+        let queue_a = MessageQueue::from_parts("topic-a", "broker-a", 0);
+        let queue_b = MessageQueue::from_parts("topic-b", "broker-b", 1);
+
+        let mut wrapper = OffsetSerializeWrapper::default();
+        wrapper.offset_table.insert(queue_a.clone(), AtomicI64::new(-42));
+        wrapper.offset_table.insert(queue_b.clone(), AtomicI64::new(100));
+
+        let serialize: OffsetSerialize = wrapper.into();
+        let json = serialize.serialize_json().expect("offset serialize should encode");
+        let decoded = OffsetSerialize::decode_str(&json).expect("offset serialize should decode");
+        let round_tripped: OffsetSerializeWrapper = decoded.into();
+
+        assert_eq!(round_tripped.offset_table.len(), 2);
+        assert_eq!(
+            round_tripped
+                .offset_table
+                .get(&queue_a)
+                .map(|v| v.load(Ordering::Relaxed)),
+            Some(-42)
+        );
+        assert_eq!(
+            round_tripped
+                .offset_table
+                .get(&queue_b)
+                .map(|v| v.load(Ordering::Relaxed)),
+            Some(100)
+        );
+    }
+
+    #[test]
+    fn offset_larger_than_i32_max_is_not_narrowed() {
+        let queue = MessageQueue::from_parts("topic-a", "broker-a", 0);
+        let large_offset = i64::from(i32::MAX) + 1000;
+
+        let mut wrapper = OffsetSerializeWrapper::default();
+        wrapper.offset_table.insert(queue.clone(), AtomicI64::new(large_offset));
+
+        let serialize: OffsetSerialize = wrapper.into();
+        let json = serialize.serialize_json().expect("offset serialize should encode");
+        let decoded = OffsetSerialize::decode_str(&json).expect("offset serialize should decode");
+        let round_tripped: OffsetSerializeWrapper = decoded.into();
+
+        assert_eq!(
+            round_tripped
+                .offset_table
+                .get(&queue)
+                .map(|v| v.load(Ordering::Relaxed)),
+            Some(large_offset)
+        );
+    }
+
+    #[test]
+    fn invalid_queue_key_is_skipped_while_valid_entries_are_kept() {
+        let queue = MessageQueue::from_parts("topic-a", "broker-a", 0);
+        let mut offset_table = HashMap::new();
+        offset_table.insert(queue_key("topic-a", "broker-a", 0), 7);
+        offset_table.insert("not a valid message queue key".to_string(), 99);
+        let serialize = OffsetSerialize { offset_table };
+
+        let wrapper: OffsetSerializeWrapper = serialize.into();
+
+        assert_eq!(wrapper.offset_table.len(), 1);
+        assert_eq!(
+            wrapper.offset_table.get(&queue).map(|v| v.load(Ordering::Relaxed)),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn empty_offset_table_round_trips_with_persisted_field_name() {
+        let wrapper = OffsetSerializeWrapper::default();
+
+        let serialize: OffsetSerialize = wrapper.into();
+        let json = serialize.serialize_json().expect("offset serialize should encode");
+
+        assert!(json.contains("\"offsetTable\""));
+        let decoded = OffsetSerialize::decode_str(&json).expect("offset serialize should decode");
+        let round_tripped: OffsetSerializeWrapper = decoded.into();
+
+        assert!(round_tripped.offset_table.is_empty());
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10530

### Brief Description

Adds an inline `tests` module to `rocketmq-client/src/consumer/store/offset_serialize_wrapper.rs` exercising the `OffsetSerializeWrapper <-> OffsetSerialize` conversions through a full JSON round trip:

- Two queues with different topics/brokers/queue IDs round-trip through wrapper -> `OffsetSerialize` -> JSON -> `OffsetSerialize` -> wrapper, retaining every key and signed offset.
- An offset larger than `i32::MAX` survives the round trip without narrowing.
- Mixing one valid serialized queue key with one invalid string key in `OffsetSerialize` discards only the invalid entry.
- An empty table round-trips and keeps the persisted `offsetTable` field name.

No production conversion logic changed.

### How Did You Test This Change?

```bash
cargo test -p rocketmq-client-rust --lib consumer::store::offset_serialize_wrapper::tests
cargo fmt -p rocketmq-client-rust -- --check
```

All commands pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for offset data persistence and restoration, including large and signed values.
  - Verified that invalid queue entries are ignored while valid entries remain available.
  - Added coverage for empty offset tables and consistent JSON field handling.

- **Documentation**
  - Updated the unreleased changelog with the new offset persistence test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->