### PR TITLE
[ISSUE #10559]🐛Fix stale Classic Pull error assertions

### DIFF
--- a/rocketmq-client/tests/classic_pull_equivalence.rs
+++ b/rocketmq-client/tests/classic_pull_equivalence.rs
@@ -17,9 +17,11 @@
 
 use std::time::Duration;
 
+use rocketmq_client_rust::ClientError;
 use rocketmq_client_rust::ClientRuntime;
 use rocketmq_client_rust::ClientRuntimeConfig;
 use rocketmq_client_rust::DefaultMQPullConsumer;
+use rocketmq_client_rust::MQClientException;
 use rocketmq_client_rust::MQPullConsumerScheduleService;
 use rocketmq_client_rust::MessageQueueListener;
 use rocketmq_client_rust::MessageSelector;
@@ -29,9 +31,47 @@ use rocketmq_client_rust::PullTaskContext;
 use rocketmq_client_rust::PullTaskImpl;
 use rocketmq_client_rust::RebalancePullImpl;
 use rocketmq_client_rust::TelemetryHandle;
+use rocketmq_error::fields;
+use rocketmq_error::ErrorContext;
+use rocketmq_error::ErrorDescriptor;
 use rocketmq_model::common::message::message_queue::MessageQueue;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
+
+#[track_caller]
+fn assert_error(error: &ClientError, descriptor: &'static ErrorDescriptor) {
+    assert_eq!(error.code(), descriptor.code());
+    assert_eq!(
+        error.to_string(),
+        format!("{}: {}", descriptor.code(), descriptor.public_message())
+    );
+    error.public_view().expect("valid public error context");
+    error.diagnostic_view().expect("valid diagnostic error context");
+}
+
+#[track_caller]
+fn assert_not_initialized(error: &ClientError, component: &str) {
+    assert_error(error, &rocketmq_error::CORE_LIFECYCLE_NOT_INITIALIZED);
+    assert_eq!(
+        error.context(),
+        &ErrorContext::new().with_text(fields::COMPONENT_NAME, component)
+    );
+}
+
+#[track_caller]
+fn assert_client_exception(error: &ClientError, message: &str) {
+    assert_error(error, &rocketmq_error::CORE_ARGUMENT_INVALID);
+    assert_eq!(
+        error.context(),
+        &ErrorContext::new().with_secret_presence(fields::MESSAGE_PRESENT)
+    );
+    assert_eq!(error.public_view().unwrap().fields().count(), 0);
+    // Java compatibility text is retained in the typed source, not public rendering.
+    let source = error
+        .source_ref::<MQClientException>()
+        .expect("retained Java client exception");
+    assert_eq!(source.error_message(), Some(message));
+}
 
 fn client_runtime(owner: &RuntimeOwner, scope: &'static str) -> std::sync::Arc<ClientRuntime> {
     ClientRuntime::try_new(
@@ -97,15 +137,13 @@ fn configured_facade_fails_closed_before_start_without_unsupported_error() {
             Ok(_) => panic!("pull before start must fail closed"),
             Err(error) => error,
         };
-        assert!(pull_error.to_string().contains("not started"));
-        assert!(!pull_error.to_string().contains("not supported"));
+        assert_not_initialized(&pull_error, "DefaultMQPullConsumer not started. Call start() first.");
 
         let queue_error = consumer
             .fetch_subscribe_message_queues("TopicA")
             .await
             .expect_err("queue lookup before start must fail closed");
-        assert!(queue_error.to_string().contains("not started"));
-        assert!(!queue_error.to_string().contains("not supported"));
+        assert_not_initialized(&queue_error, "DefaultMQPullConsumer not started. Call start() first.");
 
         let report = runtime.shutdown().await;
         assert!(report.is_healthy(), "{}", report.to_json());
@@ -125,8 +163,10 @@ fn detached_legacy_constructor_reports_missing_runtime_instead_of_unsupported() 
 
     owner.block_on(async {
         let error = consumer.start().await.expect_err("detached facade has no runtime");
-        assert!(error.to_string().contains("builder"));
-        assert!(!error.to_string().contains("not supported"));
+        assert_not_initialized(
+            &error,
+            "DefaultMQPullConsumer has no ClientRuntime; create it with DefaultMQPullConsumer::builder",
+        );
     });
     owner
         .shutdown_runtime_blocking()
@@ -142,8 +182,10 @@ fn schedule_compatibility_types_are_live_or_fail_closed() {
     let register_error = service
         .register_pull_task_callback("TopicA", Callback)
         .expect_err("detached schedule service must require a runtime");
-    assert!(register_error.to_string().contains("with_client_runtime"));
-    assert!(!register_error.to_string().contains("not supported"));
+    assert_not_initialized(
+        &register_error,
+        "MQPullConsumerScheduleService has no ClientRuntime; use with_client_runtime",
+    );
 
     let mut context = PullTaskContext::new();
     assert_eq!(context.get_pull_next_delay_time_millis(), 200);
@@ -184,7 +226,7 @@ fn configured_facade_owns_start_and_shutdown_lifecycle() {
             .start()
             .await
             .expect_err("second start must fail deterministically");
-        assert!(repeated_start.to_string().contains("already started"));
+        assert_client_exception(&repeated_start, "DefaultMQPullConsumer already started");
         consumer
             .shutdown()
             .await
@@ -269,7 +311,7 @@ fn configured_schedule_service_cancels_and_joins_its_coordinator() {
             .start()
             .await
             .expect_err("second start must fail deterministically");
-        assert!(repeated_start.to_string().contains("already started"));
+        assert_client_exception(&repeated_start, "MQPullConsumerScheduleService already started");
         service
             .shutdown()
             .await


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10559

### Brief Description

Five Classic Pull equivalence tests still expected legacy diagnostic messages in public `ClientError` rendering. Update the existing assertions to check canonical error codes and public messages, typed component context for missing-runtime and pre-start errors, and the retained `MQClientException` source for repeated starts. Verify that Java exception text remains absent from public rendering and context.

The change is limited to `rocketmq-client/tests/classic_pull_equivalence.rs`. Existing startup, idempotent shutdown, listener registration, and schedule-coordinator checks remain intact.

### How Did You Test This Change?

- Before the fix, `cargo test -p rocketmq-client-rust --test classic_pull_equivalence` reproduced the reported failures: 2 passed, 5 failed.
- After the fix, the same command passed all 7 tests on Windows with Rust 1.95.0.
- `cargo fmt -p rocketmq-client-rust -- --check`: passed.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for classic pull operations and lifecycle scenarios.
  - Tests now validate structured client error codes, context, and diagnostic details instead of relying on error message text.
  - Added checks for invalid arguments, uninitialized components, repeated starts, and preserved source exception compatibility.
  - No user-facing behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->