### PR TITLE
[ISSUE #10566]🐛Preserve blocking completion across cancelled waits

### DIFF
--- a/rocketmq-runtime/src/blocking/executor.rs
+++ b/rocketmq-runtime/src/blocking/executor.rs
@@ -22,6 +22,7 @@ use dashmap::DashMap;
 use tokio::sync::Semaphore;
 
 use super::admission::GlobalBlockingBudget;
+use super::admission::GlobalBlockingPermit;
 use super::diagnostics::BlockingTaskMeta;
 use super::BlockingExecutorSnapshot;
 use super::BlockingKind;
@@ -82,16 +83,21 @@ impl Drop for QueuedBlockingTaskGuard {
     }
 }
 
-struct RunningBlockingTaskGuard<R>
+/// An admitted operation whose actual completion outlives any individual wait.
+///
+/// The owner may retain this ticket after `wait_until` expires and call `wait`
+/// to observe the real result. Dropping it abandons observation, not execution.
+pub(crate) struct BlockingTask<R>
 where
     R: Send + 'static,
 {
     join_handle: Option<tokio::task::JoinHandle<R>>,
     tasks: Arc<DashMap<BlockingTaskId, BlockingTaskMeta>>,
     task_id: BlockingTaskId,
+    wait_deadline: Instant,
 }
 
-impl<R> RunningBlockingTaskGuard<R>
+impl<R> BlockingTask<R>
 where
     R: Send + 'static,
 {
@@ -99,31 +105,46 @@ where
         join_handle: tokio::task::JoinHandle<R>,
         tasks: Arc<DashMap<BlockingTaskId, BlockingTaskMeta>>,
         task_id: BlockingTaskId,
+        wait_deadline: Instant,
     ) -> Self {
         Self {
             join_handle: Some(join_handle),
             tasks,
             task_id,
+            wait_deadline,
         }
     }
 
-    fn join_handle(&mut self) -> Option<&mut tokio::task::JoinHandle<R>> {
-        self.join_handle.as_mut()
+    /// Waits for real execution completion without changing ownership on drop.
+    pub(crate) async fn wait(&mut self) -> RuntimeResult<R> {
+        let Some(join_handle) = self.join_handle.as_mut() else {
+            return Err(RuntimeError::context_unavailable(
+                crate::RuntimeOperation::RunBlockingTask,
+            ));
+        };
+        let result = join_handle.await;
+        self.join_handle.take();
+        result.map_err(|error| RuntimeError::join(crate::RuntimeOperation::RunBlockingTask, error))
     }
 
-    fn disarm(&mut self) {
-        self.join_handle.take();
+    async fn wait_until(&mut self, deadline: Instant) -> RuntimeResult<R> {
+        match tokio::time::timeout_at(tokio::time::Instant::from_std(deadline), self.wait()).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                self.mark_timed_out();
+                Err(RuntimeError::timed_out(crate::RuntimeOperation::BlockingTask))
+            }
+        }
     }
 
     fn mark_timed_out(&mut self) {
         if let Some(mut meta) = self.tasks.get_mut(&self.task_id) {
             meta.state = BlockingTaskState::TimedOutStillRunning;
         }
-        self.join_handle.take();
     }
 }
 
-impl<R> Drop for RunningBlockingTaskGuard<R>
+impl<R> Drop for BlockingTask<R>
 where
     R: Send + 'static,
 {
@@ -131,6 +152,29 @@ where
         if self.join_handle.is_some() {
             self.mark_timed_out();
         }
+    }
+}
+
+// Field order also governs cancellation before Tokio invokes the closure:
+// destroy user captures, return execution capacity, then remove diagnostics.
+struct BlockingWork<F> {
+    operation: F,
+    permit: GlobalBlockingPermit,
+    completion: BlockingCompletionGuard,
+}
+
+impl<F> BlockingWork<F> {
+    fn run<R>(self) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        // Reverse local destruction order preserves the same ordering on panic.
+        let completion = self.completion;
+        let permit = self.permit;
+        let result = (self.operation)();
+        drop(permit);
+        drop(completion);
+        result
     }
 }
 
