### PR TITLE
[ISSUE #10572]🐛Finalize tasks after user future destruction

### DIFF
--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::future::Future;
-use std::panic::AssertUnwindSafe;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::AtomicUsize;
@@ -22,6 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use dashmap::mapref::entry::Entry;
 use futures::future::join_all;
 use futures::future::BoxFuture;
 use futures::future::FutureExt;
@@ -41,9 +41,11 @@ use crate::shutdown_report::ShutdownAnnotation;
 use crate::shutdown_report::ShutdownReport;
 use crate::shutdown_report::TaskSnapshot;
 
+mod completion;
 mod registry;
 mod shutdown;
 
+use completion::TaskExecution;
 use registry::ActiveTaskRegistry;
 use shutdown::ShutdownCoordinator;
 
@@ -201,6 +203,7 @@ struct TaskGroupInner {
     panicked: AtomicUsize,
     lifecycle: AtomicU8,
     spawn_gate: Mutex<()>,
+    settlement_gate: Mutex<()>,
     shutdown: ShutdownCoordinator,
 }
 
@@ -216,6 +219,7 @@ struct TaskMeta {
     detached: bool,
     detached_policy: Option<DetachedTaskPolicy>,
     abort_handle: Option<AbortHandle>,
+    abort_requested: bool,
     completion: Arc<TaskCompletion>,
 }
 
@@ -223,10 +227,6 @@ struct TaskMeta {
 struct TaskCompletion {
     done: AtomicU8,
     notify: Notify,
-}
-
-struct TaskCompletionGuard {
-    completion: Arc<TaskCompletion>,
 }
 
 impl TaskCompletion {
@@ -255,12 +255,6 @@ impl TaskCompletion {
             }
             notified.await;
         }
-    }
-}
-
-impl Drop for TaskCompletionGuard {
-    fn drop(&mut self) {
-        self.completion.mark_done();
     }
 }
 
@@ -535,12 +529,18 @@ impl TaskGroup {
         self.inner.cancellation_token.cancel();
     }
 
-    /// Returns the abort task.
+    /// Requests cancellation of an active task without waiting for destruction.
+    ///
+    /// Returns whether the task was still registered. Its record and resources
+    /// remain owned until the executor destroys the future.
     pub fn abort_task(&self, task_id: TaskId) -> bool {
         self.abort_task_inner(task_id).is_some()
     }
 
