### PR TITLE
[ISSUE #10579]🐛Client configuration tests expect field names in public error text

### DIFF
--- a/rocketmq-client/tests/client_config_behavior.rs
+++ b/rocketmq-client/tests/client_config_behavior.rs
@@ -15,6 +15,21 @@
 #![recursion_limit = "256"]
 
 use rocketmq_client_rust::ClientConfig;
+use rocketmq_client_rust::ClientError;
+use rocketmq_error::fields;
+use rocketmq_error::ErrorContext;
+
+#[track_caller]
+fn assert_invalid_config(error: &ClientError, key: &str) {
+    assert!(error.is(&rocketmq_error::CORE_CONFIGURATION_INVALID));
+    assert_eq!(
+        error.context(),
+        &ErrorContext::new()
+            .with_text(fields::KEY, key)
+            .with_secret_presence(fields::VALUE_PRESENT)
+            .with_secret_presence(fields::REASON_PRESENT)
+    );
+}
 
 #[test]
 fn runtime_concurrency_and_metadata_limits_are_preserved() {
@@ -41,7 +56,7 @@ fn zero_callback_concurrency_is_rejected() {
         Err(error) => error,
     };
 
-    assert!(error.to_string().contains("client_callback_executor_threads"));
+    assert_invalid_config(&error, "client_callback_executor_threads");
 }
 
 #[test]
@@ -55,7 +70,7 @@ fn enabled_concurrent_heartbeat_rejects_zero_capacity() {
         Err(error) => error,
     };
 
-    assert!(error.to_string().contains("concurrent_heartbeat_thread_pool_size"));
+    assert_invalid_config(&error, "concurrent_heartbeat_thread_pool_size");
 }
 
 #[test]
@@ -65,5 +80,5 @@ fn zero_metadata_page_size_is_rejected() {
         Err(error) => error,
     };
 
-    assert!(error.to_string().contains("max_page_size_in_get_metadata"));
+    assert_invalid_config(&error, "max_page_size_in_get_metadata");
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #10579 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved configuration validation tests to verify structured error types and contextual fields.
  - Replaced message-substring checks with assertions for configuration keys, value presence, and reason presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->