@@ -193,7 +237,22 @@ impl BlockingExecutor {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        self.spawn(name, BlockingKind::ShortIo, operation).await
+        let task = self.submit_io(name, operation).await?;
+        self.wait_for_caller(task).await
+    }
+
+    /// Admits short I/O and returns its execution-owned completion ticket.
+    pub(crate) async fn submit_io<F, R>(
+        &self,
+        name: impl Into<Arc<str>>,
+        operation: F,
+    ) -> RuntimeResult<BlockingTask<R>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.submit_inner(name.into(), BlockingKind::ShortIo, None, operation)
+            .await
     }
 
     /// Runs short blocking I/O without admitting or waiting for work beyond `deadline`.
@@ -219,7 +278,10 @@ impl BlockingExecutor {
         self.spawn_inner(name.into(), kind, None, operation).await
     }
 
-    /// Runs blocking work while bounding queue admission and execution by one absolute deadline.
+    /// Runs blocking work with one absolute deadline for admission and waiting.
+    ///
+    /// Expiry stops waiting; an already running closure retains its capacity
+    /// until it exits and may still produce side effects.
     pub async fn spawn_until<F, R>(
         &self,
         name: impl Into<Arc<str>>,
@@ -241,6 +303,39 @@ impl BlockingExecutor {
         deadline: Option<ShutdownDeadline>,
         operation: F,
     ) -> RuntimeResult<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let task = self.submit_inner(name, kind, deadline, operation).await?;
+        self.wait_for_caller(task).await
+    }
+
+    async fn wait_for_caller<R: Send + 'static>(&self, mut task: BlockingTask<R>) -> RuntimeResult<R> {
+        let task_id = task.task_id;
+        let started_at = Instant::now();
+        let deadline = task.wait_deadline;
+        let result = task.wait_until(deadline).await;
+        if result.is_ok() {
+            let elapsed = started_at.elapsed();
+            if elapsed > self.policy.warn_after {
+                tracing::warn!(
+                    task_id = task_id.as_u64(),
+                    elapsed_ms = elapsed.as_millis(),
+                    "blocking task exceeded warn_after"
+                );
+            }
+        }
+        result
+    }
+
+    async fn submit_inner<F, R>(
+        &self,
+        name: Arc<str>,
+        kind: BlockingKind,
+        deadline: Option<ShutdownDeadline>,
+        operation: F,
+    ) -> RuntimeResult<BlockingTask<R>>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
@@ -301,44 +396,21 @@ impl BlockingExecutor {
         }
         queued_task_guard.disarm();
 
-        let tasks = self.tasks.clone();
-        let completion_tasks = tasks.clone();
-        let join_handle = tokio::task::spawn_blocking(move || {
-            let _permit = permit;
-            let _completion = BlockingCompletionGuard {
-                tasks: completion_tasks,
+        let work = BlockingWork {
+            operation,
+            permit,
+            completion: BlockingCompletionGuard {
+                tasks: self.tasks.clone(),
                 task_id,
-            };
-            operation()
-        });
-        let mut running_task_guard = RunningBlockingTaskGuard::new(join_handle, tasks, task_id);
-        let Some(join_handle) = running_task_guard.join_handle() else {
-            return Err(RuntimeError::internal_failure(crate::RuntimeOperation::RunBlockingTask));
+            },
         };
-
-        match tokio::time::timeout_at(tokio::time::Instant::from_std(task_deadline), join_handle).await {
-            Ok(Ok(value)) => {
-                running_task_guard.disarm();
-                let elapsed = started_at.elapsed();
-                if elapsed > self.policy.warn_after {
-                    tracing::warn!(
-                        task_id = task_id.as_u64(),
-                        task_name = %name,
-                        elapsed_ms = elapsed.as_millis(),
-                        "blocking task exceeded warn_after"
-                    );
-                }
-                Ok(value)
-            }
-            Ok(Err(error)) => {
-                running_task_guard.disarm();
-                Err(RuntimeError::join(crate::RuntimeOperation::RunBlockingTask, error))
-            }
-            Err(_elapsed) => {
-                running_task_guard.mark_timed_out();
-                Err(RuntimeError::timed_out(crate::RuntimeOperation::BlockingTask))
-            }
-        }
+        let join_handle = tokio::task::spawn_blocking(move || work.run());
+        Ok(BlockingTask::new(
+            join_handle,
+            self.tasks.clone(),
+            task_id,
+            task_deadline,
+        ))
     }
 
     /// Returns the snapshot.