-    /// Returns the abort task and wait.
+    /// Requests cancellation and waits until the user future is destroyed.
+    ///
+    /// Returns `false` if the task was already absent or the wait expired.
+    /// A timeout does not remove the task's record or confirm cancellation.
     pub async fn abort_task_and_wait(&self, task_id: TaskId, timeout: Duration) -> bool {
         let Some(completion) = self.abort_task_inner(task_id) else {
             return false;
@@ -683,36 +683,12 @@ impl TaskGroup {
                 detached: detached_policy.is_some(),
                 detached_policy,
                 abort_handle: None,
+                abort_requested: false,
                 completion: completion.clone(),
             },
         );
 
-        let inner = self.inner.clone();
-        let token = inner.cancellation_token.clone();
-        let wrapped = async move {
-            let _completion_guard = TaskCompletionGuard {
-                completion: completion.clone(),
-            };
-            let result = AssertUnwindSafe(future).catch_unwind().await;
-            match result {
-                Ok(()) if token.is_cancelled() => {
-                    inner.finish_task(task_id, TaskResult::Cancelled);
-                    completion.mark_done();
-                }
-                Ok(()) => {
-                    inner.finish_task(task_id, TaskResult::Completed);
-                    completion.mark_done();
-                }
-                Err(error) => {
-                    tracing::error!(task_id = task_id.as_u64(), ?error, "task panicked");
-                    inner.finish_task(task_id, TaskResult::Panicked);
-                    completion.mark_done();
-                    if propagate_panic {
-                        std::panic::resume_unwind(error);
-                    }
-                }
-            }
-        };
+        let wrapped = TaskExecution::new(future, self.inner.clone(), task_id, completion, propagate_panic).run();
 
         let join_handle = if detached_policy.is_some() {
             self.inner.runtime.spawn_owned(wrapped)
@@ -721,21 +697,32 @@ impl TaskGroup {
         };
         let abort_handle = join_handle.abort_handle();
 
-        if let Some(mut meta) = self.inner.registry.tasks.get_mut(&task_id) {
+        let abort_requested = if let Some(mut meta) = self.inner.registry.tasks.get_mut(&task_id) {
             meta.abort_handle = Some(abort_handle);
             meta.state = TaskState::Running;
+            meta.abort_requested
+        } else {
+            false
+        };
+        // A diagnostic reader can discover the registered ID before this
+        // handle is installed. Honor any cancellation requested in that gap.
+        if abort_requested {
+            join_handle.abort();
         }
 
         Ok((task_id, join_handle))
     }
 
     fn abort_task_inner(&self, task_id: TaskId) -> Option<Arc<TaskCompletion>> {
-        let (_, meta) = self.inner.registry.tasks.remove(&task_id)?;
-        if let Some(abort_handle) = meta.abort_handle {
+        let (abort_handle, completion) = {
+            let mut meta = self.inner.registry.tasks.get_mut(&task_id)?;
+            meta.abort_requested = true;
+            (meta.abort_handle.clone(), meta.completion.clone())
+        };
+        if let Some(abort_handle) = abort_handle {
             abort_handle.abort();
         }
-        self.inner.aborted.fetch_add(1, Ordering::Relaxed);
-        Some(meta.completion)
+        Some(completion)
     }
 
     async fn shutdown_inner(&self) -> ShutdownReport {
@@ -776,23 +763,16 @@ impl TaskGroup {
         let (child_reports, timed_out) = tokio::join!(child_reports, tracked_shutdown);
 
         let mut report = ShutdownReport::new(self.inner.name.to_string(), started_at.elapsed());
-        report.completed = self.inner.completed.load(Ordering::Relaxed);
-        report.cancelled = self.inner.cancelled.load(Ordering::Relaxed);
-        report.panicked = self.inner.panicked.load(Ordering::Relaxed);
         report.children = child_reports;
+        self.record_task_outcomes(&mut report);
 
-        let aborted = self.inner.aborted.load(Ordering::Relaxed) + self.remove_aborted_tasks();
-        report.aborted = aborted;
+        let aborted = report.aborted;
         if aborted > 0 {
             report.annotations.push(ShutdownAnnotation::new(format!(
-                "aborted {aborted} tracked tasks after shutdown timeout"
+                "confirmed cancellation of {aborted} aborted tasks"
             )));
         }
 
-        let remaining = self.remaining_snapshots(TaskState::Leaked);
-        report.detached_still_running = remaining.iter().filter(|task| task.detached).count();
-        report.leaked = remaining.iter().filter(|task| !task.detached).count();
-        report.remaining_tasks = remaining;
         if timed_out {
             report.timed_out = aborted + report.leaked;
         }
@@ -828,23 +808,15 @@ impl TaskGroup {
         self.abort_tracked_tasks();
 
         let mut report = ShutdownReport::new(self.inner.name.to_string(), started_at.elapsed());
-        report.completed = self.inner.completed.load(Ordering::Relaxed);
-        report.cancelled = self.inner.cancelled.load(Ordering::Relaxed);
-        report.panicked = self.inner.panicked.load(Ordering::Relaxed);
         report.children = child_reports;
+        self.record_task_outcomes(&mut report);
 
-        let aborted = self.inner.aborted.load(Ordering::Relaxed) + self.remove_aborted_tasks();
-        report.aborted = aborted;
+        let aborted = report.aborted;
         if aborted > 0 {
             report.annotations.push(ShutdownAnnotation::new(format!(
-                "aborted {aborted} tracked tasks during immediate shutdown"
+                "confirmed cancellation of {aborted} aborted tasks"
             )));
         }
-
-        let remaining = self.remaining_snapshots(TaskState::Leaked);
-        report.detached_still_running = remaining.iter().filter(|task| task.detached).count();
-        report.leaked = remaining.iter().filter(|task| !task.detached).count();
-        report.remaining_tasks = remaining;
 
         if report.detached_still_running > 0 {
             report.annotations.push(ShutdownAnnotation::new(format!(
@@ -862,7 +834,7 @@ impl TaskGroup {
             if entry.detached {
                 continue;
             }
-            entry.state = TaskState::Aborted;
+            entry.abort_requested = true;
             if let Some(abort_handle) = &entry.abort_handle {
                 abort_handle.abort();
             }
@@ -874,36 +846,37 @@ impl TaskGroup {
             if entry.detached_policy != Some(DetachedTaskPolicy::AbortOnShutdown) {
                 continue;
             }
-            entry.state = TaskState::Aborted;
+            entry.abort_requested = true;
             if let Some(abort_handle) = &entry.abort_handle {
                 abort_handle.abort();
             }
         }
     }
 
-    fn remove_aborted_tasks(&self) -> usize {
-        let aborted_ids = self
-            .inner
-            .registry
-            .tasks
-            .iter()
-            .filter_map(|entry| (entry.state == TaskState::Aborted).then_some(*entry.key()))
-            .collect::<Vec<_>>();
-
-        for task_id in &aborted_ids {
-            self.inner.registry.tasks.remove(task_id);
+    fn record_task_outcomes(&self, report: &mut ShutdownReport) {
+        // Snapshot counters and active records together: a concurrent finalizer
+        // must not make a task disappear between these two observations.
+        let _settlement = self.inner.settlement_gate.lock();
+        report.completed = self.inner.completed.load(Ordering::Relaxed);
+        report.cancelled = self.inner.cancelled.load(Ordering::Relaxed);
+        report.panicked = self.inner.panicked.load(Ordering::Relaxed);
+        report.aborted = self.inner.aborted.load(Ordering::Relaxed);
+        let mut requested = 0;
+        for entry in self.inner.registry.tasks.iter() {
+            requested += usize::from(entry.abort_requested);
+            let task = entry.snapshot(TaskState::Leaked);
+            if task.detached {
+                report.detached_still_running += 1;
+            } else {
+                report.leaked += 1;
+            }
+            report.remaining_tasks.push(task);
         }
-
-        aborted_ids.len()
-    }
-
-    fn remaining_snapshots(&self, state: TaskState) -> Vec<TaskSnapshot> {
-        self.inner
-            .registry
-            .tasks
-            .iter()
-            .map(|entry| entry.value().snapshot(state))
-            .collect()
+        if requested > 0 {
+            report.annotations.push(ShutdownAnnotation::new(format!(
+                "abort requested for {requested} tasks whose destruction is not yet confirmed"
+            )));
+        }
     }
 }
 
@@ -934,6 +907,7 @@ impl TaskGroupInner {
             panicked: AtomicUsize::new(0),
             lifecycle: AtomicU8::new(STATE_OPEN),
             spawn_gate: Mutex::new(()),
+            settlement_gate: Mutex::new(()),
             shutdown: ShutdownCoordinator::new(),
         }
     }
@@ -955,14 +929,10 @@ impl TaskGroupInner {
     }
 
     fn finish_task(&self, task_id: TaskId, result: TaskResult) {
-        let Some((_, meta)) = self.registry.tasks.remove(&task_id) else {
+        let _settlement = self.settlement_gate.lock();
+        let Entry::Occupied(entry) = self.registry.tasks.entry(task_id) else {
             return;
         };
-
-        if meta.state == TaskState::Aborted {
-            self.aborted.fetch_add(1, Ordering::Relaxed);
-            return;
-        }
 
         match result {
             TaskResult::Completed => {
@@ -975,8 +945,13 @@ impl TaskGroupInner {
                 self.panicked.fetch_add(1, Ordering::Relaxed);
                 self.mark_poisoned_if_open();
             }
-            TaskResult::Aborted => {}
+            TaskResult::Aborted => {
+                self.aborted.fetch_add(1, Ordering::Relaxed);
+            }
         }
+        // A missing record is also treated as finished by wait_task. Publish
+        // the counters before removing it, after user resources were dropped.
+        entry.remove();
     }
 }
 

--- a/rocketmq-runtime/src/task_group/completion.rs
+++ b/rocketmq-runtime/src/task_group/completion.rs
@@ -1,0 +1,98 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
+use futures::FutureExt;
+
+use super::TaskCompletion;
+use super::TaskGroupInner;
+use super::TaskId;
+use super::TaskResult;
+
+// Before the first poll, struct field order destroys the user future before
+// its finalizer. Once polled, run() establishes the same order for its locals.
+// This keeps the existing inline/large-future allocation boundary intact.
+pub(super) struct TaskExecution<F> {
+    future: F,
+    finalizer: TaskFinalizer,
+    propagate_panic: bool,
+}
+
+impl<F: Future<Output = ()>> TaskExecution<F> {
+    pub(super) fn new(
+        future: F,
+        inner: Arc<TaskGroupInner>,
+        task_id: TaskId,
+        completion: Arc<TaskCompletion>,
+        propagate_panic: bool,
+    ) -> Self {
+        Self {
+            future,
+            finalizer: TaskFinalizer {
+                inner,
+                task_id,
+                completion,
+                result: TaskResult::Aborted,
+            },
+            propagate_panic,
+        }
+    }
+
+    pub(super) async fn run(self) {
+        let mut finalizer = self.finalizer;
+        let result = AssertUnwindSafe(self.future).catch_unwind().await;
+        // The awaited future has been destroyed at this statement boundary.
+        // Record the observed result once, independently of subsequent aborts.
+        match result {
+            Ok(()) => {
+                finalizer.result = if finalizer.inner.cancellation_token.is_cancelled() {
+                    TaskResult::Cancelled
+                } else {
+                    TaskResult::Completed
+                };
+            }
+            Err(error) => {
+                finalizer.result = TaskResult::Panicked;
+                tracing::error!(task_id = finalizer.task_id.as_u64(), "task panicked");
+                if self.propagate_panic {
+                    std::panic::resume_unwind(error);
+                }
+            }
+        }
+    }
+}
+
+struct TaskFinalizer {
+    inner: Arc<TaskGroupInner>,
+    task_id: TaskId,
+    completion: Arc<TaskCompletion>,
+    result: TaskResult,
+}
+
+impl Drop for TaskFinalizer {
+    fn drop(&mut self) {
+        // Also classify a panic in the user future's destructor, outside the
+        // catch_unwind that surrounds polling. No user callback runs here.
+        let result = if std::thread::panicking() {
+            TaskResult::Panicked
+        } else {
+            self.result
+        };
+        self.inner.finish_task(self.task_id, result);
+        self.completion.mark_done();
+    }
+}

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -677,23 +677,27 @@ async fn task_group_shutdown_now_aborts_without_async_wait() {
     let context = RuntimeContext::from_current("task-group-shutdown-now-test");
     let group = context.service_context("service").task_group().clone();
 
-    group
-        .spawn_service("pending-task", async move {
+    let (task_id, handle) = group
+        .spawn_service_with_handle("pending-task", async move {
             std::future::pending::<()>().await;
         })
         .unwrap();
 
     let report = group.shutdown_now();
-    assert_eq!(report.aborted, 1, "{}", report.to_json());
-    assert_eq!(report.leaked, 0, "{}", report.to_json());
+    assert_eq!(report.aborted, 0, "{}", report.to_json());
+    assert_eq!(report.leaked, 1, "{}", report.to_json());
+    assert!(group.contains_task(task_id));
     assert_eq!(
         group.lifecycle_state(),
         rocketmq_runtime::TaskGroupLifecycleState::ShutdownCompleted
     );
     assert!(group.spawn_service("late-task", async {}).is_err());
 
+    assert!(handle.await.unwrap_err().is_cancelled());
+    assert!(!group.contains_task(task_id));
     let second_report = group.shutdown(Duration::from_secs(1)).await;
-    assert_eq!(second_report.aborted, 1, "{}", second_report.to_json());
+    assert_eq!(second_report.aborted, 0, "{}", second_report.to_json());
+    assert_eq!(second_report.leaked, 1, "{}", second_report.to_json());
 }
 
 #[tokio::test]
@@ -1656,10 +1660,9 @@ fn runtime_owner_shutdown_background_closes_root_group_without_drop_fallback() {
     let report = owner.shutdown_background();
 
     assert!(
-        report
-            .children
-            .iter()
-            .any(|child| { child.name == "owner-background-test" && child.cancelled + child.aborted == 1 }),
+        report.children.iter().any(|child| {
+            child.name == "owner-background-test" && child.cancelled + child.aborted + child.leaked == 1
+        }),
         "{}",
         report.to_json()
     );

--- a/rocketmq-runtime/tests/task_completion.rs
+++ b/rocketmq-runtime/tests/task_completion.rs
@@ -1,0 +1,216 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudgetTree;
+use rocketmq_runtime::ResourcePermit;
+use rocketmq_runtime::RuntimeContext;
+use tokio::sync::oneshot;
+
+struct PendingResource {
+    permit: Option<ResourcePermit>,
+    dropped: Arc<AtomicBool>,
+    started: Option<oneshot::Sender<()>>,
+    drop_gate: Option<(oneshot::Sender<()>, mpsc::Receiver<()>)>,
+    panic_on_drop: bool,
+}
+
+impl Future for PendingResource {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<()> {
+        if let Some(started) = self.started.take() {
+            let _ = started.send(());
+        }
+        Poll::Pending
+    }
+}
+
+impl Drop for PendingResource {
+    fn drop(&mut self) {
+        if let Some((started, release)) = self.drop_gate.take() {
+            let _ = started.send(());
+            let _ = release.recv();
+        }
+        drop(self.permit.take());
+        self.dropped.store(true, Ordering::Release);
+        assert!(!self.panic_on_drop, "injected destructor panic");
+    }
+}
+
+fn pending_resource() -> (ResourceBudgetTree, Arc<AtomicBool>, PendingResource) {
+    let budget = ResourceBudgetTree::new("task-resource", BudgetLimit::new(1, 8, FullPolicy::Reject)).unwrap();
+    let dropped = Arc::new(AtomicBool::new(false));
+    let future = PendingResource {
+        permit: Some(budget.root().try_acquire_data(8).unwrap()),
+        dropped: dropped.clone(),
+        started: None,
+        drop_gate: None,
+        panic_on_drop: false,
+    };
+    (budget, dropped, future)
+}
+
+#[tokio::test]
+async fn group_abort_before_first_poll_confirms_resource_destruction() {
+    let context = RuntimeContext::from_current("before-poll");
+    let group = context.service_context("service").task_group().clone();
+    let (budget, dropped, future) = pending_resource();
+    let (id, handle) = group.spawn_service_with_handle("pending", future).unwrap();
+    assert!(group.abort_task_and_wait(id, Duration::from_secs(1)).await);
+    assert!(dropped.load(Ordering::Acquire));
+    assert_eq!(budget.root().snapshot().current_bytes, 0);
+    assert!(handle.await.unwrap_err().is_cancelled());
+    assert!(!group.contains_task(id));
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert_eq!(report.aborted, 1);
+    assert_eq!(report.completed + report.cancelled + report.panicked + report.leaked, 0);
+}
+
+#[tokio::test]
+async fn external_abort_before_first_poll_settles_the_registry() {
+    let context = RuntimeContext::from_current("external-before-poll");
+    let group = context.service_context("service").task_group().clone();
+    let (budget, dropped, future) = pending_resource();
+    let (id, handle) = group.spawn_service_with_handle("pending", future).unwrap();
+    handle.abort();
+    assert!(handle.await.unwrap_err().is_cancelled());
+    assert!(dropped.load(Ordering::Acquire));
+    assert_eq!(budget.root().snapshot().current_bytes, 0);
+    assert!(!group.contains_task(id));
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert_eq!(report.aborted, 1);
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+#[tokio::test]
+async fn external_abort_after_first_poll_settles_the_registry() {
+    let context = RuntimeContext::from_current("external-running");
+    let group = context.service_context("service").task_group().clone();
+    let (budget, dropped, mut future) = pending_resource();
+    let (started_tx, started_rx) = oneshot::channel();
+    future.started = Some(started_tx);
+    let (id, handle) = group.spawn_service_with_handle("pending", future).unwrap();
+    started_rx.await.unwrap();
+    handle.abort();
+    assert!(handle.await.unwrap_err().is_cancelled());
+    assert!(group.wait_task(id, Duration::ZERO).await);
+    assert!(dropped.load(Ordering::Acquire));
+    assert_eq!(budget.root().snapshot().current_bytes, 0);
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert_eq!(report.aborted, 1);
+    assert_eq!(report.completed + report.cancelled + report.panicked + report.leaked, 0);
+}
+
+#[tokio::test]
+async fn destructor_panic_settles_without_losing_completion() {
+    let context = RuntimeContext::from_current("destructor-panic");
+    let group = context.service_context("service").task_group().clone();
+    let (budget, dropped, mut future) = pending_resource();
+    let (started_tx, started_rx) = oneshot::channel();
+    future.started = Some(started_tx);
+    future.panic_on_drop = true;
+    let (id, handle) = group.spawn_service_with_handle("pending", future).unwrap();
+    started_rx.await.unwrap();
+    handle.abort();
+    assert!(handle.await.unwrap_err().is_panic());
+    assert!(group.wait_task(id, Duration::ZERO).await);
+    assert!(dropped.load(Ordering::Acquire));
+    assert_eq!(budget.root().snapshot().current_bytes, 0);
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert_eq!(report.panicked, 1);
+    assert_eq!(report.aborted + report.completed + report.cancelled + report.leaked, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abort_keeps_the_record_while_the_user_destructor_is_running() {
+    let context = RuntimeContext::from_current("destruction-gate");
+    let group = context.service_context("service").task_group().clone();
+    let (budget, dropped, mut future) = pending_resource();
+    let (started_tx, started_rx) = oneshot::channel();
+    let (drop_started_tx, drop_started_rx) = oneshot::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    future.started = Some(started_tx);
+    future.drop_gate = Some((drop_started_tx, release_rx));
+    let (id, handle) = group.spawn_service_with_handle("pending", future).unwrap();
+    started_rx.await.unwrap();
+    assert!(group.abort_task(id));
+    drop_started_rx.await.unwrap();
+    assert!(group.contains_task(id));
+    assert!(!group.wait_task(id, Duration::ZERO).await);
+    assert!(!dropped.load(Ordering::Acquire));
+    assert_eq!(budget.root().snapshot().current_bytes, 8);
+    let report = group.shutdown_now();
+    assert_eq!(report.aborted, 0);
+    assert_eq!(report.leaked, 1);
+    assert!(!report.is_healthy());
+
+    release_tx.send(()).unwrap();
+    assert!(handle.await.unwrap_err().is_cancelled());
+    assert!(group.wait_task(id, Duration::from_secs(1)).await);
+    assert!(dropped.load(Ordering::Acquire));
+    assert_eq!(budget.root().snapshot().current_bytes, 0);
+    assert!(!group.contains_task(id));
+    // The already-returned report is a snapshot, not a promise of later state.
+    assert_eq!(report.aborted, 0);
+    assert_eq!(report.leaked, 1);
+}
+
+#[tokio::test]
+async fn repeated_abort_and_normal_completion_each_settle_once() {
+    let context = RuntimeContext::from_current("single-settlement");
+    let group = context.service_context("service").task_group().clone();
+    let (id, pending) = group
+        .spawn_service_with_handle("pending", std::future::pending())
+        .unwrap();
+    assert!(group.abort_task(id));
+    assert!(group.abort_task(id));
+    assert!(pending.await.unwrap_err().is_cancelled());
+    let (_, completed) = group.spawn_service_with_handle("completed", async {}).unwrap();
+    completed.await.unwrap();
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert_eq!(report.aborted, 1);
+    assert_eq!(report.completed, 1);
+    assert_eq!(report.cancelled + report.panicked + report.leaked, 0);
+}
+
+#[tokio::test]
+async fn panic_propagation_also_releases_user_resources_once() {
+    let context = RuntimeContext::from_current("panic-completion");
+    let group = context.service_context("service").task_group().clone();
+    let (budget, dropped, resource) = pending_resource();
+    let (_, handle) = group
+        .spawn_service_with_handle("panicking", async move {
+            let _resource = resource;
+            panic!("injected task panic");
+        })
+        .unwrap();
+    assert!(handle.await.unwrap_err().is_panic());
+    assert!(dropped.load(Ordering::Acquire));
+    assert_eq!(budget.root().snapshot().current_bytes, 0);
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert_eq!(report.panicked, 1);
+    assert_eq!(report.aborted + report.completed + report.cancelled + report.leaked, 0);
+}

--- a/rocketmq-runtime/tests/task_group_shutdown_loom.rs
+++ b/rocketmq-runtime/tests/task_group_shutdown_loom.rs
@@ -14,6 +14,8 @@
 
 //! Loom model for the TaskGroup registration, cancellation, and join invariants.
 
+use loom::sync::atomic::AtomicBool;
+use loom::sync::atomic::Ordering;
 use loom::sync::Arc;
 use loom::sync::Mutex;
 use loom::thread;
@@ -37,20 +39,10 @@ struct TaskGroupModel {
 }
 
 #[derive(Debug)]
-struct RemovalModel {
+struct CompletionModel {
     registered: bool,
-    removals: usize,
-}
-
-impl RemovalModel {
-    fn remove_once(&mut self) -> bool {
-        if !self.registered {
-            return false;
-        }
-        self.registered = false;
-        self.removals += 1;
-        true
-    }
+    abort_requested: bool,
+    settled: usize,
 }
 
 #[derive(Debug)]
@@ -199,31 +191,64 @@ fn ha_reconnect_child_lease_racing_with_shutdown_is_tracked_or_rejected() {
 }
 
 #[test]
-fn completion_racing_with_abort_removes_the_task_once() {
+fn abort_and_report_racing_with_completion_preserve_resource_settlement() {
     loom::model(|| {
-        let removal = Arc::new(Mutex::new(RemovalModel {
+        let state = Arc::new(Mutex::new(CompletionModel {
             registered: true,
-            removals: 0,
+            abort_requested: false,
+            settled: 0,
         }));
+        let resource_live = Arc::new(AtomicBool::new(true));
+        let done = Arc::new(AtomicBool::new(false));
 
-        let completed_removal = Arc::clone(&removal);
+        let completed_state = Arc::clone(&state);
+        let completed_resource = Arc::clone(&resource_live);
+        let completed_done = Arc::clone(&done);
         let completion = thread::spawn(move || {
-            thread::yield_now();
-            completed_removal.lock().expect("completion removal lock").remove_once()
+            // Both normal return and executor cancellation destroy the future
+            // before the sole finalizer settles the registry and publishes done.
+            completed_resource.store(false, Ordering::Relaxed);
+            {
+                let mut state = completed_state.lock().expect("settlement lock");
+                assert!(state.registered);
+                state.settled += 1;
+                state.registered = false;
+            }
+            completed_done.store(true, Ordering::Release);
         });
 
-        let aborted_removal = Arc::clone(&removal);
+        let aborted_state = Arc::clone(&state);
         let abort = thread::spawn(move || {
-            thread::yield_now();
-            aborted_removal.lock().expect("abort removal lock").remove_once()
+            let mut state = aborted_state.lock().expect("abort request lock");
+            if state.registered {
+                state.abort_requested = true;
+                assert_eq!(state.settled, 0, "requesting abort does not settle a live task");
+            }
         });
 
-        let completed = completion.join().expect("completion thread");
-        let aborted = abort.join().expect("abort thread");
-        let removal = removal.lock().expect("final removal lock");
-        assert_ne!(completed, aborted, "exactly one racing path must remove the task");
-        assert!(!removal.registered);
-        assert_eq!(removal.removals, 1);
+        let observed_state = Arc::clone(&state);
+        let observed_done = Arc::clone(&done);
+        let observed_resource = Arc::clone(&resource_live);
+        let observer = thread::spawn(move || {
+            let done = observed_done.load(Ordering::Acquire);
+            if done {
+                assert!(!observed_resource.load(Ordering::Relaxed));
+            }
+            // The report uses the same settlement gate as the finalizer.
+            let state = observed_state.lock().expect("report lock");
+            assert_eq!(usize::from(state.registered) + state.settled, 1);
+            if done {
+                assert!(!state.registered);
+                assert_eq!(state.settled, 1);
+            }
+        });
+
+        completion.join().expect("completion thread");
+        abort.join().expect("abort thread");
+        observer.join().expect("observer thread");
+        let state = state.lock().expect("final state lock");
+        assert!(!state.registered);
+        assert_eq!(state.settled, 1);
     });
 }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10572

### Brief Description

TaskGroup now constructs its finalizer before submission and settles every exit path after the user future is destroyed, including cancellation before the first poll, native handle abort, and destructor panic. Abort requests retain active records until the executor confirms destruction. Terminal counters and shutdown snapshots share a settlement gate so a task cannot disappear between those observations.

Preserves the existing inline/large-future allocation boundary and native handle panic propagation. Immediate shutdown reports unresolved work instead of counting an abort request as a completed cancellation; returned reports remain frozen after late destruction. The Loom model now covers request, finalization, resource visibility, and report races.

### How Did You Test This Change?

- `cargo test -p rocketmq-runtime --test task_completion --test runtime_model --test task_submission_stack --test runtime_resource_ownership --test task_group_shutdown_loom`: 63 tests passed, including 7 new real-executor regressions, 4 Loom models, and the 1 MiB stack submission check.
- `cargo test -p rocketmq-runtime --lib --test task_group_shutdown_loom --test service_context_scope_compile_fail`: 148 library tests, the ownership compile-fail target, and the preceding Loom models passed before the final focused additions; the changed Loom target was rerun above.
- `cargo fmt -p rocketmq-runtime -- --check` and `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task cancellation and shutdown handling to preserve task tracking until cancellation is fully settled.
  * Ensured task resources and accounting are finalized exactly once across aborts, cancellations, panics, and normal completion.
  * Improved shutdown reports for tasks that remain pending or are cancelled asynchronously.

* **Tests**
  * Added coverage for task completion, resource cleanup, repeated aborts, panic handling, and race conditions during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->