### PR TITLE
[ISSUE #10567]🐛Sync standalone zstd lockfiles and fix session documentation

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
@@ -9574,27 +9574,27 @@ checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zstd"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+checksum = "bf06bd8162af0734b344780deb55b42a2429ae430870d13fcc12f238e880fe6e"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "ae42c0555055784c70058d19ba8e275528e8a99a706684868ace5da4e716a4ab"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.1.0+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0"
 dependencies = [
  "cc",
  "pkg-config",

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/README.md
@@ -44,7 +44,7 @@ old location. The new database bootstraps the administrator as described above.
 Unversioned or unsupported databases are rejected without deleting or rebuilding
 them; choose a new data directory to start fresh.
 
-Sessions expire after eight hours by default (`DASHBOARD_TAURI_SESSION_TTL_SECS` overrides this). Password changes revoke all sessions and require a new login. Account ¡ú Sessions lists safe identifiers and can sign out the entire account.
+Sessions expire after eight hours by default (`DASHBOARD_TAURI_SESSION_TTL_SECS` overrides this). Password changes revoke all sessions and require a new login. The Sessions page lists safe identifiers and can sign out the entire account.
 
 The current fresh schema is version 4; version 1/2/3 development databases are not migrated. Select a new data directory when changing from an older format.
 

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -3749,27 +3749,27 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+checksum = "bf06bd8162af0734b344780deb55b42a2429ae430870d13fcc12f238e880fe6e"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "ae42c0555055784c70058d19ba8e275528e8a99a706684868ace5da4e716a4ab"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.1.0+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10567

### Brief Description

Synchronize the GPUI dashboard and example lockfiles with the shared crates' existing zstd 0.14 requirement. Update only zstd, zstd-safe, and zstd-sys, using the versions and checksums already recorded in the root lockfile.

Repair the Tauri README's invalid UTF-8 session-navigation text with a readable description of the existing Sessions page.

### How Did You Test This Change?

- From `rocketmq-dashboard/rocketmq-dashboard-gpui/`: `cargo test --locked -p rocketmq-model --lib common::compression::compression_type::tests` - 6 passed.
- From `rocketmq-example/`: `cargo test --locked -p rocketmq-model --lib common::compression::compression_type::tests` - 6 passed.
- Parsed the lockfiles with Python `tomllib`: all unrelated package entries remain unchanged; the three updated zstd package entries match the root lockfile.
- Verified that the README decodes as UTF-8 without replacement characters and checked its Sessions description against the existing UI.
- `git diff --check` - passed.
- Full desktop application builds and graphical smoke tests were not run; validation focused on the changed dependency resolution and compression behavior. No Rust source or frontend implementation changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the README reference to the Sessions page by removing corrupted text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->