### PR TITLE
[ISSUE #10575]🐛Bind blocking execution to the injected runtime owner

### DIFF
--- a/rocketmq-runtime/src/blocking/executor.rs
+++ b/rocketmq-runtime/src/blocking/executor.rs
@@ -33,6 +33,7 @@ use super::BlockingTaskState;
 use crate::error::RuntimeContractViolation;
 use crate::error::RuntimeError;
 use crate::error::RuntimeResult;
+use crate::handle::RuntimeHandle;
 use crate::shutdown_deadline::ShutdownDeadline;
 use crate::task_group::TaskGroup;
 
@@ -40,12 +41,15 @@ use crate::task_group::TaskGroup;
 /// admission budget.
 ///
 /// Cloning this value shares queue state and capacity; it never creates a new
-/// owner. Cancellation while queued removes the task immediately. Cancellation
+/// owner. Execution always uses the injected owner's Tokio runtime, including
+/// when the submission future is polled by a different runtime.
+/// Cancellation while queued removes the task immediately. Cancellation
 /// or timeout after execution begins leaves the admission permit inside the
 /// actual blocking closure, so capacity is released only when that closure
 /// exits.
 #[derive(Debug, Clone)]
 pub struct BlockingExecutor {
+    runtime: RuntimeHandle,
     policy: Arc<BlockingPoolPolicy>,
     lane: BlockingLane,
     budget: GlobalBlockingBudget,
@@ -195,13 +199,14 @@ impl BlockingExecutor {
     /// Runtime composition roots use one shared budget through
     /// `new_managed`; this constructor preserves the existing public test and
     /// adapter surface by assigning the executor its own exact capacity.
-    pub fn new(policy: BlockingPoolPolicy, _owner_group: TaskGroup) -> Result<Self, RuntimeContractViolation> {
+    pub fn new(policy: BlockingPoolPolicy, owner_group: TaskGroup) -> Result<Self, RuntimeContractViolation> {
         policy.validate()?;
         let capacity = policy.max_concurrency;
         Ok(Self::new_with_budget(
             policy,
             BlockingLane::StorageIo,
             GlobalBlockingBudget::isolated(capacity),
+            owner_group.runtime().clone(),
         ))
     }
 
@@ -209,13 +214,20 @@ impl BlockingExecutor {
         policy: BlockingPoolPolicy,
         lane: BlockingLane,
         budget: GlobalBlockingBudget,
+        runtime: RuntimeHandle,
     ) -> Result<Self, RuntimeContractViolation> {
         policy.validate()?;
-        Ok(Self::new_with_budget(policy, lane, budget))
+        Ok(Self::new_with_budget(policy, lane, budget, runtime))
     }
 
-    fn new_with_budget(policy: BlockingPoolPolicy, lane: BlockingLane, budget: GlobalBlockingBudget) -> Self {
+    fn new_with_budget(
+        policy: BlockingPoolPolicy,
+        lane: BlockingLane,
+        budget: GlobalBlockingBudget,
+        runtime: RuntimeHandle,
+    ) -> Self {
         Self {
+            runtime,
             queue_permits: Arc::new(Semaphore::new(policy.max_queue_depth)),
             policy: Arc::new(policy),
             lane,
@@ -404,7 +416,7 @@ impl BlockingExecutor {
                 task_id,
             },
         };
-        let join_handle = tokio::task::spawn_blocking(move || work.run());
+        let join_handle = self.runtime.tokio_handle().spawn_blocking(move || work.run());
         Ok(BlockingTask::new(
             join_handle,
             self.tasks.clone(),

--- a/rocketmq-runtime/src/blocking/executor/tests.rs
+++ b/rocketmq-runtime/src/blocking/executor/tests.rs
@@ -29,6 +29,7 @@ fn executor() -> BlockingExecutor {
         },
         BlockingLane::StorageIo,
         GlobalBlockingBudget::isolated(1),
+        RuntimeHandle::new(tokio::runtime::Handle::current()),
     )
 }
 

--- a/rocketmq-runtime/src/service_context.rs
+++ b/rocketmq-runtime/src/service_context.rs
@@ -120,14 +120,24 @@ struct BlockingLanes {
 }
 
 impl BlockingLanes {
-    fn new(policies: BlockingLanePolicies, global_capacity: usize) -> Self {
+    fn new(policies: BlockingLanePolicies, global_capacity: usize, runtime: RuntimeHandle) -> Self {
         let budget = GlobalBlockingBudget::managed(global_capacity, &policies);
         Self {
-            storage_io: BlockingExecutor::new_managed(policies.storage_io, BlockingLane::StorageIo, budget.clone())
-                .expect("RuntimeConfig validates storage blocking policy before root context construction"),
-            metadata_io: BlockingExecutor::new_managed(policies.metadata_io, BlockingLane::MetadataIo, budget.clone())
-                .expect("RuntimeConfig validates metadata blocking policy before root context construction"),
-            cpu_crypto: BlockingExecutor::new_managed(policies.cpu_crypto, BlockingLane::CpuCrypto, budget)
+            storage_io: BlockingExecutor::new_managed(
+                policies.storage_io,
+                BlockingLane::StorageIo,
+                budget.clone(),
+                runtime.clone(),
+            )
+            .expect("RuntimeConfig validates storage blocking policy before root context construction"),
+            metadata_io: BlockingExecutor::new_managed(
+                policies.metadata_io,
+                BlockingLane::MetadataIo,
+                budget.clone(),
+                runtime.clone(),
+            )
+            .expect("RuntimeConfig validates metadata blocking policy before root context construction"),
+            cpu_crypto: BlockingExecutor::new_managed(policies.cpu_crypto, BlockingLane::CpuCrypto, budget, runtime)
                 .expect("RuntimeConfig validates CPU blocking policy before root context construction"),
         }
     }
@@ -177,7 +187,7 @@ impl RootServiceContext {
         diagnostics: RuntimeDiagnostics,
         resources: RuntimeResources,
     ) -> Self {
-        let blocking_lanes = BlockingLanes::new(blocking_policies, global_blocking_capacity);
+        let blocking_lanes = BlockingLanes::new(blocking_policies, global_blocking_capacity, runtime.clone());
         Self {
             name,
             runtime,

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -279,6 +279,10 @@ impl TaskGroup {
         self.inner.id
     }
 
+    pub(crate) fn runtime(&self) -> &RuntimeHandle {
+        &self.inner.runtime
+    }
+
     /// Returns the parent id.
     pub fn parent_id(&self) -> Option<TaskGroupId> {
         self.inner.parent_id

--- a/rocketmq-runtime/tests/blocking_ownership.rs
+++ b/rocketmq-runtime/tests/blocking_ownership.rs
@@ -1,0 +1,101 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use rocketmq_runtime::BlockingExecutor;
+use rocketmq_runtime::BlockingLane;
+use rocketmq_runtime::BlockingPoolPolicy;
+use rocketmq_runtime::ProcessMemoryLimit;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
+fn owner() -> RuntimeOwner {
+    RuntimeOwner::plan(RuntimeConfig::for_parallelism("blocking-owner", 1))
+        .unwrap()
+        .with_memory_limit(ProcessMemoryLimit::configured(8 * 1024 * 1024).unwrap())
+        .build()
+        .unwrap()
+}
+
+fn foreign_host() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .thread_name("foreign-blocking-host")
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn managed_lanes_execute_on_the_owner_when_called_from_a_foreign_runtime() {
+    let owner = owner();
+    let service = owner.root_context().component("component").component("child");
+    let owner_id = owner.block_on(async { tokio::runtime::Handle::current().id() });
+    let foreign = foreign_host();
+    foreign.block_on(async {
+        assert_ne!(tokio::runtime::Handle::current().id(), owner_id);
+        for lane in [
+            BlockingLane::StorageIo,
+            BlockingLane::MetadataIo,
+            BlockingLane::CpuCrypto,
+        ] {
+            let executor = service.blocking(lane).clone();
+            let actual = executor
+                .spawn_io("runtime-identity", || tokio::runtime::Handle::current().id())
+                .await
+                .unwrap();
+            assert_eq!(actual, owner_id, "{lane:?} must use its injected runtime");
+            assert!(executor.snapshot().tasks.is_empty());
+            assert_eq!(executor.snapshot().global_running, 0);
+        }
+    });
+    assert!(owner.shutdown_runtime_blocking().unwrap().is_healthy());
+}
+
+#[test]
+fn isolated_executor_uses_the_supplied_group_even_when_constructed_outside_tokio() {
+    let owner = owner();
+    let service = owner.root_context().component("isolated");
+    let owner_id = owner.block_on(async { tokio::runtime::Handle::current().id() });
+    assert!(tokio::runtime::Handle::try_current().is_err());
+    let executor = BlockingExecutor::new(BlockingPoolPolicy::default(), service.task_group().clone()).unwrap();
+    let foreign = foreign_host();
+    let actual = foreign
+        .block_on(executor.spawn_io("runtime-identity", || tokio::runtime::Handle::current().id()))
+        .unwrap();
+    assert_eq!(actual, owner_id);
+    assert_eq!(executor.snapshot().global_running, 0);
+    assert!(owner.shutdown_runtime_blocking().unwrap().is_healthy());
+}
+
+#[test]
+fn a_retained_executor_cannot_execute_on_another_runtime_after_its_owner_is_destroyed() {
+    let owner = owner();
+    let executor = owner.root_context().component("retained").metadata_io().clone();
+    assert!(owner.shutdown_runtime_blocking().unwrap().is_healthy());
+    let foreign = foreign_host();
+    let ran = Arc::new(AtomicBool::new(false));
+    let operation_ran = ran.clone();
+    foreign
+        .block_on(executor.spawn_io("after-runtime-shutdown", move || {
+            operation_ran.store(true, Ordering::Release);
+        }))
+        .expect_err("a destroyed runtime cannot execute a retained capability");
+    assert!(!ran.load(Ordering::Acquire));
+    let snapshot = executor.snapshot();
+    assert!(snapshot.tasks.is_empty());
+    assert_eq!(snapshot.global_running, 0);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #10575

### Brief Description

BlockingExecutor now stores a private RuntimeHandle and submits closures to that handle. All managed lanes inherit the root runtime, and the existing isolated constructor uses the runtime of its supplied TaskGroup. Calling from a foreign Tokio host no longer moves execution there; a retained executor cannot execute on that host after its owner runtime is destroyed.

Keeps the public constructor signature, shared admission budgets, completion cleanup, and existing error mapping. Scope shutdown admission and drain/finalization authorization remain separate follow-up work.

### How Did You Test This Change?

- The three new `blocking_ownership` regressions failed before the fix and passed afterward. They compare actual runtime IDs for managed lanes and the isolated constructor, and reject execution after owner destruction.
- `cargo test -p rocketmq-runtime --test blocking_ownership --test metadata_io_actor --test runtime_model`: 66 tests passed.
- `cargo test -p rocketmq-runtime --lib blocking::executor::tests`: 5 completion/cancellation/resource tests passed.
- `cargo fmt -p rocketmq-runtime -- --check` and `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocking operations now consistently run on their designated runtime, even when submitted from another runtime.
  * Improved reliability for managed storage, metadata, CPU, and cryptographic operations across runtime boundaries.
  * Operations correctly fail instead of running unexpectedly when their owning runtime is no longer available.

* **Tests**
  * Added coverage for runtime ownership, cross-runtime submissions, isolated executors, and unavailable owners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->