@@ -409,3 +481,6 @@ fn phase_deadline(started_at: Instant, policy_timeout: Duration, operation_deadl
         .unwrap_or(operation_deadline)
         .min(operation_deadline)
 }
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-runtime/src/blocking/executor/tests.rs
+++ b/rocketmq-runtime/src/blocking/executor/tests.rs
@@ -1,0 +1,207 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::sync::atomic::AtomicBool;
+use std::sync::mpsc;
+
+use rocketmq_error::CanonicalCondition;
+use tokio::sync::oneshot;
+
+use super::*;
+
+fn executor() -> BlockingExecutor {
+    BlockingExecutor::new_with_budget(
+        BlockingPoolPolicy {
+            max_concurrency: 1,
+            ..BlockingPoolPolicy::default()
+        },
+        BlockingLane::StorageIo,
+        GlobalBlockingBudget::isolated(1),
+    )
+}
+
+async fn gated_task(executor: &BlockingExecutor) -> (BlockingTask<usize>, mpsc::Sender<()>) {
+    let (started_tx, started_rx) = oneshot::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let task = executor
+        .submit_io("gated", move || {
+            let _ = started_tx.send(());
+            let _ = release_rx.recv();
+            42
+        })
+        .await
+        .unwrap();
+    started_rx.await.unwrap();
+    (task, release_tx)
+}
+
+fn assert_released(executor: &BlockingExecutor) {
+    let snapshot = executor.snapshot();
+    assert!(snapshot.tasks.is_empty());
+    assert_eq!(snapshot.global_running, 0);
+    assert_eq!(snapshot.global_available, 1);
+}
+
+#[tokio::test]
+async fn expired_observation_retains_capacity_and_the_late_result() {
+    let executor = executor();
+    let (mut task, release) = gated_task(&executor).await;
+
+    let error = task.wait_until(Instant::now()).await.unwrap_err();
+    assert_eq!(error.condition(), CanonicalCondition::DeadlineExceeded);
+    let snapshot = executor.snapshot();
+    assert_eq!(snapshot.timed_out_still_running, 1);
+    assert_eq!(snapshot.global_running, 1);
+    assert_eq!(snapshot.global_available, 0);
+
+    release.send(()).unwrap();
+    assert_eq!(task.wait().await.unwrap(), 42);
+    assert_released(&executor);
+    assert_eq!(
+        task.wait().await.unwrap_err().condition(),
+        CanonicalCondition::Unavailable
+    );
+}
+
+#[tokio::test]
+async fn dropping_one_wait_does_not_consume_execution_completion() {
+    let executor = executor();
+    let (mut task, release) = gated_task(&executor).await;
+    {
+        let wait = task.wait();
+        tokio::pin!(wait);
+        assert!(futures::poll!(&mut wait).is_pending());
+    }
+    assert_eq!(executor.snapshot().global_running, 1);
+
+    release.send(()).unwrap();
+    assert_eq!(task.wait().await.unwrap(), 42);
+    assert_released(&executor);
+}
+
+#[tokio::test]
+async fn abandoning_the_ticket_keeps_real_work_tracked_until_exit() {
+    let executor = executor();
+    let (task, release) = gated_task(&executor).await;
+    let completion = task.join_handle.as_ref().unwrap().abort_handle();
+    drop(task);
+    assert_eq!(executor.snapshot().timed_out_still_running, 1);
+    assert_eq!(executor.snapshot().global_available, 0);
+
+    release.send(()).unwrap();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !completion.is_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_released(&executor);
+}
+
+struct CaptureProbe {
+    executor: BlockingExecutor,
+    dropped: Arc<AtomicBool>,
+}
+
+impl Drop for CaptureProbe {
+    fn drop(&mut self) {
+        // User captures must be destroyed before releasing the operation's
+        // budget or removing the active record, even before its first run.
+        let snapshot = self.executor.snapshot();
+        self.dropped.store(
+            snapshot.global_running == 1 && snapshot.tasks.len() == 1,
+            Ordering::Release,
+        );
+    }
+}
+
+#[test]
+fn cancellation_before_execution_releases_captures_capacity_and_registry() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .max_blocking_threads(1)
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        // Occupy Tokio's only blocking thread, independently of lane admission,
+        // so the tested closure is submitted but cannot start.
+        let occupied = tokio::task::spawn_blocking(move || {
+            let _ = started_tx.send(());
+            let _ = release_rx.recv();
+        });
+        started_rx.await.unwrap();
+
+        let executor = executor();
+        let dropped = Arc::new(AtomicBool::new(false));
+        let capture = CaptureProbe {
+            executor: executor.clone(),
+            dropped: dropped.clone(),
+        };
+        let mut task = executor
+            .submit_io("never-started", move || {
+                drop(capture);
+                panic!("cancelled operation must not execute");
+            })
+            .await
+            .unwrap();
+        task.join_handle.as_ref().unwrap().abort();
+        // Let Tokio dequeue and destroy the aborted closure, then await both
+        // operations before the test runtime is dropped.
+        release_tx.send(()).unwrap();
+        occupied.await.unwrap();
+        let error = task.wait().await.unwrap_err();
+        assert!(error
+            .source()
+            .unwrap()
+            .downcast_ref::<tokio::task::JoinError>()
+            .unwrap()
+            .is_cancelled());
+        assert!(dropped.load(Ordering::Acquire));
+        assert_released(&executor);
+    });
+}
+
+#[tokio::test]
+async fn panic_settles_execution_and_destroys_user_resources() {
+    let executor = executor();
+    let dropped = Arc::new(AtomicBool::new(false));
+    let capture = CaptureProbe {
+        executor: executor.clone(),
+        dropped: dropped.clone(),
+    };
+    let mut task = executor
+        .submit_io("panicking", move || {
+            let _capture = capture;
+            panic!("injected blocking failure");
+        })
+        .await
+        .unwrap();
+    let error = task.wait().await.unwrap_err();
+    assert_eq!(error.operation(), crate::RuntimeOperation::RunBlockingTask);
+    assert!(error
+        .source()
+        .unwrap()
+        .downcast_ref::<tokio::task::JoinError>()
+        .unwrap()
+        .is_panic());
+    assert!(!error.to_string().contains("injected blocking failure"));
+    assert!(dropped.load(Ordering::Acquire));
+    assert_released(&executor);
+    assert_eq!(executor.spawn_io("after-panic", || 7).await.unwrap(), 7);
+    assert_released(&executor);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10566

### Brief Description

Separate blocking admission from caller observation with an internal completion ticket that retains the real join result across a wait timeout or dropped wait future. Existing public submission methods keep their timeout and join-error mappings.

Construct execution ownership before Tokio submission. Both normal execution and cancellation before the closure starts destroy user captures, return capacity, and remove the active record in that order. Abandoning observation continues to report running work until its actual exit. This supplies the completion boundary needed by metadata persistence without adding a public API.

### How Did You Test This Change?

- `cargo test -p rocketmq-runtime --lib blocking::executor::tests`: 5 passed.
- `cargo test -p rocketmq-runtime --test runtime_model blocking`: 12 passed.
- `cargo fmt -p rocketmq-runtime -- --check`: passed.
- `git diff --check`: passed.

Controlled channels cover late completion, dropped observations, never-started cancellation, panic, and resource destruction order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of blocking operations that exceed their wait deadline, allowing their final results to be retrieved later.
  - Ensured timed-out, cancelled, or abandoned operations continue to be tracked until they actually finish.
  - Improved cleanup of execution capacity and resources when operations are cancelled or panic.
  - Improved executor reusability after blocking tasks complete unